### PR TITLE
Add replication time control

### DIFF
--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -3912,7 +3912,7 @@ resource "aws_s3_bucket" "bucket" {
     }
   }
 }
-	`, randInt, storageClass)
+`, randInt, storageClass)
 }
 
 func testAccAWSS3BucketConfigReplicationWithSseKmsEncryptedObjects(randInt int) string {

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -3889,29 +3889,29 @@ resource "aws_s3_bucket" "bucket" {
 
 func testAccAWSS3BucketConfigReplicationWithTimeWithConfiguration(randInt int, storageClass string) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
-	resource "aws_s3_bucket" "bucket" {
-		bucket   = "tf-test-bucket-%d"
-		acl      = "private"
-	
-		versioning {
-			enabled = true
-		}
-	
-		replication_configuration {
-			role = "${aws_iam_role.role.arn}"
-			rules {
-				id     = "foobar"
-				status = "Enabled"
-				destination {
-					bucket        = "${aws_s3_bucket.destination.arn}"
-					storage_class = "%s"
-					replication_time {
-						status = "Enabled"
-					}
-				}
-			}
-		}
-	}
+resource "aws_s3_bucket" "bucket" {
+  bucket   = "tf-test-bucket-%d"
+  acl      = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  replication_configuration {
+    role = "${aws_iam_role.role.arn}"
+    rules {
+      id     = "foobar"
+      status = "Enabled"
+      destination {
+        bucket        = "${aws_s3_bucket.destination.arn}"
+        storage_class = "%s"
+        replication_time {
+          status = "Enabled"
+        }
+      }
+    }
+  }
+}
 	`, randInt, storageClass)
 }
 

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -3898,12 +3898,12 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   replication_configuration {
-    role = "${aws_iam_role.role.arn}"
+    role = aws_iam_role.role.arn
     rules {
       id     = "foobar"
       status = "Enabled"
       destination {
-        bucket        = "${aws_s3_bucket.destination.arn}"
+        bucket        = aws_s3_bucket.destination.arn
         storage_class = "%s"
         replication_time {
           status = "Enabled"

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -3890,8 +3890,8 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigReplicationWithTimeWithConfiguration(randInt int, storageClass string) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket   = "tf-test-bucket-%d"
-  acl      = "private"
+  bucket = "tf-test-bucket-%d"
+  acl    = "private"
 
   versioning {
     enabled = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10974 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
adds replication time control configuration
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSS3Bucket_ReplicationTimeControl'

...
```

EDIT: I've added logic so that you don't have to specify a filter alongside RTC in order to use the v2 api