### PR TITLE
resource/aws_emr_cluster: Fix aws_emr_security_configuration destroy issues

### DIFF
--- a/.changelog/12578.txt
+++ b/.changelog/12578.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_emr_cluster: Wait for the cluster to reach a terminated state on deletion
+```

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -972,7 +972,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	cluster, err := waitClusterCreated(conn, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error waiting for EMR Cluster (%s) to be created: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for EMR Cluster (%s) to create: %w", d.Id(), err)
 	}
 
 	// For multiple master nodes, EMR automatically enables
@@ -1377,88 +1377,25 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EMRConn
 
-	req := &emr.TerminateJobFlowsInput{
+	log.Printf("[DEBUG] Deleting EMR Cluster: (%s)", d.Id())
+	_, err := conn.TerminateJobFlows(&emr.TerminateJobFlowsInput{
 		JobFlowIds: []*string{
 			aws.String(d.Id()),
 		},
-	}
-
-	_, err := conn.TerminateJobFlows(req)
-	if err != nil {
-		log.Printf("[ERROR], %s", err)
-		return err
-	}
-
-	input := &emr.ListInstancesInput{
-		ClusterId: aws.String(d.Id()),
-	}
-	var resp *emr.ListInstancesOutput
-	var count int
-	err = resource.Retry(20*time.Minute, func() *resource.RetryError {
-		var err error
-		resp, err = conn.ListInstances(input)
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		count = CountRemainingInstances(resp, d.Id())
-		if count != 0 {
-			return resource.RetryableError(fmt.Errorf("EMR Cluster (%s) has (%d) Instances remaining", d.Id(), count))
-		}
-		return nil
 	})
 
-	if tfresource.TimedOut(err) {
-		resp, err = conn.ListInstances(input)
-
-		if err == nil {
-			count = CountRemainingInstances(resp, d.Id())
-		}
+	if err != nil {
+		return fmt.Errorf("error terminating EMR Cluster (%s): %w", d.Id(), err)
 	}
 
-	if count != 0 {
-		return fmt.Errorf("EMR Cluster (%s) has (%d) Instances remaining", d.Id(), count)
-	}
+	log.Println("[INFO] Waiting for EMR Cluster to be terminated")
+	_, err = waitClusterDeleted(conn, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error waiting for EMR Cluster (%s) Instances to drain: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for EMR Cluster (%s) to delete: %w", d.Id(), err)
 	}
 
 	return nil
-}
-
-func CountRemainingInstances(resp *emr.ListInstancesOutput, emrClusterId string) int {
-	if resp == nil {
-		log.Printf("[ERROR] response is nil")
-		return 0
-	}
-
-	instanceCount := len(resp.Instances)
-
-	if instanceCount == 0 {
-		log.Printf("[DEBUG] No instances found for EMR Cluster (%s)", emrClusterId)
-		return 0
-	}
-
-	// Collect instance status states, wait for all instances to be terminated
-	// before moving on
-	var terminated []string
-	for j, i := range resp.Instances {
-		instanceId := aws.StringValue(i.Ec2InstanceId)
-		if i.Status != nil {
-			if aws.StringValue(i.Status.State) == emr.InstanceStateTerminated {
-				terminated = append(terminated, instanceId)
-			}
-		} else {
-			log.Printf("[DEBUG] Cluster instance (%d : %s) has no status", j, instanceId)
-		}
-	}
-	if len(terminated) == instanceCount {
-		log.Printf("[DEBUG] All (%d) EMR Cluster (%s) Instances terminated", instanceCount, emrClusterId)
-		return 0
-	}
-	return len(resp.Instances)
 }
 
 func expandApplications(apps []interface{}) []*emr.Application {

--- a/internal/service/emr/find.go
+++ b/internal/service/emr/find.go
@@ -40,6 +40,13 @@ func FindClusterByID(conn *emr.EMR, id string) (*emr.Cluster, error) {
 		return nil, err
 	}
 
+	// Eventual consistency check.
+	if aws.StringValue(output.Id) != id {
+		return nil, &resource.NotFoundError{
+			LastRequest: input,
+		}
+	}
+
 	if state := aws.StringValue(output.Status.State); state == emr.ClusterStateTerminated || state == emr.ClusterStateTerminatedWithErrors {
 		return nil, &resource.NotFoundError{
 			Message:     state,

--- a/internal/service/emr/wait.go
+++ b/internal/service/emr/wait.go
@@ -14,22 +14,43 @@ const (
 	ClusterCreatedTimeout    = 75 * time.Minute
 	ClusterCreatedMinTimeout = 10 * time.Second
 	ClusterCreatedDelay      = 30 * time.Second
+
+	ClusterDeletedTimeout    = 20 * time.Minute
+	ClusterDeletedMinTimeout = 10 * time.Second
+	ClusterDeletedDelay      = 30 * time.Second
 )
 
 func waitClusterCreated(conn *emr.EMR, id string) (*emr.Cluster, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			emr.ClusterStateBootstrapping,
-			emr.ClusterStateStarting,
-		},
-		Target: []string{
-			emr.ClusterStateRunning,
-			emr.ClusterStateWaiting,
-		},
+		Pending:    []string{emr.ClusterStateBootstrapping, emr.ClusterStateStarting},
+		Target:     []string{emr.ClusterStateRunning, emr.ClusterStateWaiting},
 		Refresh:    statusCluster(conn, id),
 		Timeout:    ClusterCreatedTimeout,
 		MinTimeout: ClusterCreatedMinTimeout,
 		Delay:      ClusterCreatedDelay,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*emr.Cluster); ok {
+		if stateChangeReason := output.Status.StateChangeReason; stateChangeReason != nil {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(stateChangeReason.Code), aws.StringValue(stateChangeReason.Message)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitClusterDeleted(conn *emr.EMR, id string) (*emr.Cluster, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{emr.ClusterStateTerminating},
+		Target:     []string{emr.ClusterStateTerminated, emr.ClusterStateTerminatedWithErrors},
+		Refresh:    statusCluster(conn, id),
+		Timeout:    ClusterDeletedTimeout,
+		MinTimeout: ClusterDeletedMinTimeout,
+		Delay:      ClusterDeletedDelay,
 	}
 
 	outputRaw, err := stateConf.WaitForState()


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

This will fix #6279

Rewrite resourceAwsEMRClusterDelete to use cluster state returned by DescribeCluster instead of counting running cluster instances to check is cluster terminated. Previous approach might cause too early deletion of cluster's security group which might block deletion of ENI created for this cluster. In this case orphaned ENI is blocking deletion of security configuration as well as linked security group.

These changes was tested on our environments and has fixed painful security configuration deletion issues.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6279.
Closes #3465.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_emr_cluster: Fix aws_emr_security_configuration destroy issues
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEMRCluster_security_config'

--- PASS: TestAccAWSEMRCluster_security_config (475.02s)
```
