### PR TITLE
data-source/aws_iam_policy_document: Add functionality to merge multiple policy documents

### DIFF
--- a/.changelog/12055.txt
+++ b/.changelog/12055.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_iam_policy_document: Support merging policy documents by adding `source_policy_documents` and `override_policy_documents` arguments
+```

--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -34,6 +34,7 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 			"override_json_list": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"policy_id": {
 				Type:     schema.TypeString,
@@ -46,6 +47,7 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 			"source_json_list": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"statement": {
 				Type:     schema.TypeList,
@@ -133,9 +135,9 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 		}
 
 		// merge sourceDocs in order specified
-		for sourceJSONIndex, sourceJSON := range sourceJSONList.([]string) {
+		for sourceJSONIndex, sourceJSON := range sourceJSONList.([]interface{}) {
 			sourceDoc := &IAMPolicyDoc{}
-			if err := json.Unmarshal([]byte(sourceJSON), sourceDoc); err != nil {
+			if err := json.Unmarshal([]byte(sourceJSON.(string)), sourceDoc); err != nil {
 				return err
 			}
 
@@ -246,9 +248,9 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 
 	// merge override_json_list policies into mergedDoc in order specified
 	if overrideJSONList, hasOverideJSONList := d.GetOk("overide_json_list"); hasOverideJSONList {
-		for _, overrideJSON := range overrideJSONList.([]string) {
+		for _, overrideJSON := range overrideJSONList.([]interface{}) {
 			overrideDoc := &IAMPolicyDoc{}
-			if err := json.Unmarshal([]byte(overrideJSON), overrideDoc); err != nil {
+			if err := json.Unmarshal([]byte(overrideJSON.(string)), overrideDoc); err != nil {
 				return err
 			}
 

--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -31,6 +31,10 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"override_json_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+			},
 			"policy_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -239,6 +243,19 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 
 	// merge our current document into mergedDoc
 	mergedDoc.Merge(doc)
+
+	// merge override_json_list policies into mergedDoc in order specified
+	if overrideJSONList, hasOverideJSONList := d.GetOk("overide_json_list"); hasOverideJSONList {
+		for _, overrideJSON := range overrideJSONList.([]string) {
+			overrideDoc := &IAMPolicyDoc{}
+			if err := json.Unmarshal([]byte(overrideJSON), overrideDoc); err != nil {
+				return err
+			}
+
+			mergedDoc.Merge(overrideDoc)
+		}
+
+	}
 
 	// merge in override_json
 	if overrideJSON, hasOverrideJSON := d.GetOk("override_json"); hasOverrideJSON {

--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -247,7 +247,7 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 	mergedDoc.Merge(doc)
 
 	// merge override_json_list policies into mergedDoc in order specified
-	if overrideJSONList, hasOverideJSONList := d.GetOk("overide_json_list"); hasOverideJSONList {
+	if overrideJSONList, hasOverrideJSONList := d.GetOk("override_json_list"); hasOverrideJSONList {
 		for _, overrideJSON := range overrideJSONList.([]interface{}) {
 			overrideDoc := &IAMPolicyDoc{}
 			if err := json.Unmarshal([]byte(overrideJSON.(string)), overrideDoc); err != nil {

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -671,8 +671,7 @@ var testAccAWSIAMPolicyDocumentSourceListExpectedJSON = `{
       "Action": "bar:ActionTwo"
     }
   ]
-}
-`
+}`
 
 var testAccAWSIAMPolicyDocumentSourceBlankConfig = `
 data "aws_iam_policy_document" "test_source_blank" {
@@ -874,8 +873,7 @@ var testAccAWSIAMPolicyDocumentOverrideListExpectedJSON = `{
       "Action": "foo:ActionTwo"
     }
   ]
-}
-`
+}`
 
 var testAccAWSIAMPolicyDocumentNoStatementMergeConfig = `
 data "aws_iam_policy_document" "source" {

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -194,7 +194,7 @@ func TestAccAWSDataSourceIAMPolicyDocument_duplicateSid(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/10777
-func TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice(t *testing.T) {
+func TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_stringAndSlice(t *testing.T) {
 	dataSourceName := "data.aws_iam_policy_document.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -212,7 +212,7 @@ func TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_Strin
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/10777
-func TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals(t *testing.T) {
+func TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipals(t *testing.T) {
 	dataSourceName := "data.aws_iam_policy_document.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -229,7 +229,7 @@ func TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_Multi
 	})
 }
 
-func TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsGov(t *testing.T) {
+func TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipalsGov(t *testing.T) {
 	dataSourceName := "data.aws_iam_policy_document.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -246,7 +246,7 @@ func TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_Multi
 	})
 }
 
-func TestAccAWSDataSourceIAMPolicyDocument_Version_20081017(t *testing.T) {
+func TestAccAWSDataSourceIAMPolicyDocument_version20081017(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -98,7 +98,7 @@ func TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSIAMPolicyDocumentSourceListConflictingConfig,
-				ExpectError: regexp.MustCompile(`Found duplicate sid (.*?) in source_json_list`),
+				ExpectError: regexp.MustCompile(`duplicate Sid (.*?)`),
 			},
 		},
 	})
@@ -179,7 +179,7 @@ func TestAccAWSDataSourceIAMPolicyDocument_duplicateSid(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSIAMPolicyDocumentDuplicateSidConfig,
-				ExpectError: regexp.MustCompile(`Found duplicate sid`),
+				ExpectError: regexp.MustCompile(`duplicate Sid`),
 			},
 			{
 				Config: testAccAWSIAMPolicyDocumentDuplicateBlankSidConfig,
@@ -645,7 +645,7 @@ data "aws_iam_policy_document" "policy_c" {
 data "aws_iam_policy_document" "test_source_list" {
   version = "2012-10-17"
 
-  source_json_list = [
+  source_policy_documents = [
     data.aws_iam_policy_document.policy_a.json,
     data.aws_iam_policy_document.policy_b.json,
     data.aws_iam_policy_document.policy_c.json
@@ -768,7 +768,7 @@ data "aws_iam_policy_document" "policy_c" {
 data "aws_iam_policy_document" "test_source_list_conflicting" {
   version = "2012-10-17"
 
-  source_json_list = [
+  source_policy_documents = [
     data.aws_iam_policy_document.policy_a.json,
     data.aws_iam_policy_document.policy_b.json,
     data.aws_iam_policy_document.policy_c.json
@@ -861,7 +861,7 @@ data "aws_iam_policy_document" "policy_c" {
 data "aws_iam_policy_document" "test_override_list" {
   version = "2012-10-17"
 
-  override_json_list = [
+  override_policy_documents = [
     data.aws_iam_policy_document.policy_a.json,
     data.aws_iam_policy_document.policy_b.json,
     data.aws_iam_policy_document.policy_c.json

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -613,38 +613,43 @@ func testAccAWSIAMPolicyDocumentSourceExpectedJSON() string {
 
 var testAccAWSIAMPolicyDocumentSourceListConfig = `
 data "aws_iam_policy_document" "policy_a" {
-	statement {
-		sid = ""
-		effect = "Allow"
-		actions = [ "foo:ActionOne" ]
-	}
-	statement {
-		sid = "validSidOne"
-		effect = "Allow"
-		actions = [ "bar:ActionOne" ]
-	}
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["foo:ActionOne"]
+  }
+
+  statement {
+    sid     = "validSidOne"
+    effect  = "Allow"
+    actions = ["bar:ActionOne"]
+  }
 }
+
 data "aws_iam_policy_document" "policy_b" {
-	statement {
-		sid = "validSidTwo"
-		effect = "Deny"
-		actions = [ "foo:ActionTwo" ]
-	}
+  statement {
+    sid     = "validSidTwo"
+    effect  = "Deny"
+    actions = ["foo:ActionTwo"]
+  }
 }
+
 data "aws_iam_policy_document" "policy_c" {
-	statement {
-		sid = ""
-		effect = "Allow"
-		actions = [ "bar:ActionTwo" ]
-	}
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["bar:ActionTwo"]
+  }
 }
+
 data "aws_iam_policy_document" "test_source_list" {
-	version = "2012-10-17"
-	source_json_list = [
-		data.aws_iam_policy_document.policy_a.json,
-		data.aws_iam_policy_document.policy_b.json,
-		data.aws_iam_policy_document.policy_c.json
-	]
+  version = "2012-10-17"
+
+  source_json_list = [
+    data.aws_iam_policy_document.policy_a.json,
+    data.aws_iam_policy_document.policy_b.json,
+    data.aws_iam_policy_document.policy_c.json
+  ]
 }
 `
 var testAccAWSIAMPolicyDocumentSourceListExpectedJSON = `{
@@ -731,38 +736,43 @@ var testAccAWSIAMPolicyDocumentSourceConflictingExpectedJSON = `{
 
 var testAccAWSIAMPolicyDocumentSourceListConflictingConfig = `
 data "aws_iam_policy_document" "policy_a" {
-	statement {
-		sid = ""
-		effect = "Allow"
-		actions = [ "foo:ActionOne" ]
-	}
-	statement {
-		sid = "conflictSid"
-		effect = "Allow"
-		actions = [ "bar:ActionOne" ]
-	}
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["foo:ActionOne"]
+  }
+
+  statement {
+    sid     = "conflictSid"
+    effect  = "Allow"
+    actions = ["bar:ActionOne"]
+  }
 }
+
 data "aws_iam_policy_document" "policy_b" {
-	statement {
-		sid = "validSid"
-		effect = "Deny"
-		actions = [ "foo:ActionTwo" ]
-	}
+  statement {
+    sid     = "validSid"
+    effect  = "Deny"
+    actions = ["foo:ActionTwo"]
+  }
 }
+
 data "aws_iam_policy_document" "policy_c" {
-	statement {
-		sid = "conflictSid"
-		effect = "Allow"
-		actions = [ "bar:ActionTwo" ]
-	}
+  statement {
+    sid     = "conflictSid"
+    effect  = "Allow"
+    actions = ["bar:ActionTwo"]
+  }
 }
