### PR TITLE
Add `use_previous_values` field to `aws_cloudformation_stack`

### DIFF
--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -411,7 +411,7 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 		// values.
 		for _, el := range usePreviousValues.List() {
 			input.Parameters = append(input.Parameters, &cloudformation.Parameter{
-				ParameterKey: aws.String(el.(string)),
+				ParameterKey:     aws.String(el.(string)),
 				UsePreviousValue: aws.Bool(true),
 			})
 		}

--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -76,6 +76,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - A unique identifier of the stack.
 * `outputs` - A map of outputs from the stack.
 
+
 ## Import
 
 Cloudformation Stacks can be imported using the `name`, e.g.
@@ -83,6 +84,7 @@ Cloudformation Stacks can be imported using the `name`, e.g.
 ```
 $ terraform import aws_cloudformation_stack.stack networking-stack
 ```
+
 
 <a id="timeouts"></a>
 ## Timeouts

--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -49,32 +49,32 @@ STACK
 
 The following arguments are supported:
 
-* `name` - (Required) Stack name.
-* `template_body` - (Optional) Structure containing the template body (max size: 51,200 bytes).
-* `template_url` - (Optional) Location of a file containing the template body (max size: 460,800 bytes).
-* `capabilities` - (Optional) A list of capabilities.
+- `name` - (Required) Stack name.
+- `template_body` - (Optional) Structure containing the template body (max size: 51,200 bytes).
+- `template_url` - (Optional) Location of a file containing the template body (max size: 460,800 bytes).
+- `capabilities` - (Optional) A list of capabilities.
   Valid values: `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`, or `CAPABILITY_AUTO_EXPAND`
-* `disable_rollback` - (Optional) Set to true to disable rollback of the stack if stack creation failed.
+- `disable_rollback` - (Optional) Set to true to disable rollback of the stack if stack creation failed.
   Conflicts with `on_failure`.
-* `notification_arns` - (Optional) A list of SNS topic ARNs to publish stack related events.
-* `on_failure` - (Optional) Action to be taken if stack creation fails. This must be
+- `notification_arns` - (Optional) A list of SNS topic ARNs to publish stack related events.
+- `on_failure` - (Optional) Action to be taken if stack creation fails. This must be
   one of: `DO_NOTHING`, `ROLLBACK`, or `DELETE`. Conflicts with `disable_rollback`.
-* `parameters` - (Optional) A map of Parameter structures that specify input parameters for the stack.
-* `policy_body` - (Optional) Structure containing the stack policy body.
+- `parameters` - (Optional) A map of Parameter structures that specify input parameters for the stack.
+- `use_previous_values` - (Optional) A list of stack parameters that should be explicitly set to use previous values when updating a stack. This prevents situations where a Terraform update to the stack removes values of parameters set somewhere else.
+- `policy_body` - (Optional) Structure containing the stack policy body.
   Conflicts w/ `policy_url`.
-* `policy_url` - (Optional) Location of a file containing the stack policy.
+- `policy_url` - (Optional) Location of a file containing the stack policy.
   Conflicts w/ `policy_body`.
-* `tags` - (Optional) A list of tags to associate with this stack.
-* `iam_role_arn` - (Optional) The ARN of an IAM role that AWS CloudFormation assumes to create the stack. If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.
-* `timeout_in_minutes` - (Optional) The amount of time that can pass before the stack status becomes `CREATE_FAILED`.
+- `tags` - (Optional) A list of tags to associate with this stack.
+- `iam_role_arn` - (Optional) The ARN of an IAM role that AWS CloudFormation assumes to create the stack. If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.
+- `timeout_in_minutes` - (Optional) The amount of time that can pass before the stack status becomes `CREATE_FAILED`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - A unique identifier of the stack.
-* `outputs` - A map of outputs from the stack.
-
+- `id` - A unique identifier of the stack.
+- `outputs` - A map of outputs from the stack.
 
 ## Import
 
