### PR TITLE
Change the default description for inline security group rules to ""

### DIFF
--- a/internal/service/ec2/security_group.go
+++ b/internal/service/ec2/security_group.go
@@ -140,6 +140,7 @@ func ResourceSecurityGroup() *schema.Resource {
 						"description": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Default:      "",
 							ValidateFunc: validSecurityGroupRuleDescription,
 						},
 					},
@@ -210,6 +211,7 @@ func ResourceSecurityGroup() *schema.Resource {
 						"description": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Default:      "",
 							ValidateFunc: validSecurityGroupRuleDescription,
 						},
 					},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10097

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Change default value for description in inline security group rules to "" instead of null, to improve diffs.
```
