### PR TITLE
New Resource: aws_amplify_branch

### DIFF
--- a/.changelog/11937.txt
+++ b/.changelog/11937.txt
@@ -1,3 +1,7 @@
 ```release-note:new-resource
 aws_amplify_branch
 ```
+
+```release-note:bug
+resource/aws_amplify_app: Mark the `enable_performance_mode` argumnet in the `auto_branch_creation_config` configuration block as `ForceNew`
+```

--- a/.changelog/11937.txt
+++ b/.changelog/11937.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_amplify_branch
+```

--- a/aws/internal/service/amplify/finder/finder.go
+++ b/aws/internal/service/amplify/finder/finder.go
@@ -63,3 +63,32 @@ func BackendEnvironmentByAppIDAndEnvironmentName(conn *amplify.Amplify, appID, e
 
 	return output.BackendEnvironment, nil
 }
+
+func BranchByAppIDAndBranchName(conn *amplify.Amplify, appID, branchName string) (*amplify.Branch, error) {
+	input := &amplify.GetBranchInput{
+		AppId:      aws.String(appID),
+		BranchName: aws.String(branchName),
+	}
+
+	output, err := conn.GetBranch(input)
+
+	if tfawserr.ErrCodeEquals(err, amplify.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Branch == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Branch, nil
+}

--- a/aws/internal/service/amplify/id.go
+++ b/aws/internal/service/amplify/id.go
@@ -23,3 +23,22 @@ func BackendEnvironmentParseResourceID(id string) (string, string, error) {
 
 	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected APPID%[2]sENVIRONMENTNAME", id, backendEnvironmentResourceIDSeparator)
 }
+
+const branchResourceIDSeparator = "/"
+
+func BranchCreateResourceID(appID, branchName string) string {
+	parts := []string{appID, branchName}
+	id := strings.Join(parts, branchResourceIDSeparator)
+
+	return id
+}
+
+func BranchParseResourceID(id string) (string, string, error) {
+	parts := strings.Split(id, branchResourceIDSeparator)
+
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1], nil
+	}
+
+	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected APPID%[2]sBRANCHNAME", id, branchResourceIDSeparator)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -455,6 +455,7 @@ func Provider() *schema.Provider {
 			"aws_ami_launch_permission":                               resourceAwsAmiLaunchPermission(),
 			"aws_amplify_app":                                         resourceAwsAmplifyApp(),
 			"aws_amplify_backend_environment":                         resourceAwsAmplifyBackendEnvironment(),
+			"aws_amplify_branch":                                      resourceAwsAmplifyBranch(),
 			"aws_api_gateway_account":                                 resourceAwsApiGatewayAccount(),
 			"aws_api_gateway_api_key":                                 resourceAwsApiGatewayApiKey(),
 			"aws_api_gateway_authorizer":                              resourceAwsApiGatewayAuthorizer(),

--- a/aws/resource_aws_amplify_app.go
+++ b/aws/resource_aws_amplify_app.go
@@ -94,6 +94,7 @@ func resourceAwsAmplifyApp() *schema.Resource {
 						"enable_performance_mode": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 						},
 
 						"enable_pull_request_preview": {

--- a/aws/resource_aws_amplify_backend_environment_test.go
+++ b/aws/resource_aws_amplify_backend_environment_test.go
@@ -160,7 +160,7 @@ func testAccCheckAWSAmplifyBackendEnvironmentDestroy(s *terraform.State) error {
 			return err
 		}
 
-		return fmt.Errorf("Amplify BackendEnvironment %s still exists", rs.Primary.ID)
+		return fmt.Errorf("Amplify Backend Environment %s still exists", rs.Primary.ID)
 	}
 
 	return nil

--- a/aws/resource_aws_amplify_backend_environment_test.go
+++ b/aws/resource_aws_amplify_backend_environment_test.go
@@ -103,8 +103,6 @@ func testAccAWSAmplifyBackendEnvironment_DeploymentArtifacts_StackName(t *testin
 	})
 }
 
-// testAccAWSAmplifyBackendEnvironmentConfigDeploymentArtifactsAndStackName(rname, environmentName)
-
 func testAccCheckAWSAmplifyBackendEnvironmentExists(resourceName string, v *amplify.BackendEnvironment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/aws/resource_aws_amplify_branch.go
+++ b/aws/resource_aws_amplify_branch.go
@@ -1,0 +1,406 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/amplify"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsAmplifyBranch() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAmplifyBranchCreate,
+		Read:   resourceAwsAmplifyBranchRead,
+		Update: resourceAwsAmplifyBranchUpdate,
+		Delete: resourceAwsAmplifyBranchDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"app_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"associated_resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"backend_environment_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
+			"basic_auth_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_basic_auth": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"password": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Sensitive:    true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+						"username": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+					},
+				},
+			},
+			"branch_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9/_.-]+$`), "should only contain letters, numbers, and the symbols /_.-"),
+				),
+			},
+			"build_spec": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"custom_domains": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"destination_branch": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-z0-9-]+$`), "should only contain lowercase alphabets, numbers, and -"),
+				),
+			},
+			"enable_auto_build": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"enable_notification": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"enable_pull_request_preview": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"environment_variables": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"framework": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"pull_request_environment_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source_branch": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"stage": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "NONE",
+				ValidateFunc: validation.StringInSlice([]string{
+					amplify.StageProduction,
+					amplify.StageBeta,
+					amplify.StageDevelopment,
+					amplify.StageExperimental,
+					amplify.StagePullRequest,
+				}, false),
+			},
+			"ttl": {
+				Type:     schema.TypeString,
+				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// ttl is set to "5" by default
+					if old == "5" && new == "" {
+						return true
+					}
+					return false
+				},
+			},
+			// non-API
+			"sns_topic_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsAmplifyBranchCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).amplifyconn
+	log.Print("[DEBUG] Creating Amplify Branch")
+
+	params := &amplify.CreateBranchInput{
+		AppId:      aws.String(d.Get("app_id").(string)),
+		BranchName: aws.String(d.Get("branch_name").(string)),
+	}
+
+	if v, ok := d.GetOk("backend_environment_arn"); ok {
+		params.BackendEnvironmentArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("basic_auth_config"); ok {
+		enable, credentials := expandAmplifyBasicAuthConfig(v.([]interface{}))
+		params.EnableBasicAuth = enable
+		params.BasicAuthCredentials = credentials
+	}
+
+	if v, ok := d.GetOk("build_spec"); ok {
+		params.BuildSpec = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		params.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("display_name"); ok {
+		params.DisplayName = aws.String(v.(string))
+	}
+
+	// Note: don't use GetOk here because enable_auto_build can be false
+	if v := d.Get("enable_auto_build"); v != nil {
+		params.EnableAutoBuild = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("enable_notification"); ok {
+		params.EnableNotification = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("enable_pull_request_preview"); ok {
+		params.EnablePullRequestPreview = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("environment_variables"); ok {
+		params.EnvironmentVariables = stringMapToPointers(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("framework"); ok {
+		params.Framework = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("pull_request_environment_name"); ok {
+		params.PullRequestEnvironmentName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("stage"); ok {
+		params.Stage = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("ttl"); ok {
+		params.Ttl = aws.String(v.(string))
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		params.Tags = keyvaluetags.New(v).IgnoreAws().AmplifyTags()
+	}
+
+	resp, err := conn.CreateBranch(params)
+	if err != nil {
+		return fmt.Errorf("Error creating Amplify Branch: %s", err)
+	}
+
+	arn := *resp.Branch.BranchArn
+	d.SetId(arn[strings.Index(arn, ":apps/")+len(":apps/"):])
+
+	return resourceAwsAmplifyBranchRead(d, meta)
+}
+
+func resourceAwsAmplifyBranchRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).amplifyconn
+	log.Printf("[DEBUG] Reading Amplify Branch: %s", d.Id())
+
+	s := strings.Split(d.Id(), "/")
+	app_id := s[0]
+	branch_name := s[2]
+
+	resp, err := conn.GetBranch(&amplify.GetBranchInput{
+		AppId:      aws.String(app_id),
+		BranchName: aws.String(branch_name),
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == amplify.ErrCodeNotFoundException {
+			log.Printf("[WARN] Amplify Branch (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("app_id", app_id)
+	d.Set("associated_resources", resp.Branch.AssociatedResources)
+	d.Set("backend_environment_arn", resp.Branch.BackendEnvironmentArn)
+	d.Set("arn", resp.Branch.BranchArn)
+	if err := d.Set("basic_auth_config", flattenAmplifyBasicAuthConfig(resp.Branch.EnableBasicAuth, resp.Branch.BasicAuthCredentials)); err != nil {
+		return fmt.Errorf("error setting basic_auth_config: %s", err)
+	}
+	d.Set("branch_name", resp.Branch.BranchName)
+	d.Set("build_spec", resp.Branch.BuildSpec)
+	d.Set("custom_domains", resp.Branch.CustomDomains)
+	d.Set("description", resp.Branch.Description)
+	d.Set("destination_branch", resp.Branch.DestinationBranch)
+	d.Set("display_name", resp.Branch.DisplayName)
+	d.Set("enable_auto_build", resp.Branch.EnableAutoBuild)
+	d.Set("enable_notification", resp.Branch.EnableNotification)
+	d.Set("enable_pull_request_preview", resp.Branch.EnablePullRequestPreview)
+	if err := d.Set("environment_variables", aws.StringValueMap(resp.Branch.EnvironmentVariables)); err != nil {
+		return fmt.Errorf("error setting environment_variables: %s", err)
+	}
+	d.Set("framework", resp.Branch.Framework)
+	d.Set("pull_request_environment_name", resp.Branch.PullRequestEnvironmentName)
+	d.Set("source_branch", resp.Branch.SourceBranch)
+	d.Set("stage", resp.Branch.Stage)
+	d.Set("ttl", resp.Branch.Ttl)
+
+	// Generate SNS topic name for notification
+	d.Set("sns_topic_name", fmt.Sprintf("amplify-%s_%s", app_id, branch_name))
+
+	if err := d.Set("tags", keyvaluetags.AmplifyKeyValueTags(resp.Branch.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsAmplifyBranchUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).amplifyconn
+	log.Printf("[DEBUG] Updating Amplify Branch: %s", d.Id())
+
+	s := strings.Split(d.Id(), "/")
+	app_id := s[0]
+	branch_name := s[2]
+
+	params := &amplify.UpdateBranchInput{
+		AppId:      aws.String(app_id),
+		BranchName: aws.String(branch_name),
+	}
+
+	if d.HasChange("backend_environment_arn") {
+		params.BackendEnvironmentArn = aws.String(d.Get("backend_environment_arn").(string))
+	}
+
+	if d.HasChange("basic_auth_config") {
+		enable, credentials := expandAmplifyBasicAuthConfig(d.Get("basic_auth_config").([]interface{}))
+		params.EnableBasicAuth = enable
+		params.BasicAuthCredentials = credentials
+	}
+
+	if d.HasChange("build_spec") {
+		params.BuildSpec = aws.String(d.Get("build_spec").(string))
+	}
+
+	if d.HasChange("description") {
+		params.Description = aws.String(d.Get("description").(string))
+	}
+
+	if d.HasChange("display_name") {
+		params.DisplayName = aws.String(d.Get("display_name").(string))
+	}
+
+	if d.HasChange("enable_auto_build") {
+		params.EnableAutoBuild = aws.Bool(d.Get("enable_auto_build").(bool))
+	}
+
+	if d.HasChange("enable_notification") {
+		params.EnableNotification = aws.Bool(d.Get("enable_notification").(bool))
+	}
+
+	if d.HasChange("enable_pull_request_preview") {
+		params.EnablePullRequestPreview = aws.Bool(d.Get("enable_pull_request_preview").(bool))
+	}
+
+	if d.HasChange("environment_variables") {
+		v := d.Get("environment_variables").(map[string]interface{})
+		params.EnvironmentVariables = expandAmplifyEnvironmentVariables(v)
+	}
+
+	if d.HasChange("framework") {
+		params.Framework = aws.String(d.Get("framework").(string))
+	}
+
+	if d.HasChange("pull_request_environment_name") {
+		params.PullRequestEnvironmentName = aws.String(d.Get("pull_request_environment_name").(string))
+	}
+
+	if d.HasChange("stage") {
+		params.Stage = aws.String(d.Get("stage").(string))
+	}
+
+	if d.HasChange("ttl") {
+		params.Ttl = aws.String(d.Get("ttl").(string))
+	}
+
+	_, err := conn.UpdateBranch(params)
+	if err != nil {
+		return fmt.Errorf("Error updating Amplify Branch: %s", err)
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.AmplifyUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	return resourceAwsAmplifyBranchRead(d, meta)
+}
+
+func resourceAwsAmplifyBranchDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).amplifyconn
+	log.Printf("[DEBUG] Deleting Amplify Branch: %s", d.Id())
+
+	s := strings.Split(d.Id(), "/")
+	app_id := s[0]
+	branch_name := s[2]
+
+	params := &amplify.DeleteBranchInput{
+		AppId:      aws.String(app_id),
+		BranchName: aws.String(branch_name),
+	}
+
+	_, err := conn.DeleteBranch(params)
+	if err != nil {
+		return fmt.Errorf("Error deleting Amplify Branch: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_amplify_branch.go
+++ b/aws/resource_aws_amplify_branch.go
@@ -156,11 +156,6 @@ func resourceAwsAmplifyBranch() *schema.Resource {
 					return false
 				},
 			},
-			// non-API
-			"sns_topic_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -290,9 +285,6 @@ func resourceAwsAmplifyBranchRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("source_branch", resp.Branch.SourceBranch)
 	d.Set("stage", resp.Branch.Stage)
 	d.Set("ttl", resp.Branch.Ttl)
-
-	// Generate SNS topic name for notification
-	d.Set("sns_topic_name", fmt.Sprintf("amplify-%s_%s", app_id, branch_name))
 
 	if err := d.Set("tags", keyvaluetags.AmplifyKeyValueTags(resp.Branch.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/resource_aws_amplify_branch.go
+++ b/aws/resource_aws_amplify_branch.go
@@ -57,6 +57,14 @@ func resourceAwsAmplifyBranch() *schema.Resource {
 				Optional:     true,
 				Sensitive:    true,
 				ValidateFunc: validation.StringLenBetween(1, 2000),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// These credentials are ignored if basic auth is not enabled.
+					if d.Get("enable_basic_auth").(bool) {
+						return old == new
+					}
+
+					return true
+				},
 			},
 
 			"branch_name": {
@@ -361,6 +369,10 @@ func resourceAwsAmplifyBranchUpdate(d *schema.ResourceData, meta interface{}) er
 
 		if d.HasChange("enable_auto_build") {
 			input.EnableAutoBuild = aws.Bool(d.Get("enable_auto_build").(bool))
+		}
+
+		if d.HasChange("enable_basic_auth") {
+			input.EnableBasicAuth = aws.Bool(d.Get("enable_basic_auth").(bool))
 		}
 
 		if d.HasChange("enable_notification") {

--- a/aws/resource_aws_amplify_branch.go
+++ b/aws/resource_aws_amplify_branch.go
@@ -74,12 +74,6 @@ func resourceAwsAmplifyBranch() *schema.Resource {
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z/_.-]{1,255}$`), "should be not be more than 255 letters, numbers, and the symbols /_.-"),
 			},
 
