### PR TITLE
WIP: support for opsworks for chef automate

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -89,6 +89,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/mq"
 	"github.com/aws/aws-sdk-go/service/neptune"
 	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/aws/aws-sdk-go/service/opsworkscm"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/pinpoint"
 	"github.com/aws/aws-sdk-go/service/pricing"
@@ -264,6 +265,7 @@ type AWSClient struct {
 	mqconn                              *mq.MQ
 	neptuneconn                         *neptune.Neptune
 	opsworksconn                        *opsworks.OpsWorks
+	opsworkscmconn                      *opsworkscm.OpsWorksCM
 	organizationsconn                   *organizations.Organizations
 	partition                           string
 	pinpointconn                        *pinpoint.Pinpoint
@@ -434,6 +436,7 @@ func (c *Config) Client() (interface{}, error) {
 		mqconn:                              mq.New(sess),
 		neptuneconn:                         neptune.New(sess),
 		opsworksconn:                        opsworks.New(sess),
+		opsworkscmconn:                      opsworkscm.New(sess),
 		organizationsconn:                   organizations.New(sess),
 		partition:                           partition,
 		pinpointconn:                        pinpoint.New(sess),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -577,6 +577,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_opsworks_user_profile":                        resourceAwsOpsworksUserProfile(),
 			"aws_opsworks_permission":                          resourceAwsOpsworksPermission(),
 			"aws_opsworks_rds_db_instance":                     resourceAwsOpsworksRdsDbInstance(),
+			"aws_opsworks_chef":                                resourceAwsOpsworksChef(),
 			"aws_organizations_organization":                   resourceAwsOrganizationsOrganization(),
 			"aws_organizations_account":                        resourceAwsOrganizationsAccount(),
 			"aws_organizations_policy":                         resourceAwsOrganizationsPolicy(),

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -229,7 +229,7 @@ func resourceAwsOpsworksChefCreate(d *schema.ResourceData, meta interface{}) err
 		PreferredBackupWindow:      aws.String(d.Get("preferred_backup_window").(string)),
 		PreferredMaintenanceWindow: aws.String(d.Get("preferred_maintenance_window").(string)),
 		SecurityGroupIds:           aws.StringSlice(d.Get("security_group_ids").([]string)), // TODO: SecurityGroupIds, set?
-		ServerName:                 aws.String(d.Id().(string)),
+		ServerName:                 aws.String(d.Id()),
 		ServiceRoleArn:             aws.String(d.Get("service_role_arn").(string)),
 		SubnetIds:                  aws.StringSlice(d.Get("subnet_ids").([]string)), // TODO: set?
 	}

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -51,15 +51,13 @@ func resourceAwsOpsworksChef() *schema.Resource {
 			// Also, since these are write-only and not returned by the API, we'll probably need a custom diff function that ignores them?
 			"chef_pivotal_key": {
 				Type:      schema.TypeString,
-				Optional:  true,
-				Default:   nil,
+				Required:  true,
 				Sensitive: true,
 			},
 
 			"chef_delivery_admin_password": {
 				Type:      schema.TypeString,
-				Optional:  true,
-				Default:   nil,
+				Required:  true,
 				Sensitive: true,
 			},
 

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -1,0 +1,158 @@
+package aws
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/opsworkscm"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsOpsworksChef() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsOpsworksChefCreate,
+		Read:   resourceAwsOpsworksChefRead,
+		Update: resourceAwsOpsworksChefUpdate,
+		Delete: resourceAwsOpsworksChefDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: false,
+				Computed: false,
+			},
+			// TODO: these are the actual resource parameters
+		},
+	}
+}
+
+func resourceAwsOpsworksChefValidate(d *schema.ResourceData) error {
+	// TODO: parameter validation function
+	return nil
+}
+
+func resourceAwsOpsworksChefRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient).opsworkscmconn
+
+	req := &opsworkscm.DescribeServersInput{
+		ServerName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading OpsWorks Chef server: %s", d.Id())
+
+	var resp *opsworkscm.DescribeServersOutput
+	var dErr error
+
+	resp, dErr = client.DescribeServers(req)
+	if dErr != nil {
+		log.Printf("[DEBUG] OpsWorks Chef (%s) not found", d.Id())
+		d.SetId("")
+		return dErr
+	}
+
+	server := resp.Servers[0]
+	// TODO: figure / set attributes
+	d.Set("arn", server.ServerArn)
+
+	return nil
+}
+
+func resourceAwsOpsworksChefCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient).opsworkscmconn
+
+	err := resourceAwsOpsworksChefValidate(d)
+	if err != nil {
+		return err
+	}
+
+	req := &opsworkscm.CreateServerInput{
+		// TODO: parameters
+
+	}
+
+	log.Printf("[DEBUG] Creating OpsWorks Chef server: %s", req)
+
+	var resp *opsworkscm.CreateServerOutput
+	err = resource.Retry(20*time.Minute, func() *resource.RetryError {
+		var cerr error
+		resp, cerr = client.CreateServer(req)
+		if cerr != nil {
+			if opserr, ok := cerr.(awserr.Error); ok {
+				// If Terraform is also managing the service IAM role,
+				// it may have just been created and not yet be
+				// propagated.
+				// AWS doesn't provide a machine-readable code for this
+				// specific error, so we're forced to do fragile message
+				// matching.
+				// The full error we're looking for looks something like
+				// the following:
+				// Service Role Arn: [...] is not yet propagated, please try again in a couple of minutes
+				propErr := "not yet propagated"
+				trustErr := "not the necessary trust relationship"
+				validateErr := "validate IAM role permission"
+				if opserr.Code() == "ValidationException" && (strings.Contains(opserr.Message(), trustErr) || strings.Contains(opserr.Message(), propErr) || strings.Contains(opserr.Message(), validateErr)) {
+					log.Printf("[INFO] Waiting for service IAM role to propagate")
+					return resource.RetryableError(cerr)
+				}
+			}
+			return resource.NonRetryableError(cerr)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	serverName := *resp.Server.ServerName
+	d.SetId(serverName)
+
+	return resourceAwsOpsworksChefUpdate(d, meta)
+}
+
+func resourceAwsOpsworksChefUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient).opsworkscmconn
+
+	err := resourceAwsOpsworksChefValidate(d)
+	if err != nil {
+		return err
+	}
+
+	req := &opsworkscm.UpdateServerInput{
+		// TODO: params
+	}
+
+	// TODO: params? d.GetOk() stuff wat
+
+	log.Printf("[DEBUG] Updating OpsWorks Chef server: %s", req)
+
+	_, err = client.UpdateServer(req)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsOpsworksChefRead(d, meta)
+}
+
+func resourceAwsOpsworksChefDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient).opsworkscmconn
+
+	req := &opsworkscm.DeleteServerInput{
+		ServerName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting OpsWorks Chef server: %s", d.Id())
+
+	_, err := client.DeleteServer(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -134,6 +134,8 @@ func resourceAwsOpsworksChef() *schema.Resource {
 				Type:     schema.TypeList, // TODO: should this be a schema.TypeSet instead so order doesn't matter? check ALB and aws_instance resources?
 				Required: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				MinItems: 1,
 			},
 
 			// TODO: document this role creation
@@ -160,6 +162,8 @@ func resourceAwsOpsworksChef() *schema.Resource {
 				Type:     schema.TypeList, // TODO: schema.TypeSet? check ALB resources?
 				Required: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				MinItems: 1,
 			},
 
 			"endpoint": {

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -119,7 +119,6 @@ func resourceAwsOpsworksChef() *schema.Resource {
 
 			// TODO: document this role creation
 			// https://s3.amazonaws.com/opsworks-cm-us-east-1-prod-default-assets/misc/opsworks-cm-roles.yaml
-			// if it's optional, will they be computed? if so, is that something we can express here?
 			"service_role_arn": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -231,16 +230,20 @@ func resourceAwsOpsworksChefCreate(d *schema.ResourceData, meta interface{}) err
 		SubnetIds:                  aws.StringSlice(d.Get("subnet_ids").([]string)), // TODO: set?
 	}
 
-	// TODO: pivotal key and admin password attributes
-	// ChefPivotalKey:             aws.String(d.Get("chef_pivotal_key").(string)),
-	// ChefDeliveryAdminPassword:  aws.String(d.Get("chef_delivery_admin_password").(string)),
+	chefPivotalKeyAttribute := opsworkscm.EngineAttribute{
+		Name:  aws.String("CHEF_PIVOTAL_KEY"),
+		Value: aws.String(d.Get("chef_pivotal_key").(string)),
+	}
+
+	chefDeliveryAdminPassword := opsworkscm.EngineAttribute{
+		Name:  aws.String("CHEF_DELIVERY_ADMIN_PASSWORD"),
+		Value: aws.String(d.Get("chef_delivery_admin_password").(string)),
+	}
+
+	req.SetEngineAttributes([]*opsworkscm.EngineAttribute{&chefPivotalKeyAttribute, &chefDeliveryAdminPassword})
 
 	// TODO: possibly make these optional
-	// TODO: chef_pivotal_key, optional
-	// TODO: chef_delivery_admin_password, optional
-	// TODO: instance_profile_arn, optional
 	// TODO: security_group_ids, optional
-	// TODO: service_role_arn, optional
 	// TODO: subnet_ids, optional
 
 	if sshKeyPair, ok := d.GetOk("ssh_key_pair"); ok {

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -185,7 +185,6 @@ func resourceAwsOpsworksChefRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	server := resp.Servers[0]
-
 	d.Set("associate_public_ip_address", server.AssociatePublicIpAddress)
 	d.Set("backup_retention_count", server.BackupRetentionCount)
 	d.Set("disable_automated_backup", server.DisableAutomatedBackup)
@@ -224,6 +223,7 @@ func resourceAwsOpsworksChefCreate(d *schema.ResourceData, meta interface{}) err
 		PreferredBackupWindow:      aws.String(d.Get("preferred_backup_window").(string)),
 		PreferredMaintenanceWindow: aws.String(d.Get("preferred_maintenance_window").(string)),
 		SecurityGroupIds:           aws.StringSlice(d.Get("security_group_ids").([]string)), // TODO: SecurityGroupIds, set?
+		ServerName:                 aws.String(d.Id().(string)),
 		ServiceRoleArn:             aws.String(d.Get("service_role_arn").(string)),
 		SubnetIds:                  aws.StringSlice(d.Get("subnet_ids").([]string)), // TODO: set?
 	}

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -23,12 +23,112 @@ func resourceAwsOpsworksChef() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Optional: false,
-				Computed: false,
+			"associate_public_ip_address": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
-			// TODO: these are the actual resource parameters
+
+			"backup_retention_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+			},
+
+			"disable_automated_backup": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			// I kinda want to make this required because how else are we going to get at that info?
+			"chef_pivotal_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"chef_delivery_admin_password": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			// TODO:
+			// default and only valid. I'll leave it configurable for future proofing but
+			// validation failure, maybe?
+			"engine_model": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Single",
+			},
+
+			// TODO:
+			// default and only valid. I'll leave it configurable for future proofing but
+			// validation failure, maybe?
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "12",
+			},
+
+			// TODO: document the instance role required
+			// https://s3.amazonaws.com/opsworks-cm-us-east-1-prod-default-assets/misc/opsworks-cm-roles.yaml
+			"instance_profile_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"instance_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"ssh_key_pair": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"preferred_backup_window": {
+				Type:     schema.TypeString,
+				Required: true, // TODO: ?
+			},
+
+			"preferred_maintenance_window": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// TODO:
+			// if you don't specify this, it'll create one. I'm of the opinion that users should
+			// create it themselves. Or maybe some sort of wrapper module? I dunno.
+			"security_group_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+			},
+
+			// TODO: document this role creation
+			// https://s3.amazonaws.com/opsworks-cm-us-east-1-prod-default-assets/misc/opsworks-cm-roles.yaml
+			"service_role_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// TODO: huh?
+			// The IDs of subnets in which to launch the server EC2 instance.
+			//
+			// Amazon EC2-Classic customers: This field is required. All servers must run
+			// within a VPC. The VPC must have "Auto Assign Public IP" enabled.
+			//
+			// EC2-VPC customers: This field is optional. If you do not specify subnet IDs,
+			// your EC2 instances are created in a default subnet that is selected by Amazon
+			// EC2. If you specify subnet IDs, the VPC must have "Auto Assign Public IP"
+			// enabled.
+
+			"subnet_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+			},
 		},
 	}
 }
