### PR TITLE
Add validation for all pgp_key arguments

### DIFF
--- a/aws/resource_aws_iam_access_key.go
+++ b/aws/resource_aws_iam_access_key.go
@@ -47,9 +47,10 @@ func resourceAwsIamAccessKey() *schema.Resource {
 				Computed: true,
 			},
 			"pgp_key": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				ValidateFunc: validatePGPKey,
 			},
 			"key_fingerprint": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -37,9 +37,10 @@ func resourceAwsIamUserLoginProfile() *schema.Resource {
 				ForceNew: true,
 			},
 			"pgp_key": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validatePGPKey,
 			},
 			"password_reset_required": {
 				Type:     schema.TypeBool,

--- a/aws/resource_aws_lightsail_key_pair.go
+++ b/aws/resource_aws_lightsail_key_pair.go
@@ -36,9 +36,10 @@ func resourceAwsLightsailKeyPair() *schema.Resource {
 
 			// optional fields
 			"pgp_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validatePGPKey,
 			},
 
 			// additional info returned from the API

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/terraform/helper/encryption"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
@@ -2369,6 +2370,23 @@ func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors [
 	if len(value) > 64 {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be greater than 64 characters", k))
+	}
+
+	return
+}
+
+func validatePGPKey(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	key, err := encryption.RetrieveGPGKey(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%s: %s", k, err))
+		return
+	}
+
+	_, _, err = encryption.EncryptValue(key, "validation test", "validation test")
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%s: %s", k, err))
 	}
 
 	return


### PR DESCRIPTION
We've had two occurrences recently where `aws_iam_user_login_profile`
resources have failed to apply because the `pgp_key` argument had a key
with an expired or missing subkey.

Make it possible to catch these during code review with `terraform
validate` by attempting to encrypt a dummy value and reporting any
errors. This seems easier and more reliable than attempting to check the
validity of the actual keys and subkeys.

The dummy value is `validation test` because it gets reported in the
error. I could have bypassed this error wrapping by going directly to
`pgpkeys.EncryptShares` but it seemed better to use the same package and
error styling as `encryption.RetrieveGPGKey`.

I've used Hashicorp's key to test the codepath for Keybase because I
expect it to continue to work for the lifetime of this project.

The two keys used by the tests were generated with `gpg --batch
--gen-key` in an `alpine:3.10` container with these two respective
inputs:

    Key-Type: default
    Key-Length: 1024
    Expire-Date: 0
    Name-Real: Without Subkey
    Name-Email: without@sub.key
    %no-protection
    %commit

    Key-Type: default
    Key-Length: 1024
    Subkey-Type: 1
    Subkey-Length: 1024
    Expire-Date: 0
    Name-Real: With Subkey
    Name-Email: with@sub.key
    %no-protection
    %commit

Then they were extracted with `gpg --import <id> | base64`.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_iam_user_login_profile: Validate `pgp_key` arguments
resource/aws_resource_aws_iam_access_key: Validate `pgp_key` arguments
resource/aws_resource_aws_lightsail_key_pair: Validate `pgp_key` arguments
```

### Output from acceptance testing:

```
N/A
```
