### PR TITLE
Supporting EIPs with specified BYOIP addresses

### DIFF
--- a/.changelog/8876.txt
+++ b/.changelog/8876.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eip: Add `address` argument to recover or an IPv4 address from an address pool, supporting BYOIP
+```

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -99,6 +99,11 @@ func resourceAwsEip() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 
 			"carrier_ip": {
 				Type:     schema.TypeString,
@@ -158,7 +163,14 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 		allocOpts.TagSpecifications = ec2TagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeElasticIp)
 	}
 
-	if v, ok := d.GetOk("public_ipv4_pool"); ok {
+	// address if exists
+	addressV, addressOK := d.GetOk("address")
+
+	if addressOK && domainOpt == ec2.DomainTypeVpc {
+		// If we are in a VPC and have assigned an address: add it.
+		allocOpts.Address = aws.String(addressV.(string))
+	} else if v, ok := d.GetOk("public_ipv4_pool"); ok {
+		// If we have not assigned an address but have assigned a public_ipv4_pool: add it
 		allocOpts.PublicIpv4Pool = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -41,36 +41,64 @@ func resourceAwsEip() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"vpc": {
-				Type:     schema.TypeBool,
+			"address": {
+				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+			"allocation_id": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"associate_with_private_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"association_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"carrier_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"customer_owned_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"customer_owned_ipv4_pool": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"instance": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
+			"network_border_group": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"network_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
-			"allocation_id": {
+			"private_dns": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"association_id": {
+			"private_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"domain": {
+			"public_dns": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -79,63 +107,20 @@ func resourceAwsEip() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"public_dns": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"private_ip": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"private_dns": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"associate_with_private_ip": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"carrier_ip": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"customer_owned_ipv4_pool": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"customer_owned_ip": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"public_ipv4_pool": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
-
-			"network_border_group": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
 			"tags":     tagsSchema(),
 			"tags_all": tagsSchemaComputed(),
+			"vpc": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -163,14 +148,15 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 		allocOpts.TagSpecifications = ec2TagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeElasticIp)
 	}
 
-	// address if exists
-	addressV, addressOK := d.GetOk("address")
+	if v, ok := d.GetOk("address"); ok {
+		supportedPlatforms := meta.(*AWSClient).supportedplatforms
+		if domainOpt != ec2.DomainTypeVpc && len(supportedPlatforms) > 0 && hasEc2Classic(supportedPlatforms) {
+			return fmt.Errorf("error, address to recover cannot be set for a standard-domain EIP - must be a VPC-domain EIP")
+		}
+		allocOpts.Address = aws.String(v.(string))
+	}
 
-	if addressOK && domainOpt == ec2.DomainTypeVpc {
-		// If we are in a VPC and have assigned an address: add it.
-		allocOpts.Address = aws.String(addressV.(string))
-	} else if v, ok := d.GetOk("public_ipv4_pool"); ok {
-		// If we have not assigned an address but have assigned a public_ipv4_pool: add it
+	if v, ok := d.GetOk("public_ipv4_pool"); ok {
 		allocOpts.PublicIpv4Pool = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -667,6 +667,7 @@ func TestAccAWSEIP_BYOIPAddress_default(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
@@ -696,6 +697,7 @@ func TestAccAWSEIP_BYOIPAddress_custom(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
@@ -730,6 +732,7 @@ func TestAccAWSEIP_BYOIPAddress_custom_with_PublicIpv4Pool(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -694,7 +694,7 @@ func TestAccAWSEIP_BYOIPAddress_custom(t *testing.T) {
 
 	address := os.Getenv("AWS_EC2_EIP_BYOIP_ADDRESS")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
@@ -728,7 +728,7 @@ func TestAccAWSEIP_BYOIPAddress_custom_with_PublicIpv4Pool(t *testing.T) {
 	address := os.Getenv("AWS_EC2_EIP_BYOIP_ADDRESS")
 	poolName := os.Getenv("AWS_EC2_EIP_PUBLIC_IPV4_POOL")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
@@ -740,6 +740,7 @@ func TestAccAWSEIP_BYOIPAddress_custom_with_PublicIpv4Pool(t *testing.T) {
 					testAccCheckAWSEIPExists(resourceName, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 					resource.TestCheckResourceAttr(resourceName, "public_ip", address),
+					resource.TestCheckResourceAttr(resourceName, "public_ipv4_pool", poolName),
 				),
 			},
 		},
@@ -1034,8 +1035,8 @@ func testAccAWSEIPConfig_BYOIPAddress_custom_with_PublicIpv4Pool(address string,
 	return fmt.Sprintf(`
 resource "aws_eip" "bar" {
   vpc     = true
-  address = "%s"
-  public_ipv4_pool = %s
+  address = "%[1]s"
+  public_ipv4_pool = "%[2]s"
 }
 `, address, poolname)
 }

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -660,6 +660,92 @@ func TestAccAWSEIP_carrierIP(t *testing.T) {
 	})
 }
 
+func TestAccAWSEIP_BYOIPAddress_default(t *testing.T) {
+	// Test case address not set
+	var conf ec2.Address
+	resourceName := "aws_eip.bar"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEIPConfig_BYOIPAddress_custom_default,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_BYOIPAddress_custom(t *testing.T) {
+	// Test Case for address being set
+
+	if os.Getenv("AWS_EC2_EIP_BYOIP_ADDRESS") == "" {
+		t.Skip("Environment variable AWS_EC2_EIP_BYOIP_ADDRESS is not set")
+	}
+
+	var conf ec2.Address
+	resourceName := "aws_eip.bar"
+
+	address := os.Getenv("AWS_EC2_EIP_BYOIP_ADDRESS")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEIPConfig_BYOIPAddress_custom(address),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "public_ip", address),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_BYOIPAddress_custom_with_PublicIpv4Pool(t *testing.T) {
+	// Test Case for both address and public_ipv4_pool being set
+	if os.Getenv("AWS_EC2_EIP_BYOIP_ADDRESS") == "" {
+		t.Skip("Environment variable AWS_EC2_EIP_BYOIP_ADDRESS is not set")
+	}
+
+	if os.Getenv("AWS_EC2_EIP_PUBLIC_IPV4_POOL") == "" {
+		t.Skip("Environment variable AWS_EC2_EIP_PUBLIC_IPV4_POOL is not set")
+	}
+
+	var conf ec2.Address
+	resourceName := "aws_eip.bar"
+
+	address := os.Getenv("AWS_EC2_EIP_BYOIP_ADDRESS")
+	poolName := os.Getenv("AWS_EC2_EIP_PUBLIC_IPV4_POOL")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEIPConfig_BYOIPAddress_custom_with_PublicIpv4Pool(address, poolName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "public_ip", address),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -929,7 +1015,32 @@ resource "aws_eip" "test" {
 `)
 }
 
