### PR TITLE
Enhancement: Step Functions for Express Workflows

### DIFF
--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -93,6 +93,7 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Default:  sfn.StateMachineTypeStandard,
 				ValidateFunc: validation.StringInSlice([]string{
 					sfn.StateMachineTypeStandard,

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -205,7 +205,15 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 func resourceAwsSfnStateMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sfnconn
 
-	if d.HasChange("logging_configuration") && d.Get("type").(string) == sfn.StateMachineTypeExpress {
+	params := &sfn.UpdateStateMachineInput{
+		StateMachineArn: aws.String(d.Id()),
+		Definition:      aws.String(d.Get("definition").(string)),
+		RoleArn:         aws.String(d.Get("role_arn").(string)),
+	}
+
+	log.Printf("[DEBUG] Updating Step Function State Machine: %#v", params)
+
+	if d.HasChange("logging_configuration") {
 		params.LoggingConfiguration = expandAwsSfnLoggingConfiguration(d.Get("logging_configuration").([]interface{}))
 	}
 

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -31,6 +31,37 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(0, 1024*1024), // 1048576
 			},
 
+			"logging_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"log_destination": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"include_execution_data": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							// Default:  false,
+						},
+						"level": {
+							Type:     schema.TypeString,
+							Optional: true,
+							// Default:  sfn.LogLevelOff,
+							ValidateFunc: validation.StringInSlice([]string{
+								sfn.LogLevelAll,
+								sfn.LogLevelError,
+								sfn.LogLevelFatal,
+								sfn.LogLevelOff,
+							}, false),
+						},
+					},
+				},
+			},
+
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -53,10 +84,20 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"tags": tagsSchema(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  sfn.StateMachineTypeStandard,
+				ValidateFunc: validation.StringInSlice([]string{
+					sfn.StateMachineTypeStandard,
+					sfn.StateMachineTypeExpress,
+				}, false),
 			},
 		},
 	}
@@ -65,12 +106,13 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 func resourceAwsSfnStateMachineCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sfnconn
 	log.Print("[DEBUG] Creating Step Function State Machine")
-
 	params := &sfn.CreateStateMachineInput{
-		Definition: aws.String(d.Get("definition").(string)),
-		Name:       aws.String(d.Get("name").(string)),
-		RoleArn:    aws.String(d.Get("role_arn").(string)),
-		Tags:       keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().SfnTags(),
+		Definition:           aws.String(d.Get("definition").(string)),
+		LoggingConfiguration: expandAwsSfnLoggingConfiguration(d.Get("logging_configuration").([]interface{})),
+		Name:                 aws.String(d.Get("name").(string)),
+		RoleArn:              aws.String(d.Get("role_arn").(string)),
+		Tags:                 keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().SfnTags(),
+		Type:                 aws.String(d.Get("type").(string)),
 	}
 
 	var stateMachine *sfn.CreateStateMachineOutput
@@ -114,7 +156,6 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	log.Printf("[DEBUG] Reading Step Function State Machine: %s", d.Id())
-
 	sm, err := conn.DescribeStateMachine(&sfn.DescribeStateMachineInput{
 		StateMachineArn: aws.String(d.Id()),
 	})
@@ -132,7 +173,17 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("definition", sm.Definition)
 	d.Set("name", sm.Name)
 	d.Set("role_arn", sm.RoleArn)
+	d.Set("type", sm.Type)
 	d.Set("status", sm.Status)
