### PR TITLE
Document - Fix the url for rate based rule in wafregional_rule_group

### DIFF
--- a/website/docs/r/wafregional_rule_group.html.markdown
+++ b/website/docs/r/wafregional_rule_group.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
   * `type` - (Required) e.g. `BLOCK`, `ALLOW`, or `COUNT`
 * `priority` - (Required) Specifies the order in which the rules are evaluated. Rules with a lower value are evaluated before rules with a higher value.
 * `rule_id` - (Required) The ID of a [rule](/docs/providers/aws/r/wafregional_rule.html)
-* `type` - (Optional) The rule type, either [`REGULAR`](/docs/providers/aws/r/wafregional_rule.html), [`RATE_BASED`]((/docs/providers/aws/r/wafregional_rate_based_rule.html), or `GROUP`. Defaults to `REGULAR`.
+* `type` - (Optional) The rule type, either [`REGULAR`](/docs/providers/aws/r/wafregional_rule.html), [`RATE_BASED`](/docs/providers/aws/r/wafregional_rate_based_rule.html), or `GROUP`. Defaults to `REGULAR`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changes proposed in this pull request:

*Fix at line 54 in file [/docs/providers/aws/r/wafregional_rule_group.html](/docs/providers/aws/r/wafregional_rule_group.html)

Page at : https://www.terraform.io/docs/providers/aws/r/wafregional_rule_group.html

