### PR TITLE
Check that lambda function and lambda layers have valid SHA256 code-hash

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -209,9 +209,10 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				Computed: true,
 			},
 			"source_code_hash": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateLooksLikeSha256,
 			},
 			"source_code_size": {
 				Type:     schema.TypeInt,

--- a/aws/resource_aws_lambda_layer_version.go
+++ b/aws/resource_aws_lambda_layer_version.go
@@ -92,10 +92,11 @@ func resourceAwsLambdaLayerVersion() *schema.Resource {
 				Computed: true,
 			},
 			"source_code_hash": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validateLooksLikeSha256,
 			},
 			"source_code_size": {
 				Type:     schema.TypeInt,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2371,3 +2371,14 @@ func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors [
 
 	return
 }
+
+func validateLooksLikeSha256(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if !regexp.MustCompile(`^.{43}=$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q does not appear to be a SHA256-hashed value", k))
+	}
+
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2954,3 +2954,37 @@ func TestValidateRoute53ResolverName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidatevalidateLooksLikeSha256(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "certainlly not a SHA",
+			ErrCount: 1,
+		},
+		{
+			Value:    "6a5am9Ru14/HorRxiGcjf5ep4SJg9/weG9mJm6sO4+I=",
+			ErrCount: 0,
+		},
+		{
+			Value:    randomString(43) + "?",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(42) + "=",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(44) + "=",
+			ErrCount: 1,
+		},
+	}
+	for _, tc := range cases {
+		_, errors := validateLooksLikeSha256(tc.Value, "source_code_hash")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the SHA256-hashed value to not trigger a validation error for %q", tc.Value)
+		}
+	}
+}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Add more clear error message when lambda functions and layers don't have valid SHA256 values passed
```

I'm adding this change because I a couple of times I accidentally forgot to add `sha256` on a lambda layer and got a very nasty error that was painful to debug.

I had code like the following

``` terraform
resource "aws_lambda_layer_version" "lambda_layer" {
  filename         = "big-zip.zip"
  layer_name       = "layer-text"
  source_code_hash = filebasebase64("big-zip.zip")

  compatible_runtimes = ["nodejs8.10"]
}
```

And the error kill all other output (so I couldn't easily trace the broke resource) and just showed the following

> Error: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (117256413 vs. 4194304)

Certainly an edge-case but I figured it wouldn't hurt to make the error more friendly.

Output from acceptance testing:

I can't actually get these to run locally, any help would be appreciated.
