### PR TITLE
Find aws_lb by tags in data source

### DIFF
--- a/.changelog/6458.txt
+++ b/.changelog/6458.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_lb: Add ability to filter results by `tags`
+```

--- a/aws/data_source_aws_lb.go
+++ b/aws/data_source_aws_lb.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
@@ -159,6 +159,8 @@ func dataSourceAwsLbRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elbv2conn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
+	tagsToMatch := keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
 	input := &elbv2.DescribeLoadBalancersInput{}
 
 	if v, ok := d.GetOk("arn"); ok {
@@ -181,6 +183,31 @@ func dataSourceAwsLbRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err != nil {
 		return fmt.Errorf("error retrieving LB: %w", err)
+	}
+
+	if len(tagsToMatch) > 0 {
+		var loadBalancers []*elbv2.LoadBalancer
+
+		for _, loadBalancer := range results {
+			arn := aws.StringValue(loadBalancer.LoadBalancerArn)
+			tags, err := keyvaluetags.Elbv2ListTags(conn, arn)
+
+			if tfawserr.ErrCodeEquals(err, elbv2.ErrCodeLoadBalancerNotFoundException) {
+				continue
+			}
+
+			if err != nil {
+				return fmt.Errorf("error listing tags for (%s): %w", arn, err)
+			}
+
+			if !tags.ContainsAll(tagsToMatch) {
+				continue
+			}
+
+			loadBalancers = append(loadBalancers, loadBalancer)
+		}
+
+		results = loadBalancers
 	}
 
 	if len(results) != 1 {
@@ -268,53 +295,4 @@ func dataSourceAwsLbRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
-}
-
-func readFromDescribeTags(d *schema.ResourceData, meta interface{}, lbTags []*elbv2.Tag) error {
-	elbconn := meta.(*AWSClient).elbv2conn
-	describeLbOpts := &elbv2.DescribeLoadBalancersInput{}
-	describeResp, err := elbconn.DescribeLoadBalancers(describeLbOpts)
-	if err != nil {
-		return fmt.Errorf("Error retrieving LB: %s", err)
-	}
-
-	var matchedLb []*elbv2.LoadBalancer
-	for _, element := range describeResp.LoadBalancers {
-		describeTagsOpts := &elbv2.DescribeTagsInput{
-			ResourceArns: []*string{element.LoadBalancerArn},
-		}
-		describeTagsResp, err := elbconn.DescribeTags(describeTagsOpts)
-		if err != nil {
-			return fmt.Errorf("Error retrieving LB tags: %s", err)
-		}
-
-		if containsAllTags(describeTagsResp.TagDescriptions[0].Tags, lbTags) {
-			matchedLb = append(matchedLb, element)
-		}
-	}
-
-	if len(matchedLb) != 1 {
-		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(matchedLb))
-	}
-
-	d.SetId(aws.StringValue(matchedLb[0].LoadBalancerArn))
-	return flattenAwsLbResource(d, meta, matchedLb[0])
-}
-
-func containsAllTags(existingTags []*elbv2.Tag, requiredTags []*elbv2.Tag) bool {
-	for _, requiredTag := range requiredTags {
-		if !containsTag(existingTags, requiredTag) {
-			return false
-		}
-	}
-	return true
-}
-
-func containsTag(existingTags []*elbv2.Tag, requiredTag *elbv2.Tag) bool {
-	for _, existingTag := range existingTags {
-		if reflect.DeepEqual(existingTag, requiredTag) {
-			return true
-		}
-	}
-	return false
 }

--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 func TestAccDataSourceAWSLB_basic(t *testing.T) {
-	lbName := fmt.Sprintf("testaccawslb-basic-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_lb.alb_test_with_arn"
 	dataSourceName2 := "data.aws_lb.alb_test_with_name"
-	resourceName := "aws_lb.alb_test"
+	dataSourceName3 := "data.aws_lb.alb_test_with_tags"
+	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
@@ -21,14 +22,15 @@ func TestAccDataSourceAWSLB_basic(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSLBConfigBasic(lbName),
+				Config: testAccDataSourceAWSLBConfigBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "internal", resourceName, "internal"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "subnets.#", resourceName, "subnets.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.#", resourceName, "security_groups.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "tags.TestName", resourceName, "tags.TestName"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Config", resourceName, "tags.Config"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "enable_deletion_protection", resourceName, "enable_deletion_protection"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "idle_timeout", resourceName, "idle_timeout"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", resourceName, "vpc_id"),
@@ -42,7 +44,8 @@ func TestAccDataSourceAWSLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName2, "subnets.#", resourceName, "subnets.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "security_groups.#", resourceName, "security_groups.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrPair(dataSourceName2, "tags.TestName", resourceName, "tags.TestName"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "tags.Config", resourceName, "tags.Config"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "enable_deletion_protection", resourceName, "enable_deletion_protection"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "idle_timeout", resourceName, "idle_timeout"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "vpc_id", resourceName, "vpc_id"),
@@ -51,6 +54,21 @@ func TestAccDataSourceAWSLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName2, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "ip_address_type", resourceName, "ip_address_type"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "subnet_mapping.#", resourceName, "subnet_mapping.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "internal", resourceName, "internal"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "subnets.#", resourceName, "subnets.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "security_groups.#", resourceName, "security_groups.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "tags.Config", resourceName, "tags.Config"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "enable_deletion_protection", resourceName, "enable_deletion_protection"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "idle_timeout", resourceName, "idle_timeout"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "vpc_id", resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "zone_id", resourceName, "zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "dns_name", resourceName, "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "ip_address_type", resourceName, "ip_address_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "subnet_mapping.#", resourceName, "subnet_mapping.#"),
 				),
 			},
 		},
@@ -58,9 +76,9 @@ func TestAccDataSourceAWSLB_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAWSLB_outpost(t *testing.T) {
-	lbName := fmt.Sprintf("testaccawslb-outpost-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_lb.alb_test_with_arn"
-	resourceName := "aws_lb.alb_test"
+	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
@@ -68,14 +86,15 @@ func TestAccDataSourceAWSLB_outpost(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSLBConfigOutpost(lbName),
+				Config: testAccDataSourceAWSLBConfigOutpost(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "internal", resourceName, "internal"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "subnets.#", resourceName, "subnets.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.#", resourceName, "security_groups.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "tags.TestName", resourceName, "tags.TestName"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Config", resourceName, "tags.Config"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "enable_deletion_protection", resourceName, "enable_deletion_protection"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "idle_timeout", resourceName, "idle_timeout"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", resourceName, "vpc_id"),
@@ -92,10 +111,11 @@ func TestAccDataSourceAWSLB_outpost(t *testing.T) {
 }
 
 func TestAccDataSourceAWSLB_BackwardsCompatibility(t *testing.T) {
-	lbName := fmt.Sprintf("testaccawsalb-basic-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName1 := "data.aws_alb.alb_test_with_arn"
 	dataSourceName2 := "data.aws_alb.alb_test_with_name"
-	resourceName := "aws_alb.alb_test"
+	dataSourceName3 := "data.aws_alb.alb_test_with_tags"
+	resourceName := "aws_alb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
@@ -103,14 +123,15 @@ func TestAccDataSourceAWSLB_BackwardsCompatibility(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSLBConfigBackardsCompatibility(lbName),
+				Config: testAccDataSourceAWSLBConfigBackwardsCompatibility(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName1, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName1, "internal", resourceName, "internal"),
 					resource.TestCheckResourceAttrPair(dataSourceName1, "subnets.#", resourceName, "subnets.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName1, "security_groups.#", resourceName, "security_groups.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName1, "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrPair(dataSourceName1, "tags.TestName", resourceName, "tags.TestName"),
+					resource.TestCheckResourceAttrPair(dataSourceName1, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(dataSourceName1, "tags.Config", resourceName, "tags.Config"),
 					resource.TestCheckResourceAttrPair(dataSourceName1, "enable_deletion_protection", resourceName, "enable_deletion_protection"),
 					resource.TestCheckResourceAttrPair(dataSourceName1, "idle_timeout", resourceName, "idle_timeout"),
 					resource.TestCheckResourceAttrPair(dataSourceName1, "vpc_id", resourceName, "vpc_id"),
@@ -127,7 +148,8 @@ func TestAccDataSourceAWSLB_BackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName2, "subnets.#", resourceName, "subnets.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "security_groups.#", resourceName, "security_groups.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrPair(dataSourceName2, "tags.TestName", resourceName, "tags.TestName"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "tags.Config", resourceName, "tags.Config"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "enable_deletion_protection", resourceName, "enable_deletion_protection"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "idle_timeout", resourceName, "idle_timeout"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "vpc_id", resourceName, "vpc_id"),
@@ -136,28 +158,47 @@ func TestAccDataSourceAWSLB_BackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName2, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "ip_address_type", resourceName, "ip_address_type"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "subnet_mapping.#", resourceName, "subnet_mapping.#"),
-					resource.TestCheckResourceAttrPair(dataSourceName1, "drop_invalid_header_fields", resourceName, "drop_invalid_header_fields"),
-					resource.TestCheckResourceAttrPair(dataSourceName1, "enable_http2", resourceName, "enable_http2"),
-					resource.TestCheckResourceAttrPair(dataSourceName1, "access_logs.#", resourceName, "access_logs.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "drop_invalid_header_fields", resourceName, "drop_invalid_header_fields"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "enable_http2", resourceName, "enable_http2"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "access_logs.#", resourceName, "access_logs.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "internal", resourceName, "internal"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "subnets.#", resourceName, "subnets.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "security_groups.#", resourceName, "security_groups.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "tags.Config", resourceName, "tags.Config"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "enable_deletion_protection", resourceName, "enable_deletion_protection"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "idle_timeout", resourceName, "idle_timeout"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "vpc_id", resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "zone_id", resourceName, "zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "dns_name", resourceName, "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "ip_address_type", resourceName, "ip_address_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "subnet_mapping.#", resourceName, "subnet_mapping.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "drop_invalid_header_fields", resourceName, "drop_invalid_header_fields"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "enable_http2", resourceName, "enable_http2"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "access_logs.#", resourceName, "access_logs.#"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAWSLBConfigBasic(lbName string) string {
-	return fmt.Sprintf(`
-resource "aws_lb" "alb_test" {
-  name            = "%s"
+func testAccDataSourceAWSLBConfigBasic(rName string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+resource "aws_lb" "test" {
+  name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
 
   tags = {
-    TestName = "TestAccAWSALB_basic"
+    Name   = %[1]q
+    Config = "Basic"
   }
 }
 
@@ -166,39 +207,30 @@ variable "subnets" {
   type    = list(string)
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "alb_test" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-data-source-basic"
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-data-source-basic"
+    Name = %[1]q
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -215,21 +247,25 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    TestName = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 data "aws_lb" "alb_test_with_arn" {
-  arn = aws_lb.alb_test.arn
+  arn = aws_lb.test.arn
 }
 
 data "aws_lb" "alb_test_with_name" {
-  name = aws_lb.alb_test.name
-}
-`, lbName)
+  name = aws_lb.test.name
 }
 
-func testAccDataSourceAWSLBConfigOutpost(lbName string) string {
+data "aws_lb" "alb_test_with_tags" {
+  tags = aws_lb.test.tags
+}
+`, rName))
+}
+
+func testAccDataSourceAWSLBConfigOutpost(rName string) string {
 	return fmt.Sprintf(`
 data "aws_outposts_outposts" "test" {}
 
@@ -237,42 +273,44 @@ data "aws_outposts_outpost" "test" {
   id = tolist(data.aws_outposts_outposts.test.ids)[0]
 }
 
-resource "aws_lb" "alb_test" {
-  name            = "%s"
+resource "aws_lb" "test" {
+  name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test.id]
+  security_groups = [aws_security_group.test.id]
+  subnets         = [aws_subnet.test.id]
 
   idle_timeout               = 30
   enable_deletion_protection = false
 
   tags = {
-    TestName = "TestAccAWSALB_outpost"
+    Name   = %[1]q
+    Config = "Outposts"
   }
 }
 
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-data-source-outpost"
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "alb_test" {
-  vpc_id            = aws_vpc.alb_test.id
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.0.0/24"
   availability_zone = data.aws_outposts_outpost.test.availability_zone
   outpost_arn       = data.aws_outposts_outpost.test.arn
 
   tags = {
-    Name = "tf-acc-lb-data-source-outpost"
+    Name = %[1]q
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -289,62 +327,62 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    TestName = "TestAccAWSALB_outpost"
+    Name = %[1]q
   }
 }
 
 data "aws_lb" "alb_test_with_arn" {
-  arn = aws_lb.alb_test.arn
+  arn = aws_lb.test.arn
 }
-`, lbName)
+`, rName)
 }
 
-func testAccDataSourceAWSLBConfigBackardsCompatibility(albName string) string {
-	return fmt.Sprintf(`
-resource "aws_alb" "alb_test" {
-  name            = "%s"
+func testAccDataSourceAWSLBConfigBackwardsCompatibility(rName string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+resource "aws_alb" "test" {
+  name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
 
   tags = {
-    TestName = "TestAccAWSALB_basic"
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
+    Name   = %[1]q
+    Config = "BackwardsCompatibility"
   }
 }
 
-resource "aws_vpc" "alb_test" {
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = list(string)
+}
+
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-data-source-bc"
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "alb_test" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-data-source-bc"
+    Name = %[1]q
   }
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -361,16 +399,20 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    TestName = "TestAccAWSALB_basic"
+    Name = %[1]q
   }
 }
 
 data "aws_alb" "alb_test_with_arn" {
-  arn = aws_alb.alb_test.arn
+  arn = aws_alb.test.arn
 }
 
 data "aws_alb" "alb_test_with_name" {
-  name = aws_alb.alb_test.name
+  name = aws_alb.test.name
 }