-			"build_spec": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 25000),
-			},
-
 			"custom_domains": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -123,6 +117,7 @@ func resourceAwsAmplifyBranch() *schema.Resource {
 			"enable_performance_mode": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"enable_pull_request_preview": {
@@ -207,10 +202,6 @@ func resourceAwsAmplifyBranchCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("basic_auth_credentials"); ok {
 		input.BasicAuthCredentials = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("build_spec"); ok {
-		input.BuildSpec = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -302,7 +293,6 @@ func resourceAwsAmplifyBranchRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("backend_environment_arn", branch.BackendEnvironmentArn)
 	d.Set("basic_auth_credentials", branch.BasicAuthCredentials)
 	d.Set("branch_name", branch.BranchName)
-	d.Set("build_spec", branch.BuildSpec)
 	d.Set("custom_domains", aws.StringValueSlice(branch.CustomDomains))
 	d.Set("description", branch.Description)
 	d.Set("destination_branch", branch.DestinationBranch)
@@ -353,10 +343,6 @@ func resourceAwsAmplifyBranchUpdate(d *schema.ResourceData, meta interface{}) er
 
 		if d.HasChange("basic_auth_credentials") {
 			input.BasicAuthCredentials = aws.String(d.Get("basic_auth_credentials").(string))
-		}
-
-		if d.HasChange("build_spec") {
-			input.BuildSpec = aws.String(d.Get("build_spec").(string))
 		}
 
 		if d.HasChange("description") {

--- a/aws/resource_aws_amplify_branch.go
+++ b/aws/resource_aws_amplify_branch.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -9,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/amplify"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -28,13 +26,7 @@ func resourceAwsAmplifyBranch() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		CustomizeDiff: customdiff.Sequence(
-			SetTagsDiff,
-			customdiff.ForceNewIfChange("backend_environment_arn", func(_ context.Context, old, new, meta interface{}) bool {
-				// Any existing value cannot be cleared.
-				return new.(string) == ""
-			}),
-		),
+		CustomizeDiff: SetTagsDiff,
 
 		Schema: map[string]*schema.Schema{
 			"app_id": {

--- a/aws/resource_aws_amplify_branch_test.go
+++ b/aws/resource_aws_amplify_branch_test.go
@@ -247,7 +247,6 @@ func TestAccAWSAmplifyBranch_notification(t *testing.T) {
 				Config: testAccAWSAmplifyBranchConfigNotification(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "enable_notification", "true"),
-					resource.TestMatchResourceAttr(resourceName, "sns_topic_name", regexp.MustCompile("^amplify-[a-z0-9]+_master")),
 				),
 			},
 			{
@@ -510,10 +509,6 @@ resource "aws_amplify_branch" "test" {
   branch_name = "master"
 
   enable_notification = true
-}
-
-resource "aws_sns_topic" "test" {
-  name = aws_amplify_branch.test.sns_topic_name
 }
 `, rName)
 }

--- a/aws/resource_aws_amplify_branch_test.go
+++ b/aws/resource_aws_amplify_branch_test.go
@@ -49,6 +49,7 @@ func TestAccAWSAmplifyBranch_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "custom_domains.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "destination_branch", ""),
 					resource.TestCheckResourceAttr(resourceName, "source_branch", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{

--- a/aws/resource_aws_amplify_branch_test.go
+++ b/aws/resource_aws_amplify_branch_test.go
@@ -1,0 +1,588 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/amplify"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// Note: updating 'build_spec' does not work on AWS side
+func TestAccAWSAmplifyBranch_basic(t *testing.T) {
+	var branch amplify.Branch
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	branchName := "master"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAmplifyBranchConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAmplifyBranchExists(resourceName, &branch),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile("^arn:[^:]+:amplify:[^:]+:[^:]+:apps/[^/]+/branches/[^/]+$")),
+					resource.TestCheckResourceAttr(resourceName, "branch_name", branchName),
+					resource.TestCheckResourceAttr(resourceName, "build_spec", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "display_name", branchName),
+					resource.TestCheckResourceAttr(resourceName, "enable_auto_build", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_notification", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_pull_request_preview", "false"),
+					resource.TestCheckResourceAttr(resourceName, "pull_request_environment_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "framework", ""),
+					resource.TestCheckResourceAttr(resourceName, "stage", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "5"),
+					resource.TestCheckResourceAttr(resourceName, "environment_variables.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "associated_resources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "custom_domains.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "destination_branch", ""),
+					resource.TestCheckResourceAttr(resourceName, "source_branch", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAmplifyBranchConfigSimple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "displayname"),
+					resource.TestCheckResourceAttr(resourceName, "enable_auto_build", "false"),
+					resource.TestCheckResourceAttr(resourceName, "framework", "WEB"),
+					resource.TestCheckResourceAttr(resourceName, "stage", "PRODUCTION"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAmplifyBranch_rename(t *testing.T) {
+	var branch1, branch2 amplify.Branch
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	branchName1 := "master"
+	branchName2 := "development"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAmplifyBranchConfigBranch(rName, branchName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAmplifyBranchExists(resourceName, &branch1),
+					resource.TestCheckResourceAttr(resourceName, "branch_name", branchName1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAmplifyBranchConfigBranch(rName, branchName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAmplifyBranchExists(resourceName, &branch2),
+					testAccCheckAWSAmplifyBranchRecreated(&branch1, &branch2),
+					resource.TestCheckResourceAttr(resourceName, "branch_name", branchName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAmplifyBranch_simple(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAmplifyBranchConfigSimple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "displayname"),
+					resource.TestCheckResourceAttr(resourceName, "enable_auto_build", "false"),
+					resource.TestCheckResourceAttr(resourceName, "framework", "WEB"),
+					resource.TestCheckResourceAttr(resourceName, "stage", "PRODUCTION"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "10"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAmplifyBranch_backendEnvironment(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAmplifyBranchConfigBackendEnvironment(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "backend_environment_arn", regexp.MustCompile("^arn:[^:]+:amplify:[^:]+:[^:]+:apps/[^/]+/backendenvironments/prod")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAmplifyBranch_pullRequestPreview(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAmplifyBranchConfigPullRequestPreview(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "enable_pull_request_preview", "true"),
+					resource.TestCheckResourceAttr(resourceName, "pull_request_environment_name", "prod"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAmplifyBranch_basicAuthConfig(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	username1 := "username1"
+	password1 := "password1"
+	username2 := "username2"
+	password2 := "password2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAmplifyBranchConfigBasicAuthConfig(rName, username1, password1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_config.0.enable_basic_auth", "true"),
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_config.0.username", username1),
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_config.0.password", password1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAmplifyBranchConfigBasicAuthConfig(rName, username2, password2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_config.0.enable_basic_auth", "true"),
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_config.0.username", username2),
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_config.0.password", password2),
+				),
+			},
+			{
+				Config: testAccAWSAmplifyBranchConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_config.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAmplifyBranch_notification(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAmplifyBranchConfigNotification(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "enable_notification", "true"),
+					resource.TestMatchResourceAttr(resourceName, "sns_topic_name", regexp.MustCompile("^amplify-[a-z0-9]+_master")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAmplifyBranch_environmentVariables(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAmplifyBranchConfigEnvironmentVariables1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "environment_variables.ENVVAR1", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAmplifyBranchConfigEnvironmentVariables2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "environment_variables.ENVVAR1", "2"),
+					resource.TestCheckResourceAttr(resourceName, "environment_variables.ENVVAR2", "2"),
+				),
+			},
+			{
+				Config: testAccAWSAmplifyBranchConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAmplifyBranch_tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAmplifyBranchConfigTags1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TAG1", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAmplifyBranchConfigTags2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TAG1", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TAG2", "2"),
+				),
+			},
+			{
+				Config: testAccAWSAmplifyBranchConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAmplifyBranchExists(resourceName string, v *amplify.Branch) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).amplifyconn
+
+		id := strings.Split(rs.Primary.ID, "/")
+		app_id := id[0]
+		branch := id[2]
+
+		output, err := conn.GetBranch(&amplify.GetBranchInput{
+			AppId:      aws.String(app_id),
+			BranchName: aws.String(branch),
+		})
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.Branch == nil {
+			return fmt.Errorf("Amplify Branch (%s) not found", rs.Primary.ID)
+		}
+
+		*v = *output.Branch
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAmplifyBranchDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_amplify_branch" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).amplifyconn
+
+		id := strings.Split(rs.Primary.ID, "/")
+		app_id := id[0]
+		branch := id[2]
+
+		_, err := conn.GetBranch(&amplify.GetBranchInput{
+			AppId:      aws.String(app_id),
+			BranchName: aws.String(branch),
+		})
+
+		if isAWSErr(err, amplify.ErrCodeNotFoundException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSAmplifyBranchRecreated(i, j *amplify.Branch) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreateTime) == aws.TimeValue(j.CreateTime) {
+			return errors.New("Amplify Branch was not recreated")
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSAmplifyBranchConfig_Required(rName string) string {
+	return testAccAWSAmplifyBranchConfigBranch(rName, "master")
+}
+
+func testAccAWSAmplifyBranchConfigBranch(rName string, branchName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "%s"
+}
+`, rName, branchName)
+}
+
+func testAccAWSAmplifyBranchConfigSimple(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "master"
+
+  description       = "description"
+  display_name      = "displayname"
+  enable_auto_build = false
+  framework         = "WEB"
+  stage             = "PRODUCTION"
+  ttl               = "10"
+}
+`, rName)
+}
+
+func testAccAWSAmplifyBranchConfigBackendEnvironment(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_backend_environment" "test" {
+  app_id           = aws_amplify_app.test.id
+  environment_name = "prod"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "master"
+
+  backend_environment_arn = aws_amplify_backend_environment.test.arn
+}
+`, rName)
+}
+
+func testAccAWSAmplifyBranchConfigPullRequestPreview(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "master"
+
+  enable_pull_request_preview = true
+  pull_request_environment_name = "prod"
+}
+`, rName)
+}
+
+func testAccAWSAmplifyBranchConfigBasicAuthConfig(rName string, username, password string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "master"
+
+  basic_auth_config {
+    enable_basic_auth = true
+    username          = "%s"
+    password          = "%s"
+  }
+}
+`, rName, username, password)
+}
+
+func testAccAWSAmplifyBranchConfigNotification(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "master"
+
+  enable_notification = true
+}
+
+resource "aws_sns_topic" "test" {
+  name = aws_amplify_branch.test.sns_topic_name
+}
+`, rName)
+}
+
+func testAccAWSAmplifyBranchConfigEnvironmentVariables1(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "master"
+
+  environment_variables = {
+    ENVVAR1 = "1"
+  }
+}
+`, rName)
+}
+
+func testAccAWSAmplifyBranchConfigEnvironmentVariables2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "master"
+
+  environment_variables = {
+    ENVVAR1 = "2",
+    ENVVAR2 = "2"
+  }
+}
+`, rName)
+}
+
+func testAccAWSAmplifyBranchConfigTags1(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "master"
+
+  tags = {
+    TAG1 = "1",
+  }
+}
+`, rName)
+}
+
+func testAccAWSAmplifyBranchConfigTags2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = "%s"
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "master"
+
+  tags = {
+    TAG1 = "2",
+    TAG2 = "2",
+  }
+}
+`, rName)
+}

--- a/aws/resource_aws_amplify_branch_test.go
+++ b/aws/resource_aws_amplify_branch_test.go
@@ -177,6 +177,7 @@ func testAccAWSAmplifyBranch_BackendEnvironmentArn(t *testing.T) {
 	})
 }
 
+/*
 func TestAccAWSAmplifyBranch_simple(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_amplify_branch.test"
@@ -370,6 +371,7 @@ func TestAccAWSAmplifyBranch_environmentVariables(t *testing.T) {
 		},
 	})
 }
+*/
 
 func testAccCheckAWSAmplifyBranchExists(resourceName string, v *amplify.Branch) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -520,6 +522,7 @@ resource "aws_amplify_branch" "test" {
 `, rName, environmentName)
 }
 
