### PR TITLE
r/ssm_parameter - add support for parameter policies

### DIFF
--- a/.changelog/11830.txt
+++ b/.changelog/11830.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ssm_parameter: Add support for parameter policies
+```
+
+```release-note:enhancement
+resource/aws_ssm_parameter: Add plan time validation for `description`, `allowed_pattern`
+```

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -249,8 +249,12 @@ func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error 
 		paramInput.Description = aws.String(n.(string))
 	}
 
-	if v, ok := d.GetOk("policies"); ok {
-		paramInput.Policies = aws.String(v.(string))
+	if d.HasChange("policies") {
+		o, n := d.GetChange("policies")
+		if o.(string) == "" {
+			paramInput.Policies = aws.String("[{}]")
+		}
+		paramInput.Policies = aws.String(n.(string))
 	}
 
 	if keyID, ok := d.GetOk("key_id"); ok && d.Get("type").(string) == ssm.ParameterTypeSecureString {

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -366,7 +366,7 @@ func TestAccAWSSSMParameter_secure_with_key(t *testing.T) {
 	var param ssm.Parameter
 	randString := acctest.RandString(10)
 	name := fmt.Sprintf("%s_%s", t.Name(), randString)
-	resourceName := "aws_ssm_parameter.secret_test"
+	resourceName := "aws_ssm_parameter.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -645,7 +645,7 @@ resource "aws_ssm_parameter" "test" {
 
 func testAccAWSSSMParameterSecureConfig(rName string, value string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_parameter" "secret_test" {
+resource "aws_ssm_parameter" "test" {
   name        = "test_secure_parameter-%[1]s"
   description = "description for parameter %[1]s"
   type        = "SecureString"

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -690,7 +690,7 @@ resource "aws_ssm_parameter" "test" {
    "Type":"Expiration",
    "Version":"1.0",
    "Attributes":{
-      "Timestamp":"2050-12-02T21:34:33.000Z"
+      "Timestamp":"2050-12-02T21:34:33Z"
    }
 }]
 EOF
@@ -712,7 +712,7 @@ resource "aws_ssm_parameter" "test" {
    "Type":"Expiration",
    "Version":"1.0",
    "Attributes":{
-      "Timestamp":"2050-12-02T21:34:33.000Z"
+      "Timestamp":"2050-12-02T21:34:33Z"
    }
 },
 {

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -462,7 +462,7 @@ func TestAccAWSSSMParameter_policies(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSSSMParameterPoliciesEmptyConfig(name, "String", "test2"),
+				Config: testAccAWSSSMParameterConfigTier(name, "Advanced"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists(resourceName, &param),
 					resource.TestCheckResourceAttr(resourceName, "policies", ""),
@@ -671,12 +671,12 @@ resource "aws_ssm_parameter" "test" {
   value    = %[3]q
   tier     = "Advanced"
   policies = jsonencode([{
-   "Type":"Expiration",
-   "Version":"1.0",
-   "Attributes":{
-      "Timestamp":"2050-12-02T21:34:33Z"
-   }
-}])
+    "Type" : "Expiration",
+    "Version" : "1.0",
+    "Attributes" : {
+      "Timestamp" : "2050-12-02T21:34:33Z"
+    }
+  }])
 }
 `, rName, pType, value)
 }
@@ -689,35 +689,35 @@ resource "aws_ssm_parameter" "test" {
   value    = %[3]q
   tier     = "Advanced"
   policies = jsonencode([{
-   "Type":"Expiration",
-   "Version":"1.0",
-   "Attributes":{
-      "Timestamp":"2050-12-02T21:34:33Z"
-   }
-},
-{
-   "Type":"ExpirationNotification",
-   "Version":"1.0",
-   "Attributes":{
-      "Before":"30",
-      "Unit":"Days"
-   }
-}])
+    "Type" : "Expiration",
+    "Version" : "1.0",
+    "Attributes" : {
+      "Timestamp" : "2050-12-02T21:34:33Z"
+    }
+    },
+    {
+      "Type" : "ExpirationNotification",
+      "Version" : "1.0",
+      "Attributes" : {
+        "Before" : "30",
+        "Unit" : "Days"
+      }
+  }])
 }
 `, rName, pType, value)
 }
 
-func testAccAWSSSMParameterPoliciesEmptyConfig(rName, pType, value string) string {
-	return fmt.Sprintf(`
-resource "aws_ssm_parameter" "test" {
-  name     = %[1]q
-  type     = %[2]q
-  value    = %[3]q
-  tier     = "Advanced"
-  policies = "[{}]"
-}
-`, rName, pType, value)
-}
+// func type(rName, pType, value string) string {
+// 	return fmt.Sprintf(`
+// resource "aws_ssm_parameter" "test" {
+//   name     = %[1]q
+//   type     = %[2]q
+//   value    = %[3]q
+//   tier     = "Advanced"
+//   policies = "[{}]"
+// }
+// `, rName, pType, value)
+// }
 
 func TestAWSSSMParameterShouldUpdate(t *testing.T) {
 	data := resourceAwsSsmParameter().TestResourceData()

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -12,7 +12,7 @@ Provides an SSM Parameter resource.
 
 ## Example Usage
 
-To store a basic string parameter:
+### Basic Example
 
 ```hcl
 resource "aws_ssm_parameter" "foo" {
@@ -22,7 +22,7 @@ resource "aws_ssm_parameter" "foo" {
 }
 ```
 
-To store an encrypted string using the default SSM KMS key:
+### SecureString Parameter Example
 
 ```hcl
 resource "aws_db_instance" "default" {
@@ -50,6 +50,29 @@ resource "aws_ssm_parameter" "secret" {
 }
 ```
 
+### Parameter Policies Example
+
+```hcl
+resource "aws_ssm_parameter" "foo" {
+  name  = "foo"
+  type  = "String"
+  value = "bar"
+  tier  = "Advanced"
+
+  policies = <<EOF
+[{
+   "Type":"Expiration",
+   "Version":"1.0",
+   "Attributes":{
+      "Timestamp":"2050-12-02T21:34:33.000Z"
+   }
+}]
+EOF
+
+}
+```
+
+
 ~> **Note:** The unencrypted value of a SecureString will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
@@ -68,6 +91,7 @@ The following arguments are supported:
 * `data_type` - (Optional) The data_type of the parameter. Valid values: text and aws:ec2:image for AMI format, see the [Native parameter support for Amazon Machine Image IDs
 ](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-ec2-aliases.html)
 * `tags` - (Optional) A map of tags to assign to the object.
+* `policies` - (Optional) One or more policies to apply to a parameter. This action takes a JSON array. Can only be used with `Advanced` tier parameter. For more information about parameter policies, see Working with Parameter Policies (http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-policies.html).
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_parameter: add support for parameter policies
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMParameter_'
--- PASS: TestAccAWSSSMParameter_basic (85.26s)
--- PASS: TestAccAWSSSMParameter_disappears (59.77s)
--- PASS: TestAccAWSSSMParameter_secure (82.04s)
--- PASS: TestAccAWSSSMParameter_overwrite (158.60s)
--- PASS: TestAccAWSSSMParameter_updateType (121.77s)
--- PASS: TestAccAWSSSMParameter_updateDescription (137.42s)
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (160.97s)
--- PASS: TestAccAWSSSMParameter_fullPath (100.67s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (174.25s)
--- PASS: TestAccAWSSSMParameter_policies (111.79s)
--- PASS: TestAccAWSSSMParameter_tags (231.71s)
--- PASS: TestAccAWSSSMParameter_Tier (292.17s)
--- PASS: TestAccAWSSSMParameter_secure_with_key (197.53s)
```