+
+	loggingConfiguration := flattenAwsSfnLoggingConfiguration(sm.LoggingConfiguration)
+
+	if loggingConfiguration != nil {
+		err := d.Set("logging_configuration", loggingConfiguration)
+		if err != nil {
+			log.Printf("[DEBUG] Error setting logging_configuration %s \n", err)
+		}
+	}
 
 	if err := d.Set("creation_date", sm.CreationDate.Format(time.RFC3339)); err != nil {
 		log.Printf("[DEBUG] Error setting creation_date: %s", err)
@@ -154,11 +205,19 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 func resourceAwsSfnStateMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sfnconn
 
-	if d.HasChanges("definition", "role_arn") {
+	if d.HasChange("logging_configuration") && d.Get("type").(string) == sfn.StateMachineTypeExpress {
+		params.LoggingConfiguration = expandAwsSfnLoggingConfiguration(d.Get("logging_configuration").([]interface{}))
+	}
+
+	if d.HasChanges("definition", "role_arn", "logging_configuration") {
 		params := &sfn.UpdateStateMachineInput{
 			StateMachineArn: aws.String(d.Id()),
 			Definition:      aws.String(d.Get("definition").(string)),
 			RoleArn:         aws.String(d.Get("role_arn").(string)),
+		}
+
+		if d.HasChange("logging_configuration") {
+			params.LoggingConfiguration = expandAwsSfnLoggingConfiguration(d.Get("logging_configuration").([]interface{}))
 		}
 
 		_, err := conn.UpdateStateMachine(params)
@@ -180,7 +239,7 @@ func resourceAwsSfnStateMachineUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	return resourceAwsSfnStateMachineRead(d, meta)
+	return nil
 }
 
 func resourceAwsSfnStateMachineDelete(d *schema.ResourceData, meta interface{}) error {
@@ -205,4 +264,46 @@ func resourceAwsSfnStateMachineDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	return nil
+}
+
+func expandAwsSfnLoggingConfiguration(l []interface{}) *sfn.LoggingConfiguration {
+
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	loggingConfiguration := &sfn.LoggingConfiguration{
+		Destinations: []*sfn.LogDestination{
+			{
+				CloudWatchLogsLogGroup: &sfn.CloudWatchLogsLogGroup{
+					LogGroupArn: aws.String(m["log_destination"].(string)),
+				},
+			},
+		},
+		IncludeExecutionData: aws.Bool(m["include_execution_data"].(bool)),
+		Level:                aws.String(m["level"].(string)),
+	}
+
+	return loggingConfiguration
+}
+
+func flattenAwsSfnLoggingConfiguration(loggingConfiguration *sfn.LoggingConfiguration) []interface{} {
+
+	if loggingConfiguration == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"log_destination":        "",
+		"include_execution_data": aws.BoolValue(loggingConfiguration.IncludeExecutionData),
+		"level":                  aws.StringValue(loggingConfiguration.Level),
+	}
+
+	if len(loggingConfiguration.Destinations) > 0 {
+		m["log_destination"] = aws.StringValue(loggingConfiguration.Destinations[0].CloudWatchLogsLogGroup.LogGroupArn)
+	}
+
+	return []interface{}{m}
 }

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -57,6 +57,84 @@ func TestAccAWSSfnStateMachine_createUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAWSSfnStateMachine_express_createUpdate(t *testing.T) {
+	var sm sfn.DescribeStateMachineOutput
+	name := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSfnStateMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSfnStateMachineTypedConfig(sfn.StateMachineTypeExpress, name, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo", &sm),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "status", sfn.StateMachineStatusActive),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "name"),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "creation_date"),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "definition"),
+					resource.TestMatchResourceAttr("aws_sfn_state_machine.foo", "definition", regexp.MustCompile(`.*\"MaxAttempts\": 5.*`)),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "role_arn"),
+					// resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "logging_configuration"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.0.level", sfn.LogLevelOff),
+				),
+			},
+			{
+				Config: testAccAWSSfnStateMachineTypedConfig(sfn.StateMachineTypeExpress, name, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo", &sm),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "status", sfn.StateMachineStatusActive),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "name"),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "creation_date"),
+					resource.TestMatchResourceAttr("aws_sfn_state_machine.foo", "definition", regexp.MustCompile(`.*\"MaxAttempts\": 10.*`)),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "role_arn"),
+					// resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "logging_configuration"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.0.level", sfn.LogLevelOff),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSfnStateMachine_standard_createUpdate(t *testing.T) {
+	var sm sfn.DescribeStateMachineOutput
+	name := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSfnStateMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSfnStateMachineTypedConfig(sfn.StateMachineTypeStandard, name, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo", &sm),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "status", sfn.StateMachineStatusActive),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "name"),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "creation_date"),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "definition"),
+					resource.TestMatchResourceAttr("aws_sfn_state_machine.foo", "definition", regexp.MustCompile(`.*\"MaxAttempts\": 5.*`)),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "role_arn"),
+				),
+			},
+			{
+				Config: testAccAWSSfnStateMachineTypedConfig(sfn.StateMachineTypeStandard, name, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo", &sm),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "status", sfn.StateMachineStatusActive),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "name"),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "creation_date"),
+					resource.TestMatchResourceAttr("aws_sfn_state_machine.foo", "definition", regexp.MustCompile(`.*\"MaxAttempts\": 10.*`)),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "role_arn"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSfnStateMachine_tags(t *testing.T) {
 	var sm sfn.DescribeStateMachineOutput
 	resourceName := "aws_sfn_state_machine.test"
@@ -118,6 +196,46 @@ func TestAccAWSSfnStateMachine_disappears(t *testing.T) {
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSfnStateMachine(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSfnStateMachine_express_LoggingConfiguration(t *testing.T) {
+	var sm sfn.DescribeStateMachineOutput
+	name := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSfnStateMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSfnStateMachineExpressConfigLogConfiguration1(sfn.StateMachineTypeExpress, name, sfn.LogLevelError),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo", &sm),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "status", sfn.StateMachineStatusActive),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "name"),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "creation_date"),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "definition"),
+					resource.TestMatchResourceAttr("aws_sfn_state_machine.foo", "definition", regexp.MustCompile(`.*\"MaxAttempts\": 5.*`)),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "role_arn"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.0.level", sfn.LogLevelError),
+				),
+			},
+			{
+				Config: testAccAWSSfnStateMachineExpressConfigLogConfiguration1(sfn.StateMachineTypeExpress, name, sfn.LogLevelAll),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "status", sfn.StateMachineStatusActive),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "name"),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "creation_date"),
+					resource.TestMatchResourceAttr("aws_sfn_state_machine.foo", "definition", regexp.MustCompile(`.*\"MaxAttempts\": 5.*`)),
+					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "role_arn"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.0.level", sfn.LogLevelAll),
+				),
 			},
 		},
 	})