+
 data "aws_iam_policy_document" "test_source_list_conflicting" {
-	version = "2012-10-17"
-	source_json_list = [
-		data.aws_iam_policy_document.policy_a.json,
-		data.aws_iam_policy_document.policy_b.json,
-		data.aws_iam_policy_document.policy_c.json
-	]
+  version = "2012-10-17"
+
+  source_json_list = [
+    data.aws_iam_policy_document.policy_a.json,
+    data.aws_iam_policy_document.policy_b.json,
+    data.aws_iam_policy_document.policy_c.json
+  ]
 }
 `
 
@@ -819,38 +829,43 @@ var testAccAWSIAMPolicyDocumentOverrideExpectedJSON = `{
 
 var testAccAWSIAMPolicyDocumentOverrideListConfig = `
 data "aws_iam_policy_document" "policy_a" {
-	statement {
-		sid = ""
-		effect = "Allow"
-		actions = [ "foo:ActionOne" ]
-	}
-	statement {
-		sid = "overrideSid"
-		effect = "Allow"
-		actions = [ "bar:ActionOne" ]
-	}
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["foo:ActionOne"]
+  }
+
+  statement {
+    sid     = "overrideSid"
+    effect  = "Allow"
+    actions = ["bar:ActionOne"]
+  }
 }
+
 data "aws_iam_policy_document" "policy_b" {
-	statement {
-		sid = "validSid"
-		effect = "Deny"
-		actions = [ "foo:ActionTwo" ]
-	}
+  statement {
+    sid     = "validSid"
+    effect  = "Deny"
+    actions = ["foo:ActionTwo"]
+  }
 }
+
 data "aws_iam_policy_document" "policy_c" {
-	statement {
-		sid = "overrideSid"
-		effect = "Deny"
-		actions = [ "bar:ActionOne" ]
-	}
+  statement {
+    sid     = "overrideSid"
+    effect  = "Deny"
+    actions = ["bar:ActionOne"]
+  }
 }
+
 data "aws_iam_policy_document" "test_override_list" {
-	version = "2012-10-17"
-	override_json_list = [
-		data.aws_iam_policy_document.policy_a.json,
-		data.aws_iam_policy_document.policy_b.json,
-		data.aws_iam_policy_document.policy_c.json
-	]
+  version = "2012-10-17"
+
+  override_json_list = [
+    data.aws_iam_policy_document.policy_a.json,
+    data.aws_iam_policy_document.policy_b.json,
+    data.aws_iam_policy_document.policy_c.json
+  ]
 }
 `
 

--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
   policy document will overwrite statements with the same `sid` in the source
   json.  Statements without an `sid` cannot be overwritten.
 * `source_json_list` (Optional) - A list of IAM policy documents to import as
-  a base for the current policy document. Statements accross all policy documents
+  a base for the current policy document. Statements across all policy documents
   defined in this list or in the `source_json` attribute must be unique. Statements
   with non-blank `sid`s in the current policy document will overwrite statements
   with the same `sid` from any of the source json documents.

--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -8,13 +8,17 @@ description: |-
 
 # Data Source: aws_iam_policy_document
 
-Generates an IAM policy document in JSON format.
+Generates an IAM policy document in JSON format for use with resources that expect policy documents such as [`aws_iam_policy`](/docs/providers/aws/r/iam_policy.html).
 
-This is a data source which can be used to construct a JSON representation of
-an IAM policy document, for use with resources which expect policy documents,
-such as the `aws_iam_policy` resource.
+Using this data source to generate policy documents is *optional*. It is also valid to use literal JSON strings in your configuration or to use the `file` interpolation function to read a raw JSON policy document from a file.
+
+~> **NOTE:** AWS's IAM policy document syntax allows for replacement of [policy variables](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html) within a statement using `${...}`-style notation, which conflicts with Terraform's interpolation syntax. In order to use AWS policy variables with this data source, use `&{...}` notation for interpolations that should be processed by AWS rather than by Terraform.
 
 -> For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
+
+## Example Usage
+
+### Basic Example
 
 ```hcl
 data "aws_iam_policy_document" "example" {
@@ -71,117 +75,9 @@ resource "aws_iam_policy" "example" {
 }
 ```
 
-Using this data source to generate policy documents is *optional*. It is also
-valid to use literal JSON strings within your configuration, or to use the
-`file` interpolation function to read a raw JSON policy document from a file.
+### Example Assume-Role Policy with Multiple Principals
 
-## Argument Reference
-
-The following arguments are supported:
-
-* `policy_id` (Optional) - An ID for the policy document.
-* `source_json` (Optional) - An IAM policy document to import as a base for the
-  current policy document.  Statements with non-blank `sid`s in the current
-  policy document will overwrite statements with the same `sid` in the source
-  json.  Statements without an `sid` cannot be overwritten.
-* `source_json_list` (Optional) - A list of IAM policy documents to import as
-  a base for the current policy document. Statements across all policy documents
-  defined in this list or in the `source_json` attribute must be unique. Statements
-  with non-blank `sid`s in the current policy document will overwrite statements
-  with the same `sid` from any of the source json documents.
-* `override_json` (Optional) - An IAM policy document to import and override the
-  current policy document.  Statements with non-blank `sid`s in the override
-  document will overwrite statements with the same `sid` in the current document,
-  including any defined by the `override_json_list` attribute.
-  Statements without an `sid` cannot be overwritten.
-* `override_json_list` (Optional) - A list of IAM policy documents to import and
-  override the current policy document. Documents in this list are merged
-  iteratively, overwriting previously defined statements with non-blank matching
-  `sid`s. Statements with non-blank `sid`s will overwrite statements with the same
-  `sid` in the current document. Statements without an `sid` cannot be overwritten.
-* `statement` (Optional) - A nested configuration block (described below)
-  configuring one *statement* to be included in the policy document.
-* `version` (Optional) - IAM policy document version. Valid values: `2008-10-17`, `2012-10-17`. Defaults to `2012-10-17`. For more information, see the [AWS IAM User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html).
-
-Each document configuration may have one or more `statement` blocks, which
-each accept the following arguments:
-
-* `sid` (Optional) - An ID for the policy statement.
-* `effect` (Optional) - Either "Allow" or "Deny", to specify whether this
-  statement allows or denies the given actions. The default is "Allow".
-* `actions` (Optional) - A list of actions that this statement either allows
-  or denies. For example, ``["ec2:RunInstances", "s3:*"]``.
-* `not_actions` (Optional) - A list of actions that this statement does *not*
-  apply to. Used to apply a policy statement to all actions *except* those
-  listed.
-* `resources` (Optional) - A list of resource ARNs that this statement applies
-  to. This is required by AWS if used for an IAM policy.
-* `not_resources` (Optional) - A list of resource ARNs that this statement
-  does *not* apply to. Used to apply a policy statement to all resources
-  *except* those listed.
-* `principals` (Optional) - A nested configuration block (described below)
-  specifying a principal (or principal pattern) to which this statement applies.
-* `not_principals` (Optional) - Like `principals` except gives principals that
-  the statement does *not* apply to.
-* `condition` (Optional) - A nested configuration block (described below)
-  that defines a further, possibly-service-specific condition that constrains
-  whether this statement applies.
-
-Each policy may have either zero or more `principals` blocks or zero or more
-`not_principals` blocks, both of which each accept the following arguments:
-
-* `type` (Required) The type of principal. For AWS ARNs this is "AWS".  For AWS services (e.g. Lambda), this is "Service". For Federated access the type is "Federated".
-* `identifiers` (Required) List of identifiers for principals. When `type`
-  is "AWS", these are IAM user or role ARNs.  When `type` is "Service", these are AWS Service roles e.g. `lambda.amazonaws.com`. When `type` is "Federated", these are web identity users or SAML provider ARNs.
-
-For further examples or information about AWS principals then please refer to the [documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html).
-
-Each policy statement may have zero or more `condition` blocks, which each
-accept the following arguments:
-
-* `test` (Required) The name of the
-  [IAM condition operator](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html)
-  to evaluate.
-* `variable` (Required) The name of a
-  [Context Variable](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AvailableKeys)
-  to apply the condition to. Context variables may either be standard AWS
-  variables starting with `aws:`, or service-specific variables prefixed with
-  the service name.
-* `values` (Required) The values to evaluate the condition against. If multiple
-  values are provided, the condition matches if at least one of them applies.
-  (That is, the tests are combined with the "OR" boolean operation.)
-
-When multiple `condition` blocks are provided, they must *all* evaluate to true
-for the policy statement to apply. (In other words, the conditions are combined
-with the "AND" boolean operation.)
-
-## Context Variable Interpolation
-
-The IAM policy document format allows context variables to be interpolated
-into various strings within a statement. The native IAM policy document format
-uses `${...}`-style syntax that is in conflict with Terraform's interpolation
-syntax, so this data source instead uses `&{...}` syntax for interpolations that
-should be processed by AWS rather than by Terraform.
-
-## Wildcard Principal
-
-In order to define wildcard principal (a.k.a. anonymous user) use `type = "*"` and
-`identifiers = ["*"]`. In that case the rendered json will contain `"Principal": "*"`.
-Note, that even though the [IAM Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html)
-states that `"Principal": "*"` and `"Principal": {"AWS": "*"}` are equivalent,
-those principals have different behavior for IAM Role Trust Policy. Therefore
-Terraform will normalize the principal field only in above-mentioned case and principals
-like `type = "AWS"` and `identifiers = ["*"]` will be rendered as `"Principal": {"AWS": "*"}`.
-
-## Attributes Reference
-
-The following attribute is exported:
-
-* `json` - The above arguments serialized as a standard JSON policy document.
-
-## Example with Multiple Principals
-
-Showing how you can use this as an assume role policy as well as showing how you can specify multiple principal blocks with different types.
+You can specify multiple principal blocks with different types. You can also use this data source to generate an assume-role policy.
 
 ```hcl
 data "aws_iam_policy_document" "event_stream_bucket_role_assume_role_policy" {
@@ -206,9 +102,7 @@ data "aws_iam_policy_document" "event_stream_bucket_role_assume_role_policy" {
 }
 ```
 
-## Example with Source and Override
-
-Showing how you can use `source_json` and `override_json`
+### Example Using A Source Document
 
 ```hcl
 data "aws_iam_policy_document" "source" {
@@ -218,7 +112,7 @@ data "aws_iam_policy_document" "source" {
   }
 
   statement {
-    sid = "SidToOverwrite"
+    sid = "SidToOverride"
 
     actions   = ["s3:*"]
     resources = ["*"]
@@ -229,36 +123,7 @@ data "aws_iam_policy_document" "source_json_example" {
   source_json = data.aws_iam_policy_document.source.json
 
   statement {
-    sid = "SidToOverwrite"
-
-    actions = ["s3:*"]
-
-    resources = [
-      "arn:aws:s3:::somebucket",
-      "arn:aws:s3:::somebucket/*",
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "override" {
-  statement {
-    sid = "SidToOverwrite"
-
-    actions   = ["s3:*"]
-    resources = ["*"]
-  }
-}
-
-data "aws_iam_policy_document" "override_json_example" {
-  override_json = data.aws_iam_policy_document.override.json
-
-  statement {
-    actions   = ["ec2:*"]
-    resources = ["*"]
-  }
-
-  statement {
-    sid = "SidToOverwrite"
+    sid = "SidToOverride"
 
     actions = ["s3:*"]
 
@@ -283,7 +148,7 @@ data "aws_iam_policy_document" "override_json_example" {
       "Resource": "*"
     },
     {
-      "Sid": "SidToOverwrite",
+      "Sid": "SidToOverride",
       "Effect": "Allow",
       "Action": "s3:*",
       "Resource": [
@@ -292,6 +157,39 @@ data "aws_iam_policy_document" "override_json_example" {
       ]
     }
   ]
+}
+```
+
+### Example Using An Override Document
+
+```hcl
+data "aws_iam_policy_document" "override" {
+  statement {
+    sid = "SidToOverride"
+
+    actions   = ["s3:*"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "override_json_example" {
+  override_json = data.aws_iam_policy_document.override.json
+
+  statement {
+    actions   = ["ec2:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "SidToOverride"
+
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::somebucket",
+      "arn:aws:s3:::somebucket/*",
+    ]
+  }
 }
 ```
 
@@ -308,7 +206,7 @@ data "aws_iam_policy_document" "override_json_example" {
       "Resource": "*"
     },
     {
-      "Sid": "SidToOverwrite",
+      "Sid": "SidToOverride",
       "Effect": "Allow",
       "Action": "s3:*",
       "Resource": "*"
@@ -317,11 +215,9 @@ data "aws_iam_policy_document" "override_json_example" {
 }
 ```
 
+### Example with Both Source and Override Documents
+
 You can also combine `source_json` and `override_json` in the same document.
-
-## Example without Statement
-
-Use without a `statement`:
 
 ```hcl
 data "aws_iam_policy_document" "source" {
@@ -362,14 +258,9 @@ data "aws_iam_policy_document" "politik" {
 }
 ```
 
-## Combining multiple documents
+### Example of Merging Source Documents
 
-Multiple documents can be combined using the `source_json_list` or
-`override_json_list` attributes. `source_json_list` requires all documents
-to have unique `sid`s, while `override_json_list` will iteratively overwrite
-matching `sid`s.
-
-Examble of `source_json_list`:
+Multiple documents can be combined using the `source_policy_documents` or `override_policy_documents` attributes. `source_policy_documents` requires that all documents have unique Sids, while `override_policy_documents` will iteratively override matching Sids.
 
 ```hcl
 data "aws_iam_policy_document" "source_one" {
@@ -401,7 +292,7 @@ data "aws_iam_policy_document" "source_two" {
 }
 
 data "aws_iam_policy_document" "combined" {
-  source_json_list = [
+  source_policy_documents = [
     data.aws_iam_policy_document.source_one.json,
     data.aws_iam_policy_document.source_two.json
   ]
@@ -442,7 +333,7 @@ data "aws_iam_policy_document" "combined" {
 }
 ```
 
-Examble of `override_json_list`:
+### Example of Merging Override Documents
 
 ```hcl
 data "aws_iam_policy_document" "policy_one" {
@@ -482,7 +373,7 @@ data "aws_iam_policy_document" "policy_three" {
 }
 
 data "aws_iam_policy_document" "combined" {
-  override_json_list = [
+  override_policy_documents = [
     data.aws_iam_policy_document.policy_one.json,
     data.aws_iam_policy_document.policy_two.json,
     data.aws_iam_policy_document.policy_three.json
@@ -525,3 +416,58 @@ data "aws_iam_policy_document" "combined" {
   ]
 }
 ```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `override_json` (Optional) - IAM policy document whose statements with non-blank `sid`s will override statements with the same `sid` in the exported document including any defined by the `override_policy_documents` argument. Statements without a `sid` cannot be overridden.
+* `override_policy_documents` (Optional) - List of IAM policy documents that are merged together into the exported document, potentially overriding previously defined statements with the same `sid`s.
+* `policy_id` (Optional) - ID for the policy document.
+* `source_json` (Optional) - IAM policy document used as a base for the exported policy document.
+* `source_policy_documents` (Optional) - List of IAM policy documents that are merged together into the exported document. Statements defined in `source_policy_documents` or `source_json` must have unique `sid`s. Override statements with the same `sid` will override source statements. Statements without a `sid` cannot be overridden.
+* `statement` (Optional) - Configuration block for a policy statement. Detailed below.
+* `version` (Optional) - IAM policy document version. Valid values are `2008-10-17` and `2012-10-17`. Defaults to `2012-10-17`. For more information, see the [AWS IAM User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html).
+
+### `statement`
+
+The following arguments are optional:
+
+* `actions` (Optional) - List of actions that this statement either allows or denies. For example, `["ec2:RunInstances", "s3:*"]`.
+* `condition` (Optional) - Configuration block for a condition. Detailed below.
+* `effect` (Optional) - Whether this statement allows or denies the given actions. Valid values are `Allow` and `Deny`. Defaults to `Allow`.
+* `not_actions` (Optional) - List of actions that this statement does *not* apply to. Use to apply a policy statement to all actions *except* those listed.
+* `not_principals` (Optional) - Like `principals` except these are principals that the statement does *not* apply to.
+* `not_resources` (Optional) - List of resource ARNs that this statement does *not* apply to. Use to apply a policy statement to all resources *except* those listed.
+* `principals` (Optional) - Configuration block for principals. Detailed below.
+* `resources` (Optional) - List of resource ARNs that this statement applies to. This is required by AWS if used for an IAM policy.
+* `sid` (Optional) - Sid (statement ID) is an identifier for a policy statement.
+
+### `condition`
+
+A `condition` constrains whether a statement applies in a particular situation. Conditions can be specific to an AWS service. When using multiple `condition` blocks, they must *all* evaluate to true for the policy statement to apply. In other words, AWS evaluates the conditions as though with an "AND" boolean operation.
+
+The following arguments are required:
+
+* `test` (Required) Name of the [IAM condition operator](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html) to evaluate.
+* `values` (Required) Values to evaluate the condition against. If multiple values are provided, the condition matches if at least one of them applies. That is, AWS evaluates multiple values as though using an "OR" boolean operation.
+* `variable` (Required) Name of a [Context Variable](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AvailableKeys) to apply the condition to. Context variables may either be standard AWS variables starting with `aws:` or service-specific variables prefixed with the service name.
+
+### `principals` and `not_principals`
+
+The `principals` and `not_principals` arguments define to whom a statement applies or does not apply, respectively.
+
+~> **NOTE**: Even though the [IAM Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html) states that `"Principal": "*"` and `"Principal": {"AWS": "*"}` are equivalent, those principal elements have different behavior in some situations, e.g. IAM Role Trust Policy. To have Terraform render JSON containing `"Principal": "*"`, use `type = "*"` and `identifiers = ["*"]`. To have Terraform render JSON containing `"Principal": {"AWS": "*"}`, use `type = "AWS"` and `identifiers = ["*"]`.
+
+-> For more information about AWS principals, refer to the [AWS Identity and Access Management User Guide: AWS JSON policy elements: Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html).
+
+The following arguments are required:
+
+* `identifiers` (Required) List of identifiers for principals. When `type` is `AWS`, these are IAM principal ARNs, e.g. `arn:aws:iam::12345678901:role/yak-role`.  When `type` is `Service`, these are AWS Service roles, e.g. `lambda.amazonaws.com`. When `type` is `Federated`, these are web identity users or SAML provider ARNs, e.g. `accounts.google.com` or `arn:aws:iam::12345678901:saml-provider/yak-saml-provider`. When `type` is `CanonicalUser`, these are [canonical user IDs](https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html#FindingCanonicalId), e.g. `79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be`.
+* `type` (Required) Type of principal. Valid values include `AWS`, `Service`, `Federated`, and `CanonicalUser`.
+
+## Attributes Reference
+
+The following attribute is exported:
+
+* `json` - Standard JSON policy document rendered based on the arguments above.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

### TL;DR

This PR introduces the two new attributes `source_json_list` and `override_json_list` into the `aws_iam_policy_document` data source. This enhancement allows for the layering and combining of IAM policy documents which is incredibly useful generating permission boundaries and reducing duplicated statements across Terraform definitions.

### Design

This PR models the behaviour described by @bflad in [this comment](https://github.com/terraform-providers/terraform-provider-aws/issues/5047#issuecomment-427118985) on issue #5047.

`source_json_list` provides a method to generate a base policy from multiple policy documents. Each non-empty SID across all statements (including statements defined in the `source_json`) must be unique, or a "Found duplicate sid" will be thrown.

`override_json_list` provides a method iteratively combine policy documents, performing an overwrite / merge on any duplicated SIDs.

This behaviour was achieved by utilising the `IAMPolicyDoc.Merge` method. The proposed conceptual flow for generating policy documents is as follows:

  1. Create an `IAMPolicyDoc` based on the provided `source_json`. If no `source_json` was defined, create a blank `IAMPolicyDoc`.
  1. *(NEW)* If the `source_json_list` attribute was specified, iterate over each policy and merge them. Before each individual policy is merged in, check that none of the non-blank SIDs have already been defined.
  1. Merge the statements defined in the current Terraform block's `statement` attributes.
  1. *(NEW)* If the `override_json_list` attribute was specified, iterate over each policy and merge them.
  1. Merge the `override_json` document if the attribute was specified.

### Tests

The following tests were added to verify this new functionality:
  - TestAccAWSDataSourceIAMPolicyDocument_sourceList
  - TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting
  - TestAccAWSDataSourceIAMPolicyDocument_overrideList

The outputs from these tests (and all other `TestAccAWSDataSourceIAMPolicyDocument`) can be found in the "Output from acceptance testing" section of this PR.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes the following issues:
  - #5047
  - #11942

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_iam_policy_document: Add `source_json_list` attribute
data-source/aws_iam_policy_document: Add `override_json_list` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMPolicyDocument''

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMPolicyDocument -timeout 120m
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_basic
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_basic
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_source
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_source
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceList
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_sourceList
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_override
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_override
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_overrideList
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_overrideList
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_basic
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_overrideList
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_override
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_sourceList
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_source
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting (11.10s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (46.15s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals (46.34s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (46.37s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_overrideList (46.48s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (46.50s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceList (46.71s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (46.71s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice (46.80s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (46.80s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (50.75s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Version_20081017 (68.06s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (72.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	72.661s
```
