### PR TITLE
Resolves #11595 - Sensitive environment variables in AWS Lambda

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -230,7 +230,10 @@ func resourceAwsLambdaFunction() *schema.Resource {
 						"variables": {
 							Type:     schema.TypeMap,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:      schema.TypeString,
+								Sensitive: true,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #11595

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

Environment variables in AWS Lambda functions are used to provide secrets. Therefore we should mark the value as sensitive so it is not printed to the output of terraform plan and apply.
https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html

```release-note
aws_lambda_function does no longer print environment variables to the output of Terraform
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaFunction_envVariables'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunction_envVariables -timeout 120m
=== RUN   TestAccAWSLambdaFunction_envVariables
=== PAUSE TestAccAWSLambdaFunction_envVariables
=== CONT  TestAccAWSLambdaFunction_envVariables

--- PASS: TestAccAWSLambdaFunction_envVariables (276.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       276.236s
```
