### PR TITLE
docs/resource/aws_api_gateway_gateway_response: Fix invalid JSON in response template

### DIFF
--- a/website/docs/r/api_gateway_gateway_response.markdown
+++ b/website/docs/r/api_gateway_gateway_response.markdown
@@ -23,7 +23,7 @@ resource "aws_api_gateway_gateway_response" "test" {
   response_type = "UNAUTHORIZED"
 
   response_templates = {
-    "application/json" = "{'message':$context.error.messageString}"
+    "application/json" = "{\"message\":$context.error.messageString}"
   }
 
   response_parameters = {


### PR DESCRIPTION
Strings in JSON must be enclosed in double quotes. Update the `aws_api_gateway_gateway_response` example response template to be valid JSON.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
N/A
<!--
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
-->