### PR TITLE
Defect fix.

### DIFF
--- a/examples/eks-getting-started/eks-cluster.tf
+++ b/examples/eks-getting-started/eks-cluster.tf
@@ -67,7 +67,7 @@ resource "aws_eks_cluster" "demo" {
 
   vpc_config {
     security_group_ids = [aws_security_group.demo-cluster.id]
-    subnet_ids         = aws_subnet.demo[*].id
+    subnet_ids         = aws_subnet.demo-subnet.*.id
   }
 
   depends_on = [

--- a/examples/eks-getting-started/eks-worker-nodes.tf
+++ b/examples/eks-getting-started/eks-worker-nodes.tf
@@ -42,7 +42,7 @@ resource "aws_eks_node_group" "demo" {
   cluster_name    = aws_eks_cluster.demo.name
   node_group_name = "demo"
   node_role_arn   = aws_iam_role.demo-node.arn
-  subnet_ids      = aws_subnet.demo[*].id
+  subnet_ids      = aws_subnet.demo-subnet.*.id
 
   scaling_config {
     desired_size = 1

--- a/examples/eks-getting-started/vpc.tf
+++ b/examples/eks-getting-started/vpc.tf
@@ -15,7 +15,7 @@ resource "aws_vpc" "demo" {
   )
 }
 
-resource "aws_subnet" "demo" {
+resource "aws_subnet" "demo-subnet" {
   count = 2
 
   availability_zone = data.aws_availability_zones.available.names[count.index]


### PR DESCRIPTION
In the examples/eks-getting-started, there is a defect in the name of
the resource "aws_subnet".  The name seems to need to be unique.  This
correctes that.  Otherwise the terraform apply fails.

See https://discuss.hashicorp.com/t/eks-getting-started-fails-terraform-plan/7124

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
