### PR TITLE
New resource: aws_ec2_transit_gateway_multicast_domain

### DIFF
--- a/aws/aws_sweeper_test.go
+++ b/aws/aws_sweeper_test.go
@@ -36,7 +36,7 @@ func sharedClientForRegion(region string) (interface{}, error) {
 	// configures a default client for the region, using the above env vars
 	client, err := conf.Client()
 	if err != nil {
-		return nil, fmt.Errorf("error getting AWS client")
+		return nil, fmt.Errorf("error getting AWS client: %s", err)
 	}
 
 	sweeperAwsClients[region] = client

--- a/aws/data_source_aws_ec2_transit_gateway.go
+++ b/aws/data_source_aws_ec2_transit_gateway.go
@@ -49,8 +49,8 @@ func dataSourceAwsEc2TransitGateway() *schema.Resource {
 				Computed: true,
 			},
 			"multicast_support": {
-					Type: schema.TypeString,
-					Computed: true,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"filter": dataSourceFiltersSchema(),
 			"id": {

--- a/aws/data_source_aws_ec2_transit_gateway.go
+++ b/aws/data_source_aws_ec2_transit_gateway.go
@@ -48,6 +48,10 @@ func dataSourceAwsEc2TransitGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"multicast_support": {
+					Type: schema.TypeString,
+					Computed: true,
+			},
 			"filter": dataSourceFiltersSchema(),
 			"id": {
 				Type:     schema.TypeString,
@@ -117,6 +121,7 @@ func dataSourceAwsEc2TransitGatewayRead(d *schema.ResourceData, meta interface{}
 	d.Set("default_route_table_propagation", transitGateway.Options.DefaultRouteTablePropagation)
 	d.Set("description", transitGateway.Description)
 	d.Set("dns_support", transitGateway.Options.DnsSupport)
+	d.Set("multicast_support", transitGateway.Options.MulticastSupport)
 	d.Set("owner_id", transitGateway.OwnerId)
 	d.Set("propagation_default_route_table_id", transitGateway.Options.PropagationDefaultRouteTableId)
 

--- a/aws/ec2_transit_gateway.go
+++ b/aws/ec2_transit_gateway.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
 	"strings"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func decodeEc2TransitGatewayRouteID(id string) (string, string, error) {

--- a/aws/ec2_transit_gateway.go
+++ b/aws/ec2_transit_gateway.go
@@ -335,9 +335,7 @@ func ec2GetTransitGatewayMulticastDomainAssociations(conn *ec2.EC2, domainID str
 			return nil, nil
 		}
 
-		for _, association := range output.MulticastDomainAssociations {
-			associations = append(associations, association)
-		}
+		associations = append(associations, output.MulticastDomainAssociations...)
 
 		if aws.StringValue(output.NextToken) == "" {
 			break
@@ -370,9 +368,7 @@ func ec2SearchTransitGatewayMulticastDomainGroups(conn *ec2.EC2, domainID string
 			return nil, nil
 		}
 
-		for _, group := range output.MulticastGroups {
-			groups = append(groups, group)
-		}
+		groups = append(groups, output.MulticastGroups...)
 
 		if aws.StringValue(output.NextToken) == "" {
 			break

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -569,6 +569,7 @@ func Provider() *schema.Provider {
 			"aws_ec2_transit_gateway_route_table_propagation":         resourceAwsEc2TransitGatewayRouteTablePropagation(),
 			"aws_ec2_transit_gateway_vpc_attachment":                  resourceAwsEc2TransitGatewayVpcAttachment(),
 			"aws_ec2_transit_gateway_vpc_attachment_accepter":         resourceAwsEc2TransitGatewayVpcAttachmentAccepter(),
+			"aws_ec2_transit_gateway_multicast_domain":                resourceAwsEc2TransitGatewayMulticastDomain(),
 			"aws_ecr_lifecycle_policy":                                resourceAwsEcrLifecyclePolicy(),
 			"aws_ecr_repository":                                      resourceAwsEcrRepository(),
 			"aws_ecr_repository_policy":                               resourceAwsEcrRepositoryPolicy(),

--- a/aws/resource_aws_ec2_transit_gateway.go
+++ b/aws/resource_aws_ec2_transit_gateway.go
@@ -83,6 +83,16 @@ func resourceAwsEc2TransitGateway() *schema.Resource {
 					ec2.DnsSupportValueEnable,
 				}, false),
 			},
+			"multicast_support": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  ec2.MulticastSupportValueDisable,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.MulticastSupportValueDisable,
+					ec2.MulticastSupportValueEnable,
+				}, false),
+			},
 			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -115,6 +125,7 @@ func resourceAwsEc2TransitGatewayCreate(d *schema.ResourceData, meta interface{}
 			DefaultRouteTableAssociation: aws.String(d.Get("default_route_table_association").(string)),
 			DefaultRouteTablePropagation: aws.String(d.Get("default_route_table_propagation").(string)),
 			DnsSupport:                   aws.String(d.Get("dns_support").(string)),
+			MulticastSupport:             aws.String(d.Get("multicast_support").(string)),
 			VpnEcmpSupport:               aws.String(d.Get("vpn_ecmp_support").(string)),
 		},
 		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeTransitGateway),
@@ -183,6 +194,7 @@ func resourceAwsEc2TransitGatewayRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("default_route_table_propagation", transitGateway.Options.DefaultRouteTablePropagation)
 	d.Set("description", transitGateway.Description)
 	d.Set("dns_support", transitGateway.Options.DnsSupport)
+	d.Set("multicast_support", transitGateway.Options.MulticastSupport)
 	d.Set("owner_id", transitGateway.OwnerId)
 	d.Set("propagation_default_route_table_id", transitGateway.Options.PropagationDefaultRouteTableId)
 

--- a/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
+++ b/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
@@ -3,13 +3,11 @@ package aws
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
@@ -37,7 +35,6 @@ func resourceAwsEc2TransitGatewayMulticastDomain() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"transit_gateway_attachment_id": {
 							Type:     schema.TypeString,
-							ForceNew: true,
 							Required: true,
 						},
 						"subnet_ids": {
@@ -48,6 +45,46 @@ func resourceAwsEc2TransitGatewayMulticastDomain() *schema.Resource {
 					},
 				},
 				Set: resourceAwsEc2TransitGatewayMulticastDomainAssociationHash,
+			},
+			"members": {
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Optional:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group_ip_address": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"network_interface_ids": {
+							Type:     schema.TypeSet,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Required: true,
+						},
+					},
+				},
+				Set: resourceAwsEc2TransitGatewayMulticastDomainGroupsHash,
+			},
+			"sources": {
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Optional:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group_ip_address": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"network_interface_ids": {
+							Type:     schema.TypeSet,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Required: true,
+						},
+					},
+				},
+				Set: resourceAwsEc2TransitGatewayMulticastDomainGroupsHash,
 			},
 		},
 	}
