### PR TITLE
d/aws_route53_resolver_endpoint: Add Route53resolver endpoint datasource

### DIFF
--- a/aws/data_source_aws_route53_resolver_endpoint.go
+++ b/aws/data_source_aws_route53_resolver_endpoint.go
@@ -1,0 +1,178 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsRoute53ResolverEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRoute53ResolverEndpointRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+
+			"direction": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_addresses": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+	req := &route53resolver.ListResolverEndpointsInput{}
+
+	resolvers := make([]*route53resolver.ResolverEndpoint, 0)
+
+	rID, rIDOk := d.GetOk("id")
+	filters, filtersOk := d.GetOk("filter")
+
+	if filtersOk {
+		req.Filters = buildR53ResolverTagFilters(filters.(*schema.Set))
+	}
+
+	for {
+		resp, err := conn.ListResolverEndpoints(req)
+
+		if err != nil {
+			return fmt.Errorf("Error Reading Route53 Resolver Endpoints: %s", req)
+		}
+
+		if len(resp.ResolverEndpoints) == 0 && filtersOk {
+			return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+		}
+
+		if len(resp.ResolverEndpoints) > 1 && !rIDOk {
+			return fmt.Errorf("Your query returned more than one resolver. Please change your search criteria and try again.")
+		}
+
+		if rIDOk {
+			for _, r := range resp.ResolverEndpoints {
+				if aws.StringValue(r.Id) == rID {
+					resolvers = append(resolvers, r)
+					break
+				}
+			}
+		} else {
+			resolvers = append(resolvers, resp.ResolverEndpoints[0])
+		}
+
+		if len(resolvers) == 0 {
+			return fmt.Errorf("The ID provided could not be found")
+		}
+
+		resolver := resolvers[0]
+
+		d.SetId(aws.StringValue(resolver.Id))
+		d.Set("arn", aws.StringValue(resolver.Arn))
+		d.Set("status", aws.StringValue(resolver.Status))
+		d.Set("name", aws.StringValue(resolver.Name))
+		d.Set("vpc_id", aws.StringValue(resolver.HostVPCId))
+		d.Set("direction", aws.StringValue(resolver.Direction))
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		req.NextToken = resp.NextToken
+	}
+
+	params := &route53resolver.ListResolverEndpointIpAddressesInput{
+		ResolverEndpointId: aws.String(d.Id()),
+	}
+
+	ipAddresses := []interface{}{}
+
+	for {
+		ip, err := conn.ListResolverEndpointIpAddresses(params)
+
+		if err != nil {
+			return fmt.Errorf("error getting Route53 Resolver endpoint (%s) IP Addresses: %s", d.Id(), err)
+		}
+
+		for _, vIPAddresses := range ip.IpAddresses {
+			ipAddresses = append(ipAddresses, aws.StringValue(vIPAddresses.Ip))
+		}
+
+		d.Set("ip_addresses", ipAddresses)
+
+		if ip.NextToken == nil {
+			break
+		}
+
+		params.NextToken = ip.NextToken
+	}
+
+	return nil
+}
+
+func buildR53ResolverTagFilters(set *schema.Set) []*route53resolver.Filter {
+	var filters []*route53resolver.Filter
+
+	for _, v := range set.List() {
+		m := v.(map[string]interface{})
+		var filterValues []*string
+		for _, e := range m["values"].([]interface{}) {
+			filterValues = append(filterValues, aws.String(e.(string)))
+		}
+		filters = append(filters, &route53resolver.Filter{
+			Name:   aws.String(m["name"].(string)),
+			Values: filterValues,
+		})
+	}
+
+	return filters
+}

