### PR TITLE
Add support aws media store container cors policy resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -597,6 +597,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_mq_configuration":                                    resourceAwsMqConfiguration(),
 			"aws_media_package_channel":                               resourceAwsMediaPackageChannel(),
 			"aws_media_store_container":                               resourceAwsMediaStoreContainer(),
+			"aws_media_store_container_cors_policy":                   resourceAwsMediaStoreContainerCorsPolicy(),
 			"aws_media_store_container_policy":                        resourceAwsMediaStoreContainerPolicy(),
 			"aws_msk_cluster":                                         resourceAwsMskCluster(),
 			"aws_msk_configuration":                                   resourceAwsMskConfiguration(),

--- a/aws/resource_aws_media_store_container_cors_policy.go
+++ b/aws/resource_aws_media_store_container_cors_policy.go
@@ -1,0 +1,190 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsMediaStoreContainerCorsPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMediaStoreContainerCorsPolicyPut,
+		Read:   resourceAwsMediaStoreContainerCorsPolicyRead,
+		Update: resourceAwsMediaStoreContainerCorsPolicyPut,
+		Delete: resourceAwsMediaStoreContainerCorsPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"container_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"cors_policy": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allowed_headers": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 100,
+							MinItems: 1,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"allowed_methods": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 4,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									mediastore.MethodNamePut,
+									mediastore.MethodNameGet,
+									mediastore.MethodNameDelete,
+									mediastore.MethodNameHead,
+								}, false),
+							},
+							Set: schema.HashString,
+						},
+						"allowed_origins": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 100,
+							MinItems: 1,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"expose_headers": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 100,
+							MinItems: 0,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"max_age_seconds": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(0, 2147483647),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsMediaStoreContainerCorsPolicyPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediastoreconn
+
+	input := &mediastore.PutCorsPolicyInput{
+		ContainerName: aws.String(d.Get("container_name").(string)),
+		CorsPolicy:    expandMediaStoreContainerCorsPolicy(d.Get("cors_policy").([]interface{})),
+	}
+
+	log.Printf("[DEBUG] Media Store Container Cors Policy put configuration: %#v", input)
+	_, err := conn.PutCorsPolicy(input)
+	if err != nil {
+		return fmt.Errorf("Error putting cors policy: %s", err)
+	}
+
+	d.SetId(d.Get("container_name").(string))
+
+	return resourceAwsMediaStoreContainerCorsPolicyRead(d, meta)
+}
+
+func resourceAwsMediaStoreContainerCorsPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediastoreconn
+
+	input := &mediastore.GetCorsPolicyInput{
+		ContainerName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Media Store Container Cors Policy describe configuration: %#v", input)
+	resp, err := conn.GetCorsPolicy(input)
+	if isAWSErr(err, mediastore.ErrCodeCorsPolicyNotFoundException, "") || isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+		log.Printf("[WARN] Media Store Container Cors Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error getting cors policy: %s", err)
+	}
+
+	d.Set("container_name", d.Id())
+	d.Set("cors_policy", flattenMediaStoreContainerCorsPolicy(resp.CorsPolicy))
+
+	return nil
+}
+
+func resourceAwsMediaStoreContainerCorsPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediastoreconn
+
+	input := &mediastore.DeleteCorsPolicyInput{
+		ContainerName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Media Store Container Cors Policy delete configuration: %#v", input)
+	_, err := conn.DeleteCorsPolicy(input)
+	if isAWSErr(err, mediastore.ErrCodeCorsPolicyNotFoundException, "") || isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting cors policy: %s", err)
+	}
+
+	return nil
+}
+
+func expandMediaStoreContainerCorsPolicy(rawCorsRules []interface{}) []*mediastore.CorsRule {
+	corsRules := make([]*mediastore.CorsRule, 0, len(rawCorsRules))
+	for _, rawCorsRule := range rawCorsRules {
+		cr := rawCorsRule.(map[string]interface{})
+		corsRule := &mediastore.CorsRule{}
+		if v, ok := cr["allowed_headers"]; ok {
+			corsRule.AllowedHeaders = expandStringSet(v.(*schema.Set))
+		}
+		if v, ok := cr["allowed_methods"]; ok {
+			corsRule.AllowedMethods = expandStringSet(v.(*schema.Set))
+		}
+		if v, ok := cr["allowed_origins"]; ok {
+			corsRule.AllowedOrigins = expandStringSet(v.(*schema.Set))
+		}
+		if v, ok := cr["expose_headers"]; ok && len(v.(*schema.Set).List()) > 0 {
+			corsRule.ExposeHeaders = expandStringSet(v.(*schema.Set))
+		}
+		if v, ok := cr["max_age_seconds"]; ok {
+			corsRule.MaxAgeSeconds = aws.Int64(int64(v.(int)))
+		}
+		corsRules = append(corsRules, corsRule)
+	}
+	return corsRules
+}
+
+func flattenMediaStoreContainerCorsPolicy(corsRules []*mediastore.CorsRule) []interface{} {
+	rawCorsRules := make([]interface{}, 0, len(corsRules))
+
+	for _, corsRule := range corsRules {
+		m := map[string]interface{}{
+			"allowed_headers": schema.NewSet(schema.HashString, flattenStringList(corsRule.AllowedHeaders)),
+			"allowed_methods": schema.NewSet(schema.HashString, flattenStringList(corsRule.AllowedMethods)),
+			"allowed_origins": schema.NewSet(schema.HashString, flattenStringList(corsRule.AllowedOrigins)),
+			"expose_headers":  schema.NewSet(schema.HashString, flattenStringList(corsRule.ExposeHeaders)),
+			"max_age_seconds": aws.Int64Value(corsRule.MaxAgeSeconds),
+		}
+		rawCorsRules = append(rawCorsRules, m)
+	}
+
+	return rawCorsRules
+}

--- a/aws/resource_aws_media_store_container_cors_policy.go
+++ b/aws/resource_aws_media_store_container_cors_policy.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mediastore"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsMediaStoreContainerCorsPolicy() *schema.Resource {

--- a/aws/resource_aws_media_store_container_cors_policy_test.go
+++ b/aws/resource_aws_media_store_container_cors_policy_test.go
@@ -1,0 +1,182 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSMediaStoreContainerCorsPolicy_basic(t *testing.T) {
+	resourceName := "aws_media_store_container_cors_policy.test"
+	rName := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMediaStoreContainerCorsPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMediaStoreContainerCorsPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaStoreContainerCorsPolicyExists(resourceName),
+					resource.TestCheckResourceAttrPair(
+						resourceName, "container_name",
+						"aws_media_store_container.test", "name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSMediaStoreContainerCorsPolicy_optional(t *testing.T) {
+	resourceName := "aws_media_store_container_cors_policy.test"
+	rName := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMediaStoreContainerCorsPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMediaStoreContainerCorsPolicyConfig_optional(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaStoreContainerCorsPolicyExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSMediaStoreContainerCorsPolicy_update(t *testing.T) {
+	resourceName := "aws_media_store_container_cors_policy.test"
+	rName := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMediaStoreContainerCorsPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMediaStoreContainerCorsPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaStoreContainerCorsPolicyExists(resourceName),
+				),
+			},
+			{
+				Config: testAccMediaStoreContainerCorsPolicyConfig_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaStoreContainerCorsPolicyExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMediaStoreContainerCorsPolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_media_store_container_cors_policy" {
+			continue
+		}
+
+		input := &mediastore.GetCorsPolicyInput{
+			ContainerName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetCorsPolicy(input)
+		if err != nil {
+			if isAWSErr(err, mediastore.ErrCodeCorsPolicyNotFoundException, "") || isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+				return nil
+			}
+			return err
+		}
+		return fmt.Errorf("Media Store Container Cors Policy(%s) is stil exists.", rs.Primary.ID)
+	}
+	return nil
+}
+
+func testAccCheckAwsMediaStoreContainerCorsPolicyExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
+
+		input := &mediastore.GetCorsPolicyInput{
+			ContainerName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetCorsPolicy(input)
+
+		return err
+	}
+}
+
+func testAccMediaStoreContainerCorsPolicyConfig(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_media_store_container_cors_policy" "test" {
+	container_name = "${aws_media_store_container.test.name}"
+
+	cors_policy = {
+		allowed_headers = ["*"]
+		allowed_methods = ["GET"]
+		allowed_origins = ["*"]
+	}
+}`, testAccMediaStoreContainerConfig(rName))
+}
+
+func testAccMediaStoreContainerCorsPolicyConfig_optional(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_media_store_container_cors_policy" "test" {
+	container_name = "${aws_media_store_container.test.name}"
+
+	cors_policy = {
+		allowed_headers = ["*"]
+		allowed_methods = ["GET", "HEAD"]
+		allowed_origins = ["http://aaa.example.com"]
+		expose_headers 	= ["*"]
+		max_age_seconds = 0
+	}
+}`, testAccMediaStoreContainerConfig(rName))
+}
+
+func testAccMediaStoreContainerCorsPolicyConfig_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_media_store_container_cors_policy" "test" {
+	container_name = "${aws_media_store_container.test.name}"
+
+	cors_policy = {
+		allowed_headers = ["Access-Control-Request-Headers"]
+		allowed_methods = ["PUT", "GET"]
+		allowed_origins = ["http://aaa.example.com", "http://bbb.example.com"]
+		expose_headers 	= ["XMLHttpRequest"]
+		max_age_seconds = 3600
+	}
+}`, testAccMediaStoreContainerConfig(rName))
+}

--- a/aws/resource_aws_media_store_container_cors_policy_test.go
+++ b/aws/resource_aws_media_store_container_cors_policy_test.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mediastore"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSMediaStoreContainerCorsPolicy_basic(t *testing.T) {
@@ -139,7 +140,7 @@ func testAccMediaStoreContainerCorsPolicyConfig(rName string) string {
 resource "aws_media_store_container_cors_policy" "test" {
 	container_name = "${aws_media_store_container.test.name}"
 
-	cors_policy = {
+	cors_policy {
 		allowed_headers = ["*"]
 		allowed_methods = ["GET"]
 		allowed_origins = ["*"]
@@ -154,7 +155,7 @@ func testAccMediaStoreContainerCorsPolicyConfig_optional(rName string) string {
 resource "aws_media_store_container_cors_policy" "test" {
 	container_name = "${aws_media_store_container.test.name}"
 
-	cors_policy = {
+	cors_policy {
 		allowed_headers = ["*"]
 		allowed_methods = ["GET", "HEAD"]
 		allowed_origins = ["http://aaa.example.com"]
@@ -171,7 +172,7 @@ func testAccMediaStoreContainerCorsPolicyConfig_update(rName string) string {
 resource "aws_media_store_container_cors_policy" "test" {
 	container_name = "${aws_media_store_container.test.name}"
 
-	cors_policy = {
+	cors_policy {
 		allowed_headers = ["Access-Control-Request-Headers"]
 		allowed_methods = ["PUT", "GET"]
 		allowed_origins = ["http://aaa.example.com", "http://bbb.example.com"]

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2024,6 +2024,9 @@
                                     <a href="/docs/providers/aws/r/media_store_container.html">aws_media_store_container</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/media_store_container_cors_policy.html">aws_media_store_container_cors_policy</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/media_store_container_policy.html">aws_media_store_container_policy</a>
                                 </li>
                             </ul>

--- a/website/docs/r/media_store_container_cors_policy.html.markdown
+++ b/website/docs/r/media_store_container_cors_policy.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "aws"
+page_title: "AWS: aws_media_store_container_cors_policy"
+sidebar_current: "docs-aws-resource-media-store-container-cors-policy"
+description: |-
+  Provides a MediaStore Container Cors Policy.
+---
+
+# aws_media_store_container_cors_policy
+
+Provides a MediaStore Container Cors Policy.
+
+## Example Usage
+
+```hcl
+
+resource "aws_media_store_container" "example" {
+  name = "example"
+}
+
+resource "aws_media_store_container_cors_policy" "example" {
+  container_name = "${aws_media_store_container.example.name}"
+
+  cors_policy = {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+  }
+
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `container_name` - (Required, ForceNew) The name of the container.
+* `cors_policy` - (Required) A rule for a CORS policy. Add up to 100 rules to a CORS policy. If more than one rule applies, the service uses the first applicable rule listed. See [below](#cors_policy) for detail.
+
+### Nested Fields
+
+#### `cors_policy`
+
+* `allowed_headers` - (Required) Specifies which headers are allowed in a preflight `OPTIONS` request through the `Access-Control-Request-Headers` header.
+* `allowed_methods` - (Required) Identifies an HTTP method that the origin that is specified in the rule is allowed to execute.  The valid values are: `PUT`, `GET`, `DELETE`, and `HEAD`.
+* `allowed_origins` - (Required) One or more response headers that you want users to be able to access from their applications. e.g. from a JavaScript `XMLHttpRequest` object.
+* `expose_headers` - (Optional) One or more headers in the response that you want users to be able to access from their applications. e.g. from a JavaScript `XMLHttpRequest` object.
+* `max_age_seconds` - (Optional) The time in seconds that your browser caches the preflight response for the specified resource.(Default: `0`).
+
+## Import
+
+MediaStore Container Cors Policy can be imported using the MediaStore Container Name, e.g.
+
+```
+$ terraform import aws_media_store_container_cors_policy.example example
+```

--- a/website/docs/r/media_store_container_cors_policy.html.markdown
+++ b/website/docs/r/media_store_container_cors_policy.html.markdown
@@ -21,7 +21,7 @@ resource "aws_media_store_container" "example" {
 resource "aws_media_store_container_cors_policy" "example" {
   container_name = "${aws_media_store_container.example.name}"
 
-  cors_policy = {
+  cors_policy {
     allowed_headers = ["*"]
     allowed_methods = ["GET"]
     allowed_origins = ["*"]


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7512 

Changes proposed in this pull request:

* Add `aws_media_store_container_cors_policy` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMediaStoreContainerCorsPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSMediaStoreContainerCorsPolicy_ -timeout 120m
=== RUN   TestAccAWSMediaStoreContainerCorsPolicy_basic
=== PAUSE TestAccAWSMediaStoreContainerCorsPolicy_basic
=== RUN   TestAccAWSMediaStoreContainerCorsPolicy_optional
=== PAUSE TestAccAWSMediaStoreContainerCorsPolicy_optional
=== RUN   TestAccAWSMediaStoreContainerCorsPolicy_update
=== PAUSE TestAccAWSMediaStoreContainerCorsPolicy_update
=== CONT  TestAccAWSMediaStoreContainerCorsPolicy_basic
=== CONT  TestAccAWSMediaStoreContainerCorsPolicy_update
=== CONT  TestAccAWSMediaStoreContainerCorsPolicy_optional
--- PASS: TestAccAWSMediaStoreContainerCorsPolicy_optional (111.69s)
--- PASS: TestAccAWSMediaStoreContainerCorsPolicy_basic (111.88s)
--- PASS: TestAccAWSMediaStoreContainerCorsPolicy_update (126.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	126.988s
```
