### PR TITLE
AWS Inspector SNS subscription support

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -970,9 +970,11 @@ func (e beanstalkEnvironmentError) Error() string {
 
 type beanstalkEnvironmentErrors []*beanstalkEnvironmentError
 
-func (e beanstalkEnvironmentErrors) Len() int           { return len(e) }
-func (e beanstalkEnvironmentErrors) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
-func (e beanstalkEnvironmentErrors) Less(i, j int) bool { return e[i].eventDate.Before(*e[j].eventDate) }
+func (e beanstalkEnvironmentErrors) Len() int      { return len(e) }
+func (e beanstalkEnvironmentErrors) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
+func (e beanstalkEnvironmentErrors) Less(i, j int) bool {
+	return e[i].eventDate.Before(*e[j].eventDate)
+}
 
 func getBeanstalkEnvironmentErrors(conn *elasticbeanstalk.ElasticBeanstalk, environmentId string, t time.Time) (*multierror.Error, error) {
 	environmentErrors, err := conn.DescribeEvents(&elasticbeanstalk.DescribeEventsInput{

--- a/aws/resource_aws_inspector_assessment_event_subscriptions_template_test.go
+++ b/aws/resource_aws_inspector_assessment_event_subscriptions_template_test.go
@@ -1,0 +1,191 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSInspectorTemplateEventSubscriptions_basic(t *testing.T) {
+	prefix := resource.PrefixedUniqueId("test")
+	resourceName := "aws_inspector_assessment_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInspectorTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSInspectorTemplateAssessmentConfigTwoEventSubscriptions(prefix),
+
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "subscribe_to_event.#", "2"),
+					testAccCheckIsSubscribedToEvent(resourceName, "ASSESSMENT_RUN_STARTED"),
+					testAccCheckIsSubscribedToEvent(resourceName, "ASSESSMENT_RUN_COMPLETED"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInspectorTemplateEventSubscriptions_update(t *testing.T) {
+	prefix := resource.PrefixedUniqueId("test")
+	resourceName := "aws_inspector_assessment_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInspectorTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSInspectorTemplateAssessmentConfigBasic(prefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "subscribe_to_event.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSInspectorTemplateAssessmentConfigTwoEventSubscriptions(prefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "subscribe_to_event.#", "2"),
+					testAccCheckIsSubscribedToEvent(resourceName, "ASSESSMENT_RUN_STARTED"),
+					testAccCheckIsSubscribedToEvent(resourceName, "ASSESSMENT_RUN_COMPLETED"),
+				),
+			},
+			{
+				Config: testAccAWSInspectorTemplateAssessmentConfigReplaceOneEventSubscription(prefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "subscribe_to_event.#", "2"),
+					testAccCheckIsSubscribedToEvent(resourceName, "ASSESSMENT_RUN_STARTED"),
+					testAccCheckIsSubscribedToEvent(resourceName, "FINDING_REPORTED"),
+				),
+			},
+			{
+				Config: testAccAWSInspectorTemplateAssessmentConfigBasic(prefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "subscribe_to_event.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSInspectorTemplateAssessmentConfigBasic(prefix string) string {
+	return testAccAWSInspectorTemplateAssessmentConfig(prefix, "")
+}
+
+func testAccAWSInspectorTemplateAssessmentConfigTwoEventSubscriptions(prefix string) string {
+	return testAccAWSInspectorTemplateAssessmentConfig(prefix, awsInspectorTwoEventSubscriptions) +
+		awsInspectorEventSubscriptionsSNSTopicAndIAMPolicy(prefix)
+
+}
+
+func testAccAWSInspectorTemplateAssessmentConfigReplaceOneEventSubscription(prefix string) string {
+	return testAccAWSInspectorTemplateAssessmentConfig(prefix, awsInspectorReplacedEventSubscriptions) +
+		awsInspectorEventSubscriptionsSNSTopicAndIAMPolicy(prefix)
+}
+
+func testAccAWSInspectorTemplateAssessmentConfig(prefix string, topicSubscriptions string) string {
+	return fmt.Sprintf(
+		`
+data "aws_inspector_rules_packages" "rules" {}
+
+resource "aws_inspector_resource_group" "test" {
+  tags = {
+    Name = "bar"
+  }
+}
+
+resource "aws_inspector_assessment_target" "test" {
+  name               = "%s"
+  resource_group_arn = "${aws_inspector_resource_group.test.arn}"
+}
+
+resource "aws_inspector_assessment_template" "test" {
+  name       = "template %s"
+  target_arn = "${aws_inspector_assessment_target.test.arn}"
+  duration   = 3600
+
+  rules_package_arns = data.aws_inspector_rules_packages.rules.arns
+
+%s
+}`, prefix, prefix, topicSubscriptions)
+}
+
+var awsInspectorTwoEventSubscriptions = `
+subscribe_to_event {
+  event     = "ASSESSMENT_RUN_STARTED"
+  topic_arn = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+}
+
+subscribe_to_event {
+  event     = "ASSESSMENT_RUN_COMPLETED"
+  topic_arn = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+}
+`
+
+var awsInspectorReplacedEventSubscriptions = `
+subscribe_to_event {
+  event     = "ASSESSMENT_RUN_STARTED"
+  topic_arn = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+}
+
+subscribe_to_event {
+  event     = "FINDING_REPORTED"
+  topic_arn = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+}
+`
+
+func awsInspectorEventSubscriptionsSNSTopicAndIAMPolicy(prefix string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" { }
+
+resource "aws_sns_topic" "test_sns_topic_for_inspector" {
+  name = "inspector_%s"
+}
+
+resource "aws_sns_topic_policy" "test_sns_topic_for_inspector" {
+  arn    = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+  policy = "${data.aws_iam_policy_document.inspector-allow-write-to-test-sns-topic.json}"
+}
+
+data "aws_iam_policy_document" "inspector-allow-write-to-test-sns-topic" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    sid = "inspector"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+		"arn:aws:iam::162588757376:root",
+		"arn:aws:iam::526946625049:root",
+		"arn:aws:iam::454640832652:root",
+		"arn:aws:iam::406045910587:root",
+		"arn:aws:iam::537503971621:root",
+		"arn:aws:iam::357557129151:root",
+		"arn:aws:iam::316112463485:root",
+		"arn:aws:iam::646659390643:root",
+		"arn:aws:iam::166987590008:root",
+		"arn:aws:iam::758058086616:root"
+      ]
+    }
+
+    actions = [
+      "SNS:Subscribe",
+      "SNS:Receive",
+      "SNS:Publish",
+    ]
+
+    effect    = "Allow"
+    resources = ["${aws_sns_topic.test_sns_topic_for_inspector.arn}"]
+  }
+}
+`, prefix)
+}

--- a/aws/resource_aws_inspector_assessment_template.go
+++ b/aws/resource_aws_inspector_assessment_template.go
@@ -7,12 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/inspector"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAWSInspectorAssessmentTemplate() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsInspectorAssessmentTemplateCreate,
 		Read:   resourceAwsInspectorAssessmentTemplateRead,
+		Update: resourceAwsInspectorAssessmentTemplateUpdate,
 		Delete: resourceAwsInspectorAssessmentTemplateDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -42,6 +44,29 @@ func resourceAWSInspectorAssessmentTemplate() *schema.Resource {
 				Set:      schema.HashString,
 				Required: true,
 				ForceNew: true,
+			},
+			"subscribe_to_event": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"event": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"ASSESSMENT_RUN_STARTED",
+								"ASSESSMENT_RUN_COMPLETED",
+								"ASSESSMENT_RUN_STATE_CHANGED",
+								"FINDING_REPORTED",
+							}, false),
+						},
+						"topic_arn": {
+							Type:         schema.TypeString,
+							ValidateFunc: validateArn,
+							Required:     true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -74,6 +99,26 @@ func resourceAwsInspectorAssessmentTemplateCreate(d *schema.ResourceData, meta i
 
 	d.SetId(*resp.AssessmentTemplateArn)
 
+	subscriptions := d.Get("subscribe_to_event").(*schema.Set)
+
+	for _, s := range subscriptions.List() {
+		m := s.(map[string]interface{})
+		event := m["event"].(string)
+		topicArn := m["topic_arn"].(string)
+
+		_, err = retryOnAwsCode("AccessDeniedException", func() (interface{}, error) {
+			return conn.SubscribeToEvent(&inspector.SubscribeToEventInput{
+				Event:       &event,
+				TopicArn:    &topicArn,
+				ResourceArn: resp.AssessmentTemplateArn,
+			})
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
 	return resourceAwsInspectorAssessmentTemplateRead(d, meta)
 }
 
@@ -98,11 +143,73 @@ func resourceAwsInspectorAssessmentTemplateRead(d *schema.ResourceData, meta int
 	if resp.AssessmentTemplates != nil && len(resp.AssessmentTemplates) > 0 {
 		d.Set("name", resp.AssessmentTemplates[0].Name)
 	}
+
+	ste, err := flattenSubscribeToEvents(d, conn)
+	if err != nil {
+		return nil
+	}
+	d.Set("subscribe_to_event", ste)
+
+	return nil
+}
+
+func resourceAwsInspectorAssessmentTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
+	if d.HasChange("subscribe_to_event") {
+		conn := meta.(*AWSClient).inspectorconn
+
+		var new []map[string]interface{}
+		var old []map[string]interface{}
+		oldSubscribeToEvents, newSubscribeToEvents := d.GetChange("subscribe_to_event")
+
+		for _, o := range oldSubscribeToEvents.(*schema.Set).List() {
+			old = append(old, o.(map[string]interface{}))
+		}
+		for _, n := range newSubscribeToEvents.(*schema.Set).List() {
+			new = append(new, n.(map[string]interface{}))
+		}
+
+		for _, s := range substractEventSubscriptions(new, old) {
+			e := s["event"].(string)
+			t := s["topic_arn"].(string)
+			r := d.Id()
+
+			_, err := retryOnAwsCode("AccessDeniedException", func() (interface{}, error) {
+				return conn.SubscribeToEvent(&inspector.SubscribeToEventInput{
+					Event:       &e,
+					ResourceArn: &r,
+					TopicArn:    &t,
+				})
+			})
+
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, s := range substractEventSubscriptions(old, new) {
+			e := s["event"].(string)
+			t := s["topic_arn"].(string)
+			r := d.Id()
+
+			_, err := conn.UnsubscribeFromEvent(&inspector.UnsubscribeFromEventInput{
+				Event:       &e,
+				ResourceArn: &r,
+				TopicArn:    &t,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		return resourceAwsInspectorAssessmentTemplateRead(d, meta)
+	}
 	return nil
 }
 
 func resourceAwsInspectorAssessmentTemplateDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).inspectorconn
+
+	// subscriptions to events are removed together with the template automatically
 
 	_, err := conn.DeleteAssessmentTemplate(&inspector.DeleteAssessmentTemplateInput{
 		AssessmentTemplateArn: aws.String(d.Id()),
@@ -118,4 +225,54 @@ func resourceAwsInspectorAssessmentTemplateDelete(d *schema.ResourceData, meta i
 	}
 
 	return nil
+}
+
+func flattenSubscribeToEvents(d *schema.ResourceData, conn *inspector.Inspector) ([]map[string]interface{}, error) {
+	arn := d.Id()
+	var results []map[string]interface{}
+	var err error = nil
+	var nextToken *string = nil
+	var maxResults int64 = 100
+
+	for {
+		outPut, err := conn.ListEventSubscriptions(&inspector.ListEventSubscriptionsInput{MaxResults: &maxResults, NextToken: nextToken, ResourceArn: &arn})
+		if err != nil {
+			return results, err
+		}
+
+		for _, s := range outPut.Subscriptions {
+			for _, es := range s.EventSubscriptions {
+				m := make(map[string]interface{})
+				m["event"] = *es.Event
+				m["topic_arn"] = *s.TopicArn
+				results = append(results, m)
+			}
+		}
+
+		nextToken = outPut.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+
+	return results, err
+}
+
+// substractEventSubscriptions return elements of 'a' which are not contained in 'b'
+func substractEventSubscriptions(a []map[string]interface{}, b []map[string]interface{}) (result []map[string]interface{}) {
+	for _, e := range a {
+		if !containsEventSubscription(b, e) {
+			result = append(result, e)
+		}
+	}
+	return
+}
+
+func containsEventSubscription(s []map[string]interface{}, e map[string]interface{}) bool {
+	for _, a := range s {
+		if a["event"] == e["event"] && a["topic_arn"] == e["topic_arn"] {
+			return true
+		}
+	}
+	return false
 }

--- a/website/docs/r/inspector_assessment_template.html.markdown
+++ b/website/docs/r/inspector_assessment_template.html.markdown
@@ -24,6 +24,11 @@ resource "aws_inspector_assessment_template" "foo" {
     "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-JJOtZiqQ",
     "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-vg5GGHSD",
   ]
+
+  subscribe_to_event {
+    event = "ASSESSMENT_RUN_COMPLETED"
+    topic_arn = "arn:aws:sns:ap-southeast-2:123456789012:mytopic"
+  }
 }
 ```
 
@@ -35,6 +40,11 @@ The following arguments are supported:
 * `target_arn` - (Required) The assessment target ARN to attach the template to.
 * `duration` - (Required) The duration of the inspector run.
 * `rules_package_arns` - (Required) The rules to be used during the run.
+* `subscribe_to_event` (Optional) - A list of objects representing a subscription of an SNS topic to life-cycle events. The keys are documented below.
+
+The `subscribe_to_event` object supports the following arguments:
+* `event` - (Required) The name (or names) of the event (or events) the SNS topic is subscribing to. Allowed values are: `ASSESSMENT_RUN_STARTED`, `ASSESSMENT_RUN_COMPLETED`, `ASSESSMENT_RUN_STATE_CHANGED`, and `FINDING_REPORTED`.
+* `topic_arn` - (Required) The ARN of the subscribing SNS topic.
 
 ## Attributes Reference
 

--- a/website/docs/r/inspector_assessment_template.html.markdown
+++ b/website/docs/r/inspector_assessment_template.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `subscribe_to_event` (Optional) - A list of objects representing a subscription of an SNS topic to life-cycle events. The keys are documented below.
 
 The `subscribe_to_event` object supports the following arguments:
+
 * `event` - (Required) The name (or names) of the event (or events) the SNS topic is subscribing to. Allowed values are: `ASSESSMENT_RUN_STARTED`, `ASSESSMENT_RUN_COMPLETED`, `ASSESSMENT_RUN_STATE_CHANGED`, and `FINDING_REPORTED`.
 * `topic_arn` - (Required) The ARN of the subscribing SNS topic.
 


### PR DESCRIPTION
Based on PR: terraform-providers/terraform-provider-aws#3957
Fixes: #843

Fixed some issues covered in previous PR and fixed Tests

```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./...  -timeout=120s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.704s
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.011s
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.015s
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.069s
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.025s
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.026s
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.024s
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	3.268s
```

```
make testacc TESTARGS='-run=TestAccAWSInspectorTemplate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSInspectorTemplate -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSInspectorTemplateEventSubscriptions_basic
=== PAUSE TestAccAWSInspectorTemplateEventSubscriptions_basic
=== RUN   TestAccAWSInspectorTemplateEventSubscriptions_update
=== PAUSE TestAccAWSInspectorTemplateEventSubscriptions_update
=== RUN   TestAccAWSInspectorTemplate_basic
=== PAUSE TestAccAWSInspectorTemplate_basic
=== CONT  TestAccAWSInspectorTemplateEventSubscriptions_basic
=== CONT  TestAccAWSInspectorTemplate_basic
=== CONT  TestAccAWSInspectorTemplateEventSubscriptions_update
--- PASS: TestAccAWSInspectorTemplateEventSubscriptions_basic (47.58s)
--- PASS: TestAccAWSInspectorTemplate_basic (62.62s)
--- PASS: TestAccAWSInspectorTemplateEventSubscriptions_update (141.42s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	141.465s