--- a/aws/data_source_aws_route53_resolver_endpoint.go
+++ b/aws/data_source_aws_route53_resolver_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceAwsRoute53ResolverEndpoint() *schema.Resource {
@@ -92,11 +92,11 @@ func dataSourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta inter
 		}
 
 		if len(resp.ResolverEndpoints) == 0 && filtersOk {
-			return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+			return fmt.Errorf("Your query returned no results. Please change your search criteria and try again")
 		}
 
 		if len(resp.ResolverEndpoints) > 1 && !rIDOk {
-			return fmt.Errorf("Your query returned more than one resolver. Please change your search criteria and try again.")
+			return fmt.Errorf("your query returned more than one resolver. Please change your search criteria and try again")
 		}
 
 		if rIDOk {

--- a/aws/data_source_aws_route53_resolver_endpoint.go
+++ b/aws/data_source_aws_route53_resolver_endpoint.go
@@ -48,7 +48,7 @@ func dataSourceAwsRoute53ResolverEndpoint() *schema.Resource {
 				Computed: true,
 			},
 
-			"id": {
+			"resolver_endpoint_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -77,7 +77,7 @@ func dataSourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta inter
 
 	resolvers := make([]*route53resolver.ResolverEndpoint, 0)
 
-	rID, rIDOk := d.GetOk("id")
+	rID, rIDOk := d.GetOk("resolver_endpoint_id")
 	filters, filtersOk := d.GetOk("filter")
 
 	if filtersOk {
@@ -96,7 +96,7 @@ func dataSourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta inter
 		}
 
 		if len(resp.ResolverEndpoints) > 1 && !rIDOk {
-			return fmt.Errorf("your query returned more than one resolver. Please change your search criteria and try again")
+			return fmt.Errorf("Your query returned more than one resolver. Please change your search criteria and try again")
 		}
 
 		if rIDOk {
@@ -117,6 +117,7 @@ func dataSourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta inter
 		resolver := resolvers[0]
 
 		d.SetId(aws.StringValue(resolver.Id))
+		d.Set("resolver_endpoint_id", resolver.Id)
 		d.Set("arn", aws.StringValue(resolver.Arn))
 		d.Set("status", aws.StringValue(resolver.Status))
 		d.Set("name", aws.StringValue(resolver.Name))

--- a/aws/data_source_aws_route53_resolver_endpoint_test.go
+++ b/aws/data_source_aws_route53_resolver_endpoint_test.go
@@ -1,0 +1,215 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsRoute53ResolverEndpoint_Basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	rInt := acctest.RandInt()
+	direction := "INBOUND"
+	resourceName := "aws_route53_resolver_endpoint.foo"
+	datasourceName := "data.aws_route53_resolver_endpoint.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistent,
+				ExpectError: regexp.MustCompile("The ID provided could not be found"),
+			},
+			{
+				Config: testAccDataSourceRoute53ResolverEndpointConfig_initial(rInt, direction, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "ip_addresses.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRoute53ResolverEndpoint_Filter(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	rInt := acctest.RandInt()
+	direction := "OUTBOUND"
+	resourceName := "aws_route53_resolver_endpoint.foo"
+	datasourceName := "data.aws_route53_resolver_endpoint.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistentFilter,
+				ExpectError: regexp.MustCompile("Your query returned no results. Please change your search criteria and try again."),
+			},
+			{
+				Config: testAccDataSourceRoute53ResolverEndpointConfig_filter(rInt, direction, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "ip_addresses.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRoute53ResolverEndpointConfig_base(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "foo" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "terraform-testacc-r53-resolver-vpc-%d"
+  }
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "sn1" {
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 0)}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+
+  tags = {
+    Name = "tf-acc-r53-resolver-sn1-%d"
+  }
+}
+
+resource "aws_subnet" "sn2" {
+  vpc_id            = "${aws_vpc.foo.id}"
+
+  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 1)}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+
+  tags = {
+    Name = "tf-acc-r53-resolver-sn2-%d"
+  }
+}
+
+resource "aws_subnet" "sn3" {
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 2)}"
+  availability_zone = "${data.aws_availability_zones.available.names[2]}"
+
+  tags = {
+    Name = "tf-acc-r53-resolver-sn3-%d"
+  }
+}
+
+resource "aws_security_group" "sg1" {
+  vpc_id = "${aws_vpc.foo.id}"
+  name   = "tf-acc-r53-resolver-sg1-%d"
+
+  tags = {
+    Name = "tf-acc-r53-resolver-sg1-%d"
+  }
+}
+
+resource "aws_security_group" "sg2" {
+  vpc_id = "${aws_vpc.foo.id}"
+  name   = "tf-acc-r53-resolver-sg2-%d"
+
+  tags = {
+    Name = "tf-acc-r53-resolver-sg2-%d"
+  }
+}
+`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccDataSourceRoute53ResolverEndpointConfig_initial(rInt int, direction, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_route53_resolver_endpoint" "foo" {
+  direction = "%s"
+  name      = "%s"
+
+  security_group_ids = [
+    "${aws_security_group.sg1.id}",
+    "${aws_security_group.sg2.id}",
+  ]
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn1.id}"
+  }
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn2.id}"
+    ip        = "${cidrhost(aws_subnet.sn2.cidr_block, 8)}"
+  }
+
+  tags = {
+    Environment = "production"
+    Usage = "original"
+  }
+}
+
+data "aws_route53_resolver_endpoint" "foo" {
+	id = "${aws_route53_resolver_endpoint.foo.id}"
+}
+`, testAccDataSourceRoute53ResolverEndpointConfig_base(rInt), direction, name)
+}
+
+func testAccDataSourceRoute53ResolverEndpointConfig_filter(rInt int, direction, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_route53_resolver_endpoint" "foo" {
+  direction = "%s"
+  name      = "%s"
+
+  security_group_ids = [
+    "${aws_security_group.sg1.id}",
+    "${aws_security_group.sg2.id}",
+  ]
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn1.id}"
+  }
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn2.id}"
+    ip        = "${cidrhost(aws_subnet.sn2.cidr_block, 8)}"
+  }
+
+  tags = {
+    Environment = "production"
+    Usage = "original"
+  }
+}
+
+data "aws_route53_resolver_endpoint" "foo" {
+	filter {
+		name = "NAME"
+		values = ["${aws_route53_resolver_endpoint.foo.name}"]
+	}
+}
+`, testAccDataSourceRoute53ResolverEndpointConfig_base(rInt), direction, name)
+}
+
+const testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistent = `
+data "aws_route53_resolver_endpoint" "foo" {
+	id = "rslvr-in-8g85830108dd4c82b"
+}
+`
+
+const testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistentFilter = `
+data "aws_route53_resolver_endpoint" "foo" {
+	filter {
+		name = "NAME"
+		values = ["None-Existent-Resource"]
+	}
+}
+`

--- a/aws/data_source_aws_route53_resolver_endpoint_test.go
+++ b/aws/data_source_aws_route53_resolver_endpoint_test.go
@@ -83,7 +83,7 @@ resource "aws_subnet" "sn1" {
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-      Name = "tf-acc-r53-resolver-sn1-%d"
+    Name = "tf-acc-r53-resolver-sn1-%d"
   }
 }
 
@@ -103,7 +103,7 @@ resource "aws_subnet" "sn3" {
   availability_zone = data.aws_availability_zones.available.names[2]
 
   tags = {
-      Name = "tf-acc-r53-resolver-sn3-%d"
+    Name = "tf-acc-r53-resolver-sn3-%d"
   }
 }
 
@@ -112,7 +112,7 @@ resource "aws_security_group" "sg1" {
   name   = "tf-acc-r53-resolver-sg1-%d"
 
   tags = {
-       Name = "tf-acc-r53-resolver-sg1-%d"
+    Name = "tf-acc-r53-resolver-sg1-%d"
   }
 }
 
@@ -121,7 +121,7 @@ resource "aws_security_group" "sg2" {
   name   = "tf-acc-r53-resolver-sg2-%d"
 
   tags = {
-      Name = "tf-acc-r53-resolver-sg2-%d"
+    Name = "tf-acc-r53-resolver-sg2-%d"
   }
 }
 `, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
