### PR TITLE
[WIP] Add option to stop an instance before trying to remove an attached volume

### DIFF
--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -55,6 +55,8 @@ to detach the volume from the instance to which it is attached at destroy
 time, and instead just remove the attachment from Terraform state. This is
 useful when destroying an instance which has volumes created by some other
 means attached.
+* `stop_instance_before_detaching` - (Optional, Boolean) Set this to true to ensure that the target instance is stopped
+before trying to detach the volume. Stops the instance, if it is not already stopped.
 
 ## Attributes Reference
 


### PR DESCRIPTION
So far, if you attached a volume to an instance and the volume is mounted inside the OS
(and in use by an application), it gets quite difficult to detach a volume from an instance without 
potential data loss by a force detach. Otherwise the destroy of a volume attachment often times out.

This adds an option to stop the instance before trying to detach the volume from it.

It is still a WIP because i need help writing tests for it. I'll appreciate every help, if someone feels like it :) 
Right now i only did manual testing and so far everything looks good.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Superceded, fixed by #21144

Fixes #6673
Fixes #2084
Fixes #2957
Fixes #4770
Fixes #288
Fixes #1017
Relates #4293
Relates #1991

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
Add option `stop_instance_before_detaching` to aws_volume_attachment to stop an instance before trying to detach a volume.
```
