### PR TITLE
WIP: Dynamodb gsi new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -445,6 +445,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dx_public_virtual_interface":                         resourceAwsDxPublicVirtualInterface(),
 			"aws_dx_transit_virtual_interface":                        resourceAwsDxTransitVirtualInterface(),
 			"aws_dynamodb_table":                                      resourceAwsDynamoDbTable(),
+			"aws_dynamodb_table_gsi":                                  resourceAwsDynamoDbTableGsi(),
 			"aws_dynamodb_table_item":                                 resourceAwsDynamoDbTableItem(),
 			"aws_dynamodb_global_table":                               resourceAwsDynamoDbGlobalTable(),
 			"aws_ebs_default_kms_key":                                 resourceAwsEbsDefaultKmsKey(),

--- a/aws/resource_aws_dynamodb_table_gsi.go
+++ b/aws/resource_aws_dynamodb_table_gsi.go
@@ -1,0 +1,345 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsDynamoDbTableGsi() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDynamoDbTableGsiCreate,
+		Read:   resourceAwsDynamoDbTableGsiRead,
+		Update: resourceAwsDynamoDbTableGsiUpdate,
+		Delete: resourceAwsDynamoDbTableGsiDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		// ???
+		// CustomizeDiff: customdiff.Sequence(
+		// 	func(diff *schema.ResourceDiff, v interface{}) error {
+		// 		return validateDynamoDbTableAttributes(diff)
+		// 	},
+		// ),
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"table_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"hash_key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"range_key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"attribute": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								dynamodb.ScalarAttributeTypeB,
+								dynamodb.ScalarAttributeTypeN,
+								dynamodb.ScalarAttributeTypeS,
+							}, false),
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+					return hashcode.String(buf.String())
+				},
+			},
+			"write_capacity": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"read_capacity": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"projection_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"non_key_attributes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceAwsDynamoDbTableGsiCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dynamodbconn
+
+	tableName := d.Get("table_name").(string)
+	keySchemaMap := map[string]interface{}{
+		"hash_key": d.Get("hash_key").(string),
+	}
+	if v, ok := d.GetOk("range_key"); ok {
+		keySchemaMap["range_key"] = v.(string)
+	}
+
+	log.Printf("[DEBUG] Creating DynamoDB table index with key schema: %#v", keySchemaMap)
+	req := &dynamodb.UpdateTableInput{
+		TableName: aws.String(tableName),
+	}
+
+	// TODO: replace with keySchema
+	if v, ok := d.GetOk("attribute"); ok {
+		aSet := v.(*schema.Set)
+		req.AttributeDefinitions = expandDynamoDbAttributes(aSet.List())
+	}
+
+	projection := &dynamodb.Projection{
+		ProjectionType: aws.String(d.Get("projection_type").(string)),
+	}
+
+	if v, ok := d.GetOk("non_key_attributes"); ok && len(v.([]interface{})) > 0 {
+		projection.NonKeyAttributes = expandStringList(v.([]interface{}))
+	}
+
+	createOp := &dynamodb.GlobalSecondaryIndexUpdate{
+		Create: &dynamodb.CreateGlobalSecondaryIndexAction{
+			IndexName: aws.String(d.Id()),
+			KeySchema: expandDynamoDbKeySchema(keySchemaMap),
+			ProvisionedThroughput: expandDynamoDbProvisionedThroughput(map[string]interface{}{
+				"read_capacity":  d.Get("read_capacity"),
+				"write_capacity": d.Get("write_capacity"),
+			}),
+			Projection: projection,
+		},
+	}
+	req.GlobalSecondaryIndexUpdates = []*dynamodb.GlobalSecondaryIndexUpdate{createOp}
+
+	var output *dynamodb.UpdateTableOutput
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		output, err = conn.UpdateTable(req)
+		if err != nil {
+			if isAWSErr(err, "ThrottlingException", "") {
+				return resource.RetryableError(err)
+			}
+			// TODO: double check error codes for GSI creation
+			if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "can be created, updated, or deleted simultaneously") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "indexed tables that can be created simultaneously") {
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// TODO: what ouputs do we get from GSI creation?
+	// d.SetId(*output.TableDescription.TableName)
+
+	if err := waitForDynamoDbGSIToBeActive(d.Get("table_name").(string), d.Id(), conn); err != nil {
+		return err
+	}
+
+	// ???
+	return resourceAwsDynamoDbTableGsiUpdate(d, meta)
+}
+
+func resourceAwsDynamoDbTableGsiUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dynamodbconn
+
+	req := &dynamodb.UpdateTableInput{
+		TableName: aws.String(d.Get("table_name").(string)),
+		GlobalSecondaryIndexUpdates: []*dynamodb.GlobalSecondaryIndexUpdate{
+			{
+				Update: &dynamodb.UpdateGlobalSecondaryIndexAction{
+					IndexName: aws.String(d.Id()),
+					ProvisionedThroughput: expandDynamoDbProvisionedThroughput(map[string]interface{}{
+						"read_capacity":  d.Get("read_capacity"),
+						"write_capacity": d.Get("write_capacity"),
+					}),
+				},
+			},
+		},
+	}
+
+	if v, ok := d.GetOk("attribute"); ok {
+		aSet := v.(*schema.Set)
+		req.AttributeDefinitions = expandDynamoDbAttributes(aSet.List())
+	}
+
+	log.Printf("[DEBUG] Updating DynamoDB table GSI: %s", req)
+	var output *dynamodb.UpdateTableOutput
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		output, err = conn.UpdateTable(req)
+		if err != nil {
+			if isAWSErr(err, "ThrottlingException", "") {
+				return resource.RetryableError(err)
+			}
+			// TODO: double check error codes for GSI creation
+			if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "can be created, updated, or deleted simultaneously") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "indexed tables that can be created simultaneously") {
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := waitForDynamoDbGSIToBeActive(d.Get("table_name").(string), d.Id(), conn); err != nil {
+		return err
+	}
+
+	return resourceAwsDynamoDbTableGsiRead(d, meta)
+}
+
+func resourceAwsDynamoDbTableGsiRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dynamodbconn
+	tableName := d.Get("table_name").(string)
+
+	result, err := conn.DescribeTable(&dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	err = flattenAwsDynamoDbTableGsiResource(d, result.Table)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsDynamoDbTableGsiDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dynamodbconn
+
+	log.Printf("[DEBUG] DynamoDB delete index: %s", d.Id())
+
+	req := &dynamodb.UpdateTableInput{
+		TableName: aws.String(d.Get("table_name").(string)),
+		GlobalSecondaryIndexUpdates: []*dynamodb.GlobalSecondaryIndexUpdate{
+			{
+				Update: &dynamodb.UpdateGlobalSecondaryIndexAction{
+					IndexName: aws.String(d.Id()),
+				},
+			},
+		},
+	}
+
+	if v, ok := d.GetOk("attribute"); ok {
+		aSet := v.(*schema.Set)
+		req.AttributeDefinitions = expandDynamoDbAttributes(aSet.List())
+	}
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.UpdateTable(req)
+		if err != nil {
+			// Subscriber limit exceeded: Only 10 tables can be created, updated, or deleted simultaneously
+			if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "simultaneously") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, dynamodb.ErrCodeResourceInUseException, "") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, dynamodb.ErrCodeResourceNotFoundException, "Requested resource not found: ") {
+				return resource.NonRetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	err := waitForDynamoDbGSIToBeActive(d.Get("table_name").(string), d.Id(), conn)
+
+	return err
+}
+
+// Helpers
+
+func flattenAwsDynamoDbTableGsiResource(d *schema.ResourceData, table *dynamodb.TableDescription) error {
+	attributes := []interface{}{}
+	for _, attrdef := range table.AttributeDefinitions {
+		attribute := map[string]string{
+			"name": *attrdef.AttributeName,
+			"type": *attrdef.AttributeType,
+		}
+		attributes = append(attributes, attribute)
+	}
+
+	d.Set("attribute", attributes)
+	d.Set("table_name", table.TableName)
+
+	for _, gsiObject := range table.GlobalSecondaryIndexes {
+		if *gsiObject.IndexName == d.Id() {
+			d.Set("write_capacity", gsiObject.ProvisionedThroughput.WriteCapacityUnits)
+			d.Set("read_capacity", gsiObject.ProvisionedThroughput.ReadCapacityUnits)
+			d.Set("projection_type", gsiObject.Projection.ProjectionType)
+
+			for _, attribute := range gsiObject.KeySchema {
+				if *attribute.KeyType == dynamodb.KeyTypeHash {
+					d.Set("hash_key", attribute.AttributeName)
+				}
+
+				if *attribute.KeyType == dynamodb.KeyTypeRange {
+					d.Set("range_key", attribute.AttributeName)
+				}
+			}
+
+			nonKeyAttrs := make([]string, 0, len(gsiObject.Projection.NonKeyAttributes))
+			for _, nonKeyAttr := range gsiObject.Projection.NonKeyAttributes {
+				nonKeyAttrs = append(nonKeyAttrs, *nonKeyAttr)
+			}
+			d.Set("non_key_attributes", nonKeyAttrs)
+
+			break
+		}
+	}
+
+	return nil
+}

