### PR TITLE
Introduce settings flag to stop execution if credentials were expired

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -382,7 +382,7 @@ func (c *Config) Client() (interface{}, error) {
 			{Name: "Terraform", Version: c.terraformVersion,
 				Extra: []string{"+https://www.terraform.io"}},
 		},
-		StopOnExpiredCreds:      c.StopOnExpiredCreds,
+		StopOnExpiredCreds: c.StopOnExpiredCreds,
 	}
 
 	sess, accountID, partition, err := awsbase.GetSessionWithAccountIDAndPartition(awsbaseConfig)

--- a/aws/config.go
+++ b/aws/config.go
@@ -151,13 +151,14 @@ import (
 )
 
 type Config struct {
-	AccessKey     string
-	SecretKey     string
-	CredsFilename string
-	Profile       string
-	Token         string
-	Region        string
-	MaxRetries    int
+	AccessKey          string
+	SecretKey          string
+	CredsFilename      string
+	Profile            string
+	Token              string
+	Region             string
+	MaxRetries         int
+	StopOnExpiredCreds bool
 
 	AssumeRoleARN         string
 	AssumeRoleExternalID  string
@@ -381,6 +382,7 @@ func (c *Config) Client() (interface{}, error) {
 			{Name: "Terraform", Version: c.terraformVersion,
 				Extra: []string{"+https://www.terraform.io"}},
 		},
+		StopOnExpiredCreds:      c.StopOnExpiredCreds,
 	}
 
 	sess, accountID, partition, err := awsbase.GetSessionWithAccountIDAndPartition(awsbaseConfig)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -72,6 +72,13 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["max_retries"],
 			},
 
+			"stop_on_expired_creds": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["stop_on_expired_creds"],
+			},
+
 			"allowed_account_ids": {
 				Type:          schema.TypeSet,
 				Elem:          &schema.Schema{Type: schema.TypeString},
@@ -922,6 +929,8 @@ func init() {
 		"max_retries": "The maximum number of times an AWS API request is\n" +
 			"being executed. If the API request still fails, an error is\n" +
 			"thrown.",
+
+		"stop_on_expired_creds": "Stop execution if expired credentials error happen.",
 
 		"endpoint": "Use this to override the default service endpoint URL",
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -190,6 +190,8 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   experiencing transient failures. The delay between the subsequent API
   calls increases exponentially.
 
+* `stop_on_expired_creds` - (Optional) Do not retry if expired credentials error happen. Default value: `false`.
+
 * `allowed_account_ids` - (Optional) List of allowed, white listed, AWS
   account IDs to prevent you from mistakenly using an incorrect one (and
   potentially end up destroying a live environment). Conflicts with


### PR DESCRIPTION
Closes #12023
Closes #9601
Closes #4502
Closes #2068
Closes #1351
Closes #1307

and more I think.

Changes proposed in this pull request:

* Introduce new settings parameter to stop retrying if AWS credentials are expired. To keep existing behavior (retry MaxRetries times) defaulted to `false`

Depends on https://github.com/hashicorp/aws-sdk-go-base/pull/23