### PR TITLE
Data source for aws_appautoscaling_policy

### DIFF
--- a/aws/data_source_aws_appautoscaling_policy.go
+++ b/aws/data_source_aws_appautoscaling_policy.go
@@ -99,6 +99,7 @@ func policyDescriptionAttributes(d *schema.ResourceData, policy *applicationauto
 	d.Set("arn", policy.PolicyARN)
 	d.Set("policy_type", policy.PolicyType)
 	d.Set("resource_id", policy.ResourceId)
+	d.Set("service_namespace", policy.ServiceNamespace)
 	d.Set("scalable_dimension", policy.ScalableDimension)
 	return nil
 }

--- a/aws/data_source_aws_appautoscaling_policy.go
+++ b/aws/data_source_aws_appautoscaling_policy.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAwsAppautoscalingPolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsAppautoscalingPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				// https://github.com/boto/botocore/blob/9f322b1/botocore/data/autoscaling/2011-01-01/service-2.json#L1862-L1873
+				ValidateFunc: validation.StringLenBetween(0, 255),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"policy_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"scalable_dimension": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsAppautoscalingPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appautoscalingconn
+	d.SetId(time.Now().UTC().String())
+
+	policyName := d.Get("name").(string)
+	serviceNamespace := d.Get("service_namespace").(string)
+
+	input := &applicationautoscaling.DescribeScalingPoliciesInput{
+		ServiceNamespace: aws.String(serviceNamespace),
+		PolicyNames: []*string{
+			aws.String(policyName),
+		},
+	}
+
+	log.Printf("[DEBUG] Reading Autoscaling Policy: %s", input)
+
+	result, err := conn.DescribeScalingPolicies(input)
+
+	log.Printf("[DEBUG] Checking for error: %s", err)
+
+	if err != nil {
+		return fmt.Errorf("error describing Autoscaling Policy: %s", err)
+	}
+
+	log.Printf("[DEBUG] Found Autoscaling Policy: %s", result)
+
+	if len(result.ScalingPolicies) < 1 {
+		return fmt.Errorf("Your query did not return any results. Please try a different search criteria.")
+	}
+
+	if len(result.ScalingPolicies) > 1 {
+		return fmt.Errorf("Your query returned more than one result. Please try a more " +
+			"specific search criteria.")
+	}
+
+	// If execution made it to this point, we have exactly one 1 policy returned
+	// and this is a safe operation
+	policy := result.ScalingPolicies[0]
+
+	log.Printf("[DEBUG] aws_appautoscaling_policy - AutoScaling Policy found: %s", *policy.PolicyName)
+
+	err1 := policyDescriptionAttributes(d, policy)
+	return err1
+}
+
+// Populate group attribute fields with the returned group
+func policyDescriptionAttributes(d *schema.ResourceData, policy *applicationautoscaling.ScalingPolicy) error {
+	log.Printf("[DEBUG] Setting attributes: %s", policy)
+	d.Set("name", policy.PolicyName)
+	d.Set("arn", policy.PolicyARN)
+	d.Set("policy_type", policy.PolicyType)
+	d.Set("resource_id", policy.ResourceId)
+	d.Set("scalable_dimension", policy.ScalableDimension)
+	return nil
+}

--- a/aws/data_source_aws_appautoscaling_policy_test.go
+++ b/aws/data_source_aws_appautoscaling_policy_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSAppautoscalingPolicyDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_appautoscaling_policy.test"
+	resourceName := "aws_appautoscaling_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAppautoscalingPolicyDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_type", dataSourceName, "policy_type"),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_id", dataSourceName, "resource_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "scalable_dimension", dataSourceName, "scalable_dimension"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_namespace", dataSourceName, "service_namespace"),
+				),
+			},
+		},
+	})
+}
+
+var testAppautoscalingPolicyDataSourceConfig = fmt.Sprintf(`
+resource "aws_appautoscaling_policy" "test" {
+	name               = "tf-autoscaling-test-policy"
+	policy_type        = "TargetTrackingScaling"
+	resource_id        = "service/clusterName/serviceName"
+	scalable_dimension = "ecs:service:DesiredCount"
+	service_namespace  = "ecs"
+}
+`)

--- a/aws/data_source_aws_appautoscaling_policy_test.go
+++ b/aws/data_source_aws_appautoscaling_policy_test.go
@@ -4,19 +4,21 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 func TestAccAWSAppautoscalingPolicyDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_appautoscaling_policy.test"
 	resourceName := "aws_appautoscaling_policy.test"
+	rName := fmt.Sprintf("tf-app-policy-test-%s", acctest.RandString(4))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAppautoscalingPolicyDataSourceConfig,
+				Config: testAppautoscalingPolicyDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
@@ -30,12 +32,66 @@ func TestAccAWSAppautoscalingPolicyDataSource_basic(t *testing.T) {
 	})
 }
 
