### PR TITLE
(terraform-providers/terraform-provider-aws#11986) Add ability to enable/disable logging config

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -977,7 +977,14 @@ func expandLoggingConfig(m map[string]interface{}) *cloudfront.LoggingConfig {
 		lc.Prefix = aws.String(m["prefix"].(string))
 		lc.Bucket = aws.String(m["bucket"].(string))
 		lc.IncludeCookies = aws.Bool(m["include_cookies"].(bool))
-		lc.Enabled = aws.Bool(true)
+
+		var rawEnableFlag interface{} = m["Enabled"]
+		if rawEnableFlag != nil {
+			lc.Enabled = aws.Bool(rawEnableFlag.(bool))
+		} else {
+			lc.Enabled = aws.Bool(true) // preserve backwards compatibility
+		}
+
 	} else {
 		lc.Prefix = aws.String("")
 		lc.Bucket = aws.String("")

--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -978,7 +978,7 @@ func expandLoggingConfig(m map[string]interface{}) *cloudfront.LoggingConfig {
 		lc.Bucket = aws.String(m["bucket"].(string))
 		lc.IncludeCookies = aws.Bool(m["include_cookies"].(bool))
 
-		var rawEnableFlag interface{} = m["Enabled"]
+		var rawEnableFlag interface{} = m["enabled"]
 		if rawEnableFlag != nil {
 			lc.Enabled = aws.Bool(rawEnableFlag.(bool))
 		} else {

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -220,6 +220,15 @@ func loggingConfigConf() map[string]interface{} {
 	}
 }
 
+func loggingConfigConfDisabled() map[string]interface{} {
+	return map[string]interface{}{
+		"include_cookies": false,
+		"bucket":          "mylogs.s3.amazonaws.com",
+		"prefix":          "myprefix",
+		"enabled":         false,
+	}
+}
+
 func customErrorResponsesConfSet() *schema.Set {
 	return schema.NewSet(customErrorResponseHash, customErrorResponsesConf())
 }
@@ -836,6 +845,24 @@ func TestCloudFrontStructure_expandLoggingConfig(t *testing.T) {
 	lc := expandLoggingConfig(data)
 	if !*lc.Enabled {
 		t.Fatalf("Expected Enabled to be true, got %v", *lc.Enabled)
+	}
+	if *lc.Prefix != "myprefix" {
+		t.Fatalf("Expected Prefix to be myprefix, got %v", *lc.Prefix)
+	}
+	if *lc.Bucket != "mylogs.s3.amazonaws.com" {
+		t.Fatalf("Expected Bucket to be mylogs.s3.amazonaws.com, got %v", *lc.Bucket)
+	}
+	if *lc.IncludeCookies {
+		t.Fatalf("Expected IncludeCookies to be false, got %v", *lc.IncludeCookies)
+	}
+}
+
+func TestCloudFrontStructure_expandLoggingConfigDisabled(t *testing.T) {
+	data := loggingConfigConfDisabled()
+
+	lc := expandLoggingConfig(data)
+	if *lc.Enabled {
+		t.Fatalf("Expected Enabled to be false, got %v", *lc.Enabled)
 	}
 	if *lc.Prefix != "myprefix" {
 		t.Fatalf("Expected Prefix to be myprefix, got %v", *lc.Prefix)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #11986 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds ability to retain logging configuration while disabling it
```