### PR TITLE
Add force_delete optional parameter to resource_aws_ecr_repository

### DIFF
--- a/.changelog/9913.txt
+++ b/.changelog/9913.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/resource_aws_ecr_repository: Add `force_new` parameter.
+```

--- a/.changelog/9913.txt
+++ b/.changelog/9913.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/resource_aws_ecr_repository: Add `force_new` parameter.
+resource/aws_ecr_repository: Add `force_delete` parameter.
 ```

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -375,7 +375,7 @@ func resourceRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
 			return resource.NonRetryableError(err)
 		}
 
-		return resource.RetryableError(fmt.Errorf("%q: Timeout while waiting for the ECR Repository to be deleted", d.Id()))
+		return resource.RetryableError(fmt.Errorf("ECR Repository (%s) still exists", d.Id()))
 	})
 	if tfresource.TimedOut(err) {
 		_, err = conn.DescribeRepositories(input)

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -65,6 +65,10 @@ func ResourceRepository() *schema.Resource {
 				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
 				ForceNew:         true,
 			},
+			"force_delete": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"image_scanning_configuration": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -346,13 +350,16 @@ func resourceRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
 	_, err := conn.DeleteRepository(&ecr.DeleteRepositoryInput{
 		RepositoryName: aws.String(d.Id()),
 		RegistryId:     aws.String(d.Get("registry_id").(string)),
-		Force:          aws.Bool(true),
+		Force:          aws.Bool(d.Get("force_delete").(bool)),
 	})
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, ecr.ErrCodeRepositoryNotFoundException) {
 			return nil
 		}
-		return fmt.Errorf("error deleting ECR repository: %s", err)
+		if tfawserr.ErrCodeEquals(err, ecr.ErrCodeRepositoryNotEmptyException) {
+			return fmt.Errorf("ECR Repository (%s) not empty, consider using force_delete: %w", d.Id(), err)
+		}
+		return fmt.Errorf("error deleting ECR Repository (%s): %w", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Waiting for ECR Repository %q to be deleted", d.Id())

--- a/website/docs/r/ecr_repository.html.markdown
+++ b/website/docs/r/ecr_repository.html.markdown
@@ -29,6 +29,8 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the repository.
 * `encryption_configuration` - (Optional) Encryption configuration for the repository. See [below for schema](#encryption_configuration).
+* `force_delete` - (Optional) If `true`, will delete the repository even if it contains images.
+  Defaults to `false`.
 * `image_tag_mutability` - (Optional) The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`.
 * `image_scanning_configuration` - (Optional) Configuration block that defines image scanning configuration for the repository. By default, image scanning must be manually triggered. See the [ECR User Guide](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html) for more information about image scanning.
     * `scan_on_push` - (Required) Indicates whether images are scanned after being pushed to the repository (true) or not scanned (false).


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #9911

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```
ENHANCEMENTS:
* resource/resource_aws_ecr_repository supports now force_delete, It can be set to false to avoid accidentally deleting the repository if it still contains images. ([#9911](https://github.com/terraform-providers/terraform-provider-aws/issues/9911))
```

Output from acceptance testing:
It is hard to test since at least one image needs to be pushed to the ECR repo. I manually tested the changes.

```
> terraform apply
aws_ecr_repository.repository: Refreshing state... (ID: victor)

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ aws_ecr_repository.repository
      force_delete: "true" => "false"


Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_ecr_repository.repository: Modifying... (ID: victor)
  force_delete: "true" => "false"
aws_ecr_repository.repository: Modifications complete after 0s (ID: victor)

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
```
> terraform destroy
aws_ecr_repository.repository: Refreshing state... (ID: victor)

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  - aws_ecr_repository.repository


Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

aws_ecr_repository.repository: Destroying... (ID: victor)

Error: Error applying plan:

1 error(s) occurred:

* aws_ecr_repository.repository (destroy): 1 error(s) occurred:

* aws_ecr_repository.repository: error ECR repository not empty, consider using force_delete: RepositoryNotEmptyException: The repository with name 'victor' in registry with id '...' cannot be deleted because it still contains images
	status code: 400, request id: c09a3fa8-e184-4fd8-9242-c7fe41c385a4

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```
