### PR TITLE
r/aws_opsworks_custom_layer - add cloudwatch configuration + disappears test

### DIFF
--- a/.changelog/12433.txt
+++ b/.changelog/12433.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_opsworks_custom_layer: Add support for `cloudwatch_configuration`
+```
+
+```release-note:enhancement
+resource/aws_opsworks_custom_layer: Add plan time validation for `ebs_volume.type`
+```

--- a/.changelog/12433.txt
+++ b/.changelog/12433.txt
@@ -3,5 +3,5 @@ resource/aws_opsworks_custom_layer: Add support for `cloudwatch_configuration`
 ```
 
 ```release-note:enhancement
-resource/aws_opsworks_custom_layer: Add plan time validation for `ebs_volume.type`
+resource/aws_opsworks_custom_layer: Add plan time validation for `ebs_volume.type` and `custom_json`.
 ```

--- a/internal/service/opsworks/custom_layer_test.go
+++ b/internal/service/opsworks/custom_layer_test.go
@@ -19,7 +19,7 @@ import (
 // and `aws-opsworks-service-role`, and Opsworks stacks named `tf-acc`.
 
 func TestAccOpsWorksCustomLayer_basic(t *testing.T) {
-	name := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var opslayer opsworks.Layer
 	resourceName := "aws_opsworks_custom_layer.test"
 
@@ -30,10 +30,10 @@ func TestAccOpsWorksCustomLayer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckCustomLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomLayerVPCCreateConfig(name),
+				Config: testAccCustomLayerVPCCreateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "auto_assign_elastic_ips", "false"),
 					resource.TestCheckResourceAttr(resourceName, "auto_healing", "true"),
 					resource.TestCheckResourceAttr(resourceName, "drain_elb_on_shutdown", "true"),
@@ -62,7 +62,7 @@ func TestAccOpsWorksCustomLayer_basic(t *testing.T) {
 }
 
 func TestAccOpsWorksCustomLayer_tags(t *testing.T) {
-	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var opslayer opsworks.Layer
 	resourceName := "aws_opsworks_custom_layer.test"
 
@@ -73,7 +73,7 @@ func TestAccOpsWorksCustomLayer_tags(t *testing.T) {
 		CheckDestroy: testAccCheckCustomLayerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomLayerTags1Config(name, "key1", "value1"),
+				Config: testAccCustomLayerTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -86,7 +86,7 @@ func TestAccOpsWorksCustomLayer_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCustomLayerTags2Config(name, "key1", "value1updated", "key2", "value2"),
+				Config: testAccCustomLayerTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -95,7 +95,7 @@ func TestAccOpsWorksCustomLayer_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCustomLayerTags1Config(name, "key2", "value2"),
+				Config: testAccCustomLayerTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -139,6 +139,11 @@ func TestAccOpsWorksCustomLayer_noVPC(t *testing.T) {
 						"encrypted":       "false",
 					}),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccCustomLayerUpdateConfig(rName),

--- a/internal/service/opsworks/custom_layer_test.go
+++ b/internal/service/opsworks/custom_layer_test.go
@@ -440,7 +440,7 @@ resource "aws_security_group" "tf-ops-acc-layer3" {
   }
 }
 
-resource "aws_opsworks_custom_layer" "tf-acc" {
+resource "aws_opsworks_custom_layer" "test" {
   stack_id               = aws_opsworks_stack.tf-acc.id
   name                   = "%[1]s"
   short_name             = "tf-ops-acc-custom-layer"

--- a/internal/service/opsworks/custom_layer_test.go
+++ b/internal/service/opsworks/custom_layer_test.go
@@ -174,7 +174,7 @@ func TestAccOpsWorksCustomLayer_noVPC(t *testing.T) {
 	})
 }
 
-func TestAccOpsworksCustomLayer_cloudwatch(t *testing.T) {
+func TestAccOpsWorksCustomLayer_cloudwatch(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var opslayer opsworks.Layer
 	resourceName := "aws_opsworks_custom_layer.test"
@@ -239,7 +239,7 @@ func TestAccOpsworksCustomLayer_cloudwatch(t *testing.T) {
 	})
 }
 
-func TestAccOpsworksCustomLayer_disappears(t *testing.T) {
+func TestAccOpsWorksCustomLayer_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var opslayer opsworks.Layer
 	resourceName := "aws_opsworks_custom_layer.test"

--- a/internal/service/opsworks/layers.go
+++ b/internal/service/opsworks/layers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -50,157 +51,209 @@ var (
 
 func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 	resourceSchema := map[string]*schema.Schema{
+		"arn": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"auto_assign_elastic_ips": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
-
 		"auto_assign_public_ips": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
-
+		"auto_healing": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		"cloudwatch_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				if old == "1" && new == "0" && !d.Get("cloudwatch_configuration.0.enabled").(bool) {
+					return true
+				}
+				return false
+			},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+							if old == "false" && new == "" {
+								return true
+							}
+							return false
+						},
+					},
+					"log_streams": {
+						Type:     schema.TypeList,
+						Optional: true,
+						DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+							if old == "1" && new == "0" && !d.Get("cloudwatch_configuration.0.enabled").(bool) {
+								return true
+							}
+							return false
+						},
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"batch_count": {
+									Type:         schema.TypeInt,
+									Default:      1000,
+									Optional:     true,
+									ValidateFunc: validation.IntAtMost(10000),
+								},
+								"batch_size": {
+									Type:         schema.TypeInt,
+									Default:      32768,
+									Optional:     true,
+									ValidateFunc: validation.IntAtMost(1048576),
+								},
+								"buffer_duration": {
+									Type:         schema.TypeInt,
+									Default:      5000,
+									Optional:     true,
+									ValidateFunc: validation.IntAtLeast(5000),
+								},
+								"datetime_format": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"encoding": {
+									Type:         schema.TypeString,
+									Optional:     true,
+									Default:      opsworks.CloudWatchLogsEncodingUtf8,
+									ValidateFunc: validation.StringInSlice(opsworks.CloudWatchLogsEncoding_Values(), false),
+								},
+								"file": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"file_fingerprint_lines": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "1",
+								},
+								"initial_position": {
+									Type:         schema.TypeString,
+									Optional:     true,
+									Default:      opsworks.CloudWatchLogsInitialPositionStartOfFile,
+									ValidateFunc: validation.StringInSlice(opsworks.CloudWatchLogsInitialPosition_Values(), false),
+								},
+								"log_group_name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"multiline_start_pattern": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"time_zone": {
+									Type:         schema.TypeString,
+									Optional:     true,
+									ValidateFunc: validation.StringInSlice(opsworks.CloudWatchLogsTimeZone_Values(), false),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"custom_instance_profile_arn": {
 			Type:         schema.TypeString,
 			Optional:     true,
 			ValidateFunc: verify.ValidARN,
 		},