@@ -350,4 +468,272 @@ EOF
   }
 }
 `, rName, tag1Key, tag1Value, tag2Key, tag2Value)
+}
+
+func testAccAWSSfnStateMachineTypedConfig(rType string, rName string, rMaxAttempts int) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_iam_role_policy" "iam_policy_for_lambda" {
+  name = "iam_policy_for_lambda_%s"
+  role = "${aws_iam_role.iam_for_lambda.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ],
+    "Resource": "arn:${data.aws_partition.current.partition}:logs:*:*:*"
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda_%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "iam_policy_for_sfn" {
+  name = "iam_policy_for_sfn_%s"
+  role = "${aws_iam_role.iam_for_sfn.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction"
+      ],
+        "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_sfn" {
+  name = "iam_for_sfn_%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "states.${data.aws_region.current.name}.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "lambda_function_test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "sfn-%s"
+  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  handler       = "exports.example"
+  runtime       = "nodejs12.x"
+}
+
+resource "aws_sfn_state_machine" "foo" {
+  name     = "test_sfn_%s"
+  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  type	   = "%s"
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example of the Amazon States Language using an AWS Lambda Function with %s State Machine",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Task",
+      "Resource": "${aws_lambda_function.lambda_function_test.arn}",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "IntervalSeconds": 5,
+          "MaxAttempts": %d,
+          "BackoffRate": 8.0
+        }
+      ],
+      "End": true
+    }
+  }
+}
+EOF
+}
+`, rName, rName, rName, rName, rName, rName, rType, rType, rMaxAttempts)
+}
+
+func testAccAWSSfnStateMachineExpressConfigLogConfiguration1(rType string, rName string, rLevel string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_iam_role_policy" "iam_policy_for_lambda" {
+  name = "iam_policy_for_lambda_%s"
+  role = "${aws_iam_role.iam_for_lambda.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ],
+    "Resource": "arn:${data.aws_partition.current.partition}:logs:*:*:*"
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda_%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "iam_policy_for_sfn" {
+  name = "iam_policy_for_sfn_%s"
+  role = "${aws_iam_role.iam_for_sfn.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction",
+        "logs:CreateLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:UpdateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:PutResourcePolicy",
+        "logs:DescribeResourcePolicies",
+        "logs:DescribeLogGroups"
+      ],
+        "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_sfn" {
+  name = "iam_for_sfn_%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "states.${data.aws_region.current.name}.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "lambda_function_test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "sfn-%s"
+  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  handler       = "exports.example"
+  runtime       = "nodejs12.x"
+}
+
+resource "aws_cloudwatch_log_group" "log_group_for_sfn" {
+  name = "log_group_sfn_%s"
+}
+
+resource "aws_sfn_state_machine" "foo" {
+  name     = "test_sfn_%s"
+  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  type	   = "%s"
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example of the Amazon States Language using an AWS Lambda Function with %s State Machine",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Task",
+      "Resource": "${aws_lambda_function.lambda_function_test.arn}",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "IntervalSeconds": 5,
+          "MaxAttempts": 5,
+          "BackoffRate": 8.0
+        }
+      ],
+      "End": true
+    }
+  }
+}
+EOF
+
+  logging_configuration {
+    log_destination = "${aws_cloudwatch_log_group.log_group_for_sfn.arn}"
+    include_execution_data = false
+    level = "%s"
+  }
+
+  tags = {
+	"key1" = "value1"
+  }
+}
+`, rName, rName, rName, rName, rName, rName, rName, rType, rType, rLevel)
 }

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -225,7 +225,7 @@ func TestAccAWSSfnStateMachine_express_LoggingConfiguration(t *testing.T) {
 			{
 				Config: testAccAWSSfnStateMachineExpressConfigLogConfiguration1(sfn.StateMachineTypeExpress, name, sfn.LogLevelAll),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo"),
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo", &sm),
 					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "status", sfn.StateMachineStatusActive),
 					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "name"),
 					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "creation_date"),

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -89,7 +89,6 @@ func TestAccAWSSfnStateMachine_express_createUpdate(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "creation_date"),
 					resource.TestMatchResourceAttr("aws_sfn_state_machine.foo", "definition", regexp.MustCompile(`.*\"MaxAttempts\": 10.*`)),
 					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "role_arn"),
-					// resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "logging_configuration"),
 					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.0.level", sfn.LogLevelOff),
 				),

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -76,7 +76,6 @@ func TestAccAWSSfnStateMachine_express_createUpdate(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "definition"),
 					resource.TestMatchResourceAttr("aws_sfn_state_machine.foo", "definition", regexp.MustCompile(`.*\"MaxAttempts\": 5.*`)),
 					resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "role_arn"),
-					// resource.TestCheckResourceAttrSet("aws_sfn_state_machine.foo", "logging_configuration"),
 					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "logging_configuration.0.level", sfn.LogLevelOff),
 				),

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -37,6 +37,7 @@ EOF
 ```
 
 ### Basic (Express Workflow)
+
 ```hcl
 # ...
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -86,11 +86,11 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
   }
 }
 EOF
- 
+
   logging_configuration {
-    log_destination = "${aws_cloudwatch_log_group.log_group_for_sfn.arn}"
+    log_destination        = "${aws_cloudwatch_log_group.log_group_for_sfn.arn}"
     include_execution_data = true
-    level = "ERROR"
+    level                  = "ERROR"
   }
 }
 ```

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides a Step Function State Machine resource
 
 ## Example Usage
-
+### Basic (Standard Workflow)
 ```hcl
 # ...
 
@@ -35,6 +35,65 @@ EOF
 }
 ```
 
+### Basic (Express Workflow)
+```hcl
+# ...
+
+resource "aws_sfn_state_machine" "sfn_state_machine" {
+  name     = "my-state-machine"
+  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  type     = "EXPRESS"
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example of the Amazon States Language using an AWS Lambda Function",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Task",
+      "Resource": "${aws_lambda_function.lambda.arn}",
+      "End": true
+    }
+  }
+}
+EOF
+}
+```
+
+### Logging
+
+~> *NOTE:* Logging is only accepted for EXPRESS Workflows. See the [AWS Step Functions Developer Guide](https://docs.aws.amazon.com/step-functions/latest/dg/welcome.html) for more information about enabling Step Function logging.
+
+```hcl
+# ...
+
+resource "aws_sfn_state_machine" "sfn_state_machine" {
+  name     = "my-state-machine"
+  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  type     = "EXPRESS"
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example of the Amazon States Language using an AWS Lambda Function",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Task",
+      "Resource": "${aws_lambda_function.lambda.arn}",
+      "End": true
+    }
+  }
+}
+EOF
+ 
+  logging_configuration {
+     log_destination = "${aws_cloudwatch_log_group.log_group_for_sfn.arn}"
+     include_execution_data = true
+     level = "ERROR"
+   }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -43,6 +102,13 @@ The following arguments are supported:
 * `definition` - (Required) The Amazon States Language definition of the state machine.
 * `role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role to use for this state machine.
 * `tags` - (Optional) Key-value map of resource tags
+* `logging_configuration` - (Optional) Defines what execution history events are logged and where they are logged. The logging_configuration parameter is only valid when type is set to EXPRESS. By default, the level is set to OFF. For more information see [Logging Express Workflows](https://docs.aws.amazon.com/step-functions/latest/dg/cw-logs.html) and [Log Levels](https://docs.aws.amazon.com/step-functions/latest/dg/cloudwatch-log-level.html) in the AWS Step Functions User Guide.
+* `type` - (Optional) Determines whether a Standard or Express state machine is created. The default is STANDARD. You cannot update the type of a state machine once it has been created. Valid Values: STANDARD | EXPRESS
+
+### `logging_configuration` Configuration Block
+* `log_destination` - (Optional) Amazon Resource Name (ARN) of CloudWatch log group. Make sure the State Machine does have the right IAM Policies for Logging. 
+* `include_execution_data` - (Optional) Determines whether execution data is included in your log. When set to FALSE, data is excluded.
+* `level` - (Optional) Defines which category of execution history events are logged. Valid Values: ALL | ERROR | FATAL | OFF
 
 ## Attributes Reference
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -62,7 +62,7 @@ EOF
 
 ### Logging
 
-~> *NOTE:* Logging is only accepted for EXPRESS Workflows. See the [AWS Step Functions Developer Guide](https://docs.aws.amazon.com/step-functions/latest/dg/welcome.html) for more information about enabling Step Function logging.
+~> *NOTE:* See the [AWS Step Functions Developer Guide](https://docs.aws.amazon.com/step-functions/latest/dg/welcome.html) for more information about enabling Step Function logging.
 
 ```hcl
 # ...