-var testAppautoscalingPolicyDataSourceConfig = fmt.Sprintf(`
-resource "aws_appautoscaling_policy" "test" {
-	name               = "tf-autoscaling-test-policy"
-	policy_type        = "TargetTrackingScaling"
-	resource_id        = "service/clusterName/serviceName"
+func testAppautoscalingPolicyDataSourceConfig(r string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+	name = %[1]q
+  }
+  
+  resource "aws_ecs_task_definition" "test" {
+	family = %[1]q
+  
+	container_definitions = <<EOF
+  [
+	{
+	  "name": "busybox",
+	  "image": "busybox:latest",
+	  "cpu": 10,
+	  "memory": 128,
+	  "essential": true
+	}
+  ]
+  EOF
+  }
+  
+  resource "aws_ecs_service" "test" {
+	cluster                            = "${aws_ecs_cluster.test.id}"
+	deployment_maximum_percent         = 200
+	deployment_minimum_healthy_percent = 50
+	desired_count                      = 0
+	name                               = %[1]q
+	task_definition                    = "${aws_ecs_task_definition.test.arn}"
+  }
+  
+  resource "aws_appautoscaling_target" "test" {
+	max_capacity       = 4
+	min_capacity       = 0
+	resource_id        = "service/${aws_ecs_cluster.test.name}/${aws_ecs_service.test.name}"
 	scalable_dimension = "ecs:service:DesiredCount"
 	service_namespace  = "ecs"
+  }
+  
+  resource "aws_appautoscaling_policy" "test" {
+	name               = %[1]q
+	resource_id        = "${aws_appautoscaling_target.test.resource_id}"
+	scalable_dimension = "${aws_appautoscaling_target.test.scalable_dimension}"
+	service_namespace  = "${aws_appautoscaling_target.test.service_namespace}"
+  
+	step_scaling_policy_configuration {
+	  adjustment_type         = "ChangeInCapacity"
+	  cooldown                = 60
+	  metric_aggregation_type = "Average"
+  
+	  step_adjustment {
+		metric_interval_lower_bound = 0
+		scaling_adjustment          = 1
+	  }
+	}
+  }
+
+data "aws_appautoscaling_policy" "test" {
+  name              = aws_appautoscaling_policy.test.name
+  service_namespace = "ecs"
+}  
+`, r)
 }
-`)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -168,6 +168,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_arn":                                       dataSourceAwsArn(),
 			"aws_autoscaling_group":                         dataSourceAwsAutoscalingGroup(),
 			"aws_autoscaling_groups":                        dataSourceAwsAutoscalingGroups(),
+			"aws_appautoscaling_policy":                     dataSourceAwsAppautoscalingPolicy(),
 			"aws_availability_zone":                         dataSourceAwsAvailabilityZone(),
 			"aws_availability_zones":                        dataSourceAwsAvailabilityZones(),
 			"aws_batch_compute_environment":                 dataSourceAwsBatchComputeEnvironment(),

--- a/website/docs/d/appautoscaling_policy.html.markdown
+++ b/website/docs/d/appautoscaling_policy.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "Application Autoscaling"
+layout: "aws"
+page_title: "AWS: aws_appautoscaling_policy"
+description: |-
+  Provides an Application AutoScaling Policy data source.
+---
+
+# aws_appautoscaling_policy
+
+Provides information about an Application AutoScaling Policy.
+
+## Example Usage
+
+```hcl
+variable "name" {
+  type = "string"
+}
+
+variable "service_namespace" {
+  type = "string"
+}
+
+data "aws_appautoscaling_policy" "test" {
+  name              = var.name
+  service_namespace = var.service_namespace
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the policy.
+* `service_namespace` - (Required) The AWS service namespace of the scalable target. Documentation can be found in the `ServiceNamespace` parameter at: [AWS Application Auto Scaling API Reference](http://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_RegisterScalableTarget.html#API_RegisterScalableTarget_RequestParameters)
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) identifying your policy.
+* `policy_type` - Type of scaling policy.
+* `resource_id` - The resource type and unique identifier string for the resource associated with the scaling policy.
+* `scalable_dimension` - The scalable dimension of the scalable target.


### PR DESCRIPTION
Usage:
```
data "aws_appautoscaling_policy" "test" {
  name              = "tf-test-policy"  #required
  service_namespace = "ecs"     #required
}
output "test" {
  value = data.aws_appautoscaling_policy.test.resource_id
}
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Data source:  `aws_appautoscaling_policy`. Supports only `name`, `arn`, `policy_type`, `resource_id`, `scalable_dimension` and `service_namespace` for now
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAppautoscalingPolicyDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAppautoscalingPolicyDataSource -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]

=== RUN   TestAccAWSAppautoscalingPolicyDataSource_basic
=== PAUSE TestAccAWSAppautoscalingPolicyDataSource_basic
=== CONT  TestAccAWSAppautoscalingPolicyDataSource_basic
--- PASS: TestAccAWSAppautoscalingPolicyDataSource_basic (117.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	117.252s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.021s [no tests to run]
...
```
