### PR TITLE
Retry InvalidTarget errors for AWS LB target group attachment.

### DIFF
--- a/aws/resource_aws_lb_target_group_attachment.go
+++ b/aws/resource_aws_lb_target_group_attachment.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
@@ -67,7 +68,19 @@ func resourceAwsLbAttachmentCreate(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[INFO] Registering Target %s with Target Group %s", d.Get("target_id").(string),
 		d.Get("target_group_arn").(string))
 
-	_, err := elbconn.RegisterTargets(params)
+	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := elbconn.RegisterTargets(params)
+
+		if isAWSErr(err, "InvalidTarget", "") {
+			return resource.RetryableError(fmt.Errorf("Error attaching instance to LB, retrying: %s", err))
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("Error registering targets with target group: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8537

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Retry InvalidTarget errors for aws_lb_target_group_attachment resources.
```