### PR TITLE
fix KMS name validation check

### DIFF
--- a/.changelog/13000.txt
+++ b/.changelog/13000.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_kms_alias: Fix `name` plan time validation
+```
+
+```release-note:bug
+resource/aws_kms_alias: Fix `name` and `name_prefix` plan time validation
+```

--- a/internal/service/kms/alias.go
+++ b/internal/service/kms/alias.go
@@ -36,7 +36,7 @@ func ResourceAlias() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validName,
+				ValidateFunc:  validNameForResource,
 			},
 
 			"name_prefix": {
@@ -45,7 +45,7 @@ func ResourceAlias() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validName,
+				ValidateFunc:  validNameForResource,
 			},
 
 			"target_key_arn": {

--- a/internal/service/kms/alias_data_source.go
+++ b/internal/service/kms/alias_data_source.go
@@ -19,7 +19,7 @@ func DataSourceAlias() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validName,
+				ValidateFunc: validNameForDataSource,
 			},
 			"target_key_arn": {
 				Type:     schema.TypeString,

--- a/internal/service/kms/validate.go
+++ b/internal/service/kms/validate.go
@@ -21,6 +21,11 @@ func validGrantName(v interface{}, k string) (ws []string, es []error) {
 
 func validName(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
+
+	if regexp.MustCompile(`^(alias\/aws)`).MatchString(value) {
+		es = append(es, fmt.Errorf("%q cannot begin with reserved AWS CMK prefix 'alias/aws'", k))
+	}
+
 	if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9:/_-]+$`).MatchString(value) {
 		es = append(es, fmt.Errorf(
 			"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9:/_-]", k))

--- a/internal/service/kms/validate.go
+++ b/internal/service/kms/validate.go
@@ -19,16 +19,26 @@ func validGrantName(v interface{}, k string) (ws []string, es []error) {
 	return
 }
 
-func validName(v interface{}, k string) (ws []string, es []error) {
+func validNameForDataSource(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+
+	if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9/_-]+$`).MatchString(value) {
+		es = append(es, fmt.Errorf(
+			"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9/_-]", k))
+	}
+	return
+}
+
+func validNameForResource(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
 	if regexp.MustCompile(`^(alias\/aws)`).MatchString(value) {
 		es = append(es, fmt.Errorf("%q cannot begin with reserved AWS CMK prefix 'alias/aws'", k))
 	}
 
-	if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9:/_-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9/_-]+$`).MatchString(value) {
 		es = append(es, fmt.Errorf(
-			"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9:/_-]", k))
+			"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9/_-]", k))
 	}
 	return
 }

--- a/internal/service/kms/validate_test.go
+++ b/internal/service/kms/validate_test.go
@@ -35,18 +35,22 @@ func TestValidGrantName(t *testing.T) {
 	}
 }
 
-func TestValidName(t *testing.T) {
+func TestValidNameForDataSource(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
 	}{
 		{
 			Value:    "alias/aws/s3",
-			ErrCount: 1,
+			ErrCount: 0,
 		},
 		{
 			Value:    "alias/hashicorp",
 			ErrCount: 0,
+		},
+		{
+			Value:    "alias/Service:Test",
+			ErrCount: 1,
 		},
 		{
 			Value:    "hashicorp",
@@ -59,7 +63,42 @@ func TestValidName(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, errors := validName(tc.Value, "name")
+		_, errors := validNameForDataSource(tc.Value, "name")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("AWS KMS Alias Name validation failed: %v", errors)
+		}
+	}
+}
+
+func TestValidNameForResource(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "alias/hashicorp",
+			ErrCount: 0,
+		},
+		{
+			Value:    "alias/aws/s3",
+			ErrCount: 1,
+		},
+		{
+			Value:    "alias/Service:Test",
+			ErrCount: 1,
+		},
+		{
+			Value:    "hashicorp",
+			ErrCount: 1,
+		},
+		{
+			Value:    "hashicorp/terraform",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validNameForResource(tc.Value, "name")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("AWS KMS Alias Name validation failed: %v", errors)
 		}

--- a/internal/service/kms/validate_test.go
+++ b/internal/service/kms/validate_test.go
@@ -42,7 +42,7 @@ func TestValidName(t *testing.T) {
 	}{
 		{
 			Value:    "alias/aws/s3",
-			ErrCount: 0,
+			ErrCount: 1,
 		},
 		{
 			Value:    "alias/hashicorp",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12891

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fix KMS name validation check
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TEST=./aws TESTARGS='-run=TestValidateAwsKmsName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestValidateAwsKmsName -timeout 120m
=== RUN   TestValidateAwsKmsName
--- PASS: TestValidateAwsKmsName (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.069s

...
```