-
-		"elastic_load_balancer": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-
 		"custom_setup_recipes": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
-
 		"custom_configure_recipes": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
-
 		"custom_deploy_recipes": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
-
 		"custom_undeploy_recipes": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
-
 		"custom_shutdown_recipes": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
-
 		"custom_security_group_ids": {
 			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 		},
-
 		"custom_json": {
-			Type: schema.TypeString,
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringIsJSON,
 			StateFunc: func(v interface{}) string {
 				json, _ := structure.NormalizeJsonString(v)
 				return json
 			},
 			Optional: true,
 		},
-
-		"auto_healing": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
-		},
-
-		"install_updates_on_boot": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
-		},
-
-		"instance_shutdown_timeout": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Default:  120,
-		},
-
 		"drain_elb_on_shutdown": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  true,
 		},
-
-		"system_packages": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-			Set:      schema.HashString,
-		},
-
-		"stack_id": {
-			Type:     schema.TypeString,
-			ForceNew: true,
-			Required: true,
-		},
-
-		"use_ebs_optimized_instances": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-		},
-
 		"ebs_volume": {
 			Type:     schema.TypeSet,
 			Optional: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-
 					"iops": {
 						Type:     schema.TypeInt,
 						Optional: true,
 						Default:  0,
 					},
-
 					"mount_point": {
 						Type:     schema.TypeString,
 						Required: true,
 					},
-
 					"number_of_disks": {
 						Type:     schema.TypeInt,
 						Required: true,
 					},
-
 					"raid_level": {
 						Type:     schema.TypeString,
 						Optional: true,
 						Default:  "",
 					},
-
 					"size": {
 						Type:     schema.TypeInt,
 						Required: true,
 					},
-
 					"type": {
 						Type:     schema.TypeString,
 						Optional: true,
 						Default:  "standard",
+						ValidateFunc: validation.StringInSlice([]string{
+							"standard",
+							"io1",
+							"gp2",
+							"st1",
+							"sc1",
+						}, false),
 					},
-
 					"encrypted": {
 						Type:     schema.TypeBool,
 						Optional: true,
@@ -213,9 +266,35 @@ func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 				return create.StringHashcode(m["mount_point"].(string))
 			},
 		},