-func testAccEIPInstanceConfig() string {
+const testAccAWSEIPConfig_BYOIPAddress_custom_default = `
+resource "aws_eip" "bar" {
+	vpc = true
+}
+`
+
+func testAccAWSEIPConfig_BYOIPAddress_custom(address string) string {
+	return fmt.Sprintf(`
+resource "aws_eip" "bar" {
+  vpc     = true
+  address = "%s"
+}
+`, address)
+}
+
+func testAccAWSEIPConfig_BYOIPAddress_custom_with_PublicIpv4Pool(address string, poolname string) string {
+	return fmt.Sprintf(`
+resource "aws_eip" "bar" {
+  vpc     = true
+  address = "%s"
+  public_ipv4_pool = %s
+}
+`, address, poolname)
+}
+
+func testAccAWSEIPInstanceConfig() string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -663,7 +663,7 @@ func TestAccAWSEIP_carrierIP(t *testing.T) {
 func TestAccAWSEIP_BYOIPAddress_default(t *testing.T) {
 	// Test case address not set
 	var conf ec2.Address
-	resourceName := "aws_eip.bar"
+	resourceName := "aws_eip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -691,7 +691,7 @@ func TestAccAWSEIP_BYOIPAddress_custom(t *testing.T) {
 	}
 
 	var conf ec2.Address
-	resourceName := "aws_eip.bar"
+	resourceName := "aws_eip.test"
 
 	address := os.Getenv("AWS_EC2_EIP_BYOIP_ADDRESS")
 
@@ -725,7 +725,7 @@ func TestAccAWSEIP_BYOIPAddress_custom_with_PublicIpv4Pool(t *testing.T) {
 	}
 
 	var conf ec2.Address
-	resourceName := "aws_eip.bar"
+	resourceName := "aws_eip.test"
 
 	address := os.Getenv("AWS_EC2_EIP_BYOIP_ADDRESS")
 	poolName := os.Getenv("AWS_EC2_EIP_PUBLIC_IPV4_POOL")
@@ -997,7 +997,7 @@ func testAccEIPPublicIPv4PoolCustomConfig(poolName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
   vpc              = true
-  public_ipv4_pool = "%s"
+  public_ipv4_pool = %[1]q
 }
 `, poolName)
 }
@@ -1020,14 +1020,14 @@ resource "aws_eip" "test" {
 }
 
 const testAccAWSEIPConfig_BYOIPAddress_custom_default = `
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
   vpc = true
 }
 `
 
 func testAccAWSEIPConfig_BYOIPAddress_custom(address string) string {
 	return fmt.Sprintf(`
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
   vpc     = true
   address = %[1]q
 }
