### PR TITLE
 r/aws_iam_user_login_profile  - Make the PGP key in optional

### DIFF
--- a/.changelog/12384.txt
+++ b/.changelog/12384.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iam_user_login_profile: Make `pgp_key` optional
+```

--- a/internal/service/iam/user_login_profile.go
+++ b/internal/service/iam/user_login_profile.go
@@ -40,13 +40,14 @@ func ResourceUserLoginProfile() *schema.Resource {
 			},
 			"pgp_key": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"password_reset_required": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
+				// Default:  true,
 				ForceNew: true,
 			},
 			"password_length": {
@@ -62,6 +63,10 @@ func ResourceUserLoginProfile() *schema.Resource {
 				Computed: true,
 			},
 			"encrypted_password": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"password": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -127,38 +132,46 @@ func resourceUserLoginProfileCreate(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*conns.AWSClient).IAMConn
 	username := d.Get("user").(string)
 
-	encryptionKey, err := RetrieveGPGKey(strings.TrimSpace(d.Get("pgp_key").(string)))
-	if err != nil {
-		return fmt.Errorf("error retrieving GPG Key during IAM User Login Profile (%s) creation: %s", username, err)
-	}
-
-	passwordResetRequired := d.Get("password_reset_required").(bool)
 	passwordLength := d.Get("password_length").(int)
 	initialPassword, err := GeneratePassword(passwordLength)
 	if err != nil {
 		return err
 	}
 
-	fingerprint, encrypted, err := EncryptValue(encryptionKey, initialPassword, "Password")
-	if err != nil {
-		return fmt.Errorf("error encrypting password during IAM User Login Profile (%s) creation: %s", username, err)
-	}
-
 	request := &iam.CreateLoginProfileInput{
 		UserName:              aws.String(username),
 		Password:              aws.String(initialPassword),
-		PasswordResetRequired: aws.Bool(passwordResetRequired),
+		PasswordResetRequired: aws.Bool(d.Get("password_reset_required").(bool)),
 	}
 
 	log.Println("[DEBUG] Create IAM User Login Profile request:", request)
 	createResp, err := conn.CreateLoginProfile(request)
 	if err != nil {
-		return fmt.Errorf("Error creating IAM User Login Profile for %q: %s", username, err)
+		return fmt.Errorf("Error creating IAM User Login Profile for %q: %w", username, err)
 	}
 
 	d.SetId(aws.StringValue(createResp.LoginProfile.UserName))
-	d.Set("key_fingerprint", fingerprint)
-	d.Set("encrypted_password", encrypted)
+
+	if v, ok := d.GetOk("pgp_key"); ok {
+		pgpKey := v.(string)
+		pgpKey = strings.TrimSuffix(pgpKey, "\n")
+
+		encryptionKey, err := RetrieveGPGKey(pgpKey)
+		if err != nil {
+			return fmt.Errorf("error retrieving GPG Key during IAM User Login Profile (%s) creation: %w", username, err)
+		}
+
+		fingerprint, encrypted, err := EncryptValue(encryptionKey, initialPassword, "Password")
+		if err != nil {
+			return fmt.Errorf("error encrypting password during IAM User Login Profile (%s) creation: %w", username, err)
+		}
+
+		d.Set("key_fingerprint", fingerprint)
+		d.Set("encrypted_password", encrypted)
+	} else {
+		d.Set("password", initialPassword)
+	}
+
 	return nil
 }
 
@@ -205,7 +218,10 @@ func resourceUserLoginProfileRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("error reading IAM User Login Profile (%s): empty response", d.Id())
 	}
 
-	d.Set("user", output.LoginProfile.UserName)
+	loginProfile := output.LoginProfile
+
+	d.Set("user", loginProfile.UserName)
+	d.Set("password_reset_required", loginProfile.PasswordResetRequired)
 
 	return nil
 }
@@ -248,7 +264,7 @@ func resourceUserLoginProfileDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting IAM User Login Profile (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting IAM User Login Profile (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/iam/user_login_profile.go
+++ b/internal/service/iam/user_login_profile.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"math/big"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -47,7 +46,6 @@ func ResourceUserLoginProfile() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
-				// Default:  true,
 				ForceNew: true,
 			},
 			"password_length": {
@@ -153,10 +151,10 @@ func resourceUserLoginProfileCreate(d *schema.ResourceData, meta interface{}) er
 	d.SetId(aws.StringValue(createResp.LoginProfile.UserName))
 
 	if v, ok := d.GetOk("pgp_key"); ok {
-		pgpKey := v.(string)
-		pgpKey = strings.TrimSuffix(pgpKey, "\n")
+		// pgpKey := v.(string)
+		// pgpKey = strings.TrimPrefix(strings.TrimSuffix(pgpKey, "\n"), "\n")
 
-		encryptionKey, err := RetrieveGPGKey(pgpKey)
+		encryptionKey, err := RetrieveGPGKey(v.(string))
 		if err != nil {
 			return fmt.Errorf("error retrieving GPG Key during IAM User Login Profile (%s) creation: %w", username, err)
 		}

--- a/internal/service/iam/user_login_profile.go
+++ b/internal/service/iam/user_login_profile.go
@@ -151,9 +151,6 @@ func resourceUserLoginProfileCreate(d *schema.ResourceData, meta interface{}) er
 	d.SetId(aws.StringValue(createResp.LoginProfile.UserName))
 
 	if v, ok := d.GetOk("pgp_key"); ok {
-		// pgpKey := v.(string)
-		// pgpKey = strings.TrimPrefix(strings.TrimSuffix(pgpKey, "\n"), "\n")
-
 		encryptionKey, err := RetrieveGPGKey(v.(string))
 		if err != nil {
 			return fmt.Errorf("error retrieving GPG Key during IAM User Login Profile (%s) creation: %w", username, err)

--- a/internal/service/iam/user_login_profile_test.go
+++ b/internal/service/iam/user_login_profile_test.go
@@ -66,7 +66,8 @@ func TestIAMPasswordPolicyCheck(t *testing.T) {
 func TestAccIAMUserLoginProfile_basic(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
-	username := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
+	resourceName := "aws_iam_user_login_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -75,26 +76,24 @@ func TestAccIAMUserLoginProfile_basic(t *testing.T) {
 		CheckDestroy: testAccCheckUserLoginProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserLoginProfileConfig_Required(username, "/", testPubKey1),
+				Config: testAccUserLoginProfileConfig_Required(rName, testPubKey1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserLoginProfileExists("aws_iam_user_login_profile.user", &conf),
-					testDecryptPasswordAndTest("aws_iam_user_login_profile.user", "aws_iam_access_key.user", testPrivKey1),
-					resource.TestCheckResourceAttrSet("aws_iam_user_login_profile.user", "encrypted_password"),
-					resource.TestCheckResourceAttrSet("aws_iam_user_login_profile.user", "key_fingerprint"),
-					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_length", "20"),
-					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_reset_required", "true"),
-					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "pgp_key", testPubKey1+"\n"),
+					testAccCheckUserLoginProfileExists(resourceName, &conf),
+					testDecryptPasswordAndTest(resourceName, "aws_iam_access_key.test", testPrivKey1),
+					resource.TestCheckResourceAttrSet(resourceName, "encrypted_password"),
+					resource.TestCheckResourceAttrSet(resourceName, "key_fingerprint"),
+					resource.TestCheckResourceAttr(resourceName, "password_length", "20"),
+					resource.TestCheckResourceAttr(resourceName, "pgp_key", testPubKey1+"\n"),
 				),
 			},
 			{
-				ResourceName:      "aws_iam_user_login_profile.user",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"encrypted_password",
 					"key_fingerprint",
 					"password_length",
-					"password_reset_required",
 					"pgp_key",
 				},
 			},
@@ -105,7 +104,8 @@ func TestAccIAMUserLoginProfile_basic(t *testing.T) {
 func TestAccIAMUserLoginProfile_keybase(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
-	username := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
+	resourceName := "aws_iam_user_login_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -114,25 +114,23 @@ func TestAccIAMUserLoginProfile_keybase(t *testing.T) {
 		CheckDestroy: testAccCheckUserLoginProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserLoginProfileConfig_Required(username, "/", "keybase:terraformacctest"),
+				Config: testAccUserLoginProfileConfig_Required(rName, "keybase:terraformacctest"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserLoginProfileExists("aws_iam_user_login_profile.user", &conf),
-					resource.TestCheckResourceAttrSet("aws_iam_user_login_profile.user", "encrypted_password"),
-					resource.TestCheckResourceAttrSet("aws_iam_user_login_profile.user", "key_fingerprint"),
-					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_length", "20"),
-					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_reset_required", "true"),
-					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "pgp_key", "keybase:terraformacctest\n"),
+					testAccCheckUserLoginProfileExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "encrypted_password"),
+					resource.TestCheckResourceAttrSet(resourceName, "key_fingerprint"),
+					resource.TestCheckResourceAttr(resourceName, "password_length", "20"),
+					resource.TestCheckResourceAttr(resourceName, "pgp_key", "keybase:terraformacctest\n"),
 				),
 			},
 			{
-				ResourceName:      "aws_iam_user_login_profile.user",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"encrypted_password",
 					"key_fingerprint",
 					"password_length",
-					"password_reset_required",
 					"pgp_key",
 				},
 			},
@@ -141,7 +139,7 @@ func TestAccIAMUserLoginProfile_keybase(t *testing.T) {
 }
 
 func TestAccIAMUserLoginProfile_keybaseDoesntExist(t *testing.T) {
-	username := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -151,7 +149,7 @@ func TestAccIAMUserLoginProfile_keybaseDoesntExist(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// We own this account but it doesn't have any key associated with it
-				Config:      testAccUserLoginProfileConfig_Required(username, "/", "keybase:terraform_nope"),
+				Config:      testAccUserLoginProfileConfig_Required(rName, "keybase:terraform_nope"),
 				ExpectError: regexp.MustCompile(`Error retrieving Public Key`),
 			},
 		},
@@ -159,7 +157,7 @@ func TestAccIAMUserLoginProfile_keybaseDoesntExist(t *testing.T) {
 }
 
 func TestAccIAMUserLoginProfile_notAKey(t *testing.T) {
-	username := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -169,7 +167,7 @@ func TestAccIAMUserLoginProfile_notAKey(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// We own this account but it doesn't have any key associated with it
-				Config:      testAccUserLoginProfileConfig_Required(username, "/", "lolimnotakey"),
+				Config:      testAccUserLoginProfileConfig_Required(rName, "lolimnotakey"),
 				ExpectError: regexp.MustCompile(`Error encrypting Password`),
 			},
 		},
@@ -179,7 +177,8 @@ func TestAccIAMUserLoginProfile_notAKey(t *testing.T) {
 func TestAccIAMUserLoginProfile_passwordLength(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
-	username := fmt.Sprintf("test-user-%d", sdkacctest.RandInt())
+	resourceName := "aws_iam_user_login_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -188,23 +187,81 @@ func TestAccIAMUserLoginProfile_passwordLength(t *testing.T) {
 		CheckDestroy: testAccCheckUserLoginProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserLoginProfileConfig_PasswordLength(username, "/", testPubKey1, 128),
+				Config: testAccUserLoginProfileConfig_PasswordLength(rName, testPubKey1, 128),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserLoginProfileExists("aws_iam_user_login_profile.user", &conf),
-					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_length", "128"),
+					testAccCheckUserLoginProfileExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "password_length", "128"),
 				),
 			},
 			{
-				ResourceName:      "aws_iam_user_login_profile.user",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"encrypted_password",
 					"key_fingerprint",
 					"password_length",
-					"password_reset_required",
 					"pgp_key",
 				},
+			},
+		},
+	})
+}
+
+func TestAccIAMUserLoginProfile_nogpg(t *testing.T) {
+	var conf iam.GetLoginProfileOutput
+
+	resourceName := "aws_iam_user_login_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserLoginProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserLoginProfileConfigNoGPG(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserLoginProfileExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "password_length", "20"),
+					resource.TestCheckResourceAttrSet(resourceName, "password"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"encrypted_password",
+					"key_fingerprint",
+					"password_length",
+					"password",
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMUserLoginProfile_disappears(t *testing.T) {
+	var conf iam.GetLoginProfileOutput
+
+	resourceName := "aws_iam_user_login_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserLoginProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserLoginProfileConfig_Required(rName, testPubKey1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserLoginProfileExists(resourceName, &conf),
+					acctest.CheckResourceDisappears(acctest.Provider, tfiam.ResourceUserLoginProfile(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -321,11 +378,10 @@ func testAccCheckUserLoginProfileExists(n string, res *iam.GetLoginProfileOutput
 	}
 }
 
-func testAccUserLoginProfileConfig_base(rName, path string) string {
+func testAccUserLoginProfileConfig_base(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_user" "user" {
+resource "aws_iam_user" "test" {
   name          = "%s"
-  path          = "%s"
   force_destroy = true
 }
 
@@ -333,7 +389,7 @@ data "aws_caller_identity" "current" {}
 
 data "aws_partition" "current" {}
 
-data "aws_iam_policy_document" "user" {
+data "aws_iam_policy_document" "test" {
   statement {
     effect    = "Allow"
     actions   = ["iam:GetAccountPasswordPolicy"]
@@ -347,45 +403,49 @@ data "aws_iam_policy_document" "user" {
   }
 }
 
-resource "aws_iam_user_policy" "user" {
+resource "aws_iam_user_policy" "test" {
   name   = "AllowChangeOwnPassword"
-  user   = aws_iam_user.user.name
-  policy = data.aws_iam_policy_document.user.json
+  user   = aws_iam_user.test.name
+  policy = data.aws_iam_policy_document.test.json
 }
 
-resource "aws_iam_access_key" "user" {
-  user = aws_iam_user.user.name
+resource "aws_iam_access_key" "test" {
+  user = aws_iam_user.test.name
 }
-`, rName, path)
+`, rName)
 }
 
-func testAccUserLoginProfileConfig_PasswordLength(rName, path, pgpKey string, passwordLength int) string {
-	return fmt.Sprintf(`
-%s
-
-resource "aws_iam_user_login_profile" "user" {
-  user            = aws_iam_user.user.name
+func testAccUserLoginProfileConfig_PasswordLength(rName, pgpKey string, passwordLength int) string {
+	return testAccUserLoginProfileConfig_base(rName) + fmt.Sprintf(`
+resource "aws_iam_user_login_profile" "test" {
+  user            = aws_iam_user.test.name
   password_length = %d
 
   pgp_key = <<EOF
 %s
 EOF
 }
-`, testAccUserLoginProfileConfig_base(rName, path), passwordLength, pgpKey)
+`, passwordLength, pgpKey)
 }
 
-func testAccUserLoginProfileConfig_Required(rName, path, pgpKey string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "aws_iam_user_login_profile" "user" {
-  user = aws_iam_user.user.name
+func testAccUserLoginProfileConfig_Required(rName, pgpKey string) string {
+	return testAccUserLoginProfileConfig_base(rName) + fmt.Sprintf(`
+resource "aws_iam_user_login_profile" "test" {
+  user = aws_iam_user.test.name
 
   pgp_key = <<EOF
 %s
 EOF
 }
-`, testAccUserLoginProfileConfig_base(rName, path), pgpKey)
+`, pgpKey)
+}
+
+func testAccUserLoginProfileConfigNoGPG(rName string) string {
+	return testAccUserLoginProfileConfig_base(rName) + `
+resource "aws_iam_user_login_profile" "test" {
+  user = aws_iam_user.test.name
+}
+`
 }
 
 const testPubKey1 = `mQENBFXbjPUBCADjNjCUQwfxKL+RR2GA6pv/1K+zJZ8UWIF9S0lk7cVIEfJiprzzwiMwBS5cD0da

--- a/internal/service/iam/user_login_profile_test.go
+++ b/internal/service/iam/user_login_profile_test.go
@@ -260,6 +260,7 @@ func TestAccIAMUserLoginProfile_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserLoginProfileExists(resourceName, &conf),
 					acctest.CheckResourceDisappears(acctest.Provider, tfiam.ResourceUserLoginProfile(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfiam.ResourceUserLoginProfile(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/website/docs/r/iam_user_login_profile.html.markdown
+++ b/website/docs/r/iam_user_login_profile.html.markdown
@@ -36,14 +36,15 @@ output "password" {
 The following arguments are supported:
 
 * `user` - (Required) The IAM user's name.
-* `pgp_key` - (Required) Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Only applies on resource creation. Drift detection is not possible with this argument.
-* `password_length` - (Optional, default 20) The length of the generated password on resource creation. Only applies on resource creation. Drift detection is not possible with this argument.
-* `password_reset_required` - (Optional, default "true") Whether the user should be forced to reset the generated password on resource creation. Only applies on resource creation. Drift detection is not possible with this argument.
+* `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Only applies on resource creation. Drift detection is not possible with this argument.
+* `password_length` - (Optional) The length of the generated password on resource creation. Only applies on resource creation. Drift detection is not possible with this argument. Default value is `20`.
+* `password_reset_required` - (Optional) Whether the user should be forced to reset the generated password on resource creation. Only applies on resource creation.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `password` - The plain text password, only available when `pgp_key` is not provided.
 * `key_fingerprint` - The fingerprint of the PGP key used to encrypt the password. Only available if password was handled on Terraform resource creation, not import.
 * `encrypted_password` - The encrypted password, base64 encoded. Only available if password was handled on Terraform resource creation, not import.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #4564

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSUserLoginProfile_'
--- PASS: TestAccAWSUserLoginProfile_notAKey (34.68s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (36.00s)
--- PASS: TestAccAWSUserLoginProfile_disappears (51.75s)
--- PASS: TestAccAWSUserLoginProfile_no_pgp (56.59s)
--- PASS: TestAccAWSUserLoginProfile_keybase (56.59s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (57.24s)
--- PASS: TestAccAWSUserLoginProfile_basic (65.99s)
...
```

Cant test this unfortunately as i don't have delete user permissions in my account :(
