### PR TITLE
r/aws_cognito_user_pool_domain - add wait for deployment argument

### DIFF
--- a/aws/resource_aws_cognito_user_pool_domain.go
+++ b/aws/resource_aws_cognito_user_pool_domain.go
@@ -16,6 +16,7 @@ func resourceAwsCognitoUserPoolDomain() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsCognitoUserPoolDomainCreate,
 		Read:   resourceAwsCognitoUserPoolDomainRead,
+		Update: resourceAwsCognitoUserPoolDomainRead,
 		Delete: resourceAwsCognitoUserPoolDomainDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -55,6 +56,11 @@ func resourceAwsCognitoUserPoolDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"wait_for_deployment": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -88,8 +94,10 @@ func resourceAwsCognitoUserPoolDomainCreate(d *schema.ResourceData, meta interfa
 
 	d.SetId(domain)
 
-	if _, err := waiter.UserPoolDomainCreated(conn, d.Id(), timeout); err != nil {
-		return fmt.Errorf("error waiting for User Pool Domain (%s) creation: %w", d.Id(), err)
+	if d.Get("wait_for_deployment").(bool) {
+		if _, err := waiter.UserPoolDomainCreated(conn, d.Id(), timeout); err != nil {
+			return fmt.Errorf("error waiting for User Pool Domain (%s) creation: %w", d.Id(), err)
+		}
 	}
 
 	return resourceAwsCognitoUserPoolDomainRead(d, meta)

--- a/aws/resource_aws_cognito_user_pool_domain.go
+++ b/aws/resource_aws_cognito_user_pool_domain.go
@@ -16,7 +16,6 @@ func resourceAwsCognitoUserPoolDomain() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsCognitoUserPoolDomainCreate,
 		Read:   resourceAwsCognitoUserPoolDomainRead,
-		Update: resourceAwsCognitoUserPoolDomainRead,
 		Delete: resourceAwsCognitoUserPoolDomainDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -59,6 +58,7 @@ func resourceAwsCognitoUserPoolDomain() *schema.Resource {
 			"wait_for_deployment": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 				Default:  true,
 			},
 		},

--- a/aws/resource_aws_cognito_user_pool_domain_test.go
+++ b/aws/resource_aws_cognito_user_pool_domain_test.go
@@ -76,6 +76,8 @@ func testSweepCognitoUserPoolDomains(region string) error {
 func TestAccAWSCognitoUserPoolDomain_basic(t *testing.T) {
 	domainName := fmt.Sprintf("tf-acc-test-domain-%d", acctest.RandInt())
 	poolName := fmt.Sprintf("tf-acc-test-pool-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "aws_cognito_user_pool_domain.test"
+	userPoolResourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -85,19 +87,22 @@ func TestAccAWSCognitoUserPoolDomain_basic(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolDomainConfig_basic(domainName, poolName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolDomainExists("aws_cognito_user_pool_domain.main"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_domain.main", "domain", domainName),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "name", poolName),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "aws_account_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "cloudfront_distribution_arn"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "s3_bucket"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "version"),
+					testAccCheckAWSCognitoUserPoolDomainExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "domain", domainName),
+					resource.TestCheckResourceAttrPair(resourceName, "user_pool_id", userPoolResourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "aws_account_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloudfront_distribution_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "s3_bucket"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
 			},
 			{
-				ResourceName:      "aws_cognito_user_pool_domain.main",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -135,6 +140,9 @@ func TestAccAWSCognitoUserPoolDomain_custom(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -208,12 +216,28 @@ func testAccCheckAWSCognitoUserPoolDomainDestroy(s *terraform.State) error {
 
 func testAccAWSCognitoUserPoolDomainConfig_basic(domainName, poolName string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool_domain" "main" {
+resource "aws_cognito_user_pool_domain" "test" {
   domain       = "%s"
+  user_pool_id = aws_cognito_user_pool.test.id
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = "%s"
+}
+`, domainName, poolName)
+}
+
+func testAccAWSCognitoUserPoolDomainConfigWaitForDeployment(domainName, poolName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool_domain" "test" {
+  domain              = "%s"
+  user_pool_id        = "${aws_cognito_user_pool.test.id}"
+  wait_for_deployment = false
+
   user_pool_id = aws_cognito_user_pool.main.id
 }
 
-resource "aws_cognito_user_pool" "main" {
+resource "aws_cognito_user_pool" "test" {
   name = "%s"
 }
 `, domainName, poolName)

--- a/website/docs/r/cognito_user_pool_domain.markdown
+++ b/website/docs/r/cognito_user_pool_domain.markdown
@@ -62,6 +62,9 @@ The following arguments are supported:
 * `domain` - (Required) The domain string.
 * `user_pool_id` - (Required) The user pool ID.
 * `certificate_arn` - (Optional) The ARN of an ISSUED ACM certificate in us-east-1 for a custom domain.
+  * `wait_for_deployment` (Optional) - If enabled, the resource will wait for
+    the user pool domain status to change from `Creating` to `Active`. Setting
+    this to`false` will skip the process. Default: `true`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11665

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cognito_user_pool_domain - add `wait_for_deployment` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPoolDomain_'
--- PASS: TestAccAWSCognitoUserPoolDomain_basic (78.12s)
--- PASS: TestAccAWSCognitoUserPoolDomain_wait_for_deployment (67.84s)
```
