### PR TITLE
[WIP] [Advice needed] Add data source SSM Parameters

### DIFF
--- a/aws/data_source_aws_ssm_parameters.go
+++ b/aws/data_source_aws_ssm_parameters.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	//"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	//"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsSsmParameters() *schema.Resource {
+	parameterSchema := map[string]*schema.Schema{
+		"arn": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"type": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"value": {
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+	}
+
+	return &schema.Resource{
+		Read: dataAwsSsmParametersRead,
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:     schema.TypeString,
+				Computed: false,
+				Required: true,
+			},
+			"parameters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: parameterSchema,
+				},
+			},
+		},
+	}
+}
+
+func dataAwsSsmParametersRead(d *schema.ResourceData, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	path := d.Get("path").(string)
+
+	parameters := make([]ssm.Parameter, 0)
+	var nextToken string
+
+	for {
+		paramInput := &ssm.GetParametersByPathInput{
+			Path:           &path,
+			MaxResults:     aws.Int64(10),
+			Recursive:      aws.Bool(false),
+			WithDecryption: aws.Bool(false),
+		}
+
+		if nextToken != "" {
+			paramInput.NextToken = aws.String(nextToken)
+		}
+
+		log.Printf("[DEBUG] Reading SSM Parameters: %s", paramInput)
+		resp, err := ssmconn.GetParametersByPath(paramInput)
+
+		if err != nil {
+			return fmt.Errorf("error describing SSM parameters: %s", err)
+		}
+
+		for _, parameter := range resp.Parameters {
+			parameters = append(parameters, *parameter)
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+		nextToken = *resp.NextToken
+	}
+
+	parsedParameters := make([]*map[string]string, len(parameters))
+	for i, parameter := range parameters {
+		data := awsSsmParameterToMap(&parameter, meta.(*AWSClient))
+		parsedParameters[i] = &data
+	}
+
+	d.SetId(path)
+
+	if err := d.Set("parameters", &parsedParameters); err != nil {
+		return fmt.Errorf("error setting parameters: %s", err)
+	}
+
+	return nil
+}
+
+func awsSsmParameterToMap(parameter *ssm.Parameter, awsClient *AWSClient) map[string]string {
+	arnData := calculateAwsSsmParameterArn(*parameter.Name, awsClient)
+
+	return map[string]string{
+		"arn":   arnData.String(),
+		"name":  aws.StringValue(parameter.Name),
+		"type":  aws.StringValue(parameter.Type),
+		"value": aws.StringValue(parameter.Value),
+	}
+}

--- a/aws/data_source_aws_ssm_parameters_test.go
+++ b/aws/data_source_aws_ssm_parameters_test.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSSsmParametersDataSource_basic(t *testing.T) {
+	resourceName := "data.aws_ssm_parameters.test"
+	name := "/path/parameter"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsSsmParametersDataSourceConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "/path/parameter/value1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "TestValue1"),
+
+					resource.TestCheckResourceAttr(resourceName, "parameters.1.name", "/path/parameter/value2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.1.value", "TestValue2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsSsmParametersDataSourceConfig(name string) string {
+	return fmt.Sprintf(`
+locals {
+	prefix = "%s"
+}
+
+resource "aws_ssm_parameter" "value1" {
+	name = "${local.prefix}/value1"
+	type = "String"
+	value = "TestValue1"
+}
+
+resource "aws_ssm_parameter" "value2" {
+	name = "${local.prefix}/value2"
+	type = "String"
+	value = "TestValue2"
+}
+
+data "aws_ssm_parameters" "test" {
+	path = "${local.prefix}"
+	depends_on = ["aws_ssm_parameter.value1", "aws_ssm_parameter.value2"]
+}
+`, name)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -253,6 +253,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_sqs_queue":                                 dataSourceAwsSqsQueue(),
 			"aws_ssm_document":                              dataSourceAwsSsmDocument(),
 			"aws_ssm_parameter":                             dataSourceAwsSsmParameter(),
+			"aws_ssm_parameters":                            dataSourceAwsSsmParameters(),
 			"aws_storagegateway_local_disk":                 dataSourceAwsStorageGatewayLocalDisk(),
 			"aws_subnet":                                    dataSourceAwsSubnet(),
 			"aws_subnet_ids":                                dataSourceAwsSubnetIDs(),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes prosposed in this PR:
* This should add a new data source called aws_ssm_parameters which  is inteded to fetch keys by path. This is useful when you assume that a specific path will have n keys to be used like /environment/my-machine/dev-keys/{dev-1, dev-2, dev3}
* I also slightly refactored ssm_parameter to reuse its function.

## Missing:
- [ ] Add documentation
- [ ] Fix test output

## Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSsmParametersDataSource_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSsmParametersDataSource_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSsmParametersDataSource_basic
=== PAUSE TestAccAWSSsmParametersDataSource_basic
=== CONT  TestAccAWSSsmParametersDataSource_basic
--- FAIL: TestAccAWSSsmParametersDataSource_basic (31.31s)
    testing.go:538: Step 0 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        CREATE: data.aws_ssm_parameters.test
          parameters.#: "" => "<computed>"
          path:         "" => "/path/parameter"
        
        STATE:
        
        aws_ssm_parameter.value1:
          ID = /path/parameter/value1
          provider = provider.aws
          allowed_pattern = 
          arn = arn:aws:ssm:us-west-2:account-id:parameter/path/parameter/value1
          description = 
          key_id = 
          name = /path/parameter/value1
          tags.% = 0
          type = String
          value = TestValue1
        
          Dependencies:
            local.prefix
        aws_ssm_parameter.value2:
          ID = /path/parameter/value2
          provider = provider.aws
          allowed_pattern = 
          arn = arn:aws:ssm:us-west-2:account-id:parameter/path/parameter/value2
          description = 
          key_id = 
          name = /path/parameter/value2
          tags.% = 0
          type = String
          value = TestValue2
        
          Dependencies:
            local.prefix
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       31.359s
make: *** [testacc] Error 1
```

## My questions
 - The test is breaking and I assume that it is because I am using a data source and it will reload everytime, isn't that the intended behavior?

Let me know if this is useful and if I need to change anything.
Cheers