### PR TITLE
r/aws_cognito_user_pool - add support for account recovery setting

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -541,7 +541,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"recovery_mechanisms": {
+						"recovery_mechanism": {
 							Type:     schema.TypeSet,
 							Required: true,
 							MinItems: 1,
@@ -1292,7 +1292,7 @@ func expandCognitoUserPoolAccountRecoverySettingConfig(config map[string]interfa
 
 	mechs := make([]*cognitoidentityprovider.RecoveryOptionType, 0)
 
-	if v, ok := config["recovery_mechanisms"]; ok {
+	if v, ok := config["recovery_mechanism"]; ok {
 		data := v.(*schema.Set).List()
 
 		for _, m := range data {
@@ -1333,7 +1333,7 @@ func flattenCognitoUserPoolAccountRecoverySettingConfig(config *cognitoidentityp
 		mechanisms = append(mechanisms, mech)
 	}
 
-	settings["recovery_mechanisms"] = mechanisms
+	settings["recovery_mechanism"] = mechanisms
 
 	return []interface{}{settings}
 }

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -548,13 +548,9 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"name": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											cognitoidentityprovider.RecoveryOptionNameTypeAdminOnly,
-											cognitoidentityprovider.RecoveryOptionNameTypeVerifiedEmail,
-											cognitoidentityprovider.RecoveryOptionNameTypeVerifiedPhoneNumber,
-										}, false),
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(cognitoidentityprovider.RecoveryOptionNameType_Values(), false),
 									},
 									"priority": {
 										Type:     schema.TypeInt,

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -539,13 +539,13 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 			"account_recovery_setting": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"recovery_mechanisms": {
 							Type:     schema.TypeSet,
-							Optional: true,
+							Required: true,
+							MinItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"name": {

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -762,7 +762,7 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 		resp, err = conn.CreateUserPool(params)
 	}
 	if err != nil {
-		return fmt.Errorf("Error creating Cognito User Pool: %s", err)
+		return fmt.Errorf("error creating Cognito User Pool: %w", err)
 	}
 
 	d.SetId(*resp.UserPool.Id)
@@ -836,7 +836,7 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err := d.Set("admin_create_user_config", flattenCognitoUserPoolAdminCreateUserConfig(resp.UserPool.AdminCreateUserConfig)); err != nil {
-		return fmt.Errorf("Failed setting admin_create_user_config: %s", err)
+		return fmt.Errorf("failed setting admin_create_user_config: %w", err)
 	}
 	if resp.UserPool.AliasAttributes != nil {
 		d.Set("alias_attributes", flattenStringList(resp.UserPool.AliasAttributes))
@@ -859,7 +859,7 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("email_verification_message", resp.UserPool.EmailVerificationMessage)
 	}
 	if err := d.Set("lambda_config", flattenCognitoUserPoolLambdaConfig(resp.UserPool.LambdaConfig)); err != nil {
-		return fmt.Errorf("Failed setting lambda_config: %s", err)
+		return fmt.Errorf("failed setting lambda_config: %w", err)
 	}
 	if resp.UserPool.SmsVerificationMessage != nil {
 		d.Set("sms_verification_message", resp.UserPool.SmsVerificationMessage)
@@ -869,22 +869,22 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err := d.Set("device_configuration", flattenCognitoUserPoolDeviceConfiguration(resp.UserPool.DeviceConfiguration)); err != nil {
-		return fmt.Errorf("Failed setting device_configuration: %s", err)
+		return fmt.Errorf("failed setting device_configuration: %w", err)
 	}
 
 	if err := d.Set("account_recovery_setting", flattenCognitoUserPoolAccountRecoverySettingConfig(resp.UserPool.AccountRecoverySetting)); err != nil {
-		return fmt.Errorf("Failed setting account_recovery_setting: %s", err)
+		return fmt.Errorf("failed setting account_recovery_setting: %w", err)
 	}
 
 	if resp.UserPool.EmailConfiguration != nil {
 		if err := d.Set("email_configuration", flattenCognitoUserPoolEmailConfiguration(resp.UserPool.EmailConfiguration)); err != nil {
-			return fmt.Errorf("Failed setting email_configuration: %s", err)
+			return fmt.Errorf("failed setting email_configuration: %w", err)
 		}
 	}
 
 	if resp.UserPool.Policies != nil && resp.UserPool.Policies.PasswordPolicy != nil {
 		if err := d.Set("password_policy", flattenCognitoUserPoolPasswordPolicy(resp.UserPool.Policies.PasswordPolicy)); err != nil {
-			return fmt.Errorf("Failed setting password_policy: %s", err)
+			return fmt.Errorf("failed setting password_policy: %w", err)
 		}
 	}
 
@@ -893,11 +893,11 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		configuredSchema = v.(*schema.Set).List()
 	}
 	if err := d.Set("schema", flattenCognitoUserPoolSchema(expandCognitoUserPoolSchema(configuredSchema), resp.UserPool.SchemaAttributes)); err != nil {
-		return fmt.Errorf("Failed setting schema: %s", err)
+		return fmt.Errorf("failed setting schema: %w", err)
 	}
 
 	if err := d.Set("sms_configuration", flattenCognitoSmsConfiguration(resp.UserPool.SmsConfiguration)); err != nil {
-		return fmt.Errorf("Failed setting sms_configuration: %s", err)
+		return fmt.Errorf("failed setting sms_configuration: %w", err)
 	}
 
 	if resp.UserPool.UsernameAttributes != nil {
@@ -905,22 +905,22 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err := d.Set("username_configuration", flattenCognitoUserPoolUsernameConfiguration(resp.UserPool.UsernameConfiguration)); err != nil {
-		return fmt.Errorf("Failed setting username_configuration: %s", err)
+		return fmt.Errorf("failed setting username_configuration: %w", err)
 	}
 
 	if err := d.Set("user_pool_add_ons", flattenCognitoUserPoolUserPoolAddOns(resp.UserPool.UserPoolAddOns)); err != nil {
-		return fmt.Errorf("Failed setting user_pool_add_ons: %s", err)
+		return fmt.Errorf("failed setting user_pool_add_ons: %w", err)
 	}
 
 	if err := d.Set("verification_message_template", flattenCognitoUserPoolVerificationMessageTemplate(resp.UserPool.VerificationMessageTemplate)); err != nil {
-		return fmt.Errorf("Failed setting verification_message_template: %s", err)
+		return fmt.Errorf("failed setting verification_message_template: %w", err)
 	}
 
 	d.Set("creation_date", resp.UserPool.CreationDate.Format(time.RFC3339))
 	d.Set("last_modified_date", resp.UserPool.LastModifiedDate.Format(time.RFC3339))
 	d.Set("name", resp.UserPool.Name)
 	if err := d.Set("tags", keyvaluetags.CognitoidentityKeyValueTags(resp.UserPool.UserPoolTags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	input := &cognitoidentityprovider.GetUserPoolMfaConfigInput{
@@ -942,7 +942,7 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("mfa_configuration", output.MfaConfiguration)
 
 	if err := d.Set("software_token_mfa_configuration", flattenCognitoSoftwareTokenMfaConfiguration(output.SoftwareTokenMfaConfiguration)); err != nil {
-		return fmt.Errorf("error setting software_token_mfa_configuration: %s", err)
+		return fmt.Errorf("error setting software_token_mfa_configuration: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -116,7 +116,7 @@ func TestAccAWSCognitoUserPool_recovery(t *testing.T) {
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "account_recovery_setting.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "account_recovery_setting.0.recovery_mechanisms.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "account_recovery_setting.0.recovery_mechanism.#", "1"),
 				),
 			},
 			{
@@ -130,7 +130,7 @@ func TestAccAWSCognitoUserPool_recovery(t *testing.T) {
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "account_recovery_setting.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "account_recovery_setting.0.recovery_mechanisms.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "account_recovery_setting.0.recovery_mechanism.#", "2"),
 				),
 			},
 			{
@@ -139,7 +139,7 @@ func TestAccAWSCognitoUserPool_recovery(t *testing.T) {
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "account_recovery_setting.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "account_recovery_setting.0.recovery_mechanisms.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "account_recovery_setting.0.recovery_mechanism.#", "1"),
 				),
 			},
 		},

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -30,7 +30,7 @@ func init() {
 func testSweepCognitoUserPools(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
-		return fmt.Errorf("Error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.(*AWSClient).cognitoidpconn
 
@@ -52,7 +52,7 @@ func testSweepCognitoUserPools(region string) error {
 				UserPoolId: userPool.Id,
 			})
 			if err != nil {
-				log.Printf("[ERROR] Failed deleting Cognito User Pool (%s): %s", name, err)
+				log.Printf("[ERROR] Failed deleting Cognito User Pool (%s): %w", name, err)
 			}
 		}
 		return !isLast

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -148,7 +147,7 @@ func TestAccAWSCognitoUserPool_recovery(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -157,7 +156,7 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfiguration(name),
+				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfiguration(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "true"),
@@ -172,7 +171,7 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdated(name),
+				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "false"),
 					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and constant password is {####}. "),
@@ -186,7 +185,7 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
 
 // Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11858
 func TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy(t *testing.T) {
-	name := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -195,7 +194,7 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigAndPasswordPolicy(name),
+				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigAndPasswordPolicy(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "true"),
@@ -249,7 +248,7 @@ func TestAccAWSCognitoUserPool_withAdvancedSecurityMode(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withDeviceConfiguration(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -258,7 +257,7 @@ func TestAccAWSCognitoUserPool_withDeviceConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withDeviceConfiguration(name),
+				Config: testAccAWSCognitoUserPoolConfig_withDeviceConfiguration(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.challenge_required_on_new_device", "true"),
@@ -271,7 +270,7 @@ func TestAccAWSCognitoUserPool_withDeviceConfiguration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withDeviceConfigurationUpdated(name),
+				Config: testAccAWSCognitoUserPoolConfig_withDeviceConfigurationUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.challenge_required_on_new_device", "false"),
 					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.device_only_remembered_on_user_prompt", "true"),
@@ -282,7 +281,7 @@ func TestAccAWSCognitoUserPool_withDeviceConfiguration(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withEmailVerificationMessage(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	subject := acctest.RandString(10)
 	updatedSubject := acctest.RandString(10)
 	message := fmt.Sprintf("%s {####}", acctest.RandString(10))
@@ -295,7 +294,7 @@ func TestAccAWSCognitoUserPool_withEmailVerificationMessage(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailVerificationMessage(name, subject, message),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailVerificationMessage(rName, subject, message),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "email_verification_subject", subject),
@@ -308,7 +307,7 @@ func TestAccAWSCognitoUserPool_withEmailVerificationMessage(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailVerificationMessage(name, updatedSubject, upatedMessage),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailVerificationMessage(rName, updatedSubject, upatedMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "email_verification_subject", updatedSubject),
 					resource.TestCheckResourceAttr(resourceName, "email_verification_message", upatedMessage),
@@ -721,8 +720,8 @@ func TestAccAWSCognitoUserPool_SmsVerificationMessage(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
-	name := acctest.RandString(5)
-	replyTo := fmt.Sprintf("tf-acc-reply-%s@terraformtesting.com", name)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	replyTo := fmt.Sprintf("tf-acc-reply-%s@terraformtesting.com", rName)
 	resourceName := "aws_cognito_user_pool.test"
 
 	sourceARN, ok := os.LookupEnv("TEST_AWS_SES_VERIFIED_EMAIL_ARN")
@@ -736,7 +735,7 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, "", "", "", "COGNITO_DEFAULT"),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(rName, "", "", "", "COGNITO_DEFAULT"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", ""),
@@ -750,7 +749,7 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, replyTo, sourceARN, "John Smith <john@smith.com>", "DEVELOPER"),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(rName, replyTo, sourceARN, "John Smith <john@smith.com>", "DEVELOPER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", replyTo),
@@ -764,7 +763,7 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withTags(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -773,7 +772,7 @@ func TestAccAWSCognitoUserPool_withTags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_Tags1(name, "key1", "value1"),
+				Config: testAccAWSCognitoUserPoolConfig_Tags1(rName, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -786,7 +785,7 @@ func TestAccAWSCognitoUserPool_withTags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_Tags2(name, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAWSCognitoUserPoolConfig_Tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -794,7 +793,7 @@ func TestAccAWSCognitoUserPool_withTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_Tags1(name, "key2", "value2"),
+				Config: testAccAWSCognitoUserPoolConfig_Tags1(rName, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -806,7 +805,7 @@ func TestAccAWSCognitoUserPool_withTags(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withAliasAttributes(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -815,7 +814,7 @@ func TestAccAWSCognitoUserPool_withAliasAttributes(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withAliasAttributes(name),
+				Config: testAccAWSCognitoUserPoolConfig_withAliasAttributes(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "alias_attributes.#", "1"),
@@ -829,7 +828,7 @@ func TestAccAWSCognitoUserPool_withAliasAttributes(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withAliasAttributesUpdated(name),
+				Config: testAccAWSCognitoUserPoolConfig_withAliasAttributesUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "alias_attributes.#", "2"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "alias_attributes.*", "email"),
@@ -843,7 +842,7 @@ func TestAccAWSCognitoUserPool_withAliasAttributes(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -852,7 +851,7 @@ func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withPasswordPolicy(name),
+				Config: testAccAWSCognitoUserPoolConfig_withPasswordPolicy(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "password_policy.#", "1"),
@@ -870,7 +869,7 @@ func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withPasswordPolicyUpdated(name),
+				Config: testAccAWSCognitoUserPoolConfig_withPasswordPolicyUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "password_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "password_policy.0.minimum_length", "9"),
@@ -886,7 +885,7 @@ func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withUsernameConfiguration(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -895,7 +894,7 @@ func TestAccAWSCognitoUserPool_withUsernameConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withUsernameConfiguration(name),
+				Config: testAccAWSCognitoUserPoolConfig_withUsernameConfiguration(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "username_configuration.#", "1"),
@@ -908,7 +907,7 @@ func TestAccAWSCognitoUserPool_withUsernameConfiguration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withUsernameConfigurationUpdated(name),
+				Config: testAccAWSCognitoUserPoolConfig_withUsernameConfigurationUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "username_configuration.#", "1"),
@@ -920,7 +919,7 @@ func TestAccAWSCognitoUserPool_withUsernameConfiguration(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -929,7 +928,7 @@ func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withLambdaConfig(name),
+				Config: testAccAWSCognitoUserPoolConfig_withLambdaConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "1"),
@@ -951,7 +950,7 @@ func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withLambdaConfigUpdated(name),
+				Config: testAccAWSCognitoUserPoolConfig_withLambdaConfigUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.create_auth_challenge"),
@@ -971,7 +970,7 @@ func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -980,7 +979,7 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withSchemaAttributes(name),
+				Config: testAccAWSCognitoUserPoolConfig_withSchemaAttributes(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "schema.#", "2"),
@@ -1012,7 +1011,7 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withSchemaAttributesUpdated(name),
+				Config: testAccAWSCognitoUserPoolConfig_withSchemaAttributesUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "schema.#", "3"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "schema.*", map[string]string{
@@ -1060,7 +1059,7 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_withVerificationMessageTemplate(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1069,7 +1068,7 @@ func TestAccAWSCognitoUserPool_withVerificationMessageTemplate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate(name),
+				Config: testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.default_email_option", "CONFIRM_WITH_LINK"),
@@ -1093,7 +1092,7 @@ func TestAccAWSCognitoUserPool_withVerificationMessageTemplate(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate_DefaultEmailOption(name),
+				Config: testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate_DefaultEmailOption(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
 					resource.TestCheckResourceAttr(resourceName, "email_verification_message", "{####} Baz"),
@@ -1113,7 +1112,7 @@ func TestAccAWSCognitoUserPool_withVerificationMessageTemplate(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPool_update(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	optionalMfa := "OPTIONAL"
 	offMfa := "OFF"
 	authenticationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
@@ -1126,7 +1125,7 @@ func TestAccAWSCognitoUserPool_update(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_update(name, optionalMfa, authenticationMessage),
+				Config: testAccAWSCognitoUserPoolConfig_update(rName, optionalMfa, authenticationMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_verified_attributes.#", "1"),
@@ -1145,7 +1144,6 @@ func TestAccAWSCognitoUserPool_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Foo"),
 				),
 			},
 			{
@@ -1154,7 +1152,7 @@ func TestAccAWSCognitoUserPool_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_update(name, optionalMfa, updatedAuthenticationMessage),
+				Config: testAccAWSCognitoUserPoolConfig_update(rName, optionalMfa, updatedAuthenticationMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_verified_attributes.#", "1"),
@@ -1173,11 +1171,10 @@ func TestAccAWSCognitoUserPool_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Foo"),
 				),
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_update(name, offMfa, updatedAuthenticationMessage),
+				Config: testAccAWSCognitoUserPoolConfig_update(rName, offMfa, updatedAuthenticationMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_verified_attributes.#", "1"),
@@ -1196,8 +1193,28 @@ func TestAccAWSCognitoUserPool_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Foo"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_Name(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCognitoUserPool(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -1218,7 +1235,7 @@ func testAccCheckAWSCognitoUserPoolDestroy(s *terraform.State) error {
 		_, err := conn.DescribeUserPool(params)
 
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cognitoidentityprovider.ErrCodeResourceNotFoundException {
+			if isAWSErr(err, cognitoidentityprovider.ErrCodeResourceNotFoundException, "") {
 				return nil
 			}
 			return err
@@ -1367,10 +1384,10 @@ resource "aws_cognito_user_pool" "test" {
 `, rName)
 }
 
-func testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfiguration(name string) string {
+func testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfiguration(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   admin_create_user_config {
     allow_admin_create_user_only = true
@@ -1382,13 +1399,13 @@ resource "aws_cognito_user_pool" "test" {
     }
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdated(name string) string {
+func testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   admin_create_user_config {
     allow_admin_create_user_only = false
@@ -1400,7 +1417,7 @@ resource "aws_cognito_user_pool" "test" {
     }
   }
 }
-`, name)
+`, rName)
 }
 
 func testAccAWSCognitoUserPoolConfig_AdvancedSecurityMode(rName string, advancedSecurityMode string) string {
@@ -1415,44 +1432,44 @@ resource "aws_cognito_user_pool" "test" {
 `, rName, advancedSecurityMode)
 }
 
-func testAccAWSCognitoUserPoolConfig_withDeviceConfiguration(name string) string {
+func testAccAWSCognitoUserPoolConfig_withDeviceConfiguration(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   device_configuration {
     challenge_required_on_new_device      = true
     device_only_remembered_on_user_prompt = false
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccAWSCognitoUserPoolConfig_withDeviceConfigurationUpdated(name string) string {
+func testAccAWSCognitoUserPoolConfig_withDeviceConfigurationUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   device_configuration {
     challenge_required_on_new_device      = false
     device_only_remembered_on_user_prompt = true
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccAWSCognitoUserPoolConfig_withEmailVerificationMessage(name, subject, message string) string {
+func testAccAWSCognitoUserPoolConfig_withEmailVerificationMessage(rName, subject, message string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name                       = "terraform-test-pool-%s"
-  email_verification_subject = "%s"
-  email_verification_message = "%s"
+  name                       = %[1]q
+  email_verification_subject = "%[2]s"
+  email_verification_message = "%[3]s"
 
   verification_message_template {
     default_email_option = "CONFIRM_WITH_CODE"
   }
 }
-`, name, subject, message)
+`, rName, subject, message)
 }
 
 func testAccAWSCognitoUserPoolConfig_MfaConfiguration(rName string, mfaConfiguration string) string {
@@ -1553,7 +1570,7 @@ resource "aws_cognito_user_pool" "test" {
 `, rName, smsVerificationMessage)
 }
 
-func testAccAWSCognitoUserPoolConfig_Tags1(name, tagKey1, tagValue1 string) string {
+func testAccAWSCognitoUserPoolConfig_Tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q
@@ -1562,10 +1579,10 @@ resource "aws_cognito_user_pool" "test" {
     %[2]q = %[3]q
   }
 }
-`, name, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1)
 }
 
-func testAccAWSCognitoUserPoolConfig_Tags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAWSCognitoUserPoolConfig_Tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q
@@ -1575,13 +1592,13 @@ resource "aws_cognito_user_pool" "test" {
     %[4]q = %[5]q
   }
 }
-`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, email, arn, from, account string) string {
+func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(rName, email, arn, from, account string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%[1]s"
+  name = %[1]q
 
   email_configuration {
     reply_to_email_address = %[2]q
@@ -1593,25 +1610,25 @@ resource "aws_cognito_user_pool" "test" {
 `, name, email, arn, from, account)
 }
 
-func testAccAWSCognitoUserPoolConfig_withAliasAttributes(name string) string {
+func testAccAWSCognitoUserPoolConfig_withAliasAttributes(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   alias_attributes = ["preferred_username"]
 }
-`, name)
+`, rName)
 }
 
-func testAccAWSCognitoUserPoolConfig_withAliasAttributesUpdated(name string) string {
+func testAccAWSCognitoUserPoolConfig_withAliasAttributesUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   alias_attributes         = ["email", "preferred_username"]
   auto_verified_attributes = ["email"]
 }
-`, name)
+`, rName)
 }
 
 func testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigAndPasswordPolicy(rName string) string {
@@ -1638,7 +1655,7 @@ resource "aws_cognito_user_pool" "test" {
 func testAccAWSCognitoUserPoolConfig_withPasswordPolicy(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   password_policy {
     minimum_length                   = 7
@@ -1655,7 +1672,7 @@ resource "aws_cognito_user_pool" "test" {
 func testAccAWSCognitoUserPoolConfig_withPasswordPolicyUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   password_policy {
     minimum_length                   = 9
@@ -1672,7 +1689,7 @@ resource "aws_cognito_user_pool" "test" {
 func testAccAWSCognitoUserPoolConfig_withUsernameConfiguration(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   username_configuration {
     case_sensitive = true
@@ -1684,7 +1701,7 @@ resource "aws_cognito_user_pool" "test" {
 func testAccAWSCognitoUserPoolConfig_withUsernameConfigurationUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   username_configuration {
     case_sensitive = false
@@ -1696,7 +1713,7 @@ resource "aws_cognito_user_pool" "test" {
 func testAccAWSCognitoUserPoolConfig_withLambdaConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "%s"
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -1717,14 +1734,14 @@ EOF
 
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
-  function_name = "%[1]s"
+  function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
   runtime       = "nodejs12.x"
 }
 
 resource "aws_cognito_user_pool" "test" {
-  name = "%[1]s"
+  name = %[1]q
 
   lambda_config {
     create_auth_challenge          = aws_lambda_function.test.arn
@@ -1745,7 +1762,7 @@ resource "aws_cognito_user_pool" "test" {
 func testAccAWSCognitoUserPoolConfig_withLambdaConfigUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "%s"
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -1766,7 +1783,7 @@ EOF
 
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
-  function_name = "%[1]s"
+  function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
   runtime       = "nodejs12.x"
@@ -1781,7 +1798,7 @@ resource "aws_lambda_function" "second" {
 }
 
 resource "aws_cognito_user_pool" "test" {
-  name = "%[1]s"
+  name = %[1]q
 
   lambda_config {
     create_auth_challenge          = aws_lambda_function.second.arn
@@ -1878,7 +1895,7 @@ resource "aws_cognito_user_pool" "test" {
 func testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   # Setting Verification template attributes like EmailMessage, EmailSubject or SmsMessage
   # will implicitly set EmailVerificationMessage, EmailVerificationSubject and SmsVerificationMessage
@@ -1899,7 +1916,7 @@ resource "aws_cognito_user_pool" "test" {
 func testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate_DefaultEmailOption(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   email_verification_message = "{####} Baz"
   email_verification_subject = "BazBaz {####}"
@@ -1918,7 +1935,7 @@ data "aws_caller_identity" "current" {
 }
 
 resource "aws_iam_role" "test" {
-  name = "test-role-%s"
+  name = %[1]q
   path = "/service-role/"
 
   assume_role_policy = <<POLICY
@@ -1944,7 +1961,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "test-role-policy-%s"
+  name = %[1]q
   role = aws_iam_role.test.id
 
   policy = <<EOF
@@ -1966,14 +1983,14 @@ EOF
 }
 
 resource "aws_cognito_user_pool" "test" {
-  name                     = "terraform-test-pool-%s"
+  name                     = %[1]q
   auto_verified_attributes = ["email"]
-  mfa_configuration        = "%s"
+  mfa_configuration        = "%[2]s"
 
   email_verification_message = "Foo {####} Bar"
   email_verification_subject = "FooBar {####}"
   sms_verification_message   = "{####} Baz"
-  sms_authentication_message = "%s"
+  sms_authentication_message = "%[3]s"
 
   admin_create_user_config {
     allow_admin_create_user_only = true
@@ -1998,10 +2015,6 @@ resource "aws_cognito_user_pool" "test" {
     external_id    = data.aws_caller_identity.current.account_id
     sns_caller_arn = aws_iam_role.test.arn
   }
-
-  tags = {
-    "Name" = "Foo"
-  }
 }
-`, name, name, name, mfaconfig, smsAuthMsg)
+`, name, mfaconfig, smsAuthMsg)
 }

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -1607,7 +1607,7 @@ resource "aws_cognito_user_pool" "test" {
     email_sending_account  = %[5]q
   }
 }
-`, name, email, arn, from, account)
+`, rName, email, arn, from, account)
 }
 
 func testAccAWSCognitoUserPoolConfig_withAliasAttributes(rName string) string {

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -1340,7 +1340,7 @@ resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
   account_recovery_setting {
-    recovery_mechanisms {
+    recovery_mechanism {
       name     = "verified_email"
       priority = 1
     }
@@ -1355,12 +1355,12 @@ resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
   account_recovery_setting {
-    recovery_mechanisms {
+    recovery_mechanism {
       name     = "verified_email"
       priority = 1
     }
 
-    recovery_mechanisms {
+    recovery_mechanism {
       name     = "verified_phone_number"
       priority = 2
     }
@@ -1375,7 +1375,7 @@ resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
   account_recovery_setting {
-    recovery_mechanisms {
+    recovery_mechanism {
       name     = "verified_phone_number"
       priority = 1
     }

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -51,7 +51,7 @@ func testSweepCognitoUserPools(region string) error {
 				UserPoolId: userPool.Id,
 			})
 			if err != nil {
-				log.Printf("[ERROR] Failed deleting Cognito User Pool (%s): %w", name, err)
+				log.Printf("[ERROR] Failed deleting Cognito User Pool (%s): %s", name, err)
 			}
 		}
 		return !isLast

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -221,7 +221,6 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
     - [`aws_athena_workgroup` resource](/docs/providers/aws/r/athena_workgroup.html)
     - [`aws_budgets_budget` resource](/docs/providers/aws/r/budgets_budget.html)
     - [`aws_cognito_identity_pool` resource](/docs/providers/aws/r/cognito_identity_pool.html)
-    - [`aws_cognito_user_pool` resource](/docs/providers/aws/r/cognito_user_pool.html)
     - [`aws_cognito_user_pools` data source](/docs/providers/aws/d/cognito_user_pools.html)
     - [`aws_default_network_acl` resource](/docs/providers/aws/r/default_network_acl.html)
     - [`aws_default_vpc_dhcp_options`](/docs/providers/aws/r/default_vpc_dhcp_options.html)

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -40,6 +40,26 @@ resource "aws_cognito_user_pool" "example" {
 }
 ```
 
+### Using Account Recovery Setting
+
+```hcl
+resource "aws_cognito_user_pool" "test" {
+  name = "mypool"
+
+  account_recovery_setting {
+    recovery_mechanisms {
+      name     = "verified_email"
+      priority = 1
+    }
+
+    recovery_mechanisms {
+      name     = "verified_phone_number"
+      priority = 2
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -68,6 +88,7 @@ The following arguments are supported:
 * `username_configuration` - (Optional) The [Username Configuration](#username-configuration).
 * `user_pool_add_ons` - (Optional) Configuration block for [user pool add-ons](#user-pool-add-ons) to enable user pool advanced security mode features.
 * `verification_message_template` (Optional) - The [verification message templates](#verification-message-template) configuration.
+* `account_recovery_setting` (Optional) - The [account_recovery_setting](#account-recovery-setting) configuration.
 
 #### Admin Create User Config
 
@@ -185,6 +206,12 @@ The following arguments are required in the `software_token_mfa_configuration` c
 * `email_subject` (Optional) - The subject line for the email message template. Conflicts with `email_verification_subject` argument.
 * `email_subject_by_link` (Optional) - The subject line for the email message template for sending a confirmation link to the user.
 * `sms_message` (Optional) - The SMS message template. Must contain the `{####}` placeholder. Conflicts with `sms_verification_message` argument.
+  
+### Account Recovery Setting
+
+* `recovery_mechanisms` (Required) - The list of Account Recovery Options of the following structure:
+    * `name` (Required) - Specifies the recovery method for a user. can be of the following: `verified_email`, `verified_phone_number`, and `admin_only`.
+    * `priority` (Required) - A positive integer specifying priority of a method with 1 being the highest priority.
 
 ## Attribute Reference
 

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -47,12 +47,12 @@ resource "aws_cognito_user_pool" "test" {
   name = "mypool"
 
   account_recovery_setting {
-    recovery_mechanisms {
+    recovery_mechanism {
       name     = "verified_email"
       priority = 1
     }
 
-    recovery_mechanisms {
+    recovery_mechanism {
       name     = "verified_phone_number"
       priority = 2
     }
@@ -209,7 +209,7 @@ The following arguments are required in the `software_token_mfa_configuration` c
   
 ### Account Recovery Setting
 
-* `recovery_mechanisms` (Required) - The list of Account Recovery Options of the following structure:
+* `recovery_mechanism` (Required) - The list of Account Recovery Options of the following structure:
     * `name` (Required) - Specifies the recovery method for a user. can be of the following: `verified_email`, `verified_phone_number`, and `admin_only`.
     * `priority` (Required) - A positive integer specifying priority of a method with 1 being the highest priority.
 

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -210,7 +210,7 @@ The following arguments are required in the `software_token_mfa_configuration` c
 ### Account Recovery Setting
 
 * `recovery_mechanism` (Required) - The list of Account Recovery Options of the following structure:
-    * `name` (Required) - Specifies the recovery method for a user. can be of the following: `verified_email`, `verified_phone_number`, and `admin_only`.
+    * `name` (Required) - Specifies the recovery method for a user. Can be of the following: `verified_email`, `verified_phone_number`, and `admin_only`.
     * `priority` (Required) - A positive integer specifying priority of a method with 1 being the highest priority.
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11220
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resouce_aws_cognito_user_pool: add support for account recovery setting
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPool_'
--- PASS: TestAccAWSCognitoUserPool_basic (48.59s)
--- PASS: TestAccAWSCognitoUserPool_recovery (114.12s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (103.63s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy (47.56s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (78.45s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (85.15s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration (147.53s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration (129.68s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration (91.63s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration (108.50s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration (101.67s)
--- PASS: TestAccAWSCognitoUserPool_SmsAuthenticationMessage (81.63s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration (129.93s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId (121.34s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn (109.63s)
--- PASS: TestAccAWSCognitoUserPool_SmsVerificationMessage (79.68s)
--- PASS: TestAccAWSCognitoUserPool_withTags (111.92s)
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (79.91s)
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (79.13s)
--- PASS: TestAccAWSCognitoUserPool_withUsernameConfiguration (80.23s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (126.40s)
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (84.25s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (77.63s)
--- PASS: TestAccAWSCognitoUserPool_update (143.22s)

--- FAIL: TestAccAWSCognitoUserPool_withEmailConfiguration (63.24s)
```

TestAccAWSCognitoUserPool_withEmailConfiguration  seems to have failed but i dont think its relevant the changes as it failed on:

```
2020/03/18 13:57:20 [ERROR] <root>: eval: *terraform.EvalApplyPost, err: Error updating Cognito User pool: InvalidParameterException: Unable to send email message, please try again
2020/03/18 13:57:20 [ERROR] <root>: eval: *terraform.EvalSequence, err: Error updating Cognito User pool: InvalidParameterException: Unable to send email message, please try again
2020/03/18 13:57:20 [DEBUG] New state was assigned lineage "b19a8bb8-2e21-41f7-1e30-be8390d53f9f"
    TestAccAWSCognitoUserPool_withEmailConfiguration: testing.go:654: Step 2 error: errors during apply:
        
        Error: Error updating Cognito User pool: InvalidParameterException: Unable to send email message, please try again
        
          on C:\Users\ilial\AppData\Local\Temp\tf-test650923783\main.tf line 2:
          (source code not available)
```
