### PR TITLE
r/spot_instance_request: add import support + refactor tests

### DIFF
--- a/.changelog/12787.txt
+++ b/.changelog/12787.txt
@@ -2,5 +2,5 @@
 resource/aws_spot_instance_request: Add import support
 ```
 ```release-note:enhancement
-resource/aws_spot_instance_request: Add plan time validation for `spot_type`
+resource/aws_spot_instance_request: Add plan time validation for `spot_type` and `block_duration_minutes`
 ```

--- a/.changelog/12787.txt
+++ b/.changelog/12787.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+resource/aws_spot_instance_request: Add import support
+```
+```release-note:enhancement
+resource/aws_spot_instance_request: Add plan time validation for `spot_type`
+```

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -419,7 +419,7 @@ resource "aws_eip_association" "test" {
 `)
 }
 
-func testAccAWSEIPAssociationConfig_spotInstance(rInt int) string {
+func testAccAWSEIPAssociationConfig_spotInstance(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
@@ -440,7 +440,7 @@ resource "aws_internet_gateway" "test" {
 }
 
 resource "aws_key_pair" "test" {
-  key_name   = "tmp-key-%d"
+  key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
@@ -461,7 +461,7 @@ resource "aws_eip_association" "test" {
   allocation_id = aws_eip.test.id
   instance_id   = aws_spot_instance_request.test.spot_instance_id
 }
-`, rInt))
+`, rName))
 }
 
 func testAccAWSEIPAssociationConfig_instance() string {

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -120,7 +120,7 @@ func TestAccAWSEIPAssociation_ec2Classic(t *testing.T) {
 
 func TestAccAWSEIPAssociation_spotInstance(t *testing.T) {
 	var a ec2.Address
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eip_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -129,7 +129,7 @@ func TestAccAWSEIPAssociation_spotInstance(t *testing.T) {
 		CheckDestroy:      testAccCheckAWSEIPAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIPAssociationConfig_spotInstance(rInt),
+				Config: testAccAWSEIPAssociationConfig_spotInstance(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEIPExists("aws_eip.test", &a),
 					testAccCheckAWSEIPAssociationExists(resourceName, &a),

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -263,6 +263,7 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 		// If the spot request was not found, return nil so that we can show
 		// that it is gone.
 		if isAWSErr(err, "InvalidSpotInstanceRequestID.NotFound", "") {
+			log.Printf("[WARN] EC2 Spot Instance Request (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
@@ -273,6 +274,7 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 
 	// If nothing was found, then return no state
 	if len(resp.SpotInstanceRequests) == 0 {
+		log.Printf("[WARN] EC2 Spot Instance Request (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -89,9 +89,10 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 				Computed: true,
 			}
 			s["block_duration_minutes"] = &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntDivisibleBy(60),
 			}
 			s["instance_interruption_behaviour"] = &schema.Schema{
 				Type:         schema.TypeString,

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -61,13 +61,10 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 				},
 			}
 			s["spot_type"] = &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  ec2.SpotInstanceTypePersistent,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.SpotInstanceTypePersistent,
-					ec2.SpotInstanceTypeOneTime,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ec2.SpotInstanceTypePersistent,
+				ValidateFunc: validation.StringInSlice(ec2.SpotInstanceType_Values(), false),
 			}
 			s["wait_for_fulfillment"] = &schema.Schema{
 				Type:     schema.TypeBool,
@@ -97,15 +94,11 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 				ForceNew: true,
 			}
 			s["instance_interruption_behaviour"] = &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  ec2.InstanceInterruptionBehaviorTerminate,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.InstanceInterruptionBehaviorTerminate,
-					ec2.InstanceInterruptionBehaviorStop,
-					ec2.InstanceInterruptionBehaviorHibernate,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ec2.InstanceInterruptionBehaviorTerminate,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ec2.InstanceInterruptionBehavior_Values(), false),
 			}
 			s["valid_from"] = &schema.Schema{
 				Type:         schema.TypeString,
@@ -365,7 +358,7 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 		for _, ni := range instance.NetworkInterfaces {
 			if *ni.Attachment.DeviceIndex == 0 {
 				d.Set("subnet_id", ni.SubnetId)
-				d.Set("network_interface_id", ni.NetworkInterfaceId)
+				d.Set("primary_network_interface_id", ni.NetworkInterfaceId)
 				d.Set("associate_public_ip_address", ni.Association != nil)
 				d.Set("ipv6_address_count", len(ni.Ipv6Addresses))
 
@@ -377,7 +370,6 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		d.Set("subnet_id", instance.SubnetId)
 		d.Set("primary_network_interface_id", "")
-		d.Set("network_interface_id", "")
 	}
 
 	if err := d.Set("ipv6_addresses", ipv6Addresses); err != nil {

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -19,6 +19,9 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 		Read:   resourceAwsSpotInstanceRequestRead,
 		Delete: resourceAwsSpotInstanceRequestDelete,
 		Update: resourceAwsSpotInstanceRequestUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -158,19 +161,19 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("valid_from"); ok {
-		valid_from, err := time.Parse(time.RFC3339, v.(string))
+		validFrom, err := time.Parse(time.RFC3339, v.(string))
 		if err != nil {
 			return err
 		}
-		spotOpts.ValidFrom = aws.Time(valid_from)
+		spotOpts.ValidFrom = aws.Time(validFrom)
 	}
 
 	if v, ok := d.GetOk("valid_until"); ok {
-		valid_until, err := time.Parse(time.RFC3339, v.(string))
+		validUntil, err := time.Parse(time.RFC3339, v.(string))
 		if err != nil {
 			return err
 		}
-		spotOpts.ValidUntil = aws.Time(valid_until)
+		spotOpts.ValidUntil = aws.Time(validUntil)
 	}
 
 	// Placement GroupName can only be specified when instanceInterruptionBehavior is not set or set to 'terminate'
@@ -342,7 +345,7 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		var ipv6Addresses []string
+		var ipv6Addresses []*string
 		if len(instance.NetworkInterfaces) > 0 {
 			for _, ni := range instance.NetworkInterfaces {
 				if *ni.Attachment.DeviceIndex == 0 {
@@ -352,7 +355,7 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 					d.Set("ipv6_address_count", len(ni.Ipv6Addresses))
 
 					for _, address := range ni.Ipv6Addresses {
-						ipv6Addresses = append(ipv6Addresses, *address.Ipv6Address)
+						ipv6Addresses = append(ipv6Addresses, address.Ipv6Address)
 					}
 				}
 			}
@@ -361,7 +364,7 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 			d.Set("primary_network_interface_id", "")
 		}
 
-		if err := d.Set("ipv6_addresses", ipv6Addresses); err != nil {
+		if err := d.Set("ipv6_addresses", flattenStringSet(ipv6Addresses)); err != nil {
 			log.Printf("[WARN] Error setting ipv6_addresses for AWS Spot Instance (%s): %s", d.Id(), err)
 		}
 

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -314,25 +314,16 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 	d.Set("instance_type", request.LaunchSpecification.InstanceType)
 	d.Set("ami", request.LaunchSpecification.ImageId)
 
-	var sgs []*string
-	for _, sg := range request.LaunchSpecification.SecurityGroups {
-		sgs = append(sgs, sg.GroupId)
-	}
-
-	if err := d.Set("vpc_security_group_ids", flattenStringSet(sgs)); err != nil {
-		return fmt.Errorf("error setting vpc_security_group_ids: %s", err)
-	}
-
-	if d.Get("get_password_data").(bool) {
-		passwordData, err := getAwsEc2InstancePasswordData(*request.InstanceId, conn)
-		if err != nil {
-			return err
-		}
-		d.Set("password_data", passwordData)
-	} else {
-		d.Set("get_password_data", false)
-		d.Set("password_data", nil)
-	}
+	//if d.Get("get_password_data").(bool) {
+	//	passwordData, err := getAwsEc2InstancePasswordData(*request.InstanceId, conn)
+	//	if err != nil {
+	//		return err
+	//	}
+	//	d.Set("password_data", passwordData)
+	//} else {
+	//	d.Set("get_password_data", false)
+	//	d.Set("password_data", nil)
+	//}
 
 	return nil
 }
@@ -401,6 +392,10 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("ipv6_addresses", ipv6Addresses); err != nil {
 		log.Printf("[WARN] Error setting ipv6_addresses for AWS Spot Instance (%s): %s", d.Id(), err)
+	}
+
+	if err := readSecurityGroups(d, instance, conn); err != nil {
+		return err
 	}
 
 	if d.Get("get_password_data").(bool) {

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -55,7 +55,7 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					ec2.SpotInstanceTypePersistent,
 					ec2.SpotInstanceTypeOneTime,
-				},false),
+				}, false),
 			}
 			s["wait_for_fulfillment"] = &schema.Schema{
 				Type:     schema.TypeBool,

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -51,6 +51,7 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 			s["spot_price"] = &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldFloat, _ := strconv.ParseFloat(old, 64)
@@ -313,17 +314,6 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 	d.Set("key_name", request.LaunchSpecification.KeyName)
 	d.Set("instance_type", request.LaunchSpecification.InstanceType)
 	d.Set("ami", request.LaunchSpecification.ImageId)
-
-	//if d.Get("get_password_data").(bool) {
-	//	passwordData, err := getAwsEc2InstancePasswordData(*request.InstanceId, conn)
-	//	if err != nil {
-	//		return err
-	//	}
-	//	d.Set("password_data", passwordData)
-	//} else {
-	//	d.Set("get_password_data", false)
-	//	d.Set("password_data", nil)
-	//}
 
 	return nil
 }

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -687,6 +687,7 @@ resource "aws_spot_instance_request" "test" {
   key_name             = "${aws_key_pair.test.key_name}"
   spot_price           = "0.05"
   wait_for_fulfillment = true
+  subnet_id            = "${aws_subnet.test.id}"
 
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -870,7 +870,6 @@ data "aws_ami" "test" {
   filter {
     name   = "name"
 	values = ["Windows_Server-2016-English-Core-Base-*"]
-
   }
 }
 

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -315,7 +315,7 @@ func TestAccAWSSpotInstanceRequest_getPasswordData(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment", "password_data", "get_password_data"},
 			},
 		},
 	})
@@ -382,51 +382,6 @@ func TestAccAWSSpotInstanceRequest_tags(t *testing.T) {
 					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSSpotInstanceRequest_volumeTags(t *testing.T) {
-	var sir ec2.SpotInstanceRequest
-	resourceName := "aws_spot_instance_request.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotInstanceRequestConfigVolumeTags1(rName, "key1", "value1"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
-					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "volume_tags.key1", "value1"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
-			},
-			{
-				Config: testAccAWSSpotInstanceRequestConfigVolumeTags2(rName, "key1", "value1updated", "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
-					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "volume_tags.key1", "value1updated"),
-					resource.TestCheckResourceAttr(resourceName, "volume_tags.key2", "value2"),
-				),
-			},
-			{
-				Config: testAccAWSSpotInstanceRequestConfigVolumeTags1(rName, "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
-					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "volume_tags.key2", "value2"),
 				),
 			},
 		},
@@ -967,39 +922,6 @@ resource "aws_spot_instance_request" "test" {
   wait_for_fulfillment = true
 
   tags = {
-    %[1]q = %[2]q
-    %[3]q = %[4]q
-  }
-}
-`, tagKey1, tagValue1, tagKey2, tagValue2)
-}
-
-func testAccAWSSpotInstanceRequestConfigVolumeTags1(rName, tagKey1, tagValue1 string) string {
-	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
-resource "aws_spot_instance_request" "test" {
-  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
-  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
-  key_name             = "${aws_key_pair.test.key_name}"
-  spot_price           = "0.05"
-  wait_for_fulfillment = true
-
-  volume_tags = {
-    %[1]q = %[2]q
-  }
-}
-`, tagKey1, tagValue1)
-}
-
-func testAccAWSSpotInstanceRequestConfigVolumeTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
-resource "aws_spot_instance_request" "test" {
-  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
-  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
-  key_name             = "${aws_key_pair.test.key_name}"
-  spot_price           = "0.05"
-  wait_for_fulfillment = true
-
-  volume_tags = {
     %[1]q = %[2]q
     %[3]q = %[4]q
   }

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestAccAWSSpotInstanceRequest_basic(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
-	rInt := acctest.RandInt()
 	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,7 +23,7 @@ func TestAccAWSSpotInstanceRequest_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfig(rInt),
+				Config: testAccAWSSpotInstanceRequestConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckAWSSpotInstanceRequestAttributes(&sir),
@@ -79,7 +79,8 @@ func TestAccAWSSpotInstanceRequest_tags(t *testing.T) {
 
 func TestAccAWSSpotInstanceRequest_withLaunchGroup(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
-	rInt := acctest.RandInt()
+	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -87,18 +88,14 @@ func TestAccAWSSpotInstanceRequest_withLaunchGroup(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfig_withLaunchGroup(rInt),
+				Config: testAccAWSSpotInstanceRequestConfig_withLaunchGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo", &sir),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckAWSSpotInstanceRequestAttributes(&sir),
-					testCheckKeyPair(fmt.Sprintf("tmp-key-%d", rInt), &sir),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_bid_status", "fulfilled"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "launch_group", "terraform-test-group"),
+					testCheckKeyPair(rName, &sir),
+					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_group", "terraform-test-group"),
 				),
 			},
 		},
@@ -107,7 +104,8 @@ func TestAccAWSSpotInstanceRequest_withLaunchGroup(t *testing.T) {
 
 func TestAccAWSSpotInstanceRequest_withBlockDuration(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
-	rInt := acctest.RandInt()
+	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -115,18 +113,14 @@ func TestAccAWSSpotInstanceRequest_withBlockDuration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfig_withBlockDuration(rInt),
+				Config: testAccAWSSpotInstanceRequestConfig_withBlockDuration(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo", &sir),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckAWSSpotInstanceRequestAttributes(&sir),
-					testCheckKeyPair(fmt.Sprintf("tmp-key-%d", rInt), &sir),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_bid_status", "fulfilled"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "block_duration_minutes", "60"),
+					testCheckKeyPair(rName, &sir),
+					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "block_duration_minutes", "60"),
 				),
 			},
 		},
@@ -135,7 +129,8 @@ func TestAccAWSSpotInstanceRequest_withBlockDuration(t *testing.T) {
 
 func TestAccAWSSpotInstanceRequest_vpc(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
-	rInt := acctest.RandInt()
+	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -143,17 +138,14 @@ func TestAccAWSSpotInstanceRequest_vpc(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfigVPC(rInt),
+				Config: testAccAWSSpotInstanceRequestConfigVPC(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo_VPC", &sir),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckAWSSpotInstanceRequestAttributes(&sir),
-					testCheckKeyPair(fmt.Sprintf("tmp-key-%d", rInt), &sir),
+					testCheckKeyPair(rName, &sir),
 					testAccCheckAWSSpotInstanceRequestAttributesVPC(&sir),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo_VPC", "spot_bid_status", "fulfilled"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo_VPC", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 				),
 			},
 		},
@@ -162,7 +154,8 @@ func TestAccAWSSpotInstanceRequest_vpc(t *testing.T) {
 
 func TestAccAWSSpotInstanceRequest_validUntil(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
-	rInt := acctest.RandInt()
+	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := testAccAWSSpotInstanceRequestValidUntil(t)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -171,17 +164,14 @@ func TestAccAWSSpotInstanceRequest_validUntil(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfigValidUntil(rInt, validUntil),
+				Config: testAccAWSSpotInstanceRequestConfigValidUntil(rName, validUntil),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo", &sir),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckAWSSpotInstanceRequestAttributes(&sir),
-					testCheckKeyPair(fmt.Sprintf("tmp-key-%d", rInt), &sir),
+					testCheckKeyPair(rName, &sir),
 					testAccCheckAWSSpotInstanceRequestAttributesValidUntil(&sir, validUntil),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_bid_status", "fulfilled"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 				),
 			},
 		},
@@ -190,7 +180,8 @@ func TestAccAWSSpotInstanceRequest_validUntil(t *testing.T) {
 
 func TestAccAWSSpotInstanceRequest_withoutSpotPrice(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
-	rInt := acctest.RandInt()
+	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -198,15 +189,12 @@ func TestAccAWSSpotInstanceRequest_withoutSpotPrice(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfig_withoutSpotPrice(rInt),
+				Config: testAccAWSSpotInstanceRequestConfig_withoutSpotPrice(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo", &sir),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
 					testAccCheckAWSSpotInstanceRequestAttributesCheckSIRWithoutSpot(&sir),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_bid_status", "fulfilled"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 				),
 			},
 		},
@@ -215,7 +203,8 @@ func TestAccAWSSpotInstanceRequest_withoutSpotPrice(t *testing.T) {
 
 func TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
-	rInt := acctest.RandInt()
+	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -223,13 +212,11 @@ func TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt),
+				Config: testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo", &sir),
-					testAccCheckAWSSpotInstanceRequest_InstanceAttributes(&sir, rInt),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "associate_public_ip_address", "true"),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
+					testAccCheckAWSSpotInstanceRequest_InstanceAttributes(&sir, rName),
+					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 				),
 			},
 		},
@@ -238,7 +225,8 @@ func TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress(t *testing.T) {
 
 func TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
-	rInt := acctest.RandInt()
+	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -246,14 +234,12 @@ func TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt),
+				Config: testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo", &sir),
-					testAccCheckAWSSpotInstanceRequest_InstanceAttributes(&sir, rInt),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
+					testAccCheckAWSSpotInstanceRequest_InstanceAttributes(&sir, rName),
 					testAccCheckAWSSpotInstanceRequest_NetworkInterfaceAttributes(&sir),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "associate_public_ip_address", "true"),
+					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 				),
 			},
 		},
@@ -262,7 +248,8 @@ func TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes(t *testing.T) {
 
 func TestAccAWSSpotInstanceRequest_getPasswordData(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
-	rInt := acctest.RandInt()
+	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -270,11 +257,10 @@ func TestAccAWSSpotInstanceRequest_getPasswordData(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfig_getPasswordData(rInt),
+				Config: testAccAWSSpotInstanceRequestConfig_getPasswordData(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo", &sir),
-					resource.TestCheckResourceAttrSet("aws_spot_instance_request.foo", "password_data"),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
+					resource.TestCheckResourceAttrSet(resourceName, "password_data"),
 				),
 			},
 		},
@@ -337,7 +323,7 @@ func testAccCheckAWSSpotInstanceRequestDestroy(s *terraform.State) error {
 			// not found
 			continue
 		}
-		if aws.StringValue(s.State) == "canceled" || aws.StringValue(s.State) == "closed" {
+		if aws.StringValue(s.State) == ec2.SpotInstanceStateCancelled || aws.StringValue(s.State) == ec2.SpotInstanceStateClosed {
 			// Requests stick around for a while, so we make sure it's cancelled
 			// or closed.
 			continue
@@ -401,7 +387,7 @@ func testAccCheckAWSSpotInstanceRequestAttributes(
 		if *sir.SpotPrice != "0.050000" {
 			return fmt.Errorf("Unexpected spot price: %s", *sir.SpotPrice)
 		}
-		if *sir.State != "active" {
+		if *sir.State != ec2.SpotInstanceStateActive {
 			return fmt.Errorf("Unexpected request state: %s", *sir.State)
 		}
 		if *sir.Status.Code != "fulfilled" {
@@ -424,7 +410,7 @@ func testAccCheckAWSSpotInstanceRequestAttributesValidUntil(
 func testAccCheckAWSSpotInstanceRequestAttributesCheckSIRWithoutSpot(
 	sir *ec2.SpotInstanceRequest) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *sir.State != "active" {
+		if *sir.State != ec2.SpotInstanceStateActive {
 			return fmt.Errorf("Unexpected request state: %s", *sir.State)
 		}
 		if *sir.Status.Code != "fulfilled" {
@@ -434,12 +420,12 @@ func testAccCheckAWSSpotInstanceRequestAttributesCheckSIRWithoutSpot(
 	}
 }
 
-func testAccCheckAWSSpotInstanceRequest_InstanceAttributes(sir *ec2.SpotInstanceRequest, rInt int) resource.TestCheckFunc {
+func testAccCheckAWSSpotInstanceRequest_InstanceAttributes(sir *ec2.SpotInstanceRequest, rName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		instance, err := resourceAwsInstanceFindByID(conn, aws.StringValue(sir.InstanceId))
 		if err != nil {
-			if isAWSErr(err, "InvalidInstanceID.NotFound", "") {
+			if isAWSErr(err, "InvalidInstanceID.NotFound" ,"") {
 				return fmt.Errorf("Spot Instance %q not found", aws.StringValue(sir.InstanceId))
 			}
 			return err
@@ -454,13 +440,13 @@ func testAccCheckAWSSpotInstanceRequest_InstanceAttributes(sir *ec2.SpotInstance
 		for _, s := range instance.SecurityGroups {
 			// Hardcoded name for the security group that should be added inside the
 			// VPC
-			if *s.GroupName == fmt.Sprintf("tf_test_sg_ssh-%d", rInt) {
+			if *s.GroupName == rName {
 				sgMatch = true
 			}
 		}
 
 		if !sgMatch {
-			return fmt.Errorf("Error in matching Spot Instance Security Group, expected 'tf_test_sg_ssh-%d', got %s", rInt, instance.SecurityGroups)
+			return fmt.Errorf("Error in matching Spot Instance Security Group, expected %s, got %s", rName, instance.SecurityGroups)
 		}
 
 		return nil
@@ -498,6 +484,7 @@ func testAccCheckAWSSpotInstanceRequestAttributesVPC(
 
 func TestAccAWSSpotInstanceRequest_InterruptStop(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
+	resourceName := "aws_spot_instance_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -507,14 +494,10 @@ func TestAccAWSSpotInstanceRequest_InterruptStop(t *testing.T) {
 			{
 				Config: testAccAWSSpotInstanceRequestInterruptConfig("stop"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo", &sir),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_bid_status", "fulfilled"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "instance_interruption_behaviour", "stop"),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
+					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "instance_interruption_behaviour", "stop"),
 				),
 			},
 		},
@@ -523,6 +506,7 @@ func TestAccAWSSpotInstanceRequest_InterruptStop(t *testing.T) {
 
 func TestAccAWSSpotInstanceRequest_InterruptHibernate(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
+	resourceName := "aws_spot_instance_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -532,300 +516,184 @@ func TestAccAWSSpotInstanceRequest_InterruptHibernate(t *testing.T) {
 			{
 				Config: testAccAWSSpotInstanceRequestInterruptConfig("hibernate"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotInstanceRequestExists(
-						"aws_spot_instance_request.foo", &sir),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_bid_status", "fulfilled"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "instance_interruption_behaviour", "hibernate"),
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
+					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "instance_interruption_behaviour", "hibernate"),
 				),
 			},
 		},
 	})
 }
 
-func testAccAWSSpotInstanceRequestConfig(rInt int) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro") +
-		fmt.Sprintf(`
-resource "aws_key_pair" "test" {
-  key_name   = "tmp-key-%d"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_spot_instance_request" "test" {
-  ami                  = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
-  key_name             = aws_key_pair.test.key_name
-  spot_price           = "0.05"
-  wait_for_fulfillment = true
-}
-`, rInt)
-}
-
-func testAccAWSSpotInstanceRequestTagsConfig1(rName, tagKey1, tagValue1 string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro") +
-		fmt.Sprintf(`
+func testAccAWSSpotInstanceRequestConfigBase(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+`, rName)
+}
+
+func testAccAWSSpotInstanceRequestConfig(rName string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
+resource "aws_spot_instance_request" "test" {
+  ami                  = "ami-4fccb37f"
+  instance_type        = "m1.small"
+  key_name             = "${aws_key_pair.test.key_name}"
+  spot_price           = "0.05"
+  wait_for_fulfillment = true
 
   tags = {
     Name = %[1]q
   }
 }
+`, rName)
+}
 
