### PR TITLE
r/ssm_patch_baseline - approved/rejected patch enhancements + arn + validations

### DIFF
--- a/.changelog/11772.txt
+++ b/.changelog/11772.txt
@@ -4,7 +4,7 @@ resource/aws_ssm_patch_baseline: Adds plan time validation for `name`, `descript
 ```
 
 ```release-note:enhancement
-resource/aws_ssm_patch_baseline: Adds support for `rejected_patches_action` and `approved_patches_enable_non_security`.
+resource/aws_ssm_patch_baseline: Add `approved_patches_enable_non_security` and `rejected_patches_action` arguments
 ```
 
 ```release-note:enhancement

--- a/.changelog/11772.txt
+++ b/.changelog/11772.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_ssm_patch_baseline: Add plan time validation for `name`, `description`, `global_filter.key`, `global_filter.values`,
+`approved_patches`, `rejected_patches`.
+```

--- a/.changelog/11772.txt
+++ b/.changelog/11772.txt
@@ -1,4 +1,12 @@
 ```release-note:enhancement
-resource/aws_ssm_patch_baseline: Add plan time validation for `name`, `description`, `global_filter.key`, `global_filter.values`,
+resource/aws_ssm_patch_baseline: Adds plan time validation for `name`, `description`, `global_filter.key`, `global_filter.values`,
 `approved_patches`, `rejected_patches`.
+```
+
+```release-note:enhancement
+resource/aws_ssm_patch_baseline: Adds support for `rejected_patches_action` and `approved_patches_enable_non_security`.
+```
+
+```release-note:enhancement
+resource/aws_ssm_patch_baseline: Adds `arn` attribute.
 ```

--- a/.changelog/11772.txt
+++ b/.changelog/11772.txt
@@ -1,6 +1,6 @@
 ```release-note:enhancement
 resource/aws_ssm_patch_baseline: Adds plan time validation for `name`, `description`, `global_filter.key`, `global_filter.values`,
-`approved_patches`, `rejected_patches`.
+`approved_patches`, `rejected_patches`, `approval_rule.approve_after_days`, `approval_rule.patch_filter.key`, and `approval_rule.patch_filter.values`.
 ```
 
 ```release-note:enhancement

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -75,8 +75,9 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"approve_after_days": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntBetween(0, 100),
 						},
 
 						"compliance_level": {
@@ -99,13 +100,19 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(ssm.PatchFilterKey_Values(), false),
 									},
 									"values": {
 										Type:     schema.TypeList,
 										Required: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										MaxItems: 20,
+										MinItems: 1,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringLenBetween(1, 64),
+										},
 									},
 								},
 							},

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -177,7 +177,7 @@ func resourceAwsSsmPatchBaselineCreate(d *schema.ResourceData, meta interface{})
 		params.ApprovalRules = expandAwsSsmPatchRuleGroup(d)
 	}
 
-	if v, ok := d.GetOk("approved_patches_enable_non_security"); ok && aws.StringValue(params.OperatingSystem) != ssm.OperatingSystemWindows {
+	if v, ok := d.GetOk("approved_patches_enable_non_security"); ok {
 		params.ApprovedPatchesEnableNonSecurity = aws.Bool(v.(bool))
 	}
 

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -25,11 +26,16 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.Any(
+					validation.StringLenBetween(3, 128),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`), ""),
+				),
 			},
 
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 
 			"global_filter": {
@@ -39,13 +45,19 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(ssm.PatchFilterKey_Values(), false),
 						},
 						"values": {
 							Type:     schema.TypeList,
 							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							MaxItems: 20,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringLenBetween(1, 64),
+							},
 						},
 					},
 				},
@@ -99,13 +111,21 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 			"approved_patches": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				MaxItems: 50,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(1, 100),
+				},
 			},
 
 			"rejected_patches": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				MaxItems: 50,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(1, 100),
+				},
 			},
 
 			"operating_system": {

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -177,7 +177,7 @@ func resourceAwsSsmPatchBaselineCreate(d *schema.ResourceData, meta interface{})
 		params.ApprovalRules = expandAwsSsmPatchRuleGroup(d)
 	}
 