-		"arn": {
+		"elastic_load_balancer": {
 			Type:     schema.TypeString,
-			Computed: true,
+			Optional: true,
+		},
+		"install_updates_on_boot": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		"instance_shutdown_timeout": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  120,
+		},
+		"system_packages": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Set:      schema.HashString,
+		},
+		"stack_id": {
+			Type:     schema.TypeString,
+			ForceNew: true,
+			Required: true,
+		},
+		"use_ebs_optimized_instances": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
 		},
 		"tags":     tftags.TagsSchema(),
 		"tags_all": tftags.TagsSchemaComputed(),
@@ -307,6 +386,9 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, meta interface{}) erro
 	d.Set("system_packages", flex.FlattenStringList(layer.Packages))
 	d.Set("stack_id", layer.StackId)
 	d.Set("use_ebs_optimized_instances", layer.UseEbsOptimizedInstances)
+	if err := d.Set("cloudwatch_configuration", flattenOpsworksCloudWatchConfig(layer.CloudWatchLogsConfiguration)); err != nil {
+		return fmt.Errorf("error setting cloudwatch_configuration: %w", err)
+	}
 
 	if lt.CustomShortName {
 		d.Set("short_name", layer.Shortname)
@@ -399,6 +481,10 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, meta interface{}) er
 		VolumeConfigurations:        lt.VolumeConfigurations(d),
 	}
 
+	if v, ok := d.GetOk("cloudwatch_configuration"); ok {
+		req.CloudWatchLogsConfiguration = expandOpsworksCloudWatchConfig(v.([]interface{}))
+	}
+
 	if lt.CustomShortName {
 		req.Shortname = aws.String(d.Get("short_name").(string))
 	} else {
@@ -468,6 +554,10 @@ func (lt *opsworksLayerType) Update(d *schema.ResourceData, meta interface{}) er
 		UseEbsOptimizedInstances:    aws.Bool(d.Get("use_ebs_optimized_instances").(bool)),
 		Attributes:                  attributes,
 		VolumeConfigurations:        lt.VolumeConfigurations(d),
+	}
+
+	if v, ok := d.GetOk("cloudwatch_configuration"); ok {
+		req.CloudWatchLogsConfiguration = expandOpsworksCloudWatchConfig(v.([]interface{}))
 	}
 
 	if lt.CustomShortName {
@@ -723,4 +813,149 @@ func (lt *opsworksLayerType) SetVolumeConfigurations(d *schema.ResourceData, v [
 	}
 
 	d.Set("ebs_volume", newValue)
+}
+
+func expandOpsworksCloudWatchConfig(l []interface{}) *opsworks.CloudWatchLogsConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &opsworks.CloudWatchLogsConfiguration{
+		Enabled:    aws.Bool(m["enabled"].(bool)),
+		LogStreams: expandOpsworksCloudWatchConfigLogStream(m["log_streams"].([]interface{})),
+	}
+
+	return config
+}
+
+func expandOpsworksCloudWatchConfigLogStream(l []interface{}) []*opsworks.CloudWatchLogsLogStream {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	logStreams := make([]*opsworks.CloudWatchLogsLogStream, 0)
+
+	for _, m := range l {
+		item := m.(map[string]interface{})
+		logStream := &opsworks.CloudWatchLogsLogStream{}
+
+		if v, ok := item["batch_count"]; ok {
+			logStream.BatchCount = aws.Int64(int64(v.(int)))
+		}
+
+		if v, ok := item["batch_size"]; ok {
+			logStream.BatchSize = aws.Int64(int64(v.(int)))
+		}
+
+		if v, ok := item["buffer_duration"]; ok {
+			logStream.BufferDuration = aws.Int64(int64(v.(int)))
+		}
+
+		if v, ok := item["datetime_format"]; ok {
+			logStream.DatetimeFormat = aws.String(v.(string))
+		}
+
+		if v, ok := item["encoding"]; ok {
+			logStream.Encoding = aws.String(v.(string))
+		}
+
+		if v, ok := item["file"]; ok {
+			logStream.File = aws.String(v.(string))
+		}
+
+		if v, ok := item["file_fingerprint_lines"]; ok {
+			logStream.FileFingerprintLines = aws.String(v.(string))
+		}
+
+		if v, ok := item["initial_position"]; ok {
+			logStream.InitialPosition = aws.String(v.(string))
+		}
+
+		if v, ok := item["log_group_name"]; ok {
+			logStream.LogGroupName = aws.String(v.(string))
+		}
+
+		if v, ok := item["multiline_start_pattern"]; ok {
+			logStream.MultiLineStartPattern = aws.String(v.(string))
+		}
+
+		if v, ok := item["time_zone"]; ok {
+			logStream.TimeZone = aws.String(v.(string))
+		}
+
+		logStreams = append(logStreams, logStream)
+	}
+
+	return logStreams
+}
+
+func flattenOpsworksCloudWatchConfig(cloudwatchConfig *opsworks.CloudWatchLogsConfiguration) []map[string]interface{} {
+	if cloudwatchConfig == nil {
+		return nil
+	}
+
+	p := map[string]interface{}{
+		"enabled":     aws.BoolValue(cloudwatchConfig.Enabled),
+		"log_streams": flattenOpsworksCloudWatchConfigLogStreams(cloudwatchConfig.LogStreams),
+	}
+
+	return []map[string]interface{}{p}
+}
+
+func flattenOpsworksCloudWatchConfigLogStreams(logStreams []*opsworks.CloudWatchLogsLogStream) []interface{} {
+	out := make([]interface{}, len(logStreams))
+
+	for i, logStream := range logStreams {
+		m := make(map[string]interface{})
+
+		if logStream.TimeZone != nil {
+			m["time_zone"] = aws.StringValue(logStream.TimeZone)
+		}
+
+		if logStream.MultiLineStartPattern != nil {
+			m["multiline_start_pattern"] = aws.StringValue(logStream.MultiLineStartPattern)
+		}
+
+		if logStream.Encoding != nil {
+			m["encoding"] = aws.StringValue(logStream.Encoding)
+		}
+
+		if logStream.LogGroupName != nil {
+			m["log_group_name"] = aws.StringValue(logStream.LogGroupName)
+		}
+
+		if logStream.File != nil {
+			m["file"] = aws.StringValue(logStream.File)
+		}
+
+		if logStream.DatetimeFormat != nil {
+			m["datetime_format"] = aws.StringValue(logStream.DatetimeFormat)
+		}
+
+		if logStream.FileFingerprintLines != nil {
+			m["file_fingerprint_lines"] = aws.StringValue(logStream.FileFingerprintLines)
+		}
+
+		if logStream.InitialPosition != nil {
+			m["initial_position"] = aws.StringValue(logStream.InitialPosition)
+		}
+
+		if logStream.BatchSize != nil {
+			m["batch_size"] = aws.Int64Value(logStream.BatchSize)
+		}
+
+		if logStream.BatchCount != nil {
+			m["batch_count"] = aws.Int64Value(logStream.BatchCount)
+		}
+
+		if logStream.BufferDuration != nil {
+			m["buffer_duration"] = aws.Int64Value(logStream.BufferDuration)
+		}
+
+		out[i] = m
+	}
+
+	return out
 }

--- a/website/docs/r/opsworks_custom_layer.html.markdown
+++ b/website/docs/r/opsworks_custom_layer.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 * `stack_id` - (Required) The id of the stack the layer will belong to.
 * `auto_assign_elastic_ips` - (Optional) Whether to automatically assign an elastic IP address to the layer's instances.
 * `auto_assign_public_ips` - (Optional) For stacks belonging to a VPC, whether to automatically assign a public IP address to each of the layer's instances.
+* `cloudwatch_configuration` - (Optional) Will create an EBS volume and connect it to the layer's instances. See [Cloudwatch Configuration](#cloudwatch-configuration).
 * `custom_instance_profile_arn` - (Optional) The ARN of an IAM profile that will be used for the layer's instances.
 * `custom_security_group_ids` - (Optional) Ids for a set of security groups to apply to the layer's instances.
 * `auto_healing` - (Optional) Whether to enable auto-healing for the layer.
@@ -38,7 +39,7 @@ The following arguments are supported:
 * `drain_elb_on_shutdown` - (Optional) Whether to enable Elastic Load Balancing connection draining.
 * `system_packages` - (Optional) Names of a set of system packages to install on the layer's instances.
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
-* `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
+* `ebs_volume` - (Optional) Will create an EBS volume and connect it to the layer's instances. See [EBS Volume](#ebs-volume).
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
@@ -52,7 +53,7 @@ lifecycle events, if custom cookbooks are enabled on the layer's stack:
 * `custom_shutdown_recipes`
 * `custom_undeploy_recipes`
 
-An `ebs_volume` block supports the following arguments:
+### EBS Volume
 
 * `mount_point` - (Required) The path to mount the EBS volume on the layer's instances.
 * `size` - (Required) The size of the volume in gigabytes.
@@ -61,6 +62,26 @@ An `ebs_volume` block supports the following arguments:
 * `type` - (Optional) The type of volume to create. This may be `standard` (the default), `io1` or `gp2`.
 * `iops` - (Optional) For PIOPS volumes, the IOPS per disk.
 * `encrypted` - (Optional) Encrypt the volume.
+
+### Cloudwatch Configuration
+
+* `enabled` - (Optional)
+* `log_streams` - (Optional) A block the specifies how an opsworks logs look like. See [Log Streams](#log-streams).
+
+#### Log Streams
+
+* `file` - (Required) Specifies log files that you want to push to CloudWatch Logs. File can point to a specific file or multiple files (by using wild card characters such as /var/log/system.log*).
+* `log_group_name` - (Required) Specifies the destination log group. A log group is created automatically if it doesn't already exist.
+* `batch_count` - (Optional) Specifies the max number of log events in a batch, up to `10000`. The default value is `1000`.
+* `batch_size` - (Optional) Specifies the maximum size of log events in a batch, in bytes, up to `1048576` bytes. The default value is `32768` bytes.
+* `buffer_duration` - (Optional) Specifies the time duration for the batching of log events. The minimum value is `5000` and default value is `5000`.
+* `datetime_format` - (Optional) Specifies how the timestamp is extracted from logs. For more information, see the CloudWatch Logs Agent Reference (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html).
+* `encoding` - (Optional) Specifies the encoding of the log file so that the file can be read correctly. The default is `utf_8`.
+* `file_fingerprint_lines` - (Optional) Specifies the range of lines for identifying a file. The valid values are one number, or two dash-delimited numbers, such as `1`, `2-5`. The default value is `1`.
+* `initial_position` - (Optional) Specifies where to start to read data (`start_of_file` or `end_of_file`). The default is `start_of_file`.
+* `multiline_start_pattern` - (Optional) Specifies the pattern for identifying the start of a log message.
+* `time_zone` - (Optional) Specifies the time zone of log event time stamps.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2656
Closes #15010
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_opsworks_custom_layer - add cloudwatch configuration
resource_aws_opsworks_custom_layer - add plan time validation to `ebs_volume.type`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccOpsWorksCustomLayer_ PKG=opsworks
--- PASS: TestAccOpsWorksCustomLayer_basic (112.16s)
--- PASS: TestAccOpsWorksCustomLayer_disappears (125.37s)
--- PASS: TestAccOpsWorksCustomLayer_noVPC (221.92s)
--- PASS: TestAccOpsWorksCustomLayer_cloudwatch (280.16s)
--- PASS: TestAccOpsWorksCustomLayer_tags (364.21s)
```
