### PR TITLE
data-source/lb_listener: set optional arguments as computed

### DIFF
--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -17,17 +17,20 @@ func dataSourceAwsLbListener() *schema.Resource {
 			"arn": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"load_balancer_arn", "port"},
 			},
 
 			"load_balancer_arn": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"arn"},
 			},
 			"port": {
 				Type:          schema.TypeInt,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"arn"},
 			},
 

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -211,6 +211,18 @@ data "aws_lb_listener" "from_lb_and_port" {
   load_balancer_arn = "${aws_lb.alb_test.arn}"
   port              = "${aws_lb_listener.front_end.port}"
 }
+
+output "front_end_load_balancer_arn" {
+  value = "${data.aws_lb_listener.front_end.load_balancer_arn}"
+}
+
+output "front_end_port" {
+  value = "${data.aws_lb_listener.front_end.port}"
+}
+
+output "from_lb_and_port_arn" {
+  value = "${data.aws_lb_listener.from_lb_and_port.arn}"
+}
 `, lbName, targetGroupName)
 }
 


### PR DESCRIPTION
fix #4315 

It's more of a misconfiguration on resource schema. Not sure if tests are needed here but added a few outputs to check optional arguments.