### PR TITLE
route_table: fail creation if later read does not find resource

### DIFF
--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -140,7 +140,15 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 			d.Id(), err)
 	}
 
-	return resourceAwsRouteTableUpdate(d, meta)
+	if err := resourceAwsRouteTableUpdate(d, meta); err != nil {
+		return fmt.Errorf("Error updating route table after creating it: %s", err)
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("Route table not found after creating it: %s", err)
+	}
+
+	return nil
 }
 
 func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Fixes #7644

**Changes proposed in this pull request:**

The typical route table creation steps involve making an ec2/CreateRouteTable
request, an ec2/DescribeRouteTables request, some other requests to update
the route table, followed by a final ec2.DescribeRouteTables request. If
the response to the final ec2/DescribeRouteTables request is
InvalidRouteTableID.NotFound, then the ID of the route table resource is
cleared so that the route table resource is not retained. However, the
creation is still considered a success. This results in either (1) failures
from other resources that depend upon the route table resource or (2) a report
of a successful apply even though one of the resources needed does not
actually exist.

These changes adjust the result of the creation in the case where the route
table cannot be found on the final ec2/DescribeRouteTables request. Instead
of reporting success for the creation, report failure.

**Output from acceptance testing:**

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSRouteTable'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSRouteTable -timeout 120m
=== RUN   TestAccAWSRouteTable_importBasic
=== PAUSE TestAccAWSRouteTable_importBasic
=== RUN   TestAccAWSRouteTable_importWithCreate
=== PAUSE TestAccAWSRouteTable_importWithCreate
=== RUN   TestAccAWSRouteTable_importComplex
--- FAIL: TestAccAWSRouteTable_importComplex (1.75s)
    testing.go:538: Step 0 error: config is invalid: resource 'aws_route_table.mod' config: unknown resource 'aws_vpc.default' referenced in variable aws_vpc.default.id
=== RUN   TestAccAWSRouteTableAssociation_basic
=== PAUSE TestAccAWSRouteTableAssociation_basic
=== RUN   TestAccAWSRouteTable_basic
=== PAUSE TestAccAWSRouteTable_basic
=== RUN   TestAccAWSRouteTable_instance
=== PAUSE TestAccAWSRouteTable_instance
=== RUN   TestAccAWSRouteTable_ipv6
=== PAUSE TestAccAWSRouteTable_ipv6
=== RUN   TestAccAWSRouteTable_tags
=== PAUSE TestAccAWSRouteTable_tags
=== RUN   TestAccAWSRouteTable_panicEmptyRoute
=== PAUSE TestAccAWSRouteTable_panicEmptyRoute
=== RUN   TestAccAWSRouteTable_Route_TransitGatewayID
=== PAUSE TestAccAWSRouteTable_Route_TransitGatewayID
=== RUN   TestAccAWSRouteTable_vpcPeering
=== PAUSE TestAccAWSRouteTable_vpcPeering
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
=== PAUSE TestAccAWSRouteTable_vgwRoutePropagation
=== CONT  TestAccAWSRouteTable_importBasic
=== CONT  TestAccAWSRouteTable_tags
=== CONT  TestAccAWSRouteTable_basic
=== CONT  TestAccAWSRouteTable_vpcPeering
=== CONT  TestAccAWSRouteTable_instance
=== CONT  TestAccAWSRouteTable_ipv6
=== CONT  TestAccAWSRouteTable_vgwRoutePropagation
=== CONT  TestAccAWSRouteTable_Route_TransitGatewayID
=== CONT  TestAccAWSRouteTable_panicEmptyRoute
=== CONT  TestAccAWSRouteTableAssociation_basic
=== CONT  TestAccAWSRouteTable_importWithCreate
--- PASS: TestAccAWSRouteTable_panicEmptyRoute (23.41s)
--- PASS: TestAccAWSRouteTable_ipv6 (37.57s)
--- PASS: TestAccAWSRouteTable_vpcPeering (47.70s)
--- PASS: TestAccAWSRouteTable_importBasic (51.64s)
--- PASS: TestAccAWSRouteTable_tags (56.44s)
--- PASS: TestAccAWSRouteTable_importWithCreate (68.76s)
--- PASS: TestAccAWSRouteTable_basic (73.45s)
--- PASS: TestAccAWSRouteTableAssociation_basic (75.51s)
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (79.54s)
--- PASS: TestAccAWSRouteTable_instance (253.18s)
--- PASS: TestAccAWSRouteTable_Route_TransitGatewayID (350.79s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	352.581s
make: *** [GNUmakefile:20: testacc] Error 1
```

Note that the failing test `TestAccAWSRouteTable_importComplex` fails with the same error when run against the master branch.

I cannot determine a way to verify the behavior of these changes with the acceptance tests. Is there a way to hijack certain requests sent to AWS to produce desired abnormal responses?