### PR TITLE
maintenance window task cloudwatch config

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -158,6 +158,7 @@ func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters(t *te
 	resourceName := "aws_ssm_maintenance_window_task.test"
 	serviceRoleResourceName := "aws_iam_role.test"
 	s3BucketResourceName := "aws_s3_bucket.foo"
+	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.foo"
 
 	name := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
@@ -182,6 +183,7 @@ func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters(t *te
 					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.run_command_parameters.0.comment", "test comment update"),
 					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.run_command_parameters.0.timeout_seconds", "60"),
 					resource.TestCheckResourceAttrPair(resourceName, "task_invocation_parameters.0.run_command_parameters.0.output_s3_bucket", s3BucketResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "task_invocation_parameters.0.run_command_parameters.0.cloudwatch_output_config.0.cloudwatch_log_group_name", cloudwatchLogGroupResourceName, "name"),
 				),
 			},
 			{
@@ -704,6 +706,10 @@ resource "aws_s3_bucket" "foo" {
     force_destroy = true
 }
 
+resource "aws_cloudwatch_log_group" "foo" {
+    name = "foo"
+}
+
 resource "aws_ssm_maintenance_window_task" "test" {
   window_id = "${aws_ssm_maintenance_window.test.id}"
   task_type = "RUN_COMMAND"
@@ -725,6 +731,10 @@ resource "aws_ssm_maintenance_window_task" "test" {
       timeout_seconds      = %[3]d
       output_s3_bucket     = "${aws_s3_bucket.foo.id}"
       output_s3_key_prefix = "foo"
+      cloudwatch_output_config {
+        cloudwatch_log_group_name = "${aws_cloudwatch_log_group.foo.name}"
+        cloudwatch_output_enabled = true
+      }
       parameter {
         name = "commands"
         values = ["date"]

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -182,6 +182,7 @@ The following arguments are supported:
 
 `run_command_parameters` supports the following:
 
+* `cloudwatch_output_config` - (Optional) Configuration for sending command execution logs to CloudWatch Logs. Documented below.
 * `comment` - (Optional) Information about the command(s) to execute.
 * `document_hash` - (Optional) The SHA-256 or SHA-1 hash created by the system when the document was created. SHA-1 hashes have been deprecated.
 * `document_hash_type` - (Optional) SHA-256 or SHA-1. SHA-1 hashes have been deprecated. Valid values: `Sha256` and `Sha1`
@@ -196,6 +197,11 @@ The following arguments are supported:
 
 * `input` - (Optional) The inputs for the STEP_FUNCTION task.
 * `name` - (Optional) The name of the STEP_FUNCTION task.
+
+`cloudwatch_output_config` supports the following:
+
+* `cloudwatch_log_group_name` - (Optional) The name of the CloudWatch log group to send command output. If you don't specify a group name, Systems Manager automatically creates a log group for you.
+* `cloudwatch_output_enabled` - (Required) Enable logging command output to CloudWatch Logs.
 
 `notification_config` supports the following:
 


### PR DESCRIPTION
This branch adds the cloudwatch output configurations to the aws_ssm_maintenance_window_task for RunCommand tasks. This lets you output task execution logs to Cloudwatch instead of S3.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
 * add support to SSM Maintenance Tasks for logging to CloudWatch Logs
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMMaintenanceWindowTask'
=== RUN   TestAccAWSSSMMaintenanceWindowTask_basic
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_basic
=== RUN   TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== CONT  TestAccAWSSSMMaintenanceWindowTask_basic
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters
--- PASS: TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig (60.69s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters (67.25s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskParameters (68.17s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (99.68s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (104.96s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters (106.88s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters (143.15s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters (148.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	148.295s
...
```