### PR TITLE
Support multiple values per one cost filter in aws_budgets_budget resource

### DIFF
--- a/.changelog/9092.txt
+++ b/.changelog/9092.txt
@@ -1,3 +1,11 @@
 ```release-note:enhancement
 resource/aws_budgets_budget: Add the `cost_filter` argument which allows multiple `values` to be specified per filter. This new argument will eventually replace the `cost_filters` argument
 ```
+
+```release-note:bug
+resource/aws_budgets_budget: Change the service name in the `arn` attribute from `budgetservice` to `budgets`
+```
+
+```release-note:bug
+resource/aws_budgets_budget_action: Change the service name in the `arn` attribute from `budgetservice` to `budgets`
+```

--- a/.changelog/9092.txt
+++ b/.changelog/9092.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_budgets_budget: Add the `cost_filter` argument which allows multiple `values` to be specified per filter. This new argument will eventually replace the `cost_filters` argument
+```

--- a/.changelog/9092.txt
+++ b/.changelog/9092.txt
@@ -2,6 +2,10 @@
 resource/aws_budgets_budget: Add the `cost_filter` argument which allows multiple `values` to be specified per filter. This new argument will eventually replace the `cost_filters` argument
 ```
 
+```release-note:enhancement
+resource/aws_budgets_budget: Change `time_period_start` to an optional argument. If you don't specify a start date, AWS defaults to the start of your chosen time period
+```
+
 ```release-note:bug
 resource/aws_budgets_budget: Change the service name in the `arn` attribute from `budgetservice` to `budgets`
 ```

--- a/.changelog/9092.txt
+++ b/.changelog/9092.txt
@@ -11,5 +11,9 @@ resource/aws_budgets_budget: Change the service name in the `arn` attribute from
 ```
 
 ```release-note:bug
