### PR TITLE
Add support Media Store Container Metric Policy resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -666,6 +666,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_media_convert_queue":                                 resourceAwsMediaConvertQueue(),
 			"aws_media_package_channel":                               resourceAwsMediaPackageChannel(),
 			"aws_media_store_container":                               resourceAwsMediaStoreContainer(),
+			"aws_media_store_container_metric_policy":                 resourceAwsMediaStoreContainerMetricPolicy(),
 			"aws_media_store_container_policy":                        resourceAwsMediaStoreContainerPolicy(),
 			"aws_msk_cluster":                                         resourceAwsMskCluster(),
 			"aws_msk_configuration":                                   resourceAwsMskConfiguration(),

--- a/aws/resource_aws_media_store_container_metric_policy.go
+++ b/aws/resource_aws_media_store_container_metric_policy.go
@@ -1,0 +1,186 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsMediaStoreContainerMetricPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMediaStoreContainerMetricPolicyPut,
+		Read:   resourceAwsMediaStoreContainerMetricPolicyRead,
+		Update: resourceAwsMediaStoreContainerMetricPolicyPut,
+		Delete: resourceAwsMediaStoreContainerMetricPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"container_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"metric_policy": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"container_level_metrics": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								mediastore.ContainerLevelMetricsEnabled,
+								mediastore.ContainerLevelMetricsDisabled,
+							}, false),
+						},
+						"metric_policy_rule": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MinItems: 1,
+							MaxItems: 300,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"object_group": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"object_group_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsMediaStoreContainerMetricPolicyPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediastoreconn
+
+	rawMetricPolicyList := d.Get("metric_policy").([]interface{})
+
+	input := &mediastore.PutMetricPolicyInput{
+		ContainerName: aws.String(d.Get("container_name").(string)),
+		MetricPolicy:  expandMediaStoreMetricPolicy(rawMetricPolicyList[0].(map[string]interface{})),
+	}
+
+	_, err := conn.PutMetricPolicy(input)
+	if err != nil {
+		return fmt.Errorf("Error putting MediaStore Metric Policy: %s", err)
+	}
+
+	d.SetId(d.Get("container_name").(string))
+	return resourceAwsMediaStoreContainerMetricPolicyRead(d, meta)
+}
+
+func resourceAwsMediaStoreContainerMetricPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediastoreconn
+
+	input := &mediastore.GetMetricPolicyInput{
+		ContainerName: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetMetricPolicy(input)
+	if err != nil {
+		if isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+			log.Printf("[WARN] MediaContainer %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		if isAWSErr(err, mediastore.ErrCodePolicyNotFoundException, "") {
+			log.Printf("[WARN] MediaContainer Metric Policy for %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("container_name", d.Id())
+
+	if err := d.Set("metric_policy", flattenMediaStoreMetricPolicy(resp.MetricPolicy)); err != nil {
+		return fmt.Errorf("error setting metric_policy: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsMediaStoreContainerMetricPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediastoreconn
+
+	input := &mediastore.DeleteMetricPolicyInput{
+		ContainerName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteMetricPolicy(input)
+	if err != nil {
+		if isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+			return nil
+		}
+		if isAWSErr(err, mediastore.ErrCodePolicyNotFoundException, "") {
+			return nil
+		}
+		// if isAWSErr(err, mediastore.ErrCodeContainerInUseException, "Container must be ACTIVE in order to perform this operation") {
+		// 	return nil
+		// }
+		return err
+	}
+
+	return nil
+}
+
+func expandMediaStoreMetricPolicy(rawMetricPolicy map[string]interface{}) *mediastore.MetricPolicy {
+	return &mediastore.MetricPolicy{
+		ContainerLevelMetrics: aws.String(rawMetricPolicy["container_level_metrics"].(string)),
+		MetricPolicyRules:     expandMediaStoreMetricPolicyRules(rawMetricPolicy["metric_policy_rule"].([]interface{})),
+	}
+}
+
+func flattenMediaStoreMetricPolicy(metricPolicy *mediastore.MetricPolicy) []map[string]interface{} {
+	m := make(map[string]interface{})
+	m["container_level_metrics"] = aws.StringValue(metricPolicy.ContainerLevelMetrics)
+	m["metric_policy_rule"] = flattenMediaStoreMetricPolicyRules(metricPolicy.MetricPolicyRules)
+
+	return []map[string]interface{}{m}
+}
+
+func expandMediaStoreMetricPolicyRules(rawMetricPolicyRules []interface{}) []*mediastore.MetricPolicyRule {
+	metricPolicyRules := make([]*mediastore.MetricPolicyRule, 0, len(rawMetricPolicyRules))
+
+	for _, m := range rawMetricPolicyRules {
+		rawMetricPolicyRule := m.(map[string]interface{})
+		metricPolicyRule := &mediastore.MetricPolicyRule{
+			ObjectGroup:     aws.String(rawMetricPolicyRule["object_group"].(string)),
+			ObjectGroupName: aws.String(rawMetricPolicyRule["object_group_name"].(string)),
+		}
+
+		metricPolicyRules = append(metricPolicyRules, metricPolicyRule)
+	}
+
+	return metricPolicyRules
+}
+
+func flattenMediaStoreMetricPolicyRules(metricPolicyRules []*mediastore.MetricPolicyRule) []interface{} {
+	out := make([]interface{}, 0, len(metricPolicyRules))
+
+	for _, metricPolicyRule := range metricPolicyRules {
+		m := map[string]interface{}{
+			"object_group":      aws.StringValue(metricPolicyRule.ObjectGroup),
+			"object_group_name": aws.StringValue(metricPolicyRule.ObjectGroupName),
+		}
+		out = append(out, m)
+	}
+
+	return out
+}

--- a/aws/resource_aws_media_store_container_metric_policy_test.go
+++ b/aws/resource_aws_media_store_container_metric_policy_test.go
@@ -1,0 +1,150 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSMediaStoreContainerMetricPolicy_basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_media_store_container_metric_policy.test"
+	containerResourceName := "aws_media_store_container.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaStore(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMediaStoreContainerMetricPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMediaStoreContainerMetricPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaStoreContainerMetricPolicyExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "container_name", containerResourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "metric_policy.0.container_level_metrics", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "metric_policy.0.metric_policy_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_policy.0.metric_policy_rule.0.object_group", "baseball/saturday"),
+					resource.TestCheckResourceAttr(resourceName, "metric_policy.0.metric_policy_rule.0.object_group_name", "baseballGroup"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccMediaStoreContainerMetricPolicyConfigUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaStoreContainerMetricPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "metric_policy.0.metric_policy_rule.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metric_policy.0.metric_policy_rule.0.object_group", "baseball/sunday"),
+					resource.TestCheckResourceAttr(resourceName, "metric_policy.0.metric_policy_rule.0.object_group_name", "baseballGroup"),
+					resource.TestCheckResourceAttr(resourceName, "metric_policy.0.metric_policy_rule.1.object_group", "football/sunday"),
+					resource.TestCheckResourceAttr(resourceName, "metric_policy.0.metric_policy_rule.1.object_group_name", "footballGroup"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMediaStoreContainerMetricPolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_media_store_container_metric_policy" {
+			continue
+		}
+
+		input := &mediastore.GetMetricPolicyInput{
+			ContainerName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetMetricPolicy(input)
+		if err != nil {
+			if isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
+				return nil
+			}
+			if isAWSErr(err, mediastore.ErrCodePolicyNotFoundException, "") {
+				return nil
+			}
+			if isAWSErr(err, mediastore.ErrCodeContainerInUseException, "Container must be ACTIVE in order to perform this operation") {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("Expected MediaStore Container Metric Policy to be destroyed, %s found", rs.Primary.ID)
+	}
+	return nil
+}
+
+func testAccCheckAwsMediaStoreContainerMetricPolicyExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
+
+		input := &mediastore.GetMetricPolicyInput{
+			ContainerName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetMetricPolicy(input)
+
+		return err
+	}
+}
+
+func testAccMediaStoreContainerMetricPolicyConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_media_store_container" "test" {
+  name = "tf_mediastore_%s"
+}
+
+resource "aws_media_store_container_metric_policy" "test" {
+  container_name = "${aws_media_store_container.test.name}"
+
+  metric_policy {
+	container_level_metrics = "DISABLED"
+
+	metric_policy_rule {
+		object_group      = "baseball/saturday"
+		object_group_name = "baseballGroup"
+	}
+  }
+}
+`, rName)
+}
+
+func testAccMediaStoreContainerMetricPolicyConfigUpdate(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_media_store_container" "test" {
+  name = "tf_mediastore_%s"
+}
+
+resource "aws_media_store_container_metric_policy" "test" {
+  container_name = "${aws_media_store_container.test.name}"
+
+  metric_policy {
+	container_level_metrics = "DISABLED"
+
+	metric_policy_rule {
+		object_group      = "baseball/sunday"
+		object_group_name = "baseballGroup"
+	}
+
+	metric_policy_rule {
+		object_group      = "football/sunday"
+		object_group_name = "footballGroup"
+	}
+  }
+}
+`, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2206,6 +2206,9 @@
                                     <a href="/docs/providers/aws/r/media_store_container.html">aws_media_store_container</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/media_store_container_metric_policy.html">aws_media_store_container_metric_policy</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/media_store_container_policy.html">aws_media_store_container_policy</a>
                                 </li>
                             </ul>

--- a/website/docs/r/media_store_container_metric_policy.html.markdown
+++ b/website/docs/r/media_store_container_metric_policy.html.markdown
@@ -1,0 +1,58 @@
+---
+subcategory: "MediaStore"
+layout: "aws"
+page_title: "AWS: aws_media_store_container_metric_policy"
+description: |-
+  Provides a MediaStore Container Metric Policy.
+---
+
+# Resource: aws_media_store_container_metric_policy
+
+Provides a MediaStore Container Metric Policy.
+
+## Example Usage
+
+```hcl
+resource "aws_media_store_container" "example" {
+  name = "example"
+}
+
+resource "aws_media_store_container_metric_policy" "example" {
+  container_name = aws_media_store_container.example.name
+
+  metric_policy {
+    container_level_metrics = "DISABLED"
+
+    metric_policy_rule {
+      object_group      = "baseball/saturday"
+      object_group_name = "baseballGroup"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `container_name` - (Required) The name of the container.
+* `metric_policy` - (Required) Configure Metric Policy properties. See below for details.
+
+The `metric_policy` block supports the following:
+
+* `container_level_metrics` - (Required) A setting to enable or disable metrics at the container level.
+* `metric_policy_rule` - (Optional) The rules that enable metrics at the object level. By default, you can include up to five rules. You can also request a quota increase (https://console.aws.amazon.com/servicequotas/home?region=us-east-1#!/services/mediastore/quotas) to allow up to 300 rules per policy. See below for details.
+
+Each `metric_policy_rule` supports the following:
+
+* `object_group` - (Required) A path or file name that defines which objects to include in the group. Wildcards (*) are acceptable.
+* `object_group_name` - (Required) A name that allows you to refer to the object group.
+
+
+## Import
+
+MediaStore Container Metric Policy can be imported using the MediaStore Container Name, e.g.
+
+```
+$ terraform import aws_media_store_container_metric_policy.example example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12968

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Features:
- resource/aws_media_store_container_metric_policy: add support Media Store Container Metric Policy resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMediaStoreContainerMetricPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMediaStoreContainerMetricPolicy_basic -timeout 120m
=== RUN   TestAccAWSMediaStoreContainerMetricPolicy_basic
=== PAUSE TestAccAWSMediaStoreContainerMetricPolicy_basic
=== CONT  TestAccAWSMediaStoreContainerMetricPolicy_basic
--- PASS: TestAccAWSMediaStoreContainerMetricPolicy_basic (144.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	146.263s
```
