### PR TITLE
resource/dynamodb_table: Support final_backup_identifier

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -628,7 +628,7 @@ func resourceAwsDynamoDbTableDelete(d *schema.ResourceData, meta interface{}) er
 			BackupName: aws.String(backupName.(string)),
 			TableName:  aws.String(d.Id()),
 		}
-		err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+		err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 			_, err := conn.CreateBackup(backupInput)
 			if err == nil {
 				return nil

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -2034,7 +2034,7 @@ resource "aws_dynamodb_table" "test" {
     type = "S"
   }
 
-	final_backup_identifier = "%s"
+  final_backup_identifier = "%s"
 }
 `, rName, rName)
 }

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -1014,6 +1014,26 @@ func TestAccAWSDynamoDbTable_encryption(t *testing.T) {
 	})
 }
 
+func TestAccAWSDynamoDbTable_final_backup(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbConfig_final_backup(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.test", &conf),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSDynamoDbTableDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
 
@@ -1999,4 +2019,22 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
   }
 }
 `, rName, attrName1, attrType1, attrName2, attrType2, hashKey, rangeKey)
+}
+
+func testAccAWSDynamoDbConfig_final_backup(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name = "%s"
+  read_capacity = 1
+  write_capacity = 1
+  hash_key = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+	final_backup_identifier = "%s"
+}
+`, rName, rName)
 }

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -106,8 +106,7 @@ attributes, etc.
 * `server_side_encryption` - (Optional) Encryption at rest options. AWS DynamoDB tables are automatically encrypted at rest with an AWS owned Customer Master Key if this argument isn't specified.
 * `tags` - (Optional) A map of tags to populate on the created table.
 * `point_in_time_recovery` - (Optional) Point-in-time recovery options.
-* `final_backup_identifier` - (Optional) The name of your final table backup
-when this table is deleted. If omitted, no final backup will be made.
+* `final_backup_identifier` - (Optional) The name of your final table backup when this table is deleted. If omitted, no final backup will be made.
 
 ### Timeouts
 

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -106,6 +106,8 @@ attributes, etc.
 * `server_side_encryption` - (Optional) Encryption at rest options. AWS DynamoDB tables are automatically encrypted at rest with an AWS owned Customer Master Key if this argument isn't specified.
 * `tags` - (Optional) A map of tags to populate on the created table.
 * `point_in_time_recovery` - (Optional) Point-in-time recovery options.
+* `final_backup_identifier` - (Optional) The name of your final table backup
+when this table is deleted. If omitted, no final backup will be made.
 
 ### Timeouts
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Closes #4175

Changes proposed in this pull request:

* Add `final_backup_identifier` which creates backup when the table will be deleted.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDynamoDbTable_final_backup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDynamoDbTable_final_backup -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_final_backup
=== PAUSE TestAccAWSDynamoDbTable_final_backup
=== CONT  TestAccAWSDynamoDbTable_final_backup
--- PASS: TestAccAWSDynamoDbTable_final_backup (225.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	225.328s
```
