### PR TITLE
r/instance: add instance market options

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1879,7 +1879,7 @@ func buildAwsInstanceOpts(
 					spotOptions.SpotInstanceType = aws.String(so["spot_instance_type"].(string))
 
 					if so["valid_until"] != "" {
-						t, err := time.Parse(awsSpotInstanceTimeLayout, so["valid_until"].(string))
+						t, err := time.Parse(time.RFC3339, so["valid_until"].(string))
 						if err != nil {
 							return nil, fmt.Errorf("Error Parsing Launch Template Spot Options valid until: %s", err.Error())
 						}
@@ -2022,7 +2022,7 @@ func readSpotRequestFromInstance(instance *ec2.Instance, conn *ec2.EC2) ([]inter
 			spotRequest["instance_interruption_behavior"] = *sr.InstanceInterruptionBehavior
 			spotRequest["max_price"] = *sr.SpotPrice
 			spotRequest["spot_instance_type"] = *sr.Type
-			spotRequest["valid_until"] = aws.TimeValue(sr.ValidUntil).Format(awsSpotInstanceTimeLayout)
+			spotRequest["valid_until"] = aws.TimeValue(sr.ValidUntil).Format(time.RFC3339)
 			spotRequests = append(spotRequests, spotRequest)
 		}
 	}

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -454,6 +454,49 @@ func resourceAwsInstance() *schema.Resource {
 					},
 				},
 			},
+
+			"instance_market_options": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"market_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"spot_options": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"block_duration_minutes": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"instance_interruption_behavior": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"max_price": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"spot_instance_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"valid_until": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -497,6 +540,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		SubnetId:                          instanceOpts.SubnetID,
 		UserData:                          instanceOpts.UserData64,
 		CreditSpecification:               instanceOpts.CreditSpecification,
+		InstanceMarketOptions:             instanceOpts.InstanceMarketOptions,
 	}
 
 	_, ipv6CountOk := d.GetOk("ipv6_address_count")
@@ -771,6 +815,9 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if _, ok := d.GetOk("ephemeral_block_device"); !ok {
 		d.Set("ephemeral_block_device", []interface{}{})
+	}
+	if err := readSpotRequest(d, instance, conn); err != nil {
+		return err
 	}
 
 	// Instance attributes
