### PR TITLE
Add reader_endpoint_address attribute for aws_elasticache_replication_group resource

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -153,6 +153,10 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"reader_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"replication_group_description": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -489,6 +493,7 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		} else {
 			d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
 			d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
+			d.Set("reader_endpoint_address", rgp.NodeGroups[0].ReaderEndpoint.Address)
 		}
 
 		d.Set("auto_minor_version_upgrade", c.AutoMinorVersionUpgrade)

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -345,6 +345,8 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 						resourceName, "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
 						resourceName, "primary_endpoint_address"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "reader_endpoint_address"),
 				),
 			},
 			{
@@ -380,6 +382,8 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 						resourceName, "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
 						resourceName, "primary_endpoint_address"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "reader_endpoint_address"),
 				),
 			},
 			{

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -150,6 +150,7 @@ In addition to all arguments above, the following attributes are exported:
 * `configuration_endpoint_address` - The address of the replication group configuration endpoint when cluster mode is enabled.
 * `primary_endpoint_address` - (Redis only) The address of the endpoint for the primary node in the replication group, if the cluster mode is disabled.
 * `member_clusters` - The identifiers of all the nodes that are part of this replication group.
+* `reader_endpoint_address` - The address of the replica nodes in this node group (shard).
 
 ## Timeouts
 


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10519

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/aws_elasticache_replication_group: add `reader_endpoint_address` attribute
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_multiAzInVpc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_multiAzInVpc -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
=== PAUSE TestAccAWSElasticacheReplicationGroup_multiAzInVpc
=== CONT  TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1085.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1085.230s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.012s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.036s [no tests to run]
```

```
$ make testacc TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== PAUSE TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== CONT  TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (945.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	945.239s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.009s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.128s [no tests to run]
```