### PR TITLE
Closes #6399: Adds an aws_iam_assume_role_policy resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -555,6 +555,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_access_key":                                      resourceAwsIamAccessKey(),
 			"aws_iam_account_alias":                                   resourceAwsIamAccountAlias(),
 			"aws_iam_account_password_policy":                         resourceAwsIamAccountPasswordPolicy(),
+			"aws_iam_assume_role_policy":                              resourceAwsIamAssumeRolePolicy(),
 			"aws_iam_group_policy":                                    resourceAwsIamGroupPolicy(),
 			"aws_iam_group":                                           resourceAwsIamGroup(),
 			"aws_iam_group_membership":                                resourceAwsIamGroupMembership(),

--- a/aws/resource_aws_iam_assume_role_policy.go
+++ b/aws/resource_aws_iam_assume_role_policy.go
@@ -39,7 +39,7 @@ func resourceAwsIamAssumeRolePolicyCreate(d *schema.ResourceData, meta interface
 
 	assumeRolePolicyInput := &iam.UpdateAssumeRolePolicyInput{
 		RoleName:       aws.String(d.Get("role_name").(string)),
-		PolicyDocument: aws.String(d.Get("assume_role_policy").(string)),
+		PolicyDocument: aws.String(d.Get("policy").(string)),
 	}
 	_, err := iamconn.UpdateAssumeRolePolicy(assumeRolePolicyInput)
 	if err != nil {
@@ -73,7 +73,7 @@ func resourceAwsIamAssumeRolePolicyRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	if err := d.Set("assume_role_policy", assumeRolePolicy); err != nil {
+	if err := d.Set("policy", assumeRolePolicy); err != nil {
 		return err
 	}
 	return nil
@@ -82,10 +82,10 @@ func resourceAwsIamAssumeRolePolicyRead(d *schema.ResourceData, meta interface{}
 func resourceAwsIamAssumeRolePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
-	if d.HasChange("assume_role_policy") {
+	if d.HasChange("policy") {
 		assumeRolePolicyInput := &iam.UpdateAssumeRolePolicyInput{
 			RoleName:       aws.String(d.Get("role_name").(string)),
-			PolicyDocument: aws.String(d.Get("assume_role_policy").(string)),
+			PolicyDocument: aws.String(d.Get("policy").(string)),
 		}
 		_, err := iamconn.UpdateAssumeRolePolicy(assumeRolePolicyInput)
 		if err != nil {

--- a/aws/resource_aws_iam_assume_role_policy.go
+++ b/aws/resource_aws_iam_assume_role_policy.go
@@ -1,0 +1,114 @@
+package aws
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsIamAssumeRolePolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsIamAssumeRolePolicyCreate,
+		Read:   resourceAwsIamAssumeRolePolicyRead,
+		Update: resourceAwsIamAssumeRolePolicyUpdate,
+		Delete: resourceAwsIamAssumeRolePolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"role_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"assume_role_policy": {
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+				ValidateFunc:     validateJsonString,
+			},
+		},
+	}
+}
+
+func resourceAwsIamAssumeRolePolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	assumeRolePolicyInput := &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String(d.Get("role_name").(string)),
+		PolicyDocument: aws.String(d.Get("assume_role_policy").(string)),
+	}
+	_, err := iamconn.UpdateAssumeRolePolicy(assumeRolePolicyInput)
+	if err != nil {
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error Updating IAM Role (%s) Assume Role Policy: %s", d.Id(), err)
+	}
+
+	d.SetId(d.Get("role_name").(string))
+
+	return resourceAwsIamAssumeRolePolicyRead(d, meta)
+}
+
+func resourceAwsIamAssumeRolePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	request := &iam.GetRoleInput{
+		RoleName: aws.String(d.Id()),
+	}
+
+	getResp, err := iamconn.GetRole(request)
+	if err != nil {
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading IAM Role %s: %s", d.Id(), err)
+	}
+
+	role := getResp.Role
+
+	if err := d.Set("role_name", role.RoleName); err != nil {
+		return err
+	}
+
+	assumeRolePolicy, err := url.QueryUnescape(*role.AssumeRolePolicyDocument)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("assume_role_policy", assumeRolePolicy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceAwsIamAssumeRolePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	if d.HasChange("assume_role_policy") {
+		assumeRolePolicyInput := &iam.UpdateAssumeRolePolicyInput{
+			RoleName:       aws.String(d.Get("role_name").(string)),
+			PolicyDocument: aws.String(d.Get("assume_role_policy").(string)),
+		}
+		_, err := iamconn.UpdateAssumeRolePolicy(assumeRolePolicyInput)
+		if err != nil {
+			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
+				d.SetId("")
+				return nil
+			}
+			return fmt.Errorf("Error Updating IAM Role (%s) Assume Role Policy: %s", d.Id(), err)
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsIamAssumeRolePolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	// No need to do anything, assume role policy will be deleted when the role is deleted
+	return nil
+}

--- a/aws/resource_aws_iam_assume_role_policy_test.go
+++ b/aws/resource_aws_iam_assume_role_policy_test.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSIamAssumeRolePolicy_basic(t *testing.T) {
+	rName := acctest.RandString(10)
+	oldService := "ec2.amazonaws.com"
+	newService := "s3.amazonaws.com"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIamAssumeRolePolicy_roleConfig(rName, oldService),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAssumeRolePolicyServiceMatches(rName, oldService),
+				),
+			},
+			{
+				Config: testAccAWSIamAssumeRolePolicyConfig(rName, newService),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAssumeRolePolicyServiceMatches(rName, newService),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSIamAssumeRolePolicy_roleConfig(rName string, service string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "%s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "%s"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+`, rName, service)
+}
+
+func testAccAWSIamAssumeRolePolicyConfig(rName string, oldService string, newService string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "%s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "%s"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_assume_role_policy" "policy" {
+  role_name = "%s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "%s"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+`, rName, oldService, newService)
+}
+
+func testAccCheckAWSAssumeRolePolicyServiceMatches(rName string, service string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", rName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Role name is set")
+		}
+
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+		resp, err := iamconn.GetRole(&iam.GetRoleInput{
+			RoleName: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		actualAssumeRolePolicy := *resp.Role.AssumeRolePolicyDocument
+		expectedAssumeRolePolicy := service
+
+		if actualAssumeRolePolicy != expectedAssumeRolePolicy {
+			return fmt.Errorf("AssumeRolePolicy: '%q', expected '%q'.", actualAssumeRolePolicy, expectedAssumeRolePolicy)
+		}
+
+		return nil
+	}
+}

--- a/website/docs/r/iam_assume_role_policy.html.markdown
+++ b/website/docs/r/iam_assume_role_policy.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_assume_role_policy"
+description: |-
+  Configures the assume role policy for an IAM role.
+---
+
+# Resource: aws_iam_assume_role_policy
+
+Configures the assume role policy for an IAM role.  This is useful in cases where a terraform user has restricted access to AWS accounts that prevent them from creating IAM roles.
+
+## Example Usage
+
+```hcl
+resource "aws_iam_assume_role_policy" "test_policy" {
+  role = "${aws_iam_role.test_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy` - (Required) The policy document. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](/docs/providers/aws/guides/iam-policy-documents.html)
+* `role` - (Required) The IAM role to attach to the policy.
+
+## Attributes Reference
+
+* `id` - The name of the role associated with the policy.
+* `policy` - The policy document attached to the role.
+* `role` - The name of the role associated with the policy.

--- a/website/docs/r/iam_assume_role_policy.html.markdown
+++ b/website/docs/r/iam_assume_role_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "IAM"
 layout: "aws"
 page_title: "AWS: aws_iam_assume_role_policy"
 description: |-


### PR DESCRIPTION
This adds a resource that can be used to update the assume role
policy for an IAM role created outside of terraform, without the
need to import that role into terraform state manually.

This is useful in cases where a team using terraform is allowed
to manage permissions for IAM roles, but does not have access to
create or delete IAM roles.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6399

Changes proposed in this pull request:

* Adds a new resource to directly manage the assume role policy for IAM roles in cases where IAM roles cannot be managed themselves

TODO:
- [x] Create resource for IAM assume role policy
- [x] Write tests
- [x] Create website documentation 

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSIamAssumeRolePolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSIamAssumeRolePolicy_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIamAssumeRolePolicy_basic
=== PAUSE TestAccAWSIamAssumeRolePolicy_basic
=== CONT  TestAccAWSIamAssumeRolePolicy_basic
--- PASS: TestAccAWSIamAssumeRolePolicy_basic (43.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.296s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.936s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.451s [no tests to run]
```
