### PR TITLE
Add defaults for ECS Task Definition health checks

### DIFF
--- a/aws/ecs_task_definition_equivalency.go
+++ b/aws/ecs_task_definition_equivalency.go
@@ -76,6 +76,19 @@ func (cd containerDefinitions) Reduce(isAWSVPC bool) error {
 			}
 		}
 
+		if def.HealthCheck != nil {
+			if def.HealthCheck.Interval == nil {
+				def.HealthCheck.Interval = aws.Int64(30)
+			}
+			if def.HealthCheck.Retries == nil {
+				def.HealthCheck.Retries = aws.Int64(3)
+			}
+			if def.HealthCheck.Timeout == nil {
+				def.HealthCheck.Timeout = aws.Int64(5)
+			}
+
+		}
+
 		// Deal with fields which may be re-ordered in the API
 		sort.Slice(def.Environment, func(i, j int) bool {
 			return *def.Environment[i].Name < *def.Environment[j].Name

--- a/aws/ecs_task_definition_equivalency_test.go
+++ b/aws/ecs_task_definition_equivalency_test.go
@@ -437,6 +437,74 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_arrays(t *testing.T) {
 	}
 }
 
+func TestAwsEcsContainerDefinitionsAreEquivalent_healthCheck(t *testing.T) {
+	cfgRepresention := `
+[
+    {
+      "name": "wordpress",
+      "image": "wordpress",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 80,
+	  "hostPort": 0,
+	  "protocol": "tcp"
+        }
+      ],
+      "memory": 500,
+      "cpu": 10,
+      "healthCheck": {
+	  "command": [
+	      "CMD-SHELL",
+	      "/bin/sh",
+	      "-c",
+	      "\"curl -f http://localhost || exit 1\""
+	  ]
+      }
+    }
+]`
+
+	apiRepresentation := `
+[
+    {
+        "name": "wordpress",
+        "image": "wordpress",
+        "cpu": 10,
+        "memory": 500,
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 0,
+                "protocol": "tcp"
+            }
+        ],
+        "essential": true,
+        "environment": [],
+        "mountPoints": [],
+        "volumesFrom": [],
+        "healthCheck": {
+            "command": [
+                "CMD-SHELL",
+                "/bin/sh",
+                "-c",
+                "\"curl -f http://localhost || exit 1\""
+            ],
+           "interval": 30,
+           "timeout": 5,
+           "retries": 3
+        }
+    }
+]`
+
+	equal, err := EcsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equal {
+		t.Fatal("Expected definitions to be equal.")
+	}
+}
+
 func TestAwsEcsContainerDefinitionsAreEquivalent_negative(t *testing.T) {
 	cfgRepresention := `
 [


### PR DESCRIPTION
This PR adds defaults for ECS Task Definition health checks.  The defaults are documented at https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #4730

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/resource_aws_ecs_task_definition: Add ECS Task Definition default health check parameters if not specified (#4730)
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAwsEcsContainerDefinitionsAreEquivalent*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAwsEcsContainerDefinitionsAreEquivalent* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_basic
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_basic (0.00s)
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_portMappings
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_portMappings (0.00s)
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_portMappingsIgnoreHostPort
2019/08/29 11:16:36 [DEBUG] Canonical definitions are not equal.
First: [{"essential":true,"image":"wordpress","name":"wordpress","portMappings":[{"containerPort":80,"hostPort":80}]}]
Second: [{"essential":true,"image":"wordpress","name":"wordpress","portMappings":[{"containerPort":80}]}]
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_portMappingsIgnoreHostPort (0.00s)
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_arrays
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_arrays (0.00s)
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_healthCheck
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_healthCheck (0.00s)
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_negative
2019/08/29 11:16:36 [DEBUG] Canonical definitions are not equal.
First: [{"cpu":10,"environment":[{"name":"EXAMPLE_NAME","value":"foobar"}],"essential":true,"image":"wordpress","memory":500,"name":"wordpress"}]
Second: [{"cpu":10,"essential":true,"image":"wordpress","memory":500,"name":"wordpress"}]
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_negative (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.024s
```
