### PR TITLE
Ability to make the total time to retry getting password data configurable

### DIFF
--- a/internal/service/ec2/ec2_instance_data_source.go
+++ b/internal/service/ec2/ec2_instance_data_source.go
@@ -391,7 +391,7 @@ func dataSourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.Get("get_password_data").(bool) {
-		passwordData, err := getInstancePasswordData(aws.StringValue(instance.InstanceId), conn)
+		passwordData, err := getInstancePasswordData(d, aws.StringValue(instance.InstanceId), conn)
 		if err != nil {
 			return err
 		}

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -373,7 +373,7 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.Get("get_password_data").(bool) {
-		passwordData, err := getInstancePasswordData(*instance.InstanceId, conn)
+		passwordData, err := getInstancePasswordData(d, *instance.InstanceId, conn)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Changes proposed in this pull request:

* the total retry time to get password data was hard-coded to 15 minutes, however we have noticed that this is insufficient at times (eg. Windows instances with dynamic passwords); so allowing for the user to set a longer timeout is handy in those cases.

Thanks in advance for your feedback!

Kind regards,
David