### PR TITLE
Feature/add database name validation for aws glue resources

### DIFF
--- a/aws/resource_aws_glue_catalog_database.go
+++ b/aws/resource_aws_glue_catalog_database.go
@@ -30,9 +30,10 @@ func resourceAwsGlueCatalogDatabase() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateGlueDatabaseName,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -28,9 +28,10 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 				Computed: true,
 			},
 			"database_name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateGlueDatabaseName,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2423,3 +2423,16 @@ func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors [
 
 	return
 }
+
+func validateGlueDatabaseName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) < 1 {
+		errors = append(errors, fmt.Errorf("%q cannot be shorter than 1 character", k))
+	} else if len(value) > 255 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 255 characters", k))
+	} else if regexp.MustCompile(`[A-Z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain uppercase alphanumeric characters", k))
+	}
+	return
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7958 

Changes proposed in this pull request:

* Add validation for database name for `aws_glue_catalog_database` and `aws_glue_catalog_table` resources.

Output from acceptance testing:

* `aws_glue_catalog_database`

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCatalogDatabase_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSGlueCatalogDatabase_ -timeout 120m
=== RUN   TestAccAWSGlueCatalogDatabase_importBasic
=== PAUSE TestAccAWSGlueCatalogDatabase_importBasic
=== RUN   TestAccAWSGlueCatalogDatabase_validation
=== PAUSE TestAccAWSGlueCatalogDatabase_validation
=== RUN   TestAccAWSGlueCatalogDatabase_full
=== PAUSE TestAccAWSGlueCatalogDatabase_full
=== RUN   TestAccAWSGlueCatalogDatabase_recreates
=== PAUSE TestAccAWSGlueCatalogDatabase_recreates
=== CONT  TestAccAWSGlueCatalogDatabase_importBasic
=== CONT  TestAccAWSGlueCatalogDatabase_recreates
=== CONT  TestAccAWSGlueCatalogDatabase_full
=== CONT  TestAccAWSGlueCatalogDatabase_validation
--- PASS: TestAccAWSGlueCatalogDatabase_validation (7.48s)
--- PASS: TestAccAWSGlueCatalogDatabase_recreates (33.01s)
--- PASS: TestAccAWSGlueCatalogDatabase_importBasic (34.80s)
--- PASS: TestAccAWSGlueCatalogDatabase_full (73.09s)
PASS
ok  	github.com/terraform-providers/tmp-terraform-provider-aws/aws	73.143s
```

* `aws_glue_catalog_table`

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCatalogTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSGlueCatalogTable_ -timeout 120m
=== RUN   TestAccAWSGlueCatalogTable_importBasic
=== PAUSE TestAccAWSGlueCatalogTable_importBasic
=== RUN   TestAccAWSGlueCatalogTable_basic
=== PAUSE TestAccAWSGlueCatalogTable_basic
=== RUN   TestAccAWSGlueCatalogTable_full
=== PAUSE TestAccAWSGlueCatalogTable_full
=== RUN   TestAccAWSGlueCatalogTable_update_addValues
=== PAUSE TestAccAWSGlueCatalogTable_update_addValues
=== RUN   TestAccAWSGlueCatalogTable_update_replaceValues
=== PAUSE TestAccAWSGlueCatalogTable_update_replaceValues
=== CONT  TestAccAWSGlueCatalogTable_importBasic
=== CONT  TestAccAWSGlueCatalogTable_full
=== CONT  TestAccAWSGlueCatalogTable_basic
=== CONT  TestAccAWSGlueCatalogTable_update_replaceValues
=== CONT  TestAccAWSGlueCatalogTable_update_addValues
--- PASS: TestAccAWSGlueCatalogTable_basic (33.85s)
--- PASS: TestAccAWSGlueCatalogTable_full (34.45s)
--- PASS: TestAccAWSGlueCatalogTable_importBasic (37.49s)
--- PASS: TestAccAWSGlueCatalogTable_update_replaceValues (54.69s)
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (54.81s)
PASS
ok  	github.com/terraform-providers/tmp-terraform-provider-aws/aws	54.886s
```
