### PR TITLE
Add Media Connect Flow resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -638,6 +638,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_main_route_table_association":                        resourceAwsMainRouteTableAssociation(),
 			"aws_mq_broker":                                           resourceAwsMqBroker(),
 			"aws_mq_configuration":                                    resourceAwsMqConfiguration(),
+			"aws_media_connect_flow":                                  resourceAWSMediaConnectFlow(),
 			"aws_media_convert_queue":                                 resourceAwsMediaConvertQueue(),
 			"aws_media_package_channel":                               resourceAwsMediaPackageChannel(),
 			"aws_media_store_container":                               resourceAwsMediaStoreContainer(),

--- a/aws/resource_aws_media_connect_flow.go
+++ b/aws/resource_aws_media_connect_flow.go
@@ -1,0 +1,519 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediaconnect"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+const (
+	AWSMediaConnectFlowRetryTimeout       = 30 * time.Minute
+	AWSMediaConnectFlowDeleteRetryTimeout = 60 * time.Minute
+	AWSMediaConnectFlowRetryDelay         = 5 * time.Second
+	AWSMediaConnectFlowRetryMinTimeout    = 3 * time.Second
+)
+
+func resourceAWSMediaConnectFlow() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAWSMediaConnectFlowCreate,
+		Read:   resourceAWSMediaConnectFlowRead,
+		Update: resourceAWSMediaConnectFlowUpdate,
+		Delete: resourceAWSMediaConnectFlowDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(AWSMediaConnectFlowRetryTimeout),
+			Update: schema.DefaultTimeout(AWSMediaConnectFlowRetryTimeout),
+			Delete: schema.DefaultTimeout(AWSMediaConnectFlowDeleteRetryTimeout),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateMediaConnectFlowName,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"egress_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validateMediaConnectFlowSourceName,
+							ConflictsWith: []string{
+								"source.entitlement_arn",
+							},
+						},
+						"decryption": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"algorithm": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"aes128",
+											"aes192",
+											"aes256",
+										}, false),
+									},
+									"key_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"role_arn": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"secret_arn": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Managed by Terraform",
+							ConflictsWith: []string{
+								"source.entitlement_arn",
+							},
+						},
+						"entitlement_arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ConflictsWith: []string{
+								"source.name",
+								"source.description",
+								"source.ingest_ip",
+								"source.ingest_port",
+								"source.max_bitrate",
+								"source.max_latency",
+								"source.protocol",
+								"source.stream_id",
+								"source.whitelist_cidr",
+							},
+						},
+						"ingest_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ingest_port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ConflictsWith: []string{
+								"source.entitlement_arn",
+							},
+						},
+						"max_bitrate": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntBetween(1, 200000000),
+							ConflictsWith: []string{
+								"source.entitlement_arn",
+							},
+						},
+						"max_latency": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ConflictsWith: []string{
+								"source.entitlement_arn",
+							},
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"zixi-push",
+								"rtp-fec",
+								"rtp",
+							}, false),
+							ConflictsWith: []string{
+								"source.entitlement_arn",
+							},
+						},
+						"smoothing_latency": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"stream_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ConflictsWith: []string{
+								"source.entitlement_arn",
+							},
+						},
+						"whitelist_cidr": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ConflictsWith: []string{
+								"source.entitlement_arn",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAWSMediaConnectFlowCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediaconnectconn
+
+	createOpts := &mediaconnect.CreateFlowInput{
+		Name: aws.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("availability_zone"); ok {
+		createOpts.AvailabilityZone = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("source"); ok {
+		createOpts.Source = expandAWSMediaConnectFlowSource(v.([]interface{}))
+	}
+
+	log.Printf("[DEBUG] Media Connect Flow create configuration: %#v", createOpts)
+	resp, err := conn.CreateFlow(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating elemental media connect flow: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.Flow.FlowArn))
+
+	return resourceAWSMediaConnectFlowRead(d, meta)
+}
+
+func resourceAWSMediaConnectFlowRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediaconnectconn
+
+	descOpts := &mediaconnect.DescribeFlowInput{
+		FlowArn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Media Connect Flow describe configuration: %#v", descOpts)
+	resp, err := conn.DescribeFlow(descOpts)
+	if err != nil {
+		if isAWSErr(err, mediaconnect.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] Media Connect Flow %s not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error describing Media Connect Flow %s: %s", d.Id(), err)
+	}
+
+	d.Set("arn", resp.Flow.FlowArn)
+	d.Set("name", resp.Flow.Name)
+	d.Set("description", resp.Flow.Description)
+	d.Set("availability_zone", resp.Flow.AvailabilityZone)
+	d.Set("egress_ip", aws.StringValue(resp.Flow.EgressIp))
+	d.Set("source", flattenAWSMediaConnectFlowSource(resp.Flow.Source))
+
+	return nil
+}
+
+func resourceAWSMediaConnectFlowUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediaconnectconn
+
+	if d.HasChange("source") {
+		err := updateAWSMediaConnectFlowSource(conn, d.Id(), d.Get("source").([]interface{}))
+		if err != nil {
+			if isAWSErr(err, mediaconnect.ErrCodeNotFoundException, "") {
+				log.Printf("[WARN] Media Connect Flow %s not found, removing from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return fmt.Errorf("Error updating Media Connect Flow(%s) Source: %s", d.Id(), err)
+		}
+	}
+
+	stateConf := resource.StateChangeConf{
+		Pending: []string{
+			"UPDATING",
+			"STARTING",
+			"STOPPING",
+		},
+		Target: []string{
+			"STANDBY",
+			"ACTIVE",
+		},
+		Timeout: d.Timeout(schema.TimeoutUpdate),
+		Refresh: refreshMediaConnectFlowStatus(conn, d.Id()),
+	}
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for updating Media Connect Flow(%s) Source: %s", d.Id(), err)
+	}
+
+	return resourceAWSMediaConnectFlowRead(d, meta)
+}
+
+func resourceAWSMediaConnectFlowDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediaconnectconn
+
+	deleOpts := &mediaconnect.DeleteFlowInput{
+		FlowArn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Media Connect Flow delete configuration: %#v", deleOpts)
+	if _, err := conn.DeleteFlow(deleOpts); err != nil {
+		if isAWSErr(err, mediaconnect.ErrCodeNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting Media Connect Flow %s: %s", d.Id(), err)
+	}
+
+	return waitForDeleteMediaConnectFlow(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+}
+
+func updateAWSMediaConnectFlowSource(conn *mediaconnect.MediaConnect, flowArn string, configList []interface{}) error {
+	config := configList[0].(map[string]interface{})
+	updateSourceOpts := &mediaconnect.UpdateFlowSourceInput{
+		FlowArn:   aws.String(flowArn),
+		SourceArn: aws.String(config["arn"].(string)),
+	}
+	if v, ok := config["decryption"]; ok {
+		updateSourceOpts.Decryption = expandAWSMediaConnectFlowSourceUpdateEncryption(v.([]interface{}))
+	}
+	if v, ok := config["entitlement_arn"]; ok && v.(string) != "" {
+		updateSourceOpts.EntitlementArn = aws.String(v.(string))
+	} else {
+		if v, ok := config["description"]; ok {
+			updateSourceOpts.Description = aws.String(v.(string))
+		}
+		if v, ok := config["ingest_port"]; ok && v.(int) != 0 {
+			updateSourceOpts.IngestPort = aws.Int64(int64(v.(int)))
+		}
+		if v, ok := config["max_bitrate"]; ok && v.(int) != 0 {
+			updateSourceOpts.MaxBitrate = aws.Int64(int64(v.(int)))
+		}
+		if v, ok := config["max_latency"]; ok && v.(int) != 0 {
+			updateSourceOpts.MaxLatency = aws.Int64(int64(v.(int)))
+		}
+		if v, ok := config["protocol"]; ok && v.(string) != "" {
+			updateSourceOpts.Protocol = aws.String(v.(string))
+		}
+		if v, ok := config["stream_id"]; ok && v.(string) != "" {
+			updateSourceOpts.StreamId = aws.String(v.(string))
+		}
+		if v, ok := config["whitelist_cidr"]; ok && v.(string) != "" {
+			updateSourceOpts.WhitelistCidr = aws.String(v.(string))
+		}
+	}
+
+	log.Printf("[DEBUG] Media Connect Flow Source update configuration: %#v", updateSourceOpts)
+	if _, err := conn.UpdateFlowSource(updateSourceOpts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func refreshMediaConnectFlowStatus(conn *mediaconnect.MediaConnect, flowArn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := conn.DescribeFlow(&mediaconnect.DescribeFlowInput{
+			FlowArn: aws.String(flowArn),
+		})
+		if err != nil {
+			return 42, "", err
+		}
+		flow := output.Flow
+		if flow == nil {
+			return flow, "", fmt.Errorf("Media Connect Flow (%s) missing", flowArn)
+		}
+		return flow, aws.StringValue(flow.Status), nil
+	}
+}
+
+func waitForDeleteMediaConnectFlow(conn *mediaconnect.MediaConnect, flowArn string, timeout time.Duration) error {
+	stateConf := resource.StateChangeConf{
+		Pending: []string{
+			"STANDBY",
+			"ACTIVE",
+			"UPDATING",
+			"DELETING",
+			"STARTING",
+			"STOPPING",
+		},
+		Target:     []string{""},
+		Refresh:    refreshMediaConnectFlowStatus(conn, flowArn),
+		Timeout:    timeout,
+		Delay:      AWSMediaConnectFlowRetryDelay,
+		MinTimeout: AWSMediaConnectFlowRetryMinTimeout,
+	}
+	flow, err := stateConf.WaitForState()
+	if err != nil {
+		if isAWSErr(err, mediaconnect.ErrCodeNotFoundException, "") {
+			return nil
+		}
+	}
+	if flow == nil {
+		return nil
+	}
+	return err
+}
+
+func expandAWSMediaConnectFlowSource(configList []interface{}) *mediaconnect.SetSourceRequest {
+	if len(configList) == 0 {
+		return nil
+	}
+
+	config := configList[0].(map[string]interface{})
+	sourceRequest := mediaconnect.SetSourceRequest{}
+	if v, ok := config["decryption"]; ok {
+		sourceRequest.Decryption = expandAWSMediaConnectFlowSourceEncryption(v.([]interface{}))
+	}
+	if v, ok := config["entitlement_arn"]; ok && v.(string) != "" {
+		sourceRequest.EntitlementArn = aws.String(v.(string))
+	} else {
+		if v, ok := config["name"]; ok {
+			sourceRequest.Name = aws.String(v.(string))
+		}
+		if v, ok := config["description"]; ok {
+			sourceRequest.Description = aws.String(v.(string))
+		}
+		if v, ok := config["ingest_port"]; ok && v.(int) != 0 {
+			sourceRequest.IngestPort = aws.Int64(int64(v.(int)))
+		}
+		if v, ok := config["max_bitrate"]; ok && v.(int) != 0 {
+			sourceRequest.MaxBitrate = aws.Int64(int64(v.(int)))
+		}
+		if v, ok := config["max_latency"]; ok && v.(int) != 0 {
+			sourceRequest.MaxLatency = aws.Int64(int64(v.(int)))
+		}
+		if v, ok := config["protocol"]; ok && v.(string) != "" {
+			sourceRequest.Protocol = aws.String(v.(string))
+		}
+		if v, ok := config["stream_id"]; ok && v.(string) != "" {
+			sourceRequest.StreamId = aws.String(v.(string))
+		}
+		if v, ok := config["whitelist_cidr"]; ok && v.(string) != "" {
+			sourceRequest.WhitelistCidr = aws.String(v.(string))
+		}
+	}
+
+	return &sourceRequest
+}
+
+func expandAWSMediaConnectFlowSourceEncryption(configList []interface{}) *mediaconnect.Encryption {
+	if len(configList) == 0 {
+		return nil
+	}
+	config := configList[0].(map[string]interface{})
+	encryption := mediaconnect.Encryption{}
+	if v, ok := config["algorithm"]; ok {
+		encryption.Algorithm = aws.String(v.(string))
+	}
+	if v, ok := config["key_type"]; ok {
+		encryption.KeyType = aws.String(v.(string))
+	}
+	if v, ok := config["role_arn"]; ok {
+		encryption.RoleArn = aws.String(v.(string))
+	}
+	if v, ok := config["secret_arn"]; ok {
+		encryption.SecretArn = aws.String(v.(string))
+	}
+
+	return &encryption
+}
+
+func expandAWSMediaConnectFlowSourceUpdateEncryption(configList []interface{}) *mediaconnect.UpdateEncryption {
+	if len(configList) == 0 {
+		return nil
+	}
+	config := configList[0].(map[string]interface{})
+	encryption := mediaconnect.UpdateEncryption{}
+	if v, ok := config["algorithm"]; ok {
+		encryption.Algorithm = aws.String(v.(string))
+	}
+	if v, ok := config["key_type"]; ok {
+		encryption.KeyType = aws.String(v.(string))
+	}
+	if v, ok := config["role_arn"]; ok {
+		encryption.RoleArn = aws.String(v.(string))
+	}
+	if v, ok := config["secret_arn"]; ok {
+		encryption.SecretArn = aws.String(v.(string))
+	}
+
+	return &encryption
+}
+
+func flattenAWSMediaConnectFlowSource(source *mediaconnect.Source) []map[string]interface{} {
+	if source == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"arn":               aws.StringValue(source.SourceArn),
+		"name":              aws.StringValue(source.Name),
+		"decryption":        flattenAWSMediaConnectFlowSourceEncryption(source.Decryption),
+		"description":       aws.StringValue(source.Description),
+		"entitlement_arn":   aws.StringValue(source.EntitlementArn),
+		"ingest_ip":         aws.StringValue(source.IngestIp),
+		"ingest_port":       aws.Int64Value(source.IngestPort),
+		"max_bitrate":       aws.Int64Value(source.Transport.MaxBitrate),
+		"max_latency":       aws.Int64Value(source.Transport.MaxLatency),
+		"protocol":          aws.StringValue(source.Transport.Protocol),
+		"smoothing_latency": aws.Int64Value(source.Transport.SmoothingLatency),
+		"stream_id":         aws.StringValue(source.Transport.StreamId),
+		"whitelist_cidr":    aws.StringValue(source.WhitelistCidr),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenAWSMediaConnectFlowSourceEncryption(encryption *mediaconnect.Encryption) []map[string]interface{} {
+	if encryption == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"algorithm":  aws.StringValue(encryption.Algorithm),
+		"key_type":   aws.StringValue(encryption.KeyType),
+		"role_arn":   aws.StringValue(encryption.RoleArn),
+		"secret_arn": aws.StringValue(encryption.SecretArn),
+	}
+
+	return []map[string]interface{}{m}
+}

--- a/aws/resource_aws_media_connect_flow.go
+++ b/aws/resource_aws_media_connect_flow.go
@@ -8,9 +8,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mediaconnect"
 
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 const (

--- a/aws/resource_aws_media_connect_flow.go
+++ b/aws/resource_aws_media_connect_flow.go
@@ -369,10 +369,11 @@ func refreshMediaConnectFlowStatus(conn *mediaconnect.MediaConnect, flowArn stri
 		if err != nil {
 			return 42, "", err
 		}
-		flow := output.Flow
-		if flow == nil {
-			return flow, "", fmt.Errorf("Media Connect Flow (%s) missing", flowArn)
+		if output == nil || output.Flow == nil {
+			return nil, "", nil
 		}
+		flow := output.Flow
+
 		return flow, aws.StringValue(flow.Status), nil
 	}
 }

--- a/aws/resource_aws_media_connect_flow.go
+++ b/aws/resource_aws_media_connect_flow.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -42,10 +43,13 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateMediaConnectFlowName,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 64),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must only include alphanumeric, underscore or hyphen characters"),
+				),
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,
@@ -72,10 +76,13 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 							Computed: true,
 						},
 						"name": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validateMediaConnectFlowSourceName,
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(0, 64),
+								validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must only include alphanumeric, underscore or hyphen characters"),
+							),
 							ConflictsWith: []string{
 								"source.entitlement_arn",
 							},

--- a/aws/resource_aws_media_connect_flow.go
+++ b/aws/resource_aws_media_connect_flow.go
@@ -84,7 +84,7 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 								validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must only include alphanumeric, underscore or hyphen characters"),
 							),
 							ConflictsWith: []string{
-								"source.entitlement_arn",
+								"source.0.entitlement_arn",
 							},
 						},
 						"decryption": {
@@ -122,22 +122,22 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 							Optional: true,
 							Default:  "Managed by Terraform",
 							ConflictsWith: []string{
-								"source.entitlement_arn",
+								"source.0.entitlement_arn",
 							},
 						},
 						"entitlement_arn": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ConflictsWith: []string{
-								"source.name",
-								"source.description",
-								"source.ingest_ip",
-								"source.ingest_port",
-								"source.max_bitrate",
-								"source.max_latency",
-								"source.protocol",
-								"source.stream_id",
-								"source.whitelist_cidr",
+								"source.0.name",
+								"source.0.description",
+								"source.0.ingest_ip",
+								"source.0.ingest_port",
+								"source.0.max_bitrate",
+								"source.0.max_latency",
+								"source.0.protocol",
+								"source.0.stream_id",
+								"source.0.whitelist_cidr",
 							},
 						},
 						"ingest_ip": {
@@ -148,7 +148,7 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 							ConflictsWith: []string{
-								"source.entitlement_arn",
+								"source.0.entitlement_arn",
 							},
 						},
 						"max_bitrate": {
@@ -157,14 +157,14 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 							Computed:     true,
 							ValidateFunc: validation.IntBetween(1, 200000000),
 							ConflictsWith: []string{
-								"source.entitlement_arn",
+								"source.0.entitlement_arn",
 							},
 						},
 						"max_latency": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							ConflictsWith: []string{
-								"source.entitlement_arn",
+								"source.0.entitlement_arn",
 							},
 						},
 						"protocol": {
@@ -176,7 +176,7 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 								"rtp",
 							}, false),
 							ConflictsWith: []string{
-								"source.entitlement_arn",
+								"source.0.entitlement_arn",
 							},
 						},
 						"smoothing_latency": {
@@ -188,14 +188,14 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 							Optional: true,
 							Computed: true,
 							ConflictsWith: []string{
-								"source.entitlement_arn",
+								"source.0.entitlement_arn",
 							},
 						},
 						"whitelist_cidr": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ConflictsWith: []string{
-								"source.entitlement_arn",
+								"source.0.entitlement_arn",
 							},
 						},
 					},

