### PR TITLE
guides/eks-getting-started: Add AWS CLI eks update-kubeconfig information and add kubectl configuration section link to ConfigMap section

### DIFF
--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -41,7 +41,7 @@ associated with these services, even if you choose a different architecture.
         - [EKS Master Cluster IAM Role](#eks-master-cluster-iam-role)
         - [EKS Master Cluster Security Group](#eks-master-cluster-security-group)
         - [EKS Master Cluster](#eks-master-cluster)
-        - [Obtaining kubectl Configuration From Terraform](#obtaining-kubectl-configuration-from-terraform)
+    - [Configuring kubectl for EKS](#configuring-kubectl-for-eks)
     - [Kubernetes Worker Nodes](#kubernetes-worker-nodes)
         - [Worker Node IAM Role and Instance Profile](#worker-node-iam-role-and-instance-profile)
         - [Worker Node Security Group](#worker-node-security-group)
@@ -285,14 +285,21 @@ resource "aws_eks_cluster" "demo" {
 }
 ```
 
-#### Obtaining kubectl Configuration From Terraform
+### Configuring kubectl for EKS
+
+-> This section only provides some example methods for configuring `kubectl` to communicate with EKS servers. Managing Kubernetes clients and configurations is outside the scope of this guide.
 
 If you are planning on using `kubectl` to manage the Kubernetes cluster, now
-might be a great time to configure your client. The below Terraform output
-generates a sample `kubectl` configuration to connect to your cluster.
-
-You can verify cluster access via `kubectl version` displaying server version
+might be a great time to configure your client. After configuration, you can
+verify cluster access via `kubectl version` displaying server version
 information in addition to local client version information.
+
+The AWS CLI [`eks update-kubeconfig`](https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html)
+command provides a simple method to create or update configuration files.
+
+If you would rather update your configuration manually, the below Terraform output
+generates a sample `kubectl` configuration to connect to your cluster. This can
+be placed into a Kubernetes configuration file, e.g. `~/.kube/config`
 
 ```hcl
 locals {
@@ -545,14 +552,11 @@ configuration to enable the worker nodes to join the cluster.
 
 #### Required Kubernetes Configuration to Join Worker Nodes
 
+-> While managing Kubernetes cluster and client configurations are beyond the scope of this guide, we provide an example of how to apply the required Kubernetes [`ConfigMap`](http://kubernetes.io/docs/user-guide/configmap/) via `kubectl` below for completeness. See also the [Configuring kubectl for EKS](#configuring-kubectl-for-eks) section.
+
 The EKS service does not provide a cluster-level API parameter or resource to
 automatically configure the underlying Kubernetes cluster to allow worker nodes
 to join the cluster via AWS IAM role authentication.
-
-While managing the underlying Kubernetes cluster configuration is beyond the
-scope of this guide, we provide an example of how to apply the required
-Kubernetes [`ConfigMap`](http://kubernetes.io/docs/user-guide/configmap/)
-via `kubectl` below for completeness.
 
 To output an example IAM Role authentication `ConfigMap` from your
 Terraform configuration:


### PR DESCRIPTION
Closes #5692 

Changes proposed in this pull request:

* Add AWS CLI `eks update-kubeconfig` information and link to `kubectl` configuration section
* Cross reference `kubectl` configuration section in `ConfigMap` section

Output from acceptance testing: N/A