@@ -74,7 +174,9 @@ func resourceAwsOpsworksChefCreate(d *schema.ResourceData, meta interface{}) err
 
 	req := &opsworkscm.CreateServerInput{
 		// TODO: parameters
-
+		// "name":         d.Id(),
+		// "engine":       "Chef",
+		// "engine_model": "single", // required?
 	}
 
 	log.Printf("[DEBUG] Creating OpsWorks Chef server: %s", req)

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/opsworkscm"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 const EngineModel = "Single"
@@ -38,6 +39,9 @@ func resourceAwsOpsworksChef() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  1,
+				// https://docs.aws.amazon.com/opsworks/latest/userguide/opscm-chef-backup.html
+				// I could swear I found this 1-30 limitation elsewhere, but I can't seem to find it now other than there
+				ValidateFunc: validation.IntBetween(1, 30),
 			},
 
 			"disable_automated_backup": {
@@ -53,12 +57,16 @@ func resourceAwsOpsworksChef() *schema.Resource {
 				Type:      schema.TypeString,
 				Required:  true,
 				Sensitive: true,
+				// TODO: should we?
+				// ValidateFunc: validateRsaKey,
 			},
 
 			"chef_delivery_admin_password": {
 				Type:      schema.TypeString,
 				Required:  true,
 				Sensitive: true,
+				// TODO: should we?
+				// ValidateFunc: validatePasswordOk,
 			},
 
 			// TODO:

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -84,16 +84,19 @@ func resourceAwsOpsworksChef() *schema.Resource {
 			"instance_profile_arn": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"instance_type": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"ssh_key_pair": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"preferred_backup_window": {
@@ -113,6 +116,7 @@ func resourceAwsOpsworksChef() *schema.Resource {
 			"security_group_ids": {
 				Type:     schema.TypeList, // TODO: should this be a schema.TypeSet instead so order doesn't matter? check ALB and aws_instance resources?
 				Required: true,
+				ForceNew: true,
 			},
 
 			// TODO: document this role creation
@@ -120,6 +124,7 @@ func resourceAwsOpsworksChef() *schema.Resource {
 			"service_role_arn": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			// TODO: huh?
@@ -136,6 +141,7 @@ func resourceAwsOpsworksChef() *schema.Resource {
 			"subnet_ids": {
 				Type:     schema.TypeList, // TODO: schema.TypeSet? check ALB resources?
 				Required: true,
+				ForceNew: true,
 			},
 
 			"endpoint": {

--- a/aws/resource_aws_opsworks_chef.go
+++ b/aws/resource_aws_opsworks_chef.go
@@ -82,9 +82,10 @@ func resourceAwsOpsworksChef() *schema.Resource {
 			// TODO: document the instance role required
 			// https://s3.amazonaws.com/opsworks-cm-us-east-1-prod-default-assets/misc/opsworks-cm-roles.yaml
 			"instance_profile_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"instance_type": {
@@ -101,12 +102,20 @@ func resourceAwsOpsworksChef() *schema.Resource {
 
 			"preferred_backup_window": {
 				Type:     schema.TypeString,
-				Required: true, // TODO: ?
+				Required: true,
+				ValidateFunc: validateAny(
+					validateOnceADayWindowFormat,
+					validateOnceAWeekWindowFormat,
+				),
 			},
 
 			"preferred_maintenance_window": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validateAny(
+					validateOnceADayWindowFormat,
+					validateOnceAWeekWindowFormat,
+				),
 			},
 
 			// TODO:
@@ -122,9 +131,10 @@ func resourceAwsOpsworksChef() *schema.Resource {
 			// TODO: document this role creation
 			// https://s3.amazonaws.com/opsworks-cm-us-east-1-prod-default-assets/misc/opsworks-cm-roles.yaml
 			"service_role_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 
 			// TODO: huh?
@@ -159,8 +169,6 @@ func resourceAwsOpsworksChef() *schema.Resource {
 
 func resourceAwsOpsworksChefValidate(d *schema.ResourceData) error {
 	// TODO: validation function
-	// preferredMaintenanceWindow := d.Get("preferred_maintenance_window")
-	// preferredBackupWindow := d.Get("preferred_backup_window")
 	// engineModel? // really depends if/how we're enforcing that there's only one actual valid value for these
 	// engineVersion?
 	// chefPivotalKey validate rsa? or is that too much?

--- a/aws/resource_aws_opsworks_chef_test.go
+++ b/aws/resource_aws_opsworks_chef_test.go
@@ -101,14 +101,16 @@ func testAccAwsOpsworksChefConfigCreate(name string) string {
 			name = "opsworks_chef"
 			description = "security group for opsworks chef server"
 			vpc_id = "${aws_vpc.tf-acc.id}"
-			
+
 			ingress {
+				protocol = "TCP"
 				from_port = 0
 				to_port = 443
 				cidr_blocks = ["0.0.0.0/0"]
 			}
 			
 			ingress {
+				protocol = "TCP"
 				from_port = 0
 				to_port = 22
 				cidr_blocks = ["0.0.0.0/0"]
@@ -138,7 +140,7 @@ func testAccAwsOpsworksChefConfigCreate(name string) string {
 		}
 
 		resource "aws_opsworks_chef" "%s" {
-			chef_pivotal_key = "${tls_private_key.private_key_pem}"
+			chef_pivotal_key = "${tls_private_key.opsworks_chef_rsa_key.private_key_pem}"
 			chef_delivery_admin_password = "${random_string.opsworks_chef_admin_password.result}"
 			instance_profile_arn = "${aws_iam_instance_profile.opsworks_chef_instance.arn}"
 			instance_type = "t2.medium"

--- a/aws/resource_aws_opsworks_chef_test.go
+++ b/aws/resource_aws_opsworks_chef_test.go
@@ -1,0 +1,166 @@
+package aws
+
+// import (
+// 	"fmt"
+// 	"testing"
+//
+// 	"github.com/hashicorp/terraform/helper/acctest"
+// 	"github.com/hashicorp/terraform/helper/resource"
+// 	"github.com/hashicorp/terraform/terraform"
+//
+// 	"github.com/aws/aws-sdk-go/aws"
+// 	"github.com/aws/aws-sdk-go/aws/awserr"
+// 	"github.com/aws/aws-sdk-go/service/opsworks"
+// )
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSOpsworksChefImportBasic(t *testing.T) {
+	name := acctest.RandString(10)
+
+	resourceName := fmt.Sprintf("aws_opsworks_chef.%s", name)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksChefDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksChefConfigCreate(name),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsOpsworksChefConfigCreate(name string) string {
+	return fmt.Sprintf(`
+		resource "aws_vpc" "tf-acc" {
+			cidr_block = "10.3.5.0/24"
+			tags = {
+				Name = "terraform-testacc-opsworks-chef-create"
+			}
+		}
+
+		// per https://s3.amazonaws.com/opsworks-cm-us-east-1-prod-default-assets/misc/opsworks-cm-roles.yaml
+		// per https://docs.aws.amazon.com/sdk-for-go/api/service/opsworkscm/
+		resource "aws_iam_role" "opsworks_chef_instance_role" {
+			name = "opsworks_chef_instance_role"
+			assume_role_policy = "${data.aws_iam_policy_document.opsworks_chef_instance_assumerole.json}"
+			path = "/"
+		}
+		
+		data "aws_iam_policy_document" "opsworks_chef_instance_assumerole" {
+			statement {
+				actions = ["sts:AssumeRole"]
+				principals {
+					type = "Service"
+					identifiers = ["ec2.amazonaws.com"]
+				}
+			}
+		}
+		
+		resource "aws_iam_role_policy_attachment" "opswork_chef_instance_role_ssm" {
+			role = "${aws_iam_role.opsworks_chef_instance_role.name}"
+			policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+		}
+		
+		resource "aws_iam_role_policy_attachment" "opsworks_chef_instance_role_profile" {
+			role = "${aws_iam_role.opsworks_chef_instance_role.name}"
+			policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCMInstanceProfileRole"
+		}
+
+		resource "aws_iam_instance_profile" "opsworks_chef_instance_profile" {
+			name = "opsworks_chef_instance_profile"
+			role = "${aws_iam_role.opsworks_chef_instance_role.name}"
+		}
+		
+		resource "aws_iam_role" "opsworks_chef_service" {
+			name = "opsworks_chef_service_role"
+			assume_role_policy = "${data.aws_iam_policy_document.opsworks_chef_service_assumerole.json}"
+			path = "/"
+		}
+		
+		data "aws_iam_policy_document" "opsworks_chef_service_assumerole" {
+			statement {
+				actions = ["sts:AssumeRole"]
+				principals {
+					type = "Service"
+					identifiers = ["opsworks-cm.amazonaws.com"]
+				}
+			}
+		}
+		
+		resource "aws_iam_role_policy_attachment" "opsworks_chef_service_role" {
+			role       = "${aws_iam_role.opsworks_chef_service.name}"
+			policy_arn = "arn:aws:iam::aws:policy/service-role/AWSOpsWorksCMServiceRole"
+		}
+		
+		resource "aws_security_group" "opsworks_chef" {
+			name = "opsworks_chef"
+			description = "security group for opsworks chef server"
+			vpc_id = "${aws_vpc.tf-acc.id}"
+			
+			ingress {
+				from_port = 0
+				to_port = 443
+				cidr_blocks = ["0.0.0.0/0"]
+			}
+			
+			ingress {
+				from_port = 0
+				to_port = 22
+				cidr_blocks = ["0.0.0.0/0"]
+			}
+		}
+
+		resource "aws_subnet" "tf-acc" {
+			vpc_id = "${aws_vpc.tf-acc.id}"
+			cidr_block = "${aws_vpc.tf-acc.cidr_block}"
+			availability-zone = "us-west-2a"
+			tags = {
+				Name = "tf-acc-opsworks-chef-create"
+			}
+		}
+
+		resource "tls_private_key" "opsworks_chef_rsa_key" {
+			algorithm = "RSA"
+		}
+		
+		resource "random_string" "opsworks_chef_admin_password" {
+			length = 24
+			min_lower = 1
+			min_upper = 1
+			min_numeric = 1
+			min_special = 1
+			override_special = "!/@#$%%^&+=_"
+		}
+
+		resource "aws_opsworks_chef" "%s" {
+			chef_pivotal_key = "${tls_private_key.private_key_pem}"
+			chef_delivery_admin_password = "${random_string.opsworks_chef_admin_password.result}"
+			instance_profile_arn = "${aws_iam_instance_profile.opsworks_chef_instance.arn}"
+			instance_type = "t2.medium"
+			preferred_backup_window = "Mon:08:00"
+			preferred_maintenance_window = "Sun:08:00"
+			security_group_ids = ["${aws_security_group.opsworks_chef.id}"]
+			service_role_arn = "${aws_iam_role.opsworks_chef_service.arn}"
+			subnet_ids = ["${aws_subnet.tf-acc.id}"]
+		}
+		`, name)
+}
+
+func testAccCheckAwsOpsworksChefDestroy(s *terraform.State) error {
+	// TODO: implement
+	return fmt.Errorf("not implemented")
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1011,6 +1011,16 @@ func validateOnceADayWindowFormat(v interface{}, k string) (ws []string, errors 
 	return
 }
 
+func validateStartTimeFormat(v interface{}, k string) (ws []string, errors []error) {
+	validFormat := "^((mon|tue|wed|thu|fri|sat|sun):)?([0-1][0-9]|2[0-3]):[0-5][0-9]$"
+	value := strings.ToLower(v.(string))
+	if !regexp.MustCompile(validFormat).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must satisfy the format of \"ddd:hh24:mi\", (\"ddd:\" is optional).", k))
+	}
+	return
+}
+
 // Validates that ECS Placement Constraints are set correctly
 // Takes type, and expression as strings
 func validateAwsEcsPlacementConstraint(constType, constExpr string) error {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #403

Changes proposed in this pull request:

* Add support for provisioning OpsWorks for Chef Automate instances
* Tests and documentation for above

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

WIP WIP WIP WIP WIP
...
```
