### PR TITLE
resource/aws_ses_configuration_set: Add delivery options to allow a TlsPolicy of Require to be specified

### DIFF
--- a/.changelog/11600.txt
+++ b/.changelog/11600.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ses_configuration_set: Add `delivery_options` argument
+```

--- a/aws/resource_aws_ses_configuration_set.go
+++ b/aws/resource_aws_ses_configuration_set.go
@@ -33,7 +33,8 @@ func resourceAwsSesConfigurationSet() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"tls_policy": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Default:  ses.TlsPolicyOptional,
 							ValidateFunc: validation.StringInSlice([]string{
 								ses.TlsPolicyRequire,
 								ses.TlsPolicyOptional,
@@ -116,9 +117,11 @@ func resourceAwsSesConfigurationSetRead(d *schema.ResourceData, meta interface{}
 		tlsPolicy := map[string]interface{}{
 			"tls_policy": response.DeliveryOptions.TlsPolicy,
 		}
-
 		deliveryOptions = append(deliveryOptions, tlsPolicy)
-		d.Set("delivery_options", deliveryOptions)
+
+		if err := d.Set("delivery_options", deliveryOptions); err != nil {
+			return fmt.Errorf("Error setting delivery_options for SES configuration set %s: %s", d.Id(), err)
+		}
 	}
 
 	d.Set("name", aws.StringValue(response.ConfigurationSet.Name))

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -79,9 +79,80 @@ func TestAccAWSSESConfigurationSet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckSESConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSESConfigurationSetConfig(escRandomInteger),
+				Config: testAccAWSSESConfigurationSetBasicConfig(escRandomInteger),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESConfigurationSetExists("aws_ses_configuration_set.test"),
+				),
+			},
+			{
+				ResourceName:      "aws_ses_configuration_set.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSESConfigurationSet_deliveryOptions(t *testing.T) {
+	var escRandomInteger = acctest.RandInt()
+	resourceName := "aws_ses_configuration_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESConfigurationSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSESConfigurationSetDeliveryOptionsConfig(escRandomInteger),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESConfigurationSetExists(resourceName),
+					testAccCheckAwsSESConfigurationSetRequiresTLS(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "delivery_options.*", map[string]string{
+						"tls_policy": "Require",
+					}),
+				),
+			},
+			{
+				ResourceName:      "aws_ses_configuration_set.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSESConfigurationSet_deliveryOptionsUpdate(t *testing.T) {
+	var escRandomInteger = acctest.RandInt()
+	resourceName := "aws_ses_configuration_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESConfigurationSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSESConfigurationSetBasicConfig(escRandomInteger),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESConfigurationSetExists("aws_ses_configuration_set.test"),
+					resource.TestCheckNoResourceAttr(resourceName, "delivery_options.#"),
+				),
+			},
+			{
+				Config: testAccAWSSESConfigurationSetDeliveryOptionsConfig(escRandomInteger),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESConfigurationSetExists("aws_ses_configuration_set.test"),
+					testAccCheckAwsSESConfigurationSetRequiresTLS("aws_ses_configuration_set.test"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "delivery_options.*", map[string]string{
+						"tls_policy": "Require",
+					}),
 				),
 			},
 			{
@@ -122,6 +193,37 @@ func testAccCheckAwsSESConfigurationSetExists(n string) resource.TestCheckFunc {
 	}
 }
 
+func testAccCheckAwsSESConfigurationSetRequiresTLS(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("SES configuration set not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sesconn
+
+		describeOpts := &ses.DescribeConfigurationSetInput{
+			ConfigurationSetName:           aws.String(rs.Primary.ID),
+			ConfigurationSetAttributeNames: aws.StringSlice([]string{ses.ConfigurationSetAttributeDeliveryOptions}),
+		}
+
+		response, err := conn.DescribeConfigurationSet(describeOpts)
+		if err != nil {
+			return err
+		}
+
+		if response.DeliveryOptions == nil {
+			return fmt.Errorf("The configuration set did not have DeliveryOptions set")
+		}
+
+		if aws.StringValue(response.DeliveryOptions.TlsPolicy) != ses.TlsPolicyRequire {
+			return fmt.Errorf("The configuration set did not have DeliveryOptions with a TlsPolicy setting set to Require")
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckSESConfigurationSetDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).sesconn
 
@@ -144,10 +246,21 @@ func testAccCheckSESConfigurationSetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSSESConfigurationSetConfig(escRandomInteger int) string {
+func testAccAWSSESConfigurationSetBasicConfig(escRandomInteger int) string {
 	return fmt.Sprintf(`
 resource "aws_ses_configuration_set" "test" {
-  name = "some-configuration-set-%d"
+    name = "some-configuration-set-%d"
+}
+`, escRandomInteger)
+}
+
+func testAccAWSSESConfigurationSetDeliveryOptionsConfig(escRandomInteger int) string {
+	return fmt.Sprintf(`
+resource "aws_ses_configuration_set" "test" {
+	name = "some-configuration-set-%d"
+	delivery_options {
+		tls_policy = "Require"
+	}
 }
 `, escRandomInteger)
 }

--- a/website/docs/r/ses_configuration_set.markdown
+++ b/website/docs/r/ses_configuration_set.markdown
@@ -34,11 +34,14 @@ resource "aws_ses_configuration_set" "test" {
 
 The following arguments are supported:
 
+* `delivery_options` - (Optional) A configuration block that specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). Detailed below.
 * `name` - (Required) The name of the configuration set
 
-Delivery Options (`delivery_options`) support the following:
+### delivery_options Argument Reference
 
-* `tls_policy` - (Optional) Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). Valid values: `Require` and `Optional`. If the value is `Require`, messages are only delivered if a TLS connection can be established. If the value is `Optional`, messages can be delivered in plain text if a TLS connection can't be established. Defaults to `Optional`.
+The `delivery_options` configuration block supports the following argument:
+
+* `tls_policy` - (Optional) Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). If the value is `Require`, messages are only delivered if a TLS connection can be established. If the value is `Optional`, messages can be delivered in plain text if a TLS connection can't be established. Valid values: `Require` or `Optional`. Defaults to `Optional`.
 
 ## Import
 

--- a/website/docs/r/ses_configuration_set.markdown
+++ b/website/docs/r/ses_configuration_set.markdown
@@ -18,11 +18,27 @@ resource "aws_ses_configuration_set" "test" {
 }
 ```
 
