### PR TITLE
tests/resource/aws_elastic_transcoder_pipeline: Fix naming randomization

### DIFF
--- a/aws/resource_aws_elastic_transcoder_pipeline_test.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline_test.go
@@ -241,12 +241,12 @@ func awsElasticTranscoderPipelineConfigBasic(rName string) string {
 resource "aws_elastictranscoder_pipeline" "bar" {
   input_bucket  = "${aws_s3_bucket.test_bucket.bucket}"
   output_bucket = "${aws_s3_bucket.test_bucket.bucket}"
-  name          = %q
+  name          = %[1]q
   role          = "${aws_iam_role.test_role.arn}"
 }
 
 resource "aws_iam_role" "test_role" {
-  name = %q
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -266,10 +266,10 @@ EOF
 }
 
 resource "aws_s3_bucket" "test_bucket" {
-  bucket = %q
+  bucket = %[1]q
   acl    = "private"
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 const awsElasticTranscoderPipelineConfigKmsKey = `


### PR DESCRIPTION
Previous output from acceptance testing:

```
--- FAIL: TestAccAWSElasticTranscoderPipeline_basic (4.23s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating S3 bucket: BucketAlreadyExists: The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.
        	status code: 409, request id: 3FF4239717D7FBF9, host id: QwU0llqCuM0rMXnMbrr39rQ1fgGIKsxUIdXQCynr0YBmPTm6goIIbO5hYJtPYPg5fR2k8ozm7uM=

          on /opt/teamcity-agent/temp/buildTmp/tf-test014561766/main.tf line 32:
          (source code not available)

--- FAIL: TestAccAWSElasticTranscoderPipeline_import (4.39s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating S3 bucket: BucketAlreadyExists: The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.
        	status code: 409, request id: AA79620A3F3DCA0F, host id: Z/2loT0VC9ErXa1r3ZP23FdwQNUtLlzH0YMBgZ5PFxdsGK+9hmIf2zSB4V8YFIyfUNbU0oSJlZg=

          on /opt/teamcity-agent/temp/buildTmp/tf-test978398471/main.tf line 32:
          (source code not available)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticTranscoderPipeline_basic (25.69s)
```
