### PR TITLE
#396 fix vpn connection tunnel output sorting

### DIFF
--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -591,9 +590,6 @@ func xmlConfigToTunnelInfo(xmlConfig string) (*TunnelInfo, error) {
 	if err := xml.Unmarshal([]byte(xmlConfig), &vpnConfig); err != nil {
 		return nil, fmt.Errorf("Error Unmarshalling XML: %s", err)
 	}
-
-	// don't expect consistent ordering from the XML
-	sort.Sort(vpnConfig)
 
 	tunnelInfo := TunnelInfo{
 		Tunnel1Address:          vpnConfig.Tunnels[0].OutsideAddress,

--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -584,35 +584,6 @@ const testAccAwsVpnTunnelInfoXML = `
         <ip_address>123.123.123.123</ip_address>
       </tunnel_outside_address>
       <tunnel_inside_address>
-        <ip_address>SECOND_CGW_INSIDE_ADDRESS</ip_address>
-        <network_mask>255.255.255.252</network_mask>
-        <network_cidr>30</network_cidr>
-      </tunnel_inside_address>
-    </customer_gateway>
-    <vpn_gateway>
-      <tunnel_outside_address>
-        <ip_address>SECOND_ADDRESS</ip_address>
-      </tunnel_outside_address>
-      <tunnel_inside_address>
-        <ip_address>SECOND_VGW_INSIDE_ADDRESS</ip_address>
-        <network_mask>255.255.255.252</network_mask>
-        <network_cidr>30</network_cidr>
-      </tunnel_inside_address>
-      <bgp>
-        <asn>SECOND_BGP_ASN</asn>
-        <hold_time>32</hold_time>
-      </bgp>
-    </vpn_gateway>
-    <ike>
-      <pre_shared_key>SECOND_KEY</pre_shared_key>
-    </ike>
-  </ipsec_tunnel>
-  <ipsec_tunnel>
-    <customer_gateway>
-      <tunnel_outside_address>
-        <ip_address>123.123.123.123</ip_address>
-      </tunnel_outside_address>
-      <tunnel_inside_address>
         <ip_address>FIRST_CGW_INSIDE_ADDRESS</ip_address>
         <network_mask>255.255.255.252</network_mask>
         <network_cidr>30</network_cidr>
@@ -634,6 +605,35 @@ const testAccAwsVpnTunnelInfoXML = `
     </vpn_gateway>
     <ike>
       <pre_shared_key>FIRST_KEY</pre_shared_key>
+    </ike>
+  </ipsec_tunnel>
+  <ipsec_tunnel>
+    <customer_gateway>
+      <tunnel_outside_address>
+        <ip_address>123.123.123.123</ip_address>
+      </tunnel_outside_address>
+      <tunnel_inside_address>
+        <ip_address>SECOND_CGW_INSIDE_ADDRESS</ip_address>
+        <network_mask>255.255.255.252</network_mask>
+        <network_cidr>30</network_cidr>
+      </tunnel_inside_address>
+    </customer_gateway>
+    <vpn_gateway>
+      <tunnel_outside_address>
+        <ip_address>SECOND_ADDRESS</ip_address>
+      </tunnel_outside_address>
+      <tunnel_inside_address>
+        <ip_address>SECOND_VGW_INSIDE_ADDRESS</ip_address>
+        <network_mask>255.255.255.252</network_mask>
+        <network_cidr>30</network_cidr>
+      </tunnel_inside_address>
+      <bgp>
+        <asn>SECOND_BGP_ASN</asn>
+        <hold_time>32</hold_time>
+      </bgp>
+    </vpn_gateway>
+    <ike>
+      <pre_shared_key>SECOND_KEY</pre_shared_key>
     </ike>
   </ipsec_tunnel>
 </vpn_connection>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #396 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
BUG FIXES:

* fix incorrect order (tunnel1 and tunnel2) in output of resource aws_vpn_connection
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccXXX -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.037s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.014s [no tests to run]
```
