### PR TITLE
Fix lambda provision id parser

### DIFF
--- a/aws/resource_aws_lambda_provisioned_concurrency_config_test.go
+++ b/aws/resource_aws_lambda_provisioned_concurrency_config_test.go
@@ -352,7 +352,7 @@ func testAccAWSLambdaProvisionedConcurrencyConfigRefByFunctionArn(rName, qualifi
 	return testAccAWSLambdaProvisionedConcurrencyConfigBase(rName) + fmt.Sprintf(`
 
 	resource "aws_lambda_alias" "test" {
-		count = %t ? 1 : 0
+		count 			 = %t ? 1 : 0
 		function_name    = aws_lambda_function.test.function_name
 		function_version = aws_lambda_function.test.version
 		name             = "test"
@@ -371,7 +371,7 @@ func testAccAWSLambdaProvisionedConcurrencyConfigRefByPartialFunctionArn(rName, 
 data "aws_caller_identity" "current" {}
 
 resource "aws_lambda_alias" "test" {
-	count = %t ? 1 : 0
+	count 			 = %t ? 1 : 0
 	function_name    = aws_lambda_function.test.function_name
 	function_version = aws_lambda_function.test.version
 	name             = "test"
@@ -388,7 +388,7 @@ resource "aws_lambda_provisioned_concurrency_config" "test" {
 func testAccAWSLambdaProvisionedConcurrencyConfigRefByFunctionName(rName, qualifierAddress string, createAlias bool) string {
 	return testAccAWSLambdaProvisionedConcurrencyConfigBase(rName) + fmt.Sprintf(`
 resource "aws_lambda_alias" "test" {
-	count = %t ? 1 : 0
+	count 			= %t ? 1 : 0
 	function_name    = aws_lambda_function.test.function_name
 	function_version = aws_lambda_function.test.version
 	name             = "test"

--- a/aws/resource_aws_lambda_provisioned_concurrency_config_test.go
+++ b/aws/resource_aws_lambda_provisioned_concurrency_config_test.go
@@ -143,12 +143,13 @@ func TestAccAWSLambdaProvisionedConcurrencyConfig_ProvisionedConcurrentExecution
 
 func TestAccAWSLambdaProvisionedConcurrencyConfig_Qualifier_AliasName(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	lambdaAliasResourceName := "aws_lambda_alias.test"
-	qualifierAddress := fmt.Sprintf("%s[0].name", lambdaAliasResourceName)
+	lambdaAliasResourceName := "aws_lambda_alias.test.0"
+	qualifierAddress := fmt.Sprintf("%s.name", lambdaAliasResourceName)
 	createAlias := true
 	resourceName := "aws_lambda_provisioned_concurrency_config.test"
 
 	resource.ParallelTest(t, resource.TestCase{
+
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLambdaProvisionedConcurrencyConfigDestroy,


### PR DESCRIPTION
# Overview

This PR primarily encompasses three modifications that are delineated by each of the commits included in the PR:

1. Generate unique id for Lambda function name so that the tests can run in parallel 
1. Support all the permitted variations of the `function_name` parameter value per the [PutProvisionedConcurrencyConfig API documentation](https://docs.aws.amazon.com/lambda/latest/dg/API_PutProvisionedConcurrencyConfig.html) and update test cases
1. Use more explicit variable names, i.e., `lambdaName` instead of `rName` since the value is used as the `function_name` property for Lambda resource by the config generator
 
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11152

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lambda_provisioned_concurrency_config: Allow `function_arn` and `partial_arn` as valid `function_name` parameter values
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaProvisionedConcurrencyConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaProvisionedConcurrencyConfig -timeout 120m
=== RUN   TestAccAWSLambdaProvisionedConcurrencyConfig_QualifierFunctionName
=== PAUSE TestAccAWSLambdaProvisionedConcurrencyConfig_QualifierFunctionName
=== RUN   TestAccAWSLambdaProvisionedConcurrencyConfig_disappears_LambdaFunction
=== PAUSE TestAccAWSLambdaProvisionedConcurrencyConfig_disappears_LambdaFunction
=== RUN   TestAccAWSLambdaProvisionedConcurrencyConfig_disappears_LambdaProvisionedConcurrencyConfig
=== PAUSE TestAccAWSLambdaProvisionedConcurrencyConfig_disappears_LambdaProvisionedConcurrencyConfig
=== RUN   TestAccAWSLambdaProvisionedConcurrencyConfig_ProvisionedConcurrentExecutions
=== PAUSE TestAccAWSLambdaProvisionedConcurrencyConfig_ProvisionedConcurrentExecutions
=== RUN   TestAccAWSLambdaProvisionedConcurrencyConfig_Qualifier_AliasName
=== PAUSE TestAccAWSLambdaProvisionedConcurrencyConfig_Qualifier_AliasName
=== CONT  TestAccAWSLambdaProvisionedConcurrencyConfig_QualifierFunctionName
=== CONT  TestAccAWSLambdaProvisionedConcurrencyConfig_Qualifier_AliasName
=== CONT  TestAccAWSLambdaProvisionedConcurrencyConfig_disappears_LambdaProvisionedConcurrencyConfig
=== CONT  TestAccAWSLambdaProvisionedConcurrencyConfig_disappears_LambdaFunction
=== CONT  TestAccAWSLambdaProvisionedConcurrencyConfig_ProvisionedConcurrentExecutions
--- PASS: TestAccAWSLambdaProvisionedConcurrencyConfig_disappears_LambdaFunction (245.96s)
--- PASS: TestAccAWSLambdaProvisionedConcurrencyConfig_disappears_LambdaProvisionedConcurrencyConfig (269.41s)
--- PASS: TestAccAWSLambdaProvisionedConcurrencyConfig_Qualifier_AliasName (397.47s)
--- PASS: TestAccAWSLambdaProvisionedConcurrencyConfig_ProvisionedConcurrentExecutions (400.98s)
--- PASS: TestAccAWSLambdaProvisionedConcurrencyConfig_QualifierFunctionName (518.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       529.681s

...
```
