### PR TITLE
Add iot events configuration resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -552,6 +552,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_inspector_resource_group":                            resourceAWSInspectorResourceGroup(),
 			"aws_instance":                                            resourceAwsInstance(),
 			"aws_internet_gateway":                                    resourceAwsInternetGateway(),
+			"aws_iot_event_configurations":                            resourceAwsIotEventConfigurations(),
 			"aws_iot_certificate":                                     resourceAwsIotCertificate(),
 			"aws_iot_policy":                                          resourceAwsIotPolicy(),
 			"aws_iot_policy_attachment":                               resourceAwsIotPolicyAttachment(),

--- a/aws/resource_aws_iot_event_configurations.go
+++ b/aws/resource_aws_iot_event_configurations.go
@@ -1,0 +1,112 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAwsIotEventConfigurations() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsIotEventConfigurationsUpdate,
+		Read:   resourceAwsIotEventConfigurationsRead,
+		Update: resourceAwsIotEventConfigurationsUpdate,
+		Delete: resourceAwsIotEventConfigurationsCleanAll,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"values": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeBool,
+			},
+		},
+	}
+}
+
+func resourceAwsIotEventConfigurationsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	params := &iot.DescribeEventConfigurationsInput{}
+	out, err := conn.DescribeEventConfigurations(params)
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Update IoT Event Configuration: %s", out)
+
+	eventConfigurations := out.EventConfigurations
+	rawValues := make(map[string]interface{})
+	for key, value := range eventConfigurations {
+		rawValues[key] = aws.BoolValue(value.Enabled)
+	}
+
+	d.Set("values", rawValues)
+
+	return nil
+}
+
+func resourceAwsIotEventConfigurationsUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	rawValues := d.Get("values").(map[string]interface{})
+	eventConfigurations := make(map[string]*iot.Configuration)
+	for key, enabled := range rawValues {
+		eventConfigurations[key] = &iot.Configuration{
+			Enabled: aws.Bool(enabled.(bool)),
+		}
+	}
+
+	params := &iot.UpdateEventConfigurationsInput{
+		EventConfigurations: eventConfigurations,
+	}
+
+	out, err := conn.UpdateEventConfigurations(params)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("event-configurations")
+	log.Printf("[DEBUG] Update IoT Event Configuration: %s", out)
+	return resourceAwsIotEventConfigurationsRead(d, meta)
+}
+
+func resourceAwsIotEventConfigurationsCleanAll(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	params := &iot.DescribeEventConfigurationsInput{}
+	out, err := conn.DescribeEventConfigurations(params)
+
+	if err != nil {
+		return err
+	}
+
+	eventConfigurations := out.EventConfigurations
+	cleanedEventConfigurations := make(map[string]*iot.Configuration)
+	for key := range eventConfigurations {
+		cleanedEventConfigurations[key] = &iot.Configuration{
+			Enabled: aws.Bool(false),
+		}
+	}
+
+	updateParams := &iot.UpdateEventConfigurationsInput{
+		EventConfigurations: cleanedEventConfigurations,
+	}
+
+	_, err = conn.UpdateEventConfigurations(updateParams)
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Clean IoT Event Configuration: %s", out)
+
+	return nil
+}

--- a/aws/resource_aws_iot_event_configurations_test.go
+++ b/aws/resource_aws_iot_event_configurations_test.go
@@ -1,0 +1,89 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSIoTEventConfigurations_basic(t *testing.T) {
+	resourceName := "aws_iot_event_configurations.event_configurations"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTEventConfigurationsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTEventConfigurations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.THING", "true"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.THING_GROUP", "false"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.THING_TYPE", "false"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.THING_GROUP_MEMBERSHIP", "false"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.THING_GROUP_HIERARCHY", "false"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.THING_TYPE_ASSOCIATION", "false"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.JOB", "false"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.JOB_EXECUTION", "false"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.POLICY", "false"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.CERTIFICATE", "true"),
+					resource.TestCheckResourceAttr("aws_iot_event_configurations.event_configurations", "values.CA_CERTIFICATE", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSIoTEventConfigurationsDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).iotconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_iot_event_configurations" {
+			continue
+		}
+
+		params := &iot.DescribeEventConfigurationsInput{}
+		out, err := conn.DescribeEventConfigurations(params)
+
+		if err != nil {
+			return err
+		}
+
+		for key, value := range out.EventConfigurations {
+			if *value.Enabled != false {
+				return fmt.Errorf("Event configuration under key %s not equals false", key)
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func testAccAWSIoTEventConfigurations_basic() string {
+	return fmt.Sprintf(`
+resource "aws_iot_event_configurations" "event_configurations" {
+	values = {
+		"THING" = true,
+		"THING_GROUP" = false,
+		"THING_TYPE" = false,
+		"THING_GROUP_MEMBERSHIP" = false,
+		"THING_GROUP_HIERARCHY" = false,
+		"THING_TYPE_ASSOCIATION" = false,
+		"JOB" = false,
+		"JOB_EXECUTION" = false,
+		"POLICY" = false,
+		"CERTIFICATE" = true,
+		"CA_CERTIFICATE" = false,
+	}
+}
+`)
+}

--- a/website/docs/r/iot_event_configurations.html.markdown
+++ b/website/docs/r/iot_event_configurations.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iot_event_configurations"
+description: |-
+    Creates and manages an AWS IoT Thing.
+---
+
+# Resource: aws_iot_event_configurations
+
+Manages an AWS Event Configurations.
+
+## Example Usage
+
+```hcl
+resource "aws_iot_event_configurations" "example" {
+    values = {
+		"THING" = true,
+		"THING_GROUP" = false,
+		"THING_TYPE" = false,
+		"THING_GROUP_MEMBERSHIP" = false,
+		"THING_GROUP_HIERARCHY" = false,
+		"THING_TYPE_ASSOCIATION" = false,
+		"JOB" = false,
+		"JOB_EXECUTION" = false,
+		"POLICY" = false,
+		"CERTIFICATE" = true,
+		"CA_CERTIFICATE" = false,
+    }
+}
+```
+
+## Argument Reference
+
+* `values` - (Optional) Map. The new event configuration values. You can use only these strings as keys: THING_GROUP_HIERARCHY, THING_GROUP_MEMBERSHIP, THING_TYPE, THING_TYPE_ASSOCIATION, THING_GROUP, THING, POLICY, CA_CERTIFICATE, JOB_EXECUTION, CERTIFICATE, JOB. Use boolean for values of mapping.
+
+
+## Import
+
+IOT Event Configurations can be imported using the name, e.g.
+
+```
+$ terraform import aws_iot_event_configurations.example event-configurations
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10628.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22750.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add aws_iot_event_configurations resource
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSIoTEventConfigurations_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIoTEventConfigurations_ -timeout 120m
=== RUN   TestAccAWSIoTEventConfigurations_basic
=== PAUSE TestAccAWSIoTEventConfigurations_basic
=== CONT  TestAccAWSIoTEventConfigurations_basic
--- PASS: TestAccAWSIoTEventConfigurations_basic (34.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws

```
