### PR TITLE
r/route53_record - support zero ttl

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -138,7 +138,8 @@ func resourceAwsRoute53Record() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 								value := v.(string)
-								if value != route53.ResourceRecordSetFailoverPrimary && value != route53.ResourceRecordSetFailoverSecondary {
+								if value != route53.ResourceRecordSetFailoverPrimary &&
+									value != route53.ResourceRecordSetFailoverSecondary {
 									es = append(es, fmt.Errorf("Failover policy type must be PRIMARY or SECONDARY"))
 								}
 								return
@@ -295,7 +296,7 @@ func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if v, _ := d.GetChange("ttl"); v.(int) != 0 {
+	if v, _ := d.GetChange("ttl"); v != nil {
 		oldRec.TTL = aws.Int64(int64(v.(int)))
 	}
 

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -138,7 +138,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 								value := v.(string)
-								if value != "PRIMARY" && value != "SECONDARY" {
+								if value != route53.ResourceRecordSetFailoverPrimary && value != route53.ResourceRecordSetFailoverSecondary {
 									es = append(es, fmt.Errorf("Failover policy type must be PRIMARY or SECONDARY"))
 								}
 								return
@@ -788,7 +788,7 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (
 		Type: aws.String(d.Get("type").(string)),
 	}
 
-	if v, ok := d.GetOk("ttl"); ok {
+	if v, ok := d.GetOkExists("ttl"); ok {
 		rec.TTL = aws.Int64(int64(v.(int)))
 	}
 
@@ -812,7 +812,7 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (
 		}
 		log.Printf("[DEBUG] Creating alias: %#v", alias)
 	} else {
-		if _, ok := d.GetOk("ttl"); !ok {
+		if _, ok := d.GetOkExists("ttl"); !ok {
 			return nil, fmt.Errorf(`provider.aws: aws_route53_record: %s: "ttl": required field is not set`, d.Get("name").(string))
 		}
 

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -84,6 +85,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ConflictsWith: []string{"alias"},
+				ValidateFunc:  validation.IntBetween(0, math.MaxInt32),
 			},
 
 			"set_identifier": {
@@ -178,6 +180,15 @@ func resourceAwsRoute53Record() *schema.Resource {
 						"continent": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"AF",
+								"AN",
+								"AS",
+								"EU",
+								"OC",
+								"NA",
+								"SA",
+							}, false),
 						},
 						"country": {
 							Type:     schema.TypeString,
@@ -203,8 +214,9 @@ func resourceAwsRoute53Record() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"weight": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntBetween(0, 255),
 						},
 					},
 				},
@@ -231,7 +243,6 @@ func resourceAwsRoute53Record() *schema.Resource {
 				ConflictsWith: []string{"alias"},
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				Optional:      true,
-				Set:           schema.HashString,
 			},
 
 			"allow_overwrite": {
@@ -581,7 +592,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 
 	if record.Weight != nil {
 		v := []map[string]interface{}{{
-			"weight": aws.Int64Value((record.Weight)),
+			"weight": aws.Int64Value(record.Weight),
 		}}
 		if err := d.Set("weighted_routing_policy", v); err != nil {
 			return fmt.Errorf("Error setting weighted records for: %s, error: %w", d.Id(), err)

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -545,7 +545,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 
 	err = d.Set("records", flattenResourceRecords(record.ResourceRecords, aws.StringValue(record.Type)))
 	if err != nil {
-		return fmt.Errorf("Error setting records for: %s, error: %w", d.Id(), err)
+		return fmt.Errorf("error setting records for: %s, error: %w", d.Id(), err)
 	}
 
 	if alias := record.AliasTarget; alias != nil {
@@ -566,7 +566,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 			"type": aws.StringValue(record.Failover),
 		}}
 		if err := d.Set("failover_routing_policy", v); err != nil {
-			return fmt.Errorf("Error setting failover records for: %s, error: %w", d.Id(), err)
+			return fmt.Errorf("error setting failover records for: %s, error: %w", d.Id(), err)
 		}
 	}
 
@@ -577,7 +577,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 			"subdivision": aws.StringValue(record.GeoLocation.SubdivisionCode),
 		}}
 		if err := d.Set("geolocation_routing_policy", v); err != nil {
-			return fmt.Errorf("Error setting gelocation records for: %s, error: %w", d.Id(), err)
+			return fmt.Errorf("error setting gelocation records for: %s, error: %w", d.Id(), err)
 		}
 	}
 
