### PR TITLE
data_source/aws_elasticache_replication_group: Output read_endpoint_addresses

### DIFF
--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -41,6 +41,12 @@ func dataSourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"read_endpoint_addresses": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 			"number_cache_clusters": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -110,6 +116,15 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 		}
 		d.Set("port", rg.NodeGroups[0].PrimaryEndpoint.Port)
 		d.Set("primary_endpoint_address", rg.NodeGroups[0].PrimaryEndpoint.Address)
+
+		var rEndpoints []*string
+		for _, member := range rg.NodeGroups[0].NodeGroupMembers {
+			rEndpoints = append(rEndpoints, member.ReadEndpoint.Address)
+		}
+		if err := d.Set("read_endpoint_addresses", flattenStringList(rEndpoints)); err != nil {
+			return fmt.Errorf("error setting read_endpoint_addresses: %s", err)
+		}
+
 	}
 	d.Set("number_cache_clusters", len(rg.MemberClusters))
 	if err := d.Set("member_clusters", flattenStringList(rg.MemberClusters)); err != nil {

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -23,6 +23,7 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "automatic_failover_enabled", "true"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "port", "6379"),
 					resource.TestCheckResourceAttrSet("data.aws_elasticache_replication_group.bar", "primary_endpoint_address"),
+					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "read_endpoint_addresses", "2"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "member_clusters.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "node_type", "cache.m1.small"),

--- a/website/docs/d/elasticache_replication_group.html.markdown
+++ b/website/docs/d/elasticache_replication_group.html.markdown
@@ -40,3 +40,4 @@ In addition to all arguments above, the following attributes are exported:
 * `port` – The port number on which the configuration endpoint will accept connections.
 * `configuration_endpoint_address` - The configuration endpoint address to allow host discovery.
 * `primary_endpoint_address` - The endpoint of the primary node in this node group (shard).
+* `read_endpoint_addresses` - Reader endpoints of the nodes in this node group.


### PR DESCRIPTION
Relates to #5763

Changes proposed in this pull request:

* Adds `read_endpoint_addresses` in data_source_aws_elasticache_replication_group.go:
```
			"read_endpoint_addresses": {
				Type:     schema.TypeSet,
				Computed: true,
				Elem:     &schema.Schema{Type: schema.TypeString},
				Set:      schema.HashString,
			},
```

