### PR TITLE
Clarify aws_cloudwatch_event_target docs with ECS ARNs

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -204,7 +204,7 @@ resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {
         {
             "Effect": "Allow",
             "Action": "ecs:RunTask",
-            "Resource": "${replace(aws_ecs_task_definition.task_name.arn, "/:\\d+$/", ":*")}"
+            "Resource": "${replace(aws_ecs_task_definition.task_name.arn, "/:\\d+$/", "")}"
         }
     ]
 }
@@ -219,7 +219,7 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.task_name.arn}"
+    task_definition_arn = "${replace(aws_ecs_task_definition.task_name.arn, "/:\\d+$/", "")}"
   }
 
   input = <<DOC


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
The way the documentation was written, the Cloudwatch event target would use an ECS task definition ARN which includes the task definition revision, like `arn:aws:ecs:us-west-2:123456789012:task-definition/some-task:4`. It's likely that eventually a new task definition revision will be created at some time in the future (possibly by Terraform, possibly by a CI/CD pipeline out-of-band from Terraform). If/when that happens, the Cloudwatch event target will still be pointed to the old revision (`some-task:4`). This will cause the task to fail to run when Cloudwatch tries to run it, the RunTask API will reject it because `some-task:4` is no longer active.

The change I'm proposing shows the user how to make the event target get an ARN like `arn:aws:ecs:us-west-2:123456789012:task-definition/some-task`, without a revision number, so Cloudwatch will always run the latest revision of the task definition. Which is probably a more commonly desired behavior anyway.

