### PR TITLE
r/launch_template: ebs.delete_on_termination default to true

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -97,6 +97,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 										Optional:         true,
 										DiffSuppressFunc: suppressEquivalentTypeStringBoolean,
 										ValidateFunc:     validateTypeStringNullableBoolean,
+										Default:          "true",
 									},
 									"encrypted": {
 										// Use TypeString to allow an "unspecified" value,

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -171,6 +171,28 @@ func TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination(t *tes
 	})
 }
 
+func TestAccAWSLaunchTemplate_Ebs_DeleteOnTerminationDefault(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resourceName := "aws_launch_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_Ebs_DeleteOnTerminationDefault,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.delete_on_termination", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplate_EbsOptimized(t *testing.T) {
 	var template ec2.LaunchTemplate
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -727,6 +749,19 @@ resource "aws_autoscaling_group" "test" {
 }
 `, rName, deleteOnTermination, rName)
 }
+
+const testAccAWSLaunchTemplateConfig_Ebs_DeleteOnTerminationDefault = `
+resource "aws_launch_template" "test" {
+  name_prefix = "tf-acc-test"
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_size           = 15
+    }
+  }
+}
+`
 
 func testAccAWSLaunchTemplateConfig_EbsOptimized(rName, ebsOptimized string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6434

Changes proposed in this pull request:

* set `block_device_mappings.ebs.delete_on_termination` default to true

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
=== PAUSE TestAccAWSLaunchTemplate_importBasic
=== RUN   TestAccAWSLaunchTemplate_importData
=== PAUSE TestAccAWSLaunchTemplate_importData
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== RUN   TestAccAWSLaunchTemplate_disappears
=== PAUSE TestAccAWSLaunchTemplate_disappears
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_Ebs_DeleteOnTerminationDefault
=== PAUSE TestAccAWSLaunchTemplate_Ebs_DeleteOnTerminationDefault
=== RUN   TestAccAWSLaunchTemplate_EbsOptimized
=== PAUSE TestAccAWSLaunchTemplate_EbsOptimized
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== RUN   TestAccAWSLaunchTemplate_update
=== PAUSE TestAccAWSLaunchTemplate_update
=== RUN   TestAccAWSLaunchTemplate_tags
=== PAUSE TestAccAWSLaunchTemplate_tags
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_preference
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_preference
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_target
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_target
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t2
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t3
=== RUN   TestAccAWSLaunchTemplate_networkInterface
=== PAUSE TestAccAWSLaunchTemplate_networkInterface
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== RUN   TestAccAWSLaunchTemplate_instanceMarketOptions
=== PAUSE TestAccAWSLaunchTemplate_instanceMarketOptions
=== CONT  TestAccAWSLaunchTemplate_importBasic
=== CONT  TestAccAWSLaunchTemplate_tags
=== CONT  TestAccAWSLaunchTemplate_importData
=== CONT  TestAccAWSLaunchTemplate_disappears
=== CONT  TestAccAWSLaunchTemplate_instanceMarketOptions
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== CONT  TestAccAWSLaunchTemplate_networkInterface
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t2
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_preference
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_target
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== CONT  TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_EbsOptimized
=== CONT  TestAccAWSLaunchTemplate_update
=== CONT  TestAccAWSLaunchTemplate_Ebs_DeleteOnTerminationDefault
=== CONT  TestAccAWSLaunchTemplate_basic
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t3
--- PASS: TestAccAWSLaunchTemplate_disappears (9.69s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (11.85s)
--- PASS: TestAccAWSLaunchTemplate_Ebs_DeleteOnTerminationDefault (11.97s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (11.98s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (12.01s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (12.06s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (12.06s)
--- PASS: TestAccAWSLaunchTemplate_data (12.28s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (12.29s)
--- PASS: TestAccAWSLaunchTemplate_basic (12.53s)
--- PASS: TestAccAWSLaunchTemplate_importData (13.22s)
--- PASS: TestAccAWSLaunchTemplate_importBasic (13.58s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (17.76s)
--- PASS: TestAccAWSLaunchTemplate_tags (21.54s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (30.54s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (45.72s)
--- PASS: TestAccAWSLaunchTemplate_update (46.31s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (47.41s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (48.62s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (48.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.860s
```