--- a/aws/resource_aws_dynamodb_table_gsi_test.go
+++ b/aws/resource_aws_dynamodb_table_gsi_test.go
@@ -1,0 +1,336 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDynamoDbTableGsi_basic(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+	tableName := acctest.RandomWithPrefix("TerraformTestTable")
+	gsiName := acctest.RandomWithPrefix("TerraformTestGsi")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasic(tableName, gsiName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.table", &conf),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.table", "name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "name", gsiName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "read_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "write_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "hash_key", "TestGsiHashKey"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "projection_type", "KEYS_ONLY"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDynamoDbTableGsi_updateCapacity(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+	tableName := acctest.RandomWithPrefix("TerraformTestTable")
+	gsiName := acctest.RandomWithPrefix("TerraformTestGsi")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasic(tableName, gsiName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.table", &conf),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "name", gsiName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "read_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "write_capacity", "1"),
+				),
+			},
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasicMoreCapacity(tableName, gsiName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.table", &conf),
+
+					// TODO: check gsi was not re-created; not sure how to do this atm
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "name", gsiName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "read_capacity", "5"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "write_capacity", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDynamoDbTableGsi_updateOtherAttributes(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+	tableName := acctest.RandomWithPrefix("TerraformTestTable")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbGsiInitialOtherAttributes(tableName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.table", &conf),
+
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "name", "gsi1-index"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "hash_key", "att1"),
+					resource.TestCheckNoResourceAttr("aws_dynamodb_table_gsi.gsi", "range_key"),
+					resource.TestCheckNoResourceAttr("aws_dynamodb_table_gsi.gsi", "non_key_attributes"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "projection_type", "ALL"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "read_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "write_capacity", "1"),
+
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "name", "gsi2-index"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "hash_key", "att2"),
+					resource.TestCheckNoResourceAttr("aws_dynamodb_table_gsi.gsi2", "range_key"),
+					resource.TestCheckNoResourceAttr("aws_dynamodb_table_gsi.gsi2", "non_key_attributes"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "projection_type", "ALL"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "read_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "write_capacity", "1"),
+				),
+			},
+			{
+				Config: testAccAWSDynamoDbConfigGsiUpdatedOtherAttributes(tableName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.table", &conf),
+
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "name", "gsi-index"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "hash_key", "att1"),
+					resource.TestCheckNoResourceAttr("aws_dynamodb_table_gsi.gsi", "range_key"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "non_key_attributes.#", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "non_key_attributes.0", "RandomAttribute"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "projection_type", "INCLUDE"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "read_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "write_capacity", "1"),
+
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "name", "gsi2-index"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "hash_key", "att3"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "range_key", "att2"),
+					resource.TestCheckNoResourceAttr("aws_dynamodb_table_gsi.gsi2", "non_key_attributes"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "projection_type", "ALL"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "read_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi2", "write_capacity", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDynamoDbTableGsi_delete(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+	tableName := acctest.RandomWithPrefix("TerraformTestTable")
+	gsiName := acctest.RandomWithPrefix("TerraformTestGsi")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasic(tableName, gsiName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.table", &conf),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.table", "name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "name", gsiName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "read_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "write_capacity", "1"),
+				),
+			},
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasicDelete(tableName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.table", &conf),
+					func(*terraform.State) error {
+						if len(conf.Table.GlobalSecondaryIndexes) > 0 {
+							return fmt.Errorf("expected to find no global secondary indexes, instead found: %v", conf.Table.GlobalSecondaryIndexes)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSDynamoDbGsiConfigBasic(tableName, gsiName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "table" {
+  name = "%s"
+  read_capacity = 1
+  write_capacity = 1
+  hash_key = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_gsi" "gsi" {
+  table_name = "${aws_dynamodb_table.table.id}"
+  name = "%s"
+  hash_key = "TestGsiHashKey"
+  write_capacity = 1
+  read_capacity = 1
+  projection_type = "KEYS_ONLY"
+
+  attribute {
+    name = "TestGsiHashKey"
+    type = "S"
+  }
+}
+`, tableName, gsiName)
+}
+
+func testAccAWSDynamoDbGsiConfigBasicMoreCapacity(tableName, gsiName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "table" {
+  name = "%s"
+  read_capacity = 1
+  write_capacity = 1
+  hash_key = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_gsi" "gsi" {
+  table_name = "${aws_dynamodb_table.table.id}"
+  name = "%s"
+  hash_key = "TestGsiHashKey"
+  write_capacity = 5
+  read_capacity = 5
+  projection_type = "KEYS_ONLY"
+
+  attribute {
+    name = "TestGsiHashKey"
+    type = "S"
+  }
+}
+`, tableName, gsiName)
+}
+
+func testAccAWSDynamoDbGsiConfigBasicDelete(tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "table" {
+  name = "%s"
+  read_capacity = 1
+  write_capacity = 1
+  hash_key = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+`, tableName)
+}
+
+func testAccAWSDynamoDbGsiInitialOtherAttributes(tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "table" {
+  name           = "%s"
+  read_capacity  = "1"
+  write_capacity = "1"
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_gsi" "gsi" {
+  table_name = "${aws_dynamodb_table.table.id}"
+  name            = "gsi1-index"
+  hash_key        = "att1"
+  write_capacity  = "1"
+  read_capacity   = "1"
+  projection_type = "ALL"
+
+  attribute {
+    name = "att1"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_gsi" "gsi2" {
+  table_name = "${aws_dynamodb_table.table.id}"
+  name            = "gsi2-index"
+  hash_key        = "att2"
+  write_capacity  = "1"
+  read_capacity   = "1"
+  projection_type = "ALL"
+
+  attribute {
+    name = "att2"
+    type = "S"
+  }
+}
+`, tableName)
+}
+
+func testAccAWSDynamoDbGsiConfigUpdatedOtherAttributes(tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "table" {
+  name           = "%s"
+  read_capacity  = "1"
+  write_capacity = "1"
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_gsi" "gsi" {
+  table_name         = "${aws_dynamodb_table.table.id}"
+  name               = "gsi1-index"
+  hash_key           = "att1"
+  write_capacity     = "1"
+  read_capacity      = "1"
+  projection_type    = "INCLUDE"
+  non_key_attributes = ["RandomAttribute"]
+  
+  attribute {
+    name = "att1"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_gsi" "gsi2" {
+  table_name      = "${aws_dynamodb_table.table.id}"
+  name            = "gsi2-index"
+  hash_key        = "att3"
+  range_key       = "att2"
+  write_capacity  = "1"
+  read_capacity   = "1"
+  projection_type = "ALL"
+
+  attribute {
+    name = "att3"
+    type = "S"
+  }
+
+  attribute {
+    name = "att2"
+    type = "N"
+  }
+}
+`, tableName)
+}

--- a/aws/resource_aws_dynamodb_table_gsi_test.go
+++ b/aws/resource_aws_dynamodb_table_gsi_test.go
@@ -102,7 +102,7 @@ func TestAccAWSDynamoDbTableGsi_updateOtherAttributes(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSDynamoDbConfigGsiUpdatedOtherAttributes(tableName),
+				Config: testAccAWSDynamoDbGsiConfigUpdatedOtherAttributes(tableName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.table", &conf),
 

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -907,6 +907,10 @@
                                     <a href="/docs/providers/aws/r/dynamodb_table.html">aws_dynamodb_table</a>
                                 </li>
                                 <li>
+                        <li<%= sidebar_current("docs-aws-resource-dynamodb-table-gsi") %>>
+                            <a href="/docs/providers/aws/r/dynamodb_table_gsi.html">aws_dynamodb_table_gsi</a>
+                        </li>
+
                                     <a href="/docs/providers/aws/r/dynamodb_table_item.html">aws_dynamodb_table_item</a>
                                 </li>
                             </ul>

--- a/website/docs/r/dynamodb_table_gsi.html.markdown
+++ b/website/docs/r/dynamodb_table_gsi.html.markdown
@@ -1,0 +1,132 @@
+---
+layout: "aws"
+page_title: "AWS: dynamodb_table_gsi"
+sidebar_current: "docs-aws-resource-dynamodb-table-gsi"
+description: |-
+  Provides a DynamoDB Global Secondary Index resource
+---
+
+# aws_dynamodb_table_gsi
+
+Provides a DynamoDB Global Secondary Index resource
+
+~> **Note:** It is recommended to use `lifecycle` [`ignore_changes`](/docs/configuration/resources.html#ignore_changes) for `read_capacity` and/or `write_capacity` if there's [autoscaling policy](/docs/providers/aws/r/appautoscaling_policy.html) attached to the index.
+
+## Example Usage
+
+The following dynamodb table description models the table and GSI shown
+in the [AWS SDK example documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html)
+
+```hcl
+resource "aws_dynamodb_table" "basic-dynamodb-table" {
+  name           = "GameScores"
+  read_capacity  = 20
+  write_capacity = 20
+  hash_key       = "UserId"
+  range_key      = "GameTitle"
+
+  attribute {
+    name = "UserId"
+    type = "S"
+  }
+
+  attribute {
+    name = "GameTitle"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = false
+  }
+
+  tags {
+    Name        = "dynamodb-table-1"
+    Environment = "production"
+  }
+}
+
+resource "aws_dynamodb_table_gsi" "basic-dynamodb-table-gsi" {
+  name               = "GameTitleIndex"
+  hash_key           = "GameTitle"
+  range_key          = "TopScore"
+  write_capacity     = 10
+  read_capacity      = 10
+  projection_type    = "INCLUDE"
+  non_key_attributes = ["UserId"]
+
+  attribute {
+    name = "GameTitle"
+    type = "S"
+  }
+
+  attribute {
+    name = "TopScore"
+    type = "N"
+  }
+}
+```
+
+Notes: `attribute` can be lists
+
+```
+  attribute = [{
+    name = "UserId"
+    type = "S"
+  }, {
+    name = "GameTitle"
+    type = "S"
+  }, {
+    name = "TopScore"
+    type = "N"
+  }]
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the GSI, this needs to be unique
+  within the table definition.
+* `hash_key` - (Required, Forces new resource) The attribute to use as the hash (partition) key for the GSI. Must also be defined as an `attribute`, see below.
+* `range_key` - (Optional, Forces new resource) The attribute to use as the range (sort) key for the GSI. Must also be defined as an `attribute`, see below.
+* `write_capacity` - (Required) The number of write units for this GSI
+* `read_capacity` - (Required) The number of read units for this GSI
+* `attribute` - (Required) List of nested attribute definitions. Only required for `hash_key` and `range_key` attributes. Each attribute has two properties:
+  * `name` - (Required) The name of the attribute
+  * `type` - (Required) Attribute type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data
+* `projection_type` - (Required) One of `ALL`, `INCLUDE` or `KEYS_ONLY`
+   where `ALL` projects every attribute into the index, `KEYS_ONLY`
+    projects just the hash and range key into the index, and `INCLUDE`
+    projects only the keys specified in the _non_key_attributes_
+    parameter.
+* `non_key_attributes` - (Optional) Only required with `INCLUDE` as a
+  projection type; a list of attributes to project into the index. These
+  do not need to be defined as attributes on the table.
+
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 10 mins) Used when creating the GSI
+* `update` - (Defaults to 5 mins) Used when updating the GSI. Note that a GSI update only consists of provisioned capacity updates
+* `delete` - (Defaults to 10 mins) Used when deleting the GSI
+
+### A note about attributes
+
+Only define attributes on the table object that are going to be used as:
+
+* GSI hash key or range key
+
+The DynamoDB API expects attribute structure (name and type) to be
+passed along when creating or updating GSI/LSIs or creating the initial
+table. You should not add any attributes that belong to the table or
+other indexes. If you add attributes here that are not used in these
+scenarios it can cause an infinite loop in planning.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the index


### PR DESCRIPTION
Fixes #671 

Changes proposed in this pull request:

* Make DynamoDb GSIs as a new resource

I'm having trouble figuring out how to make this change backwards compatible, if it is indeed possible. Help or guidance in this area would greatly be appreciated. As you can see below the acceptance tests are not passing for this reason.

Another thing I would like feedback on is to change my current implementation of the GSI resource to define hash and range keys as attributes like so:

```hcl
resource "aws_dynamodb_table_gsi" "gsi" {
  table_name = "${aws_dynamodb_table.table.id}"
  name = "gsi"
  hash_key {
    name = "TestGsiHashKey"
    type = "S"
  }
  write_capacity = 1
  read_capacity = 1
  projection_type = "KEYS_ONLY"
}
```

Instead of using attribute definitions like in the dynamo table. I'll be working on making this work while I wait for feedback.

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSDynamoDbTableGsi_basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDynamoDbTableGsi_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDynamoDbTableGsi_basic
=== PAUSE TestAccAWSDynamoDbTableGsi_basic
=== CONT  TestAccAWSDynamoDbTableGsi_basic
--- FAIL: TestAccAWSDynamoDbTableGsi_basic (226.01s)
	testing.go:538: Step 0 error: After applying this step and refreshing, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_dynamodb_table.table
		  attribute.#:                                            "2" => "1"
		  attribute.2744211948.name:                              "TestGsiHashKey" => ""
		  attribute.2744211948.type:                              "S" => ""
		  attribute.2990477658.name:                              "TestTableHashKey" => "TestTableHashKey"
		  attribute.2990477658.type:                              "S" => "S"
		  global_secondary_index.#:                               "1" => "0"
		  global_secondary_index.2114864726.hash_key:             "TestGsiHashKey" => ""
		  global_secondary_index.2114864726.name:                 "TerraformTestGsi-8213957448984239991" => ""
		  global_secondary_index.2114864726.non_key_attributes.#: "0" => "0"
		  global_secondary_index.2114864726.projection_type:      "KEYS_ONLY" => ""
		  global_secondary_index.2114864726.range_key:            "" => ""
		  global_secondary_index.2114864726.read_capacity:        "1" => "0"
		  global_secondary_index.2114864726.write_capacity:       "1" => "0"
		
		STATE:
		
		aws_dynamodb_table.table:
		  ID = TerraformTestTable-8830008518106655967
		  provider = provider.aws
		  arn = arn:aws:dynamodb:us-west-2:630843564847:table/TerraformTestTable-8830008518106655967
		  attribute.# = 2
		  attribute.2744211948.name = TestGsiHashKey
		  attribute.2744211948.type = S
		  attribute.2990477658.name = TestTableHashKey
		  attribute.2990477658.type = S
		  global_secondary_index.# = 1
		  global_secondary_index.2114864726.hash_key = TestGsiHashKey
		  global_secondary_index.2114864726.name = TerraformTestGsi-8213957448984239991
		  global_secondary_index.2114864726.non_key_attributes.# = 0
		  global_secondary_index.2114864726.projection_type = KEYS_ONLY
		  global_secondary_index.2114864726.range_key = 
		  global_secondary_index.2114864726.read_capacity = 1
		  global_secondary_index.2114864726.write_capacity = 1
		  hash_key = TestTableHashKey
		  local_secondary_index.# = 0
		  name = TerraformTestTable-8830008518106655967
		  point_in_time_recovery.# = 1
		  point_in_time_recovery.0.enabled = false
		  read_capacity = 1
		  server_side_encryption.# = 0
		  stream_arn = 
		  stream_enabled = false
		  stream_label = 
		  stream_view_type = 
		  tags.% = 0
		  ttl.# = 0
		  write_capacity = 1
		aws_dynamodb_table_gsi.gsi:
		  ID = TerraformTestGsi-8213957448984239991
		  provider = provider.aws
		  attribute.# = 1
		  attribute.2744211948.name = TestGsiHashKey
		  attribute.2744211948.type = S
		  hash_key = TestGsiHashKey
		  name = TerraformTestGsi-8213957448984239991
		  non_key_attributes.# = 0
		  projection_type = KEYS_ONLY
		  read_capacity = 1
		  table_name = TerraformTestTable-8830008518106655967
		  write_capacity = 1
		
		  Dependencies:
		    aws_dynamodb_table.table
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	226.097s
...
```
