### PR TITLE
port support for client vpn endpoint

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -233,6 +233,7 @@ func resourceAwsEc2ClientVpnEndpointRead(d *schema.ResourceData, meta interface{
 	d.Set("client_cidr_block", result.ClientVpnEndpoints[0].ClientCidrBlock)
 	d.Set("server_certificate_arn", result.ClientVpnEndpoints[0].ServerCertificateArn)
 	d.Set("transport_protocol", result.ClientVpnEndpoints[0].TransportProtocol)
+	d.Set("vpn_port", result.ClientVpnEndpoints[0].VpnPort)
 	d.Set("dns_name", result.ClientVpnEndpoints[0].DnsName)
 	d.Set("dns_servers", result.ClientVpnEndpoints[0].DnsServers)
 
@@ -313,6 +314,10 @@ func resourceAwsEc2ClientVpnEndpointUpdate(d *schema.ResourceData, meta interfac
 
 	if d.HasChange("split_tunnel") {
 		req.SplitTunnel = aws.Bool(d.Get("split_tunnel").(bool))
+	}
+
+	if d.HasChange("vpn_port") {
+		req.VpnPort = aws.Int64(int64(d.Get("vpn_port").(int)))
 	}
 
 	if d.HasChange("connection_log_options") {

--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -60,6 +60,15 @@ func resourceAwsEc2ClientVpnEndpoint() *schema.Resource {
 					ec2.TransportProtocolUdp,
 				}, false),
 			},
+			"vpn_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  443,
+				ValidateFunc: validation.IntInSlice([]int{
+					443,
+					1194,
+				}),
+			},
 			"authentication_options": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -134,6 +143,7 @@ func resourceAwsEc2ClientVpnEndpointCreate(d *schema.ResourceData, meta interfac
 		ClientCidrBlock:      aws.String(d.Get("client_cidr_block").(string)),
 		ServerCertificateArn: aws.String(d.Get("server_certificate_arn").(string)),
 		TransportProtocol:    aws.String(d.Get("transport_protocol").(string)),
+		VpnPort:              aws.Int64(int64(d.Get("vpn_port").(int))),
 		SplitTunnel:          aws.Bool(d.Get("split_tunnel").(bool)),
 		TagSpecifications:    ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeClientVpnEndpoint),
 	}

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -360,16 +360,12 @@ func testAccAwsEc2ClientVpnEndpoint_splitTunnel(t *testing.T) {
 	})
 }
 
-<<<<<<< HEAD
 func testAccPreCheckClientVPNSyncronize(t *testing.T) {
 	sync.TestAccPreCheckSyncronize(t, testAccEc2ClientVpnEndpointSemaphore, "Client VPN")
 }
 
 func testAccAwsEc2ClientVpnEndpoint_vpnPort(t *testing.T) {
 	var v1, v2 ec2.ClientVpnEndpoint
-=======
-func TestAccAwsEc2ClientVpnEndpoint_vpnPort(t *testing.T) {
->>>>>>> #11633 renamed test method
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -360,12 +360,16 @@ func testAccAwsEc2ClientVpnEndpoint_splitTunnel(t *testing.T) {
 	})
 }
 
+<<<<<<< HEAD
 func testAccPreCheckClientVPNSyncronize(t *testing.T) {
 	sync.TestAccPreCheckSyncronize(t, testAccEc2ClientVpnEndpointSemaphore, "Client VPN")
 }
 
 func testAccAwsEc2ClientVpnEndpoint_vpnPort(t *testing.T) {
 	var v1, v2 ec2.ClientVpnEndpoint
+=======
+func TestAccAwsEc2ClientVpnEndpoint_vpnPort(t *testing.T) {
+>>>>>>> #11633 renamed test method
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
 

--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -45,6 +45,7 @@ The following arguments are supported:
 * `split_tunnel` - (Optional) Indicates whether split-tunnel is enabled on VPN endpoint. Default value is `false`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `transport_protocol` - (Optional) The transport protocol to be used by the VPN session. Default value is `udp`.
+* `vpn_port` - (Optional) The port number for the Client VPN endpoint. Valid values are `443` and `1194`. Default value is `443`.
 
 
 ### `authentication_options` Argument Reference


### PR DESCRIPTION
Changes proposed in this pull request:
* Added `vpn_port` to `aws_ec2_client_vpn_endpoint` resource.

Output from acceptance testing:
```
make testacc TESTARGS='-run=TestAccAwsEc2ClientVpnEndpoint_vpnPort'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAwsEc2ClientVpnEndpoint_vpnPort -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAwsEc2ClientVpnEndpoint_vpnPort
=== PAUSE TestAccAwsEc2ClientVpnEndpoint_vpnPort
=== CONT  TestAccAwsEc2ClientVpnEndpoint_vpnPort
--- PASS: TestAccAwsEc2ClientVpnEndpoint_vpnPort (41.28s)
```
Closes #11633