### PR TITLE
Refactor: use acctest.RandStringFromCharSet() instead of randomString in resource_aws_iam_user_policy

### DIFF
--- a/aws/resource_aws_iam_user_policy_test.go
+++ b/aws/resource_aws_iam_user_policy_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAccAWSIAMUserPolicy_importBasic(t *testing.T) {
-	suffix := randomString(10)
+	suffix := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resourceName := fmt.Sprintf("aws_iam_user_policy.foo_%s", suffix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -79,7 +79,7 @@ func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
 
 func TestAccAWSIAMUserPolicy_disappears(t *testing.T) {
 	var out iam.GetUserPolicyOutput
-	suffix := randomString(10)
+	suffix := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resourceName := fmt.Sprintf("aws_iam_user_policy.foo_%s", suffix)
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10040

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMUserPolicy_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSIAMUserPolicy_importBasic -timeout 120m
=== RUN   TestAccAWSIAMUserPolicy_importBasic
=== PAUSE TestAccAWSIAMUserPolicy_importBasic
=== CONT  TestAccAWSIAMUserPolicy_importBasic
--- PASS: TestAccAWSIAMUserPolicy_importBasic (38.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       38.102s

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMUserPolicy_disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSIAMUserPolicy_disappears -timeout 120m
=== RUN   TestAccAWSIAMUserPolicy_disappears
=== PAUSE TestAccAWSIAMUserPolicy_disappears
=== CONT  TestAccAWSIAMUserPolicy_disappears
--- PASS: TestAccAWSIAMUserPolicy_disappears (34.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       34.572s
```