+resource/aws_budgets_budget: Suppress plan differences with trailing zeroes for `limit_amount`
+```
+
+```release-note:bug
 resource/aws_budgets_budget_action: Change the service name in the `arn` attribute from `budgetservice` to `budgets`
 ```

--- a/aws/internal/service/budgets/finder/finder.go
+++ b/aws/internal/service/budgets/finder/finder.go
@@ -36,3 +36,121 @@ func ActionByAccountIDActionIDAndBudgetName(conn *budgets.Budgets, accountID, ac
 
 	return output.Action, nil
 }
+
+func BudgetByAccountIDAndBudgetName(conn *budgets.Budgets, accountID, budgetName string) (*budgets.Budget, error) {
+	input := &budgets.DescribeBudgetInput{
+		AccountId:  aws.String(accountID),
+		BudgetName: aws.String(budgetName),
+	}
+
+	output, err := conn.DescribeBudget(input)
+
+	if tfawserr.ErrCodeEquals(err, budgets.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Budget == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Budget, nil
+}
+
+func NotificationsByAccountIDAndBudgetName(conn *budgets.Budgets, accountID, budgetName string) ([]*budgets.Notification, error) {
+	input := &budgets.DescribeNotificationsForBudgetInput{
+		AccountId:  aws.String(accountID),
+		BudgetName: aws.String(budgetName),
+	}
+	var output []*budgets.Notification
+
+	err := conn.DescribeNotificationsForBudgetPages(input, func(page *budgets.DescribeNotificationsForBudgetOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, notification := range page.Notifications {
+			if notification == nil {
+				continue
+			}
+
+			output = append(output, notification)
+		}
+
+		return !lastPage
+	})
+
+	if tfawserr.ErrCodeEquals(err, budgets.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output) == 0 {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}
+
+func SubscribersByAccountIDBudgetNameAndNotification(conn *budgets.Budgets, accountID, budgetName string, notification *budgets.Notification) ([]*budgets.Subscriber, error) {
+	input := &budgets.DescribeSubscribersForNotificationInput{
+		AccountId:    aws.String(accountID),
+		BudgetName:   aws.String(budgetName),
+		Notification: notification,
+	}
+	var output []*budgets.Subscriber
+
+	err := conn.DescribeSubscribersForNotificationPages(input, func(page *budgets.DescribeSubscribersForNotificationOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, subscriber := range page.Subscribers {
+			if subscriber == nil {
+				continue
+			}
+
+			output = append(output, subscriber)
+		}
+
+		return !lastPage
+	})
+
+	if tfawserr.ErrCodeEquals(err, budgets.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output) == 0 {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}

--- a/aws/internal/service/budgets/id.go
+++ b/aws/internal/service/budgets/id.go
@@ -36,7 +36,7 @@ func BudgetCreateResourceID(accountID, budgetName string) string {
 func BudgetParseResourceID(id string) (string, string, error) {
 	parts := strings.Split(id, budgetResourceIDSeparator)
 
-	if len(parts) == 3 && parts[0] != "" && parts[1] != "" {
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil
 	}
 

--- a/aws/internal/service/budgets/id.go
+++ b/aws/internal/service/budgets/id.go
@@ -1,4 +1,4 @@
-package glue
+package budgets
 
 import (
 	"fmt"

--- a/aws/internal/service/budgets/id.go
+++ b/aws/internal/service/budgets/id.go
@@ -5,10 +5,40 @@ import (
 	"strings"
 )
 
-func DecodeBudgetsBudgetActionID(id string) (string, string, string, error) {
-	parts := strings.Split(id, ":")
-	if len(parts) != 3 {
-		return "", "", "", fmt.Errorf("Unexpected format of ID (%q), expected AccountID:ActionID:BudgetName", id)
+const budgetActionResourceIDSeparator = ":"
+
+func BudgetActionCreateResourceID(accountID, actionID, budgetName string) string {
+	parts := []string{accountID, actionID, budgetName}
+	id := strings.Join(parts, budgetActionResourceIDSeparator)
+
+	return id
+}
+
+func BudgetActionParseResourceID(id string) (string, string, string, error) {
+	parts := strings.Split(id, budgetActionResourceIDSeparator)
+
+	if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
+		return parts[0], parts[1], parts[2], nil
 	}
-	return parts[0], parts[1], parts[2], nil
+
+	return "", "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected AccountID%[2]sActionID%[2]sBudgetName", id, budgetActionResourceIDSeparator)
+}
+
+const budgetResourceIDSeparator = ":"
+
+func BudgetCreateResourceID(accountID, budgetName string) string {
+	parts := []string{accountID, budgetName}
+	id := strings.Join(parts, budgetResourceIDSeparator)
+
+	return id
+}
+
+func BudgetParseResourceID(id string) (string, string, error) {
+	parts := strings.Split(id, budgetResourceIDSeparator)
+
+	if len(parts) == 3 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1], nil
+	}
+
+	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected AccountID%[2]sBudgetName", id, budgetActionResourceIDSeparator)
 }

--- a/aws/internal/service/budgets/time.go
+++ b/aws/internal/service/budgets/time.go
@@ -1,0 +1,36 @@
+package budgets
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+const (
+	timePeriodLayout = "2006-01-02_15:04"
+)
+
+func TimePeriodTimestampFromString(s string) (*time.Time, error) {
+	ts, err := time.Parse(timePeriodLayout, s)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return aws.Time(ts), nil
+}
+
+func TimePeriodTimestampToString(ts *time.Time) string {
+	return aws.TimeValue(ts).Format(timePeriodLayout)
+}
+
+func ValidateTimePeriodTimestamp(v interface{}, k string) (ws []string, errors []error) {
+	_, err := time.Parse(timePeriodLayout, v.(string))
+
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q cannot be parsed as %q: %w", k, timePeriodLayout, err))
+	}
+
+	return
+}

--- a/aws/internal/service/budgets/time.go
+++ b/aws/internal/service/budgets/time.go
@@ -12,6 +12,10 @@ const (
 )
 
 func TimePeriodTimestampFromString(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+
 	ts, err := time.Parse(timePeriodLayout, s)
 
 	if err != nil {
@@ -22,6 +26,10 @@ func TimePeriodTimestampFromString(s string) (*time.Time, error) {
 }
 
 func TimePeriodTimestampToString(ts *time.Time) string {
+	if ts == nil {
+		return ""
+	}
+
 	return aws.TimeValue(ts).Format(timePeriodLayout)
 }
 

--- a/aws/internal/service/budgets/waiter/waiter.go
+++ b/aws/internal/service/budgets/waiter/waiter.go
@@ -11,7 +11,7 @@ const (
 	ActionAvailableTimeout = 2 * time.Minute
 )
 
-func ActionAvailable(conn *budgets.Budgets, id string) (*budgets.Action, error) {
+func ActionAvailable(conn *budgets.Budgets, accountID, actionID, budgetName string) (*budgets.Action, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			budgets.ActionStatusExecutionInProgress,
@@ -22,7 +22,7 @@ func ActionAvailable(conn *budgets.Budgets, id string) (*budgets.Action, error) 
 			budgets.ActionStatusExecutionFailure,
 			budgets.ActionStatusPending,
 		},
-		Refresh: ActionStatus(conn, id),
+		Refresh: ActionStatus(conn, accountID, actionID, budgetName),
 		Timeout: ActionAvailableTimeout,
 	}
 

--- a/aws/resource_aws_budgets_budget.go
+++ b/aws/resource_aws_budgets_budget.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/shopspring/decimal"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
 	tfbudgets "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/budgets"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/budgets/finder"
@@ -139,8 +140,9 @@ func resourceAwsBudgetsBudget() *schema.Resource {
 				},
 			},
 			"limit_amount": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: suppressEquivalentBudgetLimitAmount,
 			},
 			"limit_unit": {
 				Type:     schema.TypeString,
@@ -689,4 +691,20 @@ func expandBudgetSubscribers(rawList interface{}, subscriptionType string) []*bu
 		})
 	}
 	return result
+}
+
+func suppressEquivalentBudgetLimitAmount(k, old, new string, d *schema.ResourceData) bool {
+	d1, err := decimal.NewFromString(old)
+
+	if err != nil {
+		return false
+	}
+
+	d2, err := decimal.NewFromString(new)
+
+	if err != nil {
+		return false
+	}
+
+	return d1.Equal(d2)
 }

--- a/aws/resource_aws_budgets_budget.go
+++ b/aws/resource_aws_budgets_budget.go
@@ -208,7 +208,8 @@ func resourceAwsBudgetsBudget() *schema.Resource {
 			},
 			"time_period_start": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
+				Computed:     true,
 				ValidateFunc: tfbudgets.ValidateTimePeriodTimestamp,
 			},
 			"time_unit": {

--- a/aws/resource_aws_budgets_budget.go
+++ b/aws/resource_aws_budgets_budget.go
@@ -138,12 +138,10 @@ func resourceAwsBudgetsBudget() *schema.Resource {
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				ConflictsWith: []string{"cost_filter"},
-				Deprecated:    "Please use `cost_filter`. This attribute might be removed in future releases.",
 			},
 			"cost_filter": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				ConflictsWith: []string{"cost_filters"},
+				Type:     schema.TypeSet,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -159,6 +157,7 @@ func resourceAwsBudgetsBudget() *schema.Resource {
 						},
 					},
 				},
+				ConflictsWith: []string{"cost_filters"},
 			},
 			"notification": {
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_budgets_budget_action.go
+++ b/aws/resource_aws_budgets_budget_action.go
@@ -295,7 +295,7 @@ func resourceAwsBudgetsBudgetActionRead(d *schema.ResourceData, meta interface{}
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "budgetservice",
+		Service:   "budgets",
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("budget/%s/action/%s", budgetName, actionID),
 	}

--- a/aws/resource_aws_budgets_budget_action.go
+++ b/aws/resource_aws_budgets_budget_action.go
@@ -8,11 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/budgets"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	tfbudgets "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/budgets"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/budgets/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/budgets/waiter"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsBudgetsBudgetAction() *schema.Resource {
@@ -21,9 +24,11 @@ func resourceAwsBudgetsBudgetAction() *schema.Resource {
 		Read:   resourceAwsBudgetsBudgetActionRead,
 		Update: resourceAwsBudgetsBudgetActionUpdate,
 		Delete: resourceAwsBudgetsBudgetActionDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -205,39 +210,40 @@ func resourceAwsBudgetsBudgetAction() *schema.Resource {
 func resourceAwsBudgetsBudgetActionCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).budgetconn
 
-	var accountID string
-	if v, ok := d.GetOk("account_id"); ok {
-		accountID = v.(string)
-	} else {
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
 		accountID = meta.(*AWSClient).accountid
 	}
 
 	input := &budgets.CreateBudgetActionInput{
 		AccountId:        aws.String(accountID),
-		BudgetName:       aws.String(d.Get("budget_name").(string)),
+		ActionThreshold:  expandAwsBudgetsBudgetActionActionThreshold(d.Get("action_threshold").([]interface{})),
 		ActionType:       aws.String(d.Get("action_type").(string)),
 		ApprovalModel:    aws.String(d.Get("approval_model").(string)),
+		BudgetName:       aws.String(d.Get("budget_name").(string)),
+		Definition:       expandAwsBudgetsBudgetActionActionDefinition(d.Get("definition").([]interface{})),
 		ExecutionRoleArn: aws.String(d.Get("execution_role_arn").(string)),
 		NotificationType: aws.String(d.Get("notification_type").(string)),
-		ActionThreshold:  expandAwsBudgetsBudgetActionActionThreshold(d.Get("action_threshold").([]interface{})),
 		Subscribers:      expandAwsBudgetsBudgetActionSubscriber(d.Get("subscriber").(*schema.Set)),
-		Definition:       expandAwsBudgetsBudgetActionActionDefinition(d.Get("definition").([]interface{})),
 	}
 
-	var output *budgets.CreateBudgetActionOutput
-	_, err := retryOnAwsCode(budgets.ErrCodeAccessDeniedException, func() (interface{}, error) {
-		var err error
-		output, err = conn.CreateBudgetAction(input)
-		return output, err
-	})
+	log.Printf("[DEBUG] Creating Budget Action: %s", input)
+	outputRaw, err := tfresource.RetryWhenAwsErrCodeEquals(iamwaiter.PropagationTimeout, func() (interface{}, error) {
+		return conn.CreateBudgetAction(input)
+	}, budgets.ErrCodeAccessDeniedException)
+
 	if err != nil {
-		return fmt.Errorf("create Budget Action failed: %v", err)
+		return fmt.Errorf("error creating Budget Action: %w", err)
 	}
 
-	d.SetId(fmt.Sprintf("%s:%s:%s", aws.StringValue(output.AccountId), aws.StringValue(output.ActionId), aws.StringValue(output.BudgetName)))
+	output := outputRaw.(*budgets.CreateBudgetActionOutput)
+	actionID := aws.StringValue(output.ActionId)
+	budgetName := aws.StringValue(output.BudgetName)
 
-	if _, err := waiter.ActionAvailable(conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for Budget Action (%s) creation: %w", d.Id(), err)
+	d.SetId(tfbudgets.BudgetActionCreateResourceID(accountID, actionID, budgetName))
+
+	if _, err := waiter.ActionAvailable(conn, accountID, actionID, budgetName); err != nil {
+		return fmt.Errorf("error waiting for Budget Action (%s) to create: %w", d.Id(), err)
 	}
 
 	return resourceAwsBudgetsBudgetActionRead(d, meta)
@@ -245,52 +251,53 @@ func resourceAwsBudgetsBudgetActionCreate(d *schema.ResourceData, meta interface
 
 func resourceAwsBudgetsBudgetActionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).budgetconn
-	out, err := finder.ActionById(conn, d.Id())
-	if isAWSErr(err, budgets.ErrCodeNotFoundException, "") {
-		log.Printf("[WARN] Budget Action %s not found, removing from state", d.Id())
+
+	accountID, actionID, budgetName, err := tfbudgets.BudgetActionParseResourceID(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	output, err := finder.ActionByAccountIDActionIDAndBudgetName(conn, accountID, actionID, budgetName)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Budget Action (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("describe Budget Action failed: %w", err)
+		return fmt.Errorf("error reading Budget Action (%s): %w", d.Id(), err)
 	}
 
-	action := out.Action
-	if action == nil {
-		log.Printf("[WARN] Budget Action %s not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
+	d.Set("account_id", accountID)
+	d.Set("action_id", actionID)
+
+	if err := d.Set("action_threshold", flattenAwsBudgetsBudgetActionActionThreshold(output.ActionThreshold)); err != nil {
+		return fmt.Errorf("error setting action_threshold: %w", err)
 	}
 
-	budgetName := aws.StringValue(out.BudgetName)
-	actId := aws.StringValue(action.ActionId)
-	d.Set("account_id", out.AccountId)
+	d.Set("action_type", output.ActionType)
+	d.Set("approval_model", output.ApprovalModel)
 	d.Set("budget_name", budgetName)
-	d.Set("action_id", actId)
-	d.Set("action_type", action.ActionType)
-	d.Set("approval_model", action.ApprovalModel)
-	d.Set("execution_role_arn", action.ExecutionRoleArn)
-	d.Set("notification_type", action.NotificationType)
-	d.Set("status", action.Status)
 
-	if err := d.Set("subscriber", flattenAwsBudgetsBudgetActionSubscriber(action.Subscribers)); err != nil {
-		return fmt.Errorf("error setting subscriber: %w", err)
-	}
-
-	if err := d.Set("definition", flattenAwsBudgetsBudgetActionDefinition(action.Definition)); err != nil {
+	if err := d.Set("definition", flattenAwsBudgetsBudgetActionDefinition(output.Definition)); err != nil {
 		return fmt.Errorf("error setting definition: %w", err)
 	}
 
-	if err := d.Set("action_threshold", flattenAwsBudgetsBudgetActionActionThreshold(action.ActionThreshold)); err != nil {
-		return fmt.Errorf("error setting action_threshold: %w", err)
+	d.Set("execution_role_arn", output.ExecutionRoleArn)
+	d.Set("notification_type", output.NotificationType)
+	d.Set("status", output.Status)
+
+	if err := d.Set("subscriber", flattenAwsBudgetsBudgetActionSubscriber(output.Subscribers)); err != nil {
+		return fmt.Errorf("error setting subscriber: %w", err)
 	}
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Service:   "budgetservice",
 		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("budget/%s/action/%s", budgetName, actId),
+		Resource:  fmt.Sprintf("budget/%s/action/%s", budgetName, actionID),
 	}
 	d.Set("arn", arn.String())
 
@@ -298,20 +305,30 @@ func resourceAwsBudgetsBudgetActionRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceAwsBudgetsBudgetActionUpdate(d *schema.ResourceData, meta interface{}) error {
-	accountID, actionID, budgetName, err := tfbudgets.DecodeBudgetsBudgetActionID(d.Id())
+	conn := meta.(*AWSClient).budgetconn
+
+	accountID, actionID, budgetName, err := tfbudgets.BudgetActionParseResourceID(d.Id())
+
 	if err != nil {
 		return err
 	}
 
-	conn := meta.(*AWSClient).budgetconn
 	input := &budgets.UpdateBudgetActionInput{
-		BudgetName: aws.String(budgetName),
 		AccountId:  aws.String(accountID),
 		ActionId:   aws.String(actionID),
+		BudgetName: aws.String(budgetName),
+	}
+
+	if d.HasChange("action_threshold") {
+		input.ActionThreshold = expandAwsBudgetsBudgetActionActionThreshold(d.Get("action_threshold").([]interface{}))
 	}
 
 	if d.HasChange("approval_model") {
 		input.ApprovalModel = aws.String(d.Get("approval_model").(string))
+	}
+
+	if d.HasChange("definition") {
+		input.Definition = expandAwsBudgetsBudgetActionActionDefinition(d.Get("definition").([]interface{}))
 	}
 
 	if d.HasChange("execution_role_arn") {
@@ -322,49 +339,46 @@ func resourceAwsBudgetsBudgetActionUpdate(d *schema.ResourceData, meta interface
 		input.NotificationType = aws.String(d.Get("notification_type").(string))
 	}
 
-	if d.HasChange("action_threshold") {
-		input.ActionThreshold = expandAwsBudgetsBudgetActionActionThreshold(d.Get("action_threshold").([]interface{}))
-	}
-
 	if d.HasChange("subscriber") {
 		input.Subscribers = expandAwsBudgetsBudgetActionSubscriber(d.Get("subscriber").(*schema.Set))
 	}
 
-	if d.HasChange("definition") {
-		input.Definition = expandAwsBudgetsBudgetActionActionDefinition(d.Get("definition").([]interface{}))
-	}
-
+	log.Printf("[DEBUG] Updating Budget Action: %s", input)
 	_, err = conn.UpdateBudgetAction(input)
+
 	if err != nil {
-		return fmt.Errorf("Updating Budget Action failed: %w", err)
+		return fmt.Errorf("error updating Budget Action (%s): %w", d.Id(), err)
 	}
 
-	if _, err := waiter.ActionAvailable(conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for Budget Action (%s) update: %w", d.Id(), err)
+	if _, err := waiter.ActionAvailable(conn, accountID, actionID, budgetName); err != nil {
+		return fmt.Errorf("error waiting for Budget Action (%s) to update: %w", d.Id(), err)
 	}
 
 	return resourceAwsBudgetsBudgetActionRead(d, meta)
 }
 
 func resourceAwsBudgetsBudgetActionDelete(d *schema.ResourceData, meta interface{}) error {
-	accountID, actionID, budgetName, err := tfbudgets.DecodeBudgetsBudgetActionID(d.Id())
+	conn := meta.(*AWSClient).budgetconn
+
+	accountID, actionID, budgetName, err := tfbudgets.BudgetActionParseResourceID(d.Id())
+
 	if err != nil {
 		return err
 	}
 
-	conn := meta.(*AWSClient).budgetconn
+	log.Printf("[DEBUG] Deleting Budget Action: %s", d.Id())
 	_, err = conn.DeleteBudgetAction(&budgets.DeleteBudgetActionInput{
-		BudgetName: aws.String(budgetName),
 		AccountId:  aws.String(accountID),
 		ActionId:   aws.String(actionID),
+		BudgetName: aws.String(budgetName),
 	})
-	if err != nil {
-		if isAWSErr(err, budgets.ErrCodeNotFoundException, "") {
-			log.Printf("[INFO] Budget Action %s could not be found. skipping delete.", d.Id())
-			return nil
-		}
 
-		return fmt.Errorf("Deleting Budget Action failed: %w", err)
+	if tfawserr.ErrCodeEquals(err, budgets.ErrCodeNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Budget Action (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_budgets_budget_action_test.go
+++ b/aws/resource_aws_budgets_budget_action_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfbudgets "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/budgets"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/budgets/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func init() {
@@ -142,35 +144,55 @@ func testAccAWSBudgetsBudgetActionExists(resourceName string, config *budgets.Ac
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Budget Action ID is set")
+		}
+
 		conn := testAccProvider.Meta().(*AWSClient).budgetconn
-		out, err := finder.ActionById(conn, rs.Primary.ID)
+
+		accountID, actionID, budgetName, err := tfbudgets.BudgetActionParseResourceID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		output, err := finder.ActionByAccountIDActionIDAndBudgetName(conn, accountID, actionID, budgetName)
 
 		if err != nil {
 			return fmt.Errorf("Describe budget action error: %v", err)
 		}
 
-		if out.Action == nil {
-			return fmt.Errorf("No budget Action returned %v in %v", out.Action, out)
-		}
-
-		*out.Action = *config
+		*config = *output
 
 		return nil
 	}
 }
 
 func testAccAWSBudgetsBudgetActionDestroy(s *terraform.State) error {
-	meta := testAccProvider.Meta()
-	conn := meta.(*AWSClient).budgetconn
+	conn := testAccProvider.Meta().(*AWSClient).budgetconn
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_budgets_budget_action" {
 			continue
 		}
 
-		_, err := finder.ActionById(conn, rs.Primary.ID)
-		if !isAWSErr(err, budgets.ErrCodeNotFoundException, "") {
-			return fmt.Errorf("Budget Action '%s' was not deleted properly", rs.Primary.ID)
+		accountID, actionID, budgetName, err := tfbudgets.BudgetActionParseResourceID(rs.Primary.ID)
+
+		if err != nil {
+			return err
 		}
+
+		_, err = finder.ActionByAccountIDActionIDAndBudgetName(conn, accountID, actionID, budgetName)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("Budget Action %s still exists", rs.Primary.ID)
 	}
 
 	return nil

--- a/aws/resource_aws_budgets_budget_action_test.go
+++ b/aws/resource_aws_budgets_budget_action_test.go
@@ -89,7 +89,7 @@ func TestAccAWSBudgetsBudgetAction_basic(t *testing.T) {
 				Config: testAccAWSBudgetsBudgetActionConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccAWSBudgetsBudgetActionExists(resourceName, &conf),
-					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "budgetservice", regexp.MustCompile(fmt.Sprintf(`budget/%s/action/.+`, rName))),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "budgets", regexp.MustCompile(fmt.Sprintf(`budget/%s/action/.+`, rName))),
 					resource.TestCheckResourceAttrPair(resourceName, "budget_name", "aws_budgets_budget.test", "name"),
 					resource.TestCheckResourceAttrPair(resourceName, "execution_role_arn", "aws_iam_role.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "action_type", "APPLY_IAM_POLICY"),

--- a/aws/resource_aws_budgets_budget_action_test.go
+++ b/aws/resource_aws_budgets_budget_action_test.go
@@ -159,7 +159,7 @@ func testAccAWSBudgetsBudgetActionExists(resourceName string, config *budgets.Ac
 		output, err := finder.ActionByAccountIDActionIDAndBudgetName(conn, accountID, actionID, budgetName)
 
 		if err != nil {
-			return fmt.Errorf("Describe budget action error: %v", err)
+			return err
 		}
 
 		*config = *output

--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -3,9 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"reflect"
-	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -325,13 +322,16 @@ func TestAccAWSBudgetsBudget_CostTypes(t *testing.T) {
 	})
 }
 
-func TestAccAWSBudgetsBudget_basicish(t *testing.T) {
-	costFilterKey := "AZ"
+func TestAccAWSBudgetsBudget_Notifications(t *testing.T) {
+	var budget budgets.Budget
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	configBasicDefaults := testAccAWSBudgetsBudgetConfigDefaults(rName)
-	accountID := "012345678910"
-	configBasicUpdate := testAccAWSBudgetsBudgetConfigUpdate(rName)
 	resourceName := "aws_budgets_budget.test"
+	snsTopicResourceName := "aws_sns_topic.test"
+
+	domain := testAccRandomDomainName()
+	emailAddress1 := testAccRandomEmailAddress(domain)
+	emailAddress2 := testAccRandomEmailAddress(domain)
+	emailAddress3 := testAccRandomEmailAddress(domain)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(budgets.EndpointsID, t) },
@@ -340,35 +340,36 @@ func TestAccAWSBudgetsBudget_basicish(t *testing.T) {
 		CheckDestroy: testAccAWSBudgetsBudgetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBudgetsBudgetConfig_BasicDefaults(configBasicDefaults, costFilterKey),
+				Config: testAccAWSBudgetsBudgetConfigNotifications(rName, emailAddress1, emailAddress2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
-					testAccCheckResourceAttrGlobalARN(resourceName, "arn", "budgets", fmt.Sprintf(`budget/%s`, rName)),
-					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(*configBasicDefaults.BudgetName)),
-					resource.TestCheckResourceAttr(resourceName, "budget_type", *configBasicDefaults.BudgetType),
-					resource.TestCheckResourceAttr(resourceName, "limit_amount", *configBasicDefaults.BudgetLimit.Amount),
-					resource.TestCheckResourceAttr(resourceName, "limit_unit", *configBasicDefaults.BudgetLimit.Unit),
-					resource.TestCheckResourceAttr(resourceName, "time_period_start", configBasicDefaults.TimePeriod.Start.Format("2006-01-02_15:04")),
-					resource.TestCheckResourceAttr(resourceName, "time_period_end", configBasicDefaults.TimePeriod.End.Format("2006-01-02_15:04")),
-					resource.TestCheckResourceAttr(resourceName, "time_unit", *configBasicDefaults.TimeUnit),
-				),
-			},
-			{
-				PlanOnly:    true,
-				Config:      testAccAWSBudgetsBudgetConfig_WithAccountID(configBasicDefaults, accountID, costFilterKey),
-				ExpectError: regexp.MustCompile("account_id.*" + accountID),
-			},
-			{
-				Config: testAccAWSBudgetsBudgetConfig_Basic(configBasicUpdate, costFilterKey),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicUpdate),
-					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(*configBasicUpdate.BudgetName)),
-					resource.TestCheckResourceAttr(resourceName, "budget_type", *configBasicUpdate.BudgetType),
-					resource.TestCheckResourceAttr(resourceName, "limit_amount", *configBasicUpdate.BudgetLimit.Amount),
-					resource.TestCheckResourceAttr(resourceName, "limit_unit", *configBasicUpdate.BudgetLimit.Unit),
-					resource.TestCheckResourceAttr(resourceName, "time_period_start", configBasicUpdate.TimePeriod.Start.Format("2006-01-02_15:04")),
-					resource.TestCheckResourceAttr(resourceName, "time_period_end", configBasicUpdate.TimePeriod.End.Format("2006-01-02_15:04")),
-					resource.TestCheckResourceAttr(resourceName, "time_unit", *configBasicUpdate.TimeUnit),
+					testAccAWSBudgetsBudgetExists(resourceName, &budget),
+					resource.TestCheckResourceAttr(resourceName, "budget_type", "USAGE"),
+					resource.TestCheckResourceAttr(resourceName, "cost_filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cost_filters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "limit_amount", "432.1"),
+					resource.TestCheckResourceAttr(resourceName, "limit_unit", "GBP"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "notification.*", map[string]string{
+						"comparison_operator":          "GREATER_THAN",
+						"notification_type":            "ACTUAL",
+						"subscriber_email_addresses.#": "0",
+						"subscriber_sns_topic_arns.#":  "1",
+						"threshold":                    "150",
+						"threshold_type":               "PERCENTAGE",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "notification.*.subscriber_sns_topic_arns.*", snsTopicResourceName, "arn"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "notification.*", map[string]string{
+						"comparison_operator":          "EQUAL_TO",
+						"notification_type":            "FORECASTED",
+						"subscriber_email_addresses.#": "2",
+						"subscriber_sns_topic_arns.#":  "0",
+						"threshold":                    "200.1",
+						"threshold_type":               "ABSOLUTE_VALUE",
+					}),
+					resource.TestCheckTypeSetElemAttr(resourceName, "notification.*.subscriber_email_addresses.*", emailAddress1),
+					resource.TestCheckTypeSetElemAttr(resourceName, "notification.*.subscriber_email_addresses.*", emailAddress2),
+					resource.TestCheckResourceAttr(resourceName, "time_unit", "ANNUALLY"),
 				),
 			},
 			{
@@ -376,106 +377,27 @@ func TestAccAWSBudgetsBudget_basicish(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-		},
-	})
-}
-
-func TestAccAWSBudgetsBudget_notification(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	configBasicDefaults := testAccAWSBudgetsBudgetConfigDefaults(rName)
-	configBasicDefaults.CostFilters = map[string][]*string{}
-	resourceName := "aws_budgets_budget.test"
-
-	notificationConfigDefaults := []budgets.Notification{testAccAWSBudgetsBudgetNotificationConfigDefaults()}
-	notificationConfigUpdated := []budgets.Notification{testAccAWSBudgetsBudgetNotificationConfigUpdate()}
-	twoNotificationConfigs := []budgets.Notification{
-		testAccAWSBudgetsBudgetNotificationConfigUpdate(),
-		testAccAWSBudgetsBudgetNotificationConfigDefaults(),
-	}
-
-	domain := testAccRandomDomainName()
-	address1 := testAccRandomEmailAddress(domain)
-	address2 := testAccRandomEmailAddress(domain)
-	address3 := testAccRandomEmailAddress(domain)
-
-	noEmails := []string{}
-	oneEmail := []string{address1}
-	oneOtherEmail := []string{address2}
-	twoEmails := []string{address2, address3}
-	noTopics := []string{}
-	oneTopic := []string{"${aws_sns_topic.budget_notifications.arn}"}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(budgets.EndpointsID, t) },
-		ErrorCheck:   testAccErrorCheck(t, budgets.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccAWSBudgetsBudgetDestroy,
-		Steps: []resource.TestStep{
-			// Can't create without at least one subscriber
 			{
-				Config:      testAccAWSBudgetsBudgetConfigWithNotification_Basic(configBasicDefaults, notificationConfigDefaults, noEmails, noTopics),
-				ExpectError: regexp.MustCompile(`Notification must have at least one subscriber`),
+				Config: testAccAWSBudgetsBudgetConfigNotificationsUpdated(rName, emailAddress3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
-				),
-			},
-			// Basic Notification with only email
-			{
-				Config: testAccAWSBudgetsBudgetConfigWithNotification_Basic(configBasicDefaults, notificationConfigDefaults, oneEmail, noTopics),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
-				),
-			},
-			// Change only subscriber to a different e-mail
-			{
-				Config: testAccAWSBudgetsBudgetConfigWithNotification_Basic(configBasicDefaults, notificationConfigDefaults, oneOtherEmail, noTopics),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
-				),
-			},
-			// Add a second e-mail and a topic
-			{
-				Config: testAccAWSBudgetsBudgetConfigWithNotification_Basic(configBasicDefaults, notificationConfigDefaults, twoEmails, oneTopic),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
-				),
-			},
-			// Delete both E-Mails
-			{
-				Config: testAccAWSBudgetsBudgetConfigWithNotification_Basic(configBasicDefaults, notificationConfigDefaults, noEmails, oneTopic),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
-				),
-			},
-			// Swap one Topic fo one E-Mail
-			{
-				Config: testAccAWSBudgetsBudgetConfigWithNotification_Basic(configBasicDefaults, notificationConfigDefaults, oneEmail, noTopics),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
-				),
-			},
-			// Can't update without at least one subscriber
-			{
-				Config:      testAccAWSBudgetsBudgetConfigWithNotification_Basic(configBasicDefaults, notificationConfigDefaults, noEmails, noTopics),
-				ExpectError: regexp.MustCompile(`Notification must have at least one subscriber`),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
-				),
-			},
-			// Update all non-subscription parameters
-			{
-				Config:      testAccAWSBudgetsBudgetConfigWithNotification_Basic(configBasicDefaults, notificationConfigUpdated, noEmails, noTopics),
-				ExpectError: regexp.MustCompile(`Notification must have at least one subscriber`),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
-				),
-			},
-			// Add a second subscription
-			{
-				Config:      testAccAWSBudgetsBudgetConfigWithNotification_Basic(configBasicDefaults, twoNotificationConfigs, noEmails, noTopics),
-				ExpectError: regexp.MustCompile(`Notification must have at least one subscriber`),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAWSBudgetsBudgetExistsAndIsValid(resourceName, configBasicDefaults),
+					testAccAWSBudgetsBudgetExists(resourceName, &budget),
+					resource.TestCheckResourceAttr(resourceName, "budget_type", "USAGE"),
+					resource.TestCheckResourceAttr(resourceName, "cost_filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cost_filters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "limit_amount", "432.1"),
+					resource.TestCheckResourceAttr(resourceName, "limit_unit", "GBP"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "notification.*", map[string]string{
+						"comparison_operator":          "LESS_THAN",
+						"notification_type":            "ACTUAL",
+						"subscriber_email_addresses.#": "1",
+						"subscriber_sns_topic_arns.#":  "0",
+						"threshold":                    "123.45",
+						"threshold_type":               "ABSOLUTE_VALUE",
+					}),
+					resource.TestCheckTypeSetElemAttr(resourceName, "notification.*.subscriber_email_addresses.*", emailAddress3),
+					resource.TestCheckResourceAttr(resourceName, "time_unit", "ANNUALLY"),
 				),
 			},
 		},
@@ -513,104 +435,6 @@ func testAccAWSBudgetsBudgetExists(resourceName string, v *budgets.Budget) resou
 	}
 }
 
-func testAccAWSBudgetsBudgetExistsAndIsValid(resourceName string, config budgets.Budget) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Budget ID is set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).budgetconn
-
-		accountID, budgetName, err := tfbudgets.BudgetParseResourceID(rs.Primary.ID)
-
-		if err != nil {
-			return err
-		}
-
-		output, err := finder.BudgetByAccountIDAndBudgetName(conn, accountID, budgetName)
-
-		if err != nil {
-			return err
-		}
-
-		if aws.StringValue(output.BudgetLimit.Amount) != aws.StringValue(config.BudgetLimit.Amount) {
-			return fmt.Errorf("budget limit incorrectly set %v != %v", aws.StringValue(config.BudgetLimit.Amount),
-				aws.StringValue(output.BudgetLimit.Amount))
-		}
-
-		if err := testAccAWSBudgetsBudgetCheckCostTypes(config, *output.CostTypes); err != nil {
-			return err
-		}
-
-		if err := testAccAWSBudgetsBudgetCheckTimePeriod(*config.TimePeriod, *output.TimePeriod); err != nil {
-			return err
-		}
-
-		if !reflect.DeepEqual(output.CostFilters, config.CostFilters) {
-			return fmt.Errorf("cost filter not set properly: %v != %v", output.CostFilters, config.CostFilters)
-		}
-
-		return nil
-	}
-}
-
-func testAccAWSBudgetsBudgetCheckTimePeriod(configTimePeriod, timePeriod budgets.TimePeriod) error {
-	if configTimePeriod.End.Format("2006-01-02_15:04") != timePeriod.End.Format("2006-01-02_15:04") {
-		return fmt.Errorf("TimePeriodEnd not set properly '%v' should be '%v'", *timePeriod.End, *configTimePeriod.End)
-	}
-
-	if configTimePeriod.Start.Format("2006-01-02_15:04") != timePeriod.Start.Format("2006-01-02_15:04") {
-		return fmt.Errorf("TimePeriodStart not set properly '%v' should be '%v'", *timePeriod.Start, *configTimePeriod.Start)
-	}
-
-	return nil
-}
-
-func testAccAWSBudgetsBudgetCheckCostTypes(config budgets.Budget, costTypes budgets.CostTypes) error {
-	if *costTypes.IncludeCredit != *config.CostTypes.IncludeCredit {
-		return fmt.Errorf("IncludeCredit not set properly '%v' should be '%v'", *costTypes.IncludeCredit, *config.CostTypes.IncludeCredit)
-	}
-
-	if *costTypes.IncludeOtherSubscription != *config.CostTypes.IncludeOtherSubscription {
-		return fmt.Errorf("IncludeOtherSubscription not set properly '%v' should be '%v'", *costTypes.IncludeOtherSubscription, *config.CostTypes.IncludeOtherSubscription)
-	}
-
-	if *costTypes.IncludeRecurring != *config.CostTypes.IncludeRecurring {
-		return fmt.Errorf("IncludeRecurring not set properly  '%v' should be '%v'", *costTypes.IncludeRecurring, *config.CostTypes.IncludeRecurring)
-	}
-
-	if *costTypes.IncludeRefund != *config.CostTypes.IncludeRefund {
-		return fmt.Errorf("IncludeRefund not set properly '%v' should be '%v'", *costTypes.IncludeRefund, *config.CostTypes.IncludeRefund)
-	}
-
-	if *costTypes.IncludeSubscription != *config.CostTypes.IncludeSubscription {
-		return fmt.Errorf("IncludeSubscription not set properly '%v' should be '%v'", *costTypes.IncludeSubscription, *config.CostTypes.IncludeSubscription)
-	}
-
-	if *costTypes.IncludeSupport != *config.CostTypes.IncludeSupport {
-		return fmt.Errorf("IncludeSupport not set properly '%v' should be '%v'", *costTypes.IncludeSupport, *config.CostTypes.IncludeSupport)
-	}
-
-	if *costTypes.IncludeTax != *config.CostTypes.IncludeTax {
-		return fmt.Errorf("IncludeTax not set properly '%v' should be '%v'", *costTypes.IncludeTax, *config.CostTypes.IncludeTax)
-	}
-
-	if *costTypes.IncludeUpfront != *config.CostTypes.IncludeUpfront {
-		return fmt.Errorf("IncludeUpfront not set properly '%v' should be '%v'", *costTypes.IncludeUpfront, *config.CostTypes.IncludeUpfront)
-	}
-
-	if *costTypes.UseBlended != *config.CostTypes.UseBlended {
-		return fmt.Errorf("UseBlended not set properly '%v' should be '%v'", *costTypes.UseBlended, *config.CostTypes.UseBlended)
-	}
-
-	return nil
-}
-
 func testAccAWSBudgetsBudgetDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).budgetconn
 
@@ -639,96 +463,6 @@ func testAccAWSBudgetsBudgetDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccAWSBudgetsBudgetConfigUpdate(name string) budgets.Budget {
-	dateNow := time.Now().UTC()
-	futureDate := dateNow.AddDate(0, 0, 14)
-	startDate := dateNow.AddDate(0, 0, -14)
-	return budgets.Budget{
-		BudgetName: aws.String(name),
-		BudgetType: aws.String("COST"),
-		BudgetLimit: &budgets.Spend{
-			Amount: aws.String("500.0"),
-			Unit:   aws.String("USD"),
-		},
-		CostFilters: map[string][]*string{
-			"AZ": {
-				aws.String(testAccGetAlternateRegion()),
-				aws.String(testAccGetThirdRegion()),
-			},
-		},
-		CostTypes: &budgets.CostTypes{
-			IncludeCredit:            aws.Bool(true),
-			IncludeOtherSubscription: aws.Bool(true),
-			IncludeRecurring:         aws.Bool(true),
-			IncludeRefund:            aws.Bool(true),
-			IncludeSubscription:      aws.Bool(false),
-			IncludeSupport:           aws.Bool(true),
-			IncludeTax:               aws.Bool(false),
-			IncludeUpfront:           aws.Bool(true),
-			UseBlended:               aws.Bool(false),
-		},
-		TimeUnit: aws.String("MONTHLY"),
-		TimePeriod: &budgets.TimePeriod{
-			End:   &futureDate,
-			Start: &startDate,
-		},
-	}
-}
-
-func testAccAWSBudgetsBudgetConfigDefaults(name string) budgets.Budget {
-	dateNow := time.Now().UTC()
-	futureDate := time.Date(2087, 6, 15, 00, 0, 0, 0, time.UTC)
-	startDate := dateNow.AddDate(0, 0, -14)
-	return budgets.Budget{
-		BudgetName: aws.String(name),
-		BudgetType: aws.String("COST"),
-		BudgetLimit: &budgets.Spend{
-			Amount: aws.String("100.0"),
-			Unit:   aws.String("USD"),
-		},
-		CostFilters: map[string][]*string{
-			"AZ": {
-				aws.String(testAccGetRegion()),
-				aws.String(testAccGetThirdRegion()),
-			},
-		},
-		CostTypes: &budgets.CostTypes{
-			IncludeCredit:            aws.Bool(true),
-			IncludeOtherSubscription: aws.Bool(true),
-			IncludeRecurring:         aws.Bool(true),
-			IncludeRefund:            aws.Bool(true),
-			IncludeSubscription:      aws.Bool(true),
-			IncludeSupport:           aws.Bool(true),
-			IncludeTax:               aws.Bool(true),
-			IncludeUpfront:           aws.Bool(true),
-			UseBlended:               aws.Bool(false),
-		},
-		TimeUnit: aws.String("MONTHLY"),
-		TimePeriod: &budgets.TimePeriod{
-			End:   &futureDate,
-			Start: &startDate,
-		},
-	}
-}
-
-func testAccAWSBudgetsBudgetNotificationConfigDefaults() budgets.Notification {
-	return budgets.Notification{
-		NotificationType:   aws.String(budgets.NotificationTypeActual),
-		ThresholdType:      aws.String(budgets.ThresholdTypeAbsoluteValue),
-		Threshold:          aws.Float64(100.0),
-		ComparisonOperator: aws.String(budgets.ComparisonOperatorGreaterThan),
-	}
-}
-
-func testAccAWSBudgetsBudgetNotificationConfigUpdate() budgets.Notification {
-	return budgets.Notification{
-		NotificationType:   aws.String(budgets.NotificationTypeForecasted),
-		ThresholdType:      aws.String(budgets.ThresholdTypePercentage),
-		Threshold:          aws.Float64(200.0),
-		ComparisonOperator: aws.String(budgets.ComparisonOperatorLessThan),
-	}
 }
 
 func testAccAWSBudgetsBudgetConfig(rName string) string {
@@ -831,158 +565,54 @@ resource "aws_budgets_budget" "test" {
 `, rName, startDate, endDate, testAccGetAlternateRegion(), testAccGetThirdRegion())
 }
 
