### PR TITLE
Add support Relational Database for appsync datasource

### DIFF
--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -89,13 +89,14 @@ The following arguments are supported:
 
 * `api_id` - (Required) The API ID for the GraphQL API for the DataSource.
 * `name` - (Required) A user-supplied name for the DataSource.
-* `type` - (Required) The type of the DataSource. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `HTTP`, `NONE`.
+* `type` - (Required) The type of the DataSource. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `HTTP`, `NONE`, `RELATIONAL_DATABASE`.
 * `description` - (Optional) A description of the DataSource.
 * `service_role_arn` - (Optional) The IAM service role ARN for the data source.
 * `dynamodb_config` - (Optional) DynamoDB settings. See [below](#dynamodb_config)
 * `elasticsearch_config` - (Optional) Amazon Elasticsearch settings. See [below](#elasticsearch_config)
 * `http_config` - (Optional) HTTP settings. See [below](#http_config)
 * `lambda_config` - (Optional) AWS Lambda settings. See [below](#lambda_config)
+* `relational_database_config` (Optional) AWS RDS settings. See [below](#relational_database_config)
 
 ### dynamodb_config
 
@@ -123,6 +124,23 @@ The following arguments are supported:
 The following arguments are supported:
 
 * `function_arn` - (Required) The ARN for the Lambda function.
+
+### relational_database_config
+
+The following arguments are supported:
+
+* `http_endpoint_config` - (Required) The Amazon RDS HTTP endpoint configuration. See [below](#http_endpoint_config)
+* `source_type` - (Optional) Source type for the relational database. Valid values: `RDS_HTTP_ENDPOINT`.
+
+### http_endpoint_config
+
+The following arguments are supported:
+
+* `cluster_identifier` - (Required) Amazon RDS cluster identifier.
+* `secret_store_arn` - (Required) AWS secret store ARN for database credentials.
+* `database_name` - (Optional) Logical database name.
+* `region` - (Optional) AWS Region for RDS HTTP endpoint. Defaults to current region.
+* `schema` - (Optional) Logical schema name.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8870

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_appsync_datasource: Add `relational_database_config` attribute
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsAppsyncDatasource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsAppsyncDatasource_ -timeout 120m
=== RUN   TestAccAwsAppsyncDatasource_basic
=== PAUSE TestAccAwsAppsyncDatasource_basic
=== RUN   TestAccAwsAppsyncDatasource_Description
=== PAUSE TestAccAwsAppsyncDatasource_Description
=== RUN   TestAccAwsAppsyncDatasource_DynamoDBConfig_Region
=== PAUSE TestAccAwsAppsyncDatasource_DynamoDBConfig_Region
=== RUN   TestAccAwsAppsyncDatasource_DynamoDBConfig_UseCallerCredentials
=== PAUSE TestAccAwsAppsyncDatasource_DynamoDBConfig_UseCallerCredentials
=== RUN   TestAccAwsAppsyncDatasource_ElasticsearchConfig_Region
=== PAUSE TestAccAwsAppsyncDatasource_ElasticsearchConfig_Region
=== RUN   TestAccAwsAppsyncDatasource_HTTPConfig_Endpoint
=== PAUSE TestAccAwsAppsyncDatasource_HTTPConfig_Endpoint
=== RUN   TestAccAwsAppsyncDatasource_Type
=== PAUSE TestAccAwsAppsyncDatasource_Type
=== RUN   TestAccAwsAppsyncDatasource_Type_DynamoDB
=== PAUSE TestAccAwsAppsyncDatasource_Type_DynamoDB
=== RUN   TestAccAwsAppsyncDatasource_Type_Elasticsearch
=== PAUSE TestAccAwsAppsyncDatasource_Type_Elasticsearch
=== RUN   TestAccAwsAppsyncDatasource_Type_HTTP
=== PAUSE TestAccAwsAppsyncDatasource_Type_HTTP
=== RUN   TestAccAwsAppsyncDatasource_Type_Lambda
=== PAUSE TestAccAwsAppsyncDatasource_Type_Lambda
=== RUN   TestAccAwsAppsyncDatasource_Type_None
=== PAUSE TestAccAwsAppsyncDatasource_Type_None
=== RUN   TestAccAwsAppsyncDatasource_Type_RelationalDatabase
=== PAUSE TestAccAwsAppsyncDatasource_Type_RelationalDatabase
=== RUN   TestAccAwsAppsyncDatasource_Type_RelationalDatabaseWithOptions
=== PAUSE TestAccAwsAppsyncDatasource_Type_RelationalDatabaseWithOptions
=== CONT  TestAccAwsAppsyncDatasource_basic
=== CONT  TestAccAwsAppsyncDatasource_Type_DynamoDB
=== CONT  TestAccAwsAppsyncDatasource_Type_RelationalDatabaseWithOptions
=== CONT  TestAccAwsAppsyncDatasource_Type_RelationalDatabase
=== CONT  TestAccAwsAppsyncDatasource_Type_None
=== CONT  TestAccAwsAppsyncDatasource_Type_Lambda
=== CONT  TestAccAwsAppsyncDatasource_Type_HTTP
=== CONT  TestAccAwsAppsyncDatasource_Type_Elasticsearch
=== CONT  TestAccAwsAppsyncDatasource_DynamoDBConfig_Region
=== CONT  TestAccAwsAppsyncDatasource_Type
=== CONT  TestAccAwsAppsyncDatasource_HTTPConfig_Endpoint
=== CONT  TestAccAwsAppsyncDatasource_ElasticsearchConfig_Region
=== CONT  TestAccAwsAppsyncDatasource_Description
=== CONT  TestAccAwsAppsyncDatasource_DynamoDBConfig_UseCallerCredentials
--- PASS: TestAccAwsAppsyncDatasource_Type_HTTP (88.24s)
--- PASS: TestAccAwsAppsyncDatasource_Type_None (89.49s)
--- PASS: TestAccAwsAppsyncDatasource_basic (91.83s)
--- PASS: TestAccAwsAppsyncDatasource_Type_Lambda (101.68s)
--- PASS: TestAccAwsAppsyncDatasource_Description (111.81s)
--- PASS: TestAccAwsAppsyncDatasource_Type (112.83s)
--- PASS: TestAccAwsAppsyncDatasource_HTTPConfig_Endpoint (117.12s)
--- PASS: TestAccAwsAppsyncDatasource_DynamoDBConfig_Region (147.26s)
--- PASS: TestAccAwsAppsyncDatasource_DynamoDBConfig_UseCallerCredentials (154.31s)
--- FAIL: TestAccAwsAppsyncDatasource_Type_DynamoDB (186.25s)
    testing.go:568: Step 0 error: Check failed: Check 4/6 error: aws_appsync_datasource.test: Attribute 'dynamodb_config.0.region' expected "us-west-2", got "us-east-1"
--- PASS: TestAccAwsAppsyncDatasource_Type_RelationalDatabase (369.33s)
--- PASS: TestAccAwsAppsyncDatasource_Type_RelationalDatabaseWithOptions (401.28s)
--- PASS: TestAccAwsAppsyncDatasource_ElasticsearchConfig_Region (748.96s)
--- FAIL: TestAccAwsAppsyncDatasource_Type_Elasticsearch (890.21s)
    testing.go:568: Step 0 error: Check failed: Check 4/6 error: aws_appsync_datasource.test: Attribute 'elasticsearch_config.0.region' expected "us-west-2", got "us-east-1"
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	890.361s
make: *** [testacc] Error 1
```

Retry  `TestAccAwsAppsyncDatasource_Type_DynamoDB`
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsAppsyncDatasource_Type_DynamoDB'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsAppsyncDatasource_Type_DynamoDB -timeout 120m
=== RUN   TestAccAwsAppsyncDatasource_Type_DynamoDB
=== PAUSE TestAccAwsAppsyncDatasource_Type_DynamoDB
=== CONT  TestAccAwsAppsyncDatasource_Type_DynamoDB
--- PASS: TestAccAwsAppsyncDatasource_Type_DynamoDB (153.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	153.337s
```

Retry `TestAccAwsAppsyncDatasource_Type_Elasticsearch`
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsAppsyncDatasource_Type_Elasticsearch'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsAppsyncDatasource_Type_Elasticsearch -timeout 120m
=== RUN   TestAccAwsAppsyncDatasource_Type_Elasticsearch
=== PAUSE TestAccAwsAppsyncDatasource_Type_Elasticsearch
=== CONT  TestAccAwsAppsyncDatasource_Type_Elasticsearch
--- PASS: TestAccAwsAppsyncDatasource_Type_Elasticsearch (1061.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1062.036s
```
