### PR TITLE
Fix issue when creating default route table that has a route propagation

### DIFF
--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -212,6 +212,10 @@ func revokeAllRouteTableRules(defaultRouteTableId string, meta interface{}) erro
 			// See aws_vpc_endpoint
 			continue
 		}
+		if *r.Origin == "EnableVgwRoutePropagation" {
+			// Skipping because its from a Gateway associations. Already removed above
+			continue
+		}
 
 		if r.DestinationCidrBlock != nil {
 			log.Printf(


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes issue where creating a new `aws_default_route_table` that contains routes propagated from a virtual gateway would fail since it would try to remove the propagated route as if it was a user defined route.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDefaultRouteTable'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDefaultRouteTable -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDefaultRouteTable_basic
=== PAUSE TestAccAWSDefaultRouteTable_basic
=== RUN   TestAccAWSDefaultRouteTable_swap
=== PAUSE TestAccAWSDefaultRouteTable_swap
=== RUN   TestAccAWSDefaultRouteTable_Route_TransitGatewayID
=== PAUSE TestAccAWSDefaultRouteTable_Route_TransitGatewayID
=== RUN   TestAccAWSDefaultRouteTable_vpc_endpoint
=== PAUSE TestAccAWSDefaultRouteTable_vpc_endpoint
=== CONT  TestAccAWSDefaultRouteTable_basic
=== CONT  TestAccAWSDefaultRouteTable_vpc_endpoint
=== CONT  TestAccAWSDefaultRouteTable_Route_TransitGatewayID
=== CONT  TestAccAWSDefaultRouteTable_swap
--- PASS: TestAccAWSDefaultRouteTable_basic (40.43s)
--- PASS: TestAccAWSDefaultRouteTable_vpc_endpoint (41.52s)
--- PASS: TestAccAWSDefaultRouteTable_swap (58.95s)
--- PASS: TestAccAWSDefaultRouteTable_Route_TransitGatewayID (324.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	324.636s
...
```