@@ -586,7 +586,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 			"region": aws.StringValue(record.Region),
 		}}
 		if err := d.Set("latency_routing_policy", v); err != nil {
-			return fmt.Errorf("Error setting latency records for: %s, error: %w", d.Id(), err)
+			return fmt.Errorf("error setting latency records for: %s, error: %w", d.Id(), err)
 		}
 	}
 
@@ -595,13 +595,13 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 			"weight": aws.Int64Value(record.Weight),
 		}}
 		if err := d.Set("weighted_routing_policy", v); err != nil {
-			return fmt.Errorf("Error setting weighted records for: %s, error: %w", d.Id(), err)
+			return fmt.Errorf("error setting weighted records for: %s, error: %w", d.Id(), err)
 		}
 	}
 
 	if record.MultiValueAnswer != nil {
 		if err := d.Set("multivalue_answer_routing_policy", record.MultiValueAnswer); err != nil {
-			return fmt.Errorf("Error setting multivalue answer records for: %s, error: %w", d.Id(), err)
+			return fmt.Errorf("error setting multivalue answer records for: %s, error: %w", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -136,14 +136,10 @@ func resourceAwsRoute53Record() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-								value := v.(string)
-								if value != route53.ResourceRecordSetFailoverPrimary &&
-									value != route53.ResourceRecordSetFailoverSecondary {
-									es = append(es, fmt.Errorf("Failover policy type must be PRIMARY or SECONDARY"))
-								}
-								return
-							},
+							ValidateFunc: validation.StringInSlice([]string{
+								route53.ResourceRecordSetFailoverPrimary,
+								route53.ResourceRecordSetFailoverSecondary,
+							}, false),
 						},
 					},
 				},
