### PR TITLE
Add example for cloudfront_distribution with s3 webhosting endpoint

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -159,6 +159,7 @@ resource "aws_s3_bucket" "website-bucket" {
     index_document = "index.html"
   }
 }
+
 data "aws_iam_policy_document" "bucket-policy" {
   statement {
     actions   = ["s3:GetObject"]
@@ -176,28 +177,10 @@ data "aws_iam_policy_document" "bucket-policy" {
     }
   }
 }
+
 resource "aws_s3_bucket_policy" "bucket-policy" {
   bucket = "${aws_s3_bucket.website-bucket.id}"
-
   policy = "${data.aws_iam_policy_document.bucket-policy.json}"
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "ReadWithSecretUserAgent",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": "s3:GetObject",
-            "Resource": "arn:aws:s3:::${aws_s3_bucket.website-bucket.id}/*",
-            "Condition": {
-                "StringEquals": {
-                    "aws:UserAgent": "${local.cloudfront-authentication-user-agent}"
-                }
-            }
-        }
-    ]
-}
-POLICY
 }
 
 resource "aws_cloudfront_distribution" "distribution" {

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -214,7 +214,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       query_string = false
 
       cookies {
-        forward = "all"
+        forward = "none"
       }
     }
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -206,7 +206,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   comment = "A distribution for our S3 Website Endpoint"
 
   default_cache_behavior {
-    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    allowed_methods  = ["HEAD", "GET", "OPTIONS"]
     cached_methods   = ["HEAD", "GET", "OPTIONS"]
     target_origin_id = "${local.origin_id}"
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -179,7 +179,7 @@ data "aws_iam_policy_document" "bucket-policy" {
 resource "aws_s3_bucket_policy" "bucket-policy" {
   bucket = "${aws_s3_bucket.website-bucket.id}"
 
-  policy = <<POLICY
+  policy = "${data.aws_iam_policy_document.bucket-policy.json}"
 {
     "Version": "2012-10-17",
     "Statement": [

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -159,7 +159,23 @@ resource "aws_s3_bucket" "website-bucket" {
     index_document = "index.html"
   }
 }
+data "aws_iam_policy_document" "bucket-policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.website-bucket.arn}/*"]
 
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:UserAgent"
+      values   = ["${local.cloudfront-authentication-user-agent}"]
+    }
+  }
+}
 resource "aws_s3_bucket_policy" "bucket-policy" {
   bucket = "${aws_s3_bucket.website-bucket.id}"
 


### PR DESCRIPTION
The change adds another example with separate headers.

- The AWS API (and the resource docs) were unclear about this and this commit clarifies it with an example.
- Targets current Terraform version.

Fixes #4757 