### PR TITLE
issue #4674 manage default aws_db_subnet_group

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -373,6 +373,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_db_security_group":                            resourceAwsDbSecurityGroup(),
 			"aws_db_snapshot":                                  resourceAwsDbSnapshot(),
 			"aws_db_subnet_group":                              resourceAwsDbSubnetGroup(),
+			"aws_default_db_subnet_group":                      resourceAwsDefaultDbSubnetGroup(),
 			"aws_devicefarm_project":                           resourceAwsDevicefarmProject(),
 			"aws_directory_service_directory":                  resourceAwsDirectoryServiceDirectory(),
 			"aws_directory_service_conditional_forwarder":      resourceAwsDirectoryServiceConditionalForwarder(),

--- a/aws/resource_aws_default_db_subnet_group.go
+++ b/aws/resource_aws_default_db_subnet_group.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDefaultDbSubnetGroup() *schema.Resource {
+	// reuse aws_db_subnet_group schema, and methods for READ
+	defDbSubnetGroup := resourceAwsDbSubnetGroup()
+	defDbSubnetGroup.Create = resourceAwsDefaultDbSubnetGroupCreate
+	defDbSubnetGroup.Delete = resourceAwsDefaultDbSubnetGroupDelete
+	defDbSubnetGroup.Update = resourceAwsDefaultDbSubnetGroupUpdate
+
+	// name is a computed value for Default DB Subnet Group
+	defDbSubnetGroup.Schema["name"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	delete(defDbSubnetGroup.Schema, "name_prefix")
+
+	return defDbSubnetGroup
+}
+
+func resourceAwsDefaultDbSubnetGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	rdsconn := meta.(*AWSClient).rdsconn
+
+	describeOpts := rds.DescribeDBSubnetGroupsInput{
+		DBSubnetGroupName: aws.String("default"),
+	}
+
+	describeResp, err := rdsconn.DescribeDBSubnetGroups(&describeOpts)
+	if err != nil {
+		return err
+	}
+
+	if describeResp.DBSubnetGroups == nil || len(describeResp.DBSubnetGroups) == 0 {
+		return fmt.Errorf("No default DB Subnet Group found in this region.")
+	}
+
+	subnetGroup := describeResp.DBSubnetGroups[0]
+	d.SetId(aws.StringValue(subnetGroup.DBSubnetGroupName))
+	d.Set("arn", subnetGroup.DBSubnetGroupArn)
+
+	return resourceAwsDefaultDbSubnetGroupUpdate(d, meta)
+}
+
+func resourceAwsDefaultDbSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+	d.Partial(true)
+
+	if d.HasChange("subnet_ids") {
+		_, n := d.GetChange("subnet_ids")
+		if n == nil {
+			n = new(schema.Set)
+		}
+
+		ns := n.(*schema.Set)
+
+		var sIds []*string
+		for _, s := range ns.List() {
+			sIds = append(sIds, aws.String(s.(string)))
+		}
+
+		_, err := conn.ModifyDBSubnetGroup(&rds.ModifyDBSubnetGroupInput{
+			DBSubnetGroupName:        aws.String(d.Id()),
+			DBSubnetGroupDescription: aws.String(d.Get("description").(string)),
+			SubnetIds:                sIds,
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("description") && !d.HasChange("subnet_ids") {
+		subnetIdsSet := d.Get("subnet_ids").(*schema.Set)
+		sIds := make([]*string, subnetIdsSet.Len())
+		for i, subnetId := range subnetIdsSet.List() {
+			sIds[i] = aws.String(subnetId.(string))
+		}
+
+		_, err := conn.ModifyDBSubnetGroup(&rds.ModifyDBSubnetGroupInput{
+			DBSubnetGroupName:        aws.String(d.Id()),
+			DBSubnetGroupDescription: aws.String(d.Get("description").(string)),
+			SubnetIds:                sIds,
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	arn := d.Get("arn").(string)
+	if err := setTagsRDS(conn, d, arn); err != nil {
+		return err
+	} else {
+		d.SetPartial("tags")
+	}
+
+	d.Partial(false)
+
+	return resourceAwsDbSubnetGroupRead(d, meta)
+}
+
+func resourceAwsDefaultDbSubnetGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy Default DB Subnet Group. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/aws/resource_aws_default_db_subnet_group_test.go
+++ b/aws/resource_aws_default_db_subnet_group_test.go
@@ -1,0 +1,65 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+)
+
+func TestAccAWSDefaultDBSubnetGroup_basic(t *testing.T) {
+	var v rds.DBSubnetGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDefaultDBSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDefaultDBSubnetGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBSubnetGroupExists(
+						"aws_default_db_subnet_group.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_default_db_subnet_group.default", "name", "default"),
+					resource.TestCheckResourceAttr(
+						"aws_default_db_subnet_group.default", "description", "Managed by Terraform"),
+					resource.TestMatchResourceAttr(
+						"aws_default_db_subnet_group.default", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:subgrp:default"))),
+					resource.TestCheckResourceAttr(
+						"aws_default_db_subnet_group.default", "tags.%", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDefaultDBSubnetGroupDestroy(s *terraform.State) error {
+	// We expect thid resource to still exist
+	return nil
+}
+
+const testAccDefaultDBSubnetGroupConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_default_subnet" "default_az1" {
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_default_subnet" "default_az2" {
+  availability_zone = "us-west-2b"
+}
+
+resource "aws_default_db_subnet_group" "default" {
+  subnet_ids = ["${aws_default_subnet.default_az1.id}", "${aws_default_subnet.default_az2.id}"]
+  tags {
+    Name = "Default DB subnet group"
+  }
+}
+`

--- a/website/docs/r/default_db_subnet_group.html.markdown
+++ b/website/docs/r/default_db_subnet_group.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "aws"
+page_title: "AWS: aws_default_db_subnet_group"
+sidebar_current: "docs-aws-resource-default-db-subnet-group"
+description: |-
+  Manage a default DB subnet group resource.
+---
+
+# aws_default_db_subnet_group
+
+Provides a resource to manage a default DB subnet group in the current region.
+
+The `aws_default_db_subnet_group` behaves differently from normal resources, in that 
+Terraform does not _create_ this resource, but 
+instead "adopts" it into management.
+
+### Removing `aws_default_db_subnet_group` from your configuration
+
+The `aws_default_db_subnet_group` resource allows you to manage a region's default DB subnet group,
+but Terraform cannot destroy it. Removing this resource from your configuration will remove it from your statefile and management, but will not destroy the subnet group. You can resume managing the subnet group via the AWS Console.
+
+## Example Usage
+
+```hcl
+resource "aws_default_db_subnet_group" "default" {
+  subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  tags {
+    Name = "Default DB subnet group"
+  }
+}
+```
+## Argument Reference
+
+The arguments of an `aws_default_db_subnet_group` differ from `aws_db_subnet_group` resources.
+Namely, the `name` argument is computed.
+
+The following arguments are still supported:
+
+* `description` - (Optional) A description of the subnet group.
+* `subnet_ids` – (Required) A list of VPC subnet IDs for the subnet group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The DB subnet group name.
+* `arn` - The ARN of the DB subnet group.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Ref #4674 

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDefaultDBSubnetGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDefaultDBSubnetGroup_basic -timeout 120m
=== RUN   TestAccAWSDefaultDBSubnetGroup_basic
--- PASS: TestAccAWSDefaultDBSubnetGroup_basic (38.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws
...
```
