### PR TITLE
DMS Endpoint: Apply extra_connection_attributes to all engine types in DMS

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -279,14 +279,14 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 		if v, ok := d.GetOk("database_name"); ok {
 			request.DatabaseName = aws.String(v.(string))
 		}
-		if v, ok := d.GetOk("extra_connection_attributes"); ok {
-			request.ExtraConnectionAttributes = aws.String(v.(string))
-		}
 		if v, ok := d.GetOk("kms_key_arn"); ok {
 			request.KmsKeyId = aws.String(v.(string))
 		}
 	}
 
+	if v, ok := d.GetOk("extra_connection_attributes"); ok {
+		request.ExtraConnectionAttributes = aws.String(v.(string))
+	}
 	if v, ok := d.GetOk("certificate_arn"); ok {
 		request.CertificateArn = aws.String(v.(string))
 	}
@@ -562,12 +562,12 @@ func resourceAwsDmsEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoi
 		}
 	default:
 		d.Set("database_name", endpoint.DatabaseName)
-		d.Set("extra_connection_attributes", endpoint.ExtraConnectionAttributes)
 		d.Set("port", endpoint.Port)
 		d.Set("server_name", endpoint.ServerName)
 		d.Set("username", endpoint.Username)
 	}
 
+	d.Set("extra_connection_attributes", endpoint.ExtraConnectionAttributes)
 	d.Set("kms_key_arn", endpoint.KmsKeyId)
 	d.Set("ssl_mode", endpoint.SslMode)
 

--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -275,17 +275,16 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 		request.Port = aws.Int64(int64(d.Get("port").(int)))
 		request.ServerName = aws.String(d.Get("server_name").(string))
 		request.Username = aws.String(d.Get("username").(string))
-
 		if v, ok := d.GetOk("database_name"); ok {
 			request.DatabaseName = aws.String(v.(string))
-		}
-		if v, ok := d.GetOk("kms_key_arn"); ok {
-			request.KmsKeyId = aws.String(v.(string))
 		}
 	}
 
 	if v, ok := d.GetOk("extra_connection_attributes"); ok {
 		request.ExtraConnectionAttributes = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("kms_key_arn"); ok {
+		request.KmsKeyId = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("certificate_arn"); ok {
 		request.CertificateArn = aws.String(v.(string))

--- a/aws/resource_aws_dms_endpoint_test.go
+++ b/aws/resource_aws_dms_endpoint_test.go
@@ -63,11 +63,12 @@ func TestAccAwsDmsEndpointS3(t *testing.T) {
 				Config: dmsEndpointS3Config(randId),
 				Check: resource.ComposeTestCheckFunc(
 					checkDmsEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", "addColumnName=true;bucketFolder=bucket_folder;bucketName=bucket_name;compressionType=NONE;csvDelimiter=,;csvRowDelimiter=\\n;"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.external_table_definition", ""),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_row_delimiter", "\\n"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_delimiter", ","),
-					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_folder", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_folder", "bucket_folder"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_name", "bucket_name"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.compression_type", "NONE"),
 				),
@@ -82,7 +83,7 @@ func TestAccAwsDmsEndpointS3(t *testing.T) {
 				Config: dmsEndpointS3ConfigUpdate(randId),
 				Check: resource.ComposeTestCheckFunc(
 					checkDmsEndpointExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", "key=value;"),
+					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", "addColumnName=false;bucketFolder=new-bucket_folder;bucketName=new-bucket_name;compressionType=GZIP;csvDelimiter=.;csvRowDelimiter=\\r;"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.external_table_definition", "new-external_table_definition"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_row_delimiter", "\\r"),
@@ -395,7 +396,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	endpoint_type = "target"
 	engine_name = "s3"
 	ssl_mode = "none"
-	extra_connection_attributes = ""
+	extra_connection_attributes = "addColumnName=true;bucketFolder=bucket_folder;bucketName=bucket_name;compressionType=NONE;csvDelimiter=,;csvRowDelimiter=\\n;"
 	tags {
 		Name = "tf-test-s3-endpoint-%[1]s"
 		Update = "to-update"
@@ -403,6 +404,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	}
 	s3_settings {
 		service_access_role_arn = "${aws_iam_role.iam_role.arn}"
+		bucket_folder = "bucket_folder"
 		bucket_name = "bucket_name"
 	}
 
@@ -467,7 +469,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	endpoint_type = "target"
 	engine_name = "s3"
 	ssl_mode = "none"
-	extra_connection_attributes = "key=value;"
+	extra_connection_attributes = "addColumnName=false;bucketFolder=new-bucket_folder;bucketName=new-bucket_name;compressionType=GZIP;csvDelimiter=.;csvRowDelimiter=\\r;"
 	tags {
 		Name = "tf-test-s3-endpoint-%[1]s"
 		Update = "updated"


### PR DESCRIPTION
Changes proposed in this pull request:

* For certain DMS endpoint engines, there is a dedicated set of the engine-specific settings. `s3_settings` for `s3` and `mongodb_settings` for `mongodb` to name a few. However, there exist engine-specific attributes that can only be changed via `extra_connection_attributes`. While this appears to be an inconsistent behaviour of the corresponding AWS API, we have to make `extra_connection_attributes` available to _all_ engine types. One example is `addColumnName` for `s3`. It's currently not being handled under `s3_settings` hence must be specified in `extra_connection_attributes` if you want a non-default behaviour (in this case, `false`).

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsDmsEndpointS3'
```

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAwsDmsEndpointS3 -timeout 120m
?      github.com/terraform-providers/terraform-provider-aws  [no test files]
=== RUN   TestAccAwsDmsEndpointS3
--- PASS: TestAccAwsDmsEndpointS3 (81.30s)
PASS
ok     github.com/terraform-providers/terraform-provider-aws/aws      81.309s
```