### PR TITLE
Fix RDS autoscale diff suppression logic

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -101,21 +101,13 @@ func resourceAwsDbInstance() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					mas := d.Get("max_allocated_storage").(int)
 
-					newInt, err := strconv.Atoi(new)
-
-					if err != nil {
-						return false
-					}
-
-					oldInt, err := strconv.Atoi(old)
-
-					if err != nil {
+					if _, err := strconv.Atoi(old); err != nil {
 						return false
 					}
 
 					// Allocated is higher than the configuration
 					// and autoscaling is enabled
-					if oldInt > newInt && mas > newInt {
+					if newInt, err := strconv.Atoi(new); err == nil && mas >= newInt {
 						return true
 					}
 


### PR DESCRIPTION
Per the docs (https://www.terraform.io/docs/providers/aws/r/db_instance.html#storage-autoscaling), anytime allocated storage is less than `max_allocated_storage`, the changes should be suppressed. The previous logic was only suppressing changes when `allocated_storage` decreased (which isn't possible?)

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Fix RDS allocated_storage diff suppression when autoscaling storage is enabled
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=^TestAccAWSDBInstance"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=^TestAccAWSDBInstance -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDBInstance_basic
=== PAUSE TestAccAWSDBInstance_basic
=== RUN   TestAccAWSDBInstance_namePrefix
=== PAUSE TestAccAWSDBInstance_namePrefix
=== RUN   TestAccAWSDBInstance_generatedName
=== PAUSE TestAccAWSDBInstance_generatedName
=== RUN   TestAccAWSDBInstance_kmsKey
=== PAUSE TestAccAWSDBInstance_kmsKey
=== RUN   TestAccAWSDBInstance_subnetGroup
=== PAUSE TestAccAWSDBInstance_subnetGroup
=== RUN   TestAccAWSDBInstance_optionGroup
=== PAUSE TestAccAWSDBInstance_optionGroup
=== RUN   TestAccAWSDBInstance_iamAuth
=== PAUSE TestAccAWSDBInstance_iamAuth
=== RUN   TestAccAWSDBInstance_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_DeletionProtection
=== PAUSE TestAccAWSDBInstance_DeletionProtection
=== RUN   TestAccAWSDBInstance_FinalSnapshotIdentifier
=== PAUSE TestAccAWSDBInstance_FinalSnapshotIdentifier
=== RUN   TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot
=== PAUSE TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot
=== RUN   TestAccAWSDBInstance_IsAlreadyBeingDeleted
=== PAUSE TestAccAWSDBInstance_IsAlreadyBeingDeleted
=== RUN   TestAccAWSDBInstance_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_Password
=== PAUSE TestAccAWSDBInstance_Password
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection (0.00s)
    resource_aws_db_instance_test.go:696: CreateDBInstanceReadReplica API currently ignores DeletionProtection=true with SourceDBInstanceIdentifier set
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_Port
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_Port
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_S3Import
=== PAUSE TestAccAWSDBInstance_S3Import
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Monitoring
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Monitoring
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Port
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Port
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Tags
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Tags
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset
--- SKIP: TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset (0.00s)
    resource_aws_db_instance_test.go:1488: To be fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/5959
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== RUN   TestAccAWSDBInstance_MonitoringInterval
=== PAUSE TestAccAWSDBInstance_MonitoringInterval
=== RUN   TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled
=== PAUSE TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled
=== RUN   TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved
=== PAUSE TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved
=== RUN   TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled
=== PAUSE TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled
=== RUN   TestAccAWSDBInstance_separate_iops_update
=== PAUSE TestAccAWSDBInstance_separate_iops_update
=== RUN   TestAccAWSDBInstance_portUpdate
=== PAUSE TestAccAWSDBInstance_portUpdate
=== RUN   TestAccAWSDBInstance_MSSQL_TZ
=== PAUSE TestAccAWSDBInstance_MSSQL_TZ
=== RUN   TestAccAWSDBInstance_MSSQL_Domain
=== PAUSE TestAccAWSDBInstance_MSSQL_Domain
=== RUN   TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore
=== PAUSE TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore
=== RUN   TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== PAUSE TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== RUN   TestAccAWSDBInstance_MinorVersion
=== PAUSE TestAccAWSDBInstance_MinorVersion
=== RUN   TestAccAWSDBInstance_ec2Classic
=== PAUSE TestAccAWSDBInstance_ec2Classic
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
=== PAUSE TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate
=== PAUSE TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== PAUSE TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql
=== PAUSE TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_basic
=== CONT  TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== CONT  TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate
=== CONT  TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
=== CONT  TestAccAWSDBInstance_ec2Classic
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== CONT  TestAccAWSDBInstance_MinorVersion
=== CONT  TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved
=== CONT  TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled
=== CONT  TestAccAWSDBInstance_MonitoringInterval
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql
=== CONT  TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== CONT  TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Tags
=== CONT  TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore
--- SKIP: TestAccAWSDBInstance_ec2Classic (5.42s)
    provider_test.go:214: This test can only run in EC2 Classic, platforms available in us-west-2: ["VPC"]
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
--- FAIL: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (8.31s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating DB Instance: InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t2.micro, Engine=oracle-se, EngineVersion=11.2.0.4.v21, LicenseModel=bring-your-own-license. For supported combinations of instance class and database engine version, see the documentation.
                status code: 400, request id: b8a04655-3ad0-4838-9d03-99512cf767f8
        
          on /var/folders/1g/vw1nd8z13gd6fmnr1f388dsh0000gn/T/tf-test324512857/main.tf line 2:
          (source code not available)
        
        
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
--- PASS: TestAccAWSDBInstance_MinorVersion (368.24s)
=== CONT  TestAccAWSDBInstance_MSSQL_Domain
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (512.22s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (548.20s)
=== CONT  TestAccAWSDBInstance_MSSQL_TZ
--- PASS: TestAccAWSDBInstance_basic (565.50s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Port
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled (697.23s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved (832.16s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled (834.52s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (974.66s)
=== CONT  TestAccAWSDBInstance_portUpdate
--- PASS: TestAccAWSDBInstance_MonitoringInterval (1005.96s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1251.61s)
=== CONT  TestAccAWSDBInstance_separate_iops_update
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1329.25s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1461.62s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
--- PASS: TestAccAWSDBInstance_portUpdate (547.06s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (1643.64s)
=== CONT  TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1718.86s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1762.45s)
=== CONT  TestAccAWSDBInstance_DeletionProtection
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1769.81s)
=== CONT  TestAccAWSDBInstance_generatedName
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1264.95s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Monitoring
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1855.43s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
--- PASS: TestAccAWSDBInstance_separate_iops_update (700.17s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (1954.27s)
=== CONT  TestAccAWSDBInstance_Password
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2016.92s)
=== CONT  TestAccAWSDBInstance_MaxAllocatedStorage
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1545.26s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1247.61s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (753.28s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating DB Instance: InvalidParameterValue: The auto-minor-version-upgrade value is not valid for the Read Replica
                status code: 400, request id: 3ce049a5-c8f8-4546-9c5e-908fbb8ed924
        
          on /var/folders/1g/vw1nd8z13gd6fmnr1f388dsh0000gn/T/tf-test893624974/main.tf line 13:
          (source code not available)
        
        
=== CONT  TestAccAWSDBInstance_subnetGroup
--- PASS: TestAccAWSDBInstance_kmsKey (522.58s)
=== CONT  TestAccAWSDBInstance_IsAlreadyBeingDeleted
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1644.95s)
=== CONT  TestAccAWSDBInstance_AllowMajorVersionUpgrade
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1506.41s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled
--- PASS: TestAccAWSDBInstance_generatedName (454.76s)
=== CONT  TestAccAWSDBInstance_namePrefix
--- PASS: TestAccAWSDBInstance_DeletionProtection (518.41s)
=== CONT  TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot
--- PASS: TestAccAWSDBInstance_Password (522.14s)
=== CONT  TestAccAWSDBInstance_FinalSnapshotIdentifier
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1678.89s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1509.52s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (425.82s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (525.11s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone
--- PASS: TestAccAWSDBInstance_namePrefix (552.14s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (869.29s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow
--- PASS: TestAccAWSDBInstance_subnetGroup (974.96s)
=== CONT  TestAccAWSDBInstance_iamAuth
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1599.70s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (808.68s)
=== CONT  TestAccAWSDBInstance_optionGroup
--- FAIL: TestAccAWSDBInstance_optionGroup (6.78s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating DB Instance: InvalidParameterCombination: The option group tf-option-test-8540581002133896234 is for mysql 5.6, and your DB instance is mysql 5.7.
                status code: 400, request id: 1eac592c-2793-41f6-aaa1-47a4529ebd18
        
          on /var/folders/1g/vw1nd8z13gd6fmnr1f388dsh0000gn/T/tf-test666176115/main.tf line 9:
          (source code not available)
        
        
=== CONT  TestAccAWSDBInstance_S3Import
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1396.08s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (890.94s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1183.40s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1309.53s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_Port
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1586.24s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
--- PASS: TestAccAWSDBInstance_iamAuth (436.07s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset
--- PASS: TestAccAWSDBInstance_MSSQL_Domain (3167.38s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1527.47s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1914.84s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1192.50s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1855.48s)
--- FAIL: TestAccAWSDBInstance_S3Import (681.85s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: unexpected state 'incompatible-restore', wanted target 'available, storage-optimization'. last error: %!s(<nil>)
        
          on /var/folders/1g/vw1nd8z13gd6fmnr1f388dsh0000gn/T/tf-test180085720/main.tf line 103:
          (source code not available)
        
        
    testing.go:630: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during apply: unexpected state 'incompatible-restore', wanted target ''. last error: %!s(<nil>)
        
        State: aws_db_instance.s3:
          ID = tf-acc-s3-import-test-7235115147348413035-db
          provider = provider.aws
          address = tf-acc-s3-import-test-7235115147348413035-db.cxn84uytvqyi.us-west-2.rds.amazonaws.com
          allocated_storage = 5
          arn = arn:aws:rds:us-west-2:902839739775:db:tf-acc-s3-import-test-7235115147348413035-db
          auto_minor_version_upgrade = true
          availability_zone = us-west-2a
          backup_retention_period = 0
          backup_window = 12:46-13:16
          ca_cert_identifier = rds-ca-2015
          copy_tags_to_snapshot = false
          db_subnet_group_name = tf-acc-s3-import-test-7235115147348413035-subnet-group
          deletion_protection = false
          domain = 
          domain_iam_role_name = 
          enabled_cloudwatch_logs_exports.# = 0
          endpoint = tf-acc-s3-import-test-7235115147348413035-db.cxn84uytvqyi.us-west-2.rds.amazonaws.com:3306
          engine = mysql
          engine_version = 5.6.41
          hosted_zone_id = Z1PVIF0B656C1W
          iam_database_authentication_enabled = false
          identifier = tf-acc-s3-import-test-7235115147348413035-db
          instance_class = db.t2.small
          iops = 0
          kms_key_id = 
          license_model = general-public-license
          maintenance_window = sun:12:01-sun:12:31
          max_allocated_storage = 0
          monitoring_interval = 0
          monitoring_role_arn = 
          multi_az = false
          name = baz
          option_group_name = default:mysql-5-6
          parameter_group_name = default.mysql5.6
          password = barbarbarbar
          performance_insights_enabled = false
          performance_insights_kms_key_id = 
          performance_insights_retention_period = 0
          port = 3306
          publicly_accessible = false
          replicas.# = 0
          replicate_source_db = 
          resource_id = db-FSAFE6I4AQMMQDDDVSUZSSQCRI
          s3_import.# = 1
          s3_import.0.bucket_name = tf-acc-test-1091766172425720357
          s3_import.0.bucket_prefix = 74wsc
          s3_import.0.ingestion_role = arn:aws:iam::902839739775:role/tf-acc-s3-import-test-7235115147348413035-role
          s3_import.0.source_engine = mysql
          s3_import.0.source_engine_version = 5.6
          security_group_names.# = 0
          skip_final_snapshot = true
          status = incompatible-restore
          storage_encrypted = false
          storage_type = gp2
          tags.% = 0
          timezone = 
          username = foo
          vpc_security_group_ids.# = 1
          vpc_security_group_ids.1305788027 = sg-0dc6d1b8049b7245c
        aws_db_subnet_group.foo:
          ID = tf-acc-s3-import-test-7235115147348413035-subnet-group
          provider = provider.aws
          arn = arn:aws:rds:us-west-2:902839739775:subgrp:tf-acc-s3-import-test-7235115147348413035-subnet-group
          description = Managed by Terraform
          name = tf-acc-s3-import-test-7235115147348413035-subnet-group
          subnet_ids.# = 2
          subnet_ids.444068289 = subnet-0a1359a0891e05466
          subnet_ids.447003774 = subnet-0e3d22bf3fbf171ed
          tags.% = 1
          tags.Name = tf-dbsubnet-group-test
        
          Dependencies:
            aws_subnet.bar
            aws_subnet.foo
        aws_iam_role.rds_s3_access_role:
          ID = tf-acc-s3-import-test-7235115147348413035-role
          provider = provider.aws
          arn = arn:aws:iam::902839739775:role/tf-acc-s3-import-test-7235115147348413035-role
          assume_role_policy = {"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"rds.amazonaws.com"},"Action":"sts:AssumeRole"}]}
          create_date = 2019-10-18T15:13:34Z
          description = 
          force_detach_policies = false
          max_session_duration = 3600
          name = tf-acc-s3-import-test-7235115147348413035-role
          path = /
          tags.% = 0
          unique_id = AROA5ENLREV7QRZHCP3WL
        aws_s3_bucket.xtrabackup:
          ID = tf-acc-test-1091766172425720357
          provider = provider.aws
          acceleration_status = 
          acl = private
          arn = arn:aws:s3:::tf-acc-test-1091766172425720357
          bucket = tf-acc-test-1091766172425720357
          bucket_domain_name = tf-acc-test-1091766172425720357.s3.amazonaws.com
          bucket_regional_domain_name = tf-acc-test-1091766172425720357.s3.us-west-2.amazonaws.com
          cors_rule.# = 0
          force_destroy = false
          hosted_zone_id = Z3BJ6K6RIION7M
          lifecycle_rule.# = 0
          logging.# = 0
          object_lock_configuration.# = 0
          region = us-west-2
          replication_configuration.# = 0
          request_payer = BucketOwner
          server_side_encryption_configuration.# = 0
          tags.% = 0
          versioning.# = 1
          versioning.0.enabled = false
          versioning.0.mfa_delete = false
          website.# = 0
        aws_subnet.bar:
          ID = subnet-0a1359a0891e05466
          provider = provider.aws
          arn = arn:aws:ec2:us-west-2:902839739775:subnet/subnet-0a1359a0891e05466
          assign_ipv6_address_on_creation = false
          availability_zone = us-west-2b
          availability_zone_id = usw2-az2
          cidr_block = 10.1.2.0/24
          ipv6_cidr_block = 
          ipv6_cidr_block_association_id = 
          map_public_ip_on_launch = false
          owner_id = 902839739775
          tags.% = 1
          tags.Name = tf-acc-db-instance-with-subnet-group-2
          vpc_id = vpc-0b54038e129f33dcc
        
          Dependencies:
            aws_vpc.foo
        aws_subnet.foo:
          ID = subnet-0e3d22bf3fbf171ed
          provider = provider.aws
          arn = arn:aws:ec2:us-west-2:902839739775:subnet/subnet-0e3d22bf3fbf171ed
          assign_ipv6_address_on_creation = false
          availability_zone = us-west-2a
          availability_zone_id = usw2-az1
          cidr_block = 10.1.1.0/24
          ipv6_cidr_block = 
          ipv6_cidr_block_association_id = 
          map_public_ip_on_launch = false
          owner_id = 902839739775
          tags.% = 1
          tags.Name = tf-acc-db-instance-with-subnet-group-1
          vpc_id = vpc-0b54038e129f33dcc
        
          Dependencies:
            aws_vpc.foo
        aws_vpc.foo:
          ID = vpc-0b54038e129f33dcc
          provider = provider.aws
          arn = arn:aws:ec2:us-west-2:902839739775:vpc/vpc-0b54038e129f33dcc
          assign_generated_ipv6_cidr_block = false
          cidr_block = 10.1.0.0/16
          default_network_acl_id = acl-02490b95170874f95
          default_route_table_id = rtb-09ca101467d94a348
          default_security_group_id = sg-0dc6d1b8049b7245c
          dhcp_options_id = dopt-f9399f81
          enable_classiclink = false
          enable_classiclink_dns_support = false
          enable_dns_hostnames = false
          enable_dns_support = true
          instance_tenancy = default
          ipv6_association_id = 
          ipv6_cidr_block = 
          main_route_table_id = rtb-09ca101467d94a348
          owner_id = 902839739775
          tags.% = 1
          tags.Name = terraform-testacc-db-instance-with-subnet-group
--- PASS: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (3918.47s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1348.62s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1261.58s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1652.80s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1510.98s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1290.78s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1752.45s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1211.61s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1360.13s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1704.77s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1606.13s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1843.24s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (4176.85s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade (2799.34s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       6186.464s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.005s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.031s [no tests to run]
make: *** [testacc] Error 1
```

These failures don't appear to be related to my changes except the 1 max allocated storage