### PR TITLE
Add validate DynamoDB indexes

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1843,11 +1843,22 @@ func validateDynamoDbTableAttributes(d *schema.ResourceDiff) error {
 
 		if _, ok := indexedAttributes[attrName]; !ok {
 			missingAttrDefs = append(missingAttrDefs, attrName)
+		} else {
+			delete(indexedAttributes, attrName)
 		}
 	}
 
 	if len(missingAttrDefs) > 0 {
 		return fmt.Errorf("All attributes must be indexed. Unused attributes: %q", missingAttrDefs)
+	}
+
+	if len(indexedAttributes) > 0 {
+		missingIndexes := []string{}
+		for index := range indexedAttributes {
+			missingIndexes = append(missingIndexes, index)
+		}
+
+		return fmt.Errorf("All indexes must be attribute. Unused indexes: %q", missingIndexes)
 	}
 
 	return nil


### PR DESCRIPTION
Nice to meet you.

Changes proposed in this pull request:

* In the DynamoDB validation, when there is an index which does not exist in the attribute, I fixed to be an error.

There was no original test in `validateDynamoDbTableAttributes`.
I thought about writing a test but stopped because I did not know how to create the argument `schema.ResourceDiff`.

I performed this fix on `terraform plan` and confirmed that the results are correct.
The following is the execution log at that time.

main.tf

```tf
terraform {
  required_version = "> 0.11.0"
}

provider "aws" {
  region = "ap-northeast-1"
}

resource "aws_dynamodb_table" "test_table" {
  name           = "TestTable"
  hash_key       = "ID"
  range_key      = "UserID"
  read_capacity  = 5
  write_capacity = 5

  attribute {
    name = "ID"
    type = "S"
  }

  local_secondary_index {
    name            = "StatusIndex"
    range_key       = "Status"
    projection_type = "KEY_ONLY"
  }
}
```

log

```console
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

Error: Error running plan: 1 error(s) occurred:

* aws_dynamodb_table.test_table: 1 error(s) occurred:

* aws_dynamodb_table.test_table: All indexes must be attribute. Unused indexes: ["UserID" "Status"]
```