### PR TITLE
r/glacier_vault: fix policy diff + read after create + refactor tests

### DIFF
--- a/aws/resource_aws_glacier_vault.go
+++ b/aws/resource_aws_glacier_vault.go
@@ -167,6 +167,8 @@ func resourceAwsGlacierVaultRead(d *schema.ResourceData, meta interface{}) error
 
 	if isAWSErr(err, glacier.ErrCodeResourceNotFoundException, "") {
 		d.Set("access_policy", "")
+	} else if err != nil {
+		return fmt.Errorf("error getting access policy for Glacier Vault (%s): %s", d.Id(), err)
 	} else if pol != nil && pol.Policy != nil {
 		policy, err := structure.NormalizeJsonString(aws.StringValue(pol.Policy.Policy))
 		if err != nil {

--- a/aws/resource_aws_glacier_vault.go
+++ b/aws/resource_aws_glacier_vault.go
@@ -185,11 +185,11 @@ func resourceAwsGlacierVaultRead(d *schema.ResourceData, meta interface{}) error
 	if isAWSErr(err, glacier.ErrCodeResourceNotFoundException, "") {
 		d.Set("access_policy", "")
 	} else if err != nil {
-		return fmt.Errorf("error getting access policy for Glacier Vault (%s): %s", d.Id(), err)
+		return fmt.Errorf("error getting access policy for Glacier Vault (%s): %w", d.Id(), err)
 	} else if pol != nil && pol.Policy != nil {
 		policy, err := structure.NormalizeJsonString(aws.StringValue(pol.Policy.Policy))
 		if err != nil {
-			return fmt.Errorf("access policy contains an invalid JSON: %s", err)
+			return fmt.Errorf("access policy contains an invalid JSON: %w", err)
 		}
 		d.Set("access_policy", policy)
 	}
@@ -200,7 +200,7 @@ func resourceAwsGlacierVaultRead(d *schema.ResourceData, meta interface{}) error
 	} else if pol != nil {
 		d.Set("notification", notifications)
 	} else {
-		return err
+		return fmt.Errorf("error setting notification: %w", err)
 	}
 
 	return nil
@@ -242,7 +242,7 @@ func resourceAwsGlacierVaultNotificationUpdate(conn *glacier.Glacier, d *schema.
 			})
 
 			if err != nil {
-				return fmt.Errorf("Error Updating Glacier Vault Notifications: %s", err.Error())
+				return fmt.Errorf("Error Updating Glacier Vault Notifications: %w", err)
 			}
 		}
 	} else {
@@ -251,7 +251,7 @@ func resourceAwsGlacierVaultNotificationUpdate(conn *glacier.Glacier, d *schema.
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error Removing Glacier Vault Notifications: %s", err.Error())
+			return fmt.Errorf("Error Removing Glacier Vault Notifications: %w", err)
 		}
 
 	}
@@ -306,7 +306,7 @@ func getGlacierVaultNotification(conn *glacier.Glacier, vaultName string) ([]map
 
 	response, err := conn.GetVaultNotifications(request)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading Glacier Vault Notifications: %s", err.Error())
+		return nil, fmt.Errorf("Error reading Glacier Vault Notifications: %w", err)
 	}
 
 	notifications := make(map[string]interface{})

--- a/aws/resource_aws_glacier_vault.go
+++ b/aws/resource_aws_glacier_vault.go
@@ -48,13 +48,10 @@ func resourceAwsGlacierVault() *schema.Resource {
 			},
 
 			"access_policy": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsJSON,
-				StateFunc: func(v interface{}) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
-				},
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 
 			"notification": {

--- a/aws/resource_aws_glacier_vault.go
+++ b/aws/resource_aws_glacier_vault.go
@@ -175,8 +175,6 @@ func resourceAwsGlacierVaultRead(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("access policy contains an invalid JSON: %s", err)
 		}
 		d.Set("access_policy", policy)
-	} else {
-		return err
 	}
 
 	notifications, err := getGlacierVaultNotification(conn, d.Id())

--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -271,8 +271,8 @@ func testAccCheckGlacierVaultExists(name string, vault *glacier.DescribeVaultOut
 			return fmt.Errorf("No ID is set")
 		}
 
-		glacierconn := testAccProvider.Meta().(*AWSClient).glacierconn
-		out, err := glacierconn.DescribeVault(&glacier.DescribeVaultInput{
+		conn := testAccProvider.Meta().(*AWSClient).glacierconn
+		out, err := conn.DescribeVault(&glacier.DescribeVaultInput{
 			VaultName: aws.String(rs.Primary.ID),
 		})
 
@@ -446,7 +446,7 @@ resource "aws_glacier_vault" "test" {
   name = %[1]q
 
   tags = {
-	%[2]q = %[3]q
+    %[2]q = %[3]q
   }
 }
 `, rName, tagKey1, tagValue1)
@@ -458,8 +458,8 @@ resource "aws_glacier_vault" "test" {
   name = %[1]q
 
   tags = {
-	%[2]q = %[3]q
-	%[4]q = %[5]q
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -232,7 +233,7 @@ func TestAccAWSGlacierVault_disappears(t *testing.T) {
 				Config: testAccGlacierVaultBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlacierVaultExists(resourceName, &vault),
-					testAccCheckGlacierVaultDisappears(&vault),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsGlacierVault(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -272,17 +273,6 @@ func testAccCheckGlacierVaultExists(name string, vault *glacier.DescribeVaultOut
 		*vault = *out
 
 		return nil
-	}
-}
-
-func testAccCheckGlacierVaultDisappears(vault *glacier.DescribeVaultOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).glacierconn
-		_, err := conn.DeleteVault(&glacier.DeleteVaultInput{
-			VaultName: vault.VaultName,
-		})
-
-		return err
 	}
 }
 

--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -105,7 +105,7 @@ func TestAccAWSGlacierVault_notification(t *testing.T) {
 	var vault glacier.DescribeVaultOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_glacier_vault.test"
-	snsResourceName := "aws_sns_topic_test"
+	snsResourceName := "aws_sns_topic.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -366,6 +366,10 @@ resource "aws_glacier_vault" "test" {
 
 func testAccGlacierVaultPolicyConfig(rName string) string {
 	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
 resource "aws_glacier_vault" "test" {
   name = %[1]q
 
@@ -385,7 +389,7 @@ resource "aws_glacier_vault" "test" {
              "glacier:AbortMultipartUpload",
              "glacier:CompleteMultipartUpload"
           ],
-          "Resource": ["*"]
+          "Resource": ["arn:aws:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"]
        }
     ]
 }

--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -297,8 +297,8 @@ func testAccCheckVaultNotificationsMissing(name string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		glacierconn := testAccProvider.Meta().(*AWSClient).glacierconn
-		out, err := glacierconn.GetVaultNotifications(&glacier.GetVaultNotificationsInput{
+		conn := testAccProvider.Meta().(*AWSClient).glacierconn
+		out, err := conn.GetVaultNotifications(&glacier.GetVaultNotificationsInput{
 			VaultName: aws.String(rs.Primary.ID),
 		})
 
@@ -349,7 +349,7 @@ resource "aws_glacier_vault" "test" {
 
 func testAccGlacierVaultNotificationConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sns_topic" "aws_sns_topic" {
+resource "aws_sns_topic" "test" {
   name = %[1]q
 }
 
@@ -357,7 +357,7 @@ resource "aws_glacier_vault" "test" {
   name = %[1]q
 
   notification {
-    sns_topic = aws_sns_topic.aws_sns_topic.arn
+    sns_topic = aws_sns_topic.test.arn
     events    = ["ArchiveRetrievalCompleted", "InventoryRetrievalCompleted"]
   }
 }

--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -91,6 +91,8 @@ func TestAccAWSGlacierVault_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "glacier", regexp.MustCompile(`vaults/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "access_policy", ""),
 				),
 			},
 			{

--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -88,7 +88,7 @@ func TestAccAWSGlacierVault_basic(t *testing.T) {
 				Config: testAccGlacierVaultBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlacierVaultExists(resourceName, &vault),
-					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "glacier", regexp.MustCompile(`vaults/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "0"),

--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -375,6 +375,8 @@ resource "aws_glacier_vault" "test" {
 
 func testAccGlacierVaultPolicyConfig(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
@@ -397,7 +399,7 @@ resource "aws_glacier_vault" "test" {
              "glacier:AbortMultipartUpload",
              "glacier:CompleteMultipartUpload"
           ],
-          "Resource": ["arn:aws:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"]
+          "Resource": ["arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"]
        }
     ]
 }
@@ -408,6 +410,8 @@ EOF
 
 func testAccGlacierVaultPolicyConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
@@ -431,7 +435,7 @@ resource "aws_glacier_vault" "test" {
              "glacier:AbortMultipartUpload",
              "glacier:CompleteMultipartUpload"
           ],
-          "Resource": ["arn:aws:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"]
+          "Resource": ["arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"]
        }
     ]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12619 (possibly)
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glacier_vault: remove from state when vault does not exist.
resource_aws_glacier_vault: add plan time validation to `sns_topic` in the `notification` block.
resource_aws_glacier_vault: add plan time validation to `events` in the `notification` block.
resource_aws_glacier_vault: fix diff for `access_policy`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlacierVault_'
--- PASS: TestAccAWSGlacierVault_basic (51.11s)
--- PASS: TestAccAWSGlacierVault_tags (145.51s)
--- PASS: TestAccAWSGlacierVault_disappears (32.80s)
--- PASS: TestAccAWSGlacierVault_notification (134.42s)
--- PASS: TestAccAWSGlacierVault_policy (79.08s)
```
