### PR TITLE
r/cloudwatch_log_destination: add plan time validation to `role_arn` and `target_arn`

### DIFF
--- a/.changelog/11687.txt
+++ b/.changelog/11687.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_log_destination: Add plan time validation to `role_arn`, `name` and `target_arn`.
+```

--- a/aws/resource_aws_cloudwatch_log_destination.go
+++ b/aws/resource_aws_cloudwatch_log_destination.go
@@ -32,13 +32,15 @@ func resourceAwsCloudWatchLogDestination() *schema.Resource {
 			},
 
 			"role_arn": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"target_arn": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"arn": {
@@ -53,21 +55,20 @@ func resourceAwsCloudWatchLogDestinationPut(d *schema.ResourceData, meta interfa
 	conn := meta.(*AWSClient).cloudwatchlogsconn
 
 	name := d.Get("name").(string)
-	role_arn := d.Get("role_arn").(string)
-	target_arn := d.Get("target_arn").(string)
+	roleArn := d.Get("role_arn").(string)
+	targetArn := d.Get("target_arn").(string)
 
 	params := &cloudwatchlogs.PutDestinationInput{
 		DestinationName: aws.String(name),
-		RoleArn:         aws.String(role_arn),
-		TargetArn:       aws.String(target_arn),
+		RoleArn:         aws.String(roleArn),
+		TargetArn:       aws.String(targetArn),
 	}
 
-	var resp *cloudwatchlogs.PutDestinationOutput
 	var err error
 	err = resource.Retry(3*time.Minute, func() *resource.RetryError {
-		resp, err = conn.PutDestination(params)
+		_, err = conn.PutDestination(params)
 
-		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "Could not deliver test message to specified") {
+		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "") {
 			return resource.RetryableError(err)
 		}
 		if err != nil {
@@ -76,20 +77,20 @@ func resourceAwsCloudWatchLogDestinationPut(d *schema.ResourceData, meta interfa
 		return nil
 	})
 	if isResourceTimeoutError(err) {
-		resp, err = conn.PutDestination(params)
+		_, err = conn.PutDestination(params)
 	}
 	if err != nil {
 		return fmt.Errorf("Error putting cloudwatch log destination: %s", err)
 	}
 	d.SetId(name)
-	d.Set("arn", resp.Destination.Arn)
-	return nil
+
+	return resourceAwsCloudWatchLogDestinationRead(d, meta)
 }
 
 func resourceAwsCloudWatchLogDestinationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudwatchlogsconn
-	name := d.Get("name").(string)
-	destination, exists, err := lookupCloudWatchLogDestination(conn, name, nil)
+
+	destination, exists, err := lookupCloudWatchLogDestination(conn, d.Id(), nil)
 	if err != nil {
 		return err
 	}
@@ -99,7 +100,6 @@ func resourceAwsCloudWatchLogDestinationRead(d *schema.ResourceData, meta interf
 		return nil
 	}
 
-	d.SetId(name)
 	d.Set("arn", destination.Arn)
 	d.Set("role_arn", destination.RoleArn)
 	d.Set("target_arn", destination.TargetArn)
@@ -110,14 +110,12 @@ func resourceAwsCloudWatchLogDestinationRead(d *schema.ResourceData, meta interf
 func resourceAwsCloudWatchLogDestinationDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudwatchlogsconn
 
-	name := d.Get("name").(string)
-
 	params := &cloudwatchlogs.DeleteDestinationInput{
-		DestinationName: aws.String(name),
+		DestinationName: aws.String(d.Id()),
 	}
 	_, err := conn.DeleteDestination(params)
 	if err != nil {
-		return fmt.Errorf("Error deleting Destination with name %s", name)
+		return fmt.Errorf("Error deleting Destination with name %s", d.Id())
 	}
 
 	return nil

--- a/aws/resource_aws_cloudwatch_log_destination.go
+++ b/aws/resource_aws_cloudwatch_log_destination.go
@@ -2,12 +2,14 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsCloudWatchLogDestination() *schema.Resource {
@@ -29,6 +31,10 @@ func resourceAwsCloudWatchLogDestination() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.Any(
+					validation.StringLenBetween(1, 512),
+					validation.StringMatch(regexp.MustCompile(`[^:*]*`), ""),
+				),
 			},
 
 			"role_arn": {

--- a/aws/resource_aws_cloudwatch_log_destination_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_test.go
@@ -56,7 +56,7 @@ func TestAccAWSCloudwatchLogDestination_disappears(t *testing.T) {
 				Config: testAccAWSCloudwatchLogDestinationConfig(rstring),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloudwatchLogDestinationExists(resourceName, &destination),
-					testAccCheckAWSCloudwatchLogDestinationDisappears(&destination),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchLogDestination(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -104,18 +104,6 @@ func testAccCheckAWSCloudwatchLogDestinationExists(n string, d *cloudwatchlogs.D
 		*d = *destination
 
 		return nil
-	}
-}
-
-func testAccCheckAWSCloudwatchLogDestinationDisappears(d *cloudwatchlogs.Destination) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-
-		conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
-		input := &cloudwatchlogs.DeleteDestinationInput{DestinationName: d.DestinationName}
-
-		_, err := conn.DeleteDestination(input)
-
-		return err
 	}
 }
 

--- a/aws/resource_aws_cloudwatch_log_destination_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -13,6 +14,8 @@ import (
 func TestAccAWSCloudwatchLogDestination_basic(t *testing.T) {
 	var destination cloudwatchlogs.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
+	streamResourceName := "aws_kinesis_stream.test"
+	roleResourceName := "aws_iam_role.test"
 	rstring := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,12 +27,38 @@ func TestAccAWSCloudwatchLogDestination_basic(t *testing.T) {
 				Config: testAccAWSCloudwatchLogDestinationConfig(rstring),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloudwatchLogDestinationExists(resourceName, &destination),
+					resource.TestCheckResourceAttrPair(resourceName, "target_arn", streamResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", roleResourceName, "arn"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "logs", regexp.MustCompile(`destination:.+`)),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudwatchLogDestination_disappears(t *testing.T) {
+	var destination cloudwatchlogs.Destination
+	resourceName := "aws_cloudwatch_log_destination.test"
+
+	rstring := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudwatchLogDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudwatchLogDestinationConfig(rstring),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloudwatchLogDestinationExists(resourceName, &destination),
+					testAccCheckAWSCloudwatchLogDestinationDisappears(&destination),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -78,10 +107,22 @@ func testAccCheckAWSCloudwatchLogDestinationExists(n string, d *cloudwatchlogs.D
 	}
 }
 
+func testAccCheckAWSCloudwatchLogDestinationDisappears(d *cloudwatchlogs.Destination) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
+		input := &cloudwatchlogs.DeleteDestinationInput{DestinationName: d.DestinationName}
+
+		_, err := conn.DeleteDestination(input)
+
+		return err
+	}
+}
+
 func testAccAWSCloudwatchLogDestinationConfig(rstring string) string {
 	return fmt.Sprintf(`
 resource "aws_kinesis_stream" "test" {
-  name        = "RootAccess_%s"
+  name        = "RootAccess_%[1]s"
   shard_count = 1
 }
 
