### PR TITLE
Fix wait for ASG capacity when increasing min size

### DIFF
--- a/.changelog/12018.txt
+++ b/.changelog/12018.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_autoscaling_group: Prevent infinite wait for capacity when increasing `min_size` and not specifying `desired_capacity`
+```

--- a/internal/service/autoscaling/group_waiting.go
+++ b/internal/service/autoscaling/group_waiting.go
@@ -185,11 +185,13 @@ func CapacitySatisfiedCreate(d *schema.ResourceData, haveASG, haveELB int) (bool
 
 // CapacitySatisfiedUpdate only cares about specific targets
 func CapacitySatisfiedUpdate(d *schema.ResourceData, haveASG, haveELB int) (bool, string) {
-	if wantASG := d.Get("desired_capacity").(int); wantASG > 0 {
-		if haveASG != wantASG {
-			return false, fmt.Sprintf(
-				"Need exactly %d healthy instances in ASG, have %d", wantASG, haveASG)
-		}
+	minASG := d.Get("min_size").(int)
+	if wantASG := d.Get("desired_capacity").(int); wantASG > minASG {
+		minASG = wantASG
+	}
+	if haveASG != minASG {
+		return false, fmt.Sprintf(
+			"Need exactly %d healthy instances in ASG, have %d", minASG, haveASG)
 	}
 	if wantELB := d.Get("wait_for_elb_capacity").(int); wantELB > 0 {
 		if haveELB != wantELB {

--- a/internal/service/autoscaling/group_waiting_test.go
+++ b/internal/service/autoscaling/group_waiting_test.go
@@ -157,8 +157,33 @@ func TestCapacitySatisfiedUpdate(t *testing.T) {
 			Data:            map[string]interface{}{},
 			ExpectSatisfied: true,
 		},
+		"min_size, got it": {
+			Data: map[string]interface{}{
+				"min_size": 5,
+			},
+			HaveASG:         5,
+			ExpectSatisfied: true,
+		},
+		"min_size overrides desired_capacity": {
+			Data: map[string]interface{}{
+				"min_size":         5,
+				"desired_capacity": 2,
+			},
+			HaveASG:         2,
+			ExpectSatisfied: false,
+			ExpectReason:    "Need exactly 5 healthy instances in ASG, have 2",
+		},
 		"desired_capacity, have less": {
 			Data: map[string]interface{}{
+				"desired_capacity": 5,
+			},
+			HaveASG:         2,
+			ExpectSatisfied: false,
+			ExpectReason:    "Need exactly 5 healthy instances in ASG, have 2",
+		},
+		"desired_capacity overrides min_size": {
+			Data: map[string]interface{}{
+				"min_size":         2,
 				"desired_capacity": 5,
 			},
 			HaveASG:         2,


### PR DESCRIPTION
When updating an ASG there are currently two ways `capacitySatisfiedUpdate()` might ultimately be called from `resourceAwsAutoscalingGroupUpdate()`:

 - `if d.HasChange("min_size")`, and/or
 - `if d.HasChange("desired_capacity")`

The existing approach here, only checking against `desired_capacity`, is flawed because that argument is optional while `min_size` is mandatory. If `desired_capacity` is not specified, AWS will automatically [update it](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_UpdateAutoScalingGroup.html) to match either `min_size` or `max_size` depending on whether the group is being increased or decreased.

However, the Terraform AWS provider does not predict this behaviour in advance. The new auto-updated value for `desired_capacity` is only detected at the very end of `resourceAwsAutoscalingGroupUpdate()` (after waiting for capacity) when the configuration of the updated ASG is read. Before then `d.Get("desired_capacity")` returns the existing value.

All of this presents a problem when `desired_capacity` is not specified and `min_size` is increased. We detect a change to `min_size` and thus trigger a `waitForASGCapacity()`, but then wait for exactly (existing) `desired_capacity` healthy instances. This number is less than both `min_size` and the new `desired_capacity`, meaning that even if the update is otherwise successful, we get stuck forever waiting for a smaller number of healthy instances.

The fix is to wait for whichever is the higher of `min_size` and `desired_capacity` instances.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5241

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_autoscaling_group: Prevent infinite wait for capacity when increasing `min_size` and not specifying `desired_capacity`
```

Note that I have not run acceptance tests as I do not have a suitable AWS test account configured at the moment.