### PR TITLE
Add possibility to attach iot thing to iot group

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -557,6 +557,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iot_certificate":                                     resourceAwsIotCertificate(),
 			"aws_iot_policy":                                          resourceAwsIotPolicy(),
 			"aws_iot_policy_attachment":                               resourceAwsIotPolicyAttachment(),
+			"aws_iot_thing_group_attachment":                          resourceAwsIotThingGroupAttachment(),
 			"aws_iot_thing":                                           resourceAwsIotThing(),
 			"aws_iot_thing_principal_attachment":                      resourceAwsIotThingPrincipalAttachment(),
 			"aws_iot_thing_type":                                      resourceAwsIotThingType(),

--- a/aws/resource_aws_iot_thing_group_attachment.go
+++ b/aws/resource_aws_iot_thing_group_attachment.go
@@ -1,0 +1,164 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAwsIotThingGroupAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsIotThingGroupAttachmentCreate,
+		Read:   resourceAwsIotThingGroupAttachmentRead,
+		Delete: resourceAwsIotThingGroupAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsIotThingGroupAttachmentImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"thing_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"thing_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"override_dynamics_group": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsIotThingGroupAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	params := &iot.AddThingToThingGroupInput{}
+	params.ThingName = aws.String(d.Get("thing_name").(string))
+	params.ThingGroupName = aws.String(d.Get("thing_group_name").(string))
+
+	if v, ok := d.GetOk("override_dynamics_group"); ok {
+		params.OverrideDynamicGroups = aws.Bool(v.(bool))
+	}
+
+	_, err := conn.AddThingToThingGroup(params)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resource.PrefixedUniqueId(fmt.Sprintf("%s-%s", *params.ThingName, *params.ThingGroupName)))
+
+	return resourceAwsIotThingGroupAttachmentRead(d, meta)
+}
+
+func resourceAwsIotThingGroupAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	thingName := d.Get("thing_name").(string)
+	thingGroupName := d.Get("thing_group_name").(string)
+
+	hasThingGroup, err := iotThingHasThingGroup(conn, thingName, thingGroupName, "")
+
+	if isAWSErr(err, iot.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] IoT Thing (%s) is not found", thingName)
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error finding IoT Thing Group (%s) of thing  (%s): %s", thingGroupName, thingName, err)
+	}
+
+	if !hasThingGroup {
+		log.Printf("[WARN] IoT Thing Group (%s) is not found in Thing (%s) group list", thingGroupName, thingName)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("thing_name", thingName)
+	d.Set("thing_group_name", thingGroupName)
+	if v, ok := d.GetOk("override_dynamics_group"); ok {
+		d.Set("override_dynamics_group", v.(bool))
+	}
+
+	return nil
+}
+
+func resourceAwsIotThingGroupAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	params := &iot.RemoveThingFromThingGroupInput{}
+	params.ThingName = aws.String(d.Get("thing_name").(string))
+	params.ThingGroupName = aws.String(d.Get("thing_group_name").(string))
+
+	_, err := conn.RemoveThingFromThingGroup(params)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsIotThingGroupAttachmentImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.SplitN(d.Id(), "/", 2)
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <thing-name>/<thing-group>", d.Id())
+	}
+
+	thingName := idParts[0]
+	thingGroupName := idParts[1]
+
+	d.Set("thing_name", thingName)
+	d.Set("thing_group_name", thingGroupName)
+
+	d.SetId(fmt.Sprintf("%s-%s", thingName, thingGroupName))
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func iotThingHasThingGroup(conn *iot.IoT, thingName string, thingGroupName string, nextToken string) (bool, error) {
+	maxResults := int64(20)
+
+	params := &iot.ListThingGroupsForThingInput{
+		MaxResults: aws.Int64(maxResults),
+		ThingName:  aws.String(thingName),
+	}
+
+	if len(nextToken) > 0 {
+		params.NextToken = aws.String(nextToken)
+	}
+
+	out, err := conn.ListThingGroupsForThing(params)
+	if err != nil {
+		return false, err
+	}
+
+	// Check if searched group is in current collection
+	// If it is return true
+	for _, group := range out.ThingGroups {
+		if thingGroupName == *group.GroupName {
+			return true, nil
+		}
+	}
+
+	// If group that we searched for not appear in current list
+	// then check if NextToken exists. If it is so call hasThingGroup
+	// recursively to search in next part of list. Otherwise return false
+	if out.NextToken != nil {
+		return iotThingHasThingGroup(conn, thingName, thingGroupName, *out.NextToken)
+	} else {
+		return false, nil
+	}
+}