-func testAccAWSBudgetsBudgetConfig_WithAccountID(budgetConfig budgets.Budget, accountID, costFilterKey string) string {
-	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	costFilterValue1 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
-	costFilterValue2 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][1])
-
+func testAccAWSBudgetsBudgetConfigNotifications(rName, emailAddress1, emailAddress2 string) string {
 	return fmt.Sprintf(`
-resource "aws_budgets_budget" "test" {
-  account_id        = "%s"
-  name_prefix       = "%s"
-  budget_type       = "%s"
-  limit_amount      = "%s"
-  limit_unit        = "%s"
-  time_period_start = "%s"
-  time_unit         = "%s"
-
-  cost_filter {
-    name = "%s"
-    values = [
-      "%s",
-      "%s",
-    ]
-  }
-}
-`, accountID, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue1, costFilterValue2)
-}
-
-func testAccAWSBudgetsBudgetConfig_BasicDefaults(budgetConfig budgets.Budget, costFilterKey string) string {
-	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	costFilterValue1 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
-	costFilterValue2 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][1])
-
-	return fmt.Sprintf(`
-resource "aws_budgets_budget" "test" {
-  name              = "%s"
-  budget_type       = "%s"
-  limit_amount      = "%s"
-  limit_unit        = "%s"
-  time_period_start = "%s"
-  time_unit         = "%s"
-
-  cost_filter {
-    name = "%s"
-    values = [
-      "%s",
-      "%s",
-    ]
-  }
-}
-`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue1, costFilterValue2)
-}
-
-func testAccAWSBudgetsBudgetConfig_Basic(budgetConfig budgets.Budget, costFilterKey string) string {
-	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	timePeriodEnd := budgetConfig.TimePeriod.End.Format("2006-01-02_15:04")
-	costFilterValue1 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
-	costFilterValue2 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][1])
-
-	return fmt.Sprintf(`
-resource "aws_budgets_budget" "test" {
-  name         = "%s"
-  budget_type  = "%s"
-  limit_amount = "%s"
-  limit_unit   = "%s"
-
-  cost_types {
-    include_tax          = "%t"
-    include_subscription = "%t"
-    use_blended          = "%t"
-  }
-
-  time_period_start = "%s"
-  time_period_end   = "%s"
-  time_unit         = "%s"
-
-  cost_filter {
-    name = "%s"
-    values = [
-      "%s",
-      "%s",
-    ]
-  }
-}
-`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), aws.BoolValue(budgetConfig.CostTypes.IncludeTax), aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription), aws.BoolValue(budgetConfig.CostTypes.UseBlended), timePeriodStart, timePeriodEnd, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue1, costFilterValue2)
-}
-
-func testAccAWSBudgetsBudgetConfigWithNotification_Basic(budgetConfig budgets.Budget, notifications []budgets.Notification, emails []string, topics []string) string {
-	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	timePeriodEnd := budgetConfig.TimePeriod.End.Format("2006-01-02_15:04")
-	notificationStrings := make([]string, len(notifications))
-
-	for i, notification := range notifications {
-		notificationStrings[i] = testAccAWSBudgetsBudgetConfigNotificationSnippet(notification, emails, topics)
-	}
-
-	return fmt.Sprintf(`
-resource "aws_sns_topic" "budget_notifications" {
-  name_prefix = "user-updates-topic"
+resource "aws_sns_topic" "test" {
+  name = %[1]q
 }
 
 resource "aws_budgets_budget" "test" {
-  name         = "%s"
-  budget_type  = "%s"
-  limit_amount = "%s"
-  limit_unit   = "%s"
-  cost_types {
-    include_tax          = "%t"
-    include_subscription = "%t"
-    use_blended          = "%t"
+  name         = %[1]q
+  budget_type  = "USAGE"
+  limit_amount = "432.10"
+  limit_unit   = "GBP"
+  time_unit    = "ANNUALLY"
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+	notification_type         = "ACTUAL"
+	threshold                 = 150
+	threshold_type            = "PERCENTAGE"
+	subscriber_sns_topic_arns = [aws_sns_topic.test.arn]
   }
 
-  time_period_start = "%s"
-  time_period_end   = "%s"
-  time_unit         = "%s"
-    %s
+  notification {
+    comparison_operator        = "EQUAL_TO"
+	notification_type          = "FORECASTED"
+	threshold                  = 200.10
+	threshold_type             = "ABSOLUTE_VALUE"
+	subscriber_email_addresses = [%[2]q, %[3]q]
+  }
 }
-`, aws.StringValue(budgetConfig.BudgetName),
-		aws.StringValue(budgetConfig.BudgetType),
-		aws.StringValue(budgetConfig.BudgetLimit.Amount),
-		aws.StringValue(budgetConfig.BudgetLimit.Unit),
-		aws.BoolValue(budgetConfig.CostTypes.IncludeTax),
-		aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription),
-		aws.BoolValue(budgetConfig.CostTypes.UseBlended),
-		timePeriodStart,
-		timePeriodEnd,
-		aws.StringValue(budgetConfig.TimeUnit),
-		strings.Join(notificationStrings, "\n"))
+`, rName, emailAddress1, emailAddress2)
 }
 
-func testAccAWSBudgetsBudgetConfigNotificationSnippet(notification budgets.Notification, emails []string, topics []string) string {
-	quotedEMails := make([]string, len(emails))
-	for i, email := range emails {
-		quotedEMails[i] = strconv.Quote(email)
-	}
-
-	quotedTopics := make([]string, len(topics))
-	for i, topic := range topics {
-		quotedTopics[i] = strconv.Quote(topic)
-	}
-
+func testAccAWSBudgetsBudgetConfigNotificationsUpdated(rName, emailAddress1 string) string {
 	return fmt.Sprintf(`