-`, albName)
+
+data "aws_alb" "alb_test_with_tags" {
+  tags = aws_alb.test.tags
+}
+`, rName))
 }

--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -251,7 +251,6 @@ resource "aws_lb" "alb_test" {
   }
 }
 
-resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -313,14 +312,6 @@ resource "aws_alb" "alb_test" {
 
   tags = {
     TestName = "TestAccAWSALB_basic"
-  }
-}
-
-variable "subnets" {
-  default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = list(string)
-}
-
 data "aws_availability_zones" "available" {
   state = "available"
 

--- a/website/docs/d/lb.html.markdown
+++ b/website/docs/d/lb.html.markdown
@@ -41,8 +41,9 @@ The following arguments are supported:
 
 * `arn` - (Optional) The full ARN of the load balancer.
 * `name` - (Optional) The unique name of the load balancer.
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match a pair on the desired load balancer.
 
-~> **NOTE**: When both `arn` and `name` are specified, `arn` takes precedence.
+~> **NOTE**: When both `arn` and `name` are specified, `arn` takes precedence. `tags` has lowest precedence.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Closes #12265.

Changes proposed in this pull request:

* Add tags argument into aws lb data source (some tools, like kubernetes, creates cloud resources with random names hence you are unable to find them by current possibilities of this data source. Finding load balancers by specifying tags will solve this issue)

Output from acceptance testing:

```
$make testacc TESTARGS='-run="TestAccDataSourceAWSLB_basic|TestAccDataSourceAWSLBBackwardsCompatibility"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run="TestAccDataSourceAWSLB_basic|TestAccDataSourceAWSLBBackwardsCompatibility" -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccDataSourceAWSLB_basic
=== PAUSE TestAccDataSourceAWSLB_basic
=== RUN   TestAccDataSourceAWSLBBackwardsCompatibility
=== PAUSE TestAccDataSourceAWSLBBackwardsCompatibility
=== CONT  TestAccDataSourceAWSLB_basic
=== CONT  TestAccDataSourceAWSLBBackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBBackwardsCompatibility (244.02s)
--- PASS: TestAccDataSourceAWSLB_basic (255.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	255.558s

...
```
