### PR TITLE
resource/aws_network_interface: Use first of private_ips as primary

### DIFF
--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -46,11 +46,10 @@ func resourceAwsNetworkInterface() *schema.Resource {
 			},
 
 			"private_ips": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 
 			"private_ips_count": &schema.Schema{
@@ -119,7 +118,7 @@ func resourceAwsNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 		request.Groups = expandStringList(security_groups)
 	}
 
-	private_ips := d.Get("private_ips").(*schema.Set).List()
+	private_ips := d.Get("private_ips").([]interface{})
 	if len(private_ips) != 0 {
 		request.PrivateIpAddresses = expandPrivateIPAddresses(private_ips)
 	}

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -273,21 +273,21 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 	if d.HasChange("private_ips") {
 		o, n := d.GetChange("private_ips")
 		if o == nil {
-			o = new(schema.Set)
+			o = []interface{}{}
 		}
 		if n == nil {
-			n = new(schema.Set)
+			n = []interface{}{}
 		}
 
-		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
+		os := o.([]interface{})
+		ns := n.([]interface{})
 
 		// Unassign old IP addresses
-		unassignIps := os.Difference(ns)
-		if unassignIps.Len() != 0 {
+		unassignIps := difference(os, ns)
+		if len(unassignIps) != 0 {
 			input := &ec2.UnassignPrivateIpAddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
-				PrivateIpAddresses: expandStringList(unassignIps.List()),
+				PrivateIpAddresses: expandStringList(unassignIps),
 			}
 			_, err := conn.UnassignPrivateIpAddresses(input)
 			if err != nil {
@@ -296,11 +296,11 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		}
 
 		// Assign new IP addresses
-		assignIps := ns.Difference(os)
-		if assignIps.Len() != 0 {
+		assignIps := difference(ns, os)
+		if len(assignIps) != 0 {
 			input := &ec2.AssignPrivateIpAddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
-				PrivateIpAddresses: expandStringList(assignIps.List()),
+				PrivateIpAddresses: expandStringList(assignIps),
 			}
 			_, err := conn.AssignPrivateIpAddresses(input)
 			if err != nil {
@@ -325,7 +325,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("private_ips_count") {
 		o, n := d.GetChange("private_ips_count")
-		private_ips := d.Get("private_ips").(*schema.Set).List()
+		private_ips := d.Get("private_ips").([]interface{})
 		private_ips_filtered := private_ips[:0]
 		primary_ip := d.Get("private_ip")
 
@@ -431,4 +431,19 @@ func resourceAwsEniAttachmentHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["instance"].(string)))
 	buf.WriteString(fmt.Sprintf("%d-", m["device_index"].(int)))
 	return hashcode.String(buf.String())
+}
+
+// returns items from list2 which are not contained in list1
+func difference(list1, list2 []interface{}) []interface{} {
+	result := []interface{}{}
+Items:
+	for _, item2 := range list2 {
+		for _, item1 := range list1 {
+			if item1 == item2 {
+				continue Items
+			}
+		}
+		result = append(result, item2)
+	}
+	return result
 }

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -283,7 +283,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		ns := n.([]interface{})
 
 		// Unassign old IP addresses
-		unassignIps := difference(os, ns)
+		unassignIps := difference(ns, os)
 		if len(unassignIps) != 0 {
 			input := &ec2.UnassignPrivateIpAddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
@@ -296,7 +296,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		}
 
 		// Assign new IP addresses
-		assignIps := difference(ns, os)
+		assignIps := difference(os, ns)
 		if len(assignIps) != 0 {
 			input := &ec2.AssignPrivateIpAddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),

--- a/website/docs/r/network_interface.markdown
+++ b/website/docs/r/network_interface.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `subnet_id` - (Required) Subnet ID to create the ENI in.
 * `description` - (Optional) A description for the network interface.
-* `private_ips` - (Optional) List of private IPs to assign to the ENI.
+* `private_ips` - (Optional) List of private IPs to assign to the ENI; the first listed will be the primary.
 * `private_ips_count` - (Optional) Number of private IPs to assign to the ENI.
 * `security_groups` - (Optional) List of security group IDs to assign to the ENI.
 * `attachment` - (Optional) Block to define the attachment of the ENI. Documented below.


### PR DESCRIPTION
This changes `private_ips` to List (instead of Set) for more intuitive/predictable behavior, which helps to solve issues #836 and #996.

Before this change, there was no reliable way to configure the primary_ip --> you simply got the ip address whose string value's hash had the lowest lexical sort order. Deterministic, yes, but not determined by the order the ips were specified in the list :)
