### PR TITLE
d/aws_api_gateway_domain_name: Add API Gateway Custom Domain lookup

### DIFF
--- a/aws/data_source_aws_api_gateway_domain_name.go
+++ b/aws/data_source_aws_api_gateway_domain_name.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsApiGatewayDomainName() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsApiGatewayDomainNameRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_upload_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cloudfront_domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cloudfront_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"endpoint_configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"regional_certificate_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"regional_certificate_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"regional_domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"regional_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func dataSourceAwsApiGatewayDomainNameRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayconn
+	targetDomainName := d.Get("domain_name").(string)
+	log.Printf("[DEBUG] Reading API Gateway Domain Name %s", targetDomainName)
+	domainName, err := conn.GetDomainName(&apigateway.GetDomainNameInput{
+		DomainName: aws.String(targetDomainName),
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == apigateway.ErrCodeNotFoundException {
+			return fmt.Errorf("API Gateway Domain Name (%s) not found", targetDomainName)
+		}
+
+		return err
+	}
+
+	d.SetId(*domainName.DomainName)
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "apigateway",
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("/domainnames/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+	d.Set("certificate_arn", domainName.CertificateArn)
+	d.Set("certificate_name", domainName.CertificateName)
+	if err := d.Set("certificate_upload_date", domainName.CertificateUploadDate.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Error setting certificate_upload_date: %s", err)
+	}
+	d.Set("cloudfront_domain_name", domainName.DistributionDomainName)
+	d.Set("cloudfront_zone_id", cloudFrontRoute53ZoneID)
+	d.Set("domain_name", domainName.DomainName)
+	d.Set("security_policy", domainName.SecurityPolicy)
+
+	if err := d.Set("endpoint_configuration", flattenApiGatewayEndpointConfiguration(domainName.EndpointConfiguration)); err != nil {
+		return fmt.Errorf("error setting endpoint_configuration: %s", err)
+	}
+
+	d.Set("regional_certificate_arn", domainName.RegionalCertificateArn)
+	d.Set("regional_certificate_name", domainName.RegionalCertificateName)
+	d.Set("regional_domain_name", domainName.RegionalDomainName)
+	d.Set("regional_zone_id", domainName.RegionalHostedZoneId)
+
+	if err := d.Set("tags", keyvaluetags.ApigatewayKeyValueTags(domainName.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_api_gateway_domain_name_test.go
+++ b/aws/data_source_aws_api_gateway_domain_name_test.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsApiGatewayDomainName_CertificateArn(t *testing.T) {
+	certificateArn := os.Getenv("AWS_API_GATEWAY_DOMAIN_NAME_CERTIFICATE_ARN")
+	if certificateArn == "" {
+		t.Skip(
+			"Environment variable AWS_API_GATEWAY_DOMAIN_NAME_CERTIFICATE_ARN is not set. " +
+				"This environment variable must be set to the ARN of " +
+				"an ISSUED ACM certificate in us-east-1 to enable this test.")
+	}
+
+	// This test must always run in us-east-1
+	// BadRequestException: Invalid certificate ARN: arn:aws:acm:us-west-2:123456789012:certificate/xxxxx. Certificate must be in 'us-east-1'.
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	resourceName := "aws_api_gateway_domain_name.test"
+	dataSourceName := "data.aws_api_gateway_domain_name.test"
+	rName := fmt.Sprintf("tf-acc-%s.terraformtest.com", acctest.RandString(8))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDomainNameDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsApiGatewayDomainNameConfig_CertificateArn(rName, certificateArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMatchResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "apigateway", regexp.MustCompile(`/domainnames/+.`)),
+					resource.TestCheckResourceAttr(dataSourceName, "domain_name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "cloudfront_zone_id", "Z2FDTNDATAQYW2"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name", dataSourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudfront_domain_name", dataSourceName, "cloudfront_domain_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudfront_zone_id", dataSourceName, "cloudfront_zone_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "certificate_upload_date", dataSourceName, "certificate_upload_date"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsApiGatewayDomainName_RegionalCertificateArn(t *testing.T) {
+	resourceName := "aws_api_gateway_domain_name.test"
+	dataSourceName := "data.aws_api_gateway_domain_name.test"
+	rName := fmt.Sprintf("tf-acc-%s.terraformtest.com", acctest.RandString(8))
+
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDomainNameDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsApiGatewayDomainNameConfig_RegionalCertificateArn(rName, key, certificate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMatchResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "apigateway", regexp.MustCompile(`/domainnames/+.`)),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name", dataSourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "regional_domain_name", dataSourceName, "regional_domain_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "regional_zone_id", dataSourceName, "regional_zone_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "certificate_upload_date", dataSourceName, "certificate_upload_date"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsApiGatewayDomainNameConfig_CertificateArn(domainName, certificateArn string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_domain_name" "test" {
+ domain_name     = "%s"
+ certificate_arn = "%s"
+
+ endpoint_configuration {
+   types = ["EDGE"]
+ }
+}
+
+data "aws_api_gateway_domain_name" "test" {
+ domain_name = "${aws_api_gateway_domain_name.test.domain_name}"
+}
+`, domainName, certificateArn)
+}
+
+func testAccDataSourceAwsApiGatewayDomainNameConfig_RegionalCertificateArn(domainName, key, certificate string) string {
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "test" {
+ certificate_body = "%[2]s"
+ private_key      = "%[3]s"
+}
+
+resource "aws_api_gateway_domain_name" "test" {
+ domain_name              = %[1]q
+ regional_certificate_arn = "${aws_acm_certificate.test.arn}"
+
+ endpoint_configuration {
+   types = ["REGIONAL"]
+ }
+}
+
+data "aws_api_gateway_domain_name" "test" {
+ domain_name = "${aws_api_gateway_domain_name.test.domain_name}"
+}
+`, domainName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -162,6 +162,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ami":                                       dataSourceAwsAmi(),
 			"aws_ami_ids":                                   dataSourceAwsAmiIds(),
 			"aws_api_gateway_api_key":                       dataSourceAwsApiGatewayApiKey(),
+			"aws_api_gateway_domain_name":                   dataSourceAwsApiGatewayDomainName(),
 			"aws_api_gateway_resource":                      dataSourceAwsApiGatewayResource(),
 			"aws_api_gateway_rest_api":                      dataSourceAwsApiGatewayRestApi(),
 			"aws_api_gateway_vpc_link":                      dataSourceAwsApiGatewayVpcLink(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -123,6 +123,9 @@
                                     <a href="/docs/providers/aws/d/api_gateway_api_key.html">aws_api_gateway_api_key</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/d/api_gateway_domain_name.html">aws_api_gateway_domain_name</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/d/api_gateway_resource.html">aws_api_gateway_resource</a>
                                 </li>
                                 <li>

--- a/website/docs/d/api_gateway_domain_name.html.markdown
+++ b/website/docs/d/api_gateway_domain_name.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "API Gateway (REST APIs)"
+layout: "aws"
+page_title: "AWS: aws_api_gateway_domain_name"
+description: |-
+ Get information on a custom domain name for use with AWS API Gateway.
+---
+
+# Data Source: aws_api_gateway_domain_name
+
+Use this data source to get the custom domain name for use with AWS API Gateway.
+
+## Example Usage
+
+```hcl
+resource "aws_api_gateway_domain_name" "example" {
+  domain_name     = "api.example.com"
+}
+```
+
+## Argument Reference
+
+ * `domain_name` - (Required) The fully-qualified domain name to look up.
+  If no domain name is found, an error will be returned.
+
+## Attributes Reference
+
+In addition to the arguments, the following attributes are exported:
+
+ * `arn` - The ARN of the found custom domain name.
+ * `certificate_arn` - The ARN for an AWS-managed certificate 
+   that is used by edge-optimized endpoint for this domain name.
+ * `certificate_name` - The name of the certificate that is used by 
+   edge-optimized endpoint for this domain name.
+ * `certificate_upload_date` - The upload date associated with 
+   the domain certificate.
+ * `cloudfront_domain_name` - The hostname created by Cloudfront to represent
+   the distribution that implements this domain name mapping.
+ * `cloudfront_zone_id` - For convenience, the hosted zone ID (`Z2FDTNDATAQYW2`)
+   that can be used to create a Route53 alias record for the distribution.
+ * `endpoint_configuration` - The endpoint configuration of this domain name
+   showing the endpoint types of the domain name.
+ * `regional_certificate_arn` - The ARN for an AWS-managed certificate
+   that is used for validating the regional domain name.
+ * `regional_certificate_name` - The user-friendly name of the certificate
+   that is used by regional endpoint for this domain name.
+ * `regional_domain_name` - The hostname for the custom domain's
+   regional endpoint.
+ * `regional_zone_id` - The hosted zone ID that can be used to create
+   a Route53 alias record for the regional endpoint.
+ * `tags` - A mapping of tags for the resource.

--- a/website/docs/d/api_gateway_domain_name.html.markdown
+++ b/website/docs/d/api_gateway_domain_name.html.markdown
@@ -14,7 +14,7 @@ Use this data source to get the custom domain name for use with AWS API Gateway.
 
 ```hcl
 resource "aws_api_gateway_domain_name" "example" {
-  domain_name     = "api.example.com"
+  domain_name = "api.example.com"
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

Add API Gateway Custom Domain lookup

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
**New Data Source**: `aws_api_gateway_domain_name`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsApiGatewayDomainName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsApiGatewayDomainName -timeout 120m
=== RUN   TestAccDataSourceAwsApiGatewayDomainName_CertificateArn
=== PAUSE TestAccDataSourceAwsApiGatewayDomainName_CertificateArn
=== RUN   TestAccDataSourceAwsApiGatewayDomainName_RegionalCertificateArn
=== PAUSE TestAccDataSourceAwsApiGatewayDomainName_RegionalCertificateArn
=== CONT  TestAccDataSourceAwsApiGatewayDomainName_CertificateArn
=== CONT  TestAccDataSourceAwsApiGatewayDomainName_RegionalCertificateArn
--- PASS: TestAccDataSourceAwsApiGatewayDomainName_CertificateArn (92.55s)
--- PASS: TestAccDataSourceAwsApiGatewayDomainName_RegionalCertificateArn (172.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       172.598s
```
