### PR TITLE
Add resource aws_shield_drt_role_association

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -708,6 +708,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_service_discovery_public_dns_namespace":              resourceAwsServiceDiscoveryPublicDnsNamespace(),
 			"aws_service_discovery_service":                           resourceAwsServiceDiscoveryService(),
 			"aws_servicequotas_service_quota":                         resourceAwsServiceQuotasServiceQuota(),
+			"aws_shield_drt_role_association":                         resourceAwsShieldDrtRoleAssociation(),
 			"aws_shield_protection":                                   resourceAwsShieldProtection(),
 			"aws_simpledb_domain":                                     resourceAwsSimpleDBDomain(),
 			"aws_ssm_activation":                                      resourceAwsSsmActivation(),

--- a/aws/resource_aws_shield_drt_role_association.go
+++ b/aws/resource_aws_shield_drt_role_association.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsShieldDrtRoleAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsShieldDrtRoleAssociationCreate,
+		Read:   resourceAwsShieldDrtRoleAssociationRead,
+		Update: resourceAwsShieldDrtRoleAssociationCreate,
+		Delete: resourceAwsShieldDrtRoleAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"role_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsShieldDrtRoleAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).shieldconn
+
+	input := &shield.AssociateDRTRoleInput{
+		RoleArn: aws.String(d.Get("role_arn").(string)),
+	}
+
+	_, err := conn.AssociateDRTRole(input)
+	if err != nil {
+		return fmt.Errorf("error associating DRT Role: %v", err)
+	}
+
+	d.SetId(time.Now().UTC().String())
+	return resourceAwsShieldDrtRoleAssociationRead(d, meta)
+}
+
+func resourceAwsShieldDrtRoleAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).shieldconn
+
+	input := &shield.DescribeDRTAccessInput{}
+
+	resp, err := conn.DescribeDRTAccess(input)
+	if err != nil {
+		return fmt.Errorf("error reading DRT Access: %v", err)
+	}
+
+	d.Set("role_arn", resp.RoleArn)
+
+	return nil
+}
+
+func resourceAwsShieldDrtRoleAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).shieldconn
+
+	input := &shield.DescribeDRTAccessInput{}
+
+	_, err := conn.DescribeDRTAccess(input)
+	if err != nil {
+		return fmt.Errorf("error disassociating DRT Role: %v", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/aws/resource_aws_shield_drt_role_association.go
+++ b/aws/resource_aws_shield_drt_role_association.go
@@ -62,9 +62,9 @@ func resourceAwsShieldDrtRoleAssociationRead(d *schema.ResourceData, meta interf
 func resourceAwsShieldDrtRoleAssociationDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).shieldconn
 
-	input := &shield.DescribeDRTAccessInput{}
+	input := &shield.DisassociateDRTRoleInput{}
 
-	_, err := conn.DescribeDRTAccess(input)
+	_, err := conn.DisassociateDRTRole(input)
 	if err != nil {
 		return fmt.Errorf("error disassociating DRT Role: %v", err)
 	}

--- a/aws/resource_aws_shield_drt_role_association_test.go
+++ b/aws/resource_aws_shield_drt_role_association_test.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSShieldDrtRoleAssociation_RoleArn(t *testing.T) {
+	resourceName := "aws_shield_drt_role.acctest"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	roleArn := "arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSShield(t)
+			testAccPreCheckAWSShieldDrtRoleAssociation(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSShieldDrtRoleAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSShieldDrtRoleAssociationConfig(rName, roleArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSShieldDrtRoleAssociated(resourceName, roleArn),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSShieldDrtRoleAssociationConfig(refName, roleArn string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "aws_shield_protection" "acctest" {
+  name = "${var.name}"
+}
+
+resource "aws_shield_drt_role" "acctest" {
+  role_arn   = "%s"
+  depends_on = ["aws_shield_protection.acctest"]
+}
+`, refName, roleArn)
+}
+
+func testAccPreCheckAWSShieldDrtRoleAssociation(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).shieldconn
+
+	input := &shield.DescribeDRTAccessInput{}
+
+	resp, err := conn.DescribeDRTAccess(input)
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %v", err)
+	}
+
+	if resp.RoleArn != nil {
+		t.Fatalf("A Shield DRT Role is already associated")
+	}
+}
+
+func testAccCheckAWSShieldDrtRoleAssociated(name, roleArn string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).shieldconn
+
+		input := &shield.DescribeDRTAccessInput{}
+
+		resp, err := conn.DescribeDRTAccess(input)
+		if isAWSErr(err, shield.ErrCodeResourceNotFoundException, "") {
+			return fmt.Errorf("AWS Shield DRT Role %s not associated", roleArn)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if aws.StringValue(resp.RoleArn) != roleArn {
+			return fmt.Errorf("AWS Shield DRT Role %s not associated", roleArn)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSShieldDrtRoleAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).shieldconn
+
+	input := &shield.DescribeDRTAccessInput{}
+
+	resp, err := conn.DescribeDRTAccess(input)
+	if err != nil {
+		return err
+	}
+
+	if resp != nil && aws.StringValue(resp.RoleArn) != "" {
+		return fmt.Errorf("The Shield DRT Role %v still associated", aws.StringValue(resp.RoleArn))
+	}
+
+	return nil
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2717,6 +2717,9 @@
                             <a href="#">Resources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/aws/r/shield_drt_role_association.html">aws_shield_drt_role_association</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/shield_protection.html">aws_shield_protection</a>
                                 </li>
                             </ul>

--- a/website/docs/r/shield_drt_role_association.html.markdown
+++ b/website/docs/r/shield_drt_role_association.html.markdown
@@ -1,0 +1,67 @@
+---
+layout: "aws"
+page_title: "AWS: aws_shield_drt_role_association"
+description: |-
+  Associates an IAM role with AWS Shield Advanced for DDoS Response Team (DRT) access
+---
+
+# Resource: aws_shield_drt_role_association
+
+Associates an IAM Role for the AWS Shield Advanced DDoS Response Team (DRT) to use to access your account.
+
+## Example Usage
+
+### Associate role
+
+```hcl
+resource "aws_iam_role" "shield_drt" {
+  name = "shield-drt-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": [
+          "drt.shield.amazonaws.com"
+        ]
+       }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "shield_drt" {
+  role       = "${aws_iam_role.shield_drt.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy"
+}
+
+resource "aws_shield_drt_role_association" "shield_drt" {
+  role_arn = "${aws_iam_role.shield_drt.arn}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `role_arn` - (Required) The ARN of an IAM role that the DRT team will be given access to
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the DRT role association.
+
+## Import
+
+Shield DRT role association resources can be imported by specifying an arbitrary ID e.g.
+
+```
+$ terraform import aws_shield_drt_role_association.foo bar
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10319

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: aws_shield_drt_role_association
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSShieldDrtRoleAssociation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSShieldDrtRoleAssociation -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSShieldDrtRoleAssociation
--- PASS: TestAccAWSShieldDrtRoleAssociation (38.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       38.971s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.016s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.003s [no tests to run]
```
