### PR TITLE
tests/provider: Fix unused Linting Issues and Enable in TravisCI Testing

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -9,6 +9,7 @@
         "misspell",
         "structcheck",
         "unconvert",
+        "unused",
         "varcheck",
         "vet"
     ],

--- a/aws/data_source_aws_ami_test.go
+++ b/aws/data_source_aws_ami_test.go
@@ -174,10 +174,6 @@ func TestAccAWSAmiDataSource_localNameFilter(t *testing.T) {
 	})
 }
 
-func testAccCheckAwsAmiDataSourceDestroy(s *terraform.State) error {
-	return nil
-}
-
 func testAccCheckAwsAmiDataSourceID(n string) resource.TestCheckFunc {
 	// Wait for IAM role
 	return func(s *terraform.State) error {

--- a/aws/data_source_aws_elastic_beanstalk_solution_stack_test.go
+++ b/aws/data_source_aws_elastic_beanstalk_solution_stack_test.go
@@ -25,10 +25,6 @@ func TestAccAWSElasticBeanstalkSolutionStackDataSource(t *testing.T) {
 	})
 }
 
-func testAccCheckAwsElasticBeanstalkSolutionStackDataSourceDestroy(s *terraform.State) error {
-	return nil
-}
-
 func testAccCheckAwsElasticBeanstalkSolutionStackDataSourceID(n string) resource.TestCheckFunc {
 	// Wait for solution stacks
 	return func(s *terraform.State) error {

--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -381,20 +381,6 @@ resource "aws_cloudwatch_log_group" "foobar" {
 `, rInt)
 }
 
-func testAccAWSCloudWatchLogGroupConfigWithTagsRemoval(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "foobar" {
-    name = "foo-bar-%d"
-
-    tags {
-    	Environment = "Production"
-    	Foo = "Bar"
-    	Empty = ""
-    }
-}
-`, rInt)
-}
-
 func testAccAWSCloudWatchLogGroupConfig_withRetention(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "foobar" {

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -118,11 +118,6 @@ func testAccCheckDefaultRouteTableDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDefaultRouteTableExists(s *terraform.State) error {
-	// We can't destroy this resource; it comes and goes with the VPC itself.
-	return nil
-}
-
 const testAccDefaultRouteTableConfig = `
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -923,61 +923,6 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
 }`, appName, envName)
 }
 
-func testAccBeanstalkEnvConfig_settings_update(appName, envName string) string {
-	return fmt.Sprintf(`
-resource "aws_elastic_beanstalk_application" "tftest" {
-  name = "%s"
-  description = "tf-test-desc"
-}
-
-resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-  name                = "%s"
-  application         = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux running Python"
-
-  wait_for_ready_timeout = "15m"
-
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "ENV_STATIC"
-    value     = "true"
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "ENV_UPDATE"
-    value     = "false"
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "ENV_ADD"
-    value     = "true"
-  }
-
-  setting {
-    namespace = "aws:autoscaling:scheduledaction"
-    resource  = "ScheduledAction01"
-    name      = "MinSize"
-    value     = 2
-  }
-
-  setting {
-    namespace = "aws:autoscaling:scheduledaction"
-    resource  = "ScheduledAction01"
-    name      = "MaxSize"
-    value     = 3
-  }
-
-  setting {
-    namespace = "aws:autoscaling:scheduledaction"
-    resource  = "ScheduledAction01"
-    name      = "StartTime"
-    value     = "2016-07-28T04:07:02Z"
-  }
-}`, appName, envName)
-}
-
 func testAccBeanstalkWorkerEnvConfig(instanceProfileName, roleName, policyName, appName, envName string) string {
 	return fmt.Sprintf(`
  resource "aws_iam_instance_profile" "tftest" {

--- a/aws/resource_aws_iam_account_alias_test.go
+++ b/aws/resource_aws_iam_account_alias_test.go
@@ -155,21 +155,6 @@ func testAccCheckAWSIAMAccountAliasExists(n string, a *string) resource.TestChec
 	}
 }
 
-func testAccCheckAwsIamAccountAlias(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Can't find Account Alias resource: %s", n)
-		}
-
-		if rs.Primary.Attributes["account_alias"] == "" {
-			return fmt.Errorf("Missing Account Alias")
-		}
-
-		return nil
-	}
-}
-
 func testAccAWSIAMAccountAliasConfig_with_datasource(rstring string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_account_alias" "test" {

--- a/aws/resource_aws_placement_group_test.go
+++ b/aws/resource_aws_placement_group_test.go
@@ -86,29 +86,6 @@ func testAccCheckAWSPlacementGroupExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckAWSDestroyPlacementGroup(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Placement Group ID is set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		_, err := conn.DeletePlacementGroup(&ec2.DeletePlacementGroupInput{
-			GroupName: aws.String(rs.Primary.ID),
-		})
-
-		if err != nil {
-			return fmt.Errorf("Error destroying Placement Group (%s): %s", rs.Primary.ID, err)
-		}
-		return nil
-	}
-}
-
 func testAccAWSPlacementGroupConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_placement_group" "test" {

--- a/aws/resource_aws_route53_delegation_set_test.go
+++ b/aws/resource_aws_route53_delegation_set_test.go
@@ -7,25 +7,30 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
-func TestAccAWSRoute53DelegationSet_importBasic(t *testing.T) {
+func TestAccAWSRoute53DelegationSet_basic(t *testing.T) {
+	rString := acctest.RandString(8)
+	refName := fmt.Sprintf("tf_acc_%s", rString)
 	resourceName := "aws_route53_delegation_set.test"
-	refName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:        func() { testAccPreCheck(t) },
+		IDRefreshName:   resourceName,
+		IDRefreshIgnore: []string{"reference_name"},
+		Providers:       testAccProviders,
+		CheckDestroy:    testAccCheckRoute53DelegationSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53DelegationSetConfig(refName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53DelegationSetExists(resourceName),
+				),
 			},
-
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
@@ -36,58 +41,44 @@ func TestAccAWSRoute53DelegationSet_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53DelegationSet_basic(t *testing.T) {
-	rString := acctest.RandString(8)
-	refName := fmt.Sprintf("tf_acc_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		IDRefreshName:   "aws_route53_delegation_set.test",
-		IDRefreshIgnore: []string{"reference_name"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckRoute53ZoneDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRoute53DelegationSetConfig(refName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53DelegationSetExists("aws_route53_delegation_set.test"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSRoute53DelegationSet_withZones(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
 	rString := acctest.RandString(8)
 	refName := fmt.Sprintf("tf_acc_%s", rString)
+	resourceName := "aws_route53_delegation_set.test"
 	zoneName1 := fmt.Sprintf("%s-primary.terraformtest.com", rString)
 	zoneName2 := fmt.Sprintf("%s-secondary.terraformtest.com", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		IDRefreshName:   "aws_route53_delegation_set.main",
+		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"reference_name"},
 		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckRoute53ZoneDestroy,
+		CheckDestroy:    testAccCheckRoute53DelegationSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53DelegationSetWithZonesConfig(refName, zoneName1, zoneName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53DelegationSetExists("aws_route53_delegation_set.main"),
+					testAccCheckRoute53DelegationSetExists(resourceName),
 					testAccCheckRoute53ZoneExists("aws_route53_zone.primary", &zone),
 					testAccCheckRoute53ZoneExists("aws_route53_zone.secondary", &zone),
-					testAccCheckRoute53NameServersMatch("aws_route53_delegation_set.main", "aws_route53_zone.primary"),
-					testAccCheckRoute53NameServersMatch("aws_route53_delegation_set.main", "aws_route53_zone.secondary"),
+					testAccCheckRoute53NameServersMatch(resourceName, "aws_route53_zone.primary"),
+					testAccCheckRoute53NameServersMatch(resourceName, "aws_route53_zone.secondary"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"reference_name"},
 			},
 		},
 	})
 }
 
-func testAccCheckRoute53DelegationSetDestroy(s *terraform.State, provider *schema.Provider) error {
-	conn := provider.Meta().(*AWSClient).r53conn
+func testAccCheckRoute53DelegationSetDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).r53conn
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route53_delegation_set" {
 			continue
@@ -175,18 +166,18 @@ resource "aws_route53_delegation_set" "test" {
 
 func testAccRoute53DelegationSetWithZonesConfig(refName, zoneName1, zoneName2 string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_delegation_set" "main" {
+resource "aws_route53_delegation_set" "test" {
     reference_name = "%s"
 }
 
 resource "aws_route53_zone" "primary" {
     name = "%s"
-    delegation_set_id = "${aws_route53_delegation_set.main.id}"
+    delegation_set_id = "${aws_route53_delegation_set.test.id}"
 }
 
 resource "aws_route53_zone" "secondary" {
     name = "%s"
-    delegation_set_id = "${aws_route53_delegation_set.main.id}"
+    delegation_set_id = "${aws_route53_delegation_set.test.id}"
 }
 `, refName, zoneName1, zoneName2)
 }

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -258,10 +258,6 @@ func testAccCheckRoute53HealthCheckExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testUpdateHappened(n string) resource.TestCheckFunc {
-	return nil
-}
-
 const testAccRoute53HealthCheckConfig = `
 resource "aws_route53_health_check" "foo" {
   fqdn = "dev.notexample.com"

--- a/aws/resource_aws_s3_bucket_inventory_test.go
+++ b/aws/resource_aws_s3_bucket_inventory_test.go
@@ -231,7 +231,7 @@ resource "aws_s3_bucket_inventory" "test" {
     }
   }
 }
-`, testAccAWSS3BucketMetricsConfigBucket(bucketName), inventoryName)
+`, testAccAWSS3BucketInventoryConfigBucket(bucketName), inventoryName)
 }
 
 func testAccAWSS3BucketInventoryConfigEncryptWithSSES3(bucketName, inventoryName string) string {
@@ -258,7 +258,7 @@ resource "aws_s3_bucket_inventory" "test" {
     }
   }
 }
-`, testAccAWSS3BucketMetricsConfigBucket(bucketName), inventoryName)
+`, testAccAWSS3BucketInventoryConfigBucket(bucketName), inventoryName)
 }
 
 func testAccAWSS3BucketInventoryConfigEncryptWithSSEKMS(bucketName, inventoryName string) string {
@@ -292,5 +292,5 @@ resource "aws_s3_bucket_inventory" "test" {
     }
   }
 }
-`, testAccAWSS3BucketMetricsConfigBucket(bucketName), bucketName, inventoryName)
+`, testAccAWSS3BucketInventoryConfigBucket(bucketName), bucketName, inventoryName)
 }

--- a/aws/resource_aws_secretsmanager_secret_test.go
+++ b/aws/resource_aws_secretsmanager_secret_test.go
@@ -617,49 +617,6 @@ resource "aws_secretsmanager_secret" "test" {
 `, rName)
 }
 
