### PR TITLE
r/aws_elasticache_cluster: Pin patch engine_version in the Redis example

### DIFF
--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -43,7 +43,7 @@ resource "aws_elasticache_cluster" "example" {
   node_type            = "cache.m4.large"
   num_cache_nodes      = 1
   parameter_group_name = "default.redis3.2"
-  engine_version       = "3.2"
+  engine_version       = "3.2.10"
   port                 = 6379
 }
 ```


### PR DESCRIPTION
Setting *an* engine version gets the example working, but if you don't
set the patch version, Terraform wants to rebuild the cluster the
next time you plan:

```
-/+ aws_elasticache_cluster.example (new resource required)
      id:                                              "cluster-example" => <computed> (forces new resource)
      apply_immediately:                               "" => <computed>
      availability_zone:                               "eu-west-1a" => <computed>
      az_mode:                                         "single-az" => <computed>
      cache_nodes.#:                                   "1" => <computed>
      cluster_address:                                 "" => <computed>
      cluster_id:                                      "cluster-example" => "cluster-example"
      configuration_endpoint:                          "" => <computed>
      engine:                                          "redis" => "redis"
      engine_version:                                  "3.2.10" => "3.2" (forces new resource)
      maintenance_window:                              "thu:00:00-thu:01:00" => <computed>
      node_type:                                       "cache.m4.large" => "cache.m4.large"
      num_cache_nodes:                                 "1" => "1"
      parameter_group_name:                            "default.redis3.2" => "default.redis3.2"
      port:                                            "6379" => "6379"
```

Note in particular this line:

```
      engine_version:                                  "3.2.10" => "3.2" (forces new resource)
```

Setting the patch version seems to mitigate this.

---

I should have caught this in #7033, but at that point I was only doing experimenting. I was changing other attributes, so a flapping Elasticache cluster was expected, and I didn't spot the effect of the version.