### PR TITLE
[#9209] Fix dx gateway association proposal so it works even if expired

### DIFF
--- a/aws/resource_aws_dx_gateway_association_proposal.go
+++ b/aws/resource_aws_dx_gateway_association_proposal.go
@@ -31,7 +31,11 @@ func resourceAwsDxGatewayAssociationProposal() *schema.Resource {
 					return false
 				}
 
-				return proposal != nil && aws.StringValue(proposal.ProposalState) == directconnect.GatewayAssociationProposalStateRequested
+				if proposal == nil {
+					return true
+				}
+
+				return aws.StringValue(proposal.ProposalState) == directconnect.GatewayAssociationProposalStateRequested
 			}),
 		),
 
@@ -122,8 +126,7 @@ func resourceAwsDxGatewayAssociationProposalRead(d *schema.ResourceData, meta in
 	}
 
 	if proposal == nil {
-		log.Printf("[WARN] Direct Connect Gateway Association Proposal (%s) not found, removing from state", d.Id())
-		d.SetId("")
+		//The resource may have expired, return the last known state
 		return nil
 	}
 

--- a/website/docs/r/dx_gateway_association_proposal.html.markdown
+++ b/website/docs/r/dx_gateway_association_proposal.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Direct Connect Gateway Association Proposal, typically for enabling cross-account associations. For single account associations, see the [`aws_dx_gateway_association` resource](/docs/providers/aws/r/dx_gateway_association.html).
 
+~> **NOTE:** The proposal expires after some time so the resource keeps returning the last known state. If you need to create it again you have to taint it.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Currently the proposal expires after some time which causes TF to want to recreate it and recreate everything that depends on it so it's pretty useless. This change makes the resource ignore that API doesn't return anything and keep returning the last known state. It seems to work with the expired proposals I have access to however it would be great if someone could help with testing or give some insight into what may be problems with heavy handed approach like this one. 
Closes #9209

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
resource/aws_dx_gateway_association_proposal: Return last known state for dx_gateway_associaton_proposal if expired
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
I haven't been able to run the tests, as I'm waiting for my second account. Would be nice if someone else could run them.