### PR TITLE
r/spot_fleet_request: Add additional launch_specification attributes to hashing to improve diff

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1316,6 +1316,63 @@ func hashLaunchSpecification(v interface{}) int {
 	}
 	buf.WriteString(fmt.Sprintf("%s-", m["instance_type"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["spot_price"].(string)))
+
+	if v, ok := m["vpc_security_group_ids"].(*schema.Set); ok {
+		for _, v := range v.List() {
+			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+		}
+	}
+
+	if v, ok := m["associate_public_ip_address"].(bool); ok {
+		buf.WriteString(fmt.Sprintf("%t-", v))
+	}
+
+	if v, ok := m["ebs_optimized"].(bool); ok {
+		buf.WriteString(fmt.Sprintf("%t-", v))
+	}
+
+	if v, ok := m["monitoring"].(bool); ok {
+		buf.WriteString(fmt.Sprintf("%t-", v))
+	}
+
+	if v, ok := m["iam_instance_profile"].(string); ok {
+		buf.WriteString(fmt.Sprintf("%s-", v))
+	}
+
+	if v, ok := m["iam_instance_profile_arn"].(string); ok {
+		buf.WriteString(fmt.Sprintf("%s-", v))
+	}
+
+	if v, ok := m["key_name"].(string); ok {
+		buf.WriteString(fmt.Sprintf("%s-", v))
+	}
+
+	if v, ok := m["weighted_capacity"].(string); ok {
+		buf.WriteString(fmt.Sprintf("%s-", v))
+	}
+
+	if v, ok := m["tags"].(map[string]interface{}); ok {
+		buf.WriteString(fmt.Sprintf("%d-", tagsMapToHash(v)))
+	}
+
+	if v, ok := m["root_block_device"].(*schema.Set); ok {
+		for _, v := range v.List() {
+			buf.WriteString(fmt.Sprintf("%d-", hashRootBlockDevice(v)))
+		}
+	}
+
+	if v, ok := m["ebs_block_device"].(*schema.Set); ok {
+		for _, v := range v.List() {
+			buf.WriteString(fmt.Sprintf("%d-", hashEbsBlockDevice(v)))
+		}
+	}
+
+	if v, ok := m["ephemeral_block_device"].(*schema.Set); ok {
+		for _, v := range v.List() {
+			buf.WriteString(fmt.Sprintf("%d-", hashEphemeralBlockDevice(v)))
+		}
+	}
+
 	return hashcode.String(buf.String())
 }
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #741: 

`launch_specification` currently implements its' own hashing, covering only a few attributes. Ideally, I think it should use the default hash-function to cover all attributes. However, the `user_data` fields custom state function seems to cause problems there (see more details in [this comment](https://github.com/terraform-providers/terraform-provider-aws/issues/741#issuecomment-570987832)). I couldn't figure out how to solve this issue so instead, here's a PR that solves the problem at least partially, implementing hashing at least for other attributes. 

If someone has any good ideas how to resolve the `user_data` issue, I'd be happy to close this PR and work on a more comprehensive fix for the issue. Otherwise, this PR may at least reduce the impact of the problem for some users. 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Include more launch_specification attributes in diffing
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSpotFleetRequest_updateLaunchConfig'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSpotFleetRequest_updateLaunchConfig -timeout 120m
=== RUN   TestAccAWSSpotFleetRequest_updateLaunchConfig
=== PAUSE TestAccAWSSpotFleetRequest_updateLaunchConfig
=== CONT  TestAccAWSSpotFleetRequest_updateLaunchConfig
--- PASS: TestAccAWSSpotFleetRequest_updateLaunchConfig (419.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	419.793s
...
```