-func testAccAwsSecretsManagerSecretConfig_RotationLambdaARN_Updated(rName string) string {
-	return baseAccAWSLambdaConfig(rName, rName, rName) + fmt.Sprintf(`
-# Not a real rotation function
-resource "aws_lambda_function" "test1" {
-  filename      = "test-fixtures/lambdatest.zip"
-  function_name = "%[1]s-1"
-  handler       = "exports.example"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs4.3"
-}
-
-resource "aws_lambda_permission" "test1" {
-  action         = "lambda:InvokeFunction"
-  function_name  = "${aws_lambda_function.test1.function_name}"
-  principal      = "secretsmanager.amazonaws.com"
-  statement_id   = "AllowExecutionFromSecretsManager1"
-}
-
-# Not a real rotation function
-resource "aws_lambda_function" "test2" {
-  filename      = "test-fixtures/lambdatest.zip"
-  function_name = "%[1]s-2"
-  handler       = "exports.example"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs4.3"
-}
-
-resource "aws_lambda_permission" "test2" {
-  action         = "lambda:InvokeFunction"
-  function_name  = "${aws_lambda_function.test2.function_name}"
-  principal      = "secretsmanager.amazonaws.com"
-  statement_id   = "AllowExecutionFromSecretsManager2"
-}
-
-resource "aws_secretsmanager_secret" "test" {
-  name                = "%[1]s"
-  rotation_lambda_arn = "${aws_lambda_function.test2.arn}"
-
-  depends_on = ["aws_lambda_permission.test2"]
-}
-`, rName)
-}
-
 func testAccAwsSecretsManagerSecretConfig_RotationRules(rName string, automaticallyAfterDays int) string {
 	return baseAccAWSLambdaConfig(rName, rName, rName) + fmt.Sprintf(`
 # Not a real rotation function

--- a/aws/resource_aws_security_group_rules_matching_test.go
+++ b/aws/resource_aws_security_group_rules_matching_test.go
@@ -10,10 +10,9 @@ import (
 // testing rulesForGroupPermissions
 func TestRulesMixedMatching(t *testing.T) {
 	cases := []struct {
-		groupId string
-		local   []interface{}
-		remote  []map[string]interface{}
-		saves   []map[string]interface{}
+		local  []interface{}
+		remote []map[string]interface{}
+		saves  []map[string]interface{}
 	}{
 		{
 			local: []interface{}{

--- a/aws/tagsBeanstalk_test.go
+++ b/aws/tagsBeanstalk_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestDiffBeanstalkTags(t *testing.T) {
@@ -78,28 +75,5 @@ func TestIgnoringTagsBeanstalk(t *testing.T) {
 		if !tagIgnoredBeanstalk(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckBeanstalkTags(
-	ts *[]*elasticbeanstalk.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapBeanstalk(*ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }

--- a/aws/tagsDAX_test.go
+++ b/aws/tagsDAX_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dax"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestDaxTagsDiff(t *testing.T) {
@@ -76,28 +73,5 @@ func TestTagsDaxIgnore(t *testing.T) {
 		if !tagIgnoredDax(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckDaxTags(
-	ts []*dax.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapDax(ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }

--- a/aws/tagsEC_test.go
+++ b/aws/tagsEC_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestDiffelasticacheTags(t *testing.T) {
@@ -76,28 +73,5 @@ func TestIgnoringTagsEC(t *testing.T) {
 		if !tagIgnoredEC(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckelasticacheTags(
-	ts []*elasticache.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapEC(ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }

--- a/aws/tagsEFS_test.go
+++ b/aws/tagsEFS_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/efs"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestDiffEFSTags(t *testing.T) {
@@ -76,28 +73,5 @@ func TestIgnoringTagsEFS(t *testing.T) {
 		if !tagIgnoredEFS(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckEFSTags(
-	ts *[]*efs.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapEFS(*ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }

--- a/aws/tagsKMS_test.go
+++ b/aws/tagsKMS_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 // go test -v -run="TestDiffKMSTags"
@@ -78,28 +75,5 @@ func TestIgnoringTagsKMS(t *testing.T) {
 		if !tagIgnoredKMS(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.TagKey, *tag.TagValue)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckKMSTags(
-	ts []*kms.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapKMS(ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }

--- a/aws/tagsNeptune_test.go
+++ b/aws/tagsNeptune_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/neptune"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestDiffNeptuneTags(t *testing.T) {
@@ -76,28 +73,5 @@ func TestIgnoringTagsNeptune(t *testing.T) {
 		if !tagIgnoredNeptune(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckNeptuneTags(
-	ts []*neptune.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapNeptune(ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }

--- a/aws/tagsRDS_test.go
+++ b/aws/tagsRDS_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestDiffRDSTags(t *testing.T) {
@@ -76,28 +73,5 @@ func TestIgnoringTagsRDS(t *testing.T) {
 		if !tagIgnoredRDS(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckRDSTags(
-	ts []*rds.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapRDS(ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }

--- a/aws/tagsSSM_test.go
+++ b/aws/tagsSSM_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 // go test -v -run="TestDiffSSMTags"
@@ -78,28 +75,5 @@ func TestIgnoringTagsSSM(t *testing.T) {
 		if !tagIgnoredSSM(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckSSMTags(
-	ts []*ssm.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapSSM(ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }

--- a/aws/tags_kinesis_test.go
+++ b/aws/tags_kinesis_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestDiffTagsKinesis(t *testing.T) {
@@ -76,27 +73,5 @@ func TestIgnoringTagsKinesis(t *testing.T) {
 		if !tagIgnoredKinesis(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckKinesisTags(ts []*kinesis.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapKinesis(ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }


### PR DESCRIPTION
This also found two issues with aws_route53_delegation_set and aws_s3_bucket_inventory acceptance testing, which have been fixed.

Closes #6332 

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53DelegationSet_basic (9.96s)
--- PASS: TestAccAWSRoute53DelegationSet_withZones (49.85s)
--- PASS: TestAccAWSS3BucketInventory_basic (31.49s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (35.03s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (51.84s)
```
