### PR TITLE
added fix for issue #167 - defaulting restrictions to none for cloudf…

### DIFF
--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -432,16 +432,15 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 			},
 			"restrictions": {
 				Type:     schema.TypeSet,
-				Computed: true,
+				Optional: true,
 				Set:      restrictionsHash,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"geo_restriction": {
 							Type:     schema.TypeSet,
-							Computed: true,
+							Optional: true,
 							Set:      geoRestrictionHash,
-							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"locations": {
@@ -452,7 +451,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"restriction_type": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default:  "none",
+										Default:  cloudfront.GeoRestrictionTypeNone,
 									},
 								},
 							},

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -432,14 +432,14 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 			},
 			"restrictions": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Computed: true,
 				Set:      restrictionsHash,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"geo_restriction": {
 							Type:     schema.TypeSet,
-							Required: true,
+							Computed: true,
 							Set:      geoRestrictionHash,
 							MaxItems: 1,
 							Elem: &schema.Resource{
@@ -451,7 +451,8 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									},
 									"restriction_type": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
+										Default:  "none",
 									},
 								},
 							},

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -44,9 +44,9 @@ func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFrontDistribution_S3OriginNoRestrictions(t *testing.T) {
+func TestAccAWSCloudFrontDistribution_S3Origin_Restrictions(t *testing.T) {
 	ri := acctest.RandInt()
-	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithNoRestrictions, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
+	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigRestrictions, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -369,12 +369,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 		max_ttl = 86400
 	}
 	price_class = "PriceClass_200"
-	restrictions {
-		geo_restriction {
-			restriction_type = "whitelist"
-			locations = [ "US", "CA", "GB", "DE" ]
-		}
-	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
@@ -382,7 +376,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 }
 `
 
-var testAccAWSCloudFrontDistributionS3ConfigWithNoRestrictions = `
+var testAccAWSCloudFrontDistributionS3ConfigRestrictions = `
 variable rand_id {
 	default = %d
 }
@@ -422,6 +416,13 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 		max_ttl = 86400
 	}
 	price_class = "PriceClass_200"
+
+	restrictions {
+		geo_restriction {
+			restriction_type = "whitelist"
+			locations = [ "US", "CA", "GB", "DE" ]
+		}
+	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
@@ -464,12 +465,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 		max_ttl = 86400
 	}
 	price_class = "PriceClass_200"
-	restrictions {
-		geo_restriction {
-			restriction_type = "whitelist"
-			locations = [ "US", "CA", "GB", "DE" ]
-		}
-	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
@@ -516,12 +511,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 		max_ttl = 86400
 	}
 	price_class = "PriceClass_200"
-	restrictions {
-		geo_restriction {
-			restriction_type = "whitelist"
-			locations = [ "US", "CA", "GB", "DE" ]
-		}
-	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
@@ -579,12 +568,6 @@ resource "aws_cloudfront_distribution" "custom_distribution" {
 		max_ttl = 86400
 	}
 	price_class = "PriceClass_200"
-	restrictions {
-		geo_restriction {
-			restriction_type = "whitelist"
-			locations = [ "US", "CA", "GB", "DE" ]
-		}
-	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
@@ -684,11 +667,6 @@ resource "aws_cloudfront_distribution" "multi_origin_distribution" {
 		response_code = 200
 		error_caching_min_ttl = 30
 	}
-	restrictions {
-		geo_restriction {
-			restriction_type = "none"
-		}
-	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
@@ -734,12 +712,6 @@ resource "aws_cloudfront_distribution" "no_custom_error_responses" {
 		error_code = 404
 		error_caching_min_ttl = 30
 	}
-	restrictions {
-		geo_restriction {
-			restriction_type = "whitelist"
-			locations = [ "US", "CA", "GB", "DE" ]
-		}
-	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
@@ -780,12 +752,6 @@ resource "aws_cloudfront_distribution" "no_optional_items" {
 		min_ttl = 0
 		default_ttl = 3600
 		max_ttl = 86400
-	}
-	restrictions {
-		geo_restriction {
-			restriction_type = "whitelist"
-			locations = [ "US", "CA", "GB", "DE" ]
-		}
 	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
@@ -829,12 +795,6 @@ resource "aws_cloudfront_distribution" "http_1_1" {
 		max_ttl = 86400
 	}
 	http_version = "http1.1"
-	restrictions {
-		geo_restriction {
-			restriction_type = "whitelist"
-			locations = [ "US", "CA", "GB", "DE" ]
-		}
-	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
@@ -878,12 +838,6 @@ resource "aws_cloudfront_distribution" "is_ipv6_enabled" {
 		max_ttl = 86400
 	}
 	http_version = "http1.1"
-	restrictions {
-		geo_restriction {
-			restriction_type = "whitelist"
-			locations = [ "US", "CA", "GB", "DE" ]
-		}
-	}
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -44,6 +44,31 @@ func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudFrontDistribution_S3OriginNoRestrictions(t *testing.T) {
+	ri := acctest.RandInt()
+	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithNoRestrictions, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExistence(
+						"aws_cloudfront_distribution.s3_distribution",
+					),
+					resource.TestCheckResourceAttr(
+						"aws_cloudfront_distribution.s3_distribution",
+						"hosted_zone_id",
+						"Z2FDTNDATAQYW2",
+					),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudFrontDistribution_S3OriginWithTags(t *testing.T) {
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithTags, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
@@ -350,6 +375,53 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 			locations = [ "US", "CA", "GB", "DE" ]
 		}
 	}
+	viewer_certificate {
+		cloudfront_default_certificate = true
+	}
+	%s
+}
+`
+
+var testAccAWSCloudFrontDistributionS3ConfigWithNoRestrictions = `
+variable rand_id {
+	default = %d
+}
+
+# origin bucket
+%s
+
+# log bucket
+%s
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+	origin {
+		domain_name = "${aws_s3_bucket.s3_bucket_origin.id}.s3.amazonaws.com"
+		origin_id = "myS3Origin"
+	}
+	enabled = true
+	default_root_object = "index.html"
+	logging_config {
+		include_cookies = false
+		bucket = "${aws_s3_bucket.s3_bucket_logs.id}.s3.amazonaws.com"
+		prefix = "myprefix"
+	}
+	aliases = [ "mysite.${var.rand_id}.example.com", "yoursite.${var.rand_id}.example.com" ]
+	default_cache_behavior {
+		allowed_methods = [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ]
+		cached_methods = [ "GET", "HEAD" ]
+		target_origin_id = "myS3Origin"
+		forwarded_values {
+			query_string = false
+			cookies {
+				forward = "none"
+			}
+		}
+		viewer_protocol_policy = "allow-all"
+		min_ttl = 0
+		default_ttl = 3600
+		max_ttl = 86400
+	}
+	price_class = "PriceClass_200"
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}


### PR DESCRIPTION
…ront distributions

In reference to: https://github.com/terraform-providers/terraform-provider-aws/issues/167

Currently the aws_cloudfront_distribtuion requires 

`  restrictions {
    geo_restriction {
      restriction_type = "none"
    }
  }`

The proposed changes allows this section to be computed. 

Acceptance tests output

==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3.911s

First PR so go easy on me 👍 