### PR TITLE
add database description field to aws_athena_database

### DIFF
--- a/internal/service/athena/database.go
+++ b/internal/service/athena/database.go
@@ -33,6 +33,10 @@ func ResourceDatabase() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"comment": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"force_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -93,8 +97,15 @@ func expandAthenaResultConfiguration(bucket string, encryptionConfigurationList 
 func resourceDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).AthenaConn
 
+	var databaseDescription string
+	if v, ok := d.GetOk("comment"); ok {
+		databaseDescription = strings.Replace(v.(string), "'", "\\'", -1)
+	} else {
+		databaseDescription = ""
+	}
+
 	input := &athena.StartQueryExecutionInput{
-		QueryString:         aws.String(fmt.Sprintf("create database `%s`;", d.Get("name").(string))),
+		QueryString:         aws.String(fmt.Sprintf("create database `%[1]s`  comment '%[2]s';", d.Get("name").(string), databaseDescription)),
 		ResultConfiguration: expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_configuration").([]interface{})),
 	}
 

--- a/internal/service/athena/database_test.go
+++ b/internal/service/athena/database_test.go
@@ -35,6 +35,46 @@ func TestAccAthenaDatabase_basic(t *testing.T) {
 	})
 }
 
+func TestAccAthenaDatabase_description(t *testing.T) {
+	rInt := sdkacctest.RandInt()
+	dbName := sdkacctest.RandString(8)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, athena.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaDatabaseCommentConfig(rInt, dbName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseExists("aws_athena_database.hoge"),
+					resource.TestCheckResourceAttr("aws_athena_database.hoge", "name", dbName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAthenaDatabase_unescaped_description(t *testing.T) {
+	rInt := sdkacctest.RandInt()
+	dbName := sdkacctest.RandString(8)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, athena.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaDatabaseUnescapedCommentConfig(rInt, dbName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseExists("aws_athena_database.hoge"),
+					resource.TestCheckResourceAttr("aws_athena_database.hoge", "name", dbName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAthenaDatabase_encryption(t *testing.T) {
 	rInt := sdkacctest.RandInt()
 	dbName := sdkacctest.RandString(8)
@@ -349,6 +389,38 @@ resource "aws_s3_bucket" "hoge" {
 resource "aws_athena_database" "hoge" {
   name          = "%[2]s"
   bucket        = aws_s3_bucket.hoge.bucket
+  force_destroy = %[3]t
+}
+`, randInt, dbName, forceDestroy)
+}
+
+func testAccAthenaDatabaseCommentConfig(randInt int, dbName string, forceDestroy bool) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "hoge" {
+  bucket        = "tf-test-athena-db-%[1]d"
+  force_destroy = true
+}
+
+resource "aws_athena_database" "hoge" {
+  name          = "%[2]s"
+  bucket        = aws_s3_bucket.hoge.bucket
+  comment       = "athena is a goddess"
+  force_destroy = %[3]t
+}
+`, randInt, dbName, forceDestroy)
+}
+
+func testAccAthenaDatabaseUnescapedCommentConfig(randInt int, dbName string, forceDestroy bool) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "hoge" {
+  bucket        = "tf-test-athena-db-%[1]d"
+  force_destroy = true
+}
+
+resource "aws_athena_database" "hoge" {
+  name          = "%[2]s"
+  bucket        = aws_s3_bucket.hoge.bucket
+  comment       = "athena's a goddess"
   force_destroy = %[3]t
 }
 `, randInt, dbName, forceDestroy)

--- a/website/docs/r/athena_database.html.markdown
+++ b/website/docs/r/athena_database.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the database to create.
 * `bucket` - (Required) Name of s3 bucket to save the results of the query execution.
+* `comment` - (Optional) Description of the database.
 * `encryption_configuration` - (Optional) The encryption key block AWS Athena uses to decrypt the data in S3, such as an AWS Key Management Service (AWS KMS) key. An `encryption_configuration` block is documented below.
 * `force_destroy` - (Optional, Default: false) A boolean that indicates all tables should be deleted from the database so that the database can be destroyed without error. The tables are *not* recoverable.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12374

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
 adds database description field to aws_athena_database resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAthenaDatabase'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAthenaDatabase -timeout 120m
=== RUN   TestAccAWSAthenaDatabase_basic
=== PAUSE TestAccAWSAthenaDatabase_basic
=== RUN   TestAccAWSAthenaDatabase_description
=== PAUSE TestAccAWSAthenaDatabase_description
=== RUN   TestAccAWSAthenaDatabase_unescaped_description
=== PAUSE TestAccAWSAthenaDatabase_unescaped_description
=== RUN   TestAccAWSAthenaDatabase_encryption
=== PAUSE TestAccAWSAthenaDatabase_encryption
=== RUN   TestAccAWSAthenaDatabase_nameStartsWithUnderscore
=== PAUSE TestAccAWSAthenaDatabase_nameStartsWithUnderscore
=== RUN   TestAccAWSAthenaDatabase_nameCantHaveUppercase
=== PAUSE TestAccAWSAthenaDatabase_nameCantHaveUppercase
=== RUN   TestAccAWSAthenaDatabase_destroyFailsIfTablesExist
=== PAUSE TestAccAWSAthenaDatabase_destroyFailsIfTablesExist
=== RUN   TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds
=== PAUSE TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds
=== CONT  TestAccAWSAthenaDatabase_basic
=== CONT  TestAccAWSAthenaDatabase_nameCantHaveUppercase
=== CONT  TestAccAWSAthenaDatabase_encryption
=== CONT  TestAccAWSAthenaDatabase_nameStartsWithUnderscore
=== CONT  TestAccAWSAthenaDatabase_description
=== CONT  TestAccAWSAthenaDatabase_unescaped_description
=== CONT  TestAccAWSAthenaDatabase_destroyFailsIfTablesExist
=== CONT  TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds
--- PASS: TestAccAWSAthenaDatabase_nameCantHaveUppercase (2.80s)
--- PASS: TestAccAWSAthenaDatabase_nameStartsWithUnderscore (46.29s)
--- PASS: TestAccAWSAthenaDatabase_unescaped_description (46.62s)
--- PASS: TestAccAWSAthenaDatabase_description (46.70s)
--- PASS: TestAccAWSAthenaDatabase_basic (47.37s)
--- PASS: TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds (49.60s)
--- PASS: TestAccAWSAthenaDatabase_destroyFailsIfTablesExist (57.79s)
--- PASS: TestAccAWSAthenaDatabase_encryption (69.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.619s

...
```