--- a/aws/resource_aws_media_connect_flow.go
+++ b/aws/resource_aws_media_connect_flow.go
@@ -97,9 +97,9 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 										ValidateFunc: validation.StringInSlice([]string{
-											"aes128",
-											"aes192",
-											"aes256",
+											mediaconnect.AlgorithmAes128,
+											mediaconnect.AlgorithmAes192,
+											mediaconnect.AlgorithmAes256,
 										}, false),
 									},
 									"key_type": {
@@ -276,13 +276,13 @@ func resourceAWSMediaConnectFlowUpdate(d *schema.ResourceData, meta interface{})
 
 	stateConf := resource.StateChangeConf{
 		Pending: []string{
-			"UPDATING",
-			"STARTING",
-			"STOPPING",
+			mediaconnect.StatusUpdating,
+			mediaconnect.StatusStarting,
+			mediaconnect.StatusStopping,
 		},
 		Target: []string{
-			"STANDBY",
-			"ACTIVE",
+			mediaconnect.StatusStandby,
+			mediaconnect.StatusActive,
 		},
 		Timeout: d.Timeout(schema.TimeoutUpdate),
 		Refresh: refreshMediaConnectFlowStatus(conn, d.Id()),
@@ -375,12 +375,12 @@ func refreshMediaConnectFlowStatus(conn *mediaconnect.MediaConnect, flowArn stri
 func waitForDeleteMediaConnectFlow(conn *mediaconnect.MediaConnect, flowArn string, timeout time.Duration) error {
 	stateConf := resource.StateChangeConf{
 		Pending: []string{
-			"STANDBY",
-			"ACTIVE",
-			"UPDATING",
-			"DELETING",
-			"STARTING",
-			"STOPPING",
+			mediaconnect.StatusStandby,
+			mediaconnect.StatusActive,
+			mediaconnect.StatusUpdating,
+			mediaconnect.StatusDeleting,
+			mediaconnect.StatusStarting,
+			mediaconnect.StatusStopping,
 		},
 		Target:     []string{""},
 		Refresh:    refreshMediaConnectFlowStatus(conn, flowArn),

--- a/aws/resource_aws_media_connect_flow.go
+++ b/aws/resource_aws_media_connect_flow.go
@@ -105,14 +105,19 @@ func resourceAWSMediaConnectFlow() *schema.Resource {
 									"key_type": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											mediaconnect.KeyTypeStaticKey,
+										}, false),
 									},
 									"role_arn": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
 									},
 									"secret_arn": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
 									},
 								},
 							},

