### PR TITLE
resource/aws_codebuild_project: Add arn attribute and improve id attribute documentation

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -28,6 +28,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"artifacts": {
 				Type:     schema.TypeSet,
 				Required: true,
@@ -770,6 +774,7 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+	d.Set("arn", project.Arn)
 	d.Set("description", project.Description)
 	d.Set("encryption_key", project.EncryptionKey)
 	d.Set("name", project.Name)

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -60,6 +60,7 @@ func TestAccAWSCodeBuildProject_basic(t *testing.T) {
 				Config: testAccAWSCodeBuildProjectConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "codebuild", fmt.Sprintf("project/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.1178773975.encryption_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.1178773975.location", ""),

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -233,12 +233,12 @@ The following arguments are supported:
 * `location` - (Optional) The location of the source code from git or s3.
 * `report_build_status` - (Optional) Set to `true` to report the status of a build's start and finish to your source provider. This option is only valid when your source provider is GitHub.
 
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ARN of the CodeBuild project.
+* `id` - The name (if imported via `name`) or ARN (if created via Terraform or imported via ARN) of the CodeBuild project.
+* `arn` - The ARN of the CodeBuild project.
 * `badge_url` - The URL of the build badge when `badge_enabled` is enabled.
 
 ## Import


### PR DESCRIPTION
Closes #5962 

Changes proposed in this pull request:

* Add `arn` attribute to `aws_codebuild_project`
* Document `id` attribute behavior better

Output from acceptance testing:

```
23 tests passed (all tests)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (17.08s)
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (17.28s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (17.61s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (17.96s)
--- PASS: TestAccAWSCodeBuildProject_importBasic (18.01s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (18.10s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (21.74s)
--- PASS: TestAccAWSCodeBuildProject_basic (25.83s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (25.84s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (26.01s)
--- PASS: TestAccAWSCodeBuildProject_Source_Auth (25.99s)
--- PASS: TestAccAWSCodeBuildProject_Tags (29.55s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (29.68s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus (29.83s)
--- PASS: TestAccAWSCodeBuildProject_Description (30.14s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (30.12s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (30.58s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (35.23s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (37.10s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (24.02s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (23.97s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (23.68s)
--- PASS: TestAccAWSCodeBuildProject_Cache (43.49s)
```
