### PR TITLE
Added Error output prefix to Firehose S3 backup configuration

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1367,6 +1367,7 @@ func expandS3BackupConfig(d map[string]interface{}) *firehose.S3DestinationConfi
 			SizeInMBs:         aws.Int64(int64(s3["buffer_size"].(int))),
 		},
 		Prefix:                  extractPrefixConfiguration(s3),
+		ErrorOutputPrefix:       extractErrorOutputPrefixConfiguration(s3),
 		CompressionFormat:       aws.String(s3["compression_format"].(string)),
 		EncryptionConfiguration: extractEncryptionConfiguration(s3),
 	}
@@ -1453,6 +1454,7 @@ func updateS3BackupConfig(d map[string]interface{}) *firehose.S3DestinationUpdat
 			SizeInMBs:         aws.Int64((int64)(s3["buffer_size"].(int))),
 		},
 		Prefix:                   extractPrefixConfiguration(s3),
+		ErrorOutputPrefix:        extractErrorOutputPrefixConfiguration(s3),
 		CompressionFormat:        aws.String(s3["compression_format"].(string)),
 		EncryptionConfiguration:  extractEncryptionConfiguration(s3),
 		CloudWatchLoggingOptions: extractCloudWatchLoggingConfiguration(s3),
@@ -1762,6 +1764,14 @@ func extractCloudWatchLoggingConfiguration(s3 map[string]interface{}) *firehose.
 
 func extractPrefixConfiguration(s3 map[string]interface{}) *string {
 	if v, ok := s3["prefix"]; ok {
+		return aws.String(v.(string))
+	}
+
+	return nil
+}
+
+func extractErrorOutputPrefixConfiguration(s3 map[string]interface{}) *string {
+	if v, ok := s3["error_output_prefix"]; ok {
 		return aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -96,6 +96,63 @@ func s3ConfigurationSchema() *schema.Schema {
 	}
 }
 
+func s3BackupConfigurationSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"bucket_arn": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+
+				"buffer_size": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  5,
+				},
+
+				"buffer_interval": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  300,
+				},
+
+				"compression_format": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "UNCOMPRESSED",
+				},
+
+				"kms_key_arn": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validateArn,
+				},
+
+				"role_arn": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+
+				"prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+
+				"error_output_prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+
+				"cloudwatch_logging_options": cloudWatchLoggingOptionsSchema(),
+			},
+		},
+	}
+}
+
 func processingConfigurationSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
@@ -1033,7 +1090,7 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 							},
 						},
 
-						"s3_backup_configuration": s3ConfigurationSchema(),
+						"s3_backup_configuration": s3BackupConfigurationSchema(),
 
 						"cloudwatch_logging_options": cloudWatchLoggingOptionsSchema(),
 
@@ -1085,7 +1142,7 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 							},
 						},
 
-						"s3_backup_configuration": s3ConfigurationSchema(),
+						"s3_backup_configuration": s3BackupConfigurationSchema(),
 
 						"retry_duration": {
 							Type:     schema.TypeInt,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #6984

Changes proposed in this pull request:

Added Error output prefix to Firehose S3 Backup configuration

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource'
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (122.81s)

 make testacc TESTARGS='-run=TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (162.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       162.185s

```
