### PR TITLE
Creating new resource for aws_dx_connection_accepter

### DIFF
--- a/aws/dx_conn.go
+++ b/aws/dx_conn.go
@@ -1,0 +1,81 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dxConnectionRead(id string, conn *directconnect.DirectConnect) (*directconnect.Connection, error) {
+	resp, state, err := dxConnectionStateRefresh(conn, id)()
+	if err != nil {
+		return nil, fmt.Errorf("Error reading Direct Connection: %s", err)
+	}
+	if state == directconnect.ConnectionStateDeleted {
+		return nil, nil
+	}
+
+	return resp.(*directconnect.Connection), nil
+}
+
+func dxConnectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "directconnect",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("dxcon/%s", d.Id()),
+	}.String()
+	if err := setTagsDX(conn, d, arn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func dxConnectionStateRefresh(conn *directconnect.DirectConnect, dxConId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeConnections(&directconnect.DescribeConnectionsInput{
+			ConnectionId: aws.String(dxConId),
+		})
+		if err != nil {
+			return nil, "", err
+		}
+
+		n := len(resp.Connections)
+		switch n {
+		case 0:
+			return "", directconnect.ConnectionStateDeleted, nil
+
+		case 1:
+			dxCon := resp.Connections[0]
+			return dxCon, aws.StringValue(dxCon.ConnectionState), nil
+
+		default:
+			return nil, "", fmt.Errorf("Found %d Direct Connection for %s, expected 1", n, dxConId)
+		}
+	}
+}
+
+func dxConnectionWaitUntilAvailable(conn *directconnect.DirectConnect, dxConId string, timeout time.Duration, pending, target []string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    pending,
+		Target:     target,
+		Refresh:    dxConnectionStateRefresh(conn, dxConId),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Direct Connection (%s) to become available: %s", dxConId, err)
+	}
+
+	return nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -430,6 +430,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_docdb_subnet_group":                                  resourceAwsDocDBSubnetGroup(),
 			"aws_dx_bgp_peer":                                         resourceAwsDxBgpPeer(),
 			"aws_dx_connection":                                       resourceAwsDxConnection(),
+			"aws_dx_connection_accepter":                              resourceAwsDxConnectionAccepter(),
 			"aws_dx_connection_association":                           resourceAwsDxConnectionAssociation(),
 			"aws_dx_gateway":                                          resourceAwsDxGateway(),
 			"aws_dx_gateway_association":                              resourceAwsDxGatewayAssociation(),