@@ -1036,7 +1036,7 @@ resource "aws_eip" "bar" {
 
 func testAccAWSEIPConfig_BYOIPAddress_custom_with_PublicIpv4Pool(address string, poolname string) string {
 	return fmt.Sprintf(`
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
   vpc              = true
   address          = %[1]q
   public_ipv4_pool = %[2]q

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -156,7 +156,7 @@ func TestAccAWSEIP_Instance(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEIPInstanceConfig(),
+				Config: testAccAWSEIPInstanceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
@@ -675,7 +675,7 @@ func TestAccAWSEIP_BYOIPAddress_default(t *testing.T) {
 			{
 				Config: testAccAWSEIPConfig_BYOIPAddress_custom_default,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 				),
 			},
@@ -705,7 +705,7 @@ func TestAccAWSEIP_BYOIPAddress_custom(t *testing.T) {
 			{
 				Config: testAccAWSEIPConfig_BYOIPAddress_custom(address),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 					resource.TestCheckResourceAttr(resourceName, "public_ip", address),
 				),
@@ -740,7 +740,7 @@ func TestAccAWSEIP_BYOIPAddress_custom_with_PublicIpv4Pool(t *testing.T) {
 			{
 				Config: testAccAWSEIPConfig_BYOIPAddress_custom_with_PublicIpv4Pool(address, poolName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 					resource.TestCheckResourceAttr(resourceName, "public_ip", address),
 					resource.TestCheckResourceAttr(resourceName, "public_ipv4_pool", poolName),

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -1018,7 +1018,7 @@ resource "aws_eip" "test" {
 
 const testAccAWSEIPConfig_BYOIPAddress_custom_default = `
 resource "aws_eip" "bar" {
-	vpc = true
+  vpc = true
 }
 `
 
@@ -1026,7 +1026,7 @@ func testAccAWSEIPConfig_BYOIPAddress_custom(address string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "bar" {
   vpc     = true
-  address = "%s"
+  address = %[1]q
 }
 `, address)
 }
@@ -1034,9 +1034,9 @@ resource "aws_eip" "bar" {
 func testAccAWSEIPConfig_BYOIPAddress_custom_with_PublicIpv4Pool(address string, poolname string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "bar" {
-  vpc     = true
-  address = "%[1]s"
-  public_ipv4_pool = "%[2]s"
+  vpc              = true
+  address          = %[1]q
+  public_ipv4_pool = %[2]q
 }
 `, address, poolname)
 }

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -97,16 +97,22 @@ resource "aws_eip" "byoip-ip" {
 
 The following arguments are supported:
 
+* `address` - (Optional) IP address from an EC2 BYOIP pool. This option is only available for VPC EIPs.
 * `associate_with_private_ip` - (Optional) User-specified primary or secondary private IP address to associate with the Elastic IP address. If no private IP address is specified, the Elastic IP address is associated with the primary private IP address.
 * `customer_owned_ipv4_pool` - (Optional) ID  of a customer-owned address pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing).
+* `customer_owned_ipv4_pool` - The  ID  of a customer-owned address pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing)
 * `instance` - (Optional) EC2 instance ID.
 * `network_border_group` - (Optional) Location from which the IP address is advertised. Use this parameter to limit the address to this location.
+* `network_border_group` - The location from which the IP address is advertised. Use this parameter to limit the address to this location.
 * `network_interface` - (Optional) Network interface ID to associate with.
 * `public_ipv4_pool` - (Optional) EC2 IPv4 address pool identifier or `amazon`. This option is only available for VPC EIPs.
 * `tags` - (Optional) Map of tags to assign to the resource. Tags can only be applied to EIPs in a VPC. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc` - (Optional) Boolean if the EIP is in a VPC or not.
 
 ~> **NOTE:** You can specify either the `instance` ID or the `network_interface` ID, but not both. Including both will **not** return an error from the AWS API, but will have undefined behavior. See the relevant [AssociateAddress API Call][1] for more information.
+
+~> **NOTE:** Specifying both `public_ipv4_pool` and `address` won't cause an error but `address` will be used in the
+case both options are defined as the api only requires one or the other.
 
 ## Attributes Reference
 

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -16,7 +16,7 @@ Provides an Elastic IP resource.
 
 ## Example Usage
 
-Single EIP associated with an instance:
+### Single EIP associated with an instance
 
 ```terraform
 resource "aws_eip" "lb" {
@@ -25,7 +25,7 @@ resource "aws_eip" "lb" {
 }
 ```
 
-Multiple EIPs associated with a single network interface:
+### Multiple EIPs associated with a single network interface
 
 ```terraform
 resource "aws_network_interface" "multi-ip" {
@@ -46,7 +46,7 @@ resource "aws_eip" "two" {
 }
 ```
 
-Attaching an EIP to an Instance with a pre-assigned private ip (VPC Only):
+### Attaching an EIP to an Instance with a pre-assigned private ip (VPC Only)
 
 ```terraform
 resource "aws_vpc" "default" {
@@ -84,7 +84,7 @@ resource "aws_eip" "bar" {
 }
 ```
 
-Allocating EIP from the BYOIP pool:
+### Allocating EIP from the BYOIP pool
 
 ```terraform
 resource "aws_eip" "byoip-ip" {

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -100,10 +100,8 @@ The following arguments are supported:
 * `address` - (Optional) IP address from an EC2 BYOIP pool. This option is only available for VPC EIPs.
 * `associate_with_private_ip` - (Optional) User-specified primary or secondary private IP address to associate with the Elastic IP address. If no private IP address is specified, the Elastic IP address is associated with the primary private IP address.
 * `customer_owned_ipv4_pool` - (Optional) ID  of a customer-owned address pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing).
-* `customer_owned_ipv4_pool` - The  ID  of a customer-owned address pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing)
 * `instance` - (Optional) EC2 instance ID.
 * `network_border_group` - (Optional) Location from which the IP address is advertised. Use this parameter to limit the address to this location.
-* `network_border_group` - The location from which the IP address is advertised. Use this parameter to limit the address to this location.
 * `network_interface` - (Optional) Network interface ID to associate with.
 * `public_ipv4_pool` - (Optional) EC2 IPv4 address pool identifier or `amazon`. This option is only available for VPC EIPs.
 * `tags` - (Optional) Map of tags to assign to the resource. Tags can only be applied to EIPs in a VPC. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8004

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS

* Added support for EIPs with a specified BYOIP address
```

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP_BYOIPAddress'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEIP_BYOIPAddress -timeout 120m
=== RUN   TestAccAWSEIP_BYOIPAddress_default
=== PAUSE TestAccAWSEIP_BYOIPAddress_default
=== RUN   TestAccAWSEIP_BYOIPAddress_custom
--- PASS: TestAccAWSEIP_BYOIPAddress_custom (23.06s)
=== RUN   TestAccAWSEIP_BYOIPAddress_custom_with_PublicIpv4Pool
--- PASS: TestAccAWSEIP_BYOIPAddress_custom_with_PublicIpv4Pool (21.54s)
=== CONT  TestAccAWSEIP_BYOIPAddress_default
--- PASS: TestAccAWSEIP_BYOIPAddress_default (22.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       67.099s

```