@@ -154,7 +154,7 @@ resource "aws_route53_resolver_endpoint" "foo" {
 }
 
 data "aws_route53_resolver_endpoint" "foo" {
-    resolver_endpoint_id = aws_route53_resolver_endpoint.foo.id
+  resolver_endpoint_id = aws_route53_resolver_endpoint.foo.id
 }
 `, direction, name))
 }
@@ -187,11 +187,14 @@ resource "aws_route53_resolver_endpoint" "foo" {
 
 data "aws_route53_resolver_endpoint" "foo" {
     filter {
-           name   = "Name"
-           values = [aws_route53_resolver_endpoint.foo.name]
+      name   = "Name"
+      values = [aws_route53_resolver_endpoint.foo.name]
     }
 
-   depends_on = [aws_route53_resolver_endpoint.foo]
+    filter {
+      name = "SecurityGroupIds"
+      values = [aws_security_group.sg1.id, aws_security_group.sg2.id]
+    }
 }
 `, direction, name))
 }
@@ -205,8 +208,8 @@ data "aws_route53_resolver_endpoint" "foo" {
 const testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistentFilter = `
 data "aws_route53_resolver_endpoint" "foo" {
     filter {
-           name = "Name"
-           values = ["None-Existent-Resource"]
+      name = "Name"
+      values = ["None-Existent-Resource"]
     }
 }
 `

--- a/aws/data_source_aws_route53_resolver_endpoint_test.go
+++ b/aws/data_source_aws_route53_resolver_endpoint_test.go
@@ -192,7 +192,7 @@ data "aws_route53_resolver_endpoint" "foo" {
   }
 
   filter {
-    name = "SecurityGroupIds"
+    name   = "SecurityGroupIds"
     values = [aws_security_group.sg1.id, aws_security_group.sg2.id]
   }
 }
