### PR TITLE
Make rest API data source export execution_arn

### DIFF
--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -21,6 +21,10 @@ func dataSourceAwsApiGatewayRestApi() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"execution_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -54,6 +58,8 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 	match := matchedApis[0]
 
 	d.SetId(*match.Id)
+
+	d.Set("execution_arn", resourceApiGatewayExecutionArn(d, meta))
 
 	resp, err := conn.GetResources(&apigateway.GetResourcesInput{
 		RestApiId: aws.String(d.Id()),

--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -59,7 +59,7 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 
 	d.SetId(*match.Id)
 
-	d.Set("execution_arn", resourceApiGatewayExecutionArn(d, meta))
+	d.Set("execution_arn", resourceApiGatewayExecutionArn(*match.Id, d, meta))
 
 	resp, err := conn.GetResources(&apigateway.GetResourcesInput{
 		RestApiId: aws.String(d.Id()),

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
 	rName := acctest.RandString(8)
+	resourceName := "data.aws_api_gateway_rest_api.by_name"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -18,7 +19,9 @@ func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsApiGatewayRestApiConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsApiGatewayRestApiCheck("data.aws_api_gateway_rest_api.by_name"),
+					testAccDataSourceAwsApiGatewayRestApiCheck(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "execution_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "root_resource_id"),
 				),
 			},
 		},

--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -235,14 +235,7 @@ func resourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("binary_media_types", api.BinaryMediaTypes)
 
-	execution_arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "execute-api",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  d.Id(),
-	}.String()
-	d.Set("execution_arn", execution_arn)
+	d.Set("execution_arn", resourceApiGatewayExecutionArn(d, meta))
 
 	if api.MinimumCompressionSize == nil {
 		d.Set("minimum_compression_size", -1)
@@ -447,4 +440,14 @@ func flattenApiGatewayEndpointConfiguration(endpointConfiguration *apigateway.En
 	}
 
 	return []interface{}{m}
+}
+
+func resourceApiGatewayExecutionArn(d *schema.ResourceData, meta interface{}) string {
+	return arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "execute-api",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  d.Id(),
+	}.String()
 }

--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -235,7 +235,7 @@ func resourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("binary_media_types", api.BinaryMediaTypes)
 
-	d.Set("execution_arn", resourceApiGatewayExecutionArn(d, meta))
+	d.Set("execution_arn", resourceApiGatewayExecutionArn(d.Id(), d, meta))
 
 	if api.MinimumCompressionSize == nil {
 		d.Set("minimum_compression_size", -1)
@@ -442,12 +442,12 @@ func flattenApiGatewayEndpointConfiguration(endpointConfiguration *apigateway.En
 	return []interface{}{m}
 }
 
-func resourceApiGatewayExecutionArn(d *schema.ResourceData, meta interface{}) string {
+func resourceApiGatewayExecutionArn(id string, d *schema.ResourceData, meta interface{}) string {
 	return arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Service:   "execute-api",
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
-		Resource:  d.Id(),
+		Resource:  id,
 	}.String()
 }

--- a/website/docs/d/api_gateway_rest_api.html.markdown
+++ b/website/docs/d/api_gateway_rest_api.html.markdown
@@ -30,3 +30,6 @@ data "aws_api_gateway_rest_api" "my_rest_api" {
 
  * `id` - Set to the ID of the found REST API.
  * `root_resource_id` - Set to the ID of the API Gateway Resource on the found REST API where the route matches '/'.
+ * `execution_arn` - Set to the execution ARN part to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`
+   when allowing API Gateway to invoke a Lambda function,
+   e.g. `arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j`, which can be concatenated with allowed stage, method and resource path.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
 - Export `execution_arn` attribute from `data.aws_api_gateway_rest_api`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsApiGatewayRestApi'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccDataSourceAwsApiGatewayRestApi -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccDataSourceAwsApiGatewayRestApi
=== PAUSE TestAccDataSourceAwsApiGatewayRestApi
=== CONT  TestAccDataSourceAwsApiGatewayRestApi
--- PASS: TestAccDataSourceAwsApiGatewayRestApi (25.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.416s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.016s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.005s [no tests to run]

```
