### PR TITLE
r-aws_ebs_volume snapshot functionality

### DIFF
--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -31,6 +31,7 @@ The following arguments are supported:
 
 * `availability_zone` - (Required) The AZ where the EBS volume will exist.
 * `encrypted` - (Optional) If true, the disk will be encrypted.
+* `final_snapshot` - (Optional) If true, the disk will have a snapshot created before a destroy operation. Any tags on the volume will be migrated to the snapshot (default: "false").
 * `iops` - (Optional) The amount of IOPS to provision for the disk.
 * `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2109

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_ebs_volume: Adds feature via `final_snapshot` bool directing Terraform to snapshot volume before destroying.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
root@b982db4ff594:/go/src/github.com/terraform-providers/terraform-provider-aws# AWS_PROFILE=default make testacc TEST=./aws TESTARGS='-run=TestAccAWSEBSVolume_FinalSnapshot'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEBSVolume_FinalSnapshot -timeout 120m
=== RUN   TestAccAWSEBSVolume_FinalSnapshot
=== PAUSE TestAccAWSEBSVolume_FinalSnapshot
=== CONT  TestAccAWSEBSVolume_FinalSnapshot
--- PASS: TestAccAWSEBSVolume_FinalSnapshot (118.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	118.270s
root@b982db4ff594:/go/src/github.com/terraform-providers/terraform-provider-aws#
```


*Note:* I made a number of assumptions here. @catsby originally suggested a snapshot-id parameter (kind of like how RDS has) but given that such a parameter doesn't really have a corollary in terms of ebs-snapshots, I merely went with a bool value. Further, this feature assumes all snapshots will have the same tags as the volume from which it was snapshotted. This could be expanded further later to allow a number of options like a copying tags bool, custom tags, populating the snapshot-description value, etc. I figured I would first check with hashi folks to see if this feature as-is works or if further options should be introduced for v1.

٩(⁎❛ᴗ❛⁎)۶
