### PR TITLE
r/cloudwatch_metric_alarm - add validations

### DIFF
--- a/.changelog/12817.txt
+++ b/.changelog/12817.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+resource/aws_cloudwatch_metric_alarm: Add plan time validation to `alarm_name`, 
+`comparison_operator`, `metric_name`, `metric_query.id`, `metric_query.expression`, 
+`metric_query.metric.metric_name`, `metric_query.metric.namespace`, `metric_query.metric.unit`,
+`namespace`, `period`, `statistic`, `alarm_description`, `insufficient_data_actions`, `ok_actions`, `unit`, and `extended_statistic`
+```

--- a/.changelog/12817.txt
+++ b/.changelog/12817.txt
@@ -1,6 +1,3 @@
 ```release-note:enhancement
-resource/aws_cloudwatch_metric_alarm: Add plan time validation to `alarm_name`, 
-`comparison_operator`, `metric_name`, `metric_query.id`, `metric_query.expression`, 
-`metric_query.metric.metric_name`, `metric_query.metric.namespace`, `metric_query.metric.unit`,
-`namespace`, `period`, `statistic`, `alarm_description`, `insufficient_data_actions`, `ok_actions`, `unit`, and `extended_statistic`
+resource/aws_cloudwatch_metric_alarm: Add plan time validation to `alarm_name`, `comparison_operator`, `metric_name`, `metric_query.id`, `metric_query.expression`, `metric_query.metric.metric_name`, `metric_query.metric.namespace`, `metric_query.metric.unit`, `namespace`, `period`, `statistic`, `alarm_description`, `insufficient_data_actions`, `ok_actions`, `unit`, and `extended_statistic`
 ```

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -36,17 +36,9 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Computed: true,
 			},
 			"comparison_operator": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					cloudwatch.ComparisonOperatorGreaterThanOrEqualToThreshold,
-					cloudwatch.ComparisonOperatorGreaterThanThreshold,
-					cloudwatch.ComparisonOperatorGreaterThanUpperThreshold,
-					cloudwatch.ComparisonOperatorLessThanLowerOrGreaterThanUpperThreshold,
-					cloudwatch.ComparisonOperatorLessThanLowerThreshold,
-					cloudwatch.ComparisonOperatorLessThanOrEqualToThreshold,
-					cloudwatch.ComparisonOperatorLessThanThreshold,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(cloudwatch.ComparisonOperator_Values(), false),
 			},
 			"evaluation_periods": {
 				Type:         schema.TypeInt,
@@ -100,8 +92,9 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 										Required: true,
 									},
 									"unit": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(cloudwatch.StandardUnit_Values(), false),
 									},
 								},
 							},
@@ -132,13 +125,7 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"extended_statistic", "metric_query"},
-				ValidateFunc: validation.StringInSlice([]string{
-					cloudwatch.StatisticAverage,
-					cloudwatch.StatisticMaximum,
-					cloudwatch.StatisticMinimum,
-					cloudwatch.StatisticSampleCount,
-					cloudwatch.StatisticSum,
-				}, false),
+				ValidateFunc:  validation.StringInSlice(cloudwatch.Statistic_Values(), false),
 			},
 			"threshold": {
 				Type:          schema.TypeFloat,
@@ -196,8 +183,9 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"unit": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(cloudwatch.StandardUnit_Values(), false),
 			},
 			"extended_statistic": {
 				Type:          schema.TypeString,

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -522,7 +522,6 @@ func getAwsCloudWatchPutMetricAlarmInput(d *schema.ResourceData) cloudwatch.PutM
 		params.Metrics = metrics
 	}
 
-
 	if v, ok := d.GetOk("ok_actions"); ok {
 		params.OKActions = expandStringSet(v.(*schema.Set))
 	}

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -78,7 +78,6 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 									"dimensions": {
 										Type:     schema.TypeMap,
 										Optional: true,
-										MaxItems: 10,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 									"metric_name": {
@@ -187,7 +186,6 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 			"dimensions": {
 				Type:          schema.TypeMap,
 				Optional:      true,
-				MaxItems:      10,
 				ConflictsWith: []string{"metric_query"},
 				Elem:          &schema.Schema{Type: schema.TypeString},
 			},

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -88,9 +88,9 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 									"namespace": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.Any(
+										ValidateFunc: validation.All(
 											validation.StringLenBetween(1, 255),
-											validation.StringMatch(regexp.MustCompile(`[^:].*`), ""),
+											validation.StringMatch(regexp.MustCompile(`[^:].*`), "must not contain colon characters"),
 										),
 									},
 									"period": {
@@ -125,9 +125,9 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"metric_query"},
-				ValidateFunc: validation.Any(
+				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexp.MustCompile(`[^:].*`), ""),
+					validation.StringMatch(regexp.MustCompile(`[^:].*`), "must not contain colon characters"),
 				),
 			},
 			"period": {
@@ -195,7 +195,10 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				MaxItems: 5,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validateArn,
+					ValidateFunc: validation.Any(
+						validateArn,
+						validateEC2AutomateARN,
+					),
 				},
 			},
 			"ok_actions": {
@@ -204,7 +207,10 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				MaxItems: 5,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validateArn,
+					ValidateFunc: validation.Any(
+						validateArn,
+						validateEC2AutomateARN,
+					),
 				},
 			},
 			"unit": {
@@ -216,7 +222,7 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"statistic", "metric_query"},
-				ValidateFunc:  validation.StringMatch(regexp.MustCompile(`p(\d{1,2}(\.\d{0,2})?|100)`), ""),
+				ValidateFunc:  validation.StringMatch(regexp.MustCompile(`p(\d{1,2}(\.\d{0,2})?|100)`), "must specify a value between p0.0 and p100"),
 			},
 			"treat_missing_data": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -370,7 +370,7 @@ func TestAccAWSCloudWatchMetricAlarm_disappears(t *testing.T) {
 				Config: testAccAWSCloudWatchMetricAlarmConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
-					testAccCheckCloudWatchMetricAlarmDisappears(&alarm),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchMetricAlarm(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -415,24 +415,6 @@ func testAccCheckCloudWatchMetricAlarmExists(n string, alarm *cloudwatch.MetricA
 			return fmt.Errorf("Alarm not found")
 		}
 		*alarm = *resp.MetricAlarms[0]
-
-		return nil
-	}
-}
-
-func testAccCheckCloudWatchMetricAlarmDisappears(alarm *cloudwatch.MetricAlarm) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
-		params := &cloudwatch.DeleteAlarmsInput{
-			AlarmNames: []*string{alarm.AlarmName},
-		}
-		_, err := conn.DeleteAlarms(params)
-		if err != nil {
-			if isAWSErr(err, cloudwatch.ErrCodeResourceNotFoundException, "") {
-				return nil
-			}
-			return err
-		}
 
 		return nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cloudwatch_metric_alarm: add plan time validations to `comparison_operator` and `statistic`, `metric_query.metric.unit`, `unit`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_'
--- PASS: TestAccAWSCloudWatchMetricAlarm_missingStatistic (14.22s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_disappears (32.10s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm (36.33s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_extendedStatistic (38.08s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (43.27s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction (49.03s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic (50.49s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_treatMissingData (70.35s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (76.07s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_tags (107.46s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_expression (168.96s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (340.33s)
```
