### PR TITLE
Adds reader_endpoint_address to output of aws_elasticache_replication_group

### DIFF
--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -41,6 +41,10 @@ func dataSourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"reader_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"number_cache_clusters": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -110,6 +114,7 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 		}
 		d.Set("port", rg.NodeGroups[0].PrimaryEndpoint.Port)
 		d.Set("primary_endpoint_address", rg.NodeGroups[0].PrimaryEndpoint.Address)
+		d.Set("reader_endpoint_address", rg.NodeGroups[0].ReaderEndpoint.Address)
 	}
 	d.Set("number_cache_clusters", len(rg.MemberClusters))
 	if err := d.Set("member_clusters", flattenStringList(rg.MemberClusters)); err != nil {

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -23,6 +23,7 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "automatic_failover_enabled", "true"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "port", "6379"),
 					resource.TestCheckResourceAttrSet("data.aws_elasticache_replication_group.bar", "primary_endpoint_address"),
+					resource.TestCheckResourceAttrSet("data.aws_elasticache_replication_group.bar", "reader_endpoint_address"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "member_clusters.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "node_type", "cache.m1.small"),

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -153,6 +153,10 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"reader_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"replication_group_description": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -489,6 +493,7 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		} else {
 			d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
 			d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
+			d.Set("reader_endpoint_address", rgp.NodeGroups[0].ReaderEndpoint.Address)
 		}
 
 		d.Set("auto_minor_version_upgrade", c.AutoMinorVersionUpgrade)

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -345,6 +345,8 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 						resourceName, "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
 						resourceName, "primary_endpoint_address"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "reader_endpoint_address"),
 				),
 			},
 			{
@@ -380,6 +382,8 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 						resourceName, "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
 						resourceName, "primary_endpoint_address"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "reader_endpoint_address"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11313

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

Adds reader_endpoint_address to output of aws_elasticache_replication_group

```

### Description
When creating an elasticache redis cluster (with cluster mode disabled) you get a "primary" endpoint and a read-only "reader" endpoint. The aws_elasticache_replication_group doesn't output the reader endpoint, despite this information being displayed (both the primary and reader) when you click the redis cluster in AWS: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Endpoints.html



Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== PAUSE TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== CONT  TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (846.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	847.214s


$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_multiAzInVpc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_multiAzInVpc -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
=== PAUSE TestAccAWSElasticacheReplicationGroup_multiAzInVpc
=== CONT  TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1074.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1075.637s


$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsElasticacheReplicationGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsElasticacheReplicationGroup_basic -timeout 120m
=== RUN   TestAccDataSourceAwsElasticacheReplicationGroup_basic
=== PAUSE TestAccDataSourceAwsElasticacheReplicationGroup_basic
=== CONT  TestAccDataSourceAwsElasticacheReplicationGroup_basic
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_basic (1071.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1073.012s
```