### PR TITLE
[WIP] r/aws_s3_bucket_object: Add support for ExistingObjectReplication

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -412,6 +412,7 @@ The `rules` object supports the following:
 * `prefix` - (Optional) Object keyname prefix identifying one or more objects to which the rule applies.
 * `status` - (Required) The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
 * `filter` - (Optional) Filter that identifies subset of objects to which the replication rule applies (documented below).
+* `existing_object_replication` - (Optional) Specifies configuration to replicate existing source bucket objects (documented below).
 
 ~> **NOTE on `prefix` and `filter`:** Amazon S3's latest version of the replication configuration is V2, which includes the `filter` attribute for replication rules.
 With the `filter` attribute, you can specify object filters based on the object key prefix, tags, or both to scope the objects that the rule applies to.
@@ -444,6 +445,10 @@ The `filter` object supports the following:
 * `prefix` - (Optional) Object keyname prefix that identifies subset of objects to which the rule applies.
 * `tags` - (Optional)  A mapping of tags that identifies subset of objects to which the rule applies.
 The rule applies only to objects having all the tags in its tagset.
+
+The `existing_object_replication` object supports the following:
+
+* `enabled` - (Required) Boolean which indicates if existing objects should be replicated.
 
 The `server_side_encryption_configuration` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/12223.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_s3_bucket_object: Add `existing_object_replication` attribute to `replication_configuration`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
On an account without the feature enabled by AWS support:

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_Replication_ExistingObjectReplication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket_Replication_ExistingObjectReplication -timeout 120m
=== RUN   TestAccAWSS3Bucket_Replication_ExistingObjectReplication
=== PAUSE TestAccAWSS3Bucket_Replication_ExistingObjectReplication
=== CONT  TestAccAWSS3Bucket_Replication_ExistingObjectReplication
--- FAIL: TestAccAWSS3Bucket_Replication_ExistingObjectReplication (46.88s)
    testing.go:654: Step 0 error: errors during apply:
        
        Error: Error putting S3 replication configuration: MalformedXML: The XML you provided was not well-formed or did not validate against our published schema
        	status code: 400, request id: 4B60DBAC4A659BBB, host id: 1q3E7CsvsnlvKsGHrKBHEzomBgjrQ+tE7N/FVyrJ69Zq/Ox5uY30XpOoE9zV0BuObFdHx4Zg+Gw=
        
          on /var/folders/cs/yqdfp44s6hz9pmy2_g8qpmvm0000gq/T/tf-test940239900/main.tf line 31:
          (source code not available)
        
        
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	48.173s
FAIL
make: *** [testacc] Error 1
```