+/*
 func testAccAWSAmplifyBranchConfig_Required(rName string) string {
 	return testAccAWSAmplifyBranchConfigBranch(rName, "master")
 }
@@ -661,3 +664,4 @@ resource "aws_amplify_branch" "test" {
 }
 `, rName)
 }
+*/

--- a/aws/resource_aws_amplify_branch_test.go
+++ b/aws/resource_aws_amplify_branch_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/amplify"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // Note: updating 'build_spec' does not work on AWS side

--- a/aws/resource_aws_amplify_branch_test.go
+++ b/aws/resource_aws_amplify_branch_test.go
@@ -1,54 +1,55 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/amplify"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfamplify "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/amplify"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/amplify/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-// Note: updating 'build_spec' does not work on AWS side
 func TestAccAWSAmplifyBranch_basic(t *testing.T) {
 	var branch amplify.Branch
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_amplify_branch.test"
 
-	branchName := "master"
-
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAmplify(t) },
+		ErrorCheck:   testAccErrorCheck(t, amplify.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAmplifyBranchConfig_Required(rName),
+				Config: testAccAWSAmplifyBranchConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAmplifyBranchExists(resourceName, &branch),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile("^arn:[^:]+:amplify:[^:]+:[^:]+:apps/[^/]+/branches/[^/]+$")),
-					resource.TestCheckResourceAttr(resourceName, "branch_name", branchName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "amplify", regexp.MustCompile(`apps/.+/branches/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "associated_resources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "backend_environment_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "basic_auth_credentials", ""),
+					resource.TestCheckResourceAttr(resourceName, "branch_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "build_spec", ""),
+					resource.TestCheckResourceAttr(resourceName, "custom_domains.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "display_name", branchName),
+					resource.TestCheckResourceAttr(resourceName, "destination_branch", ""),
+					resource.TestCheckResourceAttr(resourceName, "display_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "enable_auto_build", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_basic_auth", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enable_notification", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_performance_mode", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enable_pull_request_preview", "false"),
-					resource.TestCheckResourceAttr(resourceName, "pull_request_environment_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "environment_variables.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "framework", ""),
+					resource.TestCheckResourceAttr(resourceName, "pull_request_environment_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "source_branch", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "5"),
-					resource.TestCheckResourceAttr(resourceName, "environment_variables.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "associated_resources.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "custom_domains.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "destination_branch", ""),
-					resource.TestCheckResourceAttr(resourceName, "source_branch", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -57,39 +58,50 @@ func TestAccAWSAmplifyBranch_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+		},
+	})
+}
+
+func TestAccAWSAmplifyBranch_disappears(t *testing.T) {
+	var branch amplify.Branch
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_amplify_branch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAmplify(t) },
+		ErrorCheck:   testAccErrorCheck(t, amplify.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
+		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAmplifyBranchConfigSimple(rName),
+				Config: testAccAWSAmplifyBranchConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "description", "description"),
-					resource.TestCheckResourceAttr(resourceName, "display_name", "displayname"),
-					resource.TestCheckResourceAttr(resourceName, "enable_auto_build", "false"),
-					resource.TestCheckResourceAttr(resourceName, "framework", "WEB"),
-					resource.TestCheckResourceAttr(resourceName, "stage", "PRODUCTION"),
-					resource.TestCheckResourceAttr(resourceName, "ttl", "10"),
+					testAccCheckAWSAmplifyBranchExists(resourceName, &branch),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsAmplifyBranch(), resourceName),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
 }
 
-func TestAccAWSAmplifyBranch_rename(t *testing.T) {
-	var branch1, branch2 amplify.Branch
+func TestAccAWSAmplifyBranch_Tags(t *testing.T) {
+	var branch amplify.Branch
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_amplify_branch.test"
 
-	branchName1 := "master"
-	branchName2 := "development"
-
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAmplify(t) },
+		ErrorCheck:   testAccErrorCheck(t, amplify.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAmplifyBranchConfigBranch(rName, branchName1),
+				Config: testAccAWSAmplifyBranchConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAmplifyBranchExists(resourceName, &branch1),
-					resource.TestCheckResourceAttr(resourceName, "branch_name", branchName1),
+					testAccCheckAWSAmplifyBranchExists(resourceName, &branch),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
@@ -98,11 +110,20 @@ func TestAccAWSAmplifyBranch_rename(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSAmplifyBranchConfigBranch(rName, branchName2),
+				Config: testAccAWSAmplifyBranchConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAmplifyBranchExists(resourceName, &branch2),
-					testAccCheckAWSAmplifyBranchRecreated(&branch1, &branch2),
-					resource.TestCheckResourceAttr(resourceName, "branch_name", branchName2),
+					testAccCheckAWSAmplifyBranchExists(resourceName, &branch),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSAmplifyBranchConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAmplifyBranchExists(resourceName, &branch),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},
@@ -114,7 +135,8 @@ func TestAccAWSAmplifyBranch_simple(t *testing.T) {
 	resourceName := "aws_amplify_branch.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAmplify(t) },
+		ErrorCheck:   testAccErrorCheck(t, amplify.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
 		Steps: []resource.TestStep{
@@ -143,7 +165,8 @@ func TestAccAWSAmplifyBranch_backendEnvironment(t *testing.T) {
 	resourceName := "aws_amplify_branch.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAmplify(t) },
+		ErrorCheck:   testAccErrorCheck(t, amplify.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
 		Steps: []resource.TestStep{
@@ -167,7 +190,8 @@ func TestAccAWSAmplifyBranch_pullRequestPreview(t *testing.T) {
 	resourceName := "aws_amplify_branch.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAmplify(t) },
+		ErrorCheck:   testAccErrorCheck(t, amplify.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
 		Steps: []resource.TestStep{
@@ -187,7 +211,7 @@ func TestAccAWSAmplifyBranch_pullRequestPreview(t *testing.T) {
 	})
 }
 
-func TestAccAWSAmplifyBranch_basicAuthConfig(t *testing.T) {
+func TestAccAWSAmplifyBranch_BasicAuthCredentials(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_amplify_branch.test"
 
@@ -197,7 +221,8 @@ func TestAccAWSAmplifyBranch_basicAuthConfig(t *testing.T) {
 	password2 := "password2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAmplify(t) },
+		ErrorCheck:   testAccErrorCheck(t, amplify.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
 		Steps: []resource.TestStep{
@@ -239,7 +264,8 @@ func TestAccAWSAmplifyBranch_notification(t *testing.T) {
 	resourceName := "aws_amplify_branch.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAmplify(t) },
+		ErrorCheck:   testAccErrorCheck(t, amplify.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
 		Steps: []resource.TestStep{
@@ -263,7 +289,8 @@ func TestAccAWSAmplifyBranch_environmentVariables(t *testing.T) {
 	resourceName := "aws_amplify_branch.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAmplify(t) },
+		ErrorCheck:   testAccErrorCheck(t, amplify.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
 		Steps: []resource.TestStep{
@@ -297,45 +324,6 @@ func TestAccAWSAmplifyBranch_environmentVariables(t *testing.T) {
 	})
 }
 
-func TestAccAWSAmplifyBranch_tags(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_amplify_branch.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAmplifyBranchDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAmplifyBranchConfigTags1(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.TAG1", "1"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAWSAmplifyBranchConfigTags2(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.TAG1", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.TAG2", "2"),
-				),
-			},
-			{
-				Config: testAccAWSAmplifyBranchConfig_Required(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckAWSAmplifyBranchExists(resourceName string, v *amplify.Branch) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -343,67 +331,71 @@ func testAccCheckAWSAmplifyBranchExists(resourceName string, v *amplify.Branch) 
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).amplifyconn
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Amplify Branch ID is set")
+		}
 
-		id := strings.Split(rs.Primary.ID, "/")
-		app_id := id[0]
-		branch := id[2]
+		appID, branchName, err := tfamplify.BranchParseResourceID(rs.Primary.ID)
 
-		output, err := conn.GetBranch(&amplify.GetBranchInput{
-			AppId:      aws.String(app_id),
-			BranchName: aws.String(branch),
-		})
 		if err != nil {
 			return err
 		}
 
-		if output == nil || output.Branch == nil {
-			return fmt.Errorf("Amplify Branch (%s) not found", rs.Primary.ID)
+		conn := testAccProvider.Meta().(*AWSClient).amplifyconn
+
+		branch, err := finder.BranchByAppIDAndBranchName(conn, appID, branchName)
+
+		if err != nil {
+			return err
 		}
 
-		*v = *output.Branch
+		*v = *branch
 
 		return nil
 	}
 }
 
 func testAccCheckAWSAmplifyBranchDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).amplifyconn
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_amplify_branch" {
 			continue
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).amplifyconn
+		appID, branchName, err := tfamplify.BranchParseResourceID(rs.Primary.ID)
 
-		id := strings.Split(rs.Primary.ID, "/")
-		app_id := id[0]
-		branch := id[2]
+		if err != nil {
+			return err
+		}
 
-		_, err := conn.GetBranch(&amplify.GetBranchInput{
-			AppId:      aws.String(app_id),
-			BranchName: aws.String(branch),
-		})
+		_, err = finder.BranchByAppIDAndBranchName(conn, appID, branchName)
 
-		if isAWSErr(err, amplify.ErrCodeNotFoundException, "") {
+		if tfresource.NotFound(err) {
 			continue
 		}
 
 		if err != nil {
 			return err
 		}
+
+		return fmt.Errorf("Amplify Branch %s still exists", rs.Primary.ID)
 	}
 
 	return nil
 }
 
-func testAccCheckAWSAmplifyBranchRecreated(i, j *amplify.Branch) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreateTime) == aws.TimeValue(j.CreateTime) {
-			return errors.New("Amplify Branch was not recreated")
-		}
+func testAccAWSAmplifyBranchConfigName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_amplify_app" "test" {
+  name = %[1]q
+}
 
-		return nil
-	}
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = %[1]q
+}
+`, rName)
 }
 
 func testAccAWSAmplifyBranchConfig_Required(rName string) string {
@@ -548,37 +540,37 @@ resource "aws_amplify_branch" "test" {
 `, rName)
 }
 
-func testAccAWSAmplifyBranchConfigTags1(rName string) string {
+func testAccAWSAmplifyBranchConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_amplify_app" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_amplify_branch" "test" {
   app_id      = aws_amplify_app.test.id
-  branch_name = "master"
+  branch_name = %[1]q
 
   tags = {
-    TAG1 = "1",
+    %[2]q = %[3]q
   }
 }
-`, rName)
+`, rName, tagKey1, tagValue1)
 }
 
-func testAccAWSAmplifyBranchConfigTags2(rName string) string {
+func testAccAWSAmplifyBranchConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_amplify_app" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_amplify_branch" "test" {
   app_id      = aws_amplify_app.test.id
-  branch_name = "master"
+  branch_name = %[1]q
 
   tags = {
-    TAG1 = "2",
-    TAG2 = "2",
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, rName)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_amplify_test.go
+++ b/aws/resource_aws_amplify_test.go
@@ -34,6 +34,7 @@ func TestAccAWSAmplify_serial(t *testing.T) {
 			"BackendEnvironmentArn": testAccAWSAmplifyBranch_BackendEnvironmentArn,
 			"BasicAuthCredentials":  testAccAWSAmplifyBranch_BasicAuthCredentials,
 			"EnvironmentVariables":  testAccAWSAmplifyBranch_EnvironmentVariables,
+			"OptionalArguments":     testAccAWSAmplifyBranch_OptionalArguments,
 		},
 	}
 

--- a/aws/resource_aws_amplify_test.go
+++ b/aws/resource_aws_amplify_test.go
@@ -32,6 +32,7 @@ func TestAccAWSAmplify_serial(t *testing.T) {
 			"disappears":            testAccAWSAmplifyBranch_disappears,
 			"Tags":                  testAccAWSAmplifyBranch_Tags,
 			"BackendEnvironmentArn": testAccAWSAmplifyBranch_BackendEnvironmentArn,
+			"BasicAuthCredentials":  testAccAWSAmplifyBranch_BasicAuthCredentials,
 		},
 	}
 

--- a/aws/resource_aws_amplify_test.go
+++ b/aws/resource_aws_amplify_test.go
@@ -27,6 +27,12 @@ func TestAccAWSAmplify_serial(t *testing.T) {
 			"disappears":                    testAccAWSAmplifyBackendEnvironment_disappears,
 			"DeploymentArtifacts_StackName": testAccAWSAmplifyBackendEnvironment_DeploymentArtifacts_StackName,
 		},
+		"Branch": {
+			"basic":                 testAccAWSAmplifyBranch_basic,
+			"disappears":            testAccAWSAmplifyBranch_disappears,
+			"Tags":                  testAccAWSAmplifyBranch_Tags,
+			"BackendEnvironmentArn": testAccAWSAmplifyBranch_BackendEnvironmentArn,
+		},
 	}
 
 	for group, m := range testCases {

--- a/aws/resource_aws_amplify_test.go
+++ b/aws/resource_aws_amplify_test.go
@@ -28,13 +28,12 @@ func TestAccAWSAmplify_serial(t *testing.T) {
 			"DeploymentArtifacts_StackName": testAccAWSAmplifyBackendEnvironment_DeploymentArtifacts_StackName,
 		},
 		"Branch": {
-			"basic":                 testAccAWSAmplifyBranch_basic,
-			"disappears":            testAccAWSAmplifyBranch_disappears,
-			"Tags":                  testAccAWSAmplifyBranch_Tags,
-			"BackendEnvironmentArn": testAccAWSAmplifyBranch_BackendEnvironmentArn,
-			"BasicAuthCredentials":  testAccAWSAmplifyBranch_BasicAuthCredentials,
-			"EnvironmentVariables":  testAccAWSAmplifyBranch_EnvironmentVariables,
-			"OptionalArguments":     testAccAWSAmplifyBranch_OptionalArguments,
+			"basic":                testAccAWSAmplifyBranch_basic,
+			"disappears":           testAccAWSAmplifyBranch_disappears,
+			"Tags":                 testAccAWSAmplifyBranch_Tags,
+			"BasicAuthCredentials": testAccAWSAmplifyBranch_BasicAuthCredentials,
+			"EnvironmentVariables": testAccAWSAmplifyBranch_EnvironmentVariables,
+			"OptionalArguments":    testAccAWSAmplifyBranch_OptionalArguments,
 		},
 	}
 

--- a/aws/resource_aws_amplify_test.go
+++ b/aws/resource_aws_amplify_test.go
@@ -33,6 +33,7 @@ func TestAccAWSAmplify_serial(t *testing.T) {
 			"Tags":                  testAccAWSAmplifyBranch_Tags,
 			"BackendEnvironmentArn": testAccAWSAmplifyBranch_BackendEnvironmentArn,
 			"BasicAuthCredentials":  testAccAWSAmplifyBranch_BasicAuthCredentials,
+			"EnvironmentVariables":  testAccAWSAmplifyBranch_EnvironmentVariables,
 		},
 	}
 

--- a/website/docs/r/amplify_branch.html.markdown
+++ b/website/docs/r/amplify_branch.html.markdown
@@ -1,0 +1,126 @@
+---
+subcategory: "Amplify"
+layout: "aws"
+page_title: "AWS: aws_amplify_branch"
+description: |-
+  Provides an Amplify branch resource.
+---
+
+# Resource: aws_amplify_branch
+
+Provides an Amplify branch resource.
+
+## Example Usage
+
+```hcl
+resource "aws_amplify_app" "app" {
+  name = "app"
+}
+
+resource "aws_amplify_branch" "master" {
+  app_id      = aws_amplify_app.app.id
+  branch_name = "master"
+
+  framework   = "React"
+  stage       = "PRODUCTION"
+
+  environment_variables = {
+    REACT_APP_API_SERVER = "https://api.example.com"
+  }
+}
+```
+
+### Basic Authentication
+
+```hcl
+resource "aws_amplify_app" "app" {
+  name = "app"
+}
+
+resource "aws_amplify_branch" "master" {
+  app_id      = aws_amplify_app.app.id
+  branch_name = "master"
+
+  basic_auth_config {
+    // Enable basic authentication.
+    enable_basic_auth = true
+
+    username = "username"
+    password = "password"
+  }
+}
+```
+
+### Notifications
+
+Amplify uses SNS for email notifications.  In order to enable notifications, you have to set `enable_notification` in a `aws_amplify_branch` resource, as well as creating a SNS topic and subscriptions.  Use `sns_topic_name` to get a SNS topic name.  You can select any subscription protocol, such as `lambda`.
+
+```hcl
+resource "aws_amplify_app" "app" {
+  name = "app"
+}
+
+resource "aws_amplify_branch" "master" {
+  app_id      = aws_amplify_app.app.id
+  branch_name = "master"
+
+  // Enable SNS notifications.
+  enable_notification = true
+}
+
+resource "aws_sns_topic" "amplify_app_master" {
+  name = aws_amplify_branch.master.sns_topic_name
+}
+
+resource "aws_sns_topic_subscription" "amplify_app_master_lambda" {
+  topic_arn = aws_sns_topic.amplify_app_master.arn
+  protocol  = "lambda"
+  endpoint  = "arn:aws:lambda:..."
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `app_id` - (Required) Unique Id for an Amplify App.
+* `branch_name` - (Required) Name for the branch.
+* `backend_environment_arn` - (Optional) ARN for a Backend Environment, part of an Amplify App.
+* `basic_auth_config` - (Optional) Basic Authentication config for the branch. A `basic_auth_config` block is documented below.
+* `build_spec` - (Optional) BuildSpec for the branch.
+* `description` - (Optional) Description for the branch.
+* `display_name` - (Optional) Display name for a branch, will use as the default domain prefix.
+* `enable_auto_build` - (Optional) Enables auto building for the branch.
+* `enable_notifications` - (Optional) Enables notifications for the branch.
+* `enable_pull_request_preview` - (Optional) Enables Pull Request Preview for this branch.
+* `environment_variables` - (Optional) Environment Variables for the branch.
+* `framework` - (Optional) Framework for the branch.
+* `pull_request_environment_name` - (Optional) The Amplify Environment name for the pull request.
+* `stage` - (Optional) Stage for the branch. Possible values: "PRODUCTION", "BETA", "DEVELOPMENT", "EXPERIMENTAL", or "PULL_REQUEST".
+* `tags` - (Optional) Key-value mapping of resource tags.
+* `ttl` - (Optional) The content TTL for the website in seconds.
+
+An `basic_auth_config` block supports the following arguments:
+
+* `enable_basic_auth` - (Optional) Enables Basic Authorization.
+* `username` - (Optional) Basic Authorization username.
+* `password` - (Optional) Basic Authorization password.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `arn` - ARN for the Amplify App.
+* `associated_resources` - List of custom resources that are linked to this branch.
+* `custom_domains` - Custom domains for a branch, part of an Amplify App.
+* `destination_branch` - The destination branch if the branch is a pull request branch.
+* `sns_topic_name` - SNS topic name for notifications.
+* `source_branch` - The source branch if the branch is a pull request branch.
+
+## Import
+
+Amplify branch can be imported using `app_id` and `branch_name`, e.g.
+
+```
+$ terraform import aws_amplify_branch.master d2ypk4k47z8u6/branches/master
+```

--- a/website/docs/r/amplify_branch.html.markdown
+++ b/website/docs/r/amplify_branch.html.markdown
@@ -18,7 +18,7 @@ resource "aws_amplify_app" "app" {
 }
 
 resource "aws_amplify_branch" "master" {
-  app_id      = aws_amplify_app.app.id
+  app_id      = "${aws_amplify_app.app.id}"
   branch_name = "master"
 
   framework   = "React"
@@ -38,7 +38,7 @@ resource "aws_amplify_app" "app" {
 }
 
 resource "aws_amplify_branch" "master" {
-  app_id      = aws_amplify_app.app.id
+  app_id      = "${aws_amplify_app.app.id}"
   branch_name = "master"
 
   basic_auth_config {
@@ -61,7 +61,7 @@ resource "aws_amplify_app" "app" {
 }
 
 resource "aws_amplify_branch" "master" {
-  app_id      = aws_amplify_app.app.id
+  app_id      = "${aws_amplify_app.app.id}"
   branch_name = "master"
 
   // Enable SNS notifications.
@@ -77,10 +77,10 @@ resource "aws_cloudwatch_event_rule" "amplify_app_master" {
   event_pattern = jsonencode({
     "detail" = {
       "appId" = [
-        aws_amplify_app.app.id
+        "${aws_amplify_app.app.id}"
       ]
       "branchName" = [
-        aws_amplify_branch.master.branch_name
+        "${aws_amplify_branch.master.branch_name}"
       ],
       "jobStatus" = [
         "SUCCEED",
@@ -98,9 +98,9 @@ resource "aws_cloudwatch_event_rule" "amplify_app_master" {
 }
 
 resource "aws_cloudwatch_event_target" "amplify_app_master" {
-  rule      = aws_cloudwatch_event_rule.amplify_app_master.name
-  target_id = aws_amplify_branch.master.branch_name
-  arn       = aws_sns_topic.amplify_app_master.arn
+  rule      = "${aws_cloudwatch_event_rule.amplify_app_master.name}"
+  target_id = "${aws_amplify_branch.master.branch_name}"
+  arn       = "${aws_sns_topic.amplify_app_master.arn}"
 
   input_transformer {
     input_paths = {
@@ -139,14 +139,14 @@ data "aws_iam_policy_document" "amplify_app_master" {
     }
 
     resources = [
-      aws_sns_topic.amplify_app_master.arn,
+      "${aws_sns_topic.amplify_app_master.arn}",
     ]
   }
 }
 
 resource "aws_sns_topic_policy" "amplify_app_master" {
-  arn    = aws_sns_topic.amplify_app_master.arn
-  policy = data.aws_iam_policy_document.amplify_app_master.json
+  arn    = "${aws_sns_topic.amplify_app_master.arn}"
+  policy = "${data.aws_iam_policy_document.amplify_app_master.json}"
 }
 ```
 

--- a/website/docs/r/amplify_branch.html.markdown
+++ b/website/docs/r/amplify_branch.html.markdown
@@ -162,6 +162,7 @@ The following arguments are supported:
 * `description` - (Optional) The description for the branch.
 * `display_name` - (Optional) The display name for a branch. This is used as the default domain prefix.
 * `enable_auto_build` - (Optional) Enables auto building for the branch.
+* `enable_basic_auth` - (Optional) Enables basic authorization for the branch.
 * `enable_notifications` - (Optional) Enables notifications for the branch.
 * `enable_performance_mode` - (Optional) Enables performance mode for the branch.
 * `enable_pull_request_preview` - (Optional) Enables pull request previews for this branch.
@@ -178,7 +179,7 @@ The following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) for the branch.
 * `associated_resources` - A list of custom resources that are linked to this branch.
-* `custom_domains` - The custom domains for a branch of an Amplify app.
+* `custom_domains` - The custom domains for the branch.
 * `destination_branch` - The destination branch if the branch is a pull request branch.
 * `source_branch` - The source branch if the branch is a pull request branch.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/amplify_branch.html.markdown
+++ b/website/docs/r/amplify_branch.html.markdown
@@ -158,7 +158,6 @@ The following arguments are supported:
 * `branch_name` - (Required) The name for the branch.
 * `backend_environment_arn` - (Optional) The Amazon Resource Name (ARN) for a backend environment that is part of an Amplify app.
 * `basic_auth_credentials` - (Optional) The basic authorization credentials for the branch.
-* `build_spec` - (Optional) The build specification (build spec) for the branch.
 * `description` - (Optional) The description for the branch.
 * `display_name` - (Optional) The display name for a branch. This is used as the default domain prefix.
 * `enable_auto_build` - (Optional) Enables auto building for the branch.

--- a/website/docs/r/amplify_branch.html.markdown
+++ b/website/docs/r/amplify_branch.html.markdown
@@ -21,8 +21,8 @@ resource "aws_amplify_branch" "master" {
   app_id      = aws_amplify_app.example.id
   branch_name = "master"
 
-  framework   = "React"
-  stage       = "PRODUCTION"
+  framework = "React"
+  stage     = "PRODUCTION"
 
   environment_variables = {
     REACT_APP_API_SERVER = "https://api.example.com"
@@ -132,7 +132,7 @@ data "aws_iam_policy_document" "amplify_app_master" {
     ]
 
     principals {
-      type        = "Service"
+      type = "Service"
       identifiers = [
         "events.amazonaws.com",
       ]

--- a/website/docs/r/amplify_branch.html.markdown
+++ b/website/docs/r/amplify_branch.html.markdown
@@ -175,7 +175,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) for the branch.
 * `associated_resources` - A list of custom resources that are linked to this branch.

--- a/website/docs/r/amplify_branch.html.markdown
+++ b/website/docs/r/amplify_branch.html.markdown
@@ -173,7 +173,7 @@ The following arguments are supported:
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `ttl` - (Optional) The content Time To Live (TTL) for the website in seconds.
 
-## Attribute Reference
+## Attributes Reference
 
 The following attributes are exported:
 

--- a/website/docs/r/amplify_branch.html.markdown
+++ b/website/docs/r/amplify_branch.html.markdown
@@ -1,24 +1,24 @@
 ---
-subcategory: "Amplify"
+subcategory: "Amplify Console"
 layout: "aws"
 page_title: "AWS: aws_amplify_branch"
 description: |-
-  Provides an Amplify branch resource.
+  Provides an Amplify Branch resource.
 ---
 
 # Resource: aws_amplify_branch
 
-Provides an Amplify branch resource.
+Provides an Amplify Branch resource.
 
 ## Example Usage
 
-```hcl
-resource "aws_amplify_app" "app" {
+```terraform
+resource "aws_amplify_app" "example" {
   name = "app"
 }
 
 resource "aws_amplify_branch" "master" {
-  app_id      = "${aws_amplify_app.app.id}"
+  app_id      = aws_amplify_app.example.id
   branch_name = "master"
 
   framework   = "React"
@@ -32,13 +32,13 @@ resource "aws_amplify_branch" "master" {
 
 ### Basic Authentication
 
-```hcl
-resource "aws_amplify_app" "app" {
+```terraform
+resource "aws_amplify_app" "example" {
   name = "app"
 }
 
 resource "aws_amplify_branch" "master" {
-  app_id      = "${aws_amplify_app.app.id}"
+  app_id      = aws_amplify_app.example.id
   branch_name = "master"
 
   basic_auth_config {
@@ -55,13 +55,13 @@ resource "aws_amplify_branch" "master" {
 
 Amplify Console uses CloudWatch Events and SNS for email notifications.  To implement the same functionality, you need to set `enable_notification` in a `aws_amplify_branch` resource, as well as creating a CloudWatch Events Rule, a SNS topic, and SNS subscriptions.
 
-```hcl
-resource "aws_amplify_app" "app" {
+```terraform
+resource "aws_amplify_app" "example" {
   name = "app"
 }
 
 resource "aws_amplify_branch" "master" {
-  app_id      = "${aws_amplify_app.app.id}"
+  app_id      = aws_amplify_app.example.id
   branch_name = "master"
 
   // Enable SNS notifications.
@@ -77,10 +77,10 @@ resource "aws_cloudwatch_event_rule" "amplify_app_master" {
   event_pattern = jsonencode({
     "detail" = {
       "appId" = [
-        "${aws_amplify_app.app.id}"
+        aws_amplify_app.example.id
       ]
       "branchName" = [
-        "${aws_amplify_branch.master.branch_name}"
+        aws_amplify_branch.master.branch_name
       ],
       "jobStatus" = [
         "SUCCEED",
@@ -98,9 +98,9 @@ resource "aws_cloudwatch_event_rule" "amplify_app_master" {
 }
 
 resource "aws_cloudwatch_event_target" "amplify_app_master" {
-  rule      = "${aws_cloudwatch_event_rule.amplify_app_master.name}"
-  target_id = "${aws_amplify_branch.master.branch_name}"
-  arn       = "${aws_sns_topic.amplify_app_master.arn}"
+  rule      = aws_cloudwatch_event_rule.amplify_app_master.name
+  target_id = aws_amplify_branch.master.branch_name
+  arn       = aws_sns_topic.amplify_app_master.arn
 
   input_transformer {
     input_paths = {
@@ -139,14 +139,14 @@ data "aws_iam_policy_document" "amplify_app_master" {
     }
 
     resources = [
-      "${aws_sns_topic.amplify_app_master.arn}",
+      aws_sns_topic.amplify_app_master.arn,
     ]
   }
 }
 
 resource "aws_sns_topic_policy" "amplify_app_master" {
-  arn    = "${aws_sns_topic.amplify_app_master.arn}"
-  policy = "${data.aws_iam_policy_document.amplify_app_master.json}"
+  arn    = aws_sns_topic.amplify_app_master.arn
+  policy = data.aws_iam_policy_document.amplify_app_master.json
 }
 ```
 
@@ -154,43 +154,39 @@ resource "aws_sns_topic_policy" "amplify_app_master" {
 
 The following arguments are supported:
 
-* `app_id` - (Required) Unique Id for an Amplify App.
-* `branch_name` - (Required) Name for the branch.
-* `backend_environment_arn` - (Optional) ARN for a Backend Environment, part of an Amplify App.
-* `basic_auth_config` - (Optional) Basic Authentication config for the branch. A `basic_auth_config` block is documented below.
-* `build_spec` - (Optional) BuildSpec for the branch.
-* `description` - (Optional) Description for the branch.
-* `display_name` - (Optional) Display name for a branch, will use as the default domain prefix.
+* `app_id` - (Required) The unique ID for an Amplify app.
+* `branch_name` - (Required) The name for the branch.
+* `backend_environment_arn` - (Optional) The Amazon Resource Name (ARN) for a backend environment that is part of an Amplify app.
+* `basic_auth_credentials` - (Optional) The basic authorization credentials for the branch.
+* `build_spec` - (Optional) The build specification (build spec) for the branch.
+* `description` - (Optional) The description for the branch.
+* `display_name` - (Optional) The display name for a branch. This is used as the default domain prefix.
 * `enable_auto_build` - (Optional) Enables auto building for the branch.
 * `enable_notifications` - (Optional) Enables notifications for the branch.
-* `enable_pull_request_preview` - (Optional) Enables Pull Request Preview for this branch.
-* `environment_variables` - (Optional) Environment Variables for the branch.
-* `framework` - (Optional) Framework for the branch.
-* `pull_request_environment_name` - (Optional) The Amplify Environment name for the pull request.
-* `stage` - (Optional) Stage for the branch. Possible values: "PRODUCTION", "BETA", "DEVELOPMENT", "EXPERIMENTAL", or "PULL_REQUEST".
-* `tags` - (Optional) Key-value mapping of resource tags.
-* `ttl` - (Optional) The content TTL for the website in seconds.
-
-An `basic_auth_config` block supports the following arguments:
-
-* `enable_basic_auth` - (Optional) Enables Basic Authorization.
-* `username` - (Optional) Basic Authorization username.
-* `password` - (Optional) Basic Authorization password.
+* `enable_performance_mode` - (Optional) Enables performance mode for the branch.
+* `enable_pull_request_preview` - (Optional) Enables pull request previews for this branch.
+* `environment_variables` - (Optional) The environment variables for the branch.
+* `framework` - (Optional) The framework for the branch.
+* `pull_request_environment_name` - (Optional) The Amplify environment name for the pull request.
+* `stage` - (Optional) Describes the current stage for the branch. Valid values: `PRODUCTION`, `BETA`, `DEVELOPMENT`, `EXPERIMENTAL`, `PULL_REQUEST`.
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `ttl` - (Optional) The content Time To Live (TTL) for the website in seconds.
 
 ## Attribute Reference
 
 The following attributes are exported:
 
-* `arn` - ARN for the Amplify App.
-* `associated_resources` - List of custom resources that are linked to this branch.
-* `custom_domains` - Custom domains for a branch, part of an Amplify App.
+* `arn` - The Amazon Resource Name (ARN) for the branch.
+* `associated_resources` - A list of custom resources that are linked to this branch.
+* `custom_domains` - The custom domains for a branch of an Amplify app.
 * `destination_branch` - The destination branch if the branch is a pull request branch.
 * `source_branch` - The source branch if the branch is a pull request branch.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 
 Amplify branch can be imported using `app_id` and `branch_name`, e.g.
 
 ```
-$ terraform import aws_amplify_branch.master d2ypk4k47z8u6/branches/master
+$ terraform import aws_amplify_branch.master d2ypk4k47z8u6/master
 ```

--- a/website/docs/r/amplify_branch.html.markdown
+++ b/website/docs/r/amplify_branch.html.markdown
@@ -42,7 +42,7 @@ resource "aws_amplify_branch" "master" {
   branch_name = "master"
 
   basic_auth_config {
-    // Enable basic authentication.
+    # Enable basic authentication.
     enable_basic_auth = true
 
     username = "username"
@@ -64,11 +64,11 @@ resource "aws_amplify_branch" "master" {
   app_id      = aws_amplify_app.example.id
   branch_name = "master"
 
-  // Enable SNS notifications.
+  # Enable SNS notifications.
   enable_notification = true
 }
 
-// CloudWatch Events Rule for Amplify notifications
+# CloudWatch Events Rule for Amplify notifications
 
 resource "aws_cloudwatch_event_rule" "amplify_app_master" {
   name        = "amplify-${aws_amplify_app.app.id}-${aws_amplify_branch.master.branch_name}-branch-notification"
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_event_target" "amplify_app_master" {
   }
 }
 
-// SNS Topic for Amplify notifications
+# SNS Topic for Amplify notifications
 
 resource "aws_sns_topic" "amplify_app_master" {
   name = "amplify-${aws_amplify_app.app.id}_${aws_amplify_branch.master.branch_name}"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6917 

AWS Amplify service client has been merged by #9874.
Before merging this PR, #11936 must be merged.  After then, I'll run `git rebase` for this branch.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: aws_amplify_branch
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAmplifyBranch'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAmplifyBranch -timeout 120m
=== RUN   TestAccAWSAmplifyBranch_basic
=== PAUSE TestAccAWSAmplifyBranch_basic
=== RUN   TestAccAWSAmplifyBranch_rename
=== PAUSE TestAccAWSAmplifyBranch_rename
=== RUN   TestAccAWSAmplifyBranch_simple
=== PAUSE TestAccAWSAmplifyBranch_simple
=== RUN   TestAccAWSAmplifyBranch_backendEnvironment
=== PAUSE TestAccAWSAmplifyBranch_backendEnvironment
=== RUN   TestAccAWSAmplifyBranch_pullRequestPreview
=== PAUSE TestAccAWSAmplifyBranch_pullRequestPreview
=== RUN   TestAccAWSAmplifyBranch_basicAuthConfig
=== PAUSE TestAccAWSAmplifyBranch_basicAuthConfig
=== RUN   TestAccAWSAmplifyBranch_notification
=== PAUSE TestAccAWSAmplifyBranch_notification
=== RUN   TestAccAWSAmplifyBranch_environmentVariables
=== PAUSE TestAccAWSAmplifyBranch_environmentVariables
=== RUN   TestAccAWSAmplifyBranch_tags
=== PAUSE TestAccAWSAmplifyBranch_tags
=== CONT  TestAccAWSAmplifyBranch_basic
=== CONT  TestAccAWSAmplifyBranch_basicAuthConfig
=== CONT  TestAccAWSAmplifyBranch_tags
=== CONT  TestAccAWSAmplifyBranch_environmentVariables
=== CONT  TestAccAWSAmplifyBranch_notification
=== CONT  TestAccAWSAmplifyBranch_backendEnvironment
=== CONT  TestAccAWSAmplifyBranch_pullRequestPreview
=== CONT  TestAccAWSAmplifyBranch_simple
=== CONT  TestAccAWSAmplifyBranch_rename
--- PASS: TestAccAWSAmplifyBranch_pullRequestPreview (22.15s)
--- PASS: TestAccAWSAmplifyBranch_notification (23.90s)
--- PASS: TestAccAWSAmplifyBranch_rename (34.36s)
--- PASS: TestAccAWSAmplifyBranch_basic (41.88s)
--- PASS: TestAccAWSAmplifyBranch_environmentVariables (47.91s)
--- PASS: TestAccAWSAmplifyBranch_simple (52.51s)
--- PASS: TestAccAWSAmplifyBranch_backendEnvironment (52.77s)
--- PASS: TestAccAWSAmplifyBranch_basicAuthConfig (77.29s)
--- PASS: TestAccAWSAmplifyBranch_tags (77.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	79.278s
```