--- a/aws/resource_aws_media_connect_flow_test.go
+++ b/aws/resource_aws_media_connect_flow_test.go
@@ -1,0 +1,289 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediaconnect"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSMediaConnectFlowConfig_Base(t *testing.T) {
+	var flow mediaconnect.Flow
+
+	rName := fmt.Sprintf("tfacctest%s", acctest.RandString(5))
+	resourceName := "aws_media_connect_flow.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSMediaConnectFlowConfig_Base(rName, "rtp", "3010"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSMediaConnectFlowExists(resourceName, &flow),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mediaconnect", regexp.MustCompile(`flow:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrSet(resourceName, "egress_ip"),
+					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "source.0.arn", "mediaconnect", regexp.MustCompile(`source:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "source.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "source.0.description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.protocol", "rtp"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.ingest_port", "3010"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.whitelist_cidr", "10.24.34.0/23"),
+					resource.TestCheckResourceAttrSet(resourceName, "source.0.ingest_ip"),
+				),
+			},
+			{
+				Config: testAccAWSMediaConnectFlowConfig_Base(rName, "rtp-fec", "3333"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSMediaConnectFlowExists(resourceName, &flow),
+					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.protocol", "rtp-fec"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.ingest_port", "3333"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSMediaConnectFlowConfig_Decryption(t *testing.T) {
+	var flow mediaconnect.Flow
+
+	rName := fmt.Sprintf("tfacctest%s", acctest.RandString(5))
+	resourceName := "aws_media_connect_flow.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSMediaConnectFlowConfig_Decryption(rName, "aes128"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSMediaConnectFlowExists(resourceName, &flow),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mediaconnect", regexp.MustCompile(`flow:.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "egress_ip"),
+					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "source.0.arn", "mediaconnect", regexp.MustCompile(`source:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "source.0.description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.decryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.decryption.0.key_type", "static-key"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.decryption.0.algorithm", "aes128"),
+					resource.TestCheckResourceAttrPair(resourceName, "source.0.decryption.0.role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "source.0.decryption.0.secret_arn", "aws_secretsmanager_secret.test", "arn"),
+				),
+			},
+			{
+				Config: testAccAWSMediaConnectFlowConfig_Decryption(rName, "aes256"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSMediaConnectFlowExists(resourceName, &flow),
+					resource.TestCheckResourceAttr(resourceName, "source.0.decryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.decryption.0.algorithm", "aes256"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSMediaConnectFlowConfig_Options(t *testing.T) {
+	var flow mediaconnect.Flow
+
+	rName := fmt.Sprintf("tfacctest%s", acctest.RandString(5))
+	resourceName := "aws_media_connect_flow.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSMediaConnectFlowConfig_Options(rName, "us-west-2a", "Test Description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSMediaConnectFlowExists(resourceName, &flow),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.description", "Test Description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSMediaConnectFlowExists(resourceName string, flow *mediaconnect.Flow) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No  Media Connect Flow ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).mediaconnectconn
+		output, err := conn.DescribeFlow(&mediaconnect.DescribeFlowInput{
+			FlowArn: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.Flow == nil {
+			return fmt.Errorf("Media Connect Flow (%s) not found", rs.Primary.ID)
+		}
+
+		if aws.StringValue(output.Flow.FlowArn) != rs.Primary.ID {
+			return fmt.Errorf("Media Connect Flow (%s) not found", rs.Primary.ID)
+		}
+
+		*flow = *output.Flow
+
+		return nil
+	}
+}
+
+func testAccCheckAWSMediaConnectFlowDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_media_connect_flow" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).mediaconnectconn
+
+		// Handle eventual consistency
+		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+			output, err := conn.DescribeFlow(&mediaconnect.DescribeFlowInput{
+				FlowArn: aws.String(rs.Primary.ID),
+			})
+
+			if err != nil {
+				if isAWSErr(err, mediaconnect.ErrCodeNotFoundException, "") {
+					return nil
+				}
+				return resource.NonRetryableError(err)
+			}
+
+			if output != nil && output.Flow != nil && aws.StringValue(output.Flow.FlowArn) == rs.Primary.ID {
+				return resource.RetryableError(fmt.Errorf("Media Connect Flow %s still exists", rs.Primary.ID))
+			}
+
+			return nil
+		})
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSMediaConnectFlowConfig_IamRole(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+	name = %q
+  
+	assume_role_policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "mediaconnect.amazonaws.com"
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+POLICY
+}`, rName)
+}
+
+func testAccAWSMediaConnectFlowConfig_SecretsManagerSecret(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name = "%s"
+}
+`, rName)
+}
+
+func testAccAWSMediaConnectFlowConfig_Base(rName, protocol, ingressPort string) string {
+	return fmt.Sprintf(`
+resource "aws_media_connect_flow" "test" {
+	name = "%s"
+
+	source {
+		name 			= "%s"
+		protocol 		= "%s"
+		ingest_port 	= %s
+		whitelist_cidr	= "10.24.34.0/23"
+	}
+}
+	`, rName, rName, protocol, ingressPort)
+}
+
+func testAccAWSMediaConnectFlowConfig_Decryption(rName string, algorithm string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "aws_media_connect_flow" "test" {
+	name = "%s"
+
+	source {
+		name 			= "%s"
+		protocol 		= "zixi-push"
+		ingest_port 	= 2088
+		whitelist_cidr	= "10.24.34.0/23"
+
+		decryption {
+			key_type 	= "static-key"
+			algorithm	= "%s"
+			role_arn	= "${aws_iam_role.test.arn}"
+			secret_arn	= "${aws_secretsmanager_secret.test.arn}"
+		}
+	}
+}
+	`, testAccAWSMediaConnectFlowConfig_IamRole(rName), testAccAWSMediaConnectFlowConfig_SecretsManagerSecret(rName), rName, rName, algorithm)
+}
+
+func testAccAWSMediaConnectFlowConfig_Options(rName, availabilityZone, description string) string {
+	return fmt.Sprintf(`
+resource "aws_media_connect_flow" "test" {
+	name = "%s"
+	availability_zone = "%s"
+
+	source {
+		name 			= "%s"
+		description 	= "%s"
+		protocol 		= "rtp"
+		ingest_port 	= 3010
+		whitelist_cidr	= "10.24.34.0/23"
+	}
+}
+	`, rName, availabilityZone, rName, description)
+}

--- a/aws/resource_aws_media_connect_flow_test.go
+++ b/aws/resource_aws_media_connect_flow_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mediaconnect"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSMediaConnectFlowConfig_Base(t *testing.T) {

--- a/aws/resource_aws_media_connect_flow_test.go
+++ b/aws/resource_aws_media_connect_flow_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccAWSMediaConnectFlowConfig_Base(t *testing.T) {
 	var flow mediaconnect.Flow
 
-	rName := fmt.Sprintf("tfacctest%s", acctest.RandString(5))
+	rName := fmt.Sprintf("tf-acctest_%s", acctest.RandString(5))
 	resourceName := "aws_media_connect_flow.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_media_connect_flow_test.go
+++ b/aws/resource_aws_media_connect_flow_test.go
@@ -196,7 +196,9 @@ func testAccCheckAWSMediaConnectFlowDestroy(s *terraform.State) error {
 			return nil
 		})
 
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_media_connect_flow_test.go
+++ b/aws/resource_aws_media_connect_flow_test.go
@@ -207,20 +207,20 @@ func testAccCheckAWSMediaConnectFlowDestroy(s *terraform.State) error {
 func testAccAWSMediaConnectFlowConfig_IamRole(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-	name = %q
+  name = %q
   
-	assume_role_policy = <<POLICY
+  assume_role_policy = <<POLICY
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Effect": "Allow",
-			"Principal": {
-				"Service": "mediaconnect.amazonaws.com"
-			},
-			"Action": "sts:AssumeRole"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "mediaconnect.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }
 POLICY
 }`, rName)
@@ -237,16 +237,16 @@ resource "aws_secretsmanager_secret" "test" {
 func testAccAWSMediaConnectFlowConfig_Base(rName, protocol, ingressPort string) string {
 	return fmt.Sprintf(`
 resource "aws_media_connect_flow" "test" {
-	name = "%s"
+  name = "%s"
 
-	source {
-		name 			= "%s"
-		protocol 		= "%s"
-		ingest_port 	= %s
-		whitelist_cidr	= "10.24.34.0/23"
-	}
+  source {
+    name           = "%s"
+    protocol       = "%s"
+    ingest_port    = %s
+    whitelist_cidr = "10.24.34.0/23"
+  }
 }
-	`, rName, rName, protocol, ingressPort)
+`, rName, rName, protocol, ingressPort)
 }
 
 func testAccAWSMediaConnectFlowConfig_Decryption(rName string, algorithm string) string {

--- a/aws/resource_aws_media_connect_flow_test.go
+++ b/aws/resource_aws_media_connect_flow_test.go
@@ -22,7 +22,7 @@ func TestAccAWSMediaConnectFlowConfig_Base(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		CheckDestroy: testAccCheckAWSMediaConnectFlowDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSMediaConnectFlowConfig_Base(rName, "rtp", "3010"),
@@ -69,7 +69,7 @@ func TestAccAWSMediaConnectFlowConfig_Decryption(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		CheckDestroy: testAccCheckAWSMediaConnectFlowDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSMediaConnectFlowConfig_Decryption(rName, "aes128"),
@@ -113,7 +113,7 @@ func TestAccAWSMediaConnectFlowConfig_Options(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		CheckDestroy: testAccCheckAWSMediaConnectFlowDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSMediaConnectFlowConfig_Options(rName, "us-west-2a", "Test Description1"),

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2348,9 +2348,9 @@ func validateWorklinkFleetName(v interface{}, k string) (ws []string, errors []e
 
 func validateMediaConnectFlowName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters are allowed in %q", k))
+			"only alphanumeric characters and hyphens are allowed in %q", k))
 	}
 	if len(value) > 64 {
 		errors = append(errors, fmt.Errorf(

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2343,7 +2343,32 @@ func validateWorklinkFleetName(v interface{}, k string) (ws []string, errors []e
 	} else if len(value) > 48 {
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 48 characters", k))
 	}
+	return
+}
 
+func validateMediaConnectFlowName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9A-Za-z]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters are allowed in %q", k))
+	}
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 64 characters", k))
+	}
+	return
+}
+
+func validateMediaConnectFlowSourceName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9A-Za-z]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters are allowed in %q", k))
+	}
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 64 characters", k))
+	}
 	return
 }
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2346,32 +2346,6 @@ func validateWorklinkFleetName(v interface{}, k string) (ws []string, errors []e
 	return
 }
 
-func validateMediaConnectFlowName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters and hyphens are allowed in %q", k))
-	}
-	if len(value) > 64 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be greater than 64 characters", k))
-	}
-	return
-}
-
-func validateMediaConnectFlowSourceName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters are allowed in %q", k))
-	}
-	if len(value) > 64 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be greater than 64 characters", k))
-	}
-	return
-}
-
 func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors []error) {
 	// Type: String
 	// Length Constraints: Maximum length of 64.

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -68,6 +68,7 @@ Lightsail
 MQ
 Macie
 Managed Streaming for Kafka (MSK)
+MediaConnect
 MediaConvert
 MediaPackage
 MediaStore

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2121,6 +2121,19 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">MediaConnect</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/media_connect_flow.html">aws_media_connect_flow</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
                     <a href="#">MediaConvert</a>
                     <ul class="nav">
                         <li>

--- a/website/docs/r/media_connect_flow.html.markdown
+++ b/website/docs/r/media_connect_flow.html.markdown
@@ -1,0 +1,77 @@
+---
+layout: "aws"
+page_title: "AWS: aws_media_connect_flow"
+sidebar_current: "docs-aws-resource-media-connect-flow"
+description: |-
+  Provides an AWS Elemental MediaConnect Flow.
+---
+
+# aws_media_connect_flow
+
+Provides an AWS Elemental MediaConnect Flow.
+
+## Example Usage
+
+```hcl
+resource "aws_media_connect_flow" "test" {
+	name = "tfflow"
+
+	source {
+		name 			= "tfsource"
+		protocol 		= "rtp"
+		ingest_port 	= 3010
+		whitelist_cidr	= "10.24.34.0/23"
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique identifier describing the channel
+* `source` - (Required) A unique identifier describing the channel
+* `availability_zone` - (Optional) The Availability Zone that you want to create the flow in. These options are limited to the Availability Zones within the current AWS Region.
+
+The `source` object supports the following:
+
+* `name` - (Required) The type of encryption that is used on the content ingested from the source. Defined below.
+* `decryption` - (Optional) The type of encryption that is used on the content ingested from the source. Defined below.
+* `description` - (Optional) A description of the source. This description is not visible outside of the current AWS account.
+* `entitlement_arn` - (Optional) The ARN of the entitlement that allows you to subscribe to the flow. The content originator grants the entitlement, and the ARN is auto-generated as part of the originator's flow.
+* `ingest_port` - (Optional) The port that the flow listens on for incoming content. If the protocol of the source is Zixi, the port must be set to `2088`.
+* `max_bitrate` - (Optional) The smoothing max bitrate for RTP and RTP-FEC streams.
+* `max_latency` - (Optional) The maximum latency in milliseconds for Zixi-based streams.
+* `protocol` - (Optional) The protocol that the source uses to deliver the content to AWS Elemental MediaConnect.
+* `stream_id` - (Optional) The stream ID that you want to use for the transport. This parameter applies only to Zixi-based streams.
+* `whitelist_cidr` - (Optional) The range of IP addresses that are allowed to contribute content to your source. Use the form of a Classless Inter-Domain Routing (CIDR) block; for example, 10.0.0.0/16.
+
+The `decryption` object supports the following:
+
+* `algorithm` - (Required) The type of algorithm that is used for the encryption (such as aes128, aes192, or aes256).
+* `role_arn` - (Required) The Amazon Resource Name (ARN) of the role that you created during setup (when you set up AWS Elemental MediaConnect as a trusted entity).
+* `secret_arn` - (Required) The ARN of the secret that you created in AWS Secrets Manager to store the encryption key.
+* `key_type` - (Optional) The type of key that is used for the encryption. If you don't specify a keyType value, the service uses the default setting (static-key).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The same as `arn`
+* `arn` - The ARN of the flow
+* `availability_zone` - The Availability Zone that the flow was created in.
+* `description` - A description of the flow. This description appears only on the AWS Elemental MediaConnect console and is not visible outside of the current AWS account.
+* `egress_ip` - The outgoing IP address that AWS Elemental MediaConnect uses to send video from the flow.
+* `source` - 
+  * `arn` - The ARN of the source.
+  * `ingest_ip` - The IP address that the flow listens on for incoming content.
+  * `max_bitrate` - The smoothing max bitrate for RTP and RTP-FEC streams.
+  * `smoothing_latency` - The smoothing latency in milliseconds for RTP and RTP-FEC streams.
+
+## Import
+
+Media Connect Flow can be imported via the flow ARN, e.g.
+
+```
+$ terraform import aws_media_connect_flow.test arn:aws:mediaconnect:us-west-2:123456789012:flow:1-7e7a28d2-163f-4b8f:tfflow
+```

--- a/website/docs/r/media_connect_flow.html.markdown
+++ b/website/docs/r/media_connect_flow.html.markdown
@@ -30,13 +30,13 @@ resource "aws_media_connect_flow" "test" {
 The following arguments are supported:
 
 * `name` - (Required) A unique identifier describing the channel
-* `source` - (Required) A unique identifier describing the channel
+* `source` - (Required) Configuration block with source settings. Detailed below.
 * `availability_zone` - (Optional) The Availability Zone that you want to create the flow in. These options are limited to the Availability Zones within the current AWS Region.
 
 The `source` object supports the following:
 
 * `name` - (Required) The type of encryption that is used on the content ingested from the source. Defined below.
-* `decryption` - (Optional) The type of encryption that is used on the content ingested from the source. Defined below.
+* `decryption` - (Optional) Configuration block with type of encryption that is used on the content ingested from the source. Defined below.
 * `description` - (Optional) A description of the source. This description is not visible outside of the current AWS account.
 * `entitlement_arn` - (Optional) The ARN of the entitlement that allows you to subscribe to the flow. The content originator grants the entitlement, and the ARN is auto-generated as part of the originator's flow.
 * `ingest_port` - (Optional) The port that the flow listens on for incoming content. If the protocol of the source is Zixi, the port must be set to `2088`.

--- a/website/docs/r/media_connect_flow.html.markdown
+++ b/website/docs/r/media_connect_flow.html.markdown
@@ -14,14 +14,14 @@ Provides an AWS Elemental MediaConnect Flow.
 
 ```hcl
 resource "aws_media_connect_flow" "test" {
-	name = "tfflow"
+  name = "tfflow"
 
-	source {
-		name 			= "tfsource"
-		protocol 		= "rtp"
-		ingest_port 	= 3010
-		whitelist_cidr	= "10.24.34.0/23"
-	}
+  source {
+    name           = "tfsource"
+    protocol       = "rtp"
+    ingest_port    = 3010
+    whitelist_cidr = "10.24.34.0/23"
+  }
 }
 ```
 

--- a/website/docs/r/media_connect_flow.html.markdown
+++ b/website/docs/r/media_connect_flow.html.markdown
@@ -1,12 +1,12 @@
 ---
+subcategory: "MediaConnect"
 layout: "aws"
 page_title: "AWS: aws_media_connect_flow"
-sidebar_current: "docs-aws-resource-media-connect-flow"
 description: |-
   Provides an AWS Elemental MediaConnect Flow.
 ---
 
-# aws_media_connect_flow
+# Resource: aws_media_connect_flow
 
 Provides an AWS Elemental MediaConnect Flow.
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7217 

Changes proposed in this pull request:

* Add `aws_media_connect_flow` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMediaConnectFlowConfig_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSMediaConnectFlowConfig_ -timeout 120m
=== RUN   TestAccAWSMediaConnectFlowConfig_Base
=== PAUSE TestAccAWSMediaConnectFlowConfig_Base
=== RUN   TestAccAWSMediaConnectFlowConfig_Decryption
=== PAUSE TestAccAWSMediaConnectFlowConfig_Decryption
=== RUN   TestAccAWSMediaConnectFlowConfig_Options
=== PAUSE TestAccAWSMediaConnectFlowConfig_Options
=== CONT  TestAccAWSMediaConnectFlowConfig_Base
=== CONT  TestAccAWSMediaConnectFlowConfig_Options
=== CONT  TestAccAWSMediaConnectFlowConfig_Decryption
--- PASS: TestAccAWSMediaConnectFlowConfig_Options (31.37s)
--- PASS: TestAccAWSMediaConnectFlowConfig_Base (43.52s)
--- PASS: TestAccAWSMediaConnectFlowConfig_Decryption (51.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	51.724s
```
