### PR TITLE
New resource: GameLift matchmaking rule set

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -750,6 +750,7 @@ func Provider() *schema.Provider {
 			"aws_gamelift_build":                                      resourceAwsGameliftBuild(),
 			"aws_gamelift_fleet":                                      resourceAwsGameliftFleet(),
 			"aws_gamelift_game_session_queue":                         resourceAwsGameliftGameSessionQueue(),
+			"aws_gamelift_matchmaking_rule_set":                       resourceAwsGameliftMatchmakingRuleSet(),
 			"aws_glacier_vault":                                       resourceAwsGlacierVault(),
 			"aws_glacier_vault_lock":                                  resourceAwsGlacierVaultLock(),
 			"aws_globalaccelerator_accelerator":                       resourceAwsGlobalAcceleratorAccelerator(),

--- a/aws/resource_aws_gamelift_matchmaking_rule_set.go
+++ b/aws/resource_aws_gamelift_matchmaking_rule_set.go
@@ -1,0 +1,150 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsGameliftMatchmakingRuleSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGameliftMatchmakingRuleSetCreate,
+		Read:   resourceAwsGameliftMatchmakingRuleSetRead,
+		Update: resourceAwsGameliftMatchmakingRuleSetUpdate,
+		Delete: resourceAwsGameliftMatchmakingRuleSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 128),
+			},
+			"rule_set_body": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 65535),
+					validation.ValidateJsonString,
+				),
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsGameliftMatchmakingRuleSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	input := gamelift.CreateMatchmakingRuleSetInput{
+		Name:        aws.String(d.Get("name").(string)),
+		RuleSetBody: aws.String(d.Get("rule_set_body").(string)),
+		Tags:        keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().GameliftTags(),
+	}
+	log.Printf("[INFO] Creating GameLift Matchmaking Rule Set: %s", input)
+	out, err := conn.CreateMatchmakingRuleSet(&input)
+	if err != nil {
+		return fmt.Errorf("error creating GameLift Matchmaking Rule Set: %s", err)
+	}
+
+	d.SetId(*out.RuleSet.RuleSetArn)
+
+	return resourceAwsGameliftMatchmakingRuleSetRead(d, meta)
+}
+
+func resourceAwsGameliftMatchmakingRuleSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+	log.Printf("[INFO] Describing GameLift Matchmaking Rule Set: %s", d.Id())
+	out, err := conn.DescribeMatchmakingRuleSets(&gamelift.DescribeMatchmakingRuleSetsInput{
+		Names: aws.StringSlice([]string{d.Id()}),
+	})
+	if err != nil {
+		if isAWSErr(err, gamelift.ErrCodeInvalidRequestException, "Failed to find rule set") {
+			log.Printf("[WARN] GameLift Matchmaking Rule Set (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading GameLift Matchmaking Rule Set (%s): %s", d.Id(), err)
+	}
+	ruleSets := out.RuleSets
+
+	if len(ruleSets) < 1 {
+		log.Printf("[WARN] GameLift Matchmaking Rule Set (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if len(ruleSets) != 1 {
+		return fmt.Errorf("expected exactly 1 GameLift Matchmaking Rule Set, found %d under %q",
+			len(ruleSets), d.Id())
+	}
+	ruleSet := ruleSets[0]
+
+	arn := aws.StringValue(ruleSet.RuleSetArn)
+	d.Set("arn", arn)
+	d.Set("name", ruleSet.RuleSetName)
+	d.Set("rule_set_body", ruleSet.RuleSetBody)
+
+	tags, err := keyvaluetags.GameliftListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for GameLift Matchmaking Rule Set (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsGameliftMatchmakingRuleSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	log.Printf("[INFO] Updating GameLift Matchmaking Rule Set: %s", d.Id())
+
+	arn := d.Id()
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.GameliftUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating GameLift Matchmaking Rule Set (%s) tags: %s", arn, err)
+		}
+	}
+
+	return resourceAwsGameliftMatchmakingRuleSetRead(d, meta)
+}
+
+func resourceAwsGameliftMatchmakingRuleSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+	log.Printf("[INFO] Deleting GameLift Matchmaking Rule Set: %s", d.Id())
+	_, err := conn.DeleteMatchmakingRuleSet(&gamelift.DeleteMatchmakingRuleSetInput{
+		Name: aws.String(d.Get("name").(string)),
+	})
+	if isAWSErr(err, gamelift.ErrCodeNotFoundException, "") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error deleting GameLift Matchmaking Rule Set (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_gamelift_matchmaking_rule_set.go
+++ b/aws/resource_aws_gamelift_matchmaking_rule_set.go
@@ -66,7 +66,7 @@ func resourceAwsGameliftMatchmakingRuleSetCreate(d *schema.ResourceData, meta in
 		return fmt.Errorf("error creating GameLift Matchmaking Rule Set: %s", err)
 	}
 
-	d.SetId(*out.RuleSet.RuleSetArn)
+	d.SetId(aws.StringValue(out.RuleSet.RuleSetArn))
 
 	return resourceAwsGameliftMatchmakingRuleSetRead(d, meta)
 }