+### Require TLS Connections
+
+```hcl
+resource "aws_ses_configuration_set" "test" {
+  name = "some-configuration-set-test"
+
+  delivery_options {
+    tls_policy = "Require"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) The name of the configuration set
+
+Delivery Options (`delivery_options`) support the following:
+
+* `tls_policy` - (Optional) Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). Valid values: `Require` and `Optional`. If the value is `Require`, messages are only delivered if a TLS connection can be established. If the value is `Optional`, messages can be delivered in plain text if a TLS connection can't be established. Defaults to `Optional`.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11197

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ses_configuration_set: Add `tls_policy` attribute to support requiring TLS as a `delivery_option`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSESConfigurationSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSESConfigurationSet -timeout 120m
=== RUN   TestAccAWSSESConfigurationSet_basic
=== PAUSE TestAccAWSSESConfigurationSet_basic
=== RUN   TestAccAWSSESConfigurationSet_deliveryOptions
=== PAUSE TestAccAWSSESConfigurationSet_deliveryOptions
=== RUN   TestAccAWSSESConfigurationSet_deliveryOptionsUpdate
=== PAUSE TestAccAWSSESConfigurationSet_deliveryOptionsUpdate
=== CONT  TestAccAWSSESConfigurationSet_basic
=== CONT  TestAccAWSSESConfigurationSet_deliveryOptionsUpdate
=== CONT  TestAccAWSSESConfigurationSet_deliveryOptions
--- PASS: TestAccAWSSESConfigurationSet_deliveryOptions (19.28s)
--- PASS: TestAccAWSSESConfigurationSet_basic (19.53s)
--- PASS: TestAccAWSSESConfigurationSet_deliveryOptionsUpdate (32.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.772s
```
