### PR TITLE
add arn validation for policy, policy_arns and role_arn in provider assume_role config block

### DIFF
--- a/.changelog/12642.txt
+++ b/.changelog/12642.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Add validation for `role_arn`, `policy_arns`, and `policy`
+```

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/mutexkv"
 )
@@ -1445,20 +1446,25 @@ func assumeRoleSchema() *schema.Schema {
 					Description: "Unique identifier that might be required for assuming a role in another account.",
 				},
 				"policy": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Description: "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.",
+					Type:         schema.TypeString,
+					Optional:     true,
+					Description:  "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.",
+					ValidateFunc: validation.StringIsJSON,
 				},
 				"policy_arns": {
 					Type:        schema.TypeSet,
 					Optional:    true,
 					Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
-					Elem:        &schema.Schema{Type: schema.TypeString},
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validateArn,
+					},
 				},
 				"role_arn": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Description: "Amazon Resource Name of an IAM Role to assume prior to making API calls.",
+					Type:         schema.TypeString,
+					Optional:     true,
+					Description:  "Amazon Resource Name of an IAM Role to assume prior to making API calls.",
+					ValidateFunc: validateArn,
 				},
 				"session_name": {
 					Type:        schema.TypeString,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Provider - add arn validation for `assume_role_arn`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
