### PR TITLE
Add event_bus_name to aws_cloudwatch_event_target

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -248,6 +248,7 @@ DOC
 The following arguments are supported:
 
 * `rule` - (Required) The name of the rule you want to add targets to.
+* `event_bus_name` - (Optional) The event bus to associate with the rule. If you omit this, the `default` event bus is used.
 * `target_id` - (Optional) The unique target assignment ID.  If missing, will generate a random, unique id.
 * `arn` - (Required) The Amazon Resource Name (ARN) associated of the target.
 * `input` - (Optional) Valid JSON text passed to the target.
@@ -305,7 +306,7 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 ## Import
 
-Cloud Watch Event Target can be imported using the role event_rule and target_id separated by `/`.
+Cloud Watch Event Target can be imported using `event_bus_name/rule-name/target-id` (if you omit `event_bus_name`, the `default` event bus will be used).
 
  ```
 $ terraform import aws_cloudwatch_event_target.test-event-target rule-name/target-id


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/9330

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cloudwatch_event_target: Add `event_bus_name`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventTarget'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventTarget -timeout 120m
=== RUN   TestAccAWSCloudWatchEventTarget_basic
=== PAUSE TestAccAWSCloudWatchEventTarget_basic
=== RUN   TestAccAWSCloudWatchEventTarget_missingTargetId
=== PAUSE TestAccAWSCloudWatchEventTarget_missingTargetId
=== RUN   TestAccAWSCloudWatchEventTarget_full
=== PAUSE TestAccAWSCloudWatchEventTarget_full
=== RUN   TestAccAWSCloudWatchEventTarget_ssmDocument
=== PAUSE TestAccAWSCloudWatchEventTarget_ssmDocument
=== RUN   TestAccAWSCloudWatchEventTarget_ecs
=== PAUSE TestAccAWSCloudWatchEventTarget_ecs
=== RUN   TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== PAUSE TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== RUN   TestAccAWSCloudWatchEventTarget_batch
=== PAUSE TestAccAWSCloudWatchEventTarget_batch
=== RUN   TestAccAWSCloudWatchEventTarget_kinesis
=== PAUSE TestAccAWSCloudWatchEventTarget_kinesis
=== RUN   TestAccAWSCloudWatchEventTarget_sqs
=== PAUSE TestAccAWSCloudWatchEventTarget_sqs
=== RUN   TestAccAWSCloudWatchEventTarget_input_transformer
=== PAUSE TestAccAWSCloudWatchEventTarget_input_transformer
=== CONT  TestAccAWSCloudWatchEventTarget_basic
=== CONT  TestAccAWSCloudWatchEventTarget_batch
=== CONT  TestAccAWSCloudWatchEventTarget_sqs
=== CONT  TestAccAWSCloudWatchEventTarget_full
=== CONT  TestAccAWSCloudWatchEventTarget_input_transformer
=== CONT  TestAccAWSCloudWatchEventTarget_kinesis
=== CONT  TestAccAWSCloudWatchEventTarget_ssmDocument
=== CONT  TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== CONT  TestAccAWSCloudWatchEventTarget_ecs
=== CONT  TestAccAWSCloudWatchEventTarget_missingTargetId
--- PASS: TestAccAWSCloudWatchEventTarget_sqs (50.80s)
--- PASS: TestAccAWSCloudWatchEventTarget_missingTargetId (52.43s)
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (55.27s)
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (71.93s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (83.62s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount (84.49s)
--- PASS: TestAccAWSCloudWatchEventTarget_basic (90.28s)
--- PASS: TestAccAWSCloudWatchEventTarget_kinesis (99.22s)
--- PASS: TestAccAWSCloudWatchEventTarget_full (99.27s)
--- PASS: TestAccAWSCloudWatchEventTarget_batch (137.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	137.087s
```
