### PR TITLE
resource/aws_instance: Fix incorrect behavior of volume_tags (#12225)

### DIFF
--- a/aws/ec2_filters.go
+++ b/aws/ec2_filters.go
@@ -69,30 +69,6 @@ func buildEC2TagFilterList(tags []*ec2.Tag) []*ec2.Filter {
 	return filters
 }
 
-// ec2AttributeFiltersFromMultimap returns an array of EC2 Filter objects to be used when listing resources.
-//
-// The keys of the specified map are the resource attributes names used in the filter - see the documentation
-// for the relevant "Describe" action for a list of the valid names. The resource must match all the filters
-// to be included in the result.
-// The values of the specified map are lists of resource attribute values used in the filter. The resource can
-// match any of the filter values to be included in the result.
-// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html#Filtering_Resources_CLI for more details.
-func ec2AttributeFiltersFromMultimap(m map[string][]string) []*ec2.Filter {
-	if len(m) == 0 {
-		return nil
-	}
-
-	filters := []*ec2.Filter{}
-	for k, v := range m {
-		filters = append(filters, &ec2.Filter{
-			Name:   aws.String(k),
-			Values: aws.StringSlice(v),
-		})
-	}
-
-	return filters
-}
-
 // ec2TagFiltersFromMap returns an array of EC2 Filter objects to be used when listing resources.
 //
 // The filters represent exact matches for all the resource tags in the given key/value map.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12225 #5878 #5609 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
 - resource/aws_instance: Fix incorrect behavior of volume_tags (#12225)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_volumeTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSInstance_volumeTags -timeout 120m
=== RUN   TestAccAWSInstance_volumeTags
=== PAUSE TestAccAWSInstance_volumeTags
=== RUN   TestAccAWSInstance_volumeTagsComputed
=== PAUSE TestAccAWSInstance_volumeTagsComputed
=== CONT  TestAccAWSInstance_volumeTags
=== CONT  TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (153.89s)
--- PASS: TestAccAWSInstance_volumeTags (213.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	216.162s
...
```
