### PR TITLE
Fix for Resource Access Management edge case involving VPC Classic Link

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -300,6 +300,8 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "UnsupportedOperation" {
 			log.Printf("[WARN] VPC Classic Link is not supported in this region")
+		} else if isAWSErr(err, "InvalidVpcID.NotFound", "") {
+			log.Printf("[WARN] VPC Classic Link functionality you requested is not available for this VPC")
 		} else {
 			return err
 		}
@@ -322,9 +324,12 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 	respClassiclinkDnsSupport, err := conn.DescribeVpcClassicLinkDnsSupport(describeClassiclinkDnsOpts)
 	if err != nil {
-		if isAWSErr(err, "UnsupportedOperation", "The functionality you requested is not available in this region") ||
-			isAWSErr(err, "AuthFailure", "This request has been administratively disabled") {
+		if isAWSErr(err, "UnsupportedOperation", "The functionality you requested is not available in this region") {
 			log.Printf("[WARN] VPC Classic Link DNS Support is not supported in this region")
+		} else if isAWSErr(err, "AuthFailure", "This request has been administratively disabled") {
+			log.Printf("[WARN] VPC Classic Link DNS Support has been administratively disabled")
+		} else if isAWSErr(err, "InvalidVpcID.NotFound", "") {
+			log.Printf("[WARN] VPC Classic Link DNS Support functionality you requested is not available for this VPC")
 		} else {
 			return err
 		}

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -324,12 +324,9 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 	respClassiclinkDnsSupport, err := conn.DescribeVpcClassicLinkDnsSupport(describeClassiclinkDnsOpts)
 	if err != nil {
-		if isAWSErr(err, "UnsupportedOperation", "The functionality you requested is not available in this region") {
+		if isAWSErr(err, "UnsupportedOperation", "The functionality you requested is not available in this region") ||
+			isAWSErr(err, "AuthFailure", "This request has been administratively disabled") {
 			log.Printf("[WARN] VPC Classic Link DNS Support is not supported in this region")
-		} else if isAWSErr(err, "AuthFailure", "This request has been administratively disabled") {
-			log.Printf("[WARN] VPC Classic Link DNS Support has been administratively disabled")
-		} else if isAWSErr(err, "InvalidVpcID.NotFound", "") {
-			log.Printf("[WARN] VPC Classic Link DNS Support functionality you requested is not available for this VPC")
 		} else {
 			return err
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix issue with describing VpcClassicLink on VPC shared by Resource Access Manager by passing WARN
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSVpc_classiclink'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSVpc_classiclink -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSVpc_classiclinkOptionSet
=== PAUSE TestAccAWSVpc_classiclinkOptionSet
=== RUN   TestAccAWSVpc_classiclinkDnsSupportOptionSet
=== PAUSE TestAccAWSVpc_classiclinkDnsSupportOptionSet
=== CONT  TestAccAWSVpc_classiclinkOptionSet
=== CONT  TestAccAWSVpc_classiclinkDnsSupportOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (83.11s)
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (83.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	84.138s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.028s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.289s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.197s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.104s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.087s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.207s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.163s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.057s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.031s [no tests to run]

...
```

DescribeVpcClassicLink and DescribeVpcClassicLinkDnsSupport return "InvalidVpcId" if resource is shared via Resource Access Manager from another account. Instead of failing, warn and continue.