@@ -70,7 +70,6 @@ EOF
 resource "aws_sfn_state_machine" "sfn_state_machine" {
   name     = "my-state-machine"
   role_arn = "${aws_iam_role.iam_for_sfn.arn}"
-  type     = "EXPRESS"
 
   definition = <<EOF
 {

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -12,6 +12,7 @@ Provides a Step Function State Machine resource
 
 ## Example Usage
 ### Basic (Standard Workflow)
+
 ```hcl
 # ...
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -88,10 +88,10 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
 EOF
  
   logging_configuration {
-     log_destination = "${aws_cloudwatch_log_group.log_group_for_sfn.arn}"
-     include_execution_data = true
-     level = "ERROR"
-   }
+    log_destination = "${aws_cloudwatch_log_group.log_group_for_sfn.arn}"
+    include_execution_data = true
+    level = "ERROR"
+  }
 }
 ```
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -107,6 +107,7 @@ The following arguments are supported:
 * `type` - (Optional) Determines whether a Standard or Express state machine is created. The default is STANDARD. You cannot update the type of a state machine once it has been created. Valid Values: STANDARD | EXPRESS
 
 ### `logging_configuration` Configuration Block
+
 * `log_destination` - (Optional) Amazon Resource Name (ARN) of CloudWatch log group. Make sure the State Machine does have the right IAM Policies for Logging. 
 * `include_execution_data` - (Optional) Determines whether execution data is included in your log. When set to FALSE, data is excluded.
 * `level` - (Optional) Defines which category of execution history events are logged. Valid Values: ALL | ERROR | FATAL | OFF

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
 * `definition` - (Required) The Amazon States Language definition of the state machine.
 * `role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role to use for this state machine.
 * `tags` - (Optional) Key-value map of resource tags
-* `logging_configuration` - (Optional) Defines what execution history events are logged and where they are logged. The logging_configuration parameter is only valid when type is set to EXPRESS. By default, the level is set to OFF. For more information see [Logging Express Workflows](https://docs.aws.amazon.com/step-functions/latest/dg/cw-logs.html) and [Log Levels](https://docs.aws.amazon.com/step-functions/latest/dg/cloudwatch-log-level.html) in the AWS Step Functions User Guide.
+* `logging_configuration` - (Optional) Defines what execution history events are logged and where they are logged. The `logging_configuration` parameter is only valid when `type` is set to `EXPRESS`. Defaults to `OFF`. For more information see [Logging Express Workflows](https://docs.aws.amazon.com/step-functions/latest/dg/cw-logs.html) and [Log Levels](https://docs.aws.amazon.com/step-functions/latest/dg/cloudwatch-log-level.html) in the AWS Step Functions User Guide.
 * `type` - (Optional) Determines whether a Standard or Express state machine is created. The default is STANDARD. You cannot update the type of a state machine once it has been created. Valid Values: STANDARD | EXPRESS
 
 ### `logging_configuration` Configuration Block

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -18,7 +18,7 @@ Provides a Step Function State Machine resource
 
 resource "aws_sfn_state_machine" "sfn_state_machine" {
   name     = "my-state-machine"
-  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  role_arn = aws_iam_role.iam_for_sfn.arn
 
   definition = <<EOF
 {
@@ -43,7 +43,7 @@ EOF
 
 resource "aws_sfn_state_machine" "sfn_state_machine" {
   name     = "my-state-machine"
-  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  role_arn = aws_iam_role.iam_for_sfn.arn
   type     = "EXPRESS"
 
   definition = <<EOF
@@ -71,7 +71,7 @@ EOF
 
 resource "aws_sfn_state_machine" "sfn_state_machine" {
   name     = "my-state-machine"
-  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  role_arn = aws_iam_role.iam_for_sfn.arn
 
   definition = <<EOF
 {
@@ -88,7 +88,7 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
 EOF
 
   logging_configuration {
-    log_destination        = "${aws_cloudwatch_log_group.log_group_for_sfn.arn}"
+    log_destination        = aws_cloudwatch_log_group.log_group_for_sfn.arn
     include_execution_data = true
     level                  = "ERROR"
   }
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 ### `logging_configuration` Configuration Block
 
-* `log_destination` - (Optional) Amazon Resource Name (ARN) of CloudWatch log group. Make sure the State Machine does have the right IAM Policies for Logging. 
+* `log_destination` - (Optional) Amazon Resource Name (ARN) of CloudWatch log group. Make sure the State Machine does have the right IAM Policies for Logging.
 * `include_execution_data` - (Optional) Determines whether execution data is included in your log. When set to FALSE, data is excluded.
 * `level` - (Optional) Defines which category of execution history events are logged. Valid Values: ALL | ERROR | FATAL | OFF
 


### PR DESCRIPTION
Improved from https://github.com/terraform-providers/terraform-provider-aws/pull/11570

This adds support for AWS Step Functions for Express Workflows, that are ideal for high-volume, event-processing workloads such as IoT data ingestion, streaming data processing and transformation, and mobile application backends. They can run for up to five minutes. Execution history is optionally available in Amazon CloudWatch Logs. Express Workflows employ an at-least-once model, where there is a possibility that an execution might be run more than once. This makes them ideal for orchestrating idempotent actions such as transforming input data and storing via PUT in Amazon DynamoDB. Express Workflow executions are billed by the number of executions, the duration of execution, and the memory consumed.

Changes proposed in this pull request:
resource_aws_sfn_state_machine.go: Add type and logging_configuration arguments
resource_aws_sfn_state_machine_test.go: Extend acceptance tests
sfn_state_machine.html.markdown: Extend documentation

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #11348 #11374 #12192 #11570

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
IMPROVEMENTS:
Add `type` and `logging_configuration` arguments: aws_sfn_state_machine
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSfnStateMachine'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSfnStateMachine -timeout 120m
=== RUN   TestAccAWSSfnStateMachine_createUpdate
=== PAUSE TestAccAWSSfnStateMachine_createUpdate
=== RUN   TestAccAWSSfnStateMachine_express_createUpdate
=== PAUSE TestAccAWSSfnStateMachine_express_createUpdate
=== RUN   TestAccAWSSfnStateMachine_standard_createUpdate
=== PAUSE TestAccAWSSfnStateMachine_standard_createUpdate
=== RUN   TestAccAWSSfnStateMachine_Tags
=== PAUSE TestAccAWSSfnStateMachine_Tags
=== RUN   TestAccAWSSfnStateMachine_express_LoggingConfiguration
=== PAUSE TestAccAWSSfnStateMachine_express_LoggingConfiguration
=== CONT  TestAccAWSSfnStateMachine_createUpdate
=== CONT  TestAccAWSSfnStateMachine_Tags
=== CONT  TestAccAWSSfnStateMachine_standard_createUpdate
=== CONT  TestAccAWSSfnStateMachine_express_createUpdate
=== CONT  TestAccAWSSfnStateMachine_express_LoggingConfiguration
--- PASS: TestAccAWSSfnStateMachine_standard_createUpdate (91.72s)
--- PASS: TestAccAWSSfnStateMachine_express_createUpdate (103.14s)
--- PASS: TestAccAWSSfnStateMachine_createUpdate (110.65s)
--- PASS: TestAccAWSSfnStateMachine_Tags (117.36s)
--- PASS: TestAccAWSSfnStateMachine_express_LoggingConfiguration (120.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	122.905s
...
```