@@ -681,7 +677,7 @@ func findRecord(d *schema.ResourceData, meta interface{}) (*route53.ResourceReco
 	err = conn.ListResourceRecordSetsPages(lopts, func(resp *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
 		for _, recordSet := range resp.ResourceRecordSets {
 
-			responseName := strings.ToLower(cleanRecordName(*recordSet.Name))
+			responseName := strings.ToLower(cleanRecordName(aws.StringValue(recordSet.Name)))
 			responseType := strings.ToUpper(aws.StringValue(recordSet.Type))
 
 			if recordName != responseName {

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -9,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
-
-	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -1076,7 +1075,7 @@ func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 			return nil
 		}
 		rec := resp.ResourceRecordSets[0]
-		if FQDN(*rec.Name) == FQDN(name) && *rec.Type == rType {
+		if FQDN(aws.StringValue(rec.Name)) == FQDN(name) && aws.StringValue(rec.Type) == rType {
 			return fmt.Errorf("Record still exists: %#v", rec)
 		}
 	}
@@ -1110,7 +1109,7 @@ func testAccCheckRoute53RecordDisappears(zone *route53.GetHostedZoneOutput, reso
 			return nil
 		}
 
-		if err := waitForRoute53RecordSetToSync(conn, cleanChangeID(*changeInfo.Id)); err != nil {
+		if err := waitForRoute53RecordSetToSync(conn, cleanChangeID(aws.StringValue(changeInfo.Id))); err != nil {
 			return fmt.Errorf("error waiting for resource record set deletion: %s", err)
 		}
 
@@ -1153,8 +1152,8 @@ func testAccCheckRoute53RecordExists(n string, resourceRecordSet *route53.Resour
 
 		// rec := resp.ResourceRecordSets[0]
 		for _, rec := range resp.ResourceRecordSets {
-			recName := cleanRecordName(*rec.Name)
-			if FQDN(strings.ToLower(recName)) == FQDN(strings.ToLower(en)) && *rec.Type == rType {
+			recName := cleanRecordName(aws.StringValue(rec.Name))
+			if FQDN(strings.ToLower(recName)) == FQDN(strings.ToLower(en)) && aws.StringValue(rec.Type) == rType {
 				*resourceRecordSet = *rec
 
 				return nil
@@ -1186,8 +1185,8 @@ func testAccCheckRoute53RecordDoesNotExist(zoneResourceName string, recordName s
 
 		found := false
 		for _, rec := range resp.ResourceRecordSets {
-			recName := cleanRecordName(*rec.Name)
-			if FQDN(strings.ToLower(recName)) == FQDN(strings.ToLower(en)) && *rec.Type == recordType {
+			recName := cleanRecordName(aws.StringValue(rec.Name))
+			if FQDN(strings.ToLower(recName)) == FQDN(strings.ToLower(en)) && aws.StringValue(rec.Type) == recordType {
 				found = true
 				break
 			}

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -1222,15 +1222,15 @@ resource "aws_route53_record" "default" {
 
 const testAccRoute53RecordConfigZeroTTL = `
 resource "aws_route53_zone" "test" {
-	name = "notexample.com"
+  name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-	zone_id = "${aws_route53_zone.test.zone_id}"
-	name = "www.NOTexamplE.com"
-	type = "A"
-	ttl = "0"
-	records = ["127.0.0.1", "127.0.0.27"]
+  zone_id = "${aws_route53_zone.test.zone_id}"
+  name = "www.NOTexamplE.com"
+  type = "A"
+  ttl = "0"
+  records = ["127.0.0.1", "127.0.0.27"]
 }
 `
 

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -13,7 +13,6 @@ import (
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
@@ -108,7 +107,7 @@ func TestParseRecordId(t *testing.T) {
 
 func TestAccAWSRoute53Record_basic(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -132,9 +131,50 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53Record_ttl(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53RecordConfigZeroTTL,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists(resourceName, &record1),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
+			},
+			{
+				Config: testAccRoute53RecordConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists(resourceName, &record1),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "30"),
+				),
+			},
+			{
+				Config: testAccRoute53RecordConfigZeroTTL,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists(resourceName, &record1),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute53Record_underscored(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.underscore"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -160,7 +200,7 @@ func TestAccAWSRoute53Record_underscored(t *testing.T) {
 func TestAccAWSRoute53Record_disappears(t *testing.T) {
 	var record1 route53.ResourceRecordSet
 	var zone1 route53.GetHostedZoneOutput
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -208,7 +248,7 @@ func TestAccAWSRoute53Record_disappears_MultipleRecords(t *testing.T) {
 
 func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -275,7 +315,7 @@ func TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID(t *testing.T) {
 
 func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -302,7 +342,7 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 
 func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -329,7 +369,7 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 
 func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -356,7 +396,7 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 
 func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -382,7 +422,7 @@ func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 
 func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.wildcard"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -471,7 +511,7 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 
 func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.www-server1"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -502,7 +542,7 @@ func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
 
 func TestAccAWSRoute53Record_Alias_Elb(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.alias"
+	resourceName := "aws_route53_record.test"
 
 	rs := acctest.RandString(10)
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElb, rs)
@@ -586,7 +626,7 @@ func TestAccAWSRoute53Record_Alias_VpcEndpoint(t *testing.T) {
 
 func TestAccAWSRoute53Record_Alias_Uppercase(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.alias"
+	resourceName := "aws_route53_record.test"
 
 	rs := acctest.RandString(10)
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElbUppercase, rs)
@@ -651,7 +691,7 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 
 func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 	var record1, record2, record3, record4 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -661,7 +701,7 @@ func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 			{
 				Config: testAccRoute53GeolocationCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 					testAccCheckRoute53RecordExists("aws_route53_record.california", &record2),
 					testAccCheckRoute53RecordExists("aws_route53_record.oceania", &record3),
 					testAccCheckRoute53RecordExists("aws_route53_record.denmark", &record4),
@@ -770,7 +810,7 @@ func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 
 func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.sample"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -839,7 +879,7 @@ func TestAccAWSRoute53Record_NameChange(t *testing.T) {
 
 func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.basic_to_weighted"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -873,7 +913,7 @@ func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 
 func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.elb_alias_change"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -907,7 +947,7 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 
 func TestAccAWSRoute53Record_empty(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.empty"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -928,7 +968,7 @@ func TestAccAWSRoute53Record_empty(t *testing.T) {
 // Regression test for https://github.com/hashicorp/terraform/issues/8423
 func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.long_txt"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -1027,11 +1067,8 @@ func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 
 		resp, err := conn.ListResourceRecordSets(lopts)
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok {
-				// if NoSuchHostedZone, then all the things are destroyed
-				if awsErr.Code() == "NoSuchHostedZone" {
-					return nil
-				}
+			if isAWSErr(err, route53.ErrCodeNoSuchHostedZone, "") {
+				return nil
 			}
 			return err
 		}
@@ -1170,7 +1207,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com."
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "www.notexample.com"
   type    = "A"
@@ -1179,7 +1216,7 @@ resource "aws_route53_record" "default" {
 }
 
 resource "aws_route53_record" "overwriting" {
-  depends_on = [aws_route53_record.default]
+  depends_on = ["aws_route53_record.test"]
 
   allow_overwrite = %v
   zone_id         = aws_route53_zone.main.zone_id
@@ -1196,7 +1233,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "www.NOTexamplE.com"
   type    = "A"
@@ -1216,6 +1253,20 @@ resource "aws_route53_record" "default" {
   type    = "A"
   ttl     = "30"
   records = ["127.0.0.1", "127.0.0.27"]
+}
+`
+
+const testAccRoute53RecordConfigZeroTTL = `
+resource "aws_route53_zone" "main" {
+	name = "notexample.com"
+}
+
+resource "aws_route53_record" "test" {
+	zone_id = "${aws_route53_zone.main.zone_id}"
+	name = "www.NOTexamplE.com"
+	type = "A"
+	ttl = "0"
+	records = ["127.0.0.1", "127.0.0.27"]
 }
 `
 
@@ -1240,7 +1291,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "www.NOTexamplE.com"
   type    = "A"
@@ -1258,7 +1309,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "www.NOTexamplE.com."
   type    = "A"
@@ -1276,7 +1327,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "subdomain"
   type    = "A"
@@ -1290,7 +1341,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "subdomain"
   type    = "A"
@@ -1312,7 +1363,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "subdomain"
   type    = "A"
@@ -1334,7 +1385,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = "/hostedzone/${aws_route53_zone.main.zone_id}"
   name    = "subdomain"
   type    = "TXT"
@@ -1348,7 +1399,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "test"
   type    = "SPF"
@@ -1362,7 +1413,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "test"
   type    = "CAA"
@@ -1473,12 +1524,11 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   geolocation_routing_policy {
     country = "*"
   }
@@ -1589,23 +1639,23 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "alias" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "A"
 
   alias {
-    zone_id                = aws_elb.main.zone_id
-    name                   = aws_elb.main.dns_name
+    zone_id                = aws_elb.test.zone_id
+    name                   = aws_elb.test.dns_name
     evaluate_target_health = true
   }
 }
 
-resource "aws_elb" "main" {
+resource "aws_elb" "test" {
   name               = "foobar-terraform-elb-%s"
   availability_zones = slice(data.aws_availability_zones.available.names, 0, 1)
 
@@ -1628,23 +1678,23 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "alias" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "A"
 
   alias {
-    zone_id                = aws_elb.main.zone_id
-    name                   = aws_elb.main.dns_name
+    zone_id                = aws_elb.test.zone_id
+    name                   = aws_elb.test.dns_name
     evaluate_target_health = true
   }
 }
 
-resource "aws_elb" "main" {
+resource "aws_elb" "test" {
   name               = "FOOBAR-TERRAFORM-ELB-%s"
   availability_zones = slice(data.aws_availability_zones.available.names, 0, 1)
 
@@ -2007,12 +2057,12 @@ resource "aws_route53_record" "r53_weighted_alias_dev" {
 `
 
 const testAccRoute53RecordTypeChangePre = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "sample" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "sample"
   type    = "CNAME"
   ttl     = "30"
@@ -2021,12 +2071,12 @@ resource "aws_route53_record" "sample" {
 `
 
 const testAccRoute53RecordTypeChangePost = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "sample" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "sample"
   type    = "A"
   ttl     = "30"
@@ -2063,12 +2113,12 @@ resource "aws_route53_record" "sample" {
 `
 
 const testAccRoute53RecordSetIdentifierChangePre = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "basic_to_weighted" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "sample"
   type    = "A"
   ttl     = "30"
@@ -2077,12 +2127,12 @@ resource "aws_route53_record" "basic_to_weighted" {
 `
 
 const testAccRoute53RecordSetIdentifierChangePost = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "basic_to_weighted" {
-  zone_id        = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id        = aws_route53_zone.test.zone_id
   name           = "sample"
   type           = "A"
   ttl            = "30"
@@ -2105,11 +2155,11 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_elb" "alias_change" {
+resource "aws_elb" "test" {
   name               = "foobar-tf-elb-alias-change"
   availability_zones = slice(data.aws_availability_zones.available.names, 0, 1)
 
@@ -2121,26 +2171,26 @@ resource "aws_elb" "alias_change" {
   }
 }
 
-resource "aws_route53_record" "elb_alias_change" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "alias-change"
   type    = "A"
 
   alias {
-    zone_id                = aws_elb.alias_change.zone_id
-    name                   = aws_elb.alias_change.dns_name
+    zone_id                = aws_elb.test.zone_id
+    name                   = aws_elb.test.dns_name
     evaluate_target_health = true
   }
 }
 `
 
 const testAccRoute53RecordAliasChangePost = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "elb_alias_change" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "alias-change"
   type    = "CNAME"
   ttl     = "30"
@@ -2149,12 +2199,12 @@ resource "aws_route53_record" "elb_alias_change" {
 `
 
 const testAccRoute53RecordConfigEmptyName = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "empty" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = ""
   type    = "A"
   ttl     = "30"
@@ -2163,12 +2213,12 @@ resource "aws_route53_record" "empty" {
 `
 
 const testAccRoute53RecordConfigLongTxtRecord = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "long_txt" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "google.notexample.com"
   type    = "TXT"
   ttl     = "30"
@@ -2179,12 +2229,12 @@ resource "aws_route53_record" "long_txt" {
 `
 
 const testAccRoute53RecordConfigUnderscoreInName = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "underscore" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "_underscore.notexample.com"
   type    = "A"
   ttl     = "30"
@@ -2223,7 +2273,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "www-server1" {
+resource "aws_route53_record" "test" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "www"
   type    = "A"

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -1226,10 +1226,10 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = "${aws_route53_zone.test.zone_id}"
-  name = "www.NOTexamplE.com"
-  type = "A"
-  ttl = "0"
+  zone_id = aws_route53_zone.test.zone_id
+  name    = "www.NOTexamplE.com"
+  type    = "A"
+  ttl     = "0"
   records = ["127.0.0.1", "127.0.0.27"]
 }
 `

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -210,7 +210,7 @@ func TestAccAWSRoute53Record_disappears(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone1),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test", &zone1),
 					testAccCheckRoute53RecordExists(resourceName, &record1),
 					testAccCheckRoute53RecordDisappears(&zone1, &record1),
 				),
@@ -1203,12 +1203,12 @@ func testAccCheckRoute53RecordDoesNotExist(zoneResourceName string, recordName s
 
 func testAccRoute53RecordConfig_allowOverwrite(allowOverwrite bool) string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com."
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www.notexample.com"
   type    = "A"
   ttl     = "30"
@@ -1219,7 +1219,7 @@ resource "aws_route53_record" "overwriting" {
   depends_on = ["aws_route53_record.test"]
 
   allow_overwrite = %v
-  zone_id         = aws_route53_zone.main.zone_id
+  zone_id         = aws_route53_zone.test.zone_id
   name            = "www.notexample.com"
   type            = "A"
   ttl             = "30"
@@ -1229,12 +1229,12 @@ resource "aws_route53_record" "overwriting" {
 }
 
 const testAccRoute53RecordConfig = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www.NOTexamplE.com"
   type    = "A"
   ttl     = "30"
@@ -1257,12 +1257,12 @@ resource "aws_route53_record" "default" {
 `
 
 const testAccRoute53RecordConfigZeroTTL = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
 	name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-	zone_id = "${aws_route53_zone.main.zone_id}"
+	zone_id = "${aws_route53_zone.test.zone_id}"
 	name = "www.NOTexamplE.com"
 	type = "A"
 	ttl = "0"
@@ -1287,12 +1287,12 @@ resource "aws_route53_record" "test" {
 `
 
 const testAccRoute53RecordConfig_fqdn = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www.NOTexamplE.com"
   type    = "A"
   ttl     = "30"
@@ -1305,12 +1305,12 @@ resource "aws_route53_record" "test" {
 `
 
 const testAccRoute53RecordConfig_fqdn_no_op = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www.NOTexamplE.com."
   type    = "A"
   ttl     = "30"
@@ -1323,12 +1323,12 @@ resource "aws_route53_record" "test" {
 `
 
 const testAccRoute53RecordConfigSuffix = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "subdomain"
   type    = "A"
   ttl     = "30"
@@ -1337,12 +1337,12 @@ resource "aws_route53_record" "test" {
 `
 
 const testAccRoute53WildCardRecordConfig = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "subdomain"
   type    = "A"
   ttl     = "30"
@@ -1350,7 +1350,7 @@ resource "aws_route53_record" "test" {
 }
 
 resource "aws_route53_record" "wildcard" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "*.notexample.com"
   type    = "A"
   ttl     = "30"
@@ -1359,12 +1359,12 @@ resource "aws_route53_record" "wildcard" {
 `
 
 const testAccRoute53WildCardRecordConfigUpdate = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "subdomain"
   type    = "A"
   ttl     = "30"
@@ -1372,7 +1372,7 @@ resource "aws_route53_record" "test" {
 }
 
 resource "aws_route53_record" "wildcard" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "*.notexample.com"
   type    = "A"
   ttl     = "60"
@@ -1381,12 +1381,12 @@ resource "aws_route53_record" "wildcard" {
 `
 
 const testAccRoute53RecordConfigTXT = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = "/hostedzone/${aws_route53_zone.main.zone_id}"
+  zone_id = "/hostedzone/${aws_route53_zone.test.zone_id}"
   name    = "subdomain"
   type    = "TXT"
   ttl     = "30"
@@ -1395,12 +1395,12 @@ resource "aws_route53_record" "test" {
 `
 
 const testAccRoute53RecordConfigSPF = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "test"
   type    = "SPF"
   ttl     = "30"
@@ -1409,12 +1409,12 @@ resource "aws_route53_record" "test" {
 `
 
 const testAccRoute53RecordConfigCAA = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "test"
   type    = "CAA"
   ttl     = "30"
@@ -1424,11 +1424,11 @@ resource "aws_route53_record" "test" {
 `
 
 const testAccRoute53FailoverCNAMERecord = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_health_check" "foo" {
+resource "aws_route53_health_check" "test" {
   fqdn              = "dev.notexample.com"
   port              = 80
   type              = "HTTP"
@@ -1442,26 +1442,24 @@ resource "aws_route53_health_check" "foo" {
 }
 
 resource "aws_route53_record" "www-primary" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   failover_routing_policy {
     type = "PRIMARY"
   }
 
-  health_check_id = aws_route53_health_check.foo.id
+  health_check_id = aws_route53_health_check.test.id
   set_identifier  = "www-primary"
   records         = ["primary.notexample.com"]
 }
 
 resource "aws_route53_record" "www-secondary" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   failover_routing_policy {
     type = "SECONDARY"
   }
@@ -1472,16 +1470,15 @@ resource "aws_route53_record" "www-secondary" {
 `
 
 const testAccRoute53WeightedCNAMERecord = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "www-dev" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   weighted_routing_policy {
     weight = 10
   }
@@ -1491,11 +1488,10 @@ resource "aws_route53_record" "www-dev" {
 }
 
 resource "aws_route53_record" "www-live" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   weighted_routing_policy {
     weight = 90
   }
@@ -1505,11 +1501,10 @@ resource "aws_route53_record" "www-live" {
 }
 
 resource "aws_route53_record" "www-off" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   weighted_routing_policy {
     weight = 0
   }
@@ -1520,12 +1515,12 @@ resource "aws_route53_record" "www-off" {
 `
 
 const testAccRoute53GeolocationCNAMERecord = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
@@ -1538,11 +1533,10 @@ resource "aws_route53_record" "test" {
 }
 
 resource "aws_route53_record" "california" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   geolocation_routing_policy {
     country     = "US"
     subdivision = "CA"
@@ -1553,11 +1547,10 @@ resource "aws_route53_record" "california" {
 }
 
 resource "aws_route53_record" "oceania" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   geolocation_routing_policy {
     continent = "OC"
   }
@@ -1567,11 +1560,10 @@ resource "aws_route53_record" "oceania" {
 }
 
 resource "aws_route53_record" "denmark" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   geolocation_routing_policy {
     country = "DK"
   }
@@ -1582,16 +1574,15 @@ resource "aws_route53_record" "denmark" {
 `
 
 const testAccRoute53LatencyCNAMERecord = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "us-east-1" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   latency_routing_policy {
     region = "us-east-1"
   }
@@ -1601,11 +1592,10 @@ resource "aws_route53_record" "us-east-1" {
 }
 
 resource "aws_route53_record" "eu-west-1" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   latency_routing_policy {
     region = "eu-west-1"
   }
@@ -1615,11 +1605,10 @@ resource "aws_route53_record" "eu-west-1" {
 }
 
 resource "aws_route53_record" "ap-northeast-1" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
-
   latency_routing_policy {
     region = "ap-northeast-1"
   }
@@ -1709,11 +1698,11 @@ resource "aws_elb" "test" {
 
 func testAccRoute53RecordConfigAliasS3(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_s3_bucket" "website" {
+resource "aws_s3_bucket" "test" {
   bucket = %q
   acl    = "public-read"
 
@@ -1723,13 +1712,13 @@ resource "aws_s3_bucket" "website" {
 }
 
 resource "aws_route53_record" "alias" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "A"
 
   alias {
-    zone_id                = aws_s3_bucket.website.hosted_zone_id
-    name                   = aws_s3_bucket.website.website_domain
+    zone_id                = aws_s3_bucket.test.hosted_zone_id
+    name                   = aws_s3_bucket.test.website_domain
     evaluate_target_health = true
   }
 }
@@ -1870,6 +1859,10 @@ resource "aws_security_group" "test" {
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = [aws_lb.test.id]
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_vpc_endpoint" "test" {
@@ -1879,6 +1872,10 @@ resource "aws_vpc_endpoint" "test" {
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_route53_zone" "test" {
@@ -1950,7 +1947,7 @@ resource "aws_elb" "live" {
 }
 
 resource "aws_route53_record" "elb_weighted_alias_live" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "A"
 
@@ -1980,7 +1977,7 @@ resource "aws_elb" "dev" {
 }
 
 resource "aws_route53_record" "elb_weighted_alias_dev" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "A"
 
@@ -1999,12 +1996,12 @@ resource "aws_route53_record" "elb_weighted_alias_dev" {
 `
 
 const testAccRoute53WeightedR53AliasRecord = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "blue_origin" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "blue-origin"
   type    = "CNAME"
   ttl     = 5
@@ -2012,7 +2009,7 @@ resource "aws_route53_record" "blue_origin" {
 }
 
 resource "aws_route53_record" "r53_weighted_alias_live" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
 
@@ -2023,14 +2020,14 @@ resource "aws_route53_record" "r53_weighted_alias_live" {
   set_identifier = "blue"
 
   alias {
-    zone_id                = aws_route53_zone.main.zone_id
-    name                   = "${aws_route53_record.blue_origin.name}.${aws_route53_zone.main.name}"
+    zone_id                = aws_route53_zone.test.zone_id
+    name                   = "${aws_route53_record.blue_origin.name}.${aws_route53_zone.test.name}"
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "green_origin" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "green-origin"
   type    = "CNAME"
   ttl     = 5
@@ -2038,7 +2035,7 @@ resource "aws_route53_record" "green_origin" {
 }
 
 resource "aws_route53_record" "r53_weighted_alias_dev" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "CNAME"
 
@@ -2049,8 +2046,8 @@ resource "aws_route53_record" "r53_weighted_alias_dev" {
   set_identifier = "green"
 
   alias {
-    zone_id                = aws_route53_zone.main.zone_id
-    name                   = "${aws_route53_record.green_origin.name}.${aws_route53_zone.main.name}"
+    zone_id                = aws_route53_zone.test.zone_id
+    name                   = "${aws_route53_record.green_origin.name}.${aws_route53_zone.test.name}"
     evaluate_target_health = false
   }
 }
@@ -2243,12 +2240,12 @@ resource "aws_route53_record" "test" {
 `
 
 const testAccRoute53MultiValueAnswerARecord = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "www-server1" {
-  zone_id                          = aws_route53_zone.main.zone_id
+  zone_id                          = aws_route53_zone.test.zone_id
   name                             = "www"
   type                             = "A"
   ttl                              = "5"
@@ -2258,7 +2255,7 @@ resource "aws_route53_record" "www-server1" {
 }
 
 resource "aws_route53_record" "www-server2" {
-  zone_id                          = aws_route53_zone.main.zone_id
+  zone_id                          = aws_route53_zone.test.zone_id
   name                             = "www"
   type                             = "A"
   ttl                              = "5"
@@ -2269,12 +2266,12 @@ resource "aws_route53_record" "www-server2" {
 `
 
 const testaccRoute53RecordConfigWithWeightedRoutingPolicy = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
 resource "aws_route53_record" "test" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "A"
 
@@ -2289,12 +2286,12 @@ resource "aws_route53_record" "test" {
 `
 
 const testaccRoute53RecordConfigWithSimpleRoutingPolicy = `
-resource "aws_route53_zone" "main" {
+resource "aws_route53_zone" "test" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "www-server1" {
-  zone_id = aws_route53_zone.main.zone_id
+resource "aws_route53_record" "test" {
+  zone_id = aws_route53_zone.test.zone_id
   name    = "www"
   type    = "A"
   ttl     = "300"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11381, #13527

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_route53_record: allow zero value `ttl`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53Record_'
--- PASS: TestAccAWSRoute53Record_ttl (471.09s)
--- PASS: TestAccAWSRoute53Record_underscored (242.93s)
--- PASS: TestAccAWSRoute53Record_disappears (214.35s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (213.68s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (283.47s)
--- PASS: TestAccAWSRoute53Record_txtSupport (176.48s)
--- PASS: TestAccAWSRoute53Record_spfSupport (185.99s)
--- PASS: TestAccAWSRoute53Record_caaSupport (182.23s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (169.05s)
--- PASS: TestAccAWSRoute53Record_wildcard (254.55s)
--- PASS: TestAccAWSRoute53Record_failover (170.21s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (171.75s)
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (243.66s)
--- PASS: TestAccAWSRoute53Record_Alias_Elb (186.29s)
--- PASS: TestAccAWSRoute53Record_Alias_S3 (255.33s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (735.25s)
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (192.54s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (335.67s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (170.57s)
--- PASS: TestAccAWSRoute53Record_latency_basic (157.21s)
--- PASS: TestAccAWSRoute53Record_TypeChange (241.77s)
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (270.79s)
--- PASS: TestAccAWSRoute53Record_empty (172.47s)
--- PASS: TestAccAWSRoute53Record_longTXTrecord (175.81s)
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (188.49s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (264.61s)
```
