### PR TITLE
Fix static_ip_attachment attribute reference

### DIFF
--- a/website/docs/r/lightsail_static_ip_attachment.html.markdown
+++ b/website/docs/r/lightsail_static_ip_attachment.html.markdown
@@ -45,3 +45,7 @@ The following arguments are supported:
 The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The ID of the Static IP attachment.
+
+~> **Note:** Using the `${aws_lightsail_instance.test.name}` could result in the static IP attachment getting
+detached when the lightsail instance get tainted/recreated. you can use the `${aws_lightsail_instance.test.id}`
+attribute to avoid that, please see [Github issue #10143](https://github.com/terraform-providers/terraform-provider-aws/issues/10143) for more details

--- a/website/docs/r/lightsail_static_ip_attachment.html.markdown
+++ b/website/docs/r/lightsail_static_ip_attachment.html.markdown
@@ -45,5 +45,3 @@ The following arguments are supported:
 The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The ID of the Static IP attachment.
-* `static_ip_name` - The name of the allocated static IP.
-* `instance_name` - The name of the Lightsail instance to attach the IP to.

--- a/website/docs/r/lightsail_static_ip_attachment.html.markdown
+++ b/website/docs/r/lightsail_static_ip_attachment.html.markdown
@@ -44,6 +44,6 @@ The following arguments are supported:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `arn` - The ARN of the Lightsail static IP
-* `ip_address` - The allocated static IP address
-* `support_code` - The support code.
+* `id` - The ID of the Static IP attachment.
+* `static_ip_name` - The name of the allocated static IP.
+* `instance_name` - The name of the Lightsail instance to attach the IP to.


### PR DESCRIPTION
The `aws_lightsail_static_ip_attachment` doesn't expose the `
ip_address`, `support_code`, or `arn`

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix the documentation of `aws_lightsail_static_ip_attachment` resource (attribute reference)
```