### PR TITLE
[WIP] fix bug with PutRestApi removing policy

### DIFF
--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -184,6 +184,15 @@ func resourceAwsApiGatewayRestApiCreate(d *schema.ResourceData, meta interface{}
 		if err != nil {
 			return fmt.Errorf("error creating API Gateway specification: %s", err)
 		}
+		// Due to PutRestApi removing the policy from the rest api
+		_, err = conn.UpdateRestApi(&apigateway.UpdateRestApiInput{
+			RestApiId:       aws.String(d.Id()),
+			PatchOperations: resourceAwsApiGatewayRestApiUpdateOperations(d),
+		})
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] Updated API Gateway policy %s", d.Id())
 	}
 
 	return resourceAwsApiGatewayRestApiRead(d, meta)


### PR DESCRIPTION
Relates #5364

[WIP] The issue here is not that the policy is left blank on the first run. What seems to happen is that the policy is created by the CreateRestApi function and then the body is subsequently added with PutRestApi which requires an existing rest api to exist to apply the body against.

As the issue doesn't lie with terraform the only workaround I can see is to reapply the policy after the create as part of the PutRestApi step. PR tested against our infra and creates with the policy.

```release-note
NONE
```

Output from acceptance testing:
To be updated if there's interest in this fix.