--- a/aws/resource_aws_gamelift_matchmaking_rule_set.go
+++ b/aws/resource_aws_gamelift_matchmaking_rule_set.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/gamelift"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -35,7 +35,7 @@ func resourceAwsGameliftMatchmakingRuleSet() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 65535),
-					validation.ValidateJsonString,
+					validation.StringIsJSON,
 				),
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)

--- a/aws/resource_aws_gamelift_matchmaking_rule_set_test.go
+++ b/aws/resource_aws_gamelift_matchmaking_rule_set_test.go
@@ -1,0 +1,313 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+const testAccGameliftMatchmakingRuleSetPrefix = "tfAccRuleSet-"
+
+func init() {
+	resource.AddTestSweepers("aws_gamelift_matchmaking_rule_set", &resource.Sweeper{
+		Name: "aws_gamelift_matchmaking_rule_set",
+		F:    testSweepGameliftMatchmakingRuleSet,
+	})
+}
+
+func testSweepGameliftMatchmakingRuleSet(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).gameliftconn
+
+	out, err := conn.DescribeMatchmakingRuleSets(&gamelift.DescribeMatchmakingRuleSetsInput{})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Gamelift Matchmaking Rule Set sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing Gamelift Rule Set: %s", err)
+	}
+
+	if len(out.RuleSets) == 0 {
+		log.Print("[DEBUG] No Gamelift Matchmaking Rule Set to sweep")
+		return nil
+	}
+
+	log.Printf("[INFO] Found %d Gamelift Matchmaking Rule Sets", len(out.RuleSets))
+
+	for _, ruleSet := range out.RuleSets {
+		log.Printf("[INFO] Deleting Gamelift Matchmaking Rule Set %q", *ruleSet.RuleSetName)
+		_, err := conn.DeleteMatchmakingRuleSet(&gamelift.DeleteMatchmakingRuleSetInput{
+			Name: aws.String(*ruleSet.RuleSetName),
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting Gamelift Matchmaking Rule Set (%s): %s",
+				*ruleSet.RuleSetName, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccAWSGameliftMatchmakingRuleSet_basic(t *testing.T) {
+	var conf gamelift.MatchmakingRuleSet
+
+	resourceName := "aws_gamelift_matchmaking_rule_set.test"
+	ruleSetName := testAccGameliftMatchmakingRuleSetPrefix + acctest.RandString(8)
+	maxPlayers := 5
+
+	uRuleSetName := ruleSetName + "-updated"
+	uMaxPlayers := 10
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGameliftMatchmakingRuleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGameliftMatchmakingRuleSetBasicConfig(ruleSetName, maxPlayers),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftMatchmakingRuleSetExists(resourceName, &conf),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`matchmakingruleset/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleSetName),
+					resource.TestCheckResourceAttr(resourceName, "rule_set_body", testAccAWSGameliftMatchmakingRuleSetBody(maxPlayers)+"\n"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccAWSGameliftMatchmakingRuleSetBasicConfig(uRuleSetName, uMaxPlayers),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftMatchmakingRuleSetExists(resourceName, &conf),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`matchmakingruleset/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", uRuleSetName),
+					resource.TestCheckResourceAttr(resourceName, "rule_set_body", testAccAWSGameliftMatchmakingRuleSetBody(uMaxPlayers)+"\n"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGameliftMatchmakingRuleSet_tags(t *testing.T) {
+	var conf gamelift.MatchmakingRuleSet
+
+	resourceName := "aws_gamelift_matchmaking_rule_set.test"
+	ruleSetName := testAccGameliftMatchmakingRuleSetPrefix + acctest.RandString(8)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGameliftMatchmakingRuleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGameliftMatchmakingRuleSetBasicConfigTags1(ruleSetName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftMatchmakingRuleSetExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSGameliftMatchmakingRuleSetBasicConfigTags2(ruleSetName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftMatchmakingRuleSetExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSGameliftMatchmakingRuleSetBasicConfigTags1(ruleSetName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftMatchmakingRuleSetExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSGameliftMatchmakingRuleSet_disappears(t *testing.T) {
+	var conf gamelift.MatchmakingRuleSet
+
+	resourceName := "aws_gamelift_matchmaking_rule_set.test"
+	ruleSetName := testAccGameliftMatchmakingRuleSetPrefix + acctest.RandString(8)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGameliftMatchmakingRuleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGameliftMatchmakingRuleSetBasicConfig(ruleSetName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftMatchmakingRuleSetExists(resourceName, &conf),
+					testAccCheckAWSGameliftMatchmakingRuleSetDisappears(&conf),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSGameliftMatchmakingRuleSetExists(n string, res *gamelift.MatchmakingRuleSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no Gamelift Matchmaking Rule Set Name is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+		name := rs.Primary.Attributes["name"]
+		out, err := conn.DescribeMatchmakingRuleSets(&gamelift.DescribeMatchmakingRuleSetsInput{
+			Names: aws.StringSlice([]string{name}),
+		})
+		if err != nil {
+			return err
+		}
+		ruleSets := out.RuleSets
+		if len(ruleSets) == 0 {
+			return fmt.Errorf("GameLift Matchmaking Rule Set %q not found", name)
+		}
+
+		*res = *ruleSets[0]
+
+		return nil
+	}
+}
+
+func testAccCheckAWSGameliftMatchmakingRuleSetDisappears(res *gamelift.MatchmakingRuleSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+		input := &gamelift.DeleteMatchmakingRuleSetInput{Name: res.RuleSetName}
+
+		_, err := conn.DeleteMatchmakingRuleSet(input)
+
+		return err
+	}
+}
+
+func testAccCheckAWSGameliftMatchmakingRuleSetDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_gamelift_matchmaking_rule_set" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+
+		input := &gamelift.DescribeMatchmakingRuleSetsInput{
+			Names: aws.StringSlice([]string{name}),
+		}
+
+		// Deletions can take a few seconds
+		err := resource.Retry(30*time.Second, func() *resource.RetryError {
+			out, err := conn.DescribeMatchmakingRuleSets(input)
+
+			if isAWSErr(err, gamelift.ErrCodeInvalidRequestException, "Failed to find rule set") {
+				return nil
+			}
+
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			ruleSets := out.RuleSets
+
+			if len(ruleSets) > 0 {
+				return resource.RetryableError(fmt.Errorf("GameLift Matchmaking Rule Set still exists"))
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSGameliftMatchmakingRuleSetBody(maxPlayers int) string {
+	return fmt.Sprintf(`{
+	"name": "test",
+	"ruleLanguageVersion": "1.0",
+	"teams": [{
+		"name": "alpha",
+		"minPlayers": 1,
+		"maxPlayers": %[1]d
+	}]
+}`, maxPlayers)
+}
+
+func testAccAWSGameliftMatchmakingRuleSetBasicConfig(rName string, maxPlayers int) string {
+	return fmt.Sprintf(`
+resource "aws_gamelift_matchmaking_rule_set" "test" {
+  name          = %[1]q
+  rule_set_body = <<RULE_SET_BODY
+%[2]s
+RULE_SET_BODY
+}
+`, rName, testAccAWSGameliftMatchmakingRuleSetBody(maxPlayers))
+}
+
+func testAccAWSGameliftMatchmakingRuleSetBasicConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_gamelift_matchmaking_rule_set" "test" {
+  name          = %[1]q
+  rule_set_body = <<RULE_SET_BODY
+%[2]s
+RULE_SET_BODY
+  tags = {
+    %[3]q = %[4]q
+  }
+}
+`, rName, testAccAWSGameliftMatchmakingRuleSetBody(1), tagKey1, tagValue1)
+}
+
+func testAccAWSGameliftMatchmakingRuleSetBasicConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_gamelift_matchmaking_rule_set" "test" {
+  name          = %[1]q
+  rule_set_body = <<RULE_SET_BODY
+%[2]s
+RULE_SET_BODY
+  tags = {
+    %[3]q = %[4]q
+    %[5]q = %[6]q
+  }
+}
+`, rName, testAccAWSGameliftMatchmakingRuleSetBody(1), tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_gamelift_matchmaking_rule_set_test.go
+++ b/aws/resource_aws_gamelift_matchmaking_rule_set_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/gamelift"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const testAccGameliftMatchmakingRuleSetPrefix = "tfAccRuleSet-"

--- a/aws/resource_aws_gamelift_matchmaking_rule_set_test.go
+++ b/aws/resource_aws_gamelift_matchmaking_rule_set_test.go
@@ -75,6 +75,7 @@ func TestAccAWSGameliftMatchmakingRuleSet_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
+		ErrorCheck:   testAccErrorCheck(t, gamelift.EndpointsID),
 		CheckDestroy: testAccCheckAWSGameliftMatchmakingRuleSetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -115,6 +116,7 @@ func TestAccAWSGameliftMatchmakingRuleSet_tags(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
+		ErrorCheck:   testAccErrorCheck(t, gamelift.EndpointsID),
 		CheckDestroy: testAccCheckAWSGameliftMatchmakingRuleSetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -160,6 +162,7 @@ func TestAccAWSGameliftMatchmakingRuleSet_disappears(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
+		ErrorCheck:   testAccErrorCheck(t, gamelift.EndpointsID),
 		CheckDestroy: testAccCheckAWSGameliftMatchmakingRuleSetDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/website/docs/r/gamelift_matchmaking_rule_set.html.markdown
+++ b/website/docs/r/gamelift_matchmaking_rule_set.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Gamelift"
+layout: "aws"
+page_title: "AWS: aws_gamelift_matchmaking_rule_set"
+description: |-
+  Provides a Gamelift Matchmaking Rule Set resource.
+---
+
+# Resource: aws_gamelift_matchmaking_rule_set
+
+Provides a Gamelift Matchmaking Rule Set resource.
+
+## Example Usage
+
+```hcl
+resource "aws_gamelift_matchmaking_rule_set" "test" {
+  name = "example-rule-set"
+
+  rule_set_body = <<RULE_SET_BODY
+{
+  "name": "test",
+  "ruleLanguageVersion": "1.0",
+  "teams": [{
+    "name": "alpha",
+    "minPlayers": 1,
+    "maxPlayers": 5
+  }]
+}
+RULE_SET_BODY
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the matchmaking rule set.
+* `rule_set_body` - (Required) A collection of matchmaking rules, formatted as a JSON string.
+* `tags` - (Optional) Key-value mapping of resource tags.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Matchmaking Rule Set ARN.
+
+## Import
+
+Gamelift Matchmaking Rule Sets can be imported by their `name`, e.g.
+
+```
+$ terraform import aws_gamelift_matchmaking_rule_set.example example
+```

--- a/website/docs/r/gamelift_matchmaking_rule_set.html.markdown
+++ b/website/docs/r/gamelift_matchmaking_rule_set.html.markdown
@@ -8,23 +8,23 @@ description: |-
 
 # Resource: aws_gamelift_matchmaking_rule_set
 
-Provides a Gamelift Matchmaking Rule Set resource.
+Provides an Gamelift Matchmaking Rule Set resource.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "aws_gamelift_matchmaking_rule_set" "test" {
   name = "example-rule-set"
 
   rule_set_body = <<RULE_SET_BODY
 {
-  "name": "test",
+  "name": "rule-set",
   "ruleLanguageVersion": "1.0",
   "teams": [{
     "name": "alpha",
     "minPlayers": 1,
     "maxPlayers": 5
-  }]
+  }]"
 }
 RULE_SET_BODY
 }
@@ -34,19 +34,20 @@ RULE_SET_BODY
 
 The following arguments are supported:
 
-* `name` - (Required) Name of the matchmaking rule set.
-* `rule_set_body` - (Required) A collection of matchmaking rules, formatted as a JSON string.
-* `tags` - (Optional) Key-value mapping of resource tags.
+* `name` - (Required) Name of the rule set.
+* `rule_set_body` - (Required) A collection of matchmaking rules, formatted as a JSON string. Comments are not allowed in JSON, but most elements support a description field.
+* `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - Matchmaking Rule Set ARN.
+* `arn` - Rule Set ARN.
 
 ## Import
 
-Gamelift Matchmaking Rule Sets can be imported by their `name`, e.g.
+Gamelift Match Making Rule Sets can be imported by their `name`, e.g.
 
 ```
 $ terraform import aws_gamelift_matchmaking_rule_set.example example


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: aws_gamelift_matchmaking_rule_set
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGameliftMatchmakingRuleSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGameliftMatchmakingRuleSet -timeout 120m
=== RUN   TestAccAWSGameliftMatchmakingRuleSet_basic
--- PASS: TestAccAWSGameliftMatchmakingRuleSet_basic (44.35s)
=== RUN   TestAccAWSGameliftMatchmakingRuleSet_tags
--- PASS: TestAccAWSGameliftMatchmakingRuleSet_tags (61.16s)
=== RUN   TestAccAWSGameliftMatchmakingRuleSet_disappears
--- PASS: TestAccAWSGameliftMatchmakingRuleSet_disappears (20.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	125.840s
```