--- a/aws/resource_aws_iot_thing_group_attachment_test.go
+++ b/aws/resource_aws_iot_thing_group_attachment_test.go
@@ -1,0 +1,131 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSIotThingGroupAttachment_basic(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIotThingGroupAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIotThingGroupAttachmentConfig_basic(rString),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_iot_thing_group_attachment.test_attachment", "thing_name", fmt.Sprintf("test_thing_%s", rString)),
+					resource.TestCheckResourceAttr("aws_iot_thing_group_attachment.test_attachment", "thing_group_name", fmt.Sprintf("test_group_%s", rString)),
+					resource.TestCheckResourceAttr("aws_iot_thing_group_attachment.test_attachment", "override_dynamics_group", "false"),
+					testAccAWSIotThingGroupAttachmentExists_basic(rString),
+				),
+			},
+			{
+				ResourceName:      "aws_iot_thing_group_attachment.test_attachment",
+				ImportStateIdFunc: testAccAWSIotThingGroupAttachmentImportStateIdFunc("aws_iot_thing_group_attachment.test_attachment"),
+				ImportState:       true,
+				// We do not have a way to align IDs since the Create function uses resource.PrefixedUniqueId()
+				// Failed state verification, resource with ID ROLE-POLICYARN not found
+				// ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAWSIotThingGroupAttachmentExists_basic(rString string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*AWSClient).iotconn
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_iot_thing_group_attachment" {
+				continue
+			}
+
+			thingName := rs.Primary.Attributes["thing_name"]
+			thingGroupName := rs.Primary.Attributes["thing_group_name"]
+			hasThingGroup, err := iotThingHasThingGroup(conn, thingName, thingGroupName, "")
+
+			if err != nil {
+				return err
+			}
+
+			if !hasThingGroup {
+				return fmt.Errorf("IoT Thing (%s) is not in IoT Thing Group (%s)", thingName, thingGroupName)
+			}
+
+			return nil
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSIotThingGroupAttachmentDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).iotconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_iot_thing_group_attachment" {
+			continue
+		}
+
+		thingName := rs.Primary.Attributes["thing_name"]
+		thingGroupName := rs.Primary.Attributes["thing_group_name"]
+
+		hasThingGroup, err := iotThingHasThingGroup(conn, thingName, thingGroupName, "")
+
+		if isAWSErr(err, iot.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if hasThingGroup {
+			return fmt.Errorf("IoT Thing (%s) still in IoT Thing Group (%s)", thingName, thingGroupName)
+		}
+	}
+	return nil
+}
+
+func testAccAWSIotThingGroupAttachmentImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["thing_name"], rs.Primary.Attributes["thing_group_name"]), nil
+	}
+}
+
+func testAccAWSIotThingGroupAttachmentConfig_basic(rString string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_thing" "test_thing" {
+	name = "test_thing_%s"
+}
+
+resource "aws_iot_thing_group" "test_thing_group" {
+	name = "test_group_%[1]s"
+	properties {
+		attributes = {
+			"attr1": "val1",
+		}
+		merge = false
+	}
+}
+
+resource "aws_iot_thing_group_attachment" "test_attachment" {
+	thing_name = "${aws_iot_thing.test_thing.name}"
+	thing_group_name = "${aws_iot_thing_group.test_thing_group.name}"
+	override_dynamics_group = false
+}
+`, rString)
+}

--- a/website/docs/r/iot_thing_group_attachment.html.markdown
+++ b/website/docs/r/iot_thing_group_attachment.html.markdown
@@ -12,7 +12,7 @@ Allow to add IoT Thing to IoT Thing Group.
 ## Example Usage
 
 ```hcl
-resource "aws_iot_thing_group_attachment_attachment" "test_attachment" {
+resource "aws_iot_thing_group_attachment" "test_attachment" {
 	thing_name = "test_thing_name"
 	thing_group_name = "test_thing_group_name"
 	override_dynamics_group = false

--- a/website/docs/r/iot_thing_group_attachment.html.markdown
+++ b/website/docs/r/iot_thing_group_attachment.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iot_thing_group_attachment"
+description: |-
+    Allow to add IoT Thing to IoT Thing Group.
+---
+
+# Resource: aws_iot_thing_group_attachment
+
+Allow to add IoT Thing to IoT Thing Group.
+
+## Example Usage
+
+```hcl
+resource "aws_iot_thing_group_attachment_attachment" "test_attachment" {
+	thing_name = "test_thing_name"
+	thing_group_name = "test_thing_group_name"
+	override_dynamics_group = false
+}
+```
+
+## Argument Reference
+
+* `thing_name` - (Required, Forces New Resource). The name of the thing to add to a group.
+* `thing_group_name` - (Required, Forces New Resource). The name of the group to which you are adding a thing.
+* `override_dynamics_group` - (Optional) Bool. Override dynamic thing groups with static thing groups when 10-group limit is reached. If a thing belongs to 10 thing groups, and one or more of those groups are dynamic thing groups, adding a thing to a static group removes the thing from the last dynamic group.
+
+## Import
+
+IOT Thing Group Attachment can be imported using the name of thing and thing group.
+
+```
+$ terraform import aws_iot_thing_group_attachment.test_attachment thing_name/thing_group
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #10632 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add aws_iot_thing_group_attachment resource
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSIotThingGroupAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIotThingGroupAttachment_basic -timeout 120m
=== RUN   TestAccAWSIotThingGroupAttachment_basic
=== PAUSE TestAccAWSIotThingGroupAttachment_basic
=== CONT  TestAccAWSIotThingGroupAttachment_basic
--- PASS: TestAccAWSIotThingGroupAttachment_basic (41.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws    41.416s
```
