### PR TITLE
Add validation function for engine field for aws_db_instance

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -72,6 +72,22 @@ func resourceAwsDbInstance() *schema.Resource {
 					value := v.(string)
 					return strings.ToLower(value)
 				},
+				ValidateFunc: validation.StringInSlice([]string{
+					"aurora",
+					"aurora-mysql",
+					"aurora-postgresql",
+					"mariadb",
+					"mysql",
+					"oracle-ee",
+					"oracle-se",
+					"oracle-se1",
+					"oracle-se2",
+					"postgres",
+					"sqlserver-ee",
+					"sqlserver-ex",
+					"sqlserver-se",
+					"sqlserver-web",
+				}, false),
 			},
 
 			"engine_version": {
@@ -861,11 +877,6 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			default:
 				opts.DBName = aws.String(attr.(string))
 			}
-		}
-
-		// allow postgresql as input as postgres
-		if strings.ToLower(d.Get("engine").(string)) == "postgresql" {
-			d.Set("engine", "postgres")
 		}
 
 		if attr, ok := d.GetOk("allocated_storage"); ok {

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -863,6 +863,11 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			}
 		}
 
+		// allow postgresql as input as postgres
+		if strings.ToLower(d.Get("engine").(string)) == "postgresql" {
+			d.Set("engine", "postgres")
+		}
+
 		if attr, ok := d.GetOk("allocated_storage"); ok {
 			modifyDbInstanceInput.AllocatedStorage = aws.Int64(int64(attr.(int)))
 			requiresModifyDbInstance = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


This is related to closed issue [4492](https://github.com/terraform-providers/terraform-provider-aws/issues/4492). And related to the open issue [11619](https://github.com/terraform-providers/terraform-provider-aws/issues/11619)

**Summary:** 
This PR is following the suggestion of [this closed PR](https://github.com/terraform-providers/terraform-provider-aws/pull/11620#event-2953339727).  If it plans, theoretically it should apply.  If `postgresql` is not a valid input then it should error out. 

**Test**
```
resource "aws_db_instance" "foo-db" {
  allocated_storage    = 100
  iops                 = 1000
  engine               = "pfoo"
  engine_version       = "11.5"
  instance_class       = "db.m5.large"
  name                 = "foodatabase"
  identifier           = "foo-database"
  username             = "postgres"
  password             = "foo"
  db_subnet_group_name = "${aws_db_subnet_group.foo-db-subnet.id}"
  vpc_security_group_ids = ["foo"]
}
resource "aws_db_subnet_group" "foo-db-subnet" {
  name       = "foo-db-subnet"
  subnet_ids =  ["12.12.12.0/24"]

  tags = {
    Name = "foo db subnet group"
  }
}
```
```
Error: expected engine to be one of [aurora aurora-mysql aurora-postgresql mariadb mysql oracle-ee oracle-se oracle-se1 oracle-se2 postgres sqlserver-ee sqlserver-ex sqlserver-se sqlserver-web], got pfoo

  on ataccama.tf line 1, in resource "aws_db_instance" "foo-db":
   1: resource "aws_db_instance" "foo-db" {
```