### PR TITLE
r/aws_cloud9_environment_membership - add new resource

### DIFF
--- a/.changelog/11857.txt
+++ b/.changelog/11857.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_cloud9_environment_membership
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -872,7 +872,8 @@ func Provider() *schema.Provider {
 			"aws_chime_voice_connector_termination":             chime.ResourceVoiceConnectorTermination(),
 			"aws_chime_voice_connector_termination_credentials": chime.ResourceVoiceConnectorTerminationCredentials(),
 
-			"aws_cloud9_environment_ec2": cloud9.ResourceEnvironmentEC2(),
+			"aws_cloud9_environment_ec2":        cloud9.ResourceEnvironmentEC2(),
+			"aws_cloud9_environment_membership": cloud9.ResourceEnvironmentMembership(),
 
 			"aws_cloudcontrolapi_resource": cloudcontrol.ResourceResource(),
 

--- a/internal/service/cloud9/environment_membership.go
+++ b/internal/service/cloud9/environment_membership.go
@@ -1,0 +1,151 @@
+package cloud9
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloud9"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceEnvironmentMembership() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceEnvironmentMembershipCreate,
+		Read:   resourceEnvironmentMembershipRead,
+		Update: resourceEnvironmentMembershipUpdate,
+		Delete: resourceEnvironmentMembershipDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"environment_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"permissions": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(cloud9.Permissions_Values(), false),
+			},
+			"user_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceEnvironmentMembershipCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).Cloud9Conn
+
+	envId := d.Get("environment_id").(string)
+	userArn := d.Get("user_arn").(string)
+	input := &cloud9.CreateEnvironmentMembershipInput{
+		EnvironmentId: aws.String(envId),
+		Permissions:   aws.String(d.Get("permissions").(string)),
+		UserArn:       aws.String(userArn),
+	}
+
+	_, err := conn.CreateEnvironmentMembership(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating Cloud9 Environment Membership: %w", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s#%s", envId, userArn))
+
+	return resourceEnvironmentMembershipRead(d, meta)
+}
+
+func resourceEnvironmentMembershipRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).Cloud9Conn
+
+	envId, userArn, err := DecodeEnviornmentMemberId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	env, err := FindEnvironmentMembershipByID(conn, envId, userArn)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Cloud9 EC2 Environment (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Cloud9 EC2 Environment (%s): %w", d.Id(), err)
+	}
+
+	d.Set("environment_id", env.EnvironmentId)
+	d.Set("user_arn", env.UserArn)
+	d.Set("user_id", env.UserId)
+	d.Set("permissions", env.Permissions)
+
+	return nil
+}
+
+func resourceEnvironmentMembershipUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).Cloud9Conn
+
+	input := cloud9.UpdateEnvironmentMembershipInput{
+		EnvironmentId: aws.String(d.Get("environment_id").(string)),
+		Permissions:   aws.String(d.Get("permissions").(string)),
+		UserArn:       aws.String(d.Get("user_arn").(string)),
+	}
+
+	log.Printf("[INFO] Updating Cloud9 Environment Membership: %#v", input)
+	_, err := conn.UpdateEnvironmentMembership(&input)
+
+	if err != nil {
+		return fmt.Errorf("error updating Cloud9 Environment Membership (%s): %w", d.Id(), err)
+	}
+
+	return resourceEnvironmentMembershipRead(d, meta)
+}
+
+func resourceEnvironmentMembershipDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).Cloud9Conn
+
+	_, err := conn.DeleteEnvironmentMembership(&cloud9.DeleteEnvironmentMembershipInput{
+		EnvironmentId: aws.String(d.Get("environment_id").(string)),
+		UserArn:       aws.String(d.Get("user_arn").(string)),
+	})
+
+	if tfawserr.ErrCodeEquals(err, cloud9.ErrCodeNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Cloud9 EC2 Environment (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func DecodeEnviornmentMemberId(id string) (string, string, error) {
+	idParts := strings.Split(id, "#")
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return "", "", fmt.Errorf("Unexpected format of ID (%q), expected ENVIRONMENT-ID#USER-ARN", id)
+	}
+	envId := idParts[0]
+	userArn := idParts[1]
+
+	return envId, userArn, nil
+}

--- a/internal/service/cloud9/environment_membership_test.go
+++ b/internal/service/cloud9/environment_membership_test.go
@@ -1,0 +1,228 @@
+package cloud9_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloud9"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfcloud9 "github.com/hashicorp/terraform-provider-aws/internal/service/cloud9"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccEnvironmentMembership_basic(t *testing.T) {
+	var conf cloud9.EnvironmentMember
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloud9_environment_membership.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(cloud9.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cloud9.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEnvironmentMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentMembershipConfig(rName, "read-only"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentMemberExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "permissions", "read-only"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_arn", "aws_iam_user.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "environment_id", "aws_cloud9_environment_ec2.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEnvironmentMembershipConfig(rName, "read-write"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentMemberExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "permissions", "read-write"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_arn", "aws_iam_user.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "environment_id", "aws_cloud9_environment_ec2.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEnvironmentMembership_disappears(t *testing.T) {
+	var conf cloud9.EnvironmentMember
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloud9_environment_membership.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(cloud9.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cloud9.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEnvironmentMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentMembershipConfig(rName, "read-only"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentMemberExists(resourceName, &conf),
+					acctest.CheckResourceDisappears(acctest.Provider, tfcloud9.ResourceEnvironmentMembership(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfcloud9.ResourceEnvironmentMembership(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccEnvironmentMembership_disappears_env(t *testing.T) {
+	var conf cloud9.EnvironmentMember
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloud9_environment_membership.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(cloud9.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cloud9.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEnvironmentMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentMembershipConfig(rName, "read-only"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentMemberExists(resourceName, &conf),
+					acctest.CheckResourceDisappears(acctest.Provider, tfcloud9.ResourceEnvironmentEC2(), "aws_cloud9_environment_ec2.test"),
+					acctest.CheckResourceDisappears(acctest.Provider, tfcloud9.ResourceEnvironmentMembership(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEnvironmentMemberExists(n string, res *cloud9.EnvironmentMember) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cloud9 Environment Member ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).Cloud9Conn
+
+		envId, userArn, err := tfcloud9.DecodeEnviornmentMemberId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		out, err := tfcloud9.FindEnvironmentMembershipByID(conn, envId, userArn)
+		if err != nil {
+			return err
+		}
+
+		*res = *out
+
+		return nil
+	}
+}
+
+func testAccCheckEnvironmentMemberDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).Cloud9Conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloud9_environment_membership" {
+			continue
+		}
+
+		envId, userArn, err := tfcloud9.DecodeEnviornmentMemberId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = tfcloud9.FindEnvironmentMembershipByID(conn, envId, userArn)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("Cloud9 Environment Membership %q still exists.", rs.Primary.ID)
+	}
+	return nil
+}
+
+func testAccEnvironmentMemberBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # t2.micro instance type is not available in these Availability Zones
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.test.id
+  route_table_id         = aws_vpc.test.main_route_table_id
+}
+
+resource "aws_cloud9_environment_ec2" "test" {
+  instance_type = "t2.micro"
+  name          = %[1]q
+  subnet_id     = aws_subnet.test.id
+}
+`, rName)
+}
+
+func testAccEnvironmentMembershipConfig(rName, permissions string) string {
+	return testAccEnvironmentMemberBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_iam_user" "test" {
+  name = %[1]q
+}
+
+resource "aws_cloud9_environment_membership" "test" {
+  environment_id = aws_cloud9_environment_ec2.test.id
+  permissions    = %[2]q
+  user_arn       = aws_iam_user.test.arn
+}
+`, rName, permissions)
+}

--- a/internal/service/cloud9/find.go
+++ b/internal/service/cloud9/find.go
@@ -39,3 +39,36 @@ func FindEnvironmentByID(conn *cloud9.Cloud9, id string) (*cloud9.Environment, e
 
 	return env, nil
 }
+
+func FindEnvironmentMembershipByID(conn *cloud9.Cloud9, envId, userArn string) (*cloud9.EnvironmentMember, error) {
+	input := &cloud9.DescribeEnvironmentMembershipsInput{
+		EnvironmentId: aws.String(envId),
+		UserArn:       aws.String(userArn),
+	}
+	out, err := conn.DescribeEnvironmentMemberships(input)
+
+	if tfawserr.ErrCodeEquals(err, cloud9.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	envs := out.Memberships
+
+	if len(envs) == 0 {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	env := envs[0]
+
+	if env == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return env, nil
+}

--- a/website/docs/r/cloud9_environment_membership.markdown
+++ b/website/docs/r/cloud9_environment_membership.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Cloud9"
+layout: "aws"
+page_title: "AWS: aws_cloud9_environment_membership"
+description: |-
+  Provides an environment member to an AWS Cloud9 development environment.
+---
+
+# Resource: aws_cloud9_environment_membership
+
+Provides an environment member to an AWS Cloud9 development environment.
+
+## Example Usage
+
+```terraform
+resource "aws_cloud9_environment_ec2" "test" {
+  instance_type = "t2.micro"
+  name          = "some-env"
+}
+
+resource "aws_iam_user" "test" {
+  name = "some-user"
+}
+
+resource "aws_cloud9_environment_membership" "test" {
+  environment_id = aws_cloud9_environment_ec2.test.id
+  permissions    = "read-only"
+  user_arn       = aws_iam_user.test.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `environment_id` - (Required) The ID of the environment that contains the environment member you want to add.
+* `permissions` - (Required) The type of environment member permissions you want to associate with this environment member. Allowed values are `read-only` and `read-write` .
+* `user_arn` - (Required) The Amazon Resource Name (ARN) of the environment member you want to add.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the environment membership.
+* `user_id` - he user ID in AWS Identity and Access Management (AWS IAM) of the environment member.
+
+## Import
+
+Cloud9 environment membership can be imported using the `environment-id#user-arn`, e.g.
+
+```
+$ terraform import aws_cloud9_environment_membership.test environment-id#user-arn
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

Closes #15735

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloud9EnvironmentMembership_'
--- PASS: TestAccEnvironmentMembership_disappears (238.15s)
--- PASS: TestAccEnvironmentMembership_basic (350.26s)
--- PASS: TestAccEnvironmentMembership_disappears_env (200.86s)
```