--- a/aws/resource_aws_dx_connection_accepter.go
+++ b/aws/resource_aws_dx_connection_accepter.go
@@ -1,0 +1,140 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDxConnectionAccepter() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDxConnectionAccepterCreate,
+		Read:   resourceAwsDxConnectionAccepterRead,
+		Update: resourceAwsDxConnectionAccepterUpdate,
+		Delete: resourceAwsDxConnectionAccepterDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsDxConnectionAccepterImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"dx_connection_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+	}
+}
+
+func resourceAwsDxConnectionAccepterCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	dxConId := d.Get("dx_connection_id").(string)
+	req := &directconnect.ConfirmConnectionInput{
+		ConnectionId: aws.String(dxConId),
+	}
+
+	log.Printf("[DEBUG] Accepting Direct Connection: %#v", req)
+	_, err := conn.ConfirmConnection(req)
+	if err != nil {
+		return fmt.Errorf("Error accepting Direct Connection: %s", err.Error())
+	}
+
+	d.SetId(dxConId)
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "directconnect",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("dxcon/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+
+	if err := dxConnectionAccepterWaitUntilAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return err
+	}
+
+	return resourceAwsDxConnectionAccepterUpdate(d, meta)
+}
+
+func resourceAwsDxConnectionAccepterRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	dxCon, err := dxConnectionRead(d.Id(), conn)
+	if err != nil {
+		return err
+	}
+	if dxCon == nil {
+		log.Printf("[WARN] Direct Connect virtual interface (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	dxConState := aws.StringValue(dxCon.ConnectionState)
+	if dxConState != directconnect.ConnectionStateAvailable &&
+		dxConState != directconnect.ConnectionStateDown {
+		log.Printf("[WARN] Direct Connect virtual interface (%s) is '%s', removing from state", dxConState, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("dx_connection_id", dxCon.ConnectionId)
+	err1 := getTagsDX(conn, d, d.Get("arn").(string))
+	return err1
+}
+
+func resourceAwsDxConnectionAccepterUpdate(d *schema.ResourceData, meta interface{}) error {
+	if err := dxConnectionUpdate(d, meta); err != nil {
+		return err
+	}
+
+	return resourceAwsDxConnectionAccepterRead(d, meta)
+}
+
+func resourceAwsDxConnectionAccepterDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Will not delete Direct Connect virtual interface. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}
+
+func resourceAwsDxConnectionAccepterImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "directconnect",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("dxdxCon/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func dxConnectionAccepterWaitUntilAvailable(conn *directconnect.DirectConnect, conId string, timeout time.Duration) error {
+	return dxConnectionWaitUntilAvailable(
+		conn,
+		conId,
+		timeout,
+		[]string{
+			directconnect.ConnectionStateRequested,
+			directconnect.ConnectionStateOrdering,
+			directconnect.ConnectionStatePending,
+		},
+		[]string{
+			directconnect.ConnectionStateAvailable,
+			directconnect.ConnectionStateDown,
+		})
+}

--- a/website/docs/r/dx_connection_accepter.html.markdown
+++ b/website/docs/r/dx_connection_accepter.html.markdown
@@ -1,0 +1,80 @@
+---
+layout: "aws"
+page_title: "AWS: aws_dx_connection_accepter"
+sidebar_current: "docs-aws-resource-dx-connection-accepter"
+description: |-
+  Provides a resource to manage the accepter's side of a Direct Connect connection.
+---
+
+# Resource: aws_dx_connection_accepter
+
+Provides a resource to manage the accepter's side of a Direct Connect connection.
+This resource accepts ownership of a connection created by another AWS account.
+
+## Example Usage
+
+```hcl
+provider "aws" {
+  # Creator's credentials.
+}
+
+provider "aws" {
+  alias = "accepter"
+  region = "us-east-1"
+
+  # Accepter's credentials.
+}
+
+resource "aws_dx_connection" "main" {
+  name      = "tf-dx-connection"
+  bandwidth = "1Gbps"
+  location  = "EqDC2"
+}
+
+resource "aws_dx_connection_accepter" "accepter_primary" {
+  provider         = "aws.accepter"
+  dx_connection_id = "${aws_dx_connection.main.id}"
+
+  tags = {
+    Side = "Accepter"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `dx_connection_id` - (Required) The ID of the Direct Connect connection to accept.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+### Removing `aws_dx_connection_accepter` from your configuration
+
+AWS allows a Direct Connect connection to be deleted from either the allocator's or accepter's side.
+However, Terraform only allows the Direct Connect connection to be deleted from the allocator's side
+by removing the corresponding `aws_dx_connection` resource from your configuration.
+Removing a `aws_dx_connection_accepter` resource from your configuration will remove it
+from your statefile and management, **but will not delete the Direct Connect connection.**
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the connection.
+* `arn` - The ARN of the connection.
+
+## Timeouts
+
+`aws_dx_connection_accepter` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for creating connection
+- `delete` - (Default `10 minutes`) Used for destroying connection
+
+## Import
+
+Direct Connect connections can be imported using the `connection id`, e.g.
+
+```
+$ terraform import aws_dx_connection_accepter.test dxcon-33cc44dd
+```


### PR DESCRIPTION
Using the `aws_dx_hosted_public_virtual_interface_accepter` as an example, create an accepter for
AWS DirectConnect Connections.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Resolves #9366

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add new resource for confirming aws_dx_connection resources.
```

Output from acceptance testing:

N/A