### PR TITLE
resource/aws_elasticache_replication_group: Always set "primary_endpoint_address" and "configuration_endpoint_address"

### DIFF
--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -729,6 +729,7 @@ func TestAccElastiCacheReplicationGroup_multiAzInVPC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_window", "02:00-03:00"),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "7"),
+					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "primary_endpoint_address"),
 					func(s *terraform.State) error {
 						return resource.TestMatchResourceAttr(resourceName, "primary_endpoint_address", regexp.MustCompile(fmt.Sprintf("%s\\..+\\.%s", aws.StringValue(rg.ReplicationGroupId), acctest.PartitionDNSSuffix())))(s)
@@ -773,6 +774,7 @@ func TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_window", "02:00-03:00"),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "7"),
+					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "primary_endpoint_address"),
 					func(s *terraform.State) error {
 						return resource.TestMatchResourceAttr(resourceName, "primary_endpoint_address", regexp.MustCompile(fmt.Sprintf("%s\\..+\\.%s", aws.StringValue(rg.ReplicationGroupId), acctest.PartitionDNSSuffix())))(s)
@@ -836,6 +838,7 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "port", "6379"),
 					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "primary_endpoint_address"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),


### PR DESCRIPTION
Fixes #6869

Changes proposed in this pull request:

 This changeset ensures that `primary_endpoint_address` and `configuration_endpoint_address` computed attribute will always be defined, so the resource interface becomes consistent regardless of the "cluster_mode" value.

 If `cluster_mode` is turned on, then `configuration_endpoint_address` is set to a real value and `primary_endpoint_address` is an empty string. 
And vise versa: if `cluster_mode` is not enabled, then `primary_endpoint_address` is real value and `configuration_endpoint_address` is an empty string. 

That allows to avoid issues like #6869. For example, it will be possible to call the `aws_elasticache_replication_group`resource from the module and use the _output_ for endpoint address. And it will work for both states of `cluster_mode` feature without throwing an error:

```
output "configuration_endpoint_address" {
  value = "${join("",aws_elasticache_replication_group.default.*.configuration_endpoint_address)}"
}

output "primary_endpoint_address" {
  value = "${join("",aws_elasticache_replication_group.default.*.primary_endpoint_address)}"
}
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run="TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic|TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run="TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic|TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2" -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== PAUSE TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== RUN   TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic
=== PAUSE TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic
=== CONT  TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== CONT  TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (847.94s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1055.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1055.446s
...
```
