### PR TITLE
d/aws_dx_connection: Adding new data source for Direct Connect connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.24.0 (Unreleased)
 
+ENHANCEMENTS:
+
+* resource/aws_rds_cluster: Add `multimaster` to `engine_mode` argument validation (support Aurora Multi-Master Clusters) [GH-9691]
+
 BUG FIXES:
 
 * resource/aws_ami: Final retry after timeout reading AMI [GH-9674]

--- a/aws/data_source_aws_dx_connection_test.go
+++ b/aws/data_source_aws_dx_connection_test.go
@@ -18,11 +18,7 @@ func TestAccDataSourceAwsDxConnection_Basic(t *testing.T) {
 	resourceName := "aws_dx_connection.test"
 	datasourceName := "data.aws_dx_connection.test"
 
-	dxLocation, err := testAccAwsDxConnectionLocation()
-
-	if err != nil {
-		fmt.Errorf("error retrieving DX Locations")
-	}
+	dxLocation, _ := testAccAwsDxConnectionLocation()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -53,11 +49,7 @@ func TestAccDataSourceAwsDxConnection_tags(t *testing.T) {
 	resourceName := "aws_dx_connection.test"
 	datasourceName := "data.aws_dx_connection.test"
 
-	dxLocation, err := testAccAwsDxConnectionLocation()
-
-	if err != nil {
-		fmt.Errorf("error retrieving DX Locations")
-	}
+	dxLocation, _ := testAccAwsDxConnectionLocation()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -161,7 +153,7 @@ func testAccAwsDxConnectionLocation() (*string, error) {
 	resp, err := conn.DescribeLocations(input)
 
 	if err != nil {
-		fmt.Println("Error")
+		fmt.Println("Error Describing DX Locations")
 	}
 
 	rand.Seed(time.Now().Unix())

--- a/aws/data_source_aws_dx_connection_test.go
+++ b/aws/data_source_aws_dx_connection_test.go
@@ -2,24 +2,27 @@ package aws
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"math/rand"
 	"os"
 	"regexp"
 	"testing"
-
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"time"
 )
 
 func TestAccDataSourceAwsDxConnection_Basic(t *testing.T) {
-	key := "DX_LOCATION"
-	location := os.Getenv(key)
-	if location == "" {
-		t.Skipf("Environment variable %s is not set", key)
-	}
-
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	connectionName := fmt.Sprintf("tf-dx-%s", acctest.RandString(5))
 	resourceName := "aws_dx_connection.test"
 	datasourceName := "data.aws_dx_connection.test"
+
+	dxLocation, err := testAccAwsDxConnectionLocation()
+
+	if err != nil {
+		fmt.Errorf("error retrieving DX Locations")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -30,8 +33,9 @@ func TestAccDataSourceAwsDxConnection_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Direct Connect Connection not found`),
 			},
 			{
-				Config: testAccDataSourceAwsDxConnectionConfig_Name(rName, location),
+				Config: testAccDataSourceAwsDxConnectionConfig_Name(connectionName, aws.StringValue(dxLocation)),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "location", resourceName, "location"),
@@ -44,23 +48,90 @@ func TestAccDataSourceAwsDxConnection_Basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAwsDxConnectionConfig_Name(rName, location string) string {
+func TestAccDataSourceAwsDxConnection_tags(t *testing.T) {
+	connectionName := fmt.Sprintf("tf-dx-%s", acctest.RandString(5))
+	resourceName := "aws_dx_connection.test"
+	datasourceName := "data.aws_dx_connection.test"
+
+	dxLocation, err := testAccAwsDxConnectionLocation()
+
+	if err != nil {
+		fmt.Errorf("error retrieving DX Locations")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsDxConnectionConfig_tags(connectionName, aws.StringValue(dxLocation)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "location", resourceName, "location"),
+					resource.TestCheckResourceAttrPair(datasourceName, "jumbo_frame_capable", resourceName, "jumbo_frame_capable"),
+					resource.TestCheckResourceAttrPair(datasourceName, "bandwidth", resourceName, "bandwidth"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.Name", connectionName),
+					resource.TestCheckResourceAttr(datasourceName, "tags.Location", aws.StringValue(dxLocation)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsDxConnectionConfig_Name(connectionName, dxLocation string) string {
 	return fmt.Sprintf(`
 resource "aws_dx_connection" "wrong" {
-	name            = "%s-wrong"
-	bandwidth       = "1Gbps"
-	location        = "%s"
+  name            = "%[1]s-wrong"
+  bandwidth       = "1Gbps"
+  location        = %[2]q
 }
 resource "aws_dx_connection" "test" {
-	name            = "%s"
-	bandwidth       = "1Gbps"
-	location        = "%s"
+  name            = %[1]q
+  bandwidth       = "1Gbps"
+  location        = %[2]q
 }
 
 data "aws_dx_connection" "test" {
   name = "${aws_dx_connection.test.name}"
 }
-`, rName, location, rName, location)
+`, connectionName, dxLocation)
+}
+
+func testAccDataSourceAwsDxConnectionConfig_tags(connectionName, dxLocation string) string {
+	return fmt.Sprintf(`
+resource "aws_dx_connection" "wrong-tags" {
+  name            = %[1]q
+  bandwidth       = "1Gbps"
+  location        = %[2]q
+
+  tags = {
+    Name = "%[1]s-Wrong"
+    Location = %[2]q
+  }
+}
+
+resource "aws_dx_connection" "test" {
+  name            = %[1]q
+  bandwidth       = "1Gbps"
+  location        = %[2]q
+  
+  tags = {
+    Name = %[1]q
+    Location = %[2]q
+  }
+}
+
+data "aws_dx_connection" "test" {
+  name = "${aws_dx_connection.test.name}"
+  tags = {
+    Name = %[1]q
+    Location = %[2]q
+  }
+}
+`, connectionName, dxLocation)
 }
 
 const testAccDataSourceAwsDxConnectionConfig_NonExistent = `
@@ -68,3 +139,36 @@ data "aws_dx_connection" "test" {
   name = "tf-acc-test-does-not-exist"
 }
 `
+
+func testAccAwsDxConnectionLocation() (*string, error) {
+	var region string
+
+	if _, ok := os.LookupEnv("AWS_DEFAULT_REGION"); ok {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	} else {
+		region = "us-west-2"
+	}
+
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return nil, fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).dxconn
+	input := &directconnect.DescribeLocationsInput{}
+
+	resp, err := conn.DescribeLocations(input)
+
+	if err != nil {
+		fmt.Println("Error")
+	}
+
+	rand.Seed(time.Now().Unix())
+
+	dxLocation := resp.Locations[rand.Intn(len(resp.Locations))].LocationCode
+
+	fmt.Printf("Testing Connections in DX Location: %s", aws.StringValue(dxLocation))
+
+	return dxLocation, nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -141,7 +141,6 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-<<<<<<< HEAD
 			"aws_acm_certificate":                           dataSourceAwsAcmCertificate(),
 			"aws_acmpca_certificate_authority":              dataSourceAwsAcmpcaCertificateAuthority(),
 			"aws_ami":                                       dataSourceAwsAmi(),
@@ -283,6 +282,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafregional_rule":                          dataSourceAwsWafRegionalRule(),
 			"aws_wafregional_web_acl":                       dataSourceAwsWafRegionalWebAcl(),
 			"aws_workspaces_bundle":                         dataSourceAwsWorkspaceBundle(),
+
 			// Adding the Aliases for the ALB -> LB Rename
 			"aws_lb":               dataSourceAwsLb(),
 			"aws_alb":              dataSourceAwsLb(),

--- a/website/docs/d/dx_connection.html.markdown
+++ b/website/docs/d/dx_connection.html.markdown
@@ -13,18 +13,29 @@ Retrieve information about a Direct Connect Connection.
 ## Example Usage
 
 ```hcl
+# Find a connection from name only
 data "aws_dx_connection" "example" {
   name = "example"
+}
+# Find a connection from name and tags
+data "aws_dx_connection" "example" {
+  name = "example"
+  tags = {
+    Location = "PEH51"
+    LagGroup = "LAG-001"
+  }
 }
 ```
 
 ## Argument Reference
 
 * `name` - (Required) The name of the connection to retrieve.
+* `tags` - (Optional) A map of tags associated with the connection.
 
 ## Attributes Reference
 
 * `id` - The ID of the connection.
+* `arn` - The ARN of the connection.
 * `state` - The state of the connection.
 * `location` - The AWS Direct Connect location where the connection is location.
 * `bandwidth` - The Bandwidth of the connection.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:
Adds a new data resource for DX  connections: ``` aws_dx_connection ```

Lookup DX connections from a name.

example
```hcl
data "aws_dx_connection" "example" {
  name = "example"
}
```

* Adds data source aws_dx_connection

Output from acceptance testing:

```
$ DX_LOCATION=TCSH make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsDxConnection_Basic'                                                                                                   master * ] 6:09 pm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsDxConnection_Basic -timeout 120m
=== RUN   TestAccDataSourceAwsDxConnection_Basic
=== PAUSE TestAccDataSourceAwsDxConnection_Basic
=== CONT  TestAccDataSourceAwsDxConnection_Basic
--- PASS: TestAccDataSourceAwsDxConnection_Basic (24.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       24.326s

...
```