-notification {
-  threshold                  = %f
-  threshold_type             = "%s"
-  notification_type          = "%s"
-  subscriber_email_addresses = [%s]
-  subscriber_sns_topic_arns  = [%s]
-  comparison_operator        = "%s"
+resource "aws_budgets_budget" "test" {
+  name         = %[1]q
+  budget_type  = "USAGE"
+  limit_amount = "432.10"
+  limit_unit   = "GBP"
+  time_unit    = "ANNUALLY"
+
+  notification {
+    comparison_operator        = "LESS_THAN"
+	notification_type          = "ACTUAL"
+	threshold                  = 123.45
+	threshold_type             = "ABSOLUTE_VALUE"
+	subscriber_email_addresses = [%[2]q]
+  }
 }
-`, aws.Float64Value(notification.Threshold),
-		aws.StringValue(notification.ThresholdType),
-		aws.StringValue(notification.NotificationType),
-		strings.Join(quotedEMails, ","),
-		strings.Join(quotedTopics, ","),
-		aws.StringValue(notification.ComparisonOperator))
+`, rName, emailAddress1)
 }

--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -529,8 +529,8 @@ resource "aws_budgets_budget" "test" {
   cost_types {
     include_discount     = false
     include_subscription = true
-	include_tax          = false
-	use_blended          = true
+    include_tax          = false
+    use_blended          = true
   }
 }
 `, rName, startDate, endDate, testAccGetRegion(), testAccGetAlternateRegion())
@@ -554,12 +554,12 @@ resource "aws_budgets_budget" "test" {
   }
 
   cost_types {
-	include_credit       = false
+    include_credit       = false
     include_discount     = true
-	include_refund       = false
+    include_refund       = false
     include_subscription = true
-	include_tax          = true
-	use_blended          = false
+    include_tax          = true
+    use_blended          = false
   }
 }
 `, rName, startDate, endDate, testAccGetAlternateRegion(), testAccGetThirdRegion())
@@ -580,18 +580,18 @@ resource "aws_budgets_budget" "test" {
 
   notification {
     comparison_operator       = "GREATER_THAN"
-	notification_type         = "ACTUAL"
-	threshold                 = 150
-	threshold_type            = "PERCENTAGE"
-	subscriber_sns_topic_arns = [aws_sns_topic.test.arn]
+    notification_type         = "ACTUAL"
+    threshold                 = 150
+    threshold_type            = "PERCENTAGE"
+    subscriber_sns_topic_arns = [aws_sns_topic.test.arn]
   }
 
   notification {
     comparison_operator        = "EQUAL_TO"
-	notification_type          = "FORECASTED"
-	threshold                  = 200.10
-	threshold_type             = "ABSOLUTE_VALUE"
-	subscriber_email_addresses = [%[2]q, %[3]q]
+    notification_type          = "FORECASTED"
+    threshold                  = 200.10
+    threshold_type             = "ABSOLUTE_VALUE"
+    subscriber_email_addresses = [%[2]q, %[3]q]
   }
 }
 `, rName, emailAddress1, emailAddress2)
@@ -608,10 +608,10 @@ resource "aws_budgets_budget" "test" {
 
   notification {
     comparison_operator        = "LESS_THAN"
-	notification_type          = "ACTUAL"
-	threshold                  = 123.45
-	threshold_type             = "ABSOLUTE_VALUE"
-	subscriber_email_addresses = [%[2]q]
+    notification_type          = "ACTUAL"
+    threshold                  = 123.45
+    threshold_type             = "ABSOLUTE_VALUE"
+    subscriber_email_addresses = [%[2]q]
   }
 }
 `, rName, emailAddress1)

--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -109,6 +109,8 @@ func TestAccAWSBudgetsBudget_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "limit_unit", "PERCENTAGE"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "time_period_end"),
+					resource.TestCheckResourceAttrSet(resourceName, "time_period_start"),
 					resource.TestCheckResourceAttr(resourceName, "time_unit", "QUARTERLY"),
 				),
 			},

--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -447,6 +447,7 @@ func testAccAWSBudgetsBudgetConfigUpdate(name string) budgets.Budget {
 		CostFilters: map[string][]*string{
 			"AZ": {
 				aws.String(testAccGetAlternateRegion()),
+				aws.String("ap-northeast-1"),
 			},
 		},
 		CostTypes: &budgets.CostTypes{
@@ -482,6 +483,7 @@ func testAccAWSBudgetsBudgetConfigDefaults(name string) budgets.Budget {
 		CostFilters: map[string][]*string{
 			"AZ": {
 				aws.String(testAccGetRegion()),
+				aws.String("ap-northeast-1"),
 			},
 		},
 		CostTypes: &budgets.CostTypes{
@@ -523,7 +525,8 @@ func testAccAWSBudgetsBudgetNotificationConfigUpdate() budgets.Notification {
 
 func testAccAWSBudgetsBudgetConfig_WithAccountID(budgetConfig budgets.Budget, accountID, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue1 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue2 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][1])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -535,16 +538,21 @@ resource "aws_budgets_budget" "test" {
   time_period_start = "%s"
   time_unit         = "%s"
 
-  cost_filters = {
-    "%s" = "%s"
+  cost_filter {
+    name = "%s"
+    values = [
+      "%s",
+      "%s",
+    ]
   }
 }
-`, accountID, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
+`, accountID, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue1, costFilterValue2)
 }
 
 func testAccAWSBudgetsBudgetConfig_PrefixDefaults(budgetConfig budgets.Budget, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue1 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue2 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][1])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -555,17 +563,22 @@ resource "aws_budgets_budget" "test" {
   time_period_start = "%s"
   time_unit         = "%s"
 
-  cost_filters = {
-    "%s" = "%s"
+  cost_filter {
+    name = "%s"
+    values = [
+      "%s",
+      "%s",
+    ]
   }
 }
-`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
+`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue1, costFilterValue2)
 }
 
 func testAccAWSBudgetsBudgetConfig_Prefix(budgetConfig budgets.Budget, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
 	timePeriodEnd := budgetConfig.TimePeriod.End.Format("2006-01-02_15:04")
-	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue1 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue2 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][1])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -584,16 +597,21 @@ resource "aws_budgets_budget" "test" {
   time_period_end   = "%s"
   time_unit         = "%s"
 
-  cost_filters = {
-    "%s" = "%s"
+  cost_filter {
+    name = "%s"
+    values = [
+      "%s",
+      "%s",
+    ]
   }
 }
-`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), aws.BoolValue(budgetConfig.CostTypes.IncludeTax), aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription), aws.BoolValue(budgetConfig.CostTypes.UseBlended), timePeriodStart, timePeriodEnd, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
+`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), aws.BoolValue(budgetConfig.CostTypes.IncludeTax), aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription), aws.BoolValue(budgetConfig.CostTypes.UseBlended), timePeriodStart, timePeriodEnd, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue1, costFilterValue2)
 }
 
 func testAccAWSBudgetsBudgetConfig_BasicDefaults(budgetConfig budgets.Budget, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue1 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue2 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][1])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -604,17 +622,22 @@ resource "aws_budgets_budget" "test" {
   time_period_start = "%s"
   time_unit         = "%s"
 
-  cost_filters = {
-    "%s" = "%s"
+  cost_filter {
+    name = "%s"
+    values = [
+      "%s",
+      "%s",
+    ]
   }
 }
-`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
+`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue1, costFilterValue2)
 }
 
 func testAccAWSBudgetsBudgetConfig_Basic(budgetConfig budgets.Budget, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
 	timePeriodEnd := budgetConfig.TimePeriod.End.Format("2006-01-02_15:04")
-	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue1 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
+	costFilterValue2 := aws.StringValue(budgetConfig.CostFilters[costFilterKey][1])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -633,11 +656,15 @@ resource "aws_budgets_budget" "test" {
   time_period_end   = "%s"
   time_unit         = "%s"
 
-  cost_filters = {
-    "%s" = "%s"
+  cost_filter {
+    name = "%s"
+    values = [
+      "%s",
+      "%s",
+    ]
   }
 }
-`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), aws.BoolValue(budgetConfig.CostTypes.IncludeTax), aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription), aws.BoolValue(budgetConfig.CostTypes.UseBlended), timePeriodStart, timePeriodEnd, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
+`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), aws.BoolValue(budgetConfig.CostTypes.IncludeTax), aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription), aws.BoolValue(budgetConfig.CostTypes.UseBlended), timePeriodStart, timePeriodEnd, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue1, costFilterValue2)
 }
 
 func testAccAWSBudgetsBudgetConfigWithNotification_Basic(budgetConfig budgets.Budget, notifications []budgets.Notification, emails []string, topics []string) string {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/pquerna/otp v1.3.0
-	github.com/shopspring/decimal v1.2.0 // indirect
+	github.com/shopspring/decimal v1.2.0
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/pquerna/otp v1.3.0
+	github.com/shopspring/decimal v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -307,6 +307,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
+github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -117,7 +117,7 @@ resource "aws_budgets_budget" "ri_utilization" {
 
 ## Argument Reference
 
-~> **NOTE:** The `cost_filters` attribute has been deprecated and might be removed in future releases, please use `cost_filter` instead.
+~> **NOTE:** The `cost_filters` attribute will be deprecated and eventually removed in future releases, please use `cost_filter` instead.
 
 For more detailed documentation about each argument, refer to the [AWS official
 documentation](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-budget.html).

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -134,7 +134,7 @@ The following arguments are supported:
 * `limit_amount` - (Required) The amount of cost or usage being measured for a budget.
 * `limit_unit` - (Required) The unit of measurement used for the budget forecast, actual spend, or budget threshold, such as dollars or GB. See [Spend](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-spend.html) documentation.
 * `time_period_end` - (Optional) The end of the time period covered by the budget. There are no restrictions on the end date. Format: `2017-01-01_12:00`.
-* `time_period_start` - (Required) The start of the time period covered by the budget. The start date must come before the end date. Format: `2017-01-01_12:00`.
+* `time_period_start` - (Optional) The start of the time period covered by the budget. If you don't specify a start date, AWS defaults to the start of your chosen time period. The start date must come before the end date. Format: `2017-01-01_12:00`.
 * `time_unit` - (Required) The length of time until a budget resets the actual and forecasted spend. Valid values: `MONTHLY`, `QUARTERLY`, `ANNUALLY`, and `DAILY`.
 * `notification` - (Optional) Object containing [Budget Notifications](#Budget-Notification). Can be used multiple times to define more than one budget notification
 

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -22,8 +22,11 @@ resource "aws_budgets_budget" "ec2" {
   time_period_start = "2017-07-01_00:00"
   time_unit         = "MONTHLY"
 
-  cost_filters = {
-    Service = "Amazon Elastic Compute Cloud - Compute"
+  cost_filter {
+    name = "Service"
+    values = [
+      "Amazon Elastic Compute Cloud - Compute",
+    ]
   }
 
   notification {
@@ -114,6 +117,8 @@ resource "aws_budgets_budget" "ri_utilization" {
 
 ## Argument Reference
 
+~> **NOTE:** The `cost_filters` attribute has been deprecated and might be removed in future releases, please use `cost_filter` instead.
+
 For more detailed documentation about each argument, refer to the [AWS official
 documentation](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-budget.html).
 
@@ -123,8 +128,9 @@ The following arguments are supported:
 * `name` - (Optional) The name of a budget. Unique within accounts.
 * `name_prefix` - (Optional) The prefix of the name of a budget. Unique within accounts.
 * `budget_type` - (Required) Whether this budget tracks monetary cost or usage.
-* `cost_filters` - (Optional) Map of [Cost Filters](#Cost-Filters) key/value pairs to apply to the budget.
-* `cost_types` - (Optional) Object containing [Cost Types](#Cost-Types) The types of cost included in a budget, such as tax and subscriptions..
+* `cost_filter` - (Optional) A list of [CostFilter](#Cost-Filter) name/values pair to apply to budget.
+* `cost_filters` - (Optional) Map of [CostFilters](#Cost-Filters) key/value pairs to apply to the budget.
+* `cost_types` - (Optional) Object containing [CostTypes](#Cost-Types) The types of cost included in a budget, such as tax and subscriptions.
 * `limit_amount` - (Required) The amount of cost or usage being measured for a budget.
 * `limit_unit` - (Required) The unit of measurement used for the budget forecast, actual spend, or budget threshold, such as dollars or GB. See [Spend](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-spend.html) documentation.
 * `time_period_end` - (Optional) The end of the time period covered by the budget. There are no restrictions on the end date. Format: `2017-01-01_12:00`.
@@ -158,9 +164,9 @@ Valid keys for `cost_types` parameter.
 
 Refer to [AWS CostTypes documentation](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_CostTypes.html) for further detail.
 
-### Cost Filters
+### Cost Filter
 
-Valid keys for `cost_filters` parameter vary depending on the `budget_type` value.
+Valid name for `cost_filter` parameter vary depending on the `budget_type` value.
 
 * `cost`
     * `AZ`
@@ -178,6 +184,10 @@ Valid keys for `cost_filters` parameter vary depending on the `budget_type` valu
     * `TagKeyValue`
 
 Refer to [AWS CostFilter documentation](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-filter.html) for further detail.
+
+### Cost Filters
+
+Valid key for `cost_filters` is same as `cost_filter`. Please refer to [CostFilter](#Cost-Filter).
 
 ### Budget Notification
 

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -145,7 +145,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - id of resource.
 * `arn` - The ARN of the budget.
 
-
 ### Cost Types
 
 Valid keys for `cost_types` parameter.
@@ -187,7 +186,7 @@ Refer to [AWS CostFilter documentation](http://docs.aws.amazon.com/awsaccountbil
 
 ### Cost Filters
 
-Valid key for `cost_filters` is same as `cost_filter`. Please refer to [CostFilter](#Cost-Filter).
+Valid key for `cost_filters` is same as `cost_filter`. Please refer to [Cost Filter](#Cost-Filter).
 
 ### Budget Notification
 
@@ -199,7 +198,6 @@ Valid keys for `notification` parameter.
 * `notification_type` - (Required) What kind of budget value to notify on. Can be `ACTUAL` or `FORECASTED`
 * `subscriber_email_addresses` - (Optional) E-Mail addresses to notify. Either this or `subscriber_sns_topic_arns` is required.
 * `subscriber_sns_topic_arns` - (Optional) SNS topics to notify. Either this or `subscriber_email_addresses` is required.
-
 
 ## Import
 


### PR DESCRIPTION
Current aws_budgets_budget resource does not support multiple cost filter values because the `cost_filters` map takes only one string value per string key. However, AWS Budgets API and its console can handle multiple values per one cost filter key.

This change makes it to be able to handle multiple cost filter values like following syntax. This is a similar concept to `parameter` attribute of [Resource: aws_db_parameter_group](https://www.terraform.io/docs/providers/aws/r/db_parameter_group.html).

```hcl
resource "aws_budgets_budget" "monthly_cost_budget" {
  # :
  # (snip)
  # :

  cost_filter {
    name = "Region"
    values = [
      "ap-northeast-1",
      "us-east-1",
    ]
  }

  cost_filter {
    name = "PurchaseType"
    values = [
      "Spot",
    ]
  }

  # :
  # (snip)
  # :
}
```

I tried to implement like "Potential Terraform Configuration" section of https://github.com/terraform-providers/terraform-provider-aws/issues/5890 but I couldn't. I suppose the value of `TypeMap` should be primitive type (it means that we cannot use `TypeList` as the `TypeMap`'s value) by the reason reported https://github.com/hashicorp/terraform/issues/15327 .

Of course, the `cost_filter` attributes conflicts with `cost_filters`. Thus I think its good to deprecate `cost_filters` attribute.

Would you review my change and if my idea is correct?

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #5890.
Closes #10692.
Closes #12669.
Closes #13288.
Closes #19803.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Support multiple cost filter values by adding the `cost_filter` attribute and depreciating the `cost_filters` attribute
```

Output from acceptance testing:

```
[14:32:08]mozamimy@ip-10-33-164-61:terraform-provider-aws (cost-filter-multiple-values) (-'x'-).oO(
(ins)> nice -n 19 make testacc TEST=./aws TESTARGS="-run=TestAccAWSBudgetsBudget_basic" && nice -n 19 make testac
c TEST=./aws TESTARGS="-run=TestAccAWSBudgetsBudget_prefix" && nice -n 19 make testacc TEST=./aws TESTARGS="-run=
TestAccAWSBudgetsBudget_notification"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSBudgetsBudget_basic -timeout 120m
=== RUN   TestAccAWSBudgetsBudget_basic
=== PAUSE TestAccAWSBudgetsBudget_basic
=== CONT  TestAccAWSBudgetsBudget_basic
--- PASS: TestAccAWSBudgetsBudget_basic (39.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       39.297s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSBudgetsBudget_prefix -timeout 120m
=== RUN   TestAccAWSBudgetsBudget_prefix
=== PAUSE TestAccAWSBudgetsBudget_prefix
=== CONT  TestAccAWSBudgetsBudget_prefix
--- PASS: TestAccAWSBudgetsBudget_prefix (34.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       34.924s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSBudgetsBudget_notification -timeout 120m
=== RUN   TestAccAWSBudgetsBudget_notification
=== PAUSE TestAccAWSBudgetsBudget_notification
=== CONT  TestAccAWSBudgetsBudget_notification
--- PASS: TestAccAWSBudgetsBudget_notification (116.67s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       116.699s
```
