### PR TITLE
r/aws_api_gateway_stage: Support canary release deployment

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2349,6 +2349,25 @@ func normalizeCloudFormationTemplate(templateString interface{}) (string, error)
 	return checkYamlString(templateString)
 }
 
+func flattenApiGatewayStageCanarySettings(canarySettings *apigateway.CanarySettings) []interface{} {
+	settings := make(map[string]interface{})
+
+	if canarySettings == nil {
+		return nil
+	}
+
+	overrides := aws.StringValueMap(canarySettings.StageVariableOverrides)
+
+	if len(overrides) > 0 {
+		settings["stage_variable_overrides"] = overrides
+	}
+
+	settings["percent_traffic"] = canarySettings.PercentTraffic
+	settings["use_stage_cache"] = canarySettings.UseStageCache
+
+	return []interface{}{settings}
+}
+
 func flattenApiGatewayUsageApiStages(s []*apigateway.ApiStage) []map[string]interface{} {
 	stages := make([]map[string]interface{}, 0)
 

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -16,6 +16,18 @@ resource "aws_api_gateway_stage" "test" {
   stage_name    = "prod"
   rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
   deployment_id = "${aws_api_gateway_deployment.test.id}"
+  
+  variables = {
+    my_var = "normal value"
+  }
+  
+  canary_settings {
+    percent_traffic = 33.33
+    stage_variable_overrides = {
+      my_var = "overridden value"
+      my_new_var = "true"
+    }
+  }
 }
 
 resource "aws_api_gateway_rest_api" "test" {
@@ -104,6 +116,7 @@ The following arguments are supported:
 * `cache_cluster_enabled` - (Optional) Specifies whether a cache cluster is enabled for the stage
 * `cache_cluster_size` - (Optional) The size of the cache cluster for the stage, if enabled.
 	Allowed values include `0.5`, `1.6`, `6.1`, `13.5`, `28.4`, `58.2`, `118` and `237`.
+* `canary_settings` - (Optional) A map of settings for a canary deployment. Detailed below. 
 * `client_certificate_id` - (Optional) The identifier of a client certificate for the stage.
 * `description` - (Optional) The description of the stage
 * `documentation_version` - (Optional) The version of the associated API documentation
@@ -118,6 +131,13 @@ The following arguments are supported:
 * `destination_arn` - (Required) ARN of the log group to send the logs to. Automatically removes trailing `:*` if present.
 * `format` - (Required) The formatting and values recorded in the logs. 
 For more information on configuring the log format rules visit the AWS [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)
+
+#### `canary_settings`
+
+* `percent_traffic` - (Optional) The percent `0.0` - `100.0` of traffic to divert to the canary deployment.
+* `stage_variable_overrides` - (Optional) A map of overridden stage `variables` (including new variables) for the canary deployment.
+* `use_stage_cache` - (Optional) Whether the canary deployment uses the stage cache. Defaults to false.
+For more information on configuring the canary settings visit the AWS [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/canary-release.html)
 
 ## Attribute Reference
 


### PR DESCRIPTION
Fix #2727 by adding the new `canary_settings` argument to `api_gateway_stage`.

The changes are coming from #2793. I have just addressed the reviewer's comments.

### Motivation

With the release of canary deployments in API gateway I'd like to be able to:

[x] Create a canary deployment through terraform.
[x] Disable/delete a canary deployment through terraform.
[x] Update canary deployments through terraform.

I've implemented Create/Update/Delete in this pull request but did not attempt to implement promote, which I think can be accomplished today by promoting through AWS console/CLI then updating config and importing the promoted stage into terraform management.

### Documentation

[x] Updated docs/r/aws_api_gateway_stage to include the new option/nested options.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2727

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENT
resource/api_gateway_stage: Add canary_settings argument

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run 'TestAccAWSAPIGatewayStage_*'"                                                                                  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run 'TestAccAWSAPIGatewayStage_*' -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAPIGatewayStage_basic
=== PAUSE TestAccAWSAPIGatewayStage_basic
=== RUN   TestAccAWSAPIGatewayStage_accessLogSettings
=== PAUSE TestAccAWSAPIGatewayStage_accessLogSettings
=== RUN   TestAccAWSAPIGatewayStage_canarySettings
=== PAUSE TestAccAWSAPIGatewayStage_canarySettings
=== CONT  TestAccAWSAPIGatewayStage_basic
=== CONT  TestAccAWSAPIGatewayStage_canarySettings
=== CONT  TestAccAWSAPIGatewayStage_accessLogSettings
--- PASS: TestAccAWSAPIGatewayStage_canarySettings (218.63s)
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings (251.85s)
--- PASS: TestAccAWSAPIGatewayStage_basic (408.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	408.178s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.016s [no tests to run]
```