@@ -83,32 +120,15 @@ func resourceAwsEc2TransitGatewayMulticastDomainRead(d *schema.ResourceData, met
 	conn := meta.(*AWSClient).ec2conn
 	id := d.Id()
 
-	// get associations by grouping by the attachment ID
-	associations, err := ec2GetTransitGatewayMulticastDomainAssociations(conn, id)
-	if err != nil {
-		return fmt.Errorf("error getting EC2 Transit Gateway Multicast Domain (%s) associations: %s", id, err)
+	if err := resourceAwsEc2TransitGatewayMulticastDomainAssociationsRead(d, meta); err != nil {
+		return err
 	}
-
-	tgwAttachmentMap := make(map[string][]*string)
-	for _, assoc := range associations {
-		attachmentID := aws.StringValue(assoc.TransitGatewayAttachmentId)
-		subnetID := assoc.Subnet.SubnetId
-		if lst, exists := tgwAttachmentMap[attachmentID]; exists {
-			tgwAttachmentMap[attachmentID] = append(lst, subnetID)
-			continue
-		}
-		tgwAttachmentMap[attachmentID] = []*string{subnetID}
+	if err := resourceAwsEc2TransitGatewayMulticastDomainGroupsRead(d, meta, true); err != nil {
+		return err
 	}
-
-	// flatten data so that each association is to 1 tgw attachment
-	assocSet := &schema.Set{F: resourceAwsEc2TransitGatewayMulticastDomainAssociationHash}
-	for attachmentID := range tgwAttachmentMap {
-		assocData := make(map[string]interface{})
-		assocData["transit_gateway_attachment_id"] = attachmentID
-		assocData["subnet_ids"] = flattenStringSet(tgwAttachmentMap[attachmentID])
-		assocSet.Add(assocData)
+	if err := resourceAwsEc2TransitGatewayMulticastDomainGroupsRead(d, meta, false); err != nil {
+		return err
 	}
-	d.Set("association", assocSet)
 
 	multicastDomain, err := ec2DescribeTransitGatewayMulticastDomain(conn, id)
 	if multicastDomain == nil || isAWSErr(err, "InvalidTransitGatewayMulticastDomainId.NotFound", "") {
@@ -137,10 +157,81 @@ func resourceAwsEc2TransitGatewayMulticastDomainRead(d *schema.ResourceData, met
 	return nil
 }
 
-func resourceAwsEc2TransitGatewayMulticastDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEc2TransitGatewayMulticastDomainAssociationsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	id := d.Id()
 
+	// get associations by grouping by the attachment ID
+	associations, err := ec2GetTransitGatewayMulticastDomainAssociations(conn, id)
+	if err != nil {
+		return fmt.Errorf("error getting EC2 Transit Gateway Multicast Domain (%s) associations: %s", id, err)
+	}
+
+	tgwAttachmentMap := make(map[string][]*string)
+	for _, assoc := range associations {
+		attachmentID := aws.StringValue(assoc.TransitGatewayAttachmentId)
+		subnetID := assoc.Subnet.SubnetId
+		if lst, exists := tgwAttachmentMap[attachmentID]; exists {
+			tgwAttachmentMap[attachmentID] = append(lst, subnetID)
+			continue
+		}
+		tgwAttachmentMap[attachmentID] = []*string{subnetID}
+	}
+
+	// flatten data so that each association is to 1 tgw attachment
+	assocSet := &schema.Set{F: resourceAwsEc2TransitGatewayMulticastDomainAssociationHash}
+	for attachmentID := range tgwAttachmentMap {
+		assocData := make(map[string]interface{})
+		assocData["transit_gateway_attachment_id"] = attachmentID
+		assocData["subnet_ids"] = flattenStringSet(tgwAttachmentMap[attachmentID])
+		assocSet.Add(assocData)
+	}
+	d.Set("association", assocSet)
+
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainGroupsRead(d *schema.ResourceData, meta interface{}, member bool) error {
+	conn := meta.(*AWSClient).ec2conn
+	id := d.Id()
+
+	// get groups by grouping by the group IP address
+	groups, err := ec2GetTransitGatewayMulticastDomainGroups(conn, id, member)
+	if err != nil {
+		return fmt.Errorf("error getting EC2 Transit Gateway Multicast Domain (%s) groups: %s", id, err)
+	}
+
+	groupIpMap := make(map[string][]*string)
+	for _, group := range groups {
+		groupIP := aws.StringValue(group.GroupIpAddress)
+		netID := group.NetworkInterfaceId
+		if lst, exists := groupIpMap[groupIP]; exists {
+			groupIpMap[groupIP] = append(lst, netID)
+			continue
+		}
+		groupIpMap[groupIP] = []*string{netID}
+	}
+
+	groupSet := &schema.Set{F: resourceAwsEc2TransitGatewayMulticastDomainGroupsHash}
+	for groupIP := range groupIpMap {
+		groupData := make(map[string]interface{})
+		groupData["group_ip_address"] = groupIP
+		groupData["network_interface_ids"] = flattenStringSet(groupIpMap[groupIP])
+		groupSet.Add(groupData)
+	}
+
+	if member {
+		d.Set("members", groupSet)
+		return nil
+	}
+	d.Set("sources", groupSet)
+
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	id := d.Id()
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.Ec2UpdateTags(conn, id, o, n); err != nil {
@@ -148,6 +239,22 @@ func resourceAwsEc2TransitGatewayMulticastDomainUpdate(d *schema.ResourceData, m
 		}
 	}
 
+	if err := resourceAwsEc2TransitGatewayMulticastDomainAssociationsUpdate(d, meta); err != nil {
+		return err
+	}
+	if err := resourceAwsEc2TransitGatewayMulticastDomainGroupsUpdate(d, meta, true); err != nil {
+		return err
+	}
+	if err := resourceAwsEc2TransitGatewayMulticastDomainGroupsUpdate(d, meta, false); err != nil {
+		return err
+	}
+
+	return resourceAwsEc2TransitGatewayMulticastDomainRead(d, meta)
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainAssociationsUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	id := d.Id()
 	// check if association set has changed
 	if d.HasChange("association") {
 		o, n := d.GetChange("association")
@@ -156,27 +263,9 @@ func resourceAwsEc2TransitGatewayMulticastDomainUpdate(d *schema.ResourceData, m
 
 		// disassociate old associations
 		for _, assoc := range old.List() {
-			assocMap := assoc.(map[string]interface{})
-			tgwAttachmentID := assocMap["transit_gateway_attachment_id"].(string)
-			subnetIDs := expandStringSet(assocMap["subnet_ids"].(*schema.Set))
-			input := &ec2.DisassociateTransitGatewayMulticastDomainInput{
-				SubnetIds:                       subnetIDs,
-				TransitGatewayAttachmentId:      aws.String(tgwAttachmentID),
-				TransitGatewayMulticastDomainId: aws.String(id),
-			}
-
-			log.Printf("Disassociating subnets from EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
-			_, err := conn.DisassociateTransitGatewayMulticastDomain(input)
-			if err != nil {
-				return fmt.Errorf(
-					"error disassociating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, err)
-			}
-
-			// wait for subnets to be disassociated
-			if err := waitForEc2TransitGatewayMulticastDomainDisassociation(conn, id, subnetIDs); err != nil {
-				return fmt.Errorf(
-					"error waiting for EC2 Transit Gateway Multicast Domain (%s) to disassociate subnets: %s",
-					id, err)
+			assocData := assoc.(map[string]interface{})
+			if err := resourceAwsEc2TransitGatewayMulticastDomainDisassociate(conn, id, assocData); err != nil {
+				return err
 			}
 		}
 
@@ -186,69 +275,187 @@ func resourceAwsEc2TransitGatewayMulticastDomainUpdate(d *schema.ResourceData, m
 
 		// associate new subnets
 		for _, assoc := range nw.List() {
-			assocMap := assoc.(map[string]interface{})
-			tgwAttachmentID := assocMap["transit_gateway_attachment_id"].(string)
-			subnetIDs := expandStringSet(assocMap["subnet_ids"].(*schema.Set))
-			input := &ec2.AssociateTransitGatewayMulticastDomainInput{
-				SubnetIds:                       subnetIDs,
-				TransitGatewayAttachmentId:      aws.String(tgwAttachmentID),
-				TransitGatewayMulticastDomainId: aws.String(id),
+			assocData := assoc.(map[string]interface{})
+			if err := resourceAwsEc2TransitGatewayMulticastDomainAssociate(conn, id, assocData); err != nil {
+				return err
 			}
-
-			log.Printf(
-				"[DEBUG] Associating subnets to EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
-			_, err := conn.AssociateTransitGatewayMulticastDomain(input)
-			if err != nil {
-				return fmt.Errorf(
-					"error associating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, err)
-			}
-
-			// wait for associations
-			if err := waitForEc2TransitGatewayMulticastDomainAssociation(conn, id, subnetIDs); err != nil {
-				return fmt.Errorf(
-					"error waiting for EC2 Transit Gateway Multicast Domain (%s) associations: %s", id, err)
-			}
-
 			associations.Add(assoc)
 			d.Set("association", associations)
 		}
 	}
 
-	return resourceAwsEc2TransitGatewayMulticastDomainRead(d, meta)
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainGroupsUpdate(d *schema.ResourceData, meta interface{}, member bool) error {
+	conn := meta.(*AWSClient).ec2conn
+	id := d.Id()
+	key := groupType(member)
+	if d.HasChange(key) {
+		o, n := d.GetChange(key)
+		old := o.(*schema.Set).Difference(n.(*schema.Set))
+		nw := n.(*schema.Set).Difference(o.(*schema.Set))
+
+		// remove old groups
+		for _, group := range old.List() {
+			groupData := group.(map[string]interface{})
+			if err := resourceAwsEc2TransitGatewayMulticastDomainGroupDeregister(conn, id, groupData, member); err != nil {
+				return err
+			}
+		}
+
+		// save current state
+		groups := o.(*schema.Set).Intersection(n.(*schema.Set))
+		d.Set(key, groups)
+
+		// register new groups
+		for _, group := range nw.List() {
+			groupData := group.(map[string]interface{})
+			if err := resourceAwsEc2TransitGatewayMulticastDomainGroupRegister(conn, id, groupData, member); err != nil {
+				return err
+			}
+			groups.Add(group)
+			d.Set(key, groups)
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainDisassociate(conn *ec2.EC2, id string, assocData map[string]interface{}) error {
+	tgwAttachmentID := assocData["transit_gateway_attachment_id"].(string)
+	subnetIDs := expandStringSet(assocData["subnet_ids"].(*schema.Set))
+	input := &ec2.DisassociateTransitGatewayMulticastDomainInput{
+		SubnetIds:                       subnetIDs,
+		TransitGatewayAttachmentId:      aws.String(tgwAttachmentID),
+		TransitGatewayMulticastDomainId: aws.String(id),
+	}
+
+	log.Printf(
+		"[DEBUG] Disassociating subnets from EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+	if _, err := conn.DisassociateTransitGatewayMulticastDomain(input); err != nil {
+		return fmt.Errorf(
+			"error disassociating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, err)
+	}
+
+	// wait for subnets to be disassociated
+	if err := waitForEc2TransitGatewayMulticastDomainDisassociation(conn, id, subnetIDs); err != nil {
+		return fmt.Errorf(
+			"error waiting for EC2 Transit Gateway Multicast Domain (%s) to disassociate subnets: %s",
+			id, err)
+	}
+
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainAssociate(conn *ec2.EC2, id string, assocData map[string]interface{}) error {
+	tgwAttachmentID := assocData["transit_gateway_attachment_id"].(string)
+	subnetIDs := expandStringSet(assocData["subnet_ids"].(*schema.Set))
+	input := &ec2.AssociateTransitGatewayMulticastDomainInput{
+		SubnetIds:                       subnetIDs,
+		TransitGatewayAttachmentId:      aws.String(tgwAttachmentID),
+		TransitGatewayMulticastDomainId: aws.String(id),
+	}
+
+	log.Printf(
+		"[DEBUG] Associating subnets to EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+	if _, err := conn.AssociateTransitGatewayMulticastDomain(input); err != nil {
+		return fmt.Errorf(
+			"error associating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, err)
+	}
+
+	// wait for associations
+	if err := waitForEc2TransitGatewayMulticastDomainAssociation(conn, id, subnetIDs); err != nil {
+		return fmt.Errorf(
+			"error waiting for EC2 Transit Gateway Multicast Domain (%s) associations: %s", id, err)
+	}
+
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainGroupDeregister(conn *ec2.EC2, id string, groupData map[string]interface{}, member bool) error {
+	// Note: for some reason AWS made the decision to logically separate "members" from "sources" in
+	// register/deregister; however, they are unified in "search"
+	if member {
+		input := &ec2.DeregisterTransitGatewayMulticastGroupMembersInput{
+			GroupIpAddress:                  aws.String(groupData["group_ip_address"].(string)),
+			NetworkInterfaceIds:             expandStringSet(groupData["network_interface_ids"].(*schema.Set)),
+			TransitGatewayMulticastDomainId: aws.String(id),
+		}
+
+		log.Printf(
+			"[DEBUG] Deregistering members from EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+		if _, err := conn.DeregisterTransitGatewayMulticastGroupMembers(input); err != nil {
+			return fmt.Errorf(
+				"error removing member from EC2 Transit Gateway Multicast Domain (%s): %s", id, err)
+		}
+		return nil
+	}
+
+	input := &ec2.DeregisterTransitGatewayMulticastGroupSourcesInput{
+		GroupIpAddress:                  aws.String(groupData["group_ip_address"].(string)),
+		NetworkInterfaceIds:             expandStringSet(groupData["network_interface_ids"].(*schema.Set)),
+		TransitGatewayMulticastDomainId: aws.String(id),
+	}
+
+	log.Printf(
+		"[DEBUG] Deregistering sources from EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+	if _, err := conn.DeregisterTransitGatewayMulticastGroupSources(input); err != nil {
+		return fmt.Errorf(
+			"error removing source from EC2 Transit Gateway Multicast Domain (%s): %s", id, err)
+	}
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainGroupRegister(conn *ec2.EC2, id string, groupData map[string]interface{}, member bool) error {
+	// Note: for some reason AWS made the decision to logically separate "members" from "sources" in
+	// register/deregister; however, they are unified in "search"
+	if member {
+		input := &ec2.RegisterTransitGatewayMulticastGroupMembersInput{
+			GroupIpAddress:                  aws.String(groupData["group_ip_address"].(string)),
+			NetworkInterfaceIds:             expandStringSet(groupData["network_interface_ids"].(*schema.Set)),
+			TransitGatewayMulticastDomainId: aws.String(id),
+		}
+
+		log.Printf(
+			"[DEBUG] Registering members to EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+		if _, err := conn.RegisterTransitGatewayMulticastGroupMembers(input); err != nil {
+			return fmt.Errorf(
+				"error registering EC2 Transit Gateway Multicast Domain (%s) members: %s", id, err)
+		}
+		return nil
+	}
+
+	input := &ec2.RegisterTransitGatewayMulticastGroupSourcesInput{
+		GroupIpAddress:                  aws.String(groupData["group_ip_address"].(string)),
+		NetworkInterfaceIds:             expandStringSet(groupData["network_interface_ids"].(*schema.Set)),
+		TransitGatewayMulticastDomainId: aws.String(id),
+	}
+
+	log.Printf(
+		"[DEBUG] Registering sources to EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+	if _, err := conn.RegisterTransitGatewayMulticastGroupSources(input); err != nil {
+		return fmt.Errorf(
+			"error registering EC2 Transit Gateway Multicast Domain (%s) sources: %s", id, err)
+	}
+	return nil
 }
 
 func resourceAwsEc2TransitGatewayMulticastDomainDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	id := d.Id()
-	err := resourceAwsEc2TransitGatewayMulticastDomainRead(d, meta)
-	if err != nil {
+	if err := resourceAwsEc2TransitGatewayMulticastDomainRead(d, meta); err != nil {
 		return fmt.Errorf("error deleting EC2 Transit Gateway Multicast Domain (%s): %s", id, err)
 	}
 
-	// disassociate subnets
-	assocSet := d.Get("association").(*schema.Set)
-	for _, assoc := range assocSet.List() {
-		assocData := assoc.(map[string]interface{})
-		subnetIDs := expandStringSet(assocData["subnet_ids"].(*schema.Set))
-		input := &ec2.DisassociateTransitGatewayMulticastDomainInput{
-			SubnetIds:                       subnetIDs,
-			TransitGatewayAttachmentId:      aws.String(assocData["transit_gateway_attachment_id"].(string)),
-			TransitGatewayMulticastDomainId: aws.String(id),
-		}
-		log.Printf("[DEBUG] Disassociating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, input)
-		_, err := conn.DisassociateTransitGatewayMulticastDomain(input)
-		if err != nil {
-			return fmt.Errorf(
-				"error disassociating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, err)
-		}
-
-		// wait for subnets to disassociate
-		if err := waitForEc2TransitGatewayMulticastDomainDisassociation(conn, id, subnetIDs); err != nil {
-			return fmt.Errorf(
-				"error while waiting for EC2 Transit Gateway Multicast Domain (%s) subnets to disassociate: %s",
-				id, err)
-		}
-
+	if err := resourceAwsEc2TransitGatewayMulticastDomainGroupsDeregisterAll(d, meta, true); err != nil {
+		return err
+	}
+	if err := resourceAwsEc2TransitGatewayMulticastDomainGroupsDeregisterAll(d, meta, false); err != nil {
+		return err
+	}
+	if err := resourceAwsEc2TransitGatewayMulticastDomainDisassociateAll(d, meta); err != nil {
+		return err
 	}
 
 	input := &ec2.DeleteTransitGatewayMulticastDomainInput{
@@ -256,22 +463,10 @@ func resourceAwsEc2TransitGatewayMulticastDomainDelete(d *schema.ResourceData, m
 	}
 
 	log.Printf("[DEBUG] Deleting EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
-	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteTransitGatewayMulticastDomain(input)
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-
-	if isResourceTimeoutError(err) {
-		_, err = conn.DeleteTransitGatewayMulticastDomain(input)
-	}
-
+	_, err := conn.DeleteTransitGatewayMulticastDomain(input)
 	if isAWSErr(err, "InvalidTransitGatewayMulticastDomainId.NotFound", "") {
 		return nil
 	}
-
 	if err != nil {
 		return fmt.Errorf("error deleting EC2 Transit Gateway Multicast Domain: %s", err)
 	}
@@ -280,6 +475,35 @@ func resourceAwsEc2TransitGatewayMulticastDomainDelete(d *schema.ResourceData, m
 		return fmt.Errorf("error waiting for EC2 Transit Gateway Multicast Domain (%s) deletion: %s", id, err)
 	}
 
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainDisassociateAll(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	id := d.Id()
+	// disassociate subnets
+	assocSet := d.Get("association").(*schema.Set)
+	for _, assoc := range assocSet.List() {
+		assocData := assoc.(map[string]interface{})
+		if err := resourceAwsEc2TransitGatewayMulticastDomainDisassociate(conn, id, assocData); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainGroupsDeregisterAll(d *schema.ResourceData, meta interface{}, member bool) error {
+	conn := meta.(*AWSClient).ec2conn
+	id := d.Id()
+	key := groupType(member)
+	// deregister groups
+	groups := d.Get(key).(*schema.Set)
+	for _, group := range groups.List() {
+		groupData := group.(map[string]interface{})
+		if err := resourceAwsEc2TransitGatewayMulticastDomainGroupDeregister(conn, id, groupData, member); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -294,4 +518,24 @@ func resourceAwsEc2TransitGatewayMulticastDomainAssociationHash(meta interface{}
 		buf.WriteString(fmt.Sprintf("%s,", subnetID.(string)))
 	}
 	return hashcode.String(buf.String())
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainGroupsHash(meta interface{}) int {
+	m, castOk := meta.(map[string]interface{})
+	if !castOk {
+		return 0
+	}
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%s-", m["group_ip_address"].(string)))
+	for _, networkID := range m["network_interface_ids"].(*schema.Set).List() {
+		buf.WriteString(fmt.Sprintf("%s,", networkID.(string)))
+	}
+	return hashcode.String(buf.String())
+}
+
+func groupType(member bool) string {
+	if member {
+		return "members"
+	}
+	return "sources"
 }

--- a/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
+++ b/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
@@ -1,7 +1,9 @@
 package aws
 
 import (
+	"bytes"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"log"
 	"time"
 
@@ -18,9 +20,6 @@ func resourceAwsEc2TransitGatewayMulticastDomain() *schema.Resource {
 		Read:   resourceAwsEc2TransitGatewayMulticastDomainRead,
 		Update: resourceAwsEc2TransitGatewayMulticastDomainUpdate,
 		Delete: resourceAwsEc2TransitGatewayMulticastDomainDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"transit_gateway_id": {
@@ -29,13 +28,34 @@ func resourceAwsEc2TransitGatewayMulticastDomain() *schema.Resource {
 				Required: true,
 			},
 			"tags": tagsSchema(),
+			"association": {
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Optional:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"transit_gateway_attachment_id": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Required: true,
+						},
+						"subnet_ids": {
+							Type:     schema.TypeSet,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Required: true,
+						},
+					},
+				},
+				Set: resourceAwsEc2TransitGatewayMulticastDomainAssociationHash,
+			},
 		},
 	}
 }
 
 func resourceAwsEc2TransitGatewayMulticastDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	// create the domain
 	conn := meta.(*AWSClient).ec2conn
-
 	input := &ec2.CreateTransitGatewayMulticastDomainInput{
 		TransitGatewayId: aws.String(d.Get("transit_gateway_id").(string)),
 		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}),
@@ -51,20 +71,47 @@ func resourceAwsEc2TransitGatewayMulticastDomainCreate(d *schema.ResourceData, m
 	id := aws.StringValue(output.TransitGatewayMulticastDomain.TransitGatewayMulticastDomainId)
 	d.SetId(id)
 
+	// wait for the domain to become available
 	if err := waitForEc2TransitGatewayMulticastDomainCreation(conn, id); err != nil {
 		return fmt.Errorf("error waiting for EC2 Transit Gateway Multicast Domain (%s) availability: %s", id, err)
 	}
 
-	return resourceAwsEc2TransitGatewayMulticastDomainRead(d, meta)
+	return resourceAwsEc2TransitGatewayMulticastDomainUpdate(d, meta)
 }
 
 func resourceAwsEc2TransitGatewayMulticastDomainRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-
 	id := d.Id()
-	multicastDomain, err := ec2DescribeTransitGatewayMulticastDomain(conn, id)
 
-	if isAWSErr(err, "InvalidTransitGatewayMulticastDomainId.NotFound", "") {
+	// get associations by grouping by the attachment ID
+	associations, err := ec2GetTransitGatewayMulticastDomainAssociations(conn, id)
+	if err != nil {
+		return fmt.Errorf("error getting EC2 Transit Gateway Multicast Domain (%s) associations: %s", id, err)
+	}
+
+	tgwAttachmentMap := make(map[string][]*string)
+	for _, assoc := range associations {
+		attachmentID := aws.StringValue(assoc.TransitGatewayAttachmentId)
+		subnetID := assoc.Subnet.SubnetId
+		if lst, exists := tgwAttachmentMap[attachmentID]; exists {
+			tgwAttachmentMap[attachmentID] = append(lst, subnetID)
+			continue
+		}
+		tgwAttachmentMap[attachmentID] = []*string{subnetID}
+	}
+
+	// flatten data so that each association is to 1 tgw attachment
+	assocSet := &schema.Set{F: resourceAwsEc2TransitGatewayMulticastDomainAssociationHash}
+	for attachmentID := range tgwAttachmentMap {
+		assocData := make(map[string]interface{})
+		assocData["transit_gateway_attachment_id"] = attachmentID
+		assocData["subnet_ids"] = flattenStringSet(tgwAttachmentMap[attachmentID])
+		assocSet.Add(assocData)
+	}
+	d.Set("association", assocSet)
+
+	multicastDomain, err := ec2DescribeTransitGatewayMulticastDomain(conn, id)
+	if multicastDomain == nil || isAWSErr(err, "InvalidTransitGatewayMulticastDomainId.NotFound", "") {
 		log.Printf("[WARN] EC2 Transit Gateway (%s) not found, removing from state", id)
 		d.SetId("")
 		return nil
@@ -74,15 +121,11 @@ func resourceAwsEc2TransitGatewayMulticastDomainRead(d *schema.ResourceData, met
 		return fmt.Errorf("error reading EC2 Transit Gateway Multicast Domain: %s", err)
 	}
 
-	if multicastDomain == nil {
-		log.Printf("[WARN] EC2 Transit Gateway Multicast Domain (%s) not found, removing from state", id)
-		d.SetId("")
-		return nil
-	}
-
-	if aws.StringValue(multicastDomain.State) == ec2.TransitGatewayStateDeleting || aws.StringValue(multicastDomain.State) == ec2.TransitGatewayStateDeleted {
-		log.Printf("[WARN] EC2 Transit Gateway (%s) in deleted state (%s), removing from state", d.Id(),
-			aws.StringValue(multicastDomain.State))
+	if aws.StringValue(multicastDomain.State) == ec2.TransitGatewayStateDeleting ||
+		aws.StringValue(multicastDomain.State) == ec2.TransitGatewayStateDeleted {
+		log.Printf(
+			"[WARN] EC2 Transit Gateway Multicast Domain (%s) in deleted state (%s), removing from state",
+			d.Id(), aws.StringValue(multicastDomain.State))
 		d.SetId("")
 		return nil
 	}
@@ -96,36 +139,128 @@ func resourceAwsEc2TransitGatewayMulticastDomainRead(d *schema.ResourceData, met
 
 func resourceAwsEc2TransitGatewayMulticastDomainUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
+	id := d.Id()
 
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
-		id := d.Id()
 		if err := keyvaluetags.Ec2UpdateTags(conn, id, o, n); err != nil {
 			return fmt.Errorf("error updating EC2 Transit Gateway Multicast Domain (%s) tags: %s", id, err)
 		}
 	}
 
-	return nil
+	// check if association set has changed
+	if d.HasChange("association") {
+		o, n := d.GetChange("association")
+		old := o.(*schema.Set).Difference(n.(*schema.Set))
+		nw := n.(*schema.Set).Difference(o.(*schema.Set))
+
+		// disassociate old associations
+		for _, assoc := range old.List() {
+			assocMap := assoc.(map[string]interface{})
+			tgwAttachmentID := assocMap["transit_gateway_attachment_id"].(string)
+			subnetIDs := expandStringSet(assocMap["subnet_ids"].(*schema.Set))
+			input := &ec2.DisassociateTransitGatewayMulticastDomainInput{
+				SubnetIds:                       subnetIDs,
+				TransitGatewayAttachmentId:      aws.String(tgwAttachmentID),
+				TransitGatewayMulticastDomainId: aws.String(id),
+			}
+
+			log.Printf("Disassociating subnets from EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+			_, err := conn.DisassociateTransitGatewayMulticastDomain(input)
+			if err != nil {
+				return fmt.Errorf(
+					"error disassociating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, err)
+			}
+
+			// wait for subnets to be disassociated
+			if err := waitForEc2TransitGatewayMulticastDomainDisassociation(conn, id, subnetIDs); err != nil {
+				return fmt.Errorf(
+					"error waiting for EC2 Transit Gateway Multicast Domain (%s) to disassociate subnets: %s",
+					id, err)
+			}
+		}
+
+		// save current state
+		associations := o.(*schema.Set).Intersection(n.(*schema.Set))
+		d.Set("association", associations)
+
+		// associate new subnets
+		for _, assoc := range nw.List() {
+			assocMap := assoc.(map[string]interface{})
+			tgwAttachmentID := assocMap["transit_gateway_attachment_id"].(string)
+			subnetIDs := expandStringSet(assocMap["subnet_ids"].(*schema.Set))
+			input := &ec2.AssociateTransitGatewayMulticastDomainInput{
+				SubnetIds:                       subnetIDs,
+				TransitGatewayAttachmentId:      aws.String(tgwAttachmentID),
+				TransitGatewayMulticastDomainId: aws.String(id),
+			}
+
+			log.Printf(
+				"[DEBUG] Associating subnets to EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+			_, err := conn.AssociateTransitGatewayMulticastDomain(input)
+			if err != nil {
+				return fmt.Errorf(
+					"error associating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, err)
+			}
+
+			// wait for associations
+			if err := waitForEc2TransitGatewayMulticastDomainAssociation(conn, id, subnetIDs); err != nil {
+				return fmt.Errorf(
+					"error waiting for EC2 Transit Gateway Multicast Domain (%s) associations: %s", id, err)
+			}
+
+			associations.Add(assoc)
+			d.Set("association", associations)
+		}
+	}
+
+	return resourceAwsEc2TransitGatewayMulticastDomainRead(d, meta)
 }
 
 func resourceAwsEc2TransitGatewayMulticastDomainDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-
 	id := d.Id()
+	err := resourceAwsEc2TransitGatewayMulticastDomainRead(d, meta)
+	if err != nil {
+		return fmt.Errorf("error deleting EC2 Transit Gateway Multicast Domain (%s): %s", id, err)
+	}
+
+	// disassociate subnets
+	assocSet := d.Get("association").(*schema.Set)
+	for _, assoc := range assocSet.List() {
+		assocData := assoc.(map[string]interface{})
+		subnetIDs := expandStringSet(assocData["subnet_ids"].(*schema.Set))
+		input := &ec2.DisassociateTransitGatewayMulticastDomainInput{
+			SubnetIds:                       subnetIDs,
+			TransitGatewayAttachmentId:      aws.String(assocData["transit_gateway_attachment_id"].(string)),
+			TransitGatewayMulticastDomainId: aws.String(id),
+		}
+		log.Printf("[DEBUG] Disassociating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, input)
+		_, err := conn.DisassociateTransitGatewayMulticastDomain(input)
+		if err != nil {
+			return fmt.Errorf(
+				"error disassociating EC2 Transit Gateway Multicast Domain (%s) subnets: %s", id, err)
+		}
+
+		// wait for subnets to disassociate
+		if err := waitForEc2TransitGatewayMulticastDomainDisassociation(conn, id, subnetIDs); err != nil {
+			return fmt.Errorf(
+				"error while waiting for EC2 Transit Gateway Multicast Domain (%s) subnets to disassociate: %s",
+				id, err)
+		}
+
+	}
+
 	input := &ec2.DeleteTransitGatewayMulticastDomainInput{
 		TransitGatewayMulticastDomainId: aws.String(id),
 	}
 
 	log.Printf("[DEBUG] Deleting EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteTransitGatewayMulticastDomain(input)
-
-		// TODO: error handling?
-
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
-
 		return nil
 	})
 
@@ -141,9 +276,22 @@ func resourceAwsEc2TransitGatewayMulticastDomainDelete(d *schema.ResourceData, m
 		return fmt.Errorf("error deleting EC2 Transit Gateway Multicast Domain: %s", err)
 	}
 
-	if err := waitForEc2TransitGatewayMulticastDomainDeletion(conn, d.Get("transit_gateway_id").(string), id); err != nil {
+	if err := waitForEc2TransitGatewayMulticastDomainDeletion(conn, id); err != nil {
 		return fmt.Errorf("error waiting for EC2 Transit Gateway Multicast Domain (%s) deletion: %s", id, err)
 	}
 
 	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainAssociationHash(meta interface{}) int {
+	m, castOk := meta.(map[string]interface{})
+	if !castOk {
+		return 0
+	}
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%s-", m["transit_gateway_attachment_id"].(string)))
+	for _, subnetID := range m["subnet_ids"].(*schema.Set).List() {
+		buf.WriteString(fmt.Sprintf("%s,", subnetID.(string)))
+	}
+	return hashcode.String(buf.String())
 }

--- a/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
+++ b/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 

--- a/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
+++ b/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
@@ -413,7 +413,7 @@ func resourceAwsEc2TransitGatewayMulticastDomainAssociationsUpdate(d *schema.Res
 		if old.HashEqual(nw) {
 			log.Printf(
 				"[DEBUG] Flattened EC2 Transit Gateway Multicast Domain assoctiation configuration was " +
-					"determined to be equivelent")
+					"determined to be equivalent")
 			d.Set("association", n)
 			return nil
 		}
@@ -456,7 +456,7 @@ func resourceAwsEc2TransitGatewayMulticastDomainGroupsUpdate(d *schema.ResourceD
 		if old.HashEqual(nw) {
 			log.Printf(
 				"[DEBUG] Flattened EC2 Transit Gateway Multicast Domain group configuration was determined to be " +
-					"equivelent")
+					"equivalent")
 			d.Set(key, n)
 			return nil
 		}

--- a/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
+++ b/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
@@ -125,6 +125,7 @@ func resourceAwsEc2TransitGatewayMulticastDomainCreate(d *schema.ResourceData, m
 func resourceAwsEc2TransitGatewayMulticastDomainRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	id := d.Id()
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	multicastDomain, err := ec2DescribeTransitGatewayMulticastDomain(conn, id)
 	if isAWSErr(err, "InvalidTransitGatewayMulticastDomainId.NotFound", "") {
@@ -158,7 +159,7 @@ func resourceAwsEc2TransitGatewayMulticastDomainRead(d *schema.ResourceData, met
 		return nil
 	}
 
-	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(multicastDomain.Tags).IgnoreAws().Map()); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(multicastDomain.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error settings tags: %s", err)
 	}
 

--- a/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
+++ b/aws/resource_aws_ec2_transit_gateway_multicast_domain.go
@@ -1,0 +1,149 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsEc2TransitGatewayMulticastDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEc2TransitGatewayMulticastDomainCreate,
+		Read:   resourceAwsEc2TransitGatewayMulticastDomainRead,
+		Update: resourceAwsEc2TransitGatewayMulticastDomainUpdate,
+		Delete: resourceAwsEc2TransitGatewayMulticastDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"transit_gateway_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	input := &ec2.CreateTransitGatewayMulticastDomainInput{
+		TransitGatewayId: aws.String(d.Get("transit_gateway_id").(string)),
+		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}),
+			ec2.ResourceTypeTransitGatewayMulticastDomain),
+	}
+
+	log.Printf("[DEBUG] Creating EC2 Transit Gateway Multicast Domain: %s", input)
+	output, err := conn.CreateTransitGatewayMulticastDomain(input)
+	if err != nil {
+		return fmt.Errorf("error creating EC2 Transit Gateway Multicast Domain: %s", err)
+	}
+
+	id := aws.StringValue(output.TransitGatewayMulticastDomain.TransitGatewayMulticastDomainId)
+	d.SetId(id)
+
+	if err := waitForEc2TransitGatewayMulticastDomainCreation(conn, id); err != nil {
+		return fmt.Errorf("error waiting for EC2 Transit Gateway Multicast Domain (%s) availability: %s", id, err)
+	}
+
+	return resourceAwsEc2TransitGatewayMulticastDomainRead(d, meta)
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	id := d.Id()
+	multicastDomain, err := ec2DescribeTransitGatewayMulticastDomain(conn, id)
+
+	if isAWSErr(err, "InvalidTransitGatewayMulticastDomainId.NotFound", "") {
+		log.Printf("[WARN] EC2 Transit Gateway (%s) not found, removing from state", id)
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading EC2 Transit Gateway Multicast Domain: %s", err)
+	}
+
+	if multicastDomain == nil {
+		log.Printf("[WARN] EC2 Transit Gateway Multicast Domain (%s) not found, removing from state", id)
+		d.SetId("")
+		return nil
+	}
+
+	if aws.StringValue(multicastDomain.State) == ec2.TransitGatewayStateDeleting || aws.StringValue(multicastDomain.State) == ec2.TransitGatewayStateDeleted {
+		log.Printf("[WARN] EC2 Transit Gateway (%s) in deleted state (%s), removing from state", d.Id(),
+			aws.StringValue(multicastDomain.State))
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(multicastDomain.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error settings tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		id := d.Id()
+		if err := keyvaluetags.Ec2UpdateTags(conn, id, o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Transit Gateway Multicast Domain (%s) tags: %s", id, err)
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsEc2TransitGatewayMulticastDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	id := d.Id()
+	input := &ec2.DeleteTransitGatewayMulticastDomainInput{
+		TransitGatewayMulticastDomainId: aws.String(id),
+	}
+
+	log.Printf("[DEBUG] Deleting EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteTransitGatewayMulticastDomain(input)
+
+		// TODO: error handling?
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteTransitGatewayMulticastDomain(input)
+	}
+
+	if isAWSErr(err, "InvalidTransitGatewayMulticastDomainId.NotFound", "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting EC2 Transit Gateway Multicast Domain: %s", err)
+	}
+
+	if err := waitForEc2TransitGatewayMulticastDomainDeletion(conn, d.Get("transit_gateway_id").(string), id); err != nil {
+		return fmt.Errorf("error waiting for EC2 Transit Gateway Multicast Domain (%s) deletion: %s", id, err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_ec2_transit_gateway_multicast_domain_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_multicast_domain_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func init() {

--- a/aws/resource_aws_ec2_transit_gateway_multicast_domain_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_multicast_domain_test.go
@@ -1,0 +1,891 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func init() {
+	// TODO: Remove once multicast support is extended beyond us-east-1
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+}
+
+func TestAccAWSEc2TransitGatewayMulticastDomain_basic(t *testing.T) {
+	var domain ec2.TransitGatewayMulticastDomain
+	resourceName := "aws_ec2_transit_gateway_multicast_domain.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayMulticastDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayMulticastDomainExists(resourceName, &domain),
+					resource.TestCheckResourceAttrSet(resourceName, "transit_gateway_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEc2TransitGatewayMulticastDomain_disappears(t *testing.T) {
+	var domain ec2.TransitGatewayMulticastDomain
+	resourceName := "aws_ec2_transit_gateway_multicast_domain.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayMulticastDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayMulticastDomainExists(resourceName, &domain),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainDisappears(&domain),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEc2TransitGatewayMulticastDomain_Tags(t *testing.T) {
+	var domain1 ec2.TransitGatewayMulticastDomain
+	resourceName := "aws_ec2_transit_gateway_multicast_domain.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayMulticastDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigTags1("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayMulticastDomainExists(resourceName, &domain1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigTags2("key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigTags1("key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEc2TransitGatewayMulticastDomain_Associations(t *testing.T) {
+	var domain1 ec2.TransitGatewayMulticastDomain
+	var attachment1, attachment2 ec2.TransitGatewayVpcAttachment
+	var subnet1, subnet2 ec2.Subnet
+	resourceName := "aws_ec2_transit_gateway_multicast_domain.test"
+	attachmentName1 := "aws_ec2_transit_gateway_vpc_attachment.test1"
+	attachmentName2 := "aws_ec2_transit_gateway_vpc_attachment.test2"
+	subnetName1 := "aws_subnet.test1"
+	subnetName2 := "aws_subnet.test2"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayMulticastDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation1(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayMulticastDomainExists(resourceName, &domain1),
+					testAccCheckAWSEc2TransitGatewayVpcAttachmentExists(attachmentName1, &attachment1),
+					testAccCheckSubnetExists(subnetName1, &subnet1),
+					testAccCheckSubnetExists(subnetName2, &subnet2),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainAssociations(&domain1, 1, map[*ec2.TransitGatewayVpcAttachment][]*ec2.Subnet{
+						&attachment1: {&subnet1},
+					}),
+				),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation2(),
+				Check: testAccCheckAWSEc2TransitGatewayMulticastDomainAssociations(&domain1, 2, map[*ec2.TransitGatewayVpcAttachment][]*ec2.Subnet{
+					&attachment1: {
+						&subnet1,
+						&subnet2,
+					},
+				}),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation3(),
+				Check: testAccCheckAWSEc2TransitGatewayMulticastDomainAssociations(&domain1, 2, map[*ec2.TransitGatewayVpcAttachment][]*ec2.Subnet{
+					&attachment1: {
+						&subnet1,
+						&subnet2,
+					},
+				}),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation4(),
+				Check: testAccCheckAWSEc2TransitGatewayMulticastDomainAssociations(&domain1, 1, map[*ec2.TransitGatewayVpcAttachment][]*ec2.Subnet{
+					&attachment1: {&subnet1},
+				}),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation5(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayVpcAttachmentExists(attachmentName2, &attachment2),
+					testAccCheckSubnetExists(subnetName2, &subnet2),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainAssociations(&domain1, 2, map[*ec2.TransitGatewayVpcAttachment][]*ec2.Subnet{
+						&attachment1: {&subnet1},
+						&attachment2: {&subnet2},
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEc2TransitGatewayMulticastDomain_Groups(t *testing.T) {
+	var domain1 ec2.TransitGatewayMulticastDomain
+	var instance1, instance2 ec2.Instance
+	resourceName := "aws_ec2_transit_gateway_multicast_domain.test"
+	instanceName1 := "aws_instance.test1"
+	instanceName2 := "aws_instance.test2"
+	// Note: Currently only one source per-group is allowed
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayMulticastDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigGroup1(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(instanceName1, &instance1),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainExists(resourceName, &domain1),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainGroups(&domain1, 1, true, map[string][]*ec2.Instance{
+						"224.0.0.1": {&instance1},
+					}),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainGroups(&domain1, 1, false, map[string][]*ec2.Instance{
+						"224.0.0.1": {&instance1},
+					}),
+				),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigGroup2(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(instanceName2, &instance2),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainGroups(&domain1, 2, true, map[string][]*ec2.Instance{
+						"224.0.0.1": {&instance1, &instance2},
+					}),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainGroups(&domain1, 1, false, map[string][]*ec2.Instance{
+						"224.0.0.1": {&instance1},
+					})),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigGroup3(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayMulticastDomainGroups(&domain1, 2, true, map[string][]*ec2.Instance{
+						"224.0.0.1": {&instance1, &instance2},
+					}),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainGroups(&domain1, 1, false, map[string][]*ec2.Instance{
+						"224.0.0.1": {&instance1},
+					})),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayMulticastDomainConfigGroup4(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayMulticastDomainGroups(&domain1, 2, true, map[string][]*ec2.Instance{
+						"224.0.0.1": {&instance1},
+						"224.0.0.2": {&instance2},
+					}),
+					testAccCheckAWSEc2TransitGatewayMulticastDomainGroups(&domain1, 2, false, map[string][]*ec2.Instance{
+						"224.0.0.1": {&instance1},
+						"224.0.0.2": {&instance2},
+					})),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSEc2TransitGatewayMulticastDomainExists(resourceName string, multicastDomain *ec2.TransitGatewayMulticastDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		id := rs.Primary.ID
+		if id == "" {
+			return fmt.Errorf("no EC2 Transit Gateway Multicast Domain ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		domain, err := ec2DescribeTransitGatewayMulticastDomain(conn, id)
+		if err != nil {
+			return err
+		}
+
+		if domain == nil {
+			return fmt.Errorf("EC2 Transit Gateway Multicast Domain (%s) not found", id)
+		}
+
+		state := aws.StringValue(domain.State)
+		if state != ec2.TransitGatewayMulticastDomainStateAvailable {
+			return fmt.Errorf(
+				"EC2 Transit Gateway Multicast Domain (%s) exists in non-available (%s) state", id, state)
+		}
+
+		*multicastDomain = *domain
+
+		return nil
+	}
+}
+
+func testAccCheckAWSEc2TransitGatewayMulticastDomainDisappears(domain *ec2.TransitGatewayMulticastDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		id := aws.StringValue(domain.TransitGatewayMulticastDomainId)
+		input := &ec2.DeleteTransitGatewayMulticastDomainInput{
+			TransitGatewayMulticastDomainId: aws.String(id),
+		}
+
+		log.Printf("[DEBUG] Deleting EC2 Transit Gateway Multicast Domain (%s): %s", id, input)
+		if _, err := conn.DeleteTransitGatewayMulticastDomain(input); err != nil {
+			return err
+		}
+
+		return waitForEc2TransitGatewayMulticastDomainDeletion(conn, id)
+	}
+}
+
+func testAccCheckAWSEc2TransitGatewayMulticastDomainDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ec2_transit_gateway_multicast_domain" {
+			continue
+		}
+
+		id := rs.Primary.ID
+		domain, err := ec2DescribeTransitGatewayMulticastDomain(conn, id)
+		if isAWSErr(err, "InvalidTransitGatewayMulticastDomainId.NotFound", "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if domain == nil {
+			continue
+		}
+
+		state := aws.StringValue(domain.State)
+		if state != ec2.TransitGatewayMulticastDomainStateDeleted {
+			return fmt.Errorf(
+				"EC2 Transit Gateway Multicast Domain (%s) still exists in a non-deleted (%s) state",
+				id, state)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSEc2TransitGatewayMulticastDomainAssociations(domain *ec2.TransitGatewayMulticastDomain, count int, expected map[*ec2.TransitGatewayVpcAttachment][]*ec2.Subnet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		id := aws.StringValue(domain.TransitGatewayMulticastDomainId)
+
+		assocSet, err := ec2GetTransitGatewayMulticastDomainAssociations(conn, id)
+		if err != nil {
+			return err
+		}
+
+		assocLen := len(assocSet)
+		if assocLen != count {
+			return fmt.Errorf(
+				"expected %d EC2 Transit Gateway Multicast Domain assoctiations; got %d", count, assocLen)
+		}
+
+		expectedIDs := make(map[string][]string)
+		for attachment, subnets := range expected {
+			var subnetIDs []string
+			for _, subnet := range subnets {
+				subnetIDs = append(subnetIDs, aws.StringValue(subnet.SubnetId))
+			}
+			expectedIDs[aws.StringValue(attachment.TransitGatewayAttachmentId)] = subnetIDs
+		}
+
+		for _, assoc := range assocSet {
+			attachmentID := aws.StringValue(assoc.TransitGatewayAttachmentId)
+			actualSubnetID := aws.StringValue(assoc.Subnet.SubnetId)
+			subnetIDs := expectedIDs[attachmentID]
+			log.Printf("[DEBUG] Subnet IDS: %s", subnetIDs)
+			found := false
+			for _, subnetID := range subnetIDs {
+				if subnetID == actualSubnetID {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf(
+					"subnet (%s) not found for expected EC2 Transit Gateway VPC Attachment (%s)",
+					actualSubnetID, attachmentID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSEc2TransitGatewayMulticastDomainGroups(domain *ec2.TransitGatewayMulticastDomain, count int, member bool, expected map[string][]*ec2.Instance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		id := aws.StringValue(domain.TransitGatewayMulticastDomainId)
+
+		groups, err := ec2SearchTransitGatewayMulticastDomainGroupsByType(conn, id, member)
+		if err != nil {
+			return err
+		}
+
+		groupLen := len(groups)
+		groupType := resourceAwsEc2TransitGatewayMulticastDomainGroupType(member)
+		if groupLen != count {
+			return fmt.Errorf(
+				"expected %d EC2 Transit Gateway Multicast Domain groups of type %s; got %d",
+				count, groupType, groupLen)
+		}
+
+		expectedIDs := make(map[string][]string)
+		for groupIP, instances := range expected {
+			var netIDs []string
+			for _, instance := range instances {
+				netIDs = append(netIDs, aws.StringValue(instance.NetworkInterfaces[0].NetworkInterfaceId))
+			}
+			expectedIDs[groupIP] = netIDs
+		}
+
+		for _, group := range groups {
+			groupIP := aws.StringValue(group.GroupIpAddress)
+			actualNetID := aws.StringValue(group.NetworkInterfaceId)
+			netIDs := expectedIDs[groupIP]
+			log.Printf("[DEBUG] Network Interface IDs: %s", netIDs)
+			found := false
+			for _, netID := range netIDs {
+				if netID == actualNetID {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf(
+					"network interface ID (%s) not found for expected group IP (%s)", actualNetID, groupIP)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfig() string {
+	return fmt.Sprintf(`
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation1() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-east-1b"
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test1" {
+  subnet_ids         = [aws_subnet.test1.id, aws_subnet.test2.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test1.id
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id]
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation2() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-east-1b"
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test1" {
+  subnet_ids         = [aws_subnet.test1.id, aws_subnet.test2.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test1.id
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id, aws_subnet.test2.id]
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation3() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-east-1b"
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test1" {
+  subnet_ids         = [aws_subnet.test1.id, aws_subnet.test2.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test1.id
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id]
+  }
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test2.id]
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation4() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-east-1b"
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test1" {
+  subnet_ids         = [aws_subnet.test1.id, aws_subnet.test2.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test1.id
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id]
+  }
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id]
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigAssociation5() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc" "test2" {
+  cidr_block = "11.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id            = aws_vpc.test2.id
+  cidr_block        = "11.0.1.0/24"
+  availability_zone = "us-east-1b"
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test1" {
+  subnet_ids         = [aws_subnet.test1.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test1.id
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test2" {
+  subnet_ids         = [aws_subnet.test2.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test2.id
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id]
+  }
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test2.id
+    subnet_ids                    = [aws_subnet.test2.id]
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigGroup1() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_instance" "test1" {
+  ami           = "ami-04b9e92b5572fa0d1"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.test1.id
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test1" {
+  subnet_ids         = [aws_subnet.test1.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test1.id
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id]
+  }
+
+  members {
+    group_ip_address = "224.0.0.1"
+    network_interface_ids = [aws_instance.test1.primary_network_interface_id]
+  }
+
+  sources {
+    group_ip_address = "224.0.0.1"
+    network_interface_ids = [aws_instance.test1.primary_network_interface_id]
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigGroup2() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_instance" "test1" {
+  ami           = "ami-04b9e92b5572fa0d1"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.test1.id
+}
+
+resource "aws_instance" "test2" {
+  ami           = "ami-04b9e92b5572fa0d1"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.test1.id
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test1" {
+  subnet_ids         = [aws_subnet.test1.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test1.id
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id]
+  }
+
+  members {
+    group_ip_address = "224.0.0.1"
+    network_interface_ids = [aws_instance.test1.primary_network_interface_id, aws_instance.test2.primary_network_interface_id]
+  }
+
+  sources {
+    group_ip_address = "224.0.0.1"
+    network_interface_ids = [aws_instance.test1.primary_network_interface_id]
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigGroup3() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_instance" "test1" {
+  ami           = "ami-04b9e92b5572fa0d1"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.test1.id
+}
+
+resource "aws_instance" "test2" {
+  ami           = "ami-04b9e92b5572fa0d1"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.test1.id
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test1" {
+  subnet_ids         = [aws_subnet.test1.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test1.id
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id]
+  }
+
+  members {
+    group_ip_address = "224.0.0.1"
+    network_interface_ids = [aws_instance.test1.primary_network_interface_id]
+  }
+
+  members {
+    group_ip_address = "224.0.0.1"
+    network_interface_ids = [aws_instance.test2.primary_network_interface_id]
+  }
+
+  sources {
+    group_ip_address = "224.0.0.1"
+    network_interface_ids = [aws_instance.test1.primary_network_interface_id]
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigGroup4() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test1.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_instance" "test1" {
+  ami           = "ami-04b9e92b5572fa0d1"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.test1.id
+}
+
+resource "aws_instance" "test2" {
+  ami           = "ami-04b9e92b5572fa0d1"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.test1.id
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test1" {
+  subnet_ids         = [aws_subnet.test1.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test1.id
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test1.id
+    subnet_ids                    = [aws_subnet.test1.id]
+  }
+
+  members {
+    group_ip_address = "224.0.0.1"
+    network_interface_ids = [aws_instance.test1.primary_network_interface_id]
+  }
+
+  members {
+    group_ip_address = "224.0.0.2"
+    network_interface_ids = [aws_instance.test2.primary_network_interface_id]
+  }
+
+  sources {
+    group_ip_address = "224.0.0.1"
+    network_interface_ids = [aws_instance.test1.primary_network_interface_id]
+  }
+
+  sources {
+    group_ip_address = "224.0.0.2"
+    network_interface_ids = [aws_instance.test2.primary_network_interface_id]
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigTags1(tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  tags = {
+    %q = %q
+  }
+}
+`, tagKey1, tagValue1)
+}
+
+func testAccAWSEc2TransitGatewayMulticastDomainConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_ec2_transit_gateway" "test" {
+  multicast_support = "enable"
+}
+
+resource "aws_ec2_transit_gateway_multicast_domain" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  tags = {
+    %q = %q
+    %q = %q
+  }
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -22,6 +22,7 @@ func init() {
 			"aws_dx_gateway_association",
 			"aws_ec2_transit_gateway_vpc_attachment",
 			"aws_ec2_transit_gateway_peering_attachment",
+			"aws_ec2_transit_gateway_multicast_domain",
 			"aws_vpn_connection",
 		},
 	})
@@ -129,6 +130,7 @@ func TestAccAWSEc2TransitGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_route_table_propagation", ec2.DefaultRouteTablePropagationValueEnable),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "dns_support", ec2.DnsSupportValueEnable),
+					resource.TestCheckResourceAttr(resourceName, "multicast_support", ec2.MulticastSupportValueDisable),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "propagation_default_route_table_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),

--- a/website/docs/r/ec2_transit_gateway.html.markdown
+++ b/website/docs/r/ec2_transit_gateway.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 * `default_route_table_propagation` - (Optional) Whether resource attachments automatically propagate routes to the default propagation route table. Valid values: `disable`, `enable`. Default value: `enable`.
 * `description` - (Optional) Description of the EC2 Transit Gateway.
 * `dns_support` - (Optional) Whether DNS support is enabled. Valid values: `disable`, `enable`. Default value: `enable`.
+* `multicast_support` - (Optional) Whether Multicast support is enabled. Required to use `ec2_transit_gateway_multicast_domain`. Valid values: `disable`, `enable`. Default value: `disable`.
 * `tags` - (Optional) Key-value tags for the EC2 Transit Gateway.
 * `vpn_ecmp_support` - (Optional) Whether VPN Equal Cost Multipath Protocol support is enabled. Valid values: `disable`, `enable`. Default value: `enable`.
 

--- a/website/docs/r/ec2_transit_gateway_multicast_domain.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_multicast_domain.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "EC2"
+layout: "aws"
+page_title: "AWS: aws_ec2_transit_gateway_multicast_domain"
+description: |-
+  Manages an EC2 Transit Gateway Multicast Domain
+---
+
+# Resource: aws_ec2_transit_gateway_multicast_domain
+
+Manages an EC2 Transit Gateway Multicast Domain.
+
+## Example Usage
+
+```hcl
+resource "aws_ec2_transit_gateway_multicast_domain" "main" {
+  transit_gateway_id = aws_ec2_transit_gateway.main.id
+  
+  association {
+    transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.main.id
+    subnet_ids                    = [aws_subnet.main.id]
+  }
+
+  members {
+    group_ip_address      = "224.0.0.1"
+    network_interface_ids = [aws_instance.main.primary_network_interface_id]
+  }
+
+  sources {
+    group_ip_address      = "224.0.0.1"
+    network_interface_ids = [aws_instance.main.primary_network_interface_id]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `transit_gateway_id` - (Required, Forces new resource) EC2 Transit Gateway Identifier. The target resource must have 
+    `multicast_support = "enable"`.
+* `association` - (Optional) Can be specified multiple times for different EC2 Transit Gateway Attachments. Each 
+    association block supports the fields documented below. This argument is processed in 
+    [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
+* `members` - (Optional) Can be specified multiple times for different Group IP Addresses. Each members block supports 
+    the fields documented below. This argument is processed in 
+    [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
+* `sources` - (Optional) Can be specified multiple times for different Group IP Addresses. Each members block supports 
+    the fields documented below. This argument is processed in 
+    [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+The `association` block supports:
+
+* `transit_gateway_attachment_id` - (Required) EC2 Transit Gateway Attachment Identifier.
+* `subnet_ids` - (Required, Minimum items: 1) List of subnets identifiers to associate. The listed subnets must reside
+    within the specified EC2 Transit Gateway Attachment.
+    
+The `members` and `sources` blocks support:
+
+* `group_ip_address` - (Required) Multicast Group IP address. Must be valid IPv4 or IPv6 IP Address in the 224.0.0.0/4 
+    or ff00::/8 CIDR range.
+* `network_interface_ids` - (Required, Minimum items: 1) List of Network Interface Identifiers to create 
+    Multicast Group for.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11120 

### Description

This pull requests adds support for EC2 Transit Gateway Multicast Domains.

New resource: `aws_ec2_transit_gateway_multicast_domain`
Modified resource: `aws_ec2_transit_gateway`

> *Why didn't you create separate resources for members/sources/associations?*

Multicast groups and associations do not have unique identifiers, I looked to the route table and security group implementations as a reference for how I implemented these elements. I saw that the standalone route resource, fakes an ID for convenience, but I figured that could be implemented similarly down the line. For now, embedding these within the resource seemed like the most reasonable solution.

### TODO
* [x] Acceptance tests
* [x] Documentation

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:
* *New resource:* `aws_ec2_transit_gateway_multicast_domain` [GH-11474]
ENHANCEMENTS:
* resource/aws_ec2_transit_gateway: Add `multicast_support` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run TestAccAWSEc2TransitGatewayMulticastDomain -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayMulticastDomain_basic
=== PAUSE TestAccAWSEc2TransitGatewayMulticastDomain_basic
=== RUN   TestAccAWSEc2TransitGatewayMulticastDomain_disappears
=== PAUSE TestAccAWSEc2TransitGatewayMulticastDomain_disappears
=== RUN   TestAccAWSEc2TransitGatewayMulticastDomain_Tags
=== PAUSE TestAccAWSEc2TransitGatewayMulticastDomain_Tags
=== RUN   TestAccAWSEc2TransitGatewayMulticastDomain_Associations
=== PAUSE TestAccAWSEc2TransitGatewayMulticastDomain_Associations
=== RUN   TestAccAWSEc2TransitGatewayMulticastDomain_Groups
=== PAUSE TestAccAWSEc2TransitGatewayMulticastDomain_Groups
=== CONT  TestAccAWSEc2TransitGatewayMulticastDomain_basic
=== CONT  TestAccAWSEc2TransitGatewayMulticastDomain_Associations
=== CONT  TestAccAWSEc2TransitGatewayMulticastDomain_Groups
=== CONT  TestAccAWSEc2TransitGatewayMulticastDomain_Tags
=== CONT  TestAccAWSEc2TransitGatewayMulticastDomain_disappears
--- PASS: TestAccAWSEc2TransitGatewayMulticastDomain_Tags (273.25s)
--- PASS: TestAccAWSEc2TransitGatewayMulticastDomain_disappears (274.94s)
--- PASS: TestAccAWSEc2TransitGatewayMulticastDomain_basic (277.85s)
--- PASS: TestAccAWSEc2TransitGatewayMulticastDomain_Groups (640.97s)
--- PASS: TestAccAWSEc2TransitGatewayMulticastDomain_Associations (822.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	824.377s
```
