### PR TITLE
First AWS Personalize resource: aws_personalize_dataset_group

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -634,6 +634,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_organizations_policy":                                resourceAwsOrganizationsPolicy(),
 			"aws_organizations_policy_attachment":                     resourceAwsOrganizationsPolicyAttachment(),
 			"aws_organizations_organizational_unit":                   resourceAwsOrganizationsOrganizationalUnit(),
+			"aws_personalize_dataset_group":                           resourceAwsPersonalizeDatasetGroup(),
 			"aws_placement_group":                                     resourceAwsPlacementGroup(),
 			"aws_proxy_protocol_policy":                               resourceAwsProxyProtocolPolicy(),
 			"aws_quicksight_group":                                    resourceAwsQuickSightGroup(),

--- a/aws/resource_aws_personalize_dataset_group.go
+++ b/aws/resource_aws_personalize_dataset_group.go
@@ -1,0 +1,181 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/personalize"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"log"
+	"time"
+)
+
+func resourceAwsPersonalizeDatasetGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsPersonalizeDatasetGroupCreate,
+		Read:   resourceAwsPersonalizeDatasetGroupRead,
+		Delete: resourceAwsPersonalizeDatasetGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"kms_key_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+
+			"role_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+		},
+	}
+}
+
+func resourceAwsPersonalizeDatasetGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).personalizeconn
+
+	createOpts := &personalize.CreateDatasetGroupInput{
+		Name: aws.String(d.Get("name").(string)),
+	}
+
+	kmsKeyArn, hasKmsKeyArn := d.GetOk("kms_key_arn")
+	roleArn, hasRoleArn := d.GetOk("role_arn")
+
+	if hasKmsKeyArn {
+		createOpts.KmsKeyArn = aws.String(kmsKeyArn.(string))
+	}
+
+	if hasRoleArn {
+		createOpts.RoleArn = aws.String(roleArn.(string))
+	}
+
+	if hasKmsKeyArn == false && hasRoleArn {
+		return errors.New("role_arn can only be set when kms_key_arn is specified")
+	}
+
+	log.Printf("[DEBUG] Personalize dataset group create options: %#v", *createOpts)
+
+	ds, err := conn.CreateDatasetGroup(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating Personalize dataset group: %s", err)
+	}
+
+	d.SetId(*ds.DatasetGroupArn)
+	log.Printf("[INFO] Personalize dataset group ARN: %s", d.Id())
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"CREATE PENDING", "CREATE IN_PROGRESS"},
+		Target:     []string{"ACTIVE"},
+		Refresh:    resourceAwsPersonalizeDatasetGroupCreateRefreshFunc(d.Id(), conn),
+		Timeout:    10 * time.Minute,
+		Delay:      2 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Personalize dataset group (%q) to create: %s", d.Id(), err)
+	}
+	log.Printf("[DEBUG] Personalize dataset group %q created.", d.Id())
+
+	return resourceAwsPersonalizeDatasetGroupRead(d, meta)
+}
+
+func resourceAwsPersonalizeDatasetGroupCreateRefreshFunc(id string, conn *personalize.Personalize) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeDatasetGroup(&personalize.DescribeDatasetGroupInput{
+			DatasetGroupArn: aws.String(id),
+		})
+		if err != nil {
+			return nil, "error", err
+		}
+
+		if resp == nil || resp.DatasetGroup == nil {
+			return nil, "not-found", fmt.Errorf("Personalize dataset group %q could not be found.", id)
+		}
+
+		dg := resp.DatasetGroup
+		state := aws.StringValue(dg.Status)
+		log.Printf("[DEBUG] current status of %q: %q", id, state)
+		return dg, state, nil
+	}
+}
+
+func resourceAwsPersonalizeDatasetGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).personalizeconn
+
+	if _, err := arn.Parse(d.Id()); err != nil {
+		d.SetId(arn.ARN{
+			AccountID: meta.(*AWSClient).accountid,
+			Partition: meta.(*AWSClient).partition,
+			Region:    meta.(*AWSClient).region,
+			Resource:  fmt.Sprintf("dataset-group/%s", d.Id()),
+			Service:   "personalize",
+		}.String())
+	}
+
+	resp, err := conn.DescribeDatasetGroup(&personalize.DescribeDatasetGroupInput{
+		DatasetGroupArn: aws.String(d.Id()),
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+			log.Printf("[WARN] Personalize dataset group (%s) could not be found.", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	if resp == nil || resp.DatasetGroup == nil {
+		return fmt.Errorf("Personalize dataset group %q could not be found.", d.Id())
+	}
+
+	dg := resp.DatasetGroup
+
+	// In the import case, we won't have this
+	if _, ok := d.GetOk("arn"); !ok {
+		d.Set("arn", d.Id())
+	}
+
+	d.Set("name", dg.Name)
+	d.Set("kms_key_arn", dg.KmsKeyArn)
+	d.Set("role_arn", dg.RoleArn)
+
+	return nil
+}
+
+func resourceAwsPersonalizeDatasetGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).personalizeconn
+
+	log.Printf("[DEBUG] Deleting Personalize dataset group: %s", d.Id())
+	_, err := conn.DeleteDatasetGroup(&personalize.DeleteDatasetGroupInput{
+		DatasetGroupArn: aws.String(d.Id()),
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting dataset group: %s with err %s", d.Id(), err.Error())
+	}
+
+	log.Printf("[DEBUG] Personalize dataset group %q deleted.", d.Id())
+
+	return nil
+}

--- a/aws/resource_aws_personalize_dataset_group_test.go
+++ b/aws/resource_aws_personalize_dataset_group_test.go
@@ -15,7 +15,7 @@ func TestAccPersonalizeDatasetGroup_basic(t *testing.T) {
 	resourceName := "aws_personalize_dataset_group.group"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPersonalizeDatasetGroupDestroy,
 		Steps: []resource.TestStep{
@@ -46,7 +46,7 @@ func TestAccPersonalizeDatasetGroup_kms(t *testing.T) {
 	resourceName := "aws_personalize_dataset_group.group"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPersonalizeDatasetGroupDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_personalize_dataset_group_test.go
+++ b/aws/resource_aws_personalize_dataset_group_test.go
@@ -16,10 +16,6 @@ func TestAccPersonalizeDatasetGroup_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
-		/*
-			IDRefreshName:   resourceName,
-			IDRefreshIgnore: []string{"force_destroy"},
-		*/
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPersonalizeDatasetGroupDestroy,
 		Steps: []resource.TestStep{
@@ -51,10 +47,6 @@ func TestAccPersonalizeDatasetGroup_kms(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
-		/*
-			IDRefreshName:   resourceName,
-			IDRefreshIgnore: []string{"force_destroy"},
-		*/
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPersonalizeDatasetGroupDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_personalize_dataset_group_test.go
+++ b/aws/resource_aws_personalize_dataset_group_test.go
@@ -1,0 +1,200 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/personalize"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"testing"
+)
+
+func TestAccPersonalizeDatasetGroup_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_personalize_dataset_group.group"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		/*
+			IDRefreshName:   resourceName,
+			IDRefreshIgnore: []string{"force_destroy"},
+		*/
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPersonalizeDatasetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPersonalizeDatasetGroupBasicConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPersonalizeDatasetGroupExists(resourceName),
+					testAccCheckResourceAttrRegionalARN(
+						resourceName, "arn", "personalize",
+						testAccPersonalizeDatasetGroupName("dataset-group/dsg-", rInt)),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", testAccPersonalizeDatasetGroupName("dsg-", rInt)),
+					resource.TestCheckNoResourceAttr(resourceName, "kms"),
+					resource.TestCheckNoResourceAttr(resourceName, "kms.0.role_arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPersonalizeDatasetGroup_kms(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_personalize_dataset_group.group"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		/*
+			IDRefreshName:   resourceName,
+			IDRefreshIgnore: []string{"force_destroy"},
+		*/
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPersonalizeDatasetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPersonalizeDatasetGroupKMSConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPersonalizeDatasetGroupExists(resourceName),
+					testAccCheckResourceAttrRegionalARN(
+						resourceName, "arn", "personalize",
+						testAccPersonalizeDatasetGroupName("dataset-group/dsg-", rInt)),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", testAccPersonalizeDatasetGroupName("dsg-", rInt)),
+					resource.TestCheckResourceAttrSet(resourceName, "kms.0.key_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "kms.0.role_arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"kms"},
+			},
+		},
+	})
+}
+
+func testAccPersonalizeDatasetGroupBasicConfig(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_personalize_dataset_group" "group" {
+  name = "dsg-%d"
+}
+`, randInt)
+}
+
+func testAccPersonalizeDatasetGroupKMSConfig(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_personalize_dataset_group" "group" {
+  name = "dsg-%[1]d"
+
+  kms {
+    key_arn  = aws_kms_key.key.arn
+    role_arn = aws_iam_role.role.arn
+  }
+}
+
+resource "aws_kms_key" "key" {
+}
+
+resource "aws_iam_role" "role" {
+  name               = "dsg-assume-%[1]d"
+  assume_role_policy = data.aws_iam_policy_document.assume_policy.json
+}
+
+data "aws_iam_policy_document" "assume_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["personalize.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "policy" {
+  name   = "dsg-policy-%[1]d"
+  policy = data.aws_iam_policy_document.policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.policy.arn
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+
+    actions = [
+      "kms:*",
+    ]
+
+    resources = [
+      "${aws_kms_key.key.arn}"
+    ]
+  }
+}
+`, randInt)
+}
+
+func testAccPersonalizeDatasetGroupName(prefix string, randInt int) string {
+	return fmt.Sprintf("%s%d", prefix, randInt)
+}
+
+func testAccCheckPersonalizeDatasetGroupExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s\n", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).personalizeconn
+		r, err := conn.DescribeDatasetGroup(&personalize.DescribeDatasetGroupInput{
+			DatasetGroupArn: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if r == nil {
+			return fmt.Errorf("Personalize dataset group not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPersonalizeDatasetGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).personalizeconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_personalize_dataset_group" {
+			continue
+		}
+
+		_, err := conn.DescribeDatasetGroup(&personalize.DescribeDatasetGroupInput{
+			DatasetGroupArn: aws.String(rs.Primary.ID),
+		})
+
+		if isAWSErr(err, personalize.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+
+		return fmt.Errorf("Personalize Dataset Group (%s) still exists", rs.Primary.ID)
+	}
+
+	return nil
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2180,6 +2180,19 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">Personalize</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/personalize_dataset_group.html">aws_pinpoint_app</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
                     <a href="#">Pinpoint</a>
                     <ul class="nav">
                         <li>

--- a/website/docs/r/personalize_dataset_group.html.markdown
+++ b/website/docs/r/personalize_dataset_group.html.markdown
@@ -1,0 +1,100 @@
+---
+layout: "aws"
+page_title: "AWS: aws_personalize_dataset_group"
+description: |-
+  Creates a dataset group.
+---
+
+# Resource: aws_personalize_dataset_group
+
+Creates a dataset group. A dataset group contains related datasets that supply data for training a model.
+
+## Example Usage
+
+### Basic dataset group
+
+```hcl
+resource "aws_personalize_dataset_group" "group" {
+  name = "mydatasetgroup"
+}
+```
+
+### Dataset group with KMS
+
+```hcl
+resource "aws_kms_key" "key" {}
+
+resource "aws_iam_role" "role" {
+  name               = "mydataset-assume"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_policy.json}"
+}
+
+data "aws_iam_policy_document" "assume_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["personalize.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "policy" {
+  name   = "mydataset-policy"
+  policy = "${data.aws_iam_policy_document.policy.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "attach" {
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "${aws_iam_policy.policy.arn}"
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    actions = [
+      "kms:*",
+    ]
+
+    resources = [
+      "${aws_kms_key.key.arn}",
+    ]
+  }
+}
+
+resource "aws_personalize_dataset_group" "group" {
+  name = "mydataset"
+
+  kms {
+    key_arn  = "${aws_kms_key.key.arn}"
+    role_arn = "${aws_iam_role.role.arn}"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name`        (Required) - The name of the dataset group
+* `kms`         (Optional) - KMS configuration to encrypt the datasets (documented below)
+
+The `kms` object supports the following:
+
+* `key_arn`     (Required) - The Amazon Resource Name (ARN) of a KMS key used to encrypt the datasets
+* `role_arn`    (Required) - The ARN of the IAM role that has permissions to access the KMS key
+
+## Import
+
+Personalize dataset groups can be imported using the dataset group name or the full ARN.
+
+### Import by name
+```
+$ terraform import aws_personalize_dataset_group.group mydataset
+```
+
+### Import by ARN
+```
+$ terraform import aws_personalize_dataset_group.group arn:aws:personalize:eu-west-1:xxxxxxxxxxxx:dataset-group/mydataset
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: `aws_personalize_dataset_group`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccPersonalize'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccPersonalize -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccPersonalizeDatasetGroup_basic
=== PAUSE TestAccPersonalizeDatasetGroup_basic
=== RUN   TestAccPersonalizeDatasetGroup_kms
=== PAUSE TestAccPersonalizeDatasetGroup_kms
=== CONT  TestAccPersonalizeDatasetGroup_basic
=== CONT  TestAccPersonalizeDatasetGroup_kms
--- PASS: TestAccPersonalizeDatasetGroup_basic (33.65s)
--- PASS: TestAccPersonalizeDatasetGroup_kms (104.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       104.611s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.053s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.049s [no tests to run]
...
```
