### PR TITLE
provider: Create replicas in different subnets

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -527,11 +527,9 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("replicate_source_db"); ok {
 		// Read replicate_source_db that should be used for create
-		var replicate_source_db string
+		var replicate_source_db = v
 		if attr, ok := d.GetOk("replicate_source_db_create"); ok {
-			replicate_source_db = attr.(string)
-		} else {
-			replicate_source_db = v.(string)
+			replicate_source_db = attr
 		}
 
 		opts := rds.CreateDBInstanceReadReplicaInput{
@@ -541,7 +539,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			DBInstanceClass:            aws.String(d.Get("instance_class").(string)),
 			DBInstanceIdentifier:       aws.String(identifier),
 			PubliclyAccessible:         aws.Bool(d.Get("publicly_accessible").(bool)),
-			SourceDBInstanceIdentifier: aws.String(replicate_source_db),
+			SourceDBInstanceIdentifier: aws.String(replicate_source_db.(string)),
 			Tags:                       tags,
 		}
 
@@ -588,7 +586,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("kms_key_id"); ok {
 			opts.KmsKeyId = aws.String(attr.(string))
-			if arnParts := strings.Split(replicate_source_db, ":"); len(arnParts) >= 4 {
+			if arnParts := strings.Split(replicate_source_db.(string), ":"); len(arnParts) >= 4 {
 				opts.SourceRegion = aws.String(arnParts[3])
 			}
 		}

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -355,6 +355,11 @@ func resourceAwsDbInstance() *schema.Resource {
 				Optional: true,
 			},
 
+			"replicate_source_db_create": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"replicas": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -521,6 +526,14 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if v, ok := d.GetOk("replicate_source_db"); ok {
+		// Read replicate_source_db that should be used for create
+		var replicate_source_db string
+		if attr, ok := d.GetOk("replicate_source_db_create"); ok {
+			replicate_source_db = attr.(string)
+		} else {
+			replicate_source_db = v.(string)
+		}
+
 		opts := rds.CreateDBInstanceReadReplicaInput{
 			AutoMinorVersionUpgrade:    aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
 			CopyTagsToSnapshot:         aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
@@ -528,7 +541,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			DBInstanceClass:            aws.String(d.Get("instance_class").(string)),
 			DBInstanceIdentifier:       aws.String(identifier),
 			PubliclyAccessible:         aws.Bool(d.Get("publicly_accessible").(bool)),
-			SourceDBInstanceIdentifier: aws.String(v.(string)),
+			SourceDBInstanceIdentifier: aws.String(replicate_source_db),
 			Tags:                       tags,
 		}
 
@@ -575,7 +588,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("kms_key_id"); ok {
 			opts.KmsKeyId = aws.String(attr.(string))
-			if arnParts := strings.Split(v.(string), ":"); len(arnParts) >= 4 {
+			if arnParts := strings.Split(replicate_source_db, ":"); len(arnParts) >= 4 {
 				opts.SourceRegion = aws.String(arnParts[3])
 			}
 		}


### PR DESCRIPTION
Workaround for AWS API limitation

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Relates https://github.com/terraform-providers/terraform-provider-aws/issues/528

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```
provider: When creating Read replicas in different subnet groups, `replicate_source_db` expects ARN when creating and identifier on all the following runs.
That is why option to pass both is added and appropriate value will be used based on action.
```