### PR TITLE
Add quicksight group membership resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -635,6 +635,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_placement_group":                                     resourceAwsPlacementGroup(),
 			"aws_proxy_protocol_policy":                               resourceAwsProxyProtocolPolicy(),
 			"aws_quicksight_group":                                    resourceAwsQuickSightGroup(),
+			"aws_quicksight_group_membership":                         resourceAwsQuickSightGroupMembership(),
 			"aws_quicksight_user":                                     resourceAwsQuickSightUser(),
 			"aws_ram_principal_association":                           resourceAwsRamPrincipalAssociation(),
 			"aws_ram_resource_association":                            resourceAwsRamResourceAssociation(),

--- a/aws/resource_aws_quicksight_group_membership.go
+++ b/aws/resource_aws_quicksight_group_membership.go
@@ -18,6 +18,10 @@ func resourceAwsQuickSightGroupMembership() *schema.Resource {
 		Read:   resourceAwsQuickSightGroupMembershipRead,
 		Delete: resourceAwsQuickSightGroupMembershipDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_quicksight_group_membership.go
+++ b/aws/resource_aws_quicksight_group_membership.go
@@ -1,0 +1,172 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+)
+
+func resourceAwsQuickSightGroupMembership() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsQuickSightGroupMembershipCreate,
+		Read:   resourceAwsQuickSightGroupMembershipRead,
+		Delete: resourceAwsQuickSightGroupMembershipDelete,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"aws_account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"member_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "default",
+				ValidateFunc: validation.StringInSlice([]string{
+					"default",
+				}, false),
+			},
+		},
+	}
+}
+
+func resourceAwsQuickSightGroupMembershipCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).quicksightconn
+
+	awsAccountID := meta.(*AWSClient).accountid
+	namespace := d.Get("namespace").(string)
+	groupName := d.Get("group_name").(string)
+
+	if v, ok := d.GetOk("aws_account_id"); ok {
+		awsAccountID = v.(string)
+	}
+
+	createOpts := &quicksight.CreateGroupMembershipInput{
+		AwsAccountId: aws.String(awsAccountID),
+		GroupName:    aws.String(groupName),
+		MemberName:   aws.String(d.Get("member_name").(string)),
+		Namespace:    aws.String(namespace),
+	}
+
+	resp, err := conn.CreateGroupMembership(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error adding QuickSight user to group: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s/%s/%s", awsAccountID, namespace, groupName, aws.StringValue(resp.GroupMember.MemberName)))
+
+	return resourceAwsQuickSightGroupMembershipRead(d, meta)
+}
+
+func resourceAwsQuickSightGroupMembershipRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).quicksightconn
+
+	awsAccountID, namespace, groupName, userName, err := resourceAwsQuickSightGroupMembershipParseID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	listOpts := &quicksight.ListUserGroupsInput{
+		AwsAccountId: aws.String(awsAccountID),
+		Namespace:    aws.String(namespace),
+		UserName:     aws.String(userName),
+	}
+
+	found := false
+
+	for {
+		resp, err := conn.ListUserGroups(listOpts)
+		if isAWSErr(err, quicksight.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] QuickSight User %s is not found", d.Id())
+			d.SetId("")
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("Error listing QuickSight User groups (%s): %s", d.Id(), err)
+		}
+
+		for _, group := range resp.GroupList {
+			if *group.GroupName == groupName {
+				found = true
+				break
+			}
+		}
+
+		if found || resp.NextToken == nil {
+			break
+		}
+
+		listOpts.NextToken = resp.NextToken
+	}
+
+	if found {
+		d.Set("aws_account_id", awsAccountID)
+		d.Set("namespace", namespace)
+		d.Set("member_name", userName)
+		d.Set("group_name", groupName)
+	} else {
+		log.Printf("[WARN] QuickSight User-group membership %s is not found", d.Id())
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceAwsQuickSightGroupMembershipDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).quicksightconn
+
+	awsAccountID, namespace, groupName, userName, err := resourceAwsQuickSightGroupMembershipParseID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	deleteOpts := &quicksight.DeleteGroupMembershipInput{
+		AwsAccountId: aws.String(awsAccountID),
+		Namespace:    aws.String(namespace),
+		MemberName:   aws.String(userName),
+		GroupName:    aws.String(groupName),
+	}
+
+	if _, err := conn.DeleteGroupMembership(deleteOpts); err != nil {
+		if isAWSErr(err, quicksight.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting QuickSight User-group membership %s: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsQuickSightGroupMembershipParseID(id string) (string, string, string, string, error) {
+	parts := strings.SplitN(id, "/", 4)
+	if len(parts) < 4 || parts[0] == "" || parts[1] == "" || parts[2] == "" || parts[2] == "" {
+		return "", "", "", "", fmt.Errorf("unexpected format of ID (%s), expected AWS_ACCOUNT_ID/NAMESPACE/GROUP_NAME/USER_NAME", id)
+	}
+	return parts[0], parts[1], parts[2], parts[3], nil
+}

--- a/aws/resource_aws_quicksight_group_membership.go
+++ b/aws/resource_aws_quicksight_group_membership.go
@@ -165,7 +165,7 @@ func resourceAwsQuickSightGroupMembershipDelete(d *schema.ResourceData, meta int
 
 func resourceAwsQuickSightGroupMembershipParseID(id string) (string, string, string, string, error) {
 	parts := strings.SplitN(id, "/", 4)
-	if len(parts) < 4 || parts[0] == "" || parts[1] == "" || parts[2] == "" || parts[2] == "" {
+	if len(parts) < 4 || parts[0] == "" || parts[1] == "" || parts[2] == "" || parts[3] == "" {
 		return "", "", "", "", fmt.Errorf("unexpected format of ID (%s), expected AWS_ACCOUNT_ID/NAMESPACE/GROUP_NAME/USER_NAME", id)
 	}
 	return parts[0], parts[1], parts[2], parts[3], nil

--- a/aws/resource_aws_quicksight_group_membership_test.go
+++ b/aws/resource_aws_quicksight_group_membership_test.go
@@ -18,9 +18,8 @@ func TestAccAWSQuickSightGroupMembership_basic(t *testing.T) {
 	resourceName := "aws_quicksight_group_membership.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckQuickSightGroupMembershipDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSQuickSightGroupMembershipConfig(groupName, memberName),
@@ -43,9 +42,8 @@ func TestAccAWSQuickSightGroupMembership_disappears(t *testing.T) {
 	resourceName := "aws_quicksight_group_membership.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckQuickSightGroupMembershipDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSQuickSightGroupMembershipConfig(groupName, memberName),
@@ -97,45 +95,6 @@ func testAccCheckQuickSightGroupMembershipExists(resourceName string) resource.T
 
 		return fmt.Errorf("QuickSight Group (%s) not found in user's group list", rs.Primary.ID)
 	}
-}
-
-func testAccCheckQuickSightGroupMembershipDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).quicksightconn
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_quicksight_group_membership" {
-			continue
-		}
-
-		awsAccountID, namespace, groupName, userName, err := resourceAwsQuickSightGroupMembershipParseID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		input := &quicksight.ListUserGroupsInput{
-			AwsAccountId: aws.String(awsAccountID),
-			Namespace:    aws.String(namespace),
-			UserName:     aws.String(userName),
-		}
-
-		output, err := conn.ListUserGroups(input)
-
-		if err != nil {
-			return err
-		}
-
-		if output == nil || output.GroupList == nil {
-			return fmt.Errorf("QuickSight Group (%s) not found", rs.Primary.ID)
-		}
-
-		for _, group := range output.GroupList {
-			if *group.GroupName == groupName {
-				return fmt.Errorf("QuickSight Group membership (%s) was not deleted properly", rs.Primary.ID)
-			}
-		}
-
-	}
-
-	return nil
 }
 
 func testAccCheckQuickSightGroupMembershipDisappears(groupName string, memberName string) resource.TestCheckFunc {

--- a/aws/resource_aws_quicksight_group_membership_test.go
+++ b/aws/resource_aws_quicksight_group_membership_test.go
@@ -18,8 +18,11 @@ func TestAccAWSQuickSightGroupMembership_basic(t *testing.T) {
 	resourceName := "aws_quicksight_group_membership.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck: func() { testAccPreCheck(t) },
+		// There's no way to actual retrieve a group membership after
+		// the user and group have been destroyed.
+		CheckDestroy: testAccCheckQuickSightGroupMembershipWaveHandsEverythingsOkay,
+		Providers:    testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSQuickSightGroupMembershipConfig(groupName, memberName),
@@ -44,6 +47,9 @@ func TestAccAWSQuickSightGroupMembership_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		// There's no way to actual retrieve a group membership after
+		// the user and group have been destroyed.
+		CheckDestroy: testAccCheckQuickSightGroupMembershipWaveHandsEverythingsOkay,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSQuickSightGroupMembershipConfig(groupName, memberName),
@@ -55,6 +61,10 @@ func TestAccAWSQuickSightGroupMembership_disappears(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckQuickSightGroupMembershipWaveHandsEverythingsOkay(s *terraform.State) error {
+	return nil
 }
 
 func testAccCheckQuickSightGroupMembershipExists(resourceName string) resource.TestCheckFunc {

--- a/aws/resource_aws_quicksight_group_membership_test.go
+++ b/aws/resource_aws_quicksight_group_membership_test.go
@@ -1,0 +1,176 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+)
+
+func TestAccAWSQuickSightGroupMembership_basic(t *testing.T) {
+	groupName := acctest.RandomWithPrefix("tf-acc-test")
+	memberName := "tfacctest" + acctest.RandString(10)
+	resourceName := "aws_quicksight_group_membership.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckQuickSightGroupMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSQuickSightGroupMembershipConfig(groupName, memberName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQuickSightGroupMembershipExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSQuickSightGroupMembership_disappears(t *testing.T) {
+	groupName := acctest.RandomWithPrefix("tf-acc-test")
+	memberName := "tfacctest" + acctest.RandString(10)
+	resourceName := "aws_quicksight_group_membership.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckQuickSightGroupMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSQuickSightGroupMembershipConfig(groupName, memberName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQuickSightGroupMembershipExists(resourceName),
+					testAccCheckQuickSightGroupMembershipDisappears(groupName, memberName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckQuickSightGroupMembershipExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		awsAccountID, namespace, groupName, userName, err := resourceAwsQuickSightGroupMembershipParseID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).quicksightconn
+
+		input := &quicksight.ListUserGroupsInput{
+			AwsAccountId: aws.String(awsAccountID),
+			Namespace:    aws.String(namespace),
+			UserName:     aws.String(userName),
+		}
+
+		output, err := conn.ListUserGroups(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.GroupList == nil {
+			return fmt.Errorf("QuickSight Group (%s) not found", rs.Primary.ID)
+		}
+
+		for _, group := range output.GroupList {
+			if *group.GroupName == groupName {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("QuickSight Group (%s) not found in user's group list", rs.Primary.ID)
+	}
+}
+
+func testAccCheckQuickSightGroupMembershipDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).quicksightconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_quicksight_group_membership" {
+			continue
+		}
+
+		awsAccountID, namespace, groupName, userName, err := resourceAwsQuickSightGroupMembershipParseID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &quicksight.ListUserGroupsInput{
+			AwsAccountId: aws.String(awsAccountID),
+			Namespace:    aws.String(namespace),
+			UserName:     aws.String(userName),
+		}
+
+		output, err := conn.ListUserGroups(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.GroupList == nil {
+			return fmt.Errorf("QuickSight Group (%s) not found", rs.Primary.ID)
+		}
+
+		for _, group := range output.GroupList {
+			if *group.GroupName == groupName {
+				return fmt.Errorf("QuickSight Group membership (%s) was not deleted properly", rs.Primary.ID)
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckQuickSightGroupMembershipDisappears(groupName string, memberName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).quicksightconn
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_quicksight_group_membership" {
+				continue
+			}
+
+			awsAccountID, namespace, groupName, userName, err := resourceAwsQuickSightGroupMembershipParseID(rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+
+			input := &quicksight.DeleteGroupMembershipInput{
+				AwsAccountId: aws.String(awsAccountID),
+				Namespace:    aws.String(namespace),
+				MemberName:   aws.String(userName),
+				GroupName:    aws.String(groupName),
+			}
+
+			if _, err := conn.DeleteGroupMembership(input); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func testAccAWSQuickSightGroupMembershipConfig(groupName string, memberName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "aws_quicksight_group_membership" "default" {
+  group_name  = aws_quicksight_group.default.group_name
+  member_name = aws_quicksight_user.%s.user_name
+}
+`, testAccAWSQuickSightGroupConfig(groupName), testAccAWSQuickSightUserConfig(memberName), memberName)
+}

--- a/aws/resource_aws_quicksight_group_membership_test.go
+++ b/aws/resource_aws_quicksight_group_membership_test.go
@@ -28,6 +28,11 @@ func TestAccAWSQuickSightGroupMembership_basic(t *testing.T) {
 					testAccCheckQuickSightGroupMembershipExists(resourceName),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2245,6 +2245,9 @@
                                     <a href="/docs/providers/aws/r/quicksight_group.html">aws_quicksight_group</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/quicksight_group_membership.html">quicksight_group_membership</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/quicksight_user.html">aws_quicksight_user</a>
                                 </li>
                             </ul>

--- a/website/docs/r/quicksight_group_membership.html.markdown
+++ b/website/docs/r/quicksight_group_membership.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "QuickSight"
 layout: "aws"
 page_title: "AWS: aws_quicksight_group_membership"
 description: |-

--- a/website/docs/r/quicksight_group_membership.html.markdown
+++ b/website/docs/r/quicksight_group_membership.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "aws"
+page_title: "AWS: aws_quicksight_group_membership"
+description: |-
+  Manages a Resource QuickSight Group Membership.
+---
+
+# Resource: aws_quicksight_group_membership
+
+Resource for managing QuickSight Group Membership
+
+## Example Usage
+
+```hcl
+resource "aws_quicksight_group_membership" "example" {
+	group_name  = "all-access-users"
+	member_name = "john_smith"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_name` - (Required) The name of the group in which the member will be added.
+* `member_name` - (Required) The name of the member to add to the group.
+* `aws_account_id` - (Optional) The ID for the AWS account that the group is in. Currently, you use the ID for the AWS account that contains your Amazon QuickSight account.
+* `namespace` - (Optional) The namespace. Currently, you should set this to `default`.
+
+## Attributes Reference
+
+All arguments above are exported.
+
+## Import
+
+QuickSight Group membership can be imported using the AWS account ID, namespace, group name and member name separated by `/`.
+
+```
+$ terraform import aws_quicksight_group.example 123456789123/default/all-access-users/john_smith
+```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Relates #10990 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_quicksight_group_membership`
```

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSQuickSightGroupMembership'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSQuickSightGroupMembership -timeout 120m
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSQuickSightGroupMembership_basic
=== PAUSE TestAccAWSQuickSightGroupMembership_basic
=== RUN   TestAccAWSQuickSightGroupMembership_disappears
=== PAUSE TestAccAWSQuickSightGroupMembership_disappears
=== CONT  TestAccAWSQuickSightGroupMembership_basic
=== CONT  TestAccAWSQuickSightGroupMembership_disappears
--- PASS: TestAccAWSQuickSightGroupMembership_disappears (19.05s)
--- PASS: TestAccAWSQuickSightGroupMembership_basic (19.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	19.932s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.022s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.004s [no tests to run]
```
