### PR TITLE
Increase timeout period for creating lambda functions

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -387,8 +387,8 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 		params.Tags = tagsFromMapGeneric(v.(map[string]interface{}))
 	}
 
-	// IAM changes can take 1 minute to propagate in AWS
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	// IAM changes can take 3 minute to propagate in AWS
+	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 		_, err := conn.CreateFunction(params)
 		if err != nil {
 			log.Printf("[DEBUG] Error creating Lambda Function: %s", err)
@@ -756,8 +756,8 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 	if configUpdate {
 		log.Printf("[DEBUG] Send Update Lambda Function Configuration request: %#v", configReq)
 
-		// IAM changes can take 1 minute to propagate in AWS
-		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		// IAM changes can take 3 minute to propagate in AWS
+		err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 			_, err := conn.UpdateFunctionConfiguration(configReq)
 			if err != nil {
 				log.Printf("[DEBUG] Received error modifying Lambda Function Configuration %s: %s", d.Id(), err)


### PR DESCRIPTION
IAM seems to take more than a minute some times and we're semi-regularly hit with this error:

```
Error creating Lambda function: InvalidParameterValueException: The provided execution role does not have permissions to call SendMessage on SQS
```

Increasing this retry count might help.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8248 

Changes proposed in this pull request:

* Increase the timeout period to allow more time for IAM eventual consistency problems.

Output from acceptance testing:

```
❯ env AWS_PROFILE=default make testacc TESTARGS='-run=TestAccAWSLambdaFunction'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaFunction -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLambdaFunction_importLocalFile
=== PAUSE TestAccAWSLambdaFunction_importLocalFile
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
=== PAUSE TestAccAWSLambdaFunction_importLocalFile_VPC
=== RUN   TestAccAWSLambdaFunction_importS3
=== PAUSE TestAccAWSLambdaFunction_importS3
=== RUN   TestAccAWSLambdaFunction_basic
=== PAUSE TestAccAWSLambdaFunction_basic
=== RUN   TestAccAWSLambdaFunction_concurrency
=== PAUSE TestAccAWSLambdaFunction_concurrency
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
=== PAUSE TestAccAWSLambdaFunction_concurrencyCycle
=== RUN   TestAccAWSLambdaFunction_updateRuntime
=== PAUSE TestAccAWSLambdaFunction_updateRuntime
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccAWSLambdaFunction_envVariables
=== PAUSE TestAccAWSLambdaFunction_envVariables
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccAWSLambdaFunction_encryptedEnvVariables
=== RUN   TestAccAWSLambdaFunction_versioned
=== PAUSE TestAccAWSLambdaFunction_versioned
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
=== PAUSE TestAccAWSLambdaFunction_versionedUpdate
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_nilDeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_tracingConfig
=== PAUSE TestAccAWSLambdaFunction_tracingConfig
=== RUN   TestAccAWSLambdaFunction_Layers
=== PAUSE TestAccAWSLambdaFunction_Layers
=== RUN   TestAccAWSLambdaFunction_LayersUpdate
=== PAUSE TestAccAWSLambdaFunction_LayersUpdate
=== RUN   TestAccAWSLambdaFunction_VPC
=== PAUSE TestAccAWSLambdaFunction_VPC
=== RUN   TestAccAWSLambdaFunction_VPCRemoval
=== PAUSE TestAccAWSLambdaFunction_VPCRemoval
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
=== PAUSE TestAccAWSLambdaFunction_VPCUpdate
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== RUN   TestAccAWSLambdaFunction_EmptyVpcConfig
=== PAUSE TestAccAWSLambdaFunction_EmptyVpcConfig
=== RUN   TestAccAWSLambdaFunction_s3
=== PAUSE TestAccAWSLambdaFunction_s3
=== RUN   TestAccAWSLambdaFunction_localUpdate
=== PAUSE TestAccAWSLambdaFunction_localUpdate
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
=== PAUSE TestAccAWSLambdaFunction_localUpdate_nameOnly
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
=== PAUSE TestAccAWSLambdaFunction_s3Update_basic
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
=== PAUSE TestAccAWSLambdaFunction_s3Update_unversioned
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_NodeJs810
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_NodeJs810
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python27
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python27
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_java8
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_java8
=== RUN   TestAccAWSLambdaFunction_tags
=== PAUSE TestAccAWSLambdaFunction_tags
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_provided
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_provided
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python36
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python36
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python37
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python37
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_ruby25
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_ruby25
=== CONT  TestAccAWSLambdaFunction_importLocalFile
=== CONT  TestAccAWSLambdaFunction_VPCRemoval
=== CONT  TestAccAWSLambdaFunction_tags
=== CONT  TestAccAWSLambdaFunction_versioned
=== CONT  TestAccAWSLambdaFunction_VPC
=== CONT  TestAccAWSLambdaFunction_LayersUpdate
=== CONT  TestAccAWSLambdaFunction_Layers
=== CONT  TestAccAWSLambdaFunction_tracingConfig
=== CONT  TestAccAWSLambdaFunction_nilDeadLetterConfig
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfig
=== CONT  TestAccAWSLambdaFunction_versionedUpdate
=== CONT  TestAccAWSLambdaFunction_localUpdate
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_NodeJs810
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
=== CONT  TestAccAWSLambdaFunction_s3Update_basic
=== CONT  TestAccAWSLambdaFunction_localUpdate_nameOnly
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_provided
=== CONT  TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (2.35s)
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_ruby25
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (44.01s)
=== CONT  TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs810 (53.79s)
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python37
--- PASS: TestAccAWSLambdaFunction_versioned (56.83s)
=== CONT  TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_importLocalFile (58.37s)
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python36
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (59.25s)
=== CONT  TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (63.81s)
=== CONT  TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (68.09s)
=== CONT  TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_localUpdate (69.34s)
=== CONT  TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_Layers (69.66s)
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_java8
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (70.21s)
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python27
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (70.40s)
=== CONT  TestAccAWSLambdaFunction_EmptyVpcConfig
--- PASS: TestAccAWSLambdaFunction_VPC (76.88s)
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_tracingConfig (78.22s)
=== CONT  TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (22.13s)
=== CONT  TestAccAWSLambdaFunction_VPCUpdate
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (83.27s)
=== CONT  TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (84.57s)
=== CONT  TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (86.30s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (88.80s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (94.21s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (96.13s)
--- PASS: TestAccAWSLambdaFunction_tags (101.07s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (48.21s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (47.58s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (38.53s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (39.51s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (40.60s)
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (43.83s)
--- PASS: TestAccAWSLambdaFunction_s3 (37.26s)
--- PASS: TestAccAWSLambdaFunction_importS3 (51.81s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (53.80s)
--- PASS: TestAccAWSLambdaFunction_basic (37.07s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (81.98s)
--- PASS: TestAccAWSLambdaFunction_concurrency (51.44s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (63.58s)
--- PASS: TestAccAWSLambdaFunction_envVariables (92.60s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (84.85s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       161.781s
```
