### PR TITLE
Added check for on_failure before resetting disable_rollback during refresh

### DIFF
--- a/.changelog/10539.txt
+++ b/.changelog/10539.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack: Avoid conflicts with `on_failure` and `disable_rollback`
+```

--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -261,6 +261,12 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 	}
 	if stack.DisableRollback != nil {
 		d.Set("disable_rollback", stack.DisableRollback)
+
+		// takes into account that disable_rollback conflicts with on_failure and
+		// prevents forced new creation if disable_rollback is reset during refresh
+		if d.Get("on_failure") != nil {
+			d.Set("disable_rollback", false)
+		}
 	}
 	if len(stack.NotificationARNs) > 0 {
 		err = d.Set("notification_arns", flattenStringSet(stack.NotificationARNs))

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -497,7 +497,7 @@ func TestAccAWSCloudFormationStack_onFailure(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "disable_rollback", "false"),
-					resource.TestCheckResourceAttr(resourceName, "on_failure", "DO_NOTHING"),
+					resource.TestCheckResourceAttr(resourceName, "on_failure", cloudformation.OnFailureDoNothing),
 				),
 			},
 		},

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -479,13 +479,14 @@ func TestAccAWSCloudFormationStack_withTransform(t *testing.T) {
 	})
 }
 
-// Test for https://github.com/hashicorp/terraform/issues/5204
+// TestAccAWSCloudFormationStack_onFailure verifies https://github.com/hashicorp/terraform-provider-aws/issues/5204
 func TestAccAWSCloudFormationStack_onFailure(t *testing.T) {
 	var stack cloudformation.Stack
 	rName := fmt.Sprintf("tf-acc-test-cloudformation-on-failure-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, cloudformation.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -813,7 +813,7 @@ STACK
 %[2]s
 POLICY
   capabilities       = ["CAPABILITY_IAM"]
-  notification_arns  = ["${aws_sns_topic.test.arn}"]
+  notification_arns  = [aws_sns_topic.test.arn]
   on_failure         = "DELETE"
   timeout_in_minutes = 10
   tags = {

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -77,7 +77,7 @@ func testSweepCloudformationStacks(region string) error {
 
 func TestAccAWSCloudFormationStack_basic(t *testing.T) {
 	var stack cloudformation.Stack
-	stackName := acctest.RandomWithPrefix("tf-acc-test-basic")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -87,10 +87,10 @@ func TestAccAWSCloudFormationStack_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationStackConfig(stackName),
+				Config: testAccAWSCloudFormationStackConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckNoResourceAttr(resourceName, "on_failure"),
 				),
 			},
@@ -104,7 +104,7 @@ func TestAccAWSCloudFormationStack_basic(t *testing.T) {
 }
 
 func TestAccAWSCloudFormationStack_CreationFailure_DoNothing(t *testing.T) {
-	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,7 +113,7 @@ func TestAccAWSCloudFormationStack_CreationFailure_DoNothing(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSCloudFormationStackConfigCreationFailure(stackName, cloudformation.OnFailureDoNothing),
+				Config:      testAccAWSCloudFormationStackConfigCreationFailure(rName, cloudformation.OnFailureDoNothing),
 				ExpectError: regexp.MustCompile(`failed to create CloudFormation stack \(CREATE_FAILED\).*The following resource\(s\) failed to create.*This is not a valid CIDR block`),
 			},
 		},
@@ -121,7 +121,7 @@ func TestAccAWSCloudFormationStack_CreationFailure_DoNothing(t *testing.T) {
 }
 
 func TestAccAWSCloudFormationStack_CreationFailure_Delete(t *testing.T) {
-	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -130,7 +130,7 @@ func TestAccAWSCloudFormationStack_CreationFailure_Delete(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSCloudFormationStackConfigCreationFailure(stackName, cloudformation.OnFailureDelete),
+				Config:      testAccAWSCloudFormationStackConfigCreationFailure(rName, cloudformation.OnFailureDelete),
 				ExpectError: regexp.MustCompile(`failed to create CloudFormation stack, delete requested \(DELETE_COMPLETE\).*The following resource\(s\) failed to create.*This is not a valid CIDR block`),
 			},
 		},
@@ -138,7 +138,7 @@ func TestAccAWSCloudFormationStack_CreationFailure_Delete(t *testing.T) {
 }
 
 func TestAccAWSCloudFormationStack_CreationFailure_Rollback(t *testing.T) {
-	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -147,7 +147,7 @@ func TestAccAWSCloudFormationStack_CreationFailure_Rollback(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSCloudFormationStackConfigCreationFailure(stackName, cloudformation.OnFailureRollback),
+				Config:      testAccAWSCloudFormationStackConfigCreationFailure(rName, cloudformation.OnFailureRollback),
 				ExpectError: regexp.MustCompile(`failed to create CloudFormation stack, rollback requested \(ROLLBACK_COMPLETE\).*The following resource\(s\) failed to create.*This is not a valid CIDR block`),
 			},
 		},
@@ -156,7 +156,7 @@ func TestAccAWSCloudFormationStack_CreationFailure_Rollback(t *testing.T) {
 
 func TestAccAWSCloudFormationStack_UpdateFailure(t *testing.T) {
 	var stack cloudformation.Stack
-	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 
 	vpcCidrInitial := "10.0.0.0/16"
@@ -169,13 +169,13 @@ func TestAccAWSCloudFormationStack_UpdateFailure(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationStackConfig_withParams(stackName, vpcCidrInitial),
+				Config: testAccAWSCloudFormationStackConfig_withParams(rName, vpcCidrInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
 			},
 			{
-				Config:      testAccAWSCloudFormationStackConfig_withParams(stackName, vpcCidrInvalid),
+				Config:      testAccAWSCloudFormationStackConfig_withParams(rName, vpcCidrInvalid),
 				ExpectError: regexp.MustCompile(`failed to update CloudFormation stack \(UPDATE_ROLLBACK_COMPLETE\).*This is not a valid CIDR block`),
 			},
 		},
@@ -184,7 +184,7 @@ func TestAccAWSCloudFormationStack_UpdateFailure(t *testing.T) {
 
 func TestAccAWSCloudFormationStack_disappears(t *testing.T) {
 	var stack cloudformation.Stack
-	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -194,7 +194,7 @@ func TestAccAWSCloudFormationStack_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationStackConfig(stackName),
+				Config: testAccAWSCloudFormationStackConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudFormationStack(), resourceName),
@@ -207,7 +207,7 @@ func TestAccAWSCloudFormationStack_disappears(t *testing.T) {
 
 func TestAccAWSCloudFormationStack_yaml(t *testing.T) {
 	var stack cloudformation.Stack
-	stackName := fmt.Sprintf("tf-acc-test-yaml-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -217,7 +217,7 @@ func TestAccAWSCloudFormationStack_yaml(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationStackConfig_yaml(stackName),
+				Config: testAccAWSCloudFormationStackConfig_yaml(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
@@ -233,7 +233,7 @@ func TestAccAWSCloudFormationStack_yaml(t *testing.T) {
 
 func TestAccAWSCloudFormationStack_defaultParams(t *testing.T) {
 	var stack cloudformation.Stack
-	stackName := fmt.Sprintf("tf-acc-test-default-params-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -243,7 +243,7 @@ func TestAccAWSCloudFormationStack_defaultParams(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationStackConfig_defaultParams(stackName),
+				Config: testAccAWSCloudFormationStackConfig_defaultParams(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
@@ -260,7 +260,7 @@ func TestAccAWSCloudFormationStack_defaultParams(t *testing.T) {
 
 func TestAccAWSCloudFormationStack_allAttributes(t *testing.T) {
 	var stack cloudformation.Stack
-	stackName := fmt.Sprintf("tf-acc-test-all-attributes-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 	expectedPolicyBody := "{\"Statement\":[{\"Action\":\"Update:*\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Resource\":\"LogicalResourceId/StaticVPC\"},{\"Action\":\"Update:*\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Resource\":\"*\"}]}"
 
@@ -271,10 +271,10 @@ func TestAccAWSCloudFormationStack_allAttributes(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationStackConfig_allAttributesWithBodies(stackName),
+				Config: testAccAWSCloudFormationStackConfig_allAttributesWithBodies(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "capabilities.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "capabilities.*", "CAPABILITY_IAM"),
 					resource.TestCheckResourceAttr(resourceName, "disable_rollback", "false"),
@@ -295,10 +295,10 @@ func TestAccAWSCloudFormationStack_allAttributes(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"on_failure", "parameters", "policy_body"},
 			},
 			{
-				Config: testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(stackName),
+				Config: testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
-					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "capabilities.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "capabilities.*", "CAPABILITY_IAM"),
 					resource.TestCheckResourceAttr(resourceName, "disable_rollback", "false"),
@@ -319,7 +319,7 @@ func TestAccAWSCloudFormationStack_allAttributes(t *testing.T) {
 // Regression for https://github.com/hashicorp/terraform/issues/4332
 func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 	var stack cloudformation.Stack
-	stackName := fmt.Sprintf("tf-acc-test-with-params-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 
 	vpcCidrInitial := "10.0.0.0/16"
@@ -332,7 +332,7 @@ func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationStackConfig_withParams(stackName, vpcCidrInitial),
+				Config: testAccAWSCloudFormationStackConfig_withParams(rName, vpcCidrInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
@@ -346,7 +346,7 @@ func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"on_failure", "parameters"},
 			},
 			{
-				Config: testAccAWSCloudFormationStackConfig_withParams(stackName, vpcCidrUpdated),
+				Config: testAccAWSCloudFormationStackConfig_withParams(rName, vpcCidrUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
@@ -360,7 +360,7 @@ func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 // Regression for https://github.com/hashicorp/terraform/issues/4534
 func TestAccAWSCloudFormationStack_withUrl_withParams(t *testing.T) {
 	var stack cloudformation.Stack
-	rName := fmt.Sprintf("tf-acc-test-with-url-and-params-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -393,7 +393,7 @@ func TestAccAWSCloudFormationStack_withUrl_withParams(t *testing.T) {
 
 func TestAccAWSCloudFormationStack_withUrl_withParams_withYaml(t *testing.T) {
 	var stack cloudformation.Stack
-	rName := fmt.Sprintf("tf-acc-test-with-params-and-yaml-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -421,7 +421,7 @@ func TestAccAWSCloudFormationStack_withUrl_withParams_withYaml(t *testing.T) {
 // Test for https://github.com/hashicorp/terraform/issues/5653
 func TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate(t *testing.T) {
 	var stack cloudformation.Stack
-	rName := fmt.Sprintf("tf-acc-test-with-params-no-update-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -454,7 +454,8 @@ func TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate(t *testing.T) {
 
 func TestAccAWSCloudFormationStack_withTransform(t *testing.T) {
 	var stack cloudformation.Stack
-	rName := fmt.Sprintf("tf-acc-test-with-transform-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -465,14 +466,14 @@ func TestAccAWSCloudFormationStack_withTransform(t *testing.T) {
 			{
 				Config: testAccAWSCloudFormationStackConfig_withTransform(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-transform", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
 			},
 			{
 				PlanOnly: true,
 				Config:   testAccAWSCloudFormationStackConfig_withTransform(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-transform", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
 			},
 		},
@@ -589,10 +590,10 @@ func testAccCheckCloudFormationStackDisappears(stack *cloudformation.Stack) reso
 	}
 }
 
-func testAccAWSCloudFormationStackConfig(stackName string) string {
+func testAccAWSCloudFormationStackConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
-  name = "%[1]s"
+  name = %[1]q
 
   template_body = <<STACK
 {
@@ -620,10 +621,10 @@ resource "aws_cloudformation_stack" "test" {
 }
 STACK
 }
-`, stackName)
+`, rName)
 }
 
-func testAccAWSCloudFormationStackConfigCreationFailure(stackName, onFailure string) string {
+func testAccAWSCloudFormationStackConfigCreationFailure(rName, onFailure string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
   name       = %[1]q
@@ -655,13 +656,13 @@ resource "aws_cloudformation_stack" "test" {
 }
 STACK
 }
-`, stackName, onFailure)
+`, rName, onFailure)
 }
 
-func testAccAWSCloudFormationStackConfig_yaml(stackName string) string {
+func testAccAWSCloudFormationStackConfig_yaml(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
-  name = "%[1]s"
+  name = %[1]q
 
   template_body = <<STACK
 Resources:
@@ -683,13 +684,13 @@ Outputs:
     Value: !Ref MyVPC
 STACK
 }
-`, stackName)
+`, rName)
 }
 
-func testAccAWSCloudFormationStackConfig_defaultParams(stackName string) string {
+func testAccAWSCloudFormationStackConfig_defaultParams(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
-  name = "%[1]s"
+  name = %[1]q
 
   template_body = <<BODY
 {
@@ -738,17 +739,17 @@ BODY
 
 
   parameters = {
-    TopicName = "%[1]s"
+    TopicName = %[1]q
   }
 }
-`, stackName)
+`, rName)
 }
 
 var testAccAWSCloudFormationStackConfig_allAttributesWithBodies_tpl = `
 data "aws_partition" "current" {}
 
 resource "aws_cloudformation_stack" "test" {
-  name          = "%[1]s"
+  name          = %[1]q
   template_body = <<STACK
 {
   "Parameters" : {
@@ -763,7 +764,7 @@ resource "aws_cloudformation_stack" "test" {
       "Properties" : {
         "CidrBlock" : {"Ref": "VpcCIDR"},
         "Tags" : [
-          {"Key": "Name", "Value": "%[1]s"}
+          {"Key": "Name", "Value": %[1]q}
         ]
       }
     },
@@ -812,7 +813,7 @@ STACK
 %[2]s
 POLICY
   capabilities       = ["CAPABILITY_IAM"]
-  notification_arns  = ["${aws_sns_topic.cf-updates.arn}"]
+  notification_arns  = ["${aws_sns_topic.test.arn}"]
   on_failure         = "DELETE"
   timeout_in_minutes = 10
   tags = {
@@ -821,8 +822,8 @@ POLICY
   }
 }
 
-resource "aws_sns_topic" "cf-updates" {
-  name = "tf-cf-notifications"
+resource "aws_sns_topic" "test" {
+  name = %[1]q
 }
 `
 
@@ -845,26 +846,26 @@ var policyBody = `
 }
 `
 
-func testAccAWSCloudFormationStackConfig_allAttributesWithBodies(stackName string) string {
+func testAccAWSCloudFormationStackConfig_allAttributesWithBodies(rName string) string {
 	return fmt.Sprintf(
 		testAccAWSCloudFormationStackConfig_allAttributesWithBodies_tpl,
-		stackName,
+		rName,
 		policyBody)
 }
 
-func testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(stackName string) string {
+func testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(rName string) string {
 	return fmt.Sprintf(
 		testAccAWSCloudFormationStackConfig_allAttributesWithBodies_tpl,
-		stackName,
+		rName,
 		policyBody)
 }
 
-func testAccAWSCloudFormationStackConfig_withParams(stackName, cidr string) string {
+func testAccAWSCloudFormationStackConfig_withParams(rName, cidr string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
-  name = "%[1]s"
+  name = %[1]q
   parameters = {
-    VpcCIDR = "%[2]s"
+    VpcCIDR = %[2]q
   }
   template_body = <<STACK
 {
@@ -891,7 +892,7 @@ STACK
   on_failure         = "DELETE"
   timeout_in_minutes = 1
 }
-`, stackName, cidr)
+`, rName, cidr)
 }
 
 func testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, bucketKey, vpcCidr string) string {
@@ -901,7 +902,7 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "b" {
-  bucket = "%[1]s"
+  bucket = %[1]q
   acl    = "public-read"
 
   policy = <<POLICY
@@ -930,15 +931,15 @@ POLICY
 
 resource "aws_s3_bucket_object" "object" {
   bucket = aws_s3_bucket.b.id
-  key    = "%[2]s"
+  key    = %[2]q
   source = "test-fixtures/cloudformation-template.json"
 }
 
 resource "aws_cloudformation_stack" "test" {
-  name = "%[1]s"
+  name = %[1]q
 
   parameters = {
-    VpcCIDR = "%[3]s"
+    VpcCIDR = %[3]q
   }
 
   template_url       = "https://${aws_s3_bucket.b.id}.s3-${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${aws_s3_bucket_object.object.key}"
@@ -955,7 +956,7 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "b" {
-  bucket = "%[1]s"
+  bucket = %[1]q
   acl    = "public-read"
 
   policy = <<POLICY
@@ -984,15 +985,15 @@ POLICY
 
 resource "aws_s3_bucket_object" "object" {
   bucket = aws_s3_bucket.b.id
-  key    = "%[2]s"
+  key    = %[2]q
   source = "test-fixtures/cloudformation-template.yaml"
 }
 
 resource "aws_cloudformation_stack" "test" {
-  name = "%[1]s"
+  name = %[1]q
 
   parameters = {
-    VpcCIDR = "%[3]s"
+    VpcCIDR = %[3]q
   }
 
   template_url       = "https://${aws_s3_bucket.b.id}.s3-${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${aws_s3_bucket_object.object.key}"
@@ -1004,8 +1005,8 @@ resource "aws_cloudformation_stack" "test" {
 
 func testAccAWSCloudFormationStackConfig_withTransform(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudformation_stack" "with-transform" {
-  name = "%[1]s"
+resource "aws_cloudformation_stack" "test" {
+  name = %[1]q
 
   template_body = <<STACK
 {


### PR DESCRIPTION

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


Closes #5204

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
NONE
```

Output from acceptance testing:

```
TF_ACC=1 go test ./... -v -count 1 -parallel 1 -run=TestAccAWSCloudFormationStack_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudFormationStack_dataSource_basic
=== PAUSE TestAccAWSCloudFormationStack_dataSource_basic
=== RUN   TestAccAWSCloudFormationStack_dataSource_yaml
=== PAUSE TestAccAWSCloudFormationStack_dataSource_yaml
=== RUN   TestAccAWSCloudFormationStack_importBasic
=== PAUSE TestAccAWSCloudFormationStack_importBasic
=== RUN   TestAccAWSCloudFormationStack_basic
=== PAUSE TestAccAWSCloudFormationStack_basic
=== RUN   TestAccAWSCloudFormationStack_disappears
=== PAUSE TestAccAWSCloudFormationStack_disappears
=== RUN   TestAccAWSCloudFormationStack_yaml
=== PAUSE TestAccAWSCloudFormationStack_yaml
=== RUN   TestAccAWSCloudFormationStack_defaultParams
=== PAUSE TestAccAWSCloudFormationStack_defaultParams
=== RUN   TestAccAWSCloudFormationStack_allAttributes
=== PAUSE TestAccAWSCloudFormationStack_allAttributes
=== RUN   TestAccAWSCloudFormationStack_withParams
=== PAUSE TestAccAWSCloudFormationStack_withParams
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams
=== PAUSE TestAccAWSCloudFormationStack_withUrl_withParams
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
=== PAUSE TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
=== PAUSE TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
=== RUN   TestAccAWSCloudFormationStack_onFailure
=== PAUSE TestAccAWSCloudFormationStack_onFailure
=== CONT  TestAccAWSCloudFormationStack_dataSource_basic
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (73.95s)
=== CONT  TestAccAWSCloudFormationStack_onFailure
--- PASS: TestAccAWSCloudFormationStack_onFailure (54.84s)
=== CONT  TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (116.51s)
=== CONT  TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (92.23s)
=== CONT  TestAccAWSCloudFormationStack_disappears
--- PASS: TestAccAWSCloudFormationStack_disappears (70.03s)
=== CONT  TestAccAWSCloudFormationStack_basic
--- PASS: TestAccAWSCloudFormationStack_basic (66.80s)
=== CONT  TestAccAWSCloudFormationStack_importBasic
--- PASS: TestAccAWSCloudFormationStack_importBasic (69.34s)
=== CONT  TestAccAWSCloudFormationStack_dataSource_yaml
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (71.97s)
=== CONT  TestAccAWSCloudFormationStack_withParams
--- PASS: TestAccAWSCloudFormationStack_withParams (125.73s)
=== CONT  TestAccAWSCloudFormationStack_withUrl_withParams
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (162.55s)
=== CONT  TestAccAWSCloudFormationStack_allAttributes
--- PASS: TestAccAWSCloudFormationStack_allAttributes (80.48s)
=== CONT  TestAccAWSCloudFormationStack_defaultParams
--- PASS: TestAccAWSCloudFormationStack_defaultParams (68.02s)
=== CONT  TestAccAWSCloudFormationStack_yaml
--- PASS: TestAccAWSCloudFormationStack_yaml (68.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1122.636s
...
```