@@ -84,8 +84,8 @@ Cloudformation Stacks can be imported using the `name`, e.g.
 $ terraform import aws_cloudformation_stack.stack networking-stack
 ```
 
-
 <a id="timeouts"></a>
+
 ## Timeouts
 
 `aws_cloudformation_stack` provides the following

--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -49,32 +49,32 @@ STACK
 
 The following arguments are supported:
 
-- `name` - (Required) Stack name.
-- `template_body` - (Optional) Structure containing the template body (max size: 51,200 bytes).
-- `template_url` - (Optional) Location of a file containing the template body (max size: 460,800 bytes).
-- `capabilities` - (Optional) A list of capabilities.
+* `name` - (Required) Stack name.
+* `template_body` - (Optional) Structure containing the template body (max size: 51,200 bytes).
+* `template_url` - (Optional) Location of a file containing the template body (max size: 460,800 bytes).
+* `capabilities` - (Optional) A list of capabilities.
   Valid values: `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`, or `CAPABILITY_AUTO_EXPAND`
-- `disable_rollback` - (Optional) Set to true to disable rollback of the stack if stack creation failed.
+* `disable_rollback` - (Optional) Set to true to disable rollback of the stack if stack creation failed.
   Conflicts with `on_failure`.
-- `notification_arns` - (Optional) A list of SNS topic ARNs to publish stack related events.
-- `on_failure` - (Optional) Action to be taken if stack creation fails. This must be
+* `notification_arns` - (Optional) A list of SNS topic ARNs to publish stack related events.
+* `on_failure` - (Optional) Action to be taken if stack creation fails. This must be
   one of: `DO_NOTHING`, `ROLLBACK`, or `DELETE`. Conflicts with `disable_rollback`.
-- `parameters` - (Optional) A map of Parameter structures that specify input parameters for the stack.
-- `use_previous_values` - (Optional) A list of stack parameters that should be explicitly set to use previous values when updating a stack. This prevents situations where a Terraform update to the stack removes values of parameters set somewhere else.
-- `policy_body` - (Optional) Structure containing the stack policy body.
+* `parameters` - (Optional) A map of Parameter structures that specify input parameters for the stack.
+* `use_previous_values` - (Optional) A list of stack parameters that should be explicitly set to use previous values when updating a stack. This prevents situations where a Terraform update to the stack removes values of parameters set somewhere else.
+* `policy_body` - (Optional) Structure containing the stack policy body.
   Conflicts w/ `policy_url`.
-- `policy_url` - (Optional) Location of a file containing the stack policy.
+* `policy_url` - (Optional) Location of a file containing the stack policy.
   Conflicts w/ `policy_body`.
-- `tags` - (Optional) A list of tags to associate with this stack.
-- `iam_role_arn` - (Optional) The ARN of an IAM role that AWS CloudFormation assumes to create the stack. If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.
-- `timeout_in_minutes` - (Optional) The amount of time that can pass before the stack status becomes `CREATE_FAILED`.
+* `tags` - (Optional) A list of tags to associate with this stack.
+* `iam_role_arn` - (Optional) The ARN of an IAM role that AWS CloudFormation assumes to create the stack. If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.
+* `timeout_in_minutes` - (Optional) The amount of time that can pass before the stack status becomes `CREATE_FAILED`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - A unique identifier of the stack.
-- `outputs` - A map of outputs from the stack.
+* `id` - A unique identifier of the stack.
+* `outputs` - A map of outputs from the stack.
 
 ## Import
 
@@ -85,7 +85,6 @@ $ terraform import aws_cloudformation_stack.stack networking-stack
 ```
 
 <a id="timeouts"></a>
-
 ## Timeouts
 
 `aws_cloudformation_stack` provides the following


### PR DESCRIPTION
By explicitly asking Terraform to use previous values for CloudFormation templates, we can prevent situations where upon changing the template code Terraform would wipe out external changes made to the CF stack. This is subtly different from Terraform's semantics of ignoring changes, so requires a separate and more delicate approach.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #307

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Added `use_previous_values` field to `aws_cloudformation_stack` to explicitly tell CloudFormation to not change parameter values on stack update.
```