### PR TITLE
Add enable_acceleration for aws_vpn_connection

### DIFF
--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -75,6 +75,7 @@ One of the following arguments is required:
 
 Other arguments:
 
+* `enable_acceleration` - (Optional, Default `false`) Whether the VPN connection uses acceleration.  Acceleration can only be enabled on VPNs terminated on a Transit Gateway.
 * `static_routes_only` - (Optional, Default `false`) Whether the VPN connection uses static routes exclusively. Static routes must be used for devices that don't support BGP.
 * `tags` - (Optional) Tags to apply to the connection.
 * `tunnel1_inside_cidr` - (Optional) The CIDR block of the inside IP addresses for the first VPN tunnel.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11135

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_vpn_connection: Accelerated Site-to-Site VPN support
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSVpnConnection_withEnableAcceleration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSVpnConnection_withEnableAcceleration -timeout 120m
=== RUN   TestAccAWSVpnConnection_withEnableAcceleration
=== PAUSE TestAccAWSVpnConnection_withEnableAcceleration
=== CONT  TestAccAWSVpnConnection_withEnableAcceleration
--- PASS: TestAccAWSVpnConnection_withEnableAcceleration (681.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       681.603s

...
```
