### PR TITLE
Add option to allow no results when querying aws_instances Data Source

### DIFF
--- a/aws/data_source_aws_instances.go
+++ b/aws/data_source_aws_instances.go
@@ -49,6 +49,11 @@ func dataSourceAwsInstances() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"allow_no_results": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -58,6 +63,7 @@ func dataSourceAwsInstancesRead(d *schema.ResourceData, meta interface{}) error 
 
 	filters, filtersOk := d.GetOk("filter")
 	tags, tagsOk := d.GetOk("instance_tags")
+	allowNoResults := d.Get("allow_no_results").(bool)
 
 	if !filtersOk && !tagsOk {
 		return fmt.Errorf("One of filters or instance_tags must be assigned")
@@ -107,7 +113,7 @@ func dataSourceAwsInstancesRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	if len(instanceIds) < 1 {
+	if len(instanceIds) < 1 && allowNoResults == false {
 		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
 	}
 

--- a/aws/data_source_aws_instances_test.go
+++ b/aws/data_source_aws_instances_test.go
@@ -59,6 +59,23 @@ func TestAccAWSInstancesDataSource_instance_state_names(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstancesDataSource_noResults(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSourceConfig_noResults,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_instances.test", "ids.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_instances.test", "private_ips.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_instances.test", "public_ips.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 const testAccInstancesDataSourceConfig_ids = `
 data "aws_ami" "ubuntu" {
   most_recent = true
@@ -167,3 +184,14 @@ data "aws_instances" "test" {
 }
 `, rInt)
 }
+
+const testAccInstancesDataSourceConfig_noResults = `
+data "aws_instances" "test" {
+  filter {
+    name = "instance-id"
+    values = ["does", "not", "exist"]
+  }
+
+  allow_no_results = true
+}
+`

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -53,6 +53,8 @@ exactly match a pair on desired instances.
 several valid keys, for a full reference, check out
 [describe-instances in the AWS CLI reference][1].
 
+* `allow_no_results` - (Optional) Defaults to false. If true, empty lists could be returned for `ids`, `private_ips` and  `public_ips`. This is useful when querying the count of ephemeral instances (e.g. managed via autoscaling group) which may not be created yet.
+
 ## Attributes Reference
 
 * `ids` - IDs of instances found through the filter


### PR DESCRIPTION
Changes proposed in this pull request:

* Add allow_no_results option to aws_instances Data Source

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSInstancesDataSource_noResults'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSInstancesDataSource_noResults -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSInstancesDataSource_noResults
--- PASS: TestAccAWSInstancesDataSource_noResults (32.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.596s
```
