### PR TITLE
r/aws_ssm_parameter: Adding support for Intelligent-Tiering

### DIFF
--- a/.changelog/11967.txt
+++ b/.changelog/11967.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ssm_parameter: Add support for `Intelligent-Tiering`
+```

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -47,6 +47,7 @@ func resourceAwsSsmParameter() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					ssm.ParameterTierStandard,
 					ssm.ParameterTierAdvanced,
+					ssm.ParameterTierIntelligentTiering,
 				}, false),
 			},
 			"type": {

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -41,23 +41,18 @@ func resourceAwsSsmParameter() *schema.Resource {
 				Optional: true,
 			},
 			"tier": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  ssm.ParameterTierStandard,
-				ValidateFunc: validation.StringInSlice([]string{
-					ssm.ParameterTierStandard,
-					ssm.ParameterTierAdvanced,
-					ssm.ParameterTierIntelligentTiering,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ssm.ParameterTierStandard,
+				ValidateFunc: validation.StringInSlice(ssm.ParameterTier_Values(), false),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Get("tier").(string) == ssm.ParameterTierIntelligentTiering
+				},
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ssm.ParameterTypeString,
-					ssm.ParameterTypeStringList,
-					ssm.ParameterTypeSecureString,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(ssm.ParameterType_Values(), false),
 			},
 			"value": {
 				Type:      schema.TypeString,
@@ -101,8 +96,10 @@ func resourceAwsSsmParameter() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			// Prevent the following error during tier update from Advanced to Standard:
 			// ValidationException: This parameter uses the advanced-parameter tier. You can't downgrade a parameter from the advanced-parameter tier to the standard-parameter tier. If necessary, you can delete the advanced parameter and recreate it as a standard parameter.
+			// In the case of Advanced to Intelligent-Tiering, a ValidationException is not thrown
+			// but rather no change occurs without resource re-creation
 			customdiff.ForceNewIfChange("tier", func(_ context.Context, old, new, meta interface{}) bool {
-				return old.(string) == ssm.ParameterTierAdvanced && new.(string) == ssm.ParameterTierStandard
+				return old.(string) == ssm.ParameterTierAdvanced && (new.(string) == ssm.ParameterTierStandard || new.(string) == ssm.ParameterTierIntelligentTiering)
 			}),
 		),
 	}

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -55,10 +56,10 @@ func TestAccAWSSSMParameter_Tier(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMParameterConfigTier(rName, "Intelligent-Tiering"),
+				Config: testAccAWSSSMParameterConfigTier(rName, ssm.ParameterTierAdvanced),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists(resourceName, &parameter1),
-					resource.TestCheckResourceAttr(resourceName, "tier", "Standard"),
+					resource.TestCheckResourceAttr(resourceName, "tier", ssm.ParameterTierAdvanced),
 				),
 			},
 			{
@@ -68,18 +69,112 @@ func TestAccAWSSSMParameter_Tier(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"overwrite"},
 			},
 			{
-				Config: testAccAWSSSMParameterConfigTier(rName, "Standard"),
+				Config: testAccAWSSSMParameterConfigTier(rName, ssm.ParameterTierStandard),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists(resourceName, &parameter2),
-					resource.TestCheckResourceAttr(resourceName, "tier", "Standard"),
+					resource.TestCheckResourceAttr(resourceName, "tier", ssm.ParameterTierStandard),
 				),
 			},
 			{
-				Config: testAccAWSSSMParameterConfigTier(rName, "Advanced"),
+				Config: testAccAWSSSMParameterConfigTier(rName, ssm.ParameterTierAdvanced),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists(resourceName, &parameter3),
-					resource.TestCheckResourceAttr(resourceName, "tier", "Advanced"),
+					resource.TestCheckResourceAttr(resourceName, "tier", ssm.ParameterTierAdvanced),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMParameter_Tier_IntelligentTieringToStandard(t *testing.T) {
+	var parameter ssm.Parameter
+	rName := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMParameterConfigTier(rName, ssm.ParameterTierIntelligentTiering),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &parameter),
+					resource.TestCheckResourceAttr(resourceName, "tier", ssm.ParameterTierStandard),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+			{
+				Config: testAccAWSSSMParameterConfigTier(rName, ssm.ParameterTierStandard),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &parameter),
+					resource.TestCheckResourceAttr(resourceName, "tier", ssm.ParameterTierStandard),
+				),
+			},
+			{
+				Config: testAccAWSSSMParameterConfigTier(rName, ssm.ParameterTierIntelligentTiering),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &parameter),
+					resource.TestCheckResourceAttr(resourceName, "tier", ssm.ParameterTierStandard),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMParameter_Tier_IntelligentTieringToAdvanced(t *testing.T) {
+	var parameter1, parameter2 ssm.Parameter
+	rName := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMParameterConfigTier(rName, ssm.ParameterTierIntelligentTiering),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &parameter1),
+					resource.TestCheckResourceAttr(resourceName, "tier", ssm.ParameterTierStandard),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+			{
+				Config: testAccAWSSSMParameterConfigTier(rName, ssm.ParameterTierAdvanced),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &parameter1),
+					resource.TestCheckResourceAttr(resourceName, "tier", ssm.ParameterTierAdvanced),
+				),
+			},
+			{
+				Config: testAccAWSSSMParameterConfigTier(rName, ssm.ParameterTierIntelligentTiering),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &parameter2),
+					resource.TestCheckResourceAttr(resourceName, "tier", ssm.ParameterTierStandard),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
 			},
 		},
 	})
@@ -99,7 +194,7 @@ func TestAccAWSSSMParameter_disappears(t *testing.T) {
 				Config: testAccAWSSSMParameterBasicConfig(name, "String", "test2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists(resourceName, &param),
-					testAccCheckAWSSSMParameterDisappears(&param),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSsmParameter(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -476,20 +571,6 @@ func testAccCheckAWSSSMParameterExists(n string, param *ssm.Parameter) resource.
 	}
 }
 
-func testAccCheckAWSSSMParameterDisappears(param *ssm.Parameter) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ssmconn
-
-		paramInput := &ssm.DeleteParameterInput{
-			Name: param.Name,
-		}
-
-		_, err := conn.DeleteParameter(paramInput)
-
-		return err
-	}
-}
-
 func testAccCheckAWSSSMParameterDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ssmconn
 
@@ -504,13 +585,21 @@ func testAccCheckAWSSSMParameterDestroy(s *terraform.State) error {
 			},
 		}
 
-		resp, _ := conn.GetParameters(paramInput)
+		resp, err := conn.GetParameters(paramInput)
 
-		if len(resp.Parameters) > 0 {
-			return fmt.Errorf("Expected AWS SSM Parameter to be gone, but was still found")
+		if tfawserr.ErrCodeEquals(err, ssm.ErrCodeParameterNotFound) {
+			continue
 		}
 
-		return nil
+		if err != nil {
+			return fmt.Errorf("error reading SSM Parameter (%s): %w", rs.Primary.ID, err)
+		}
+
+		if resp == nil || len(resp.Parameters) == 0 {
+			continue
+		}
+
+		return fmt.Errorf("Expected AWS SSM Parameter to be gone, but was still found")
 	}
 
 	return nil

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -55,10 +55,10 @@ func TestAccAWSSSMParameter_Tier(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMParameterConfigTier(rName, "Advanced"),
+				Config: testAccAWSSSMParameterConfigTier(rName, "Intelligent-Tiering"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists(resourceName, &parameter1),
-					resource.TestCheckResourceAttr(resourceName, "tier", "Advanced"),
+					resource.TestCheckResourceAttr(resourceName, "tier", "Standard"),
 				),
 			},
 			{

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter.
 * `description` - (Optional) The description of the parameter.
-* `tier` - (Optional) The tier of the parameter. If not specified, will default to `Standard`. Valid tiers are `Standard` and `Advanced`. For more information on parameter tiers, see the [AWS SSM Parameter tier comparison and guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
+* `tier` - (Optional) The tier of the parameter. If not specified, will default to `Standard`. Valid tiers are `Standard`, `Advanced`, and `Intelligent-Tiering`. For more information on parameter tiers, see the [AWS SSM Parameter tier comparison and guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
 * `key_id` - (Optional) The KMS key id or arn for encrypting a SecureString.
 * `overwrite` - (Optional) Overwrite an existing parameter. If not specified, will default to `false` if the resource has not been created by terraform to avoid overwrite of existing resource and will default to `true` otherwise (terraform lifecycle rules should then be used to manage the update behavior).
 * `allowed_pattern` - (Optional) A regular expression used to validate the parameter value.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11800

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
r/aws_ssm_parameter: Adding support for Intelligent-Tiering
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMParameter_Tier'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSSMParameter_Tier -timeout 120m
=== RUN   TestAccAWSSSMParameter_Tier
=== PAUSE TestAccAWSSSMParameter_Tier
=== CONT  TestAccAWSSSMParameter_Tier
--- PASS: TestAccAWSSSMParameter_Tier (49.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.969s
```
