### PR TITLE
Add conflicts validation for availability_zones and subnets for aws_elb

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -67,11 +67,12 @@ func resourceAwsElb() *schema.Resource {
 			},
 
 			"availability_zones": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-				Computed: true,
-				Set:      schema.HashString,
+				Type:          schema.TypeSet,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"subnets"},
+				Set:           schema.HashString,
 			},
 
 			"instances": {
@@ -102,11 +103,12 @@ func resourceAwsElb() *schema.Resource {
 			},
 
 			"subnets": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-				Computed: true,
-				Set:      schema.HashString,
+				Type:          schema.TypeSet,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"availability_zones"},
+				Set:           schema.HashString,
 			},
 
 			"idle_timeout": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12635

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_elb: add conflicts validation for `availability_zones` and `subnets` attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSELB_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSELB_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSELB_basic
=== PAUSE TestAccAWSELB_basic
=== RUN   TestAccAWSELB_disappears
=== PAUSE TestAccAWSELB_disappears
=== RUN   TestAccAWSELB_fullCharacterRange
=== PAUSE TestAccAWSELB_fullCharacterRange
=== RUN   TestAccAWSELB_AccessLogs_enabled
=== PAUSE TestAccAWSELB_AccessLogs_enabled
=== RUN   TestAccAWSELB_AccessLogs_disabled
=== PAUSE TestAccAWSELB_AccessLogs_disabled
=== RUN   TestAccAWSELB_namePrefix
=== PAUSE TestAccAWSELB_namePrefix
=== RUN   TestAccAWSELB_generatedName
=== PAUSE TestAccAWSELB_generatedName
=== RUN   TestAccAWSELB_generatesNameForZeroValue
=== PAUSE TestAccAWSELB_generatesNameForZeroValue
=== RUN   TestAccAWSELB_availabilityZones
=== PAUSE TestAccAWSELB_availabilityZones
=== RUN   TestAccAWSELB_tags
=== PAUSE TestAccAWSELB_tags
=== RUN   TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
=== PAUSE TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
=== RUN   TestAccAWSELB_swap_subnets
=== PAUSE TestAccAWSELB_swap_subnets
=== RUN   TestAccAWSELB_InstanceAttaching
=== PAUSE TestAccAWSELB_InstanceAttaching
=== RUN   TestAccAWSELB_listener
=== PAUSE TestAccAWSELB_listener
=== RUN   TestAccAWSELB_HealthCheck
=== PAUSE TestAccAWSELB_HealthCheck
=== RUN   TestAccAWSELB_Timeout
=== PAUSE TestAccAWSELB_Timeout
=== RUN   TestAccAWSELB_ConnectionDraining
=== PAUSE TestAccAWSELB_ConnectionDraining
=== RUN   TestAccAWSELB_SecurityGroups
=== PAUSE TestAccAWSELB_SecurityGroups
=== CONT  TestAccAWSELB_basic
=== CONT  TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
=== CONT  TestAccAWSELB_namePrefix
=== CONT  TestAccAWSELB_fullCharacterRange
=== CONT  TestAccAWSELB_tags
=== CONT  TestAccAWSELB_SecurityGroups
=== CONT  TestAccAWSELB_ConnectionDraining
=== CONT  TestAccAWSELB_Timeout
=== CONT  TestAccAWSELB_HealthCheck
=== CONT  TestAccAWSELB_listener
=== CONT  TestAccAWSELB_InstanceAttaching
=== CONT  TestAccAWSELB_AccessLogs_enabled
=== CONT  TestAccAWSELB_swap_subnets
=== CONT  TestAccAWSELB_AccessLogs_disabled
=== CONT  TestAccAWSELB_availabilityZones
=== CONT  TestAccAWSELB_generatedName
=== CONT  TestAccAWSELB_generatesNameForZeroValue
=== CONT  TestAccAWSELB_disappears
--- PASS: TestAccAWSELB_basic (101.82s)
--- PASS: TestAccAWSELB_generatedName (109.99s)
--- PASS: TestAccAWSELB_availabilityZones (114.91s)
--- PASS: TestAccAWSELB_disappears (136.63s)
--- PASS: TestAccAWSELB_HealthCheck (139.00s)
--- PASS: TestAccAWSELB_namePrefix (144.16s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (150.38s)
--- PASS: TestAccAWSELB_ConnectionDraining (153.22s)
--- PASS: TestAccAWSELB_Timeout (160.00s)
--- PASS: TestAccAWSELB_swap_subnets (164.34s)
--- PASS: TestAccAWSELB_SecurityGroups (181.74s)
--- PASS: TestAccAWSELB_fullCharacterRange (184.68s)
--- PASS: TestAccAWSELB_generatesNameForZeroValue (211.15s)
--- PASS: TestAccAWSELB_tags (211.69s)
--- PASS: TestAccAWSELB_AccessLogs_enabled (220.94s)
--- PASS: TestAccAWSELB_AccessLogs_disabled (248.82s)
--- PASS: TestAccAWSELB_listener (262.06s)
--- PASS: TestAccAWSELB_InstanceAttaching (365.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	367.549s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.366s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.327s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.374s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.536s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.292s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.645s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.758s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.356s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.261s [no tests to run]
```
