### PR TITLE
New Data Source: aws_service_discovery_dns_namespace

### DIFF
--- a/aws/data_source_aws_service_discovery_dns_namespace.go
+++ b/aws/data_source_aws_service_discovery_dns_namespace.go
@@ -1,0 +1,129 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAwsServiceDiscoveryDnsNamespace() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsServiceDiscoveryDnsNamespaceRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"public",
+					"private",
+				}, false),
+			},
+			"most_recent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hosted_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsServiceDiscoveryDnsNamespaceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	name := d.Get("name").(string)
+	nsType := d.Get("type").(string)
+
+	nsTypeMapping := map[string]string{
+		"public":  servicediscovery.NamespaceTypeDnsPublic,
+		"private": servicediscovery.NamespaceTypeDnsPrivate,
+	}
+
+	input := &servicediscovery.ListNamespacesInput{
+		Filters: []*servicediscovery.NamespaceFilter{
+			{
+				Name:      aws.String("TYPE"),
+				Condition: aws.String("EQ"),
+				Values:    aws.StringSlice([]string{nsTypeMapping[nsType]}),
+			},
+		}}
+
+	var namespacesFound []*servicediscovery.NamespaceSummary
+	err := conn.ListNamespacesPages(input, func(page *servicediscovery.ListNamespacesOutput, lastPage bool) bool {
+		for _, ns := range page.Namespaces {
+			if aws.StringValue(ns.Name) == name {
+				namespacesFound = append(namespacesFound, ns)
+			}
+		}
+
+		return !lastPage
+	})
+	if err != nil {
+		return err
+	}
+
+	var namespace *servicediscovery.NamespaceSummary
+	if len(namespacesFound) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	if len(namespacesFound) > 1 {
+		recent := d.Get("most_recent").(bool)
+		log.Printf("[DEBUG] aws_service_discovery_dns_namespace - multiple results found "+
+			"and `most_recent` is set to: %t", recent)
+		if !recent {
+			return fmt.Errorf("Your query returned more than one result. " +
+				"You can set `most_recent` attribute to true.")
+		}
+
+		namespace = mostRecentNS(namespacesFound)
+	} else {
+		// Query returned single result.
+		namespace = namespacesFound[0]
+	}
+
+	d.SetId(aws.StringValue(namespace.Id))
+	d.Set("arn", namespace.Arn)
+	if namespace.Properties != nil {
+		d.Set("hosted_zone", namespace.Properties.DnsProperties.HostedZoneId)
+	}
+
+	log.Printf("[DEBUG] aws_service_discovery_dns_namespace - Single DNS Namespace found: %s", *namespace.Id)
+	return nil
+}
+
+type nsSort []*servicediscovery.NamespaceSummary
+
+func (n nsSort) Len() int      { return len(n) }
+func (n nsSort) Swap(i, j int) { n[i], n[j] = n[j], n[i] }
+func (n nsSort) Less(i, j int) bool {
+	itime := *n[i].CreateDate
+	jtime := *n[j].CreateDate
+	return jtime.Unix() < itime.Unix()
+}
+
+func mostRecentNS(nses []*servicediscovery.NamespaceSummary) *servicediscovery.NamespaceSummary {
+	sort.Sort(nsSort(nses))
+	return nses[0]
+}

--- a/aws/data_source_aws_service_discovery_dns_namespace_test.go
+++ b/aws/data_source_aws_service_discovery_dns_namespace_test.go
@@ -1,0 +1,117 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSServiceDiscoveryDnsNamespaceDataSource_public(t *testing.T) {
+	resourceName := "aws_service_discovery_public_dns_namespace.test"
+	dataSourceName := "data.aws_service_discovery_dns_namespace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSServiceDiscoveryDnsNamespaceDataSourcePublicConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "hosted_zone", resourceName, "hosted_zone"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryDnsNamespaceDataSource_mostRecentPublic(t *testing.T) {
+	resourceName := "aws_service_discovery_public_dns_namespace.recent"
+	dataSourceName := "data.aws_service_discovery_dns_namespace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSServiceDiscoveryDnsNamespaceDataSourcePublicMostRecentConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "hosted_zone", resourceName, "hosted_zone"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryDnsNamespaceDataSource_private(t *testing.T) {
+	resourceName := "aws_service_discovery_private_dns_namespace.test"
+	dataSourceName := "data.aws_service_discovery_dns_namespace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSServiceDiscoveryDnsNamespaceDataSourcePrivateConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "type", "private"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "hosted_zone", resourceName, "hosted_zone"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAWSServiceDiscoveryDnsNamespaceDataSourcePublicConfig = `
+resource "aws_service_discovery_public_dns_namespace" "test" {
+  name = "public.test.acc"
+}
+
+data "aws_service_discovery_dns_namespace" "test" {
+    name = "${aws_service_discovery_public_dns_namespace.test.name}"
+    type = "public"
+}
+`
+
+const testAccCheckAWSServiceDiscoveryDnsNamespaceDataSourcePublicMostRecentConfig = `
+resource "aws_service_discovery_public_dns_namespace" "older" {
+  name = "most-recent.test.acc"
+}
+
+resource "aws_service_discovery_public_dns_namespace" "recent" {
+  name       = "most-recent.test.acc"
+  depends_on = ["aws_service_discovery_public_dns_namespace.older"]
+}
+
+data "aws_service_discovery_dns_namespace" "test" {
+  name        = "${aws_service_discovery_public_dns_namespace.recent.name}"
+  type        = "public"
+  most_recent = true
+}
+`
+
+const testAccCheckAWSServiceDiscoveryDnsNamespaceDataSourcePrivateConfig = `
+resource "aws_vpc" "test" {
+  cidr_block = "172.0.0.0/16"
+}
+
+resource "aws_service_discovery_private_dns_namespace" "test" {
+  name = "private.test.acc"
+  vpc  = "${aws_vpc.test.id}"
+}
+
+data "aws_service_discovery_dns_namespace" "test" {
+  name = "${aws_service_discovery_private_dns_namespace.test.name}"
+  type = "private"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -277,6 +277,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_s3_bucket_objects":                         dataSourceAwsS3BucketObjects(),
 			"aws_secretsmanager_secret":                     dataSourceAwsSecretsManagerSecret(),
 			"aws_secretsmanager_secret_version":             dataSourceAwsSecretsManagerSecretVersion(),
+			"aws_service_discovery_dns_namespace":           dataSourceAwsServiceDiscoveryDnsNamespace(),
 			"aws_servicequotas_service":                     dataSourceAwsServiceQuotasService(),
 			"aws_servicequotas_service_quota":               dataSourceAwsServiceQuotasServiceQuota(),
 			"aws_sns_topic":                                 dataSourceAwsSnsTopic(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2747,6 +2747,14 @@
                     <a href="#">Service Discovery</a>
                     <ul class="nav">
                         <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/service_discovery_dns_namespace.html">aws_service_discovery_dns_namespace</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
                             <a href="#">Resources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>

--- a/website/docs/d/service_discovery_dns_namespace.html.markdown
+++ b/website/docs/d/service_discovery_dns_namespace.html.markdown
@@ -1,0 +1,83 @@
+---
+subcategory: "Service Discovery"
+layout: "aws"
+page_title: "AWS: aws_service_discovery_dns_namespace"
+description: |-
+  Provides details about a Service Discovery DNS Namespace.
+---
+
+# Data Source: aws_service_discovery_dns_namespace
+
+`aws_service_discovery_dns_namespace` provides details about a specific Service Discovery DNS Namespace.
+
+This resource can prove useful when you need to re-use a Service Discovery DNS Namespace for a new Service Discovery Service. 
+
+## Example Usage
+
+```hcl
+data "aws_service_discovery_dns_namespace" "example" {
+  name = "example.terraform.local"
+  type = "private"
+}
+
+resource "aws_service_discovery_service" "example" {
+  name = "example"
+
+  dns_config {
+    namespace_id = "${data.aws_service_discovery_dns_namespace.example.id}"
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+```
+
+```hcl
+data "aws_service_discovery_dns_namespace" "example" {
+  name = "example.terraform.com"
+  type = "public"
+}
+
+resource "aws_service_discovery_service" "example" {
+  name = "example"
+
+  dns_config {
+    namespace_id = "${data.aws_service_discovery_public_dns_namespace.example.id}"
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+  }
+
+  health_check_config {
+    failure_threshold = 10
+    resource_path     = "path"
+    type              = "HTTP"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` – (Required) The name of the namespace.
+* `type` – (Required) The type of the namespace. Valid Values: public, private.
+* `most_recent` – (Optional) If more than one result is returned, use the most recent namespace.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` – The ID of a namespace.
+* `arn` – The ARN that Amazon Route 53 assigns to the namespace.
+* `hosted_zone` – The ID for the hosted zone that Amazon Route 53 creates for a namespace.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```
**New Data Source:** `aws_service_discovery_dns_namespace`
```
### Test
Output from acceptance testing:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSServiceDiscoveryDnsNamespaceDataSource'                                                                                            okta:sandbox
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSServiceDiscoveryDnsNamespaceDataSource -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryDnsNamespaceDataSource_public
=== PAUSE TestAccAWSServiceDiscoveryDnsNamespaceDataSource_public
=== RUN   TestAccAWSServiceDiscoveryDnsNamespaceDataSource_mostRecentPublic
=== PAUSE TestAccAWSServiceDiscoveryDnsNamespaceDataSource_mostRecentPublic
=== RUN   TestAccAWSServiceDiscoveryDnsNamespaceDataSource_private
=== PAUSE TestAccAWSServiceDiscoveryDnsNamespaceDataSource_private
=== CONT  TestAccAWSServiceDiscoveryDnsNamespaceDataSource_public
=== CONT  TestAccAWSServiceDiscoveryDnsNamespaceDataSource_mostRecentPublic
=== CONT  TestAccAWSServiceDiscoveryDnsNamespaceDataSource_private
--- PASS: TestAccAWSServiceDiscoveryDnsNamespaceDataSource_public (117.20s)
--- PASS: TestAccAWSServiceDiscoveryDnsNamespaceDataSource_private (144.14s)
--- PASS: TestAccAWSServiceDiscoveryDnsNamespaceDataSource_mostRecentPublic (202.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	205.610s
```