+func testAccAWSSpotInstanceRequestConfigValidUntil(rName string, validUntil string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_instance_request" "test" {
-  ami                  = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
-  key_name             = aws_key_pair.test.key_name
+  ami                  = "ami-4fccb37f"
+  instance_type        = "m1.small"
+  key_name             = "${aws_key_pair.test.key_name}"
   spot_price           = "0.05"
+  valid_until          = %[2]q
   wait_for_fulfillment = true
-
-  tags = {
-    %[2]q = %[3]q
-  }
-}
-`, rName, tagKey1, tagValue1)
-}
-
-func testAccAWSSpotInstanceRequestTagsConfig2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro") +
-		fmt.Sprintf(`
-resource "aws_key_pair" "test" {
-  key_name   = %[1]q
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 
   tags = {
     Name = %[1]q
   }
 }
+`, rName, validUntil)
+}
 
+func testAccAWSSpotInstanceRequestConfig_withoutSpotPrice(rName string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_instance_request" "test" {
-  ami                  = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
-  key_name             = aws_key_pair.test.key_name
+  ami                  = "ami-4fccb37f"
+  instance_type        = "m1.small"
+  key_name             = "${aws_key_pair.test.key_name}"
+  wait_for_fulfillment = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccAWSSpotInstanceRequestConfig_withLaunchGroup(rName string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
+resource "aws_spot_instance_request" "test" {
+  ami                  = "ami-4fccb37f"
+  instance_type        = "m1.small"
+  key_name             = "${aws_key_pair.test.key_name}"
   spot_price           = "0.05"
   wait_for_fulfillment = true
+  launch_group         = %[1]q
 
   tags = {
-    %[2]q = %[3]q
-    %[4]q = %[5]q
+    Name = %[1]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName)
 }
 
-func testAccAWSSpotInstanceRequestConfigValidUntil(rInt int, validUntil string) string {
-	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-resource "aws_key_pair" "debugging" {
-  key_name   = "tmp-key-%d"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_spot_instance_request" "foo" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  key_name      = aws_key_pair.debugging.key_name
-
-  # base price is $0.044 hourly, so bidding above that should theoretically
-  # always fulfill
-  spot_price = "0.05"
-
-  # The end date and time of the request, the default end date is 7 days from the current date.
-  # so 12 hours from the current time will be valid time for valid_until.
-  valid_until = "%s"
-
-  # we wait for fulfillment because we want to inspect the launched instance
-  # and verify termination behavior
-  wait_for_fulfillment = true
-
-  tags = {
-    Name = "terraform-test"
-  }
-}
-`, rInt, validUntil))
-}
-
-func testAccAWSSpotInstanceRequestConfig_withoutSpotPrice(rInt int) string {
-	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-resource "aws_key_pair" "debugging" {
-  key_name   = "tmp-key-%d"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_spot_instance_request" "foo" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  key_name      = aws_key_pair.debugging.key_name
-
-  # no spot price so AWS *should* default max bid to current on-demand price
-
-  # we wait for fulfillment because we want to inspect the launched instance
-  # and verify termination behavior
-  wait_for_fulfillment = true
-
-  tags = {
-    Name = "terraform-test"
-  }
-}
-`, rInt))
-}
-
-func testAccAWSSpotInstanceRequestConfig_withLaunchGroup(rInt int) string {
-	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-resource "aws_key_pair" "debugging" {
-  key_name   = "tmp-key-%d"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_spot_instance_request" "foo" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  key_name      = aws_key_pair.debugging.key_name
-
-  # base price is $0.044 hourly, so bidding above that should theoretically
-  # always fulfill
-  spot_price = "0.05"
-
-  # we wait for fulfillment because we want to inspect the launched instance
-  # and verify termination behavior
-  wait_for_fulfillment = true
-
-  launch_group = "terraform-test-group"
-
-  tags = {
-    Name = "terraform-test"
-  }
-}
-`, rInt))
-}
-
-func testAccAWSSpotInstanceRequestConfig_withBlockDuration(rInt int) string {
-	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-resource "aws_key_pair" "debugging" {
-  key_name   = "tmp-key-%d"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_spot_instance_request" "foo" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  key_name      = aws_key_pair.debugging.key_name
-
-  # base price is $0.044 hourly, so bidding above that should theoretically
-  # always fulfill
-  spot_price = "0.05"
-
-  # we wait for fulfillment because we want to inspect the launched instance
-  # and verify termination behavior
-  wait_for_fulfillment = true
-
+func testAccAWSSpotInstanceRequestConfig_withBlockDuration(rName string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
+resource "aws_spot_instance_request" "test" {
+  ami                    = "ami-4fccb37f"
+  instance_type          = "m1.small"
+  key_name               = "${aws_key_pair.test.key_name}"
+  spot_price             = "0.05"
+  wait_for_fulfillment   = true
   block_duration_minutes = 60
 
   tags = {
-    Name = "terraform-test"
+    Name = %[1]q
   }
 }
-`, rInt))
+`, rName)
 }
 
-func testAccAWSSpotInstanceRequestConfigVPC(rInt int) string {
-	return composeConfig(
-		testAccAvailableAZsNoOptInConfig(),
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-resource "aws_vpc" "foo_VPC" {
-  cidr_block = "10.1.0.0/16"
+func testAccAWSSpotInstanceRequestConfigVPC(rName string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
 
   tags = {
     Name = "terraform-testacc-spot-instance-request-vpc"
   }
 }
 
-resource "aws_subnet" "foo_VPC" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = "10.1.1.0/24"
-  vpc_id            = aws_vpc.foo_VPC.id
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "tf-acc-spot-instance-request-vpc"
+    Name = %[1]q
   }
 }
 
-resource "aws_key_pair" "debugging" {
-  key_name   = "tmp-key-%d"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+resource "aws_subnet" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags = {
+  	Name = %[1]q
+  }
 }
 
-resource "aws_spot_instance_request" "foo_VPC" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  key_name      = aws_key_pair.debugging.key_name
-
-  # base price is $0.044 hourly, so bidding above that should theoretically
-  # always fulfill
-  spot_price = "0.05"
-
-  # VPC settings
-  subnet_id = aws_subnet.foo_VPC.id
-
-  # we wait for fulfillment because we want to inspect the launched instance
-  # and verify termination behavior
+resource "aws_spot_instance_request" "test" {
+  ami                  = "ami-4fccb37f"
+  instance_type        = "m1.small"
+  key_name             = "${aws_key_pair.test.key_name}"
+  spot_price           = "0.05"
   wait_for_fulfillment = true
 
   tags = {
-    Name = "terraform-test-VPC"
+    Name = %[1]q
   }
 }
-`, rInt))
+`, rName)
 }
 
-func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int) string {
-	return composeConfig(
-		testAccAvailableAZsNoOptInConfig(),
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-resource "aws_spot_instance_request" "foo" {
-  ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type               = data.aws_ec2_instance_type_offering.available.instance_type
+func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rName string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_spot_instance_request" "test" {
+  ami                         = "ami-4fccb37f"
+  instance_type               = "m1.small"
   spot_price                  = "0.05"
   wait_for_fulfillment        = true
-  subnet_id                   = aws_subnet.tf_test_subnet.id
-  vpc_security_group_ids      = [aws_security_group.tf_test_sg_ssh.id]
+  subnet_id                   = "${aws_subnet.test.id}"
+  vpc_security_group_ids      = ["${aws_security_group.test.id}"]
   associate_public_ip_address = true
 }
 
-resource "aws_vpc" "default" {
+resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
 
   tags = {
-    Name = "terraform-testacc-spot-instance-request-subnet-and-sg-public-ip"
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "tf_test_subnet" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  vpc_id                  = aws_vpc.default.id
+resource "aws_subnet" "test" {
+  availability_zone       = "${data.aws_availability_zones.available.names[0]}"
+  vpc_id                  = "${aws_vpc.test.id}"
   cidr_block              = "10.0.0.0/24"
   map_public_ip_on_launch = true
 
@@ -839,25 +707,21 @@ resource "aws_security_group" "tf_test_sg_ssh" {
   description = "tf_test_sg_ssh"
   vpc_id      = aws_vpc.default.id
 
-  tags = {
-    Name = "tf_test_sg_ssh-%[1]d"
+    Name = %[1]q
   }
 }
-`, rInt))
+`, rName)
 }
 
-func testAccAWSSpotInstanceRequestConfig_getPasswordData(rInt int) string {
-	return composeConfig(
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		fmt.Sprintf(`
+func testAccAWSSpotInstanceRequestConfig_getPasswordData(rName string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
 # Find latest Microsoft Windows Server 2016 Core image (Amazon deletes old ones)
-data "aws_ami" "win2016core" {
+data "aws_ami" "test" {
   most_recent = true
   owners      = ["amazon"]
 
   filter {
     name   = "name"
-    values = ["Windows_Server-2016-English-Core-Base-*"]
   }
 }
 
@@ -895,6 +759,3 @@ resource "aws_spot_instance_request" "foo" {
   wait_for_fulfillment = true
 
   instance_interruption_behaviour = "%s"
-}
-`, interruption_behavior))
-}

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -95,7 +95,7 @@ func TestAccAWSSpotInstanceRequest_withLaunchGroup(t *testing.T) {
 					testCheckKeyPair(rName, &sir),
 					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(resourceName, "launch_group", "terraform-test-group"),
+					resource.TestCheckResourceAttr(resourceName, "launch_group", rName),
 				),
 			},
 		},

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -848,7 +848,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_security_group" "test" {
   name        = %[1]q
-  vpc_id      = aws_vpc.default.id
+  vpc_id      = aws_vpc.test.id
 
   tags = {
     Name = %[1]q
@@ -869,6 +869,8 @@ data "aws_ami" "test" {
 
   filter {
     name   = "name"
+	values = ["Windows_Server-2016-English-Core-Base-*"]
+
   }
 }
 

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -562,28 +562,13 @@ func TestAccAWSSpotInstanceRequest_InterruptHibernate(t *testing.T) {
 }
 
 func testAccAWSSpotInstanceRequestConfigBase(rName string) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 
   tags = {
     Name = %[1]q
-  }
-}
-
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
   }
 }
 

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -791,7 +791,7 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-  	Name = %[1]q
+    Name = %[1]q
   }
 }
 
@@ -847,8 +847,8 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_security_group" "test" {
-  name        = %[1]q
-  vpc_id      = aws_vpc.test.id
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = %[1]q
@@ -869,7 +869,7 @@ data "aws_ami" "test" {
 
   filter {
     name   = "name"
-	values = ["Windows_Server-2016-English-Core-Base-*"]
+    values = ["Windows_Server-2016-English-Core-Base-*"]
   }
 }
 

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -34,6 +34,12 @@ func TestAccAWSSpotInstanceRequest_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
 		},
 	})
 }
@@ -98,6 +104,12 @@ func TestAccAWSSpotInstanceRequest_withLaunchGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "launch_group", rName),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
 		},
 	})
 }
@@ -123,6 +135,12 @@ func TestAccAWSSpotInstanceRequest_withBlockDuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "block_duration_minutes", "60"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
 		},
 	})
 }
@@ -147,6 +165,12 @@ func TestAccAWSSpotInstanceRequest_vpc(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_bid_status", "fulfilled"),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 		},
 	})
@@ -174,6 +198,12 @@ func TestAccAWSSpotInstanceRequest_validUntil(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
 		},
 	})
 }
@@ -197,6 +227,12 @@ func TestAccAWSSpotInstanceRequest_withoutSpotPrice(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
 		},
 	})
 }