@@ -1681,6 +1728,7 @@ type awsInstanceOpts struct {
 	SubnetID                          *string
 	UserData64                        *string
 	CreditSpecification               *ec2.CreditSpecificationRequest
+	InstanceMarketOptions             *ec2.InstanceMarketOptionsRequest
 }
 
 func buildAwsInstanceOpts(
@@ -1814,6 +1862,40 @@ func buildAwsInstanceOpts(
 	if len(blockDevices) > 0 {
 		opts.BlockDeviceMappings = blockDevices
 	}
+	if v, ok := d.GetOk("instance_market_options"); ok {
+		imo := v.(*schema.Set).List()
+
+		if len(imo) > 0 {
+			imoData := imo[0].(map[string]interface{})
+			spotOptions := &ec2.SpotMarketOptions{}
+
+			if v, ok := imoData["spot_options"]; ok {
+				vL := v.(*schema.Set).List()
+				for _, v := range vL {
+					so := v.(map[string]interface{})
+					spotOptions.BlockDurationMinutes = aws.Int64(int64(so["block_duration_minutes"].(int)))
+					spotOptions.InstanceInterruptionBehavior = aws.String(so["instance_interruption_behavior"].(string))
+					spotOptions.MaxPrice = aws.String(so["max_price"].(string))
+					spotOptions.SpotInstanceType = aws.String(so["spot_instance_type"].(string))
+
+					if so["valid_until"] != "" {
+						t, err := time.Parse(awsSpotInstanceTimeLayout, so["valid_until"].(string))
+						if err != nil {
+							return nil, fmt.Errorf("Error Parsing Launch Template Spot Options valid until: %s", err.Error())
+						}
+						spotOptions.ValidUntil = aws.Time(t)
+					}
+				}
+			}
+
+			instanceMarketOptions := &ec2.InstanceMarketOptionsRequest{
+				MarketType:  aws.String(imoData["market_type"].(string)),
+				SpotOptions: spotOptions,
+			}
+
+			opts.InstanceMarketOptions = instanceMarketOptions
+		}
+	}
 	return opts, nil
 }
 
@@ -1907,4 +1989,42 @@ func getCreditSpecifications(conn *ec2.EC2, instanceId string) ([]map[string]int
 	}
 
 	return creditSpecifications, nil
+}
+
+func readSpotRequest(d *schema.ResourceData, instance *ec2.Instance, conn *ec2.EC2) error {
+	marketOptions := make([]map[string]interface{}, 0)
+	dsir, err := readSpotRequestFromInstance(instance, conn)
+	if err != nil {
+		return err
+	}
+	if len(dsir) > 0 {
+		marketOption := make(map[string]interface{})
+		marketOption["market_type"] = "spot"
+		marketOption["spot_options"] = dsir
+		marketOptions = append(marketOptions, marketOption)
+	}
+	d.Set("instance_market_options", marketOptions)
+	return nil
+}
+
+func readSpotRequestFromInstance(instance *ec2.Instance, conn *ec2.EC2) ([]interface{}, error) {
+	spotRequests := make([]interface{}, 0)
+	if instance.SpotInstanceRequestId != nil {
+		spotInstanceRequest, err := conn.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+			SpotInstanceRequestIds: []*string{instance.SpotInstanceRequestId},
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, sr := range spotInstanceRequest.SpotInstanceRequests {
+			spotRequest := make(map[string]interface{})
+			spotRequest["block_duration_minutes"] = *sr.BlockDurationMinutes
+			spotRequest["instance_interruption_behavior"] = *sr.InstanceInterruptionBehavior
+			spotRequest["max_price"] = *sr.SpotPrice
+			spotRequest["spot_instance_type"] = *sr.Type
+			spotRequest["valid_until"] = aws.TimeValue(sr.ValidUntil).Format(awsSpotInstanceTimeLayout)
+			spotRequests = append(spotRequests, spotRequest)
+		}
+	}
+	return spotRequests, nil
 }

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -91,7 +91,9 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
   "Instance Store") volumes on the instance. See [Block Devices](#block-devices) below for details.
 * `network_interface` - (Optional) Customize network interfaces to be attached at instance boot time. See [Network Interfaces](#network-interfaces) below for more details.
 * `credit_specification` - (Optional) Customize the credit specification of the instance. See [Credit Specification](#credit-specification) below for more details.
-
+* `instance_market_options` - (Optional) The market (purchasing) option for the instance. See [Market Options](#market-options)
+  below for details.
+  
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
@@ -184,6 +186,24 @@ Credit specification can be applied/modified to the EC2 Instance at any time.
 The `credit_specification` block supports the following:
 
 * `cpu_credits` - (Optional) The credit option for CPU usage.
+
+### Market Options
+
+The market (purchasing) option for the instance.
+
+The `instance_market_options` block supports the following:
+
+* `market_type` - The market type. Can be `spot`.
+* `spot_options` - The options for [Spot Instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html)
+
+The `spot_options` block supports the following:
+
+* `block_duration_minutes` - The required duration in minutes. This value must be a multiple of 60.
+* `instance_interruption_behavior` - The behavior when a Spot Instance is interrupted. Can be `hibernate`,
+  `stop`, or `terminate`.
+* `max_price` - The maximum hourly price you're willing to pay for the Spot Instances.
+* `spot_instance_type` - The Spot Instance request type. Can be `one-time`, or `persistent`.
+* `valid_until` - The end date of the request.
 
 ### Example
 


### PR DESCRIPTION
This should address https://github.com/terraform-providers/terraform-provider-aws/issues/3340

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_instanceMarketOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstance_instanceMarketOptions -timeout 120m
=== RUN   TestAccAWSInstance_instanceMarketOptions
--- PASS: TestAccAWSInstance_instanceMarketOptions (81.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	81.509s
```