### PR TITLE
New resource: aws_lightsail_domain_entry

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -577,6 +577,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_licensemanager_association":                          resourceAwsLicenseManagerAssociation(),
 			"aws_licensemanager_license_configuration":                resourceAwsLicenseManagerLicenseConfiguration(),
 			"aws_lightsail_domain":                                    resourceAwsLightsailDomain(),
+			"aws_lightsail_domain_entry":                              resourceAwsLightsailDomainEntry(),
 			"aws_lightsail_instance":                                  resourceAwsLightsailInstance(),
 			"aws_lightsail_key_pair":                                  resourceAwsLightsailKeyPair(),
 			"aws_lightsail_static_ip":                                 resourceAwsLightsailStaticIp(),

--- a/aws/resource_aws_lightsail_domain_entry.go
+++ b/aws/resource_aws_lightsail_domain_entry.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"strings"
+)
+
+func resourceAwsLightsailDomainEntry() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsLightsailDomainEntryCreate,
+		Read:   resourceAwsLightsailDomainEntryRead,
+		Delete: resourceAwsLightsailDomainEntryDelete,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"is_alias": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"target": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"A",
+					"CNAME",
+					"MX",
+					"NS",
+					"SOA",
+					"SRV",
+					"TXT",
+				}, false),
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsLightsailDomainEntryCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+	req := &lightsail.CreateDomainEntryInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+
+		DomainEntry: &lightsail.DomainEntry{
+			IsAlias: aws.Bool(d.Get("is_alias").(bool)),
+			Name:    aws.String(d.Get("name").(string)),
+			Target:  aws.String(d.Get("target").(string)),
+			Type:    aws.String(d.Get("type").(string)),
+		},
+	}
+
+	_, err := conn.CreateDomainEntry(req)
+
+	if err != nil {
+		return err
+	}
+
+	// Generate an ID
+	vars := []string{
+		d.Get("name").(string),
+		d.Get("domain_name").(string),
+		d.Get("type").(string),
+		d.Get("target").(string),
+	}
+
+	d.SetId(strings.Join(vars, "_"))
+
+	return resourceAwsLightsailDomainEntryRead(d, meta)
+}
+
+func resourceAwsLightsailDomainEntryRead(d *schema.ResourceData, meta interface{}) error {
+
+	id_parts := strings.SplitN(d.Id(), "_", -1)
+	if len(id_parts) != 4 {
+		return nil
+	}
+	name := id_parts[0]
+	domainname := id_parts[1]
+	recordType := id_parts[2]
+	recordTarget := id_parts[3]
+
+	conn := meta.(*AWSClient).lightsailconn
+	resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+		DomainName: aws.String(domainname),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	var entry lightsail.DomainEntry
+	entryExists := false
+
+	for _, n := range resp.Domain.DomainEntries {
+		if name == *n.Name && recordType == *n.Type && recordTarget == *n.Target {
+			entry = *n
+			entryExists = true
+			break
+		}
+	}
+
+	if !entryExists {
+		d.SetId("")
+	}
+
+	d.Set("name", entry.Name)
+	d.Set("domain_name", domainname)
+	d.Set("type", entry.Type)
+	d.Set("is_alias", entry.IsAlias)
+	d.Set("target", entry.Target)
+
+	return nil
+}
+
+func resourceAwsLightsailDomainEntryDelete(d *schema.ResourceData, meta interface{}) error {
+
+	id_parts := strings.SplitN(d.Id(), "_", -1)
+	name := id_parts[0]
+	domainname := id_parts[1]
+	recordType := id_parts[2]
+	recordTarget := id_parts[3]
+
+	conn := meta.(*AWSClient).lightsailconn
+	_, err := conn.DeleteDomainEntry(&lightsail.DeleteDomainEntryInput{
+		DomainName: aws.String(domainname),
+		DomainEntry: &lightsail.DomainEntry{
+			Name:    aws.String(name),
+			Type:    aws.String(recordType),
+			Target:  aws.String(recordTarget),
+			IsAlias: aws.Bool(d.Get("is_alias").(bool)),
+		},
+	})
+
+	return err
+}