-	if v, ok := d.GetOk("approved_patches_enable_non_security"); ok {
+	if v, ok := d.GetOk("approved_patches_enable_non_security"); ok && aws.StringValue(params.OperatingSystem) != ssm.OperatingSystemWindows {
 		params.ApprovedPatchesEnableNonSecurity = aws.Bool(v.(bool))
 	}
 

--- a/aws/resource_aws_ssm_patch_baseline_test.go
+++ b/aws/resource_aws_ssm_patch_baseline_test.go
@@ -429,6 +429,7 @@ func testAccAWSSSMPatchBaselineBasicConfigApprovedPatchesNonSec(rName string) st
 	return fmt.Sprintf(`
 resource "aws_ssm_patch_baseline" "test" {
   name                                 = %q
+  operating_system                     = "AMAZON_LINUX"
   description                          = "Baseline containing all updates approved for production systems"
   approved_patches                     = ["KB123456"]
   approved_patches_compliance_level    = "CRITICAL"

--- a/aws/resource_aws_ssm_patch_baseline_test.go
+++ b/aws/resource_aws_ssm_patch_baseline_test.go
@@ -118,7 +118,7 @@ func TestAccAWSSSMPatchBaseline_disappears(t *testing.T) {
 				Config: testAccAWSSSMPatchBaselineBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMPatchBaselineExists(resourceName, &identity),
-					testAccCheckAWSSSMPatchBaselineDisappears(&identity),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSsmPatchBaseline(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -261,24 +261,6 @@ func testAccCheckAWSSSMPatchBaselineExists(n string, patch *ssm.PatchBaselineIde
 		}
 
 		return fmt.Errorf("No AWS SSM Patch Baseline found")
-	}
-}
-
-func testAccCheckAWSSSMPatchBaselineDisappears(patch *ssm.PatchBaselineIdentity) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ssmconn
-
-		id := aws.StringValue(patch.BaselineId)
-		params := &ssm.DeletePatchBaselineInput{
-			BaselineId: aws.String(id),
-		}
-
-		_, err := conn.DeletePatchBaseline(params)
-		if err != nil {
-			return fmt.Errorf("error deleting Patch Baseline %s: %s", id, err)
-		}
-
-		return nil
 	}
 }
 

--- a/aws/resource_aws_ssm_patch_baseline_test.go
+++ b/aws/resource_aws_ssm_patch_baseline_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -24,6 +25,7 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 				Config: testAccAWSSSMPatchBaselineBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMPatchBaselineExists(resourceName, &before),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ssm", regexp.MustCompile(`patchbaseline/pb-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "approved_patches.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "approved_patches.*", "KB123456"),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("patch-baseline-%s", name)),
@@ -42,6 +44,7 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 				Config: testAccAWSSSMPatchBaselineBasicConfigUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMPatchBaselineExists(resourceName, &after),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ssm", regexp.MustCompile(`patchbaseline/pb-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "approved_patches.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "approved_patches.*", "KB123456"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "approved_patches.*", "KB456789"),
@@ -50,7 +53,7 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "Baseline containing all updates approved for production systems - August 2017"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					func(*terraform.State) error {
-						if *before.BaselineId != *after.BaselineId {
+						if aws.StringValue(before.BaselineId) != aws.StringValue(after.BaselineId) {
 							t.Fatal("Baseline IDs changed unexpectedly")
 						}
 						return nil

--- a/website/docs/r/ssm_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_patch_baseline.html.markdown
@@ -132,6 +132,8 @@ The following arguments are supported:
 * `rejected_patches` - (Optional) A list of rejected patches.
 * `global_filter` - (Optional) A set of global filters used to exclude patches from the baseline. Up to 4 global filters can be specified using Key/Value pairs. Valid Keys are `PRODUCT | CLASSIFICATION | MSRC_SEVERITY | PATCH_ID`.
 * `approval_rule` - (Optional) A set of rules used to include patches in the baseline. up to 10 approval rules can be specified. Each approval_rule block requires the fields documented below.
+* `rejected_patches_action` - (Optional) Indicates whether the list of approved patches includes non-security updates that should be applied to the instances. Applies to Linux instances only.
+* `approved_patches_enable_non_security` - (Optional) The action for Patch Manager to take on patches included in the `rejected_patches` list. Allow values are `ALLOW_AS_DEPENDENCY` and `BLOCK`.
 
 The `approval_rule` block supports:
 

--- a/website/docs/r/ssm_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_patch_baseline.html.markdown
@@ -132,8 +132,8 @@ The following arguments are supported:
 * `rejected_patches` - (Optional) A list of rejected patches.
 * `global_filter` - (Optional) A set of global filters used to exclude patches from the baseline. Up to 4 global filters can be specified using Key/Value pairs. Valid Keys are `PRODUCT | CLASSIFICATION | MSRC_SEVERITY | PATCH_ID`.
 * `approval_rule` - (Optional) A set of rules used to include patches in the baseline. up to 10 approval rules can be specified. Each approval_rule block requires the fields documented below.
-* `rejected_patches_action` - (Optional) Indicates whether the list of approved patches includes non-security updates that should be applied to the instances. Applies to Linux instances only.
-* `approved_patches_enable_non_security` - (Optional) The action for Patch Manager to take on patches included in the `rejected_patches` list. Allow values are `ALLOW_AS_DEPENDENCY` and `BLOCK`.
+* `rejected_patches_action` - (Optional) The action for Patch Manager to take on patches included in the `rejected_patches` list. Allow values are `ALLOW_AS_DEPENDENCY` and `BLOCK`.
+* `approved_patches_enable_non_security` - (Optional) Indicates whether the list of approved patches includes non-security updates that should be applied to the instances. Applies to Linux instances only.
 
 The `approval_rule` block supports:
 

--- a/website/docs/r/ssm_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_patch_baseline.html.markdown
@@ -149,6 +149,7 @@ The `approval_rule` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the patch baseline.
+* `arn` - The ARN of the patch baseline.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11767

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ssm_patch_baseline: add support for `rejected_patches_action` and `approved_patches_enable_non_security`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMPatchBaseline_'
--- PASS: TestAccAWSSSMPatchBaseline_disappears (28.32s)
--- PASS: TestAccAWSSSMPatchBaseline_RejectPatchesAction (40.62s)
--- PASS: TestAccAWSSSMPatchBaseline_ApprovedPatchesNonSec (40.82s)
--- PASS: TestAccAWSSSMPatchBaseline_basic (69.62s)
--- PASS: TestAccAWSSSMPatchBaseline_OperatingSystem (69.79s)
--- PASS: TestAccAWSSSMPatchBaseline_tags (97.91s)
```
