### PR TITLE
r/mq_broker - allow updating engine version

### DIFF
--- a/.changelog/12758.txt
+++ b/.changelog/12758.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_mq_broker: Support updating broker
+resource/aws_mq_broker: Support updating broker engine version
 ```

--- a/.changelog/12758.txt
+++ b/.changelog/12758.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_mq_broker: Support updating broker engine version
+resource/aws_mq_broker: Support updating broker engine version without recreating broker
 ```

--- a/.changelog/12758.txt
+++ b/.changelog/12758.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_mq_broker: Support updating broker
+```

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -116,7 +116,6 @@ func resourceAwsMqBroker() *schema.Resource {
 			"engine_version": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"host_instance_type": {
 				Type:     schema.TypeString,
@@ -518,11 +517,12 @@ func resourceAwsMqBrokerUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChanges("configuration", "logs") {
+	if d.HasChanges("configuration", "logs", "engine_version") {
 		_, err := conn.UpdateBroker(&mq.UpdateBrokerRequest{
 			BrokerId:      aws.String(d.Id()),
 			Configuration: expandMqConfigurationId(d.Get("configuration").([]interface{})),
 			Logs:          expandMqLogs(d.Get("logs").([]interface{})),
+			EngineVersion: aws.String(d.Get("engine_version").(string)),
 		})
 		if err != nil {
 			return fmt.Errorf("error updating MQ Broker (%s) configuration: %w", d.Id(), err)

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -298,7 +298,6 @@ func resourceAwsMqBroker() *schema.Resource {
 								Type:         schema.TypeString,
 								ValidateFunc: validation.StringLenBetween(2, 100),
 							},
-							Set:      schema.HashString,
 							Optional: true,
 						},
 						"password": {

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -345,7 +345,7 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 		input.DeploymentMode = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("logs"); ok && len(v.([]interface{})) > 0 {
-		input.Logs = expandMqLogs(d.Get("logs").([]interface{}))
+		input.Logs = expandMqLogs(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("ldap_server_metadata"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.LdapServerMetadata = expandMQLDAPServerMetadata(v.([]interface{})[0].(map[string]interface{}))
@@ -354,7 +354,7 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 		input.MaintenanceWindowStartTime = expandMqWeeklyStartTime(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("security_groups"); ok && v.(*schema.Set).Len() > 0 {
-		input.SecurityGroups = expandStringSet(d.Get("security_groups").(*schema.Set))
+		input.SecurityGroups = expandStringSet(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk("storage_type"); ok {
 		input.StorageType = aws.String(v.(string))
@@ -895,13 +895,13 @@ func flattenMqBrokerInstances(instances []*mq.BrokerInstance) []interface{} {
 	for i, instance := range instances {
 		m := make(map[string]interface{})
 		if instance.ConsoleURL != nil {
-			m["console_url"] = *instance.ConsoleURL
+			m["console_url"] = aws.StringValue(instance.ConsoleURL)
 		}
 		if len(instance.Endpoints) > 0 {
 			m["endpoints"] = aws.StringValueSlice(instance.Endpoints)
 		}
 		if instance.IpAddress != nil {
-			m["ip_address"] = *instance.IpAddress
+			m["ip_address"] = aws.StringValue(instance.IpAddress)
 		}
 		l[i] = m
 	}

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -867,6 +867,40 @@ func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 	})
 }
 
+func TestAccAWSMqBroker_updateEngineVersion(t *testing.T) {
+	var broker mq.DescribeBrokerResponse
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_mq_broker.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMqBrokerConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqBrokerExists(resourceName, &broker),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+			{
+				Config: testAccMqBrokerEngineVersionUpdateConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqBrokerExists(resourceName, &broker),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.9"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSMqBroker_disappears(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -892,7 +892,7 @@ func TestAccAWSMqBroker_disappears(t *testing.T) {
 				Config: testAccMqBrokerConfig(sgName, brokerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
-					testAccCheckAwsMqBrokerDisappears(&broker),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsMqBroker(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -983,17 +983,6 @@ func testAccCheckAwsMqBrokerExists(name string, broker *mq.DescribeBrokerRespons
 		*broker = *resp
 
 		return nil
-	}
-}
-
-func testAccCheckAwsMqBrokerDisappears(broker *mq.DescribeBrokerResponse) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).mqconn
-		_, err := conn.DeleteBroker(&mq.DeleteBrokerInput{
-			BrokerId: broker.BrokerId,
-		})
-
-		return err
 	}
 }
 

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -254,8 +254,7 @@ func TestDiffAwsMqBrokerUsers(t *testing.T) {
 
 func TestAccAWSMqBroker_basic(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	sgName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -264,12 +263,12 @@ func TestAccAWSMqBroker_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerConfig(sgName, brokerName),
+				Config: testAccMqBrokerConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "simple"),
-					resource.TestCheckResourceAttr(resourceName, "broker_name", brokerName),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexp.MustCompile(`^c-[a-z0-9-]+$`)),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.revision", regexp.MustCompile(`^[0-9]+$`)),
@@ -385,10 +384,8 @@ func TestAccAWSMqBroker_throughputOptimized(t *testing.T) {
 
 func TestAccAWSMqBroker_allFieldsDefaultVpc(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	sgName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	cfgNameBefore := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	cfgNameAfter := fmt.Sprintf("tf-acc-test-updated-%s", acctest.RandString(5))
-	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rNameUpdated := acctest.RandomWithPrefix("tf-acc-test-updated")
 	resourceName := "aws_mq_broker.test"
 
 	cfgBodyBefore := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -409,11 +406,11 @@ func TestAccAWSMqBroker_allFieldsDefaultVpc(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerConfig_allFieldsDefaultVpc(sgName, cfgNameBefore, cfgBodyBefore, brokerName),
+				Config: testAccMqBrokerConfig_allFieldsDefaultVpc(rName, rName, cfgBodyBefore),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
-					resource.TestCheckResourceAttr(resourceName, "broker_name", brokerName),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexp.MustCompile(`^c-[a-z0-9-]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "2"),
@@ -480,10 +477,10 @@ func TestAccAWSMqBroker_allFieldsDefaultVpc(t *testing.T) {
 			},
 			{
 				// Update configuration in-place
-				Config: testAccMqBrokerConfig_allFieldsDefaultVpc(sgName, cfgNameBefore, cfgBodyAfter, brokerName),
+				Config: testAccMqBrokerConfig_allFieldsDefaultVpc(rName, rName, cfgBodyAfter),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, "broker_name", brokerName),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexp.MustCompile(`^c-[a-z0-9-]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "3"),
@@ -491,10 +488,10 @@ func TestAccAWSMqBroker_allFieldsDefaultVpc(t *testing.T) {
 			},
 			{
 				// Replace configuration
-				Config: testAccMqBrokerConfig_allFieldsDefaultVpc(sgName, cfgNameAfter, cfgBodyAfter, brokerName),
+				Config: testAccMqBrokerConfig_allFieldsDefaultVpc(rName, rNameUpdated, cfgBodyAfter),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, "broker_name", brokerName),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexp.MustCompile(`^c-[a-z0-9-]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "2"),
@@ -830,8 +827,7 @@ func TestAccAWSMqBroker_updateTags(t *testing.T) {
 
 func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	sgName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -840,7 +836,7 @@ func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerConfig(sgName, brokerName),
+				Config: testAccMqBrokerConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
@@ -853,7 +849,7 @@ func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
 			},
 			{
-				Config: testAccMqBrokerConfig_updateSecurityGroups(sgName, brokerName),
+				Config: testAccMqBrokerConfig_updateSecurityGroups(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
@@ -862,7 +858,7 @@ func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 			// Trigger a reboot and ensure the password change was applied
 			// User hashcode can be retrieved by calling resourceAwsMqUserHash
 			{
-				Config: testAccMqBrokerConfig_updateUsersSecurityGroups(sgName, brokerName),
+				Config: testAccMqBrokerConfig_updateUsersSecurityGroups(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
@@ -879,8 +875,7 @@ func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 
 func TestAccAWSMqBroker_disappears(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	sgName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -889,7 +884,7 @@ func TestAccAWSMqBroker_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerConfig(sgName, brokerName),
+				Config: testAccMqBrokerConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					testAccCheckAwsMqBrokerDisappears(&broker),
@@ -902,8 +897,7 @@ func TestAccAWSMqBroker_disappears(t *testing.T) {
 
 func TestAccAWSMqBroker_rabbitmq(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	sgName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -912,7 +906,7 @@ func TestAccAWSMqBroker_rabbitmq(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerConfigRabbit(sgName, brokerName),
+				Config: testAccMqBrokerConfigRabbit(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "0"),
@@ -1013,14 +1007,14 @@ func testAccPreCheckAWSMq(t *testing.T) {
 	}
 }
 
-func testAccMqBrokerConfig(sgName, brokerName string) string {
+func testAccMqBrokerConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name             = %[2]q
+  broker_name             = %[1]q
   engine_type             = "ActiveMQ"
   engine_version          = "5.15.0"
   host_instance_type      = "mq.t2.micro"
@@ -1037,7 +1031,7 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, sgName, brokerName)
+`, rName)
 }
 
 func testAccMqBrokerEBSConfig(sgName, brokerName string) string {
@@ -1048,14 +1042,14 @@ resource "aws_security_group" "test" {
 
 resource "aws_mq_broker" "test" {
   broker_name        = "%s"
-<<<<<<< HEAD
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.9"
   storage_type       = "ebs"
-=======
-  apply_immediately  = true
-  engine_type        = "ActiveMQ"
-  engine_version     = "5.15.9"
+  host_instance_type = "mq.m5.large"
+  security_groups    = [aws_security_group.test.id]
+
+  logs {
+    general = true
   }
 
   user {
@@ -1092,30 +1086,30 @@ resource "aws_mq_broker" "test" {
 `, rName)
 }
 
-func testAccMqBrokerConfig_allFieldsDefaultVpc(sgName, cfgName, cfgBody, brokerName string) string {
+func testAccMqBrokerConfig_allFieldsDefaultVpc(rName, cfgName, cfgBody string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "mq1" {
-  name = "%s-1"
+  name = %[1]q
 }
 
 resource "aws_security_group" "mq2" {
-  name = "%s-2"
+  name = "%[1]s-2"
 }
 
 resource "aws_mq_configuration" "test" {
-  name           = "%s"
+  name           = %[2]q
   engine_type    = "ActiveMQ"
   engine_version = "5.15.0"
 
   data = <<DATA
-%s
+%[3]s
 DATA
 }
 
 resource "aws_mq_broker" "test" {
   auto_minor_version_upgrade = true
   apply_immediately          = true
-  broker_name                = "%s"
+  broker_name                = %[1]q
 
   configuration {
     id       = aws_mq_configuration.test.id
@@ -1149,7 +1143,7 @@ resource "aws_mq_broker" "test" {
     groups         = ["first", "second", "third"]
   }
 }
-`, sgName, sgName, cfgName, cfgBody, brokerName)
+`, rName, cfgName, cfgBody)
 }
 
 func testAccMqBrokerConfig_allFieldsCustomVpc(sgName, cfgName, cfgBody, brokerName string) string {
@@ -1485,19 +1479,19 @@ resource "aws_mq_broker" "test" {
 `, sgName, brokerName)
 }
 
-func testAccMqBrokerConfig_updateSecurityGroups(sgName, brokerName string) string {
+func testAccMqBrokerConfig_updateSecurityGroups(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_security_group" "test2" {
-  name = "%s-2"
+  name = "%[1]s-2"
 }
 
 resource "aws_mq_broker" "test" {
   apply_immediately  = true
-  broker_name        = "%s"
+  broker_name        = %[1]q
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
@@ -1512,22 +1506,22 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, sgName, sgName, brokerName)
+`, rName)
 }
 
-func testAccMqBrokerConfig_updateUsersSecurityGroups(sgName, brokerName string) string {
+func testAccMqBrokerConfig_updateUsersSecurityGroups(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_security_group" "test2" {
-  name = "%s-2"
+  name = "%[1]s-2"
 }
 
 resource "aws_mq_broker" "test" {
   apply_immediately  = true
-  broker_name        = "%s"
+  broker_name        = %[1]q
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
@@ -1542,17 +1536,17 @@ resource "aws_mq_broker" "test" {
     password = "TestTest9999"
   }
 }
-`, sgName, sgName, brokerName)
+`, rName)
 }
 
-func testAccMqBrokerConfigRabbit(sgName, brokerName string) string {
+func testAccMqBrokerConfigRabbit(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = "%s"
+  broker_name        = %[1]q
   engine_type        = "RabbitMQ"
   engine_version     = "3.8.6"
   host_instance_type = "mq.t3.micro"
@@ -1563,5 +1557,5 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, sgName, brokerName)
+`, rName)
 }

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -1048,11 +1048,37 @@ resource "aws_security_group" "test" {
 
 resource "aws_mq_broker" "test" {
   broker_name        = "%s"
+<<<<<<< HEAD
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.9"
   storage_type       = "ebs"
-  host_instance_type = "mq.m5.large"
-  security_groups    = ["${aws_security_group.test.id}"]
+=======
+  apply_immediately  = true
+  engine_type        = "ActiveMQ"
+  engine_version     = "5.15.9"
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, sgName, brokerName)
+}
+
+func testAccMqBrokerEngineVersionUpdateConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_mq_broker" "test" {
+  broker_name        = %[1]q
+  apply_immediately  = true
+  engine_type        = "ActiveMQ"
+  engine_version     = "5.15.9"
+  host_instance_type = "mq.t2.micro"
+  security_groups    = [aws_security_group.test.id]
 
   logs {
     general = true
@@ -1063,7 +1089,7 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, sgName, brokerName)
+`, rName)
 }
 
 func testAccMqBrokerConfig_allFieldsDefaultVpc(sgName, cfgName, cfgBody, brokerName string) string {

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -258,7 +258,11 @@ func TestAccAWSMqBroker_basic(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -326,7 +330,11 @@ func TestAccAWSMqBroker_throughputOptimized(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -400,7 +408,11 @@ func TestAccAWSMqBroker_allFieldsDefaultVpc(t *testing.T) {
 </broker>`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -519,7 +531,11 @@ func TestAccAWSMqBroker_allFieldsCustomVpc(t *testing.T) {
 </broker>`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -626,7 +642,11 @@ func TestAccAWSMqBroker_EncryptionOptions_KmsKeyId(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -655,7 +675,11 @@ func TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Disabled(t *testing.T) 
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -683,7 +707,11 @@ func TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Enabled(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -711,7 +739,11 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -779,7 +811,11 @@ func TestAccAWSMqBroker_tags(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -824,7 +860,11 @@ func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -872,7 +912,11 @@ func TestAccAWSMqBroker_updateEngineVersion(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -906,7 +950,11 @@ func TestAccAWSMqBroker_disappears(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -928,7 +976,11 @@ func TestAccAWSMqBroker_rabbitmq(t *testing.T) {
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -322,8 +322,7 @@ func TestAccAWSMqBroker_basic(t *testing.T) {
 
 func TestAccAWSMqBroker_throughputOptimized(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	sgName := fmt.Sprintf("tf-acc-test-ebs-%s", acctest.RandString(5))
-	brokerName := fmt.Sprintf("tf-acc-test-ebs-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -332,11 +331,11 @@ func TestAccAWSMqBroker_throughputOptimized(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerEBSConfig(sgName, brokerName),
+				Config: testAccMqBrokerEBSConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
-					resource.TestCheckResourceAttr(resourceName, "broker_name", brokerName),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexp.MustCompile(`^c-[a-z0-9-]+$`)),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.revision", regexp.MustCompile(`^[0-9]+$`)),
@@ -1051,14 +1050,14 @@ resource "aws_mq_broker" "test" {
 `, rName)
 }
 
-func testAccMqBrokerEBSConfig(sgName, brokerName string) string {
+func testAccMqBrokerEBSConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_mq_broker" "test" {
-  broker_name        = "%s"
+  broker_name        = %[1]q
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.9"
   storage_type       = "ebs"
@@ -1074,7 +1073,7 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
   }
 }
-`, sgName, brokerName)
+`, rName)
 }
 
 func testAccMqBrokerEngineVersionUpdateConfig(rName string) string {

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -915,7 +915,7 @@ func TestAccAWSMqBroker_disappears(t *testing.T) {
 				Config: testAccMqBrokerConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
-					testAccCheckAwsMqBrokerDisappears(&broker),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsMqBroker(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -1005,17 +1005,6 @@ func testAccCheckAwsMqBrokerExists(name string, broker *mq.DescribeBrokerRespons
 		*broker = *resp
 
 		return nil
-	}
-}
-
-func testAccCheckAwsMqBrokerDisappears(broker *mq.DescribeBrokerResponse) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).mqconn
-		_, err := conn.DeleteBroker(&mq.DeleteBrokerInput{
-			BrokerId: broker.BrokerId,
-		})
-
-		return err
 	}
 }
 

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -1407,37 +1407,7 @@ resource "aws_mq_broker" "test" {
     groups   = ["admin"]
   }
 }
-<<<<<<< HEAD
-`, sgName, brokerName)
-}
-
-func testAccMqBrokerConfig_updateTags1(sgName, brokerName string) string {
-	return fmt.Sprintf(`
-resource "aws_security_group" "test" {
-  name = "%s"
-}
-
-resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = "%s"
-  engine_type        = "ActiveMQ"
-  engine_version     = "5.15.0"
-  host_instance_type = "mq.t2.micro"
-  security_groups    = [aws_security_group.test.id]
-
-  user {
-    username = "Test"
-    password = "TestTest1234"
-  }
-
-  tags = {
-    env = "test"
-  }
-}
-`, sgName, brokerName)
-=======
 `, rName)
->>>>>>> af3ba3366... refactor more names + tags tests to std
 }
 
 func testAccMqBrokerConfigTags1(rName, tagKey1, tagValue1 string) string {

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -503,10 +503,8 @@ func TestAccAWSMqBroker_allFieldsDefaultVpc(t *testing.T) {
 
 func TestAccAWSMqBroker_allFieldsCustomVpc(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	sgName := fmt.Sprintf("tf-acc-test-vpc-%s", acctest.RandString(5))
-	cfgNameBefore := fmt.Sprintf("tf-acc-test-vpc-%s", acctest.RandString(5))
-	cfgNameAfter := fmt.Sprintf("tf-acc-test-vpc-updated-%s", acctest.RandString(5))
-	brokerName := fmt.Sprintf("tf-acc-test-vpc-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rNameUpdated := acctest.RandomWithPrefix("tf-acc-test-updated")
 	resourceName := "aws_mq_broker.test"
 
 	cfgBodyBefore := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -527,11 +525,11 @@ func TestAccAWSMqBroker_allFieldsCustomVpc(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerConfig_allFieldsCustomVpc(sgName, cfgNameBefore, cfgBodyBefore, brokerName),
+				Config: testAccMqBrokerConfig_allFieldsCustomVpc(rName, rName, cfgBodyBefore),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
-					resource.TestCheckResourceAttr(resourceName, "broker_name", brokerName),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexp.MustCompile(`^c-[a-z0-9-]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "2"),
@@ -598,10 +596,10 @@ func TestAccAWSMqBroker_allFieldsCustomVpc(t *testing.T) {
 			},
 			{
 				// Update configuration in-place
-				Config: testAccMqBrokerConfig_allFieldsCustomVpc(sgName, cfgNameBefore, cfgBodyAfter, brokerName),
+				Config: testAccMqBrokerConfig_allFieldsCustomVpc(rName, rName, cfgBodyAfter),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, "broker_name", brokerName),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexp.MustCompile(`^c-[a-z0-9-]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "3"),
@@ -609,10 +607,10 @@ func TestAccAWSMqBroker_allFieldsCustomVpc(t *testing.T) {
 			},
 			{
 				// Replace configuration
-				Config: testAccMqBrokerConfig_allFieldsCustomVpc(sgName, cfgNameAfter, cfgBodyAfter, brokerName),
+				Config: testAccMqBrokerConfig_allFieldsCustomVpc(rName, rNameUpdated, cfgBodyAfter),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, "broker_name", brokerName),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexp.MustCompile(`^c-[a-z0-9-]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.revision", "2"),
@@ -710,8 +708,7 @@ func TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Enabled(t *testing.T) {
 
 func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	sgName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -720,7 +717,7 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerConfig_updateUsers1(sgName, brokerName),
+				Config: testAccMqBrokerConfig_updateUsers1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
@@ -740,7 +737,7 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 			},
 			// Adding new user + modify existing
 			{
-				Config: testAccMqBrokerConfig_updateUsers2(sgName, brokerName),
+				Config: testAccMqBrokerConfig_updateUsers2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
@@ -760,7 +757,7 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 			},
 			// Deleting user + modify existing
 			{
-				Config: testAccMqBrokerConfig_updateUsers3(sgName, brokerName),
+				Config: testAccMqBrokerConfig_updateUsers3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
@@ -777,10 +774,9 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 	})
 }
 
-func TestAccAWSMqBroker_updateTags(t *testing.T) {
+func TestAccAWSMqBroker_tags(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	sgName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -789,11 +785,11 @@ func TestAccAWSMqBroker_updateTags(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerConfig_updateTags1(sgName, brokerName),
+				Config: testAccMqBrokerConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.env", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
@@ -802,23 +798,21 @@ func TestAccAWSMqBroker_updateTags(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
 			},
-			// Modify existing tags
 			{
-				Config: testAccMqBrokerConfig_updateTags2(sgName, brokerName),
+				Config: testAccMqBrokerConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.env", "test2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.role", "test-role"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
-			// Deleting tags
 			{
-				Config: testAccMqBrokerConfig_updateTags3(sgName, brokerName),
+				Config: testAccMqBrokerConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.role", "test-role"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},
@@ -1146,7 +1140,7 @@ resource "aws_mq_broker" "test" {
 `, rName, cfgName, cfgBody)
 }
 
-func testAccMqBrokerConfig_allFieldsCustomVpc(sgName, cfgName, cfgBody, brokerName string) string {
+func testAccMqBrokerConfig_allFieldsCustomVpc(rName, cfgName, cfgBody string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -1161,12 +1155,16 @@ resource "aws_vpc" "main" {
   cidr_block = "10.11.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-mq-broker-all-fields-custom-vpc"
+    Name = %[1]q
   }
 }
 
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_route_table" "test" {
@@ -1175,6 +1173,10 @@ resource "aws_route_table" "test" {
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.test.id
+  }
+
+  tags = {
+    Name = %[1]q
   }
 }
 
@@ -1185,7 +1187,7 @@ resource "aws_subnet" "private" {
   vpc_id            = aws_vpc.main.id
 
   tags = {
-    Name = "tf-acc-mq-broker-all-fields-custom-vpc-${count.index}"
+    Name = %[1]q
   }
 }
 
@@ -1196,29 +1198,37 @@ resource "aws_route_table_association" "test" {
 }
 
 resource "aws_security_group" "mq1" {
-  name   = "%s-1"
+  name   = "%[1]s-1"
   vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_security_group" "mq2" {
-  name   = "%s-2"
+  name   = "%[1]s-2"
   vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_mq_configuration" "test" {
-  name           = "%s"
+  name           = %[2]q
   engine_type    = "ActiveMQ"
   engine_version = "5.15.0"
 
   data = <<DATA
-%s
+%[3]s
 DATA
 }
 
 resource "aws_mq_broker" "test" {
   auto_minor_version_upgrade = true
   apply_immediately          = true
-  broker_name                = "%s"
+  broker_name                = %[1]q
 
   configuration {
     id       = aws_mq_configuration.test.id
@@ -1260,7 +1270,7 @@ resource "aws_mq_broker" "test" {
 
   depends_on = [aws_internet_gateway.test]
 }
-`, sgName, sgName, cfgName, cfgBody, brokerName)
+`, rName, cfgName, cfgBody)
 }
 
 func testAccMqBrokerConfigEncryptionOptionsKmsKeyId(rName string) string {
@@ -1327,15 +1337,15 @@ resource "aws_mq_broker" "test" {
 `, rName, useAwsOwnedKey)
 }
 
-func testAccMqBrokerConfig_updateUsers1(sgName, brokerName string) string {
+func testAccMqBrokerConfig_updateUsers1(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_mq_broker" "test" {
   apply_immediately  = true
-  broker_name        = "%s"
+  broker_name        = %[1]q
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
@@ -1346,18 +1356,18 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1111"
   }
 }
-`, sgName, brokerName)
+`, rName)
 }
 
-func testAccMqBrokerConfig_updateUsers2(sgName, brokerName string) string {
+func testAccMqBrokerConfig_updateUsers2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_mq_broker" "test" {
   apply_immediately  = true
-  broker_name        = "%s"
+  broker_name        = %[1]q
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
@@ -1374,18 +1384,18 @@ resource "aws_mq_broker" "test" {
     password = "TestTest2222"
   }
 }
-`, sgName, brokerName)
+`, rName)
 }
 
-func testAccMqBrokerConfig_updateUsers3(sgName, brokerName string) string {
+func testAccMqBrokerConfig_updateUsers3(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_mq_broker" "test" {
   apply_immediately  = true
-  broker_name        = "%s"
+  broker_name        = %[1]q
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
@@ -1397,6 +1407,7 @@ resource "aws_mq_broker" "test" {
     groups   = ["admin"]
   }
 }
+<<<<<<< HEAD
 `, sgName, brokerName)
 }
 
@@ -1424,17 +1435,20 @@ resource "aws_mq_broker" "test" {
   }
 }
 `, sgName, brokerName)
+=======
+`, rName)
+>>>>>>> af3ba3366... refactor more names + tags tests to std
 }
 
-func testAccMqBrokerConfig_updateTags2(sgName, brokerName string) string {
+func testAccMqBrokerConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_mq_broker" "test" {
   apply_immediately  = true
-  broker_name        = "%s"
+  broker_name        = %[1]q
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
@@ -1446,22 +1460,21 @@ resource "aws_mq_broker" "test" {
   }
 
   tags = {
-    env  = "test2"
-    role = "test-role"
+    %[2]q = %[3]q
   }
 }
-`, sgName, brokerName)
+`, rName, tagKey1, tagValue1)
 }
 
-func testAccMqBrokerConfig_updateTags3(sgName, brokerName string) string {
+func testAccMqBrokerConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_mq_broker" "test" {
   apply_immediately  = true
-  broker_name        = "%s"
+  broker_name        = %[1]q
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
@@ -1473,10 +1486,11 @@ resource "aws_mq_broker" "test" {
   }
 
   tags = {
-    role = "test-role"
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, sgName, brokerName)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
 func testAccMqBrokerConfig_updateSecurityGroups(rName string) string {

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -892,7 +892,7 @@ func TestAccAWSMqBroker_disappears(t *testing.T) {
 				Config: testAccMqBrokerConfig(sgName, brokerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsMqBroker(), resourceName),
+					testAccCheckAwsMqBrokerDisappears(&broker),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -983,6 +983,17 @@ func testAccCheckAwsMqBrokerExists(name string, broker *mq.DescribeBrokerRespons
 		*broker = *resp
 
 		return nil
+	}
+}
+
+func testAccCheckAwsMqBrokerDisappears(broker *mq.DescribeBrokerResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).mqconn
+		_, err := conn.DeleteBroker(&mq.DeleteBrokerInput{
+			BrokerId: broker.BrokerId,
+		})
+
+		return err
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11827

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resouce_aws_mq_broker - allow updating engine version
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSMqBroker_updateEngineVersion'
--- PASS: TestAccAWSMqBroker_updateEngineVersion (1394.18s)
```
