### PR TITLE
r/aws_lambda_function: Modifying runtime creates a new version

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -268,7 +268,7 @@ func resourceAwsLambdaFunction() *schema.Resource {
 }
 
 func updateComputedAttributesOnPublish(d *schema.ResourceDiff, meta interface{}) error {
-	if needsFunctionCodeUpdate(d) {
+	if needsFunctionCodeUpdate(d) || d.HasChange("runtime") {
 		d.SetNewComputed("last_modified")
 		publish := d.Get("publish").(bool)
 		if publish {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

I recently updated a Lambda@Edge function from `nodejs10.x` to `nodejs12.x`, but I didn't need any code changes at all. When I usually update the code, I only need to apply once to:
1. update the lambda function
2. update the cloudfront distribution to use the new lambda ARN

But for this change, it only triggered (1) and not (2), so I had to apply twice to fully apply the change. I think this change should fix this.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lambda_function: Updating runtime creates a new version.
```

Output from acceptance testing:
- I don't know what new testing is appropriate. Let me know.