@@ -218,6 +254,12 @@ func TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress(t *testing.T) {
 					testAccCheckAWSSpotInstanceRequest_InstanceAttributes(&sir, rName),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 		},
 	})
@@ -242,6 +284,12 @@ func TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
 		},
 	})
 }
@@ -262,6 +310,12 @@ func TestAccAWSSpotInstanceRequest_getPasswordData(t *testing.T) {
 					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
 					resource.TestCheckResourceAttrSet(resourceName, "password_data"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 		},
 	})
@@ -535,6 +589,12 @@ func TestAccAWSSpotInstanceRequest_InterruptStop(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_interruption_behaviour", "stop"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
 		},
 	})
 }
@@ -556,6 +616,12 @@ func TestAccAWSSpotInstanceRequest_InterruptHibernate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "instance_interruption_behaviour", "hibernate"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 		},
 	})

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -388,6 +388,51 @@ func TestAccAWSSpotInstanceRequest_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSSpotInstanceRequest_volumeTags(t *testing.T) {
+	var sir ec2.SpotInstanceRequest
+	resourceName := "aws_spot_instance_request.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotInstanceRequestConfigVolumeTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
+			{
+				Config: testAccAWSSpotInstanceRequestConfigVolumeTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSpotInstanceRequestConfigVolumeTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckKeyPair(keyName string, sir *ec2.SpotInstanceRequest) resource.TestCheckFunc {
 	return func(*terraform.State) error {
 		if sir.LaunchSpecification.KeyName == nil {
@@ -922,6 +967,39 @@ resource "aws_spot_instance_request" "test" {
   wait_for_fulfillment = true
 
   tags = {
+    %[1]q = %[2]q
+    %[3]q = %[4]q
+  }
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAWSSpotInstanceRequestConfigVolumeTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
+resource "aws_spot_instance_request" "test" {
+  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
+  key_name             = "${aws_key_pair.test.key_name}"
+  spot_price           = "0.05"
+  wait_for_fulfillment = true
+
+  volume_tags = {
+    %[1]q = %[2]q
+  }
+}
+`, tagKey1, tagValue1)
+}
+
+func testAccAWSSpotInstanceRequestConfigVolumeTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
+resource "aws_spot_instance_request" "test" {
+  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
+  key_name             = "${aws_key_pair.test.key_name}"
+  spot_price           = "0.05"
+  wait_for_fulfillment = true
+
+  volume_tags = {
     %[1]q = %[2]q
     %[3]q = %[4]q
   }

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -571,9 +571,15 @@ resource "aws_key_pair" "test" {
 data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   most_recent = true
   owners      = ["amazon"]
+
   filter {
     name   = "name"
     values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
   }
 }
 

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -567,14 +567,32 @@ resource "aws_key_pair" "test" {
   key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
+
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+}
+
+data "aws_ec2_instance_type_offering" "available" {
+  filter {
+    name   = "instance-type"
+    values = ["t3.micro", "t2.micro"]
+  }
+  location_type            = "availability-zone"
+  preferred_instance_types = ["t3.micro", "t2.micro"]
+}
 `, rName)
 }
 
 func testAccAWSSpotInstanceRequestConfig(rName string) string {
 	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_instance_request" "test" {
-  ami                  = "ami-4fccb37f"
-  instance_type        = "m1.small"
+  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
   key_name             = "${aws_key_pair.test.key_name}"
   spot_price           = "0.05"
   wait_for_fulfillment = true
@@ -589,8 +607,8 @@ resource "aws_spot_instance_request" "test" {
 func testAccAWSSpotInstanceRequestConfigValidUntil(rName string, validUntil string) string {
 	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_instance_request" "test" {
-  ami                  = "ami-4fccb37f"
-  instance_type        = "m1.small"
+  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
   key_name             = "${aws_key_pair.test.key_name}"
   spot_price           = "0.05"
   valid_until          = %[2]q
@@ -606,8 +624,8 @@ resource "aws_spot_instance_request" "test" {
 func testAccAWSSpotInstanceRequestConfig_withoutSpotPrice(rName string) string {
 	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_instance_request" "test" {
-  ami                  = "ami-4fccb37f"
-  instance_type        = "m1.small"
+  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
   key_name             = "${aws_key_pair.test.key_name}"
   wait_for_fulfillment = true
 
@@ -621,8 +639,8 @@ resource "aws_spot_instance_request" "test" {
 func testAccAWSSpotInstanceRequestConfig_withLaunchGroup(rName string) string {
 	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_instance_request" "test" {
-  ami                  = "ami-4fccb37f"
-  instance_type        = "m1.small"
+  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
   key_name             = "${aws_key_pair.test.key_name}"
   spot_price           = "0.05"
   wait_for_fulfillment = true
@@ -638,8 +656,8 @@ resource "aws_spot_instance_request" "test" {
 func testAccAWSSpotInstanceRequestConfig_withBlockDuration(rName string) string {
 	return testAccAWSSpotInstanceRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_instance_request" "test" {
-  ami                    = "ami-4fccb37f"
-  instance_type          = "m1.small"
+  ami                    = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type          = "${data.aws_ec2_instance_type_offering.available.instance_type}"
   key_name               = "${aws_key_pair.test.key_name}"
   spot_price             = "0.05"
   wait_for_fulfillment   = true
@@ -682,8 +700,8 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_spot_instance_request" "test" {
-  ami                  = "ami-4fccb37f"
-  instance_type        = "m1.small"
+  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
   key_name             = "${aws_key_pair.test.key_name}"
   spot_price           = "0.05"
   wait_for_fulfillment = true
@@ -709,8 +727,8 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_spot_instance_request" "test" {
-  ami                         = "ami-4fccb37f"
-  instance_type               = "m1.small"
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type               = "${data.aws_ec2_instance_type_offering.available.instance_type}"
   spot_price                  = "0.05"
   wait_for_fulfillment        = true
   subnet_id                   = "${aws_subnet.test.id}"
@@ -761,14 +779,9 @@ data "aws_ami" "test" {
   }
 }
 
-resource "aws_key_pair" "foo" {
-  key_name   = "tf-acctest-%d"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAq6U3HQYC4g8WzU147gZZ7CKQH8TgYn3chZGRPxaGmHW1RUwsyEs0nmombmIhwxudhJ4ehjqXsDLoQpd6+c7BuLgTMvbv8LgE9LX53vnljFe1dsObsr/fYLvpU9LTlo8HgHAqO5ibNdrAUvV31ronzCZhms/Gyfdaue88Fd0/YnsZVGeOZPayRkdOHSpqme2CBrpa8myBeL1CWl0LkDG4+YCURjbaelfyZlIApLYKy3FcCan9XQFKaL32MJZwCgzfOvWIMtYcU8QtXMgnA3/I3gXk8YDUJv5P4lj0s/PJXuTM8DygVAUtebNwPuinS7wwonm5FXcWMuVGsVpG5K7FGQ== tf-acc-winpasswordtest"
-}
-
-resource "aws_spot_instance_request" "foo" {
-  ami                  = data.aws_ami.win2016core.id
-  instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
+resource "aws_spot_instance_request" "test" {
+  ami                  = "${data.aws_ami.test.id}"
+  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
   spot_price           = "0.05"
   key_name             = aws_key_pair.foo.key_name
   wait_for_fulfillment = true
@@ -777,21 +790,12 @@ resource "aws_spot_instance_request" "foo" {
 `, rInt))
 }
 
-func testAccAWSSpotInstanceRequestInterruptConfig(interruption_behavior string) string {
-	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("c5.large", "c4.large"),
-		fmt.Sprintf(`
-resource "aws_spot_instance_request" "foo" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-
-  # base price is $0.067 hourly, so bidding above that should theoretically
-  # always fulfill
-  spot_price = "0.07"
-
-  # we wait for fulfillment because we want to inspect the launched instance
-  # and verify termination behavior
+func testAccAWSSpotInstanceRequestInterruptConfig(interruptionBehavior string) string {
+	return fmt.Sprintf(`
+resource "aws_spot_instance_request" "test" {
+  ami                  = "${data.aws_ami.test.id}"
+  instance_type        = "${data.aws_ec2_instance_type_offering.available.instance_type}"
+  spot_price           = "0.07"
   wait_for_fulfillment = true
 
   instance_interruption_behaviour = "%s"

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -566,6 +566,10 @@ func testAccAWSSpotInstanceRequestConfigBase(rName string) string {
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
@@ -602,12 +606,8 @@ resource "aws_spot_instance_request" "test" {
   key_name             = "${aws_key_pair.test.key_name}"
   spot_price           = "0.05"
   wait_for_fulfillment = true
-
-  tags = {
-    Name = %[1]q
-  }
 }
-`, rName)
+`)
 }
 
 func testAccAWSSpotInstanceRequestConfigValidUntil(rName string, validUntil string) string {
@@ -792,8 +792,12 @@ resource "aws_spot_instance_request" "test" {
   key_name             = aws_key_pair.foo.key_name
   wait_for_fulfillment = true
   get_password_data    = true
+
+  tags = {
+    Name = %[1]q
+  }
 }
-`, rInt))
+`, rName)
 }
 
 func testAccAWSSpotInstanceRequestInterruptConfig(interruptionBehavior string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_spot_instance_request: add plan time validation for `spot_type`
resource_aws_spot_instance_request: import support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSpotInstanceRequest_'
--- PASS: TestAccAWSSpotInstanceRequest_basic (128.48s)
--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (134.96s)
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (103.59s)
--- PASS: TestAccAWSSpotInstanceRequest_validUntil (224.48s)
--- PASS: TestAccAWSSpotInstanceRequest_withoutSpotPrice (225.46s)
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (325.17s)
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (274.46s)
--- PASS: TestAccAWSSpotInstanceRequest_getPasswordData (370.91s)
--- PASS: TestAccAWSSpotInstanceRequest_disappears (52.47s)
--- PASS: TestAccAWSSpotInstanceRequest_vpc (257.92s)
```