--- a/aws/resource_aws_lightsail_domain_entry_test.go
+++ b/aws/resource_aws_lightsail_domain_entry_test.go
@@ -1,0 +1,172 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSLightsailDomainEntry_basic(t *testing.T) {
+	var domainEntry lightsail.DomainEntry
+	lightsailDomainName := fmt.Sprintf("tf-test-lightsail-%s.com", acctest.RandString(5))
+	lightsailDomainEntryName := fmt.Sprintf("test-%s.%s", acctest.RandString(5), lightsailDomainName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailDomainEntryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailDomainEntryConfig_basic(lightsailDomainName, lightsailDomainEntryName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailDomainEntryExists("aws_lightsail_domain_entry.entry_test", &domainEntry),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLightsailDomainEntry_disappears(t *testing.T) {
+	var domainEntry lightsail.DomainEntry
+	lightsailDomainName := fmt.Sprintf("tf-test-lightsail-%s.com", acctest.RandString(5))
+	lightsailDomainEntryName := fmt.Sprintf("test-%s.%s", acctest.RandString(5), lightsailDomainName)
+
+	domainEntryDestroy := func(*terraform.State) error {
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+		_, err := conn.DeleteDomainEntry(&lightsail.DeleteDomainEntryInput{
+			DomainName: aws.String(lightsailDomainName),
+			DomainEntry: &lightsail.DomainEntry{
+				Name:   aws.String(lightsailDomainEntryName),
+				Type:   aws.String("A"),
+				Target: aws.String("127.0.0.1"),
+			},
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error deleting Lightsail Domain Entry in disapear test")
+		}
+
+		return nil
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailDomainEntryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailDomainEntryConfig_basic(lightsailDomainName, lightsailDomainEntryName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailDomainEntryExists("aws_lightsail_domain_entry.entry_test", &domainEntry),
+					domainEntryDestroy,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSLightsailDomainEntryExists(n string, domainEntry *lightsail.DomainEntry) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Lightsail Domain Entry ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+			DomainName: aws.String(rs.Primary.Attributes["domain_name"]),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || resp.Domain == nil {
+			return fmt.Errorf("Domain (%s) not found", rs.Primary.Attributes["domain_name"])
+		}
+
+		entryExists := false
+		for _, n := range resp.Domain.DomainEntries {
+			if rs.Primary.Attributes["name"] == *n.Name && rs.Primary.Attributes["type"] == *n.Type && rs.Primary.Attributes["target"] == *n.Target {
+				*domainEntry = *n
+				entryExists = true
+				break
+			}
+		}
+
+		if !entryExists {
+			return fmt.Errorf("Domain entry (%s) not found", rs.Primary.Attributes["name"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSLightsailDomainEntryDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lightsail_domain_entry" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+			DomainName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if resp.Domain != nil {
+				return fmt.Errorf("Lightsail Domain Entry %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				return nil
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSLightsailDomainEntryConfig_basic(lightsailDomainName string, lightsailDomainEntryName string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_lightsail_domain" "domain_test" {
+  domain_name = "%s"
+}
+
+resource "aws_lightsail_domain_entry" "entry_test" {
+        domain_name = "%s"
+        name = "%s"
+        type = "A"
+        target = "127.0.0.1"
+        is_alias = false
+  		depends_on = [aws_lightsail_domain.domain_test]
+}
+
+
+`, lightsailDomainName, lightsailDomainName, lightsailDomainEntryName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1946,6 +1946,9 @@
                                     <a href="/docs/providers/aws/r/lightsail_domain.html">aws_lightsail_domain</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/lightsail_domain_entry.html">aws_lightsail_domain_entry</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/lightsail_instance.html">aws_lightsail_instance</a>
                                 </li>
                                 <li>

--- a/website/docs/r/lightsail_domain_entry.html.markdown
+++ b/website/docs/r/lightsail_domain_entry.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lightsail_domain_entry"
+sidebar_current: "docs-aws-resource-lightsail-domain-entry"
+description: |-
+  Provides an Lightsail Domain Entry
+---
+
+# Resource: aws_lightsail_domain_entry
+
+Creates a domain entry resource
+
+## Example Usage, creating a new domain
+
+```hcl
+resource "aws_lightsail_domain" "domain_test" {
+  domain_name = "mydomain.com"
+}
+
+resource "aws_lightsail_domain_entry" "entry_test" {
+  domain_name = "${aws_lightsail_domain.domain_test.domain_name}"
+  name = "a3.${aws_lightsail_domain.domain_test.domain_name}"
+  type = "A"
+  target = "127.0.0.1"
+  depends_on = ["aws_lightsail_domain.domain_test"]
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required) The name of the Lightsail domain in which to create the entry
+* `name` - (Required) Name of the entry record
+* `type` - (Required) Type of record
+* `target` - (Required) Target of the domain entry
+* `is_alias` - (Optional) If the entry should be an alias Defaults to `false`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Add new resource `aws_lightsail_domain_entry`
Closes #2731

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws/lightsail_domain_entry: New resource
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSLightsailDomainEntry_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLightsailDomainEntry_basic -timeout 120m
=== RUN   TestAccAWSLightsailDomainEntry_basic
=== PAUSE TestAccAWSLightsailDomainEntry_basic
=== CONT  TestAccAWSLightsailDomainEntry_basic
--- PASS: TestAccAWSLightsailDomainEntry_basic (33.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	33.357s

make testacc TEST=./aws TESTARGS='-run=TestAccAWSLightsailDomainEntry_disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLightsailDomainEntry_disappears -timeout 120m
=== RUN   TestAccAWSLightsailDomainEntry_disappears
=== PAUSE TestAccAWSLightsailDomainEntry_disappears
=== CONT  TestAccAWSLightsailDomainEntry_disappears
--- PASS: TestAccAWSLightsailDomainEntry_disappears (31.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	31.807s
...
```
