### PR TITLE
Add support for aws_datapipeline_definition resource

### DIFF
--- a/aws/datapipeline_helpers.go
+++ b/aws/datapipeline_helpers.go
@@ -1,0 +1,99 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+)
+
+func expandDataPipelineDefaultPipelineObject(l []interface{}) (*datapipeline.PipelineObject, error) {
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	pipelineObject := &datapipeline.PipelineObject{
+		Id:   aws.String("Default"),
+		Name: aws.String("Default"),
+	}
+	fieldList := []*datapipeline.Field{}
+
+	typeField := &datapipeline.Field{
+		Key:         aws.String("type"),
+		StringValue: aws.String("Default"),
+	}
+	fieldList = append(fieldList, typeField)
+
+	if val, ok := m["schedule_type"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("scheduleType"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := m["failure_and_rerun_mode"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("failureAndRerunMode"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := m["pipeline_log_uri"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("pipelineLogUri"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := m["role"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("role"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := m["resource_role"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("resourceRole"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	pipelineObject.Fields = fieldList
+
+	err := pipelineObject.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("Error validate default pipeline object: %s", err)
+	}
+
+	return pipelineObject, nil
+}
+
+func flattenDataPipelineDefaultPipelineObject(object *datapipeline.PipelineObject) []map[string]interface{} {
+	pipelineObject := make(map[string]interface{})
+	for _, field := range object.Fields {
+		switch aws.StringValue(field.Key) {
+		case "scheduleType":
+			pipelineObject["schedule_type"] = aws.StringValue(field.StringValue)
+		case "failureAndRerunMode":
+			pipelineObject["failure_and_rerun_mode"] = aws.StringValue(field.StringValue)
+		case "pipelineLogUri":
+			pipelineObject["pipeline_log_uri"] = aws.StringValue(field.StringValue)
+		case "role":
+			pipelineObject["role"] = aws.StringValue(field.StringValue)
+		case "resourceRole":
+			pipelineObject["resource_role"] = aws.StringValue(field.StringValue)
+		case "schedule":
+			pipelineObject["schedule"] = aws.StringValue(field.RefValue)
+		}
+	}
+
+	return []map[string]interface{}{pipelineObject}
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -405,6 +405,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cur_report_definition":                               resourceAwsCurReportDefinition(),
 			"aws_customer_gateway":                                    resourceAwsCustomerGateway(),
 			"aws_datapipeline_pipeline":                               resourceAwsDataPipelinePipeline(),
+			"aws_datapipeline_definition":                             resourceAwsDataPipelineDefinition(),
 			"aws_datasync_agent":                                      resourceAwsDataSyncAgent(),
 			"aws_datasync_location_efs":                               resourceAwsDataSyncLocationEfs(),
 			"aws_datasync_location_nfs":                               resourceAwsDataSyncLocationNfs(),

--- a/aws/resource_aws_datapipeline_definition.go
+++ b/aws/resource_aws_datapipeline_definition.go
@@ -7,8 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/datapipeline"
 
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 var dataPipelineScheduleTypeList = []string{

--- a/aws/resource_aws_datapipeline_definition.go
+++ b/aws/resource_aws_datapipeline_definition.go
@@ -1,0 +1,175 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+var dataPipelineScheduleTypeList = []string{
+	"cron",
+	"ondemand",
+	"timeseries",
+}
+
+var dataPipelineFailureAndRerunModeList = []string{
+	"cascade",
+	"none",
+}
+
+func resourceAwsDataPipelineDefinition() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDataPipelineDefinitionPut,
+		Read:   resourceAwsDataPipelineDefinitionRead,
+		Update: resourceAwsDataPipelineDefinitionPut,
+		Delete: schema.Noop,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsDataPipelineDefinitionImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"pipeline_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"default": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_role": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+
+						"role": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+
+						"schedule_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineScheduleTypeList, false),
+						},
+
+						"failure_and_rerun_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineFailureAndRerunModeList, false),
+							Default:      "none",
+						},
+
+						"pipeline_log_uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsDataPipelineDefinitionPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	pipelineID := d.Get("pipeline_id").(string)
+	input := &datapipeline.PutPipelineDefinitionInput{
+		PipelineId: aws.String(pipelineID),
+	}
+
+	pipelineObjectsConfigs := []*datapipeline.PipelineObject{}
+
+	if v, ok := d.GetOk("default"); ok {
+		pipelineObject, err := expandDataPipelineDefaultPipelineObject(v.([]interface{}))
+		if err != nil {
+			return err
+		}
+		pipelineObjectsConfigs = append(pipelineObjectsConfigs, pipelineObject)
+	}
+
+	if len(pipelineObjectsConfigs) > 0 {
+		input.PipelineObjects = pipelineObjectsConfigs
+	}
+
+	_, err := conn.PutPipelineDefinition(input)
+	if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+		log.Printf("[WARN] DataPipeline (%s) not found, removing from state", pipelineID)
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error putting DataPipeline (%s) Definition: %s", pipelineID, err)
+	}
+
+	d.SetId(pipelineID)
+	return resourceAwsDataPipelineDefinitionRead(d, meta)
+}
+
+func resourceAwsDataPipelineDefinitionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	v, err := resourceAwsDataPipelineDefinitionRetrieve(d.Id(), conn)
+	if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+		log.Printf("[WARN] DataPipeline (%s) Definition not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error getting DataPipeline (%s) Definition: %s", d.Id(), err)
+	}
+
+	if err := flattenDataPipelinePipelineObjects(d, v.PipelineObjects); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsDataPipelineDefinitionImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("pipeline_id", d.Id())
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceAwsDataPipelineDefinitionRetrieve(id string, conn *datapipeline.DataPipeline) (*datapipeline.GetPipelineDefinitionOutput, error) {
+	opts := datapipeline.GetPipelineDefinitionInput{
+		PipelineId: aws.String(id),
+	}
+	log.Printf("[DEBUG] Data Pipeline describe configuration: %#v", opts)
+
+	resp, err := conn.GetPipelineDefinition(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func flattenDataPipelinePipelineObjects(d *schema.ResourceData, pipelineObjects []*datapipeline.PipelineObject) error {
+
+	for _, pipelineObject := range pipelineObjects {
+		for _, field := range pipelineObject.Fields {
+			if aws.StringValue(field.Key) == "type" {
+				switch aws.StringValue(field.StringValue) {
+				case "Default":
+					if err := d.Set("default", flattenDataPipelineDefaultPipelineObject(pipelineObject)); err != nil {
+						return fmt.Errorf("Error setting default object: %s", err)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/aws/resource_aws_datapipeline_definition_test.go
+++ b/aws/resource_aws_datapipeline_definition_test.go
@@ -1,0 +1,269 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDataPipelineDefinition_basic(t *testing.T) {
+	var conf datapipeline.GetPipelineDefinitionOutput
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_definition.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataPipeline(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineDefinitionConfig(rName, "cron"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline_pipeline.default", "id",
+						resourceName, "pipeline_id"),
+					resource.TestCheckResourceAttr(resourceName, "default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.schedule_type", "cron"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.failure_and_rerun_mode", "none"),
+					resource.TestCheckResourceAttrPair(
+						"aws_iam_role.role", "arn",
+						resourceName, "default.0.role"),
+					resource.TestCheckResourceAttrPair(
+						"aws_iam_instance_profile.resource_role", "arn",
+						resourceName, "default.0.resource_role"),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfig(rName, "ondemand"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.schedule_type", "ondemand"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipelineDefinition_options(t *testing.T) {
+	var conf datapipeline.GetPipelineDefinitionOutput
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	bucketName1 := fmt.Sprintf("tf-test-pipeline-log-bucket-%s", acctest.RandString(5))
+	bucketName2 := fmt.Sprintf("tf-test-pipeline-log-bucket-2-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_definition.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataPipeline(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineDefinitionConfigDefaultWithOptions(rName, bucketName1, "cascade"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.failure_and_rerun_mode", "cascade"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.pipeline_log_uri", fmt.Sprintf("s3://%s/log_prefix", bucketName1)),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfigDefaultWithOptions(rName, bucketName2, "none"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.failure_and_rerun_mode", "none"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.pipeline_log_uri", fmt.Sprintf("s3://%s/log_prefix", bucketName2)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipelineDefinition_disappears(t *testing.T) {
+	var description datapipeline.PipelineDescription
+	var definition datapipeline.GetPipelineDefinitionOutput
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_definition.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataPipeline(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineDefinitionConfig(rName, "ondemand"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists("aws_datapipeline_pipeline.default", &description),
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &definition),
+					testAccCheckAWSDataPipelinePipelineDisappears(&description),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDataPipelineDefinitionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_datapipeline_definition" {
+			continue
+		}
+		// Try to find the Pipeline
+		pipelineDefinition, err := resourceAwsDataPipelineDefinitionRetrieve(rs.Primary.ID, conn)
+		if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+		if pipelineDefinition != nil {
+			return fmt.Errorf("Pipeline Definition still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDataPipelineDefinitionExists(n string, v *datapipeline.GetPipelineDefinitionOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DataPipeline ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+
+		pipelineDefinition, err := resourceAwsDataPipelineDefinitionRetrieve(rs.Primary.ID, conn)
+
+		if err != nil {
+			return err
+		}
+		if pipelineDefinition == nil {
+			return fmt.Errorf("DataPipeline Definition not found")
+		}
+
+		*v = *pipelineDefinition
+		return nil
+	}
+}
+
+func testAccAWSDataPipelineDefinitionConfigCommon(rName string) string {
+	return fmt.Sprintf(testAccAWSDataPipelinePipelineConfig(rName)+`
+resource "aws_iam_role" "role" {
+  name = "tf-test-datapipeline-role-%[1]s"
+      
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "elasticmapreduce.amazonaws.com",
+          "datapipeline.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+data "aws_iam_policy" "role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole"
+}
+resource "aws_iam_role_policy_attachment" "role" {
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "${data.aws_iam_policy.role.arn}"
+}
+resource "aws_iam_role" "resource_role" {
+  name = "tf-test-datapipeline-resource-role-%[1]s"
+      
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+data "aws_iam_policy" "resource_role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole"
+}
+resource "aws_iam_role_policy_attachment" "resource_role" {
+  role       = "${aws_iam_role.resource_role.name}"
+  policy_arn = "${data.aws_iam_policy.resource_role.arn}"
+}
+resource "aws_iam_instance_profile" "resource_role" {
+  name = "tf-test-datapipeline-resource-role-profile-%[1]s"
+  role = "${aws_iam_role.resource_role.name}"
+}
+`, rName)
+}
+
+func testAccAWSDataPipelineDefinitionConfig(rName, scheduleType string) string {
+	return fmt.Sprintf(testAccAWSDataPipelineDefinitionConfigCommon(rName)+`
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+  default {
+	schedule_type = %[2]q
+	role          = "${aws_iam_role.role.arn}"
+	resource_role = "${aws_iam_instance_profile.resource_role.arn}"
+  }
+}`, rName, scheduleType)
+
+}
+
+func testAccAWSDataPipelineDefinitionConfigDefaultWithOptions(rName, bucketName, failureAndRerunMode string) string {
+	return fmt.Sprintf(testAccAWSDataPipelineDefinitionConfigCommon(rName)+`
+resource "aws_s3_bucket" "log_bucket" {
+  bucket = %[1]q
+  acl    = "log-delivery-write"
+		
+  force_destroy = true
+}
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+  default {
+	schedule_type          = "ondemand"
+	role                   = "${aws_iam_role.role.arn}"
+	resource_role          = "${aws_iam_instance_profile.resource_role.arn}"
+	pipeline_log_uri       = "s3://${aws_s3_bucket.log_bucket.id}/log_prefix"
+	failure_and_rerun_mode = %[2]q
+  }
+}`, bucketName, failureAndRerunMode)
+
+}

--- a/aws/resource_aws_datapipeline_definition_test.go
+++ b/aws/resource_aws_datapipeline_definition_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/datapipeline"
 
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSDataPipelineDefinition_basic(t *testing.T) {

--- a/website/docs/r/datapipeline_definition.html.markdown
+++ b/website/docs/r/datapipeline_definition.html.markdown
@@ -1,0 +1,115 @@
+---
+layout: "aws"
+page_title: "AWS: aws_datapipeline_definition"
+sidebar_current: "docs-aws-resource-datapipeline-definition"
+description: |-
+  Provides a AWS DataPipeline Definition.
+---
+
+# Resource: aws_datapipeline_definition
+
+Provides a Data Pipeline Definition resource.
+
+## Example Usage
+
+```hcl
+resource "aws_iam_role" "role" {
+  name = "tf-test-datapipeline-role-%[1]s"
+      
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "elasticmapreduce.amazonaws.com",
+          "datapipeline.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+data "aws_iam_policy" "role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole"
+}
+resource "aws_iam_role_policy_attachment" "role" {
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "${data.aws_iam_policy.role.arn}"
+}
+resource "aws_iam_role" "resource_role" {
+  name = "tf-test-datapipeline-resource-role-%[1]s"
+      
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+data "aws_iam_policy" "resource_role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole"
+}
+resource "aws_iam_role_policy_attachment" "resource_role" {
+  role       = "${aws_iam_role.resource_role.name}"
+  policy_arn = "${data.aws_iam_policy.resource_role.arn}"
+}
+resource "aws_iam_instance_profile" "resource_role" {
+  name = "tf-test-datapipeline-resource-role-profile-%[1]s"
+  role = "${aws_iam_role.resource_role.name}"
+}
+resource "aws_datapipeline_pipeline" "default" {
+	name = "tf-pipeline-default"
+}
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+  default {
+	schedule_type = "ondemand"
+	role          = "${aws_iam_role.role.arn}"
+	resource_role = "${aws_iam_instance_profile.resource_role.arn}"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `pipeline_id` - (Required) The id of Pipeline.
+* `default` - (Required) The default configuration to assign to the resource. Documented below.
+
+The `default` configuration supports the following:
+
+* `resource_role` - (Required) The arn of iam instance profile attached to resources.
+* `role` - (Required) The arn of iam role, execute pipeline.
+* `schedule_type` - (Required) The parameters for the RUN_COMMAND task execution. Valid values are `cron`, `ondemand` and `none`. Default to `none`.
+* `failure_and_rerun_mode` - (Optional) The date and time to start the scheduled runs. Valid values are `cascade` and `timeseries`.
+* `pipeline_log_uri` - (Optional) The s3 bucket uri for default to output logs. Example: `s3://<bucket-name>/<prefix>`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The identifier of the pipeline.
+
+## Import
+
+`aws_datapipeline_definition` can be imported by using the id (Pipeline ID), e.g.
+
+```
+$ terraform import aws_datapipeline_definition.default df-1234567890
+```


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #1538 #9291 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Features:
- resource/aws_datapipeline_definition: Add support aws_datapipeline_definition resource
```

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataPipelineDefinition_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDataPipelineDefinition_ -timeout 120m
=== RUN   TestAccAWSDataPipelineDefinition_basic
=== PAUSE TestAccAWSDataPipelineDefinition_basic
=== RUN   TestAccAWSDataPipelineDefinition_options
=== PAUSE TestAccAWSDataPipelineDefinition_options
=== RUN   TestAccAWSDataPipelineDefinition_disappears
=== PAUSE TestAccAWSDataPipelineDefinition_disappears
=== CONT  TestAccAWSDataPipelineDefinition_basic
=== CONT  TestAccAWSDataPipelineDefinition_disappears
=== CONT  TestAccAWSDataPipelineDefinition_options
--- PASS: TestAccAWSDataPipelineDefinition_disappears (50.03s)
--- PASS: TestAccAWSDataPipelineDefinition_basic (66.97s)
--- PASS: TestAccAWSDataPipelineDefinition_options (102.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	102.315s
```
