### PR TITLE
resource/aws_iot_policy: Delete oldest policy version when max number of versions is reached

### DIFF
--- a/aws/resource_aws_iot_policy.go
+++ b/aws/resource_aws_iot_policy.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iot"
@@ -147,14 +148,22 @@ func iotPolicyPruneVersions(name string, iotconn *iot.IoT) error {
 	}
 
 	var oldestVersion *iot.PolicyVersion
+	var oldestVersionId int64
 
 	for _, version := range versions {
 		if *version.IsDefaultVersion {
 			continue
 		}
-		if oldestVersion == nil ||
-			version.CreateDate.Before(*oldestVersion.CreateDate) {
+
+		versionId, err := strconv.ParseInt(*version.VersionId, 10, 64)
+		if err != nil {
+			log.Printf("[ERROR] Unexpected version id cannot be parsed to an integer. %s", err)
+			return err
+		}
+
+		if oldestVersion == nil || versionId < oldestVersionId {
 			oldestVersion = version
+			oldestVersionId = versionId
 		}
 	}
 

--- a/aws/resource_aws_iot_policy.go
+++ b/aws/resource_aws_iot_policy.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -75,6 +76,10 @@ func resourceAwsIotPolicyRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsIotPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).iotconn
 
+	if err := iotPolicyPruneVersions(d.Id(), conn); err != nil {
+		return err
+	}
+
 	if d.HasChange("policy") {
 		_, err := conn.CreatePolicyVersion(&iot.CreatePolicyVersionInput{
 			PolicyName:     aws.String(d.Id()),
@@ -127,5 +132,57 @@ func resourceAwsIotPolicyDelete(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
+	return nil
+}
+
+// iotPolicyPruneVersions deletes the oldest non-default version if the maximum
+// number of versions (5) has been reached.
+func iotPolicyPruneVersions(name string, iotconn *iot.IoT) error {
+	versions, err := iotPolicyListVersions(name, iotconn)
+	if err != nil {
+		return err
+	}
+	if len(versions) < 5 {
+		return nil
+	}
+
+	var oldestVersion *iot.PolicyVersion
+
+	for _, version := range versions {
+		if *version.IsDefaultVersion {
+			continue
+		}
+		if oldestVersion == nil ||
+			version.CreateDate.Before(*oldestVersion.CreateDate) {
+			oldestVersion = version
+		}
+	}
+
+	err = iotPolicyDeleteVersion(name, *oldestVersion.VersionId, iotconn)
+	return err
+}
+
+func iotPolicyListVersions(name string, iotconn *iot.IoT) ([]*iot.PolicyVersion, error) {
+	request := &iot.ListPolicyVersionsInput{
+		PolicyName: aws.String(name),
+	}
+
+	response, err := iotconn.ListPolicyVersions(request)
+	if err != nil {
+		return nil, fmt.Errorf("Error listing versions for IoT policy %s: %s", name, err)
+	}
+	return response.PolicyVersions, nil
+}
+
+func iotPolicyDeleteVersion(name, versionID string, iotconn *iot.IoT) error {
+	request := &iot.DeletePolicyVersionInput{
+		PolicyName:      aws.String(name),
+		PolicyVersionId: aws.String(versionID),
+	}
+
+	_, err := iotconn.DeletePolicyVersion(request)
+	if err != nil {
+		return fmt.Errorf("Error deleting version %s from IoT policy %s: %s", versionID, name, err)
+	}
 	return nil
 }

--- a/aws/resource_aws_iot_policy_test.go
+++ b/aws/resource_aws_iot_policy_test.go
@@ -50,6 +50,59 @@ func TestAccAWSIoTPolicy_invalidJson(t *testing.T) {
 	})
 }
 
+func TestAccAWSIoTPolicy_update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("PubSubToAnyTopic-")
+	expectedVersions := []string{"1", "2", "3", "5", "6"}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTPolicyDestroy_basic,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTPolicyConfigInitialState(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_iot_policy.pubsub", "name", rName),
+					resource.TestCheckResourceAttrSet("aws_iot_policy.pubsub", "arn"),
+					resource.TestCheckResourceAttr("aws_iot_policy.pubsub", "default_version_id", "1"),
+					resource.TestCheckResourceAttrSet("aws_iot_policy.pubsub", "policy"),
+				),
+			},
+			{
+				Config: testAccAWSIoTPolicyConfig_updatePolicy(rName, "topic2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_iot_policy.pubsub", "default_version_id", "2"),
+				),
+			},
+			{
+				Config: testAccAWSIoTPolicyConfig_updatePolicy(rName, "topic3"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_iot_policy.pubsub", "default_version_id", "3"),
+				),
+			},
+			{
+				Config: testAccAWSIoTPolicyConfig_updatePolicy(rName, "topic4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_iot_policy.pubsub", "default_version_id", "4"),
+				),
+			},
+			{
+				Config: testAccAWSIoTPolicyConfig_updatePolicy(rName, "topic5"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_iot_policy.pubsub", "default_version_id", "5"),
+				),
+			},
+			{
+				Config: testAccAWSIoTPolicyConfig_updatePolicy(rName, "topic6"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_iot_policy.pubsub", "default_version_id", "6"),
+					testAccCheckAWSIoTPolicyVersions("aws_iot_policy.pubsub", expectedVersions),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSIoTPolicyDestroy_basic(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).iotconn
 
@@ -81,6 +134,50 @@ func testAccCheckAWSIoTPolicyDestroy_basic(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckAWSIoTPolicyVersions(rName string, expVersions []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", rName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).iotconn
+		params := &iot.ListPolicyVersionsInput{
+			PolicyName: aws.String(rs.Primary.Attributes["name"]),
+		}
+
+		resp, err := conn.ListPolicyVersions(params)
+		if err != nil {
+			return err
+		}
+
+		if len(expVersions) != len(resp.PolicyVersions) {
+			return fmt.Errorf("Expected %d versions, got %d", len(expVersions), len(resp.PolicyVersions))
+		}
+
+		var actVersions []string
+		for _, actVer := range resp.PolicyVersions {
+			actVersions = append(actVersions, *(actVer.VersionId))
+		}
+
+		matchedValue := false
+		for _, actVer := range actVersions {
+			matchedValue = false
+			for _, expVer := range expVersions {
+				if actVer == expVer {
+					matchedValue = true
+					break
+				}
+			}
+			if !matchedValue {
+				return fmt.Errorf("Expected: %v / Got: %v", expVersions, actVersions)
+			}
+		}
+
+		return nil
+	}
 }
 
 func testAccAWSIoTPolicyConfigInitialState(rName string) string {
@@ -119,4 +216,24 @@ resource "aws_iot_policy" "pubsub" {
 EOF
 }
 `, rName)
+}
+
+func testAccAWSIoTPolicyConfig_updatePolicy(rName string, topicName string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_policy" "pubsub" {
+  name = "%s"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["iot:*"],
+    "Resource": ["arn:aws:iot:*:*:topic/%s"]
+}]
+}
+EOF
+}
+`, rName, topicName)
+
 }

--- a/aws/resource_aws_iot_policy_test.go
+++ b/aws/resource_aws_iot_policy_test.go
@@ -52,7 +52,7 @@ func TestAccAWSIoTPolicy_invalidJson(t *testing.T) {
 
 func TestAccAWSIoTPolicy_update(t *testing.T) {
 	rName := acctest.RandomWithPrefix("PubSubToAnyTopic-")
-	expectedVersions := []string{"1", "2", "3", "5", "6"}
+	expectedVersions := []string{"2", "3", "4", "5", "6"}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
* This change adds a function call that deletes the oldest non-default IoT policy version when the creation of a new version would result in a breach of the max number of versions (5).
* Note that due to a bug in the Go SDK (+ CLI + Python SDK), all versions of the policy have the same creation date. Thus, I could not use it to find the oldest version (like in the _aws_iam_policy_ resource) and I decided to use the version IDs instead.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #9540.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/30314.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24979.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
resource/aws_iot_policy: Prune oldest non-default version of IoT policies when required to create a new version
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSIoTPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSIoTPolicy -timeout 120m
=== RUN   TestAccAWSIoTPolicy_basic
=== PAUSE TestAccAWSIoTPolicy_basic
=== RUN   TestAccAWSIoTPolicy_invalidJson
=== PAUSE TestAccAWSIoTPolicy_invalidJson
=== RUN   TestAccAWSIoTPolicy_update
=== PAUSE TestAccAWSIoTPolicy_update
=== CONT  TestAccAWSIoTPolicy_basic
=== CONT  TestAccAWSIoTPolicy_update
=== CONT  TestAccAWSIoTPolicy_invalidJson
--- PASS: TestAccAWSIoTPolicy_invalidJson (10.78s)
--- PASS: TestAccAWSIoTPolicy_basic (22.19s)
--- PASS: TestAccAWSIoTPolicy_update (109.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       109.101s
```
