### PR TITLE
Ignore Empty CORS Blocks for AWS S3 Bucket

### DIFF
--- a/.changelog/7547.txt
+++ b/.changelog/7547.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket: Prevent panic when expanding the bucket's list of `cors_rule`
+```

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -1237,6 +1237,32 @@ func TestAccS3Bucket_Security_corsEmptyOrigin(t *testing.T) {
 	})
 }
 
+func TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWithCORSSingleMethodAndEmptyOriginConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+			},
+		},
+	})
+}
+
 func TestAccS3Bucket_Security_logging(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
@@ -3859,6 +3885,19 @@ resource "aws_s3_bucket" "bucket" {
     allowed_origins = ["https://www.example.com"]
     expose_headers  = ["x-amz-server-side-encryption", "ETag"]
     max_age_seconds = 3000
+  }
+}
+`, bucketName)
+}
+
+func testAccBucketWithCORSSingleMethodAndEmptyOriginConfig(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+  bucket = %[1]q
+
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = [""]
   }
 }
 `, bucketName)

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -385,10 +385,10 @@ describing redirect behavior and when redirects are applied.
 
 The `CORS` object supports the following:
 
-* `allowed_headers` (Optional) Specifies which headers are allowed.
-* `allowed_methods` (Required) Specifies which methods are allowed. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
-* `allowed_origins` (Required) Specifies which origins are allowed.
-* `expose_headers` (Optional) Specifies expose header in the response.
+* `allowed_headers` (Optional) List of headers allowed.
+* `allowed_methods` (Required) One or more HTTP methods that you allow the origin to execute. Can be `GET`, `PUT`, `POST`, `DELETE` or `HEAD`.
+* `allowed_origins` (Required) One or more origins you want customers to be able to access the bucket from.
+* `expose_headers` (Optional) One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript `XMLHttpRequest` object).
 * `max_age_seconds` (Optional) Specifies time in seconds that browser can cache the response for a preflight request.
 
 The `versioning` object supports the following:


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7546

This PR will allow adding/removing cors blocks dynamically based on a list of allowed methods and allowed origins. Currently, empty cors blocks cause a panic.  Changes proposed in this pull request are also mentioned in issue #7546.

```hcl
resource "aws_s3_bucket" "main" {
  bucket = "${var.s3_bucket_name}"
  acl    = "private"

  cors_rule {
    allowed_methods = "${var.s3_cors_allowed_methods}"
    allowed_origins = "${var.s3_cors_allowed_origins}"
  }
}
```

Output from acceptance testing:

```
--- PASS: TestAccS3Bucket_Security_corsDelete (136.12s)
--- PASS: TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin (167.95s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (176.03s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (283.98s)
```
