### PR TITLE
Add the ability to ses_receipt_rule sns_action to set the encoding property

### DIFF
--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -269,6 +269,11 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 							Required: true,
 						},
 
+						"encoding": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"position": {
 							Type:     schema.TypeInt,
 							Required: true,
@@ -279,6 +284,11 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 					var buf bytes.Buffer
 					m := v.(map[string]interface{})
 					buf.WriteString(fmt.Sprintf("%s-", m["topic_arn"].(string)))
+
+					if _, ok := m["encoding"]; ok {
+						buf.WriteString(fmt.Sprintf("%s-", m["encoding"].(string)))
+					}
+
 					buf.WriteString(fmt.Sprintf("%d-", m["position"].(int)))
 
 					return hashcode.String(buf.String())
@@ -533,6 +543,10 @@ func resourceAwsSesReceiptRuleRead(d *schema.ResourceData, meta interface{}) err
 				"position":  i + 1,
 			}
 
+			if element.SNSAction.Encoding != nil {
+				snsAction["encoding"] = *element.SNSAction.Encoding
+			}
+
 			snsActionList = append(snsActionList, snsAction)
 		}
 
@@ -728,6 +742,10 @@ func buildReceiptRule(d *schema.ResourceData) *ses.ReceiptRule {
 
 			snsAction := &ses.SNSAction{
 				TopicArn: aws.String(elem["topic_arn"].(string)),
+			}
+
+			if elem["encoding"] != "" {
+				snsAction.Encoding = aws.String(elem["encoding"].(string))
 			}
 
 			actions[elem["position"].(int)] = &ses.ReceiptAction{

--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -271,6 +271,7 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 
 						"encoding": {
 							Type:     schema.TypeString,
+							Default:  aws.String("UTF-8"),
 							Optional: true,
 						},
 

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -358,7 +358,7 @@ func testAccCheckAwsSESReceiptRuleSNSAction(n string) resource.TestCheckFunc {
 
 		snsActionAction := actions[0].SNSAction
 		if *snsActionAction.Encoding != "UTF-8" {
-			return fmt.Errorf("Encoding (%s) was not equal to Base64", *snsActionAction.Encoding)
+			return fmt.Errorf("Encoding (%s) was not equal to UTF-8", *snsActionAction.Encoding)
 		}
 
 		return nil

--- a/website/docs/r/ses_receipt_rule.html.markdown
+++ b/website/docs/r/ses_receipt_rule.html.markdown
@@ -87,6 +87,7 @@ SNS actions support the following:
 
 * `topic_arn` - (Required) The ARN of an SNS topic to notify
 * `position` - (Required) The position of the action in the receipt rule
+* `encoding` - (Optional) The encoding to use for the email within the SNS notification
 
 Stop actions support the following:
 


### PR DESCRIPTION
The aws terraform provider does not give the ability to override the encoding property (gained by using sns_action) when using the ses_receipt_rule resource. By default aws cli defaults to UTF-8, but it is beneficial to encode with Base64 when wanting to preserve characters. This PR provides a `encoding` attribute to be used with sns_action that is optional. The two values expected to be used with this attribute are: `UTF-8` and `Base64`, although if not explicitly stated UTF-8 is the default.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #10855 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
allows the setting of the sns encoding when using sns_action with ses_receipt_rule
```

