### PR TITLE
docs: correct ecs task definition revision wildcard

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -203,7 +203,7 @@ resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {
         {
             "Effect": "Allow",
             "Action": "ecs:RunTask",
-            "Resource": "${replace(aws_ecs_task_definition.task_name.arn, "/:\\d+$/", ":*")}"
+            "Resource": "${replace(aws_ecs_task_definition.task_name.arn, "/:\\d+$/", "")}"
         }
     ]
 }


### PR DESCRIPTION
It appears the correct way to allow execution of any revision of a given task definition is to specify the task definition ARN without specifying any revision or a wildcard. Having the `:*` wildcard at the end of the policy statement resource ARN cause CloudWatch Events to fail invoking a scheduled task with `AccessDenied` error perfoming `ecs:RunTask`.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```