### PR TITLE
r/ssm_maint_windows_task - add CloudWatch config + plan time validations

### DIFF
--- a/.changelog/11774.txt
+++ b/.changelog/11774.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ssm_maintenance_window_task: Add `cloudwatch_config` argument
+```
+
+```release-note:enhancement
+resource/aws_ssm_maintenance_window_task: Add plan time validation to `task_type`, `service_role_arn`, `targets.notification_arn`, `targets.service_role_arn`
+```

--- a/.changelog/11774.txt
+++ b/.changelog/11774.txt
@@ -1,12 +1,7 @@
 ```release-note:enhancement
-resource/aws_ssm_maintenance_window_task: Add `cloudwatch_config` argument
+resource/aws_ssm_maintenance_window_task: Add `task_invocation_parameters` `run_command_parameters` block `cloudwatch_config` and `document_version` arguments
 ```
 
 ```release-note:enhancement
-resource/aws_ssm_maintenance_window_task: Add `document_version` argument
-```
-
-```release-note:enhancement
-resource/aws_ssm_maintenance_window_task: Add plan time validation to `task_type`, `service_role_arn`, `targets.notification_arn`, `targets.service_role_arn`, `max_concurrency`, `max_errors`, `targets`, `priority`, 
-`task_invocation_parameters.run_command_parameters.comment`, `task_invocation_parameters.run_command_parameters.document_hash`, `task_invocation_parameters.run_command_parameters.timeout_seconds`, `task_invocation_parameters.run_command_parameters.notification_config.notification_events` 
+resource/aws_ssm_maintenance_window_task: Add plan time validation to `max_concurrency`, `max_errors`, `priority`, `service_role_arn`, `targets`, `targets.notification_arn`, `targets.service_role_arn`, `task_type`, `task_invocation_parameters.run_command_parameters.comment`, `task_invocation_parameters.run_command_parameters.document_hash`, `task_invocation_parameters.run_command_parameters.timeout_seconds`, and `task_invocation_parameters.run_command_parameters.notification_config.notification_events` arguments
 ```

--- a/.changelog/11774.txt
+++ b/.changelog/11774.txt
@@ -3,5 +3,10 @@ resource/aws_ssm_maintenance_window_task: Add `cloudwatch_config` argument
 ```
 
 ```release-note:enhancement
-resource/aws_ssm_maintenance_window_task: Add plan time validation to `task_type`, `service_role_arn`, `targets.notification_arn`, `targets.service_role_arn`
+resource/aws_ssm_maintenance_window_task: Add `document_version` argument
+```
+
+```release-note:enhancement
+resource/aws_ssm_maintenance_window_task: Add plan time validation to `task_type`, `service_role_arn`, `targets.notification_arn`, `targets.service_role_arn`, `max_concurrency`, `max_errors`, `targets`, `priority`, 
+`task_invocation_parameters.run_command_parameters.comment`, `task_invocation_parameters.run_command_parameters.document_hash`, `task_invocation_parameters.run_command_parameters.timeout_seconds`, `task_invocation_parameters.run_command_parameters.notification_config.notification_events` 
 ```

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -268,6 +268,7 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 												"cloudwatch_log_group_name": {
 													Type:     schema.TypeString,
 													Optional: true,
+													Computed: true,
 												},
 												"cloudwatch_output_enabled": {
 													Type:     schema.TypeBool,

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -41,15 +41,10 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 			},
 
 			"task_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ssm.MaintenanceWindowTaskTypeRunCommand,
-					ssm.MaintenanceWindowTaskTypeAutomation,
-					ssm.MaintenanceWindowTaskTypeStepFunctions,
-					ssm.MaintenanceWindowTaskTypeLambda,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ssm.MaintenanceWindowTaskType_Values(), false),
 			},
 
 			"task_arn": {
@@ -82,9 +77,10 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 			},
 
 			"name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateAwsSSMMaintenanceWindowTaskName,
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`),
+					"Only alphanumeric characters, hyphens, dots & underscores allowed."),
 			},
 
 			"description": {
@@ -182,12 +178,9 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 									},
 
 									"document_hash_type": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											ssm.DocumentHashTypeSha256,
-											ssm.DocumentHashTypeSha1,
-										}, false),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(ssm.DocumentHashType_Values(), false),
 									},
 
 									"notification_config": {
@@ -209,12 +202,9 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 												},
 
 												"notification_type": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														ssm.NotificationTypeCommand,
-														ssm.NotificationTypeInvocation,
-													}, false),
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(ssm.NotificationType_Values(), false),
 												},
 											},
 										},

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -33,13 +33,13 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 			"max_concurrency": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$`), ""),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$`), "must be a number without leading zeros or a percentage between 1% and 100% without leading zeros and ending with the percentage symbol"),
 			},
 
 			"max_errors": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$`), ""),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$`), "must be zero, a number without leading zeros, or a percentage between 1% and 100% without leading zeros and ending with the percentage symbol"),
 			},
 
 			"task_type": {
@@ -192,7 +192,7 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 									"document_version": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)`), ""),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)`), "must be $DEFAULT, $LATEST, or a version number"),
 									},
 
 									"notification_config": {
@@ -211,15 +211,8 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 													Type:     schema.TypeList,
 													Optional: true,
 													Elem: &schema.Schema{
-														Type: schema.TypeString,
-														ValidateFunc: validation.StringInSlice([]string{
-															"All",
-															"InProgress",
-															"Success",
-															"TimedOut",
-															"Cancelled",
-															"Failed",
-														}, false),
+														Type:         schema.TypeString,
+														ValidateFunc: validation.StringInSlice(ssm.NotificationEvent_Values(), false),
 													},
 												},
 

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -633,7 +633,7 @@ func flattenAwsSsmTaskInvocationCommonParameters(parameters map[string][]*string
 }
 
 func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta interface{}) error {
-	ssmconn := meta.(*AWSClient).ssmconn
+	conn := meta.(*AWSClient).ssmconn
 
 	log.Printf("[INFO] Registering SSM Maintenance Window Task")
 
@@ -663,7 +663,7 @@ func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta inte
 		params.TaskInvocationParameters = expandAwsSsmTaskInvocationParameters(v.([]interface{}))
 	}
 
-	resp, err := ssmconn.RegisterTaskWithMaintenanceWindow(params)
+	resp, err := conn.RegisterTaskWithMaintenanceWindow(params)
 	if err != nil {
 		return err
 	}
@@ -674,14 +674,14 @@ func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta inte
 }
 
 func resourceAwsSsmMaintenanceWindowTaskRead(d *schema.ResourceData, meta interface{}) error {
-	ssmconn := meta.(*AWSClient).ssmconn
+	conn := meta.(*AWSClient).ssmconn
 	windowID := d.Get("window_id").(string)
 
 	params := &ssm.GetMaintenanceWindowTaskInput{
 		WindowId:     aws.String(windowID),
 		WindowTaskId: aws.String(d.Id()),
 	}
-	resp, err := ssmconn.GetMaintenanceWindowTask(params)
+	resp, err := conn.GetMaintenanceWindowTask(params)
 	if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
 		log.Printf("[WARN] Maintenance Window (%s) Task (%s) not found, removing from state", windowID, d.Id())
 		d.SetId("")
@@ -715,7 +715,7 @@ func resourceAwsSsmMaintenanceWindowTaskRead(d *schema.ResourceData, meta interf
 }
 
 func resourceAwsSsmMaintenanceWindowTaskUpdate(d *schema.ResourceData, meta interface{}) error {
-	ssmconn := meta.(*AWSClient).ssmconn
+	conn := meta.(*AWSClient).ssmconn
 	windowID := d.Get("window_id").(string)
 
 	params := &ssm.UpdateMaintenanceWindowTaskInput{
@@ -745,7 +745,7 @@ func resourceAwsSsmMaintenanceWindowTaskUpdate(d *schema.ResourceData, meta inte
 		params.TaskInvocationParameters = expandAwsSsmTaskInvocationParameters(v.([]interface{}))
 	}
 
-	_, err := ssmconn.UpdateMaintenanceWindowTask(params)
+	_, err := conn.UpdateMaintenanceWindowTask(params)
 	if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
 		log.Printf("[WARN] Maintenance Window (%s) Task (%s) not found, removing from state", windowID, d.Id())
 		d.SetId("")
@@ -760,7 +760,7 @@ func resourceAwsSsmMaintenanceWindowTaskUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceAwsSsmMaintenanceWindowTaskDelete(d *schema.ResourceData, meta interface{}) error {
-	ssmconn := meta.(*AWSClient).ssmconn
+	conn := meta.(*AWSClient).ssmconn
 
 	log.Printf("[INFO] Deregistering SSM Maintenance Window Task: %s", d.Id())
 
@@ -769,7 +769,7 @@ func resourceAwsSsmMaintenanceWindowTaskDelete(d *schema.ResourceData, meta inte
 		WindowTaskId: aws.String(d.Id()),
 	}
 
-	_, err := ssmconn.DeregisterTaskFromMaintenanceWindow(params)
+	_, err := conn.DeregisterTaskFromMaintenanceWindow(params)
 	if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
 		return nil
 	}

--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -837,9 +837,9 @@ resource "aws_ssm_maintenance_window_task" "test" {
 
   task_invocation_parameters {
     run_command_parameters {
-      document_hash       = sha256("COMMAND")
-      document_hash_type  = "Sha256"
-      service_role_arn    = aws_iam_role.test.arn
+      document_hash      = sha256("COMMAND")
+      document_hash_type = "Sha256"
+      service_role_arn   = aws_iam_role.test.arn
 
       parameter {
         name   = "commands"
@@ -847,8 +847,8 @@ resource "aws_ssm_maintenance_window_task" "test" {
       }
 
       cloudwatch_config {
-       cloudwatch_log_group_name = aws_cloudwatch_log_group.test.name
-       cloudwatch_output_enabled = %[2]t
+        cloudwatch_log_group_name = aws_cloudwatch_log_group.test.name
+        cloudwatch_output_enabled = %[2]t
       }
     }
   }

--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -822,28 +822,32 @@ resource "aws_cloudwatch_log_group" "test" {
 }
 
 resource "aws_ssm_maintenance_window_task" "test" {
-  window_id = "${aws_ssm_maintenance_window.test.id}"
-  task_type = "RUN_COMMAND"
-  task_arn = "AWS-RunShellScript"
-  priority = 1
-  service_role_arn = "${aws_iam_role.test.arn}"
-  max_concurrency = "2"
-  max_errors = "1"
+  window_id        = aws_ssm_maintenance_window.test.id
+  task_type        = "RUN_COMMAND"
+  task_arn         = "AWS-RunShellScript"
+  priority         = 1
+  service_role_arn = aws_iam_role.test.arn
+  max_concurrency  = "2"
+  max_errors       = "1"
+
   targets {
     key    = "WindowTargetIds"
-    values = ["${aws_ssm_maintenance_window_target.test.id}"]
+    values = [aws_ssm_maintenance_window_target.test.id]
   }
+
   task_invocation_parameters {
     run_command_parameters {
-      document_hash       = "${sha256("COMMAND")}"
+      document_hash       = sha256("COMMAND")
       document_hash_type  = "Sha256"
-      service_role_arn    = "${aws_iam_role.test.arn}"
+      service_role_arn    = aws_iam_role.test.arn
+
       parameter {
-        name = "commands"
+        name   = "commands"
         values = ["date"]
       }
+
       cloudwatch_config {
-       cloudwatch_log_group_name = "${aws_cloudwatch_log_group.test.name}"
+       cloudwatch_log_group_name = aws_cloudwatch_log_group.test.name
        cloudwatch_output_enabled = %[2]t
       }
     }

--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -15,23 +15,23 @@ func TestAccAWSSSMMaintenanceWindowTask_basic(t *testing.T) {
 	var before, after ssm.MaintenanceWindowTask
 	resourceName := "aws_ssm_maintenance_window_task.test"
 
-	name := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTaskDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfig(name),
+				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &before),
 				),
 			},
 			{
-				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfigUpdate(name, "test description", "RUN_COMMAND", "AWS-InstallPowerShellModule", 3, 3, 2),
+				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfigUpdate(rName, "test description", "RUN_COMMAND", "AWS-InstallPowerShellModule", 3, 3, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &after),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("maintenance-window-task-%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("maintenance-window-task-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "task_type", "RUN_COMMAND"),
 					resource.TestCheckResourceAttr(resourceName, "task_arn", "AWS-InstallPowerShellModule"),
@@ -53,7 +53,7 @@ func TestAccAWSSSMMaintenanceWindowTask_basic(t *testing.T) {
 
 func TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource(t *testing.T) {
 	var before, after ssm.MaintenanceWindowTask
-	name := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ssm_maintenance_window_task.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -62,13 +62,13 @@ func TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTaskDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfig(name),
+				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &before),
 				),
 			},
 			{
-				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfigUpdated(name),
+				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", "TestMaintenanceWindowTask"),
@@ -90,21 +90,21 @@ func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters(t *te
 	var task ssm.MaintenanceWindowTask
 	resourceName := "aws_ssm_maintenance_window_task.test"
 
-	name := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTaskDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMMaintenanceWindowTaskAutomationConfig(name, "$DEFAULT"),
+				Config: testAccAWSSSMMaintenanceWindowTaskAutomationConfig(rName, "$DEFAULT"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
 					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.automation_parameters.0.document_version", "$DEFAULT"),
 				),
 			},
 			{
-				Config: testAccAWSSSMMaintenanceWindowTaskAutomationConfigUpdate(name, "$LATEST"),
+				Config: testAccAWSSSMMaintenanceWindowTaskAutomationConfigUpdate(rName, "$LATEST"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
 					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.automation_parameters.0.document_version", "$LATEST"),
@@ -156,16 +156,16 @@ func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters(t *te
 	var task ssm.MaintenanceWindowTask
 	resourceName := "aws_ssm_maintenance_window_task.test"
 	serviceRoleResourceName := "aws_iam_role.test"
-	s3BucketResourceName := "aws_s3_bucket.foo"
+	s3BucketResourceName := "aws_s3_bucket.test"
 
-	name := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTaskDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMMaintenanceWindowTaskRunCommandConfig(name, "test comment", 30),
+				Config: testAccAWSSSMMaintenanceWindowTaskRunCommandConfig(rName, "test comment", 30),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
 					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", serviceRoleResourceName, "arn"),
@@ -175,7 +175,7 @@ func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters(t *te
 				),
 			},
 			{
-				Config: testAccAWSSSMMaintenanceWindowTaskRunCommandConfigUpdate(name, "test comment update", 60),
+				Config: testAccAWSSSMMaintenanceWindowTaskRunCommandConfigUpdate(rName, "test comment update", 60),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
 					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.run_command_parameters.0.comment", "test comment update"),
@@ -499,10 +499,10 @@ func testAccAWSSSMMaintenanceWindowTaskBasicConfigUpdate(rName, description, tas
 
 resource "aws_ssm_maintenance_window_task" "test" {
   window_id        = aws_ssm_maintenance_window.test.id
-  task_type        = "%[2]s"
-  task_arn         = "%[3]s"
+  task_type        = %[2]q
+  task_arn         = %[3]q
   name             = "maintenance-window-task-%[1]s"
-  description      = "%[4]s"
+  description      = %[4]q
   priority         = %[5]d
   service_role_arn = aws_iam_role.ssm_role_update.arn
   max_concurrency  = %[6]d
@@ -646,7 +646,7 @@ resource "aws_ssm_maintenance_window_task" "test" {
 
   task_invocation_parameters {
     automation_parameters {
-      document_version = "%[2]s"
+      document_version = %[2]q
 
       parameter {
         name   = "InstanceId"
@@ -665,8 +665,8 @@ resource "aws_ssm_maintenance_window_task" "test" {
 
 func testAccAWSSSMMaintenanceWindowTaskAutomationConfigUpdate(rName, version string) string {
 	return fmt.Sprintf(testAccAWSSSMMaintenanceWindowTaskConfigBase(rName)+`
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-s3-%[1]s"
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
   acl           = "private"
   force_destroy = true
 }
@@ -687,7 +687,7 @@ resource "aws_ssm_maintenance_window_task" "test" {
 
   task_invocation_parameters {
     automation_parameters {
-      document_version = "%[2]s"
+      document_version = %[2]q
 
       parameter {
         name   = "InstanceId"
@@ -757,7 +757,7 @@ resource "aws_ssm_maintenance_window_task" "test" {
 
   task_invocation_parameters {
     run_command_parameters {
-      comment            = "%[2]s"
+      comment            = %[2]q
       document_hash      = sha256("COMMAND")
       document_hash_type = "Sha256"
       service_role_arn   = aws_iam_role.test.arn
@@ -775,8 +775,8 @@ resource "aws_ssm_maintenance_window_task" "test" {
 
 func testAccAWSSSMMaintenanceWindowTaskRunCommandConfigUpdate(rName, comment string, timeoutSeconds int) string {
 	return fmt.Sprintf(testAccAWSSSMMaintenanceWindowTaskConfigBase(rName)+`
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-s3-%[1]s"
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
   acl           = "private"
   force_destroy = true
 }
@@ -797,12 +797,12 @@ resource "aws_ssm_maintenance_window_task" "test" {
 
   task_invocation_parameters {
     run_command_parameters {
-      comment              = "%[2]s"
+      comment              = %[2]q
       document_hash        = sha256("COMMAND")
       document_hash_type   = "Sha256"
       service_role_arn     = aws_iam_role.test.arn
       timeout_seconds      = %[3]d
-      output_s3_bucket     = aws_s3_bucket.foo.id
+      output_s3_bucket     = aws_s3_bucket.test.id
       output_s3_key_prefix = "foo"
 
       parameter {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1915,19 +1915,6 @@ func validateAwsSSMName(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func validateAwsSSMMaintenanceWindowTaskName(v interface{}, k string) (ws []string, errors []error) {
-	// https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_RegisterTaskWithMaintenanceWindow.html#systemsmanager-RegisterTaskWithMaintenanceWindow-request-Name
-	value := v.(string)
-
-	if !regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"Only alphanumeric characters, hyphens, dots & underscores allowed in %q: %q (Must satisfy regular expression pattern: ^[a-zA-Z0-9_\\-.]{3,128}$)",
-			k, value))
-	}
-
-	return
-}
-
 func validateBatchName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9a-zA-Z]{1}[0-9a-zA-Z_\-]{0,127}$`).MatchString(value) {

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -178,6 +178,7 @@ The following arguments are supported:
 * `parameter` - (Optional) The parameters for the RUN_COMMAND task execution. Documented below.
 * `service_role_arn` - (Optional) The IAM service role to assume during task execution.
 * `timeout_seconds` - (Optional) If this time is reached and the command has not already started executing, it doesn't run.
+* `cloudwatch_config` - (Optional) Configuration options for sending command output to CloudWatch Logs. Documented below.
 
 `step_functions_parameters` supports the following:
 
@@ -189,6 +190,11 @@ The following arguments are supported:
 * `notification_arn` - (Optional) An Amazon Resource Name (ARN) for a Simple Notification Service (SNS) topic. Run Command pushes notifications about command status changes to this topic.
 * `notification_events` - (Optional) The different events for which you can receive notifications. Valid values: `All`, `InProgress`, `Success`, `TimedOut`, `Cancelled`, and `Failed`
 * `notification_type` - (Optional) When specified with `Command`, receive notification when the status of a command changes. When specified with `Invocation`, for commands sent to multiple instances, receive notification on a per-instance basis when the status of a command changes. Valid values: `Command` and `Invocation`
+
+`cloudwatch_config` supports the following:
+
+* `cloudwatch_log_group_name` - (Optional) The name of the CloudWatch log group where you want to send command output. If you don't specify a group name, Systems Manager automatically creates a log group for you. The log group uses the following naming format: aws/ssm/SystemsManagerDocumentName.
+* `cloudwatch_output_enabled` - (Optional) Enables Systems Manager to send command output to CloudWatch Logs.
 
 `parameter` supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624
Relates #13826
Closes #17554

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ssm_maintance_window_task: add `cloudwatch_config` argument.
resource_aws_ssm_maintance_window_task: add plan time validation to `task_type`, `service_role_arn`, `targets.notification_arn`, `targets.service_role_arn`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMMaintenanceWindowTask_'
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (115.08s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (100.42s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters (139.40s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters (95.09s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters (140.03s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParametersCloudWatch (149.73s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters (68.90s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig (59.16s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_disappears (57.53s)
```
