### PR TITLE
Add support aws_media_store_container_lifecycle_policy resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -643,6 +643,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_media_convert_queue":                                 resourceAwsMediaConvertQueue(),
 			"aws_media_package_channel":                               resourceAwsMediaPackageChannel(),
 			"aws_media_store_container":                               resourceAwsMediaStoreContainer(),
+			"aws_media_store_container_lifecycle_policy":              resourceAwsMediaStoreContainerLifecyclePolicy(),
 			"aws_media_store_container_policy":                        resourceAwsMediaStoreContainerPolicy(),
 			"aws_msk_cluster":                                         resourceAwsMskCluster(),
 			"aws_msk_configuration":                                   resourceAwsMskConfiguration(),

--- a/aws/resource_aws_media_store_container_lifecycle_policy.go
+++ b/aws/resource_aws_media_store_container_lifecycle_policy.go
@@ -1,0 +1,107 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAwsMediaStoreContainerLifecyclePolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMediaStoreContainerLifecyclePolicyPut,
+		Read:   resourceAwsMediaStoreContainerLifecyclePolicyRead,
+		Update: resourceAwsMediaStoreContainerLifecyclePolicyPut,
+		Delete: resourceAwsMediaStoreContainerLifecyclePolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"container_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsMediaStoreContainerLifecyclePolicyPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediastoreconn
+
+	containerName := d.Get("container_name").(string)
+	input := &mediastore.PutLifecyclePolicyInput{
+		ContainerName:   aws.String(containerName),
+		LifecyclePolicy: aws.String(d.Get("policy").(string)),
+	}
+
+	_, err := conn.PutLifecyclePolicy(input)
+	if !d.IsNewResource() && isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+		log.Printf("[WARN] Media Store Container (%s) not found, removing from state", containerName)
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error putting media store container (%s) lifecycle policy: %s", containerName, err)
+	}
+
+	d.SetId(containerName)
+
+	return resourceAwsMediaStoreContainerLifecyclePolicyRead(d, meta)
+}
+
+func resourceAwsMediaStoreContainerLifecyclePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediastoreconn
+
+	input := &mediastore.GetLifecyclePolicyInput{
+		ContainerName: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetLifecyclePolicy(input)
+	if isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+		log.Printf("[WARN] Media Store Container (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if isAWSErr(err, mediastore.ErrCodePolicyNotFoundException, "") {
+		log.Printf("[WARN] Lifecycle Policy for Media Store Container (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error describing media store container (%s) lifecycle policy: %s", d.Id(), err)
+	}
+
+	d.Set("container_name", d.Id())
+	d.Set("policy", aws.StringValue(resp.LifecyclePolicy))
+
+	return nil
+}
+
+func resourceAwsMediaStoreContainerLifecyclePolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediastoreconn
+
+	input := &mediastore.DeleteLifecyclePolicyInput{
+		ContainerName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteLifecyclePolicy(input)
+	if isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+		return nil
+	}
+	if isAWSErr(err, mediastore.ErrCodePolicyNotFoundException, "") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting media store container (%s) lifecycle policy: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_media_store_container_lifecycle_policy_test.go
+++ b/aws/resource_aws_media_store_container_lifecycle_policy_test.go
@@ -1,0 +1,147 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSMediaStoreContainerLifecyclePolicy_basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_media_store_container_lifecycle_policy.test"
+	containerResourceName := "aws_media_store_container.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaStore(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMediaStoreContainerLifecyclePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMediaStoreContainerLifecyclePolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaStoreContainerLifecyclePolicyExists(resourceName),
+					resource.TestCheckResourceAttrPair(containerResourceName, "name", resourceName, "container_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSMediaStoreContainerLifecyclePolicy_disappears(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_media_store_container_lifecycle_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaStore(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMediaStoreContainerLifecyclePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMediaStoreContainerLifecyclePolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaStoreContainerLifecyclePolicyExists(resourceName),
+					testAccCheckAwsMediaStoreContainerLifecyclePolicyDisappears(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMediaStoreContainerLifecyclePolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_media_store_container_lifecycle_policy" {
+			continue
+		}
+
+		input := &mediastore.GetLifecyclePolicyInput{
+			ContainerName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetLifecyclePolicy(input)
+		if err != nil {
+			if isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+				continue
+			}
+			if isAWSErr(err, mediastore.ErrCodePolicyNotFoundException, "") {
+				continue
+			}
+			return err
+		}
+
+		return fmt.Errorf("Expected MediaStore Container Lifecycle Policy to be destroyed, %s found", rs.Primary.ID)
+	}
+	return nil
+}
+
+func testAccCheckAwsMediaStoreContainerLifecyclePolicyExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
+
+		input := &mediastore.GetLifecyclePolicyInput{
+			ContainerName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetLifecyclePolicy(input)
+
+		return err
+	}
+}
+
+func testAccCheckAwsMediaStoreContainerLifecyclePolicyDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No resource ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
+
+		input := &mediastore.DeleteLifecyclePolicyInput{
+			ContainerName: aws.String(rs.Primary.ID),
+		}
+
+		if _, err := conn.DeleteLifecyclePolicy(input); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccMediaStoreContainerLifecyclePolicyConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_media_store_container" "test" {
+  name = "tf_mediastore_%s"
+}
+
+resource "aws_media_store_container_lifecycle_policy" "test" {
+  container_name = aws_media_store_container.test.id
+  policy         = file("test-fixtures/mediastore_lifecycle_policy.json")
+}
+
+`, rName)
+}

--- a/aws/test-fixtures/mediastore_lifecycle_policy.json
+++ b/aws/test-fixtures/mediastore_lifecycle_policy.json
@@ -1,0 +1,54 @@
+{        
+    "rules": [
+         {
+            "definition": {
+                "path": [ 
+                    {"prefix": "Football/"}, 
+                    {"prefix": "Baseball/"}
+                ],
+                "days_since_create": [
+                    {"numeric": [">" , 28]}
+                ]
+            },
+            "action": "EXPIRE"
+        },
+        {
+            "definition": {
+                "path": [ { "prefix": "AwardsShow/" }  ],
+                "days_since_create": [
+                    {"numeric": [">=" , 15]}
+                ]
+            },
+            "action": "EXPIRE"
+        },
+        {
+            "definition": {
+                "path": [ { "prefix": "" }  ],
+                "days_since_create": [
+                    {"numeric": [">" , 40]}
+                ]
+            },
+            "action": "EXPIRE"
+        },
+        {
+            "definition": {
+                "path": [ { "wildcard": "Football/*.ts" }  ],
+                "days_since_create": [
+                    {"numeric": [">" , 20]}
+                ]
+            },
+            "action": "EXPIRE"
+        },
+        {
+            "definition": {
+                "path": [ 
+                    {"wildcard": "Football/index*.m3u8"}
+                ],
+                "seconds_since_create": [
+                    {"numeric": [">" , 15]}
+                ]
+            },
+            "action": "EXPIRE"
+        }
+    ]
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2167,6 +2167,9 @@
                                     <a href="/docs/providers/aws/r/media_store_container.html">aws_media_store_container</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/media_store_container_lifecycle_policy.html">aws_media_store_container_lifecycle_policy</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/media_store_container_policy.html">aws_media_store_container_policy</a>
                                 </li>
                             </ul>

--- a/website/docs/r/media_store_container_lifecycle_policy.html.markdown
+++ b/website/docs/r/media_store_container_lifecycle_policy.html.markdown
@@ -1,0 +1,95 @@
+---
+subcategory: "MediaStore"
+layout: "aws"
+page_title: "AWS: aws_media_store_container_lifecycle_policy"
+description: |-
+  Provides a MediaStore Container Lifecycle Policy.
+---
+
+# Resource: aws_media_store_container_lifecycle_policy
+
+Provides a MediaStore Container Lifecycle Policy.
+
+## Example Usage
+
+```hcl
+resource "aws_media_store_container" "example" {
+  name = "example"
+}
+
+resource "aws_media_store_container_lifecycle_policy" "example" {
+  container_name = "${aws_media_store_container.example.name}"
+
+  policy = <<EOF
+{
+    "rules": [
+         {
+            "definition": {
+                "path": [ 
+                    {"prefix": "Football/"}, 
+                    {"prefix": "Baseball/"}
+                ],
+                "days_since_create": [
+                    {"numeric": [">" , 28]}
+                ]
+            },
+            "action": "EXPIRE"
+        },
+        {
+            "definition": {
+                "path": [ { "prefix": "AwardsShow/" }  ],
+                "days_since_create": [
+                    {"numeric": [">=" , 15]}
+                ]
+            },
+            "action": "EXPIRE"
+        },
+        {
+            "definition": {
+                "path": [ { "prefix": "" }  ],
+                "days_since_create": [
+                    {"numeric": [">" , 40]}
+                ]
+            },
+            "action": "EXPIRE"
+        },
+        {
+            "definition": {
+                "path": [ { "wildcard": "Football/*.ts" }  ],
+                "days_since_create": [
+                    {"numeric": [">" , 20]}
+                ]
+            },
+            "action": "EXPIRE"
+        },
+        {
+            "definition": {
+                "path": [ 
+                    {"wildcard": "Football/index*.m3u8"}
+                ],
+                "seconds_since_create": [
+                    {"numeric": [">" , 15]}
+                ]
+            },
+            "action": "EXPIRE"
+        }
+    ]
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `container_name` - (Required) The name of the container.
+* `policy` - (Required) A JSON formatted Lifecycle Policy. For more information about Lifecycle Policy, see the [Object Lifecycle Policies in AWS Elemental MediaStore](https://docs.aws.amazon.com/mediastore/latest/ug/policies-object-lifecycle.html)
+
+## Import
+
+MediaStore Container Lifecycle Policy can be imported using the MediaStore Container Name, e.g.
+
+```
+$ terraform import aws_media_store_container_lifecycle_policy.example example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12591

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_media_store_container_lifecycle_policy: add support `aws_media_store_container_lifecycle_policy` resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSMediaStoreContainerLifecyclePolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSMediaStoreContainerLifecyclePolicy_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSMediaStoreContainerLifecyclePolicy_basic
=== PAUSE TestAccAWSMediaStoreContainerLifecyclePolicy_basic
=== RUN   TestAccAWSMediaStoreContainerLifecyclePolicy_disappears
=== PAUSE TestAccAWSMediaStoreContainerLifecyclePolicy_disappears
=== CONT  TestAccAWSMediaStoreContainerLifecyclePolicy_basic
=== CONT  TestAccAWSMediaStoreContainerLifecyclePolicy_disappears
--- PASS: TestAccAWSMediaStoreContainerLifecyclePolicy_disappears (111.55s)
--- PASS: TestAccAWSMediaStoreContainerLifecyclePolicy_basic (147.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	148.576s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.128s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.225s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.315s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.140s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.143s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.349s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.342s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.133s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.079s [no tests to run]
```
