### PR TITLE
add arn to aws_wafregional_ipset

### DIFF
--- a/aws/resource_aws_wafregional_ipset.go
+++ b/aws/resource_aws_wafregional_ipset.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
@@ -23,6 +24,10 @@ func resourceAwsWafRegionalIPSet() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"ip_set_descriptor": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -84,6 +89,15 @@ func resourceAwsWafRegionalIPSetRead(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("ip_set_descriptor", flattenWafIpSetDescriptorWR(resp.IPSet.IPSetDescriptors))
 	d.Set("name", resp.IPSet.Name)
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "waf-regional",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("ipset/%s", d.Id()),
+	}
+	d.Set("arn", arn.String())
 
 	return nil
 }

--- a/aws/resource_aws_wafregional_ipset_test.go
+++ b/aws/resource_aws_wafregional_ipset_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -34,6 +35,8 @@ func TestAccAWSWafRegionalIPSet_basic(t *testing.T) {
 						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+					resource.TestMatchResourceAttr("aws_wafregional_ipset.ipset", "arn",
+						regexp.MustCompile(`^arn:[\w-]+:waf-regional:[^:]+:\d{12}:ipset/.+$`)),
 				),
 			},
 		},

--- a/website/docs/r/wafregional_ipset.html.markdown
+++ b/website/docs/r/wafregional_ipset.html.markdown
@@ -52,3 +52,4 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF IPSet.
+* `arn` - The ARN of the WAF IPSet.


### PR DESCRIPTION

Fixes #4772 

Changes proposed in this pull request:

* Change 1
Added arn attribute to aws_wafregional_ipset

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSWafRegionalIPSet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSWafRegionalIPSet_basic -timeout 120m
=== RUN   TestAccAWSWafRegionalIPSet_basic
--- PASS: TestAccAWSWafRegionalIPSet_basic (50.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.919s
...
```