@@ -208,7 +208,7 @@ data "aws_route53_resolver_endpoint" "foo" {
 const testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistentFilter = `
 data "aws_route53_resolver_endpoint" "foo" {
   filter {
-    name = "Name"
+    name   = "Name"
     values = ["None-Existent-Resource"]
   }
 }

--- a/aws/data_source_aws_route53_resolver_endpoint_test.go
+++ b/aws/data_source_aws_route53_resolver_endpoint_test.go
@@ -186,15 +186,15 @@ resource "aws_route53_resolver_endpoint" "foo" {
 }
 
 data "aws_route53_resolver_endpoint" "foo" {
-    filter {
-      name   = "Name"
-      values = [aws_route53_resolver_endpoint.foo.name]
-    }
+  filter {
+    name   = "Name"
+    values = [aws_route53_resolver_endpoint.foo.name]
+  }
 
-    filter {
-      name = "SecurityGroupIds"
-      values = [aws_security_group.sg1.id, aws_security_group.sg2.id]
-    }
+  filter {
+    name = "SecurityGroupIds"
+    values = [aws_security_group.sg1.id, aws_security_group.sg2.id]
+  }
 }
 `, direction, name))
 }
@@ -207,9 +207,9 @@ data "aws_route53_resolver_endpoint" "foo" {
 
 const testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistentFilter = `
 data "aws_route53_resolver_endpoint" "foo" {
-    filter {
-      name = "Name"
-      values = ["None-Existent-Resource"]
-    }
+  filter {
+    name = "Name"
+    values = ["None-Existent-Resource"]
+  }
 }
 `

--- a/aws/data_source_aws_route53_resolver_endpoint_test.go
+++ b/aws/data_source_aws_route53_resolver_endpoint_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceAwsRoute53ResolverEndpoint_Basic(t *testing.T) {
@@ -22,7 +22,7 @@ func TestAccDataSourceAwsRoute53ResolverEndpoint_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistent,
-				ExpectError: regexp.MustCompile("The ID provided could not be found"),
+				ExpectError: regexp.MustCompile(`The ID provided could not be found`),
 			},
 			{
 				Config: testAccDataSourceRoute53ResolverEndpointConfig_initial(rInt, direction, name),
@@ -49,7 +49,7 @@ func TestAccDataSourceAwsRoute53ResolverEndpoint_Filter(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistentFilter,
-				ExpectError: regexp.MustCompile("Your query returned no results. Please change your search criteria and try again."),
+				ExpectError: regexp.MustCompile("Your query returned no results. Please change your search criteria and try again"),
 			},
 			{
 				Config: testAccDataSourceRoute53ResolverEndpointConfig_filter(rInt, direction, name),
@@ -78,9 +78,9 @@ resource "aws_vpc" "foo" {
 data "aws_availability_zones" "available" {}
 
 resource "aws_subnet" "sn1" {
-  vpc_id            = "${aws_vpc.foo.id}"
-  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 0)}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  vpc_id            = aws_vpc.foo.id
+  cidr_block        = cidrsubnet(aws_vpc.foo.cidr_block, 2, 0)
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-r53-resolver-sn1-%d"
@@ -88,10 +88,10 @@ resource "aws_subnet" "sn1" {
 }
 
 resource "aws_subnet" "sn2" {
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = aws_vpc.foo.id
 
-  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 1)}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  cidr_block        = cidrsubnet(aws_vpc.foo.cidr_block, 2, 1)
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-r53-resolver-sn2-%d"
@@ -99,9 +99,9 @@ resource "aws_subnet" "sn2" {
 }
 
 resource "aws_subnet" "sn3" {
-  vpc_id            = "${aws_vpc.foo.id}"
-  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 2)}"
-  availability_zone = "${data.aws_availability_zones.available.names[2]}"
+  vpc_id            = aws_vpc.foo.id
+  cidr_block        = cidrsubnet(aws_vpc.foo.cidr_block, 2, 2)
+  availability_zone = data.aws_availability_zones.available.names[2]
 
   tags = {
     Name = "tf-acc-r53-resolver-sn3-%d"
@@ -109,7 +109,7 @@ resource "aws_subnet" "sn3" {
 }
 
 resource "aws_security_group" "sg1" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = aws_vpc.foo.id
   name   = "tf-acc-r53-resolver-sg1-%d"
 
   tags = {
@@ -118,7 +118,7 @@ resource "aws_security_group" "sg1" {
 }
 
 resource "aws_security_group" "sg2" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = aws_vpc.foo.id
   name   = "tf-acc-r53-resolver-sg2-%d"
 
   tags = {
@@ -137,17 +137,17 @@ resource "aws_route53_resolver_endpoint" "foo" {
   name      = "%s"
 
   security_group_ids = [
-    "${aws_security_group.sg1.id}",
-    "${aws_security_group.sg2.id}",
+    aws_security_group.sg1.id,
+    aws_security_group.sg2.id,
   ]
 
   ip_address {
-    subnet_id = "${aws_subnet.sn1.id}"
+    subnet_id = aws_subnet.sn1.id
   }
 
   ip_address {
-    subnet_id = "${aws_subnet.sn2.id}"
-    ip        = "${cidrhost(aws_subnet.sn2.cidr_block, 8)}"
+    subnet_id = aws_subnet.sn2.id
+    ip        = cidrhost(aws_subnet.sn2.cidr_block, 8)
   }
 
   tags = {
@@ -157,7 +157,7 @@ resource "aws_route53_resolver_endpoint" "foo" {
 }
 
 data "aws_route53_resolver_endpoint" "foo" {
-	id = "${aws_route53_resolver_endpoint.foo.id}"
+	id = aws_route53_resolver_endpoint.foo.id
 }
 `, testAccDataSourceRoute53ResolverEndpointConfig_base(rInt), direction, name)
 }
@@ -171,17 +171,17 @@ resource "aws_route53_resolver_endpoint" "foo" {
   name      = "%s"
 
   security_group_ids = [
-    "${aws_security_group.sg1.id}",
-    "${aws_security_group.sg2.id}",
+    aws_security_group.sg1.id,
+    aws_security_group.sg2.id,
   ]
 
   ip_address {
-    subnet_id = "${aws_subnet.sn1.id}"
+    subnet_id = aws_subnet.sn1.id
   }
 
   ip_address {
-    subnet_id = "${aws_subnet.sn2.id}"
-    ip        = "${cidrhost(aws_subnet.sn2.cidr_block, 8)}"
+    subnet_id = aws_subnet.sn2.id
+    ip        = cidrhost(aws_subnet.sn2.cidr_block, 8)
   }
 
   tags = {
@@ -192,9 +192,11 @@ resource "aws_route53_resolver_endpoint" "foo" {
 
 data "aws_route53_resolver_endpoint" "foo" {
 	filter {
-		name = "NAME"
-		values = ["${aws_route53_resolver_endpoint.foo.name}"]
+		name = "Name"
+		values = [aws_route53_resolver_endpoint.foo.name]
 	}
+
+   depends_on = [aws_route53_resolver_endpoint.foo]
 }
 `, testAccDataSourceRoute53ResolverEndpointConfig_base(rInt), direction, name)
 }
@@ -208,7 +210,7 @@ data "aws_route53_resolver_endpoint" "foo" {
 const testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistentFilter = `
 data "aws_route53_resolver_endpoint" "foo" {
 	filter {
-		name = "NAME"
+		name = "Name"
 		values = ["None-Existent-Resource"]
 	}
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -324,6 +324,7 @@ func Provider() *schema.Provider {
 			"aws_route_table":                                dataSourceAwsRouteTable(),
 			"aws_route_tables":                               dataSourceAwsRouteTables(),
 			"aws_route53_delegation_set":                     dataSourceAwsDelegationSet(),
+			"aws_route53_resolver_endpoint":                  dataSourceAwsRoute53ResolverEndpoint(),
 			"aws_route53_resolver_rule":                      dataSourceAwsRoute53ResolverRule(),
 			"aws_route53_resolver_rules":                     dataSourceAwsRoute53ResolverRules(),
 			"aws_route53_zone":                               dataSourceAwsRoute53Zone(),

--- a/website/docs/d/route53_resolver_endpoint.html.markdown
+++ b/website/docs/d/route53_resolver_endpoint.html.markdown
@@ -31,7 +31,7 @@ data "aws_route53_resolver_endpoint" "example" {
 
 ## Argument Reference
 
-* `id` - (Optional) The ID of the Route53 Resolver Endpoint.
+* `resolver_endpoint_id` - (Optional) The ID of the Route53 Resolver Endpoint.
 * `filter` - (Optional) One or more name/value pairs to use as filters. There are
 several valid keys, for a full reference, check out
 [Route53resolver Filter value in the AWS API reference][1].

--- a/website/docs/d/route53_resolver_endpoint.html.markdown
+++ b/website/docs/d/route53_resolver_endpoint.html.markdown
@@ -16,7 +16,7 @@ This data source allows to find a list of IPaddresses associated with a specific
 
 ```hcl
 data "aws_route53_resolver_endpoint" "example" {
-  id = "rslvr-in-1abc2345ef678g91h"
+  resolver_endpoint_id = "rslvr-in-1abc2345ef678g91h"
 }
 ```
 

--- a/website/docs/d/route53_resolver_endpoint.html.markdown
+++ b/website/docs/d/route53_resolver_endpoint.html.markdown
@@ -1,7 +1,7 @@
 ---
+subcategory: "Route53 Resolver"
 layout: "aws"
 page_title: "AWS: aws_route53_resolver_endpoint"
-sidebar_current: "docs-aws-datasource-route53-resolver-endpoint"
 description: |-
     Provides details about a specific Route 53 Resolver Endpoint
 ---

--- a/website/docs/d/route53_resolver_endpoint.html.markdown
+++ b/website/docs/d/route53_resolver_endpoint.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "aws"
+page_title: "AWS: aws_route53_resolver_endpoint"
+sidebar_current: "docs-aws-datasource-route53-resolver-endpoint"
+description: |-
+    Provides details about a specific Route 53 Resolver Endpoint
+---
+
+# Data Source: aws_route53_resolver_endpoint
+
+`aws_route53_resolver_endpoint` provides details about a specific Route53 Resolver Endpoint.
+
+This data source allows to find a list of IPaddresses associated with a specific Route53 Resolver Endpoint.
+
+## Example Usage
+
+```hcl
+data "aws_route53_resolver_endpoint" "example" {
+  id = "rslvr-in-1abc2345ef678g91h"
+}
+```
+
+```hcl
+data "aws_route53_resolver_endpoint" "example" {
+  filter {
+    name   = "NAME"
+    values = ["MyResolverExampleName"]
+  }
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of the Route53 Resolver Endpoint.
+* `filter` - (Optional) One or more name/value pairs to use as filters. There are
+several valid keys, for a full reference, check out
+[Route53resolver Filter value in the AWS API reference][1].
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The computed ARN of the Route53 Resolver Endpoint.
+* `direction` - The direction of the queries to or from the Resolver Endpoint .
+* `ip_addresses` - A list of IPaddresses that have been associated with the Resolver Endpoint.
+* `status` - The current status of the Resolver Endpoint.
+* `vpc_id` - The ID of the Host VPC that the Resolver Endpoint resides in.
+
+[1]: https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_Filter.html


### PR DESCRIPTION
Route53resolver endpoint data source with filter & ID support

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8355 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
-->

```release-note
** New Data Source:** `aws_route53_resolver_endpoint`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsRoute53ResolverEndpoint'
--- PASS: TestAccDataSourceAwsRoute53ResolverEndpoint_Basic (118.34s)
--- PASS: TestAccDataSourceAwsRoute53ResolverEndpoint_Filter (295.04s)
...
```
