### PR TITLE
Add Parquet cost report format

### DIFF
--- a/aws/resource_aws_cur_report_definition.go
+++ b/aws/resource_aws_cur_report_definition.go
@@ -39,7 +39,9 @@ func resourceAwsCurReportDefinition() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					costandusagereportservice.ReportFormatTextOrcsv}, false),
+					costandusagereportservice.ReportFormatParquet,
+					costandusagereportservice.ReportFormatTextOrcsv,
+				}, false),
 			},
 			"compression": {
 				Type:     schema.TypeString,
@@ -47,6 +49,7 @@ func resourceAwsCurReportDefinition() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					costandusagereportservice.CompressionFormatGzip,
+					costandusagereportservice.CompressionFormatParquet,
 					costandusagereportservice.CompressionFormatZip,
 				}, false),
 			},
@@ -82,6 +85,7 @@ func resourceAwsCurReportDefinition() *schema.Resource {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
+						costandusagereportservice.AdditionalArtifactAthena,
 						costandusagereportservice.AdditionalArtifactQuicksight,
 						costandusagereportservice.AdditionalArtifactRedshift,
 					}, false),

--- a/website/docs/r/cur_report_definition.html.markdown
+++ b/website/docs/r/cur_report_definition.html.markdown
@@ -35,13 +35,13 @@ The following arguments are supported:
 
 * `report_name` - (Required) Unique name for the report. Must start with a number/letter and is case sensitive. Limited to 256 characters.
 * `time_unit` - (Required) The frequency on which report data are measured and displayed.  Valid values are: HOURLY, DAILY.
-* `format` - (Required) Format for report. Valid values are: textORcsv.
-* `compression` - (Required) Compression format for report. Valid values are: GZIP, ZIP.
+* `format` - (Required) Format for report. Valid values are: Parquet, textORcsv.
+* `compression` - (Required) Compression format for report. Valid values are: GZIP, Parquet, ZIP.
 * `additional_schema_elements` - (Required) A list of schema elements. Valid values are: RESOURCES.
 * `s3_bucket` - (Required) Name of the existing S3 bucket to hold generated reports.
 * `s3_prefix` - (Optional) Report path prefix. Limited to 256 characters.
 * `s3_region` - (Required) Region of the existing S3 bucket to hold generated reports.
-* `additional_artifacts` - (Required)  A list of additional artifacts. Valid values are: REDSHIFT, QUICKSIGHT.
+* `additional_artifacts` - (Required)  A list of additional artifacts. Valid values are: ATHENA, REDSHIFT, QUICKSIGHT.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8765

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cur_report_definition: Add `Parquet` as compression and report format
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsCurReportDefinition'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAwsCurReportDefinition -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsCurReportDefinition_athena
=== PAUSE TestAccAwsCurReportDefinition_athena
=== RUN   TestAccAwsCurReportDefinition_redshift_quicksight
=== PAUSE TestAccAwsCurReportDefinition_redshift_quicksight
=== CONT  TestAccAwsCurReportDefinition_athena
=== CONT  TestAccAwsCurReportDefinition_redshift_quicksight
--- PASS: TestAccAwsCurReportDefinition_athena (38.57s)
--- PASS: TestAccAwsCurReportDefinition_redshift_quicksight (39.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.966s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.017s [no tests to run]
```
