### PR TITLE
Add data capture config to Sagemaker endpoint configuration

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -535,6 +535,48 @@ func validateSagemakerModelDataUrl(v interface{}, k string) (ws []string, errors
 	return
 }
 
+func validateSagemakerDataCaptureDestinationUrl(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^(https|s3)://([^/]+)/?(.*)$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid path: %q",
+			k, value))
+	}
+	if len(value) > 512 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 512 characters: %q", k, value))
+	}
+	return
+}
+
+func validateSagemakerCsvContentType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*\/[a-zA-Z0-9](-*[a-zA-Z0-9.])*`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid content type: %q",
+			k, value))
+	}
+	if len(value) < 1 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be shorter than 1 character: %q", k, value))
+	}
+	return
+}
+
+func validateSagemakerJsonContentType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*\/[a-zA-Z0-9](-*[a-zA-Z0-9.])*`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid content type: %q",
+			k, value))
+	}
+	if len(value) < 1 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be shorter than 1 character: %q", k, value))
+	}
+	return
+}
+
 func validateCloudWatchDashboardName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 255 {

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -40,6 +40,7 @@ The following arguments are supported:
 * `kms_key_arn` - (Optional) Amazon Resource Name (ARN) of a AWS Key Management Service key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance that hosts the endpoint.
 * `name` - (Optional) The name of the endpoint configuration. If omitted, Terraform will assign a random, unique name.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+* `data_capture_config` - (Optional) Specifies the parameters to capture input/output of Sagemaker models endpoints. Fields are documented below.
 
 The `production_variants` block supports:
 
@@ -49,6 +50,29 @@ The `production_variants` block supports:
 * `initial_variant_weight` (Optional) - Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to 1.0.
 * `model_name` - (Required) The name of the model to use.
 * `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
+
+The `data_capture_config` block supports:
+
+* `initial_sampling_percentage` - (Required) Portion of data to capture. Should be between 0 and 100.
+* `destination_url` - (Required) The URL for S3 location where the captured data is stored.
+* `capture_options` - (Required) Specifies what data to capture. Fields are documented below.
+* `kms_key_id` - (Optional) Amazon Resource Name (ARN) of a AWS Key Management Service key that Amazon SageMaker uses to encrypt the captured data on Amazon S3.
+* `enable_capture` - (Optional) Flag to enable data capture. Defaults to `false`.
+* `capture_content_type_header` - (Optional) The content type headers to capture. Fields are documented below.
+
+The `capture_options` block supports:
+
+* `capture_mode` - (Required) Specifies the data to be captured. Should be one of `Input` or `Output`.
+
+The `capture_content_type_header` block supports:
+
+* `csv_content_types` - (Optional) The CSV content type headers to capture. Fields are documented below.
+* `json_content_types` - (Optional) The JSON content type headers to capture. Fields are documented below.
+
+The `csv_content_types` and `json_content_types` block both support:
+
+* `content_type` - (Required) The value of the content type header.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_sagemaker_endpoint_configuration: Add `data_capture_config` argument.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSagemakerEndpointConfiguration_DataCaptureConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSagemakerEndpointConfiguration_DataCaptureConfig -timeout 120m
=== RUN   TestAccAWSSagemakerEndpointConfiguration_DataCaptureConfig
=== PAUSE TestAccAWSSagemakerEndpointConfiguration_DataCaptureConfig
=== CONT  TestAccAWSSagemakerEndpointConfiguration_DataCaptureConfig
--- PASS: TestAccAWSSagemakerEndpointConfiguration_DataCaptureConfig (38.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       38.749s
```
