### PR TITLE
Permit leading whitespace in IAM policies by normalizing before check…

### DIFF
--- a/aws/resource_aws_iam_role_policy_test.go
+++ b/aws/resource_aws_iam_role_policy_test.go
@@ -479,13 +479,15 @@ resource "aws_iam_role_policy" "foo" {
 	name = "tf_test_policy_%s"
 	role = "${aws_iam_role.role.name}"
 	policy = <<EOF
-  {
+  x{
     "Version": "2012-10-17",
-    "Statement": {
-      "Effect": "Allow",
-      "Action": "*",
-      "Resource": "*"
-    }
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "*",
+        "Resource": "*"
+      }
+    ]
   }
   EOF
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -652,17 +652,19 @@ func validateJsonString(v interface{}, k string) (ws []string, errors []error) {
 
 func validateIAMPolicyJson(v interface{}, k string) (ws []string, errors []error) {
 	// IAM Policy documents need to be valid JSON, and pass legacy parsing
-	value := v.(string)
-	if len(value) < 1 {
+	vString := v.(string)
+	if len(vString) < 1 {
 		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy", k))
 		return
 	}
-	if value[:1] != "{" {
-		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy", k))
-		return
-	}
-	if _, err := structure.NormalizeJsonString(v); err != nil {
+	vNormalized, err := structure.NormalizeJsonString(v)
+	if err != nil {
 		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+		return
+	}
+	if vNormalized[:1] != "{" {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy", k))
+		return
 	}
 	return
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -652,8 +652,7 @@ func validateJsonString(v interface{}, k string) (ws []string, errors []error) {
 
 func validateIAMPolicyJson(v interface{}, k string) (ws []string, errors []error) {
 	// IAM Policy documents need to be valid JSON, and pass legacy parsing
-	vString := v.(string)
-	if len(vString) < 1 {
+	if len(v.(string)) < 1 {
 		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy", k))
 		return
 	}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -803,10 +803,6 @@ func TestValidateIAMPolicyJsonString(t *testing.T) {
 			Value:    ``,
 			ErrCount: 1,
 		},
-		{
-			Value:    `    {"xyz": "foo"}`,
-			ErrCount: 1,
-		},
 	}
 
 	for _, tc := range invalidCases {


### PR DESCRIPTION
Fixes #1873 

Changes proposed in this pull request:

* Normalize JSON before testing structure, to permit valid leading whitespace per the JSON spec

Output from acceptance testing:
```% make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
--- PASS: TestAccAWSLaunchTemplate_importBasic (20.12s)
=== RUN   TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_importData (20.22s)
=== RUN   TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (18.14s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (49.48s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (86.00s)
=== RUN   TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (17.86s)
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (83.03s)
=== RUN   TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_tags (32.64s)
=== RUN   TestAccAWSLaunchTemplate_nonBurstable
--- PASS: TestAccAWSLaunchTemplate_nonBurstable (16.86s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface
--- PASS: TestAccAWSLaunchTemplate_networkInterface (47.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	391.625s```
