### PR TITLE
Update config_map_aws_auth in docs to match repo

### DIFF
--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -563,7 +563,7 @@ Terraform configuration:
 
 ```hcl
 locals {
-  config-map-aws-auth = <<CONFIGMAPAWSAUTH
+  config_map_aws_auth = <<CONFIGMAPAWSAUTH
 
 
 apiVersion: v1
@@ -581,13 +581,13 @@ data:
 CONFIGMAPAWSAUTH
 }
 
-output "config-map-aws-auth" {
-  value = "${local.config-map-aws-auth}"
+output "config_map_aws_auth" {
+  value = "${local.config_map_aws_auth}"
 }
 ```
 
-* Run `terraform output config-map-aws-auth` and save the configuration into a file, e.g. `config-map-aws-auth.yaml`
-* Run `kubectl apply -f config-map-aws-auth.yaml`
+* Run `terraform output config_map_aws_auth` and save the configuration into a file, e.g. `config_map_aws_auth.yaml`
+* Run `kubectl apply -f config_map_aws_auth.yaml`
 * You can verify the worker nodes are joining the cluster via: `kubectl get nodes --watch`
 
 At this point, you should be able to utilize Kubernetes as expected!


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-aws/commit/3087f1d8e00a736c01f5062c0826e2801a7a872e changed the hyphens to underscores in the name of this output variable, but the docs still have hyphens. This will change the names in the docs so that they match the example code.