### PR TITLE
Fixed misleading error message during SNS subscription creation

### DIFF
--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -222,7 +222,13 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 
 	output, err = snsconn.Subscribe(req)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating SNS topic: %s", err)
+		var error_response error
+		if strings.Contains(err.Error(), "Invalid parameter: TopicArn") {
+			error_response = fmt.Errorf("Error creating SNS topic subscription. You may be trying to add an SNS subscription in a region different from the topic's region: %s", err)
+		} else {
+			error_response = fmt.Errorf("Error creating SNS topic subscription: %s", err)
+		}
+		return nil, error_response
 	}
 
 	log.Printf("[DEBUG] Finished subscribing to topic %s with subscription arn %s", topic_arn, *output.SubscriptionArn)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Fixed misleading error message during SNS topic subscription creation - we're not creating an SNS topic but a subscription
- Added helpful message for a particular case when operator is trying to add a subscription in an incorrect region
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
