### PR TITLE
Dynamodb item Import

### DIFF
--- a/website/docs/r/dynamodb_table_item.html.markdown
+++ b/website/docs/r/dynamodb_table_item.html.markdown
@@ -60,4 +60,35 @@ All of the arguments above are exported as attributes.
 
 ## Import
 
-DynamoDB table items cannot be imported.
+DynamoDB table items can be imported using the `table_name`, `hash_key`, `hash_key_type`, `hash_key_value` and optionally `range_key`, `range_key_type`, `range_key_value` if required, separated by underscores (`/`).
+
+### Examples
+
+Import an item with a hash key only of type string:
+
+```hcl
+resource "aws_dynamodb_table_item" "example" {
+  table_name = "test_table"
+  hash_key   = "exampleHashKey"
+
+  item = <<ITEM
+{
+  "exampleHashKey": {"S": "something"},
+  "one": {"N": "11111"},
+  "two": {"N": "22222"},
+  "three": {"N": "33333"},
+  "four": {"N": "44444"}
+}
+ITEM
+}
+```
+
+```console
+$ terraform import aws_dynamodb_table_item test_table/exampleHashKey/S/something
+```
+
+The same example as above with a range key of `number` type:
+
+```console
+$ terraform import aws_dynamodb_table_item test_table/exampleHashKey/S/something/exampleRangeKey/N/1111
+```

--- a/website/docs/r/dynamodb_table_item.html.markdown
+++ b/website/docs/r/dynamodb_table_item.html.markdown
@@ -60,7 +60,7 @@ All of the arguments above are exported as attributes.
 
 ## Import
 
-DynamoDB table items can be imported using the `table_name`, `hash_key`, `hash_key_type`, `hash_key_value` and optionally `range_key`, `range_key_type`, `range_key_value` if required, separated by underscores (`/`).
+DynamoDB table items can be imported using the `table_name`, `hash_key`, `hash_key_type`, `hash_key_value` and optionally `range_key`, `range_key_type`, `range_key_value` if required, separated by slashes (`/`).
 
 ### Examples
 
@@ -87,7 +87,7 @@ ITEM
 $ terraform import aws_dynamodb_table_item test_table/exampleHashKey/S/something
 ```
 
-The same example as above with a range key of `number` type:
+The same example as above with a range key of type number:
 
 ```console
 $ terraform import aws_dynamodb_table_item test_table/exampleHashKey/S/something/exampleRangeKey/N/1111


### PR DESCRIPTION
Fixes #8923
Relates #9664

Change proposed in this pull request:

* Add ability to import DynamoDb Items

Motivation

Managing dynamodb items in Terraform is quite useful for small configuration tables, unfortunately it has been difficult to start using it for existing tables where items could not be imported in the scenario that a delete&insert can increase latencies or service up times. This PR aims to mitigate the risk of deleting existing items by being able to import them.

Apologies if for the large PR, this was a bit more difficult than anticipated and has the downside of having lots of parts in the import string however I can't think of a way around this.

I'm currently getting lots of complaints from `make fmt` in other files, not really sure why my environment is showing this but it may cause the build to fail.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDynamoDbTableItem'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDynamoDbTableItem -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDynamoDbTableItem_basic
=== PAUSE TestAccAWSDynamoDbTableItem_basic
=== RUN   TestAccAWSDynamoDbTableItem_rangeKey
=== PAUSE TestAccAWSDynamoDbTableItem_rangeKey
=== RUN   TestAccAWSDynamoDbTableItem_withMultipleItems
=== PAUSE TestAccAWSDynamoDbTableItem_withMultipleItems
=== RUN   TestAccAWSDynamoDbTableItem_update
=== PAUSE TestAccAWSDynamoDbTableItem_update
=== RUN   TestAccAWSDynamoDbTableItem_updateWithRangeKey
=== PAUSE TestAccAWSDynamoDbTableItem_updateWithRangeKey
=== CONT  TestAccAWSDynamoDbTableItem_basic
=== CONT  TestAccAWSDynamoDbTableItem_update
=== CONT  TestAccAWSDynamoDbTableItem_rangeKey
=== CONT  TestAccAWSDynamoDbTableItem_updateWithRangeKey
=== CONT  TestAccAWSDynamoDbTableItem_withMultipleItems
--- PASS: TestAccAWSDynamoDbTableItem_updateWithRangeKey (80.98s)
--- PASS: TestAccAWSDynamoDbTableItem_withMultipleItems (132.65s)
--- PASS: TestAccAWSDynamoDbTableItem_basic (134.64s)
--- PASS: TestAccAWSDynamoDbTableItem_rangeKey (134.98s)
--- PASS: TestAccAWSDynamoDbTableItem_update (145.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	145.129s
...
```