@@ -107,7 +148,7 @@ data "aws_iam_policy_document" "role" {
 }
 
 resource "aws_iam_role" "test" {
-  name               = "CWLtoKinesisRole_%s"
+  name               = "CWLtoKinesisRole_%[1]s"
   assume_role_policy = data.aws_iam_policy_document.role.json
 }
 
@@ -138,13 +179,13 @@ data "aws_iam_policy_document" "policy" {
 }
 
 resource "aws_iam_role_policy" "test" {
-  name   = "Permissions-Policy-For-CWL_%s"
+  name   = "Permissions-Policy-For-CWL_%[1]s"
   role   = aws_iam_role.test.id
   policy = data.aws_iam_policy_document.policy.json
 }
 
 resource "aws_cloudwatch_log_destination" "test" {
-  name       = "testDestination_%s"
+  name       = "testDestination_%[1]s"
   target_arn = aws_kinesis_stream.test.arn
   role_arn   = aws_iam_role.test.arn
   depends_on = [aws_iam_role_policy.test]
@@ -176,5 +217,5 @@ resource "aws_cloudwatch_log_destination_policy" "test" {
   destination_name = aws_cloudwatch_log_destination.test.name
   access_policy    = data.aws_iam_policy_document.access.json
 }
-`, rstring, rstring, rstring, rstring)
+`, rstring)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cloudwatch_log_destination: add plan time validation to `role_arn` and `target_arn`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudwatchLogDestination_'
--- PASS: TestAccAWSCloudwatchLogDestination_basic (131.03s)
--- PASS: TestAccAWSCloudwatchLogDestination_disappears (129.64s)
```
