### PR TITLE
r/spot_fleet_request - on demand arguments

### DIFF
--- a/.changelog/13127.txt
+++ b/.changelog/13127.txt
@@ -1,7 +1,3 @@
 ```release-note:enhancement
-resource/aws_spot_fleet_request: Add plan time validation `instance_type`
-```
-
-```release-note:enhancement
 resource/aws_spot_fleet_request: Add `on_demand_allocation_strategy`, `on_demand_max_total_price`, and `on_demand_target_capacity` arguments
 ```

--- a/.changelog/13127.txt
+++ b/.changelog/13127.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_spot_fleet_request: Add plan time validation `instance_type`
+```
+
+```release-note:enhancement
+resource/aws_spot_fleet_request: Add `on_demand_allocation_strategy`, `on_demand_max_total_price`, and `on_demand_target_capacity` arguments
+```

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1132,7 +1132,7 @@ func resourceAwsSpotFleetRequestStateRefreshFunc(d *schema.ResourceData, meta in
 		resp, err := conn.DescribeSpotFleetRequests(req)
 
 		if err != nil {
-			log.Printf("Error on retrieving Spot Fleet Request when waiting: %w", err)
+			log.Printf("Error on retrieving Spot Fleet Request when waiting: %s", err)
 			return nil, "", nil
 		}
 
@@ -1158,7 +1158,7 @@ func resourceAwsSpotFleetRequestFulfillmentRefreshFunc(id string, conn *ec2.EC2)
 		resp, err := conn.DescribeSpotFleetRequests(req)
 
 		if err != nil {
-			log.Printf("Error on retrieving Spot Fleet Request when waiting: %w", err)
+			log.Printf("Error on retrieving Spot Fleet Request when waiting: %s", err)
 			return nil, "", nil
 		}
 
@@ -1343,7 +1343,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 				flatLbs = append(flatLbs, lb.Name)
 			}
 			if err := d.Set("load_balancers", flattenStringSet(flatLbs)); err != nil {
-				return fmt.Errorf("error setting load_balancers: %s", err)
+				return fmt.Errorf("error setting load_balancers: %w", err)
 			}
 		}
 
@@ -1641,7 +1641,7 @@ func resourceAwsSpotFleetRequestUpdate(d *schema.ResourceData, meta interface{})
 	if updateFlag {
 		log.Printf("[DEBUG] Modifying Spot Fleet Request: %#v", req)
 		if _, err := conn.ModifySpotFleetRequest(req); err != nil {
-			return fmt.Errorf("error updating spot request (%s): %s", d.Id(), err)
+			return fmt.Errorf("error updating spot request (%s): %w", d.Id(), err)
 		}
 
 		log.Println("[INFO] Waiting for Spot Fleet Request to be modified")
@@ -1663,7 +1663,7 @@ func resourceAwsSpotFleetRequestUpdate(d *schema.ResourceData, meta interface{})
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+			return fmt.Errorf("error updating tags: %w", err)
 		}
 	}
 
@@ -1678,7 +1678,7 @@ func resourceAwsSpotFleetRequestDelete(d *schema.ResourceData, meta interface{})
 	log.Printf("[INFO] Cancelling spot fleet request: %s", d.Id())
 	err := deleteSpotFleetRequest(d.Id(), terminateInstances, d.Timeout(schema.TimeoutDelete), conn)
 	if err != nil {
-		return fmt.Errorf("error deleting spot request (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting spot request (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -1704,7 +1704,7 @@ func deleteSpotFleetRequest(spotFleetRequestID string, terminateInstances bool, 
 		})
 
 		if err != nil || resp == nil {
-			return 0, fmt.Errorf("error reading Spot Fleet Instances (%s): %s", spotFleetRequestID, err)
+			return 0, fmt.Errorf("error reading Spot Fleet Instances (%s): %w", spotFleetRequestID, err)
 		}
 
 		return len(resp.ActiveInstances), nil

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -559,6 +559,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Type:     schema.TypeFloat,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"on_demand_max_total_price": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1656,11 +1656,10 @@ func resourceAwsSpotFleetRequestUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("on_demand_target_capacity") {
-		if val, ok := d.GetOk("on_demand_target_capacity"); ok {
+		if val, ok := d.GetOkExists("on_demand_target_capacity"); ok {
 			req.OnDemandTargetCapacity = aws.Int64(int64(val.(int)))
+			updateFlag = true
 		}
-
-		updateFlag = true
 	}
 
 	if d.HasChange("excess_capacity_termination_policy") {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1081,7 +1081,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error requesting spot fleet: %s", err)
+		return fmt.Errorf("Error requesting spot fleet: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.SpotFleetRequestId))
@@ -1132,7 +1132,7 @@ func resourceAwsSpotFleetRequestStateRefreshFunc(d *schema.ResourceData, meta in
 		resp, err := conn.DescribeSpotFleetRequests(req)
 
 		if err != nil {
-			log.Printf("Error on retrieving Spot Fleet Request when waiting: %s", err)
+			log.Printf("Error on retrieving Spot Fleet Request when waiting: %w", err)
 			return nil, "", nil
 		}
 
@@ -1158,7 +1158,7 @@ func resourceAwsSpotFleetRequestFulfillmentRefreshFunc(id string, conn *ec2.EC2)
 		resp, err := conn.DescribeSpotFleetRequests(req)
 
 		if err != nil {
-			log.Printf("Error on retrieving Spot Fleet Request when waiting: %s", err)
+			log.Printf("Error on retrieving Spot Fleet Request when waiting: %w", err)
 			return nil, "", nil
 		}
 
@@ -1298,7 +1298,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 
 	launchSpec, err := launchSpecsToSet(config.LaunchSpecifications, conn)
 	if err != nil {
-		return fmt.Errorf("error occurred while reading launch specification: %s", err)
+		return fmt.Errorf("error occurred while reading launch specification: %w", err)
 	}
 
 	d.Set("replace_unhealthy_instances", config.ReplaceUnhealthyInstances)
@@ -1318,20 +1318,20 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 
 	if len(config.LaunchTemplateConfigs) > 0 {
 		if err := d.Set("launch_template_config", flattenFleetLaunchTemplateConfig(config.LaunchTemplateConfigs)); err != nil {
-			return fmt.Errorf("error setting launch_template_config: %s", err)
+			return fmt.Errorf("error setting launch_template_config: %w", err)
 		}
 	}
 
 	if config.OnDemandTargetCapacity != nil {
-		d.Set("on_demand_target_capacity", aws.Int64Value(config.OnDemandTargetCapacity))
+		d.Set("on_demand_target_capacity", config.OnDemandTargetCapacity)
 	}
 
 	if config.OnDemandAllocationStrategy != nil {
-		d.Set("on_demand_allocation_strategy", aws.StringValue(config.OnDemandAllocationStrategy))
+		d.Set("on_demand_allocation_strategy", config.OnDemandAllocationStrategy)
 	}
 
 	if config.OnDemandMaxTotalPrice != nil {
-		d.Set("on_demand_max_total_price", aws.StringValue(config.OnDemandMaxTotalPrice))
+		d.Set("on_demand_max_total_price", config.OnDemandMaxTotalPrice)
 	}
 
 	if config.LoadBalancersConfig != nil {
@@ -1353,7 +1353,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 				flatTgs = append(flatTgs, tg.Arn)
 			}
 			if err := d.Set("target_group_arns", flattenStringSet(flatTgs)); err != nil {
-				return fmt.Errorf("error setting target_group_arns: %s", err)
+				return fmt.Errorf("error setting target_group_arns: %w", err)
 			}
 		}
 	}

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -548,14 +548,17 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			"on_demand_allocation_strategy": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"on_demand_fulfilled_capacity": {
 				Type:     schema.TypeFloat,
 				Optional: true,
+				ForceNew: true,
 			},
 			"on_demand_max_total_price": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"on_demand_target_capacity": {
 				Type:     schema.TypeInt,
@@ -1645,6 +1648,14 @@ func resourceAwsSpotFleetRequestUpdate(d *schema.ResourceData, meta interface{})
 			req.TargetCapacity = aws.Int64(int64(val.(int)))
 			updateFlag = true
 		}
+	}
+
+	if d.HasChange("on_demand_target_capacity") {
+		if val, ok := d.GetOk("on_demand_target_capacity"); ok {
+			req.OnDemandTargetCapacity = aws.Int64(int64(val.(int)))
+		}
+
+		updateFlag = true
 	}
 
 	if d.HasChange("excess_capacity_termination_policy") {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -546,14 +546,11 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Set: schema.HashString,
 			},
 			"on_demand_allocation_strategy": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  ec2.OnDemandAllocationStrategyLowestPrice,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.OnDemandAllocationStrategyPrioritized,
-					ec2.OnDemandAllocationStrategyLowestPrice,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      ec2.OnDemandAllocationStrategyLowestPrice,
+				ValidateFunc: validation.StringInSlice(ec2.OnDemandAllocationStrategy_Values(), false),
 			},
 			"on_demand_max_total_price": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1007,7 +1007,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		spotFleetConfig.SpotPrice = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("on_demand_target_capacity"); ok {
+	if v, ok := d.GetOkExists("on_demand_target_capacity"); ok {
 		spotFleetConfig.OnDemandTargetCapacity = aws.Int64(int64(v.(int)))
 	}
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -555,12 +555,6 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 					ec2.OnDemandAllocationStrategyLowestPrice,
 				}, false),
 			},
-			"on_demand_fulfilled_capacity": {
-				Type:     schema.TypeFloat,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
 			"on_demand_max_total_price": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -1025,10 +1019,6 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		spotFleetConfig.OnDemandMaxTotalPrice = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("on_demand_fulfilled_capacity"); ok {
-		spotFleetConfig.OnDemandFulfilledCapacity = aws.Float64(v.(float64))
-	}
-
 	if v, ok := d.GetOk("valid_from"); ok {
 		validFrom, err := time.Parse(time.RFC3339, v.(string))
 		if err != nil {
@@ -1175,7 +1165,7 @@ func resourceAwsSpotFleetRequestStateRefreshFunc(d *schema.ResourceData, meta in
 
 		spotFleetRequest := resp.SpotFleetRequestConfigs[0]
 
-		return spotFleetRequest, *spotFleetRequest.SpotFleetRequestState, nil
+		return spotFleetRequest, aws.StringValue(spotFleetRequest.SpotFleetRequestState), nil
 	}
 }
 
@@ -1200,7 +1190,7 @@ func resourceAwsSpotFleetRequestFulfillmentRefreshFunc(id string, conn *ec2.EC2)
 		}
 
 		cfg := resp.SpotFleetRequestConfigs[0]
-		status := *cfg.ActivityStatus
+		status := aws.StringValue(cfg.ActivityStatus)
 
 		var fleetError error
 		if status == ec2.ActivityStatusError {
@@ -1361,10 +1351,6 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 
 	if config.OnDemandMaxTotalPrice != nil {
 		d.Set("on_demand_max_total_price", aws.StringValue(config.OnDemandMaxTotalPrice))
-	}
-
-	if config.OnDemandFulfilledCapacity != nil {
-		d.Set("on_demand_fulfilled_capacity", aws.Float64Value(config.OnDemandFulfilledCapacity))
 	}
 
 	if config.LoadBalancersConfig != nil {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -549,6 +549,11 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  ec2.OnDemandAllocationStrategyLowestPrice,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.OnDemandAllocationStrategyPrioritized,
+					ec2.OnDemandAllocationStrategyLowestPrice,
+				}, false),
 			},
 			"on_demand_fulfilled_capacity": {
 				Type:     schema.TypeFloat,

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -242,10 +242,9 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							ForceNew: true,
 						},
 						"instance_type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(ec2.InstanceType_Values(), false),
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
 						},
 						"key_name": {
 							Type:         schema.TypeString,
@@ -363,10 +362,9 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										ForceNew: true,
 									},
 									"instance_type": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice(ec2.InstanceType_Values(), false),
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
 									},
 									"spot_price": {
 										Type:     schema.TypeString,

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -242,9 +242,10 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							ForceNew: true,
 						},
 						"instance_type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(ec2.InstanceType_Values(), false),
 						},
 						"key_name": {
 							Type:         schema.TypeString,
@@ -362,9 +363,10 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										ForceNew: true,
 									},
 									"instance_type": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(ec2.InstanceType_Values(), false),
 									},
 									"spot_price": {
 										Type:     schema.TypeString,
@@ -489,12 +491,10 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"replacement_strategy": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											"launch",
-										}, false),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(ec2.ReplacementStrategy_Values(), false),
 									},
 								},
 							},

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -545,6 +545,22 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				},
 				Set: schema.HashString,
 			},
+			"on_demand_allocation_strategy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"on_demand_fulfilled_capacity": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+			"on_demand_max_total_price": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"on_demand_target_capacity": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"tags":     tagsSchema(),
 			"tags_all": tagsSchemaComputed(),
 		},
@@ -988,6 +1004,22 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		spotFleetConfig.SpotPrice = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("on_demand_target_capacity"); ok {
+		spotFleetConfig.OnDemandTargetCapacity = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("on_demand_allocation_strategy"); ok {
+		spotFleetConfig.OnDemandAllocationStrategy = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("on_demand_max_total_price"); ok {
+		spotFleetConfig.OnDemandMaxTotalPrice = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("on_demand_fulfilled_capacity"); ok {
+		spotFleetConfig.OnDemandFulfilledCapacity = aws.Float64(v.(float64))
+	}
+
 	if v, ok := d.GetOk("valid_from"); ok {
 		validFrom, err := time.Parse(time.RFC3339, v.(string))
 		if err != nil {
@@ -1308,6 +1340,22 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 		if err := d.Set("launch_template_config", flattenFleetLaunchTemplateConfig(config.LaunchTemplateConfigs)); err != nil {
 			return fmt.Errorf("error setting launch_template_config: %s", err)
 		}
+	}
+
+	if config.OnDemandTargetCapacity != nil {
+		d.Set("on_demand_target_capacity", aws.Int64Value(config.OnDemandTargetCapacity))
+	}
+
+	if config.OnDemandAllocationStrategy != nil {
+		d.Set("on_demand_allocation_strategy", aws.StringValue(config.OnDemandAllocationStrategy))
+	}
+
+	if config.OnDemandMaxTotalPrice != nil {
+		d.Set("on_demand_max_total_price", aws.StringValue(config.OnDemandMaxTotalPrice))
+	}
+
+	if config.OnDemandFulfilledCapacity != nil {
+		d.Set("on_demand_fulfilled_capacity", aws.Float64Value(config.OnDemandFulfilledCapacity))
 	}
 
 	if config.LoadBalancersConfig != nil {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -265,14 +265,10 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							ForceNew: true,
 						},
 						"placement_tenancy": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								ec2.TenancyDefault,
-								ec2.TenancyDedicated,
-								ec2.TenancyHost,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(ec2.Tenancy_Values(), false),
 						},
 						"spot_price": {
 							Type:     schema.TypeString,
@@ -409,15 +405,11 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				ForceNew: false,
 			},
 			"allocation_strategy": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  ec2.AllocationStrategyLowestPrice,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.AllocationStrategyLowestPrice,
-					ec2.AllocationStrategyDiversified,
-					ec2.AllocationStrategyCapacityOptimized,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ec2.AllocationStrategyLowestPrice,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ec2.AllocationStrategy_Values(), false),
 			},
 			"instance_pools_to_use_count": {
 				Type:     schema.TypeInt,
@@ -437,15 +429,11 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				}, false),
 			},
 			"instance_interruption_behaviour": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  ec2.InstanceInterruptionBehaviorTerminate,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.InstanceInterruptionBehaviorTerminate,
-					ec2.InstanceInterruptionBehaviorStop,
-					ec2.InstanceInterruptionBehaviorHibernate,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ec2.InstanceInterruptionBehaviorTerminate,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ec2.InstanceInterruptionBehavior_Values(), false),
 			},
 			"spot_price": {
 				Type:     schema.TypeString,
@@ -470,15 +458,11 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				ValidateFunc: validation.IsRFC3339Time,
 			},
 			"fleet_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  ec2.FleetTypeMaintain,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.FleetTypeMaintain,
-					ec2.FleetTypeRequest,
-					ec2.FleetTypeInstant,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ec2.FleetTypeMaintain,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ec2.FleetType_Values(), false),
 			},
 			"spot_maintenance_strategies": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -2762,7 +2762,7 @@ resource "aws_spot_fleet_request" "test" {
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestOnDemandTargetCapacityConfig(rName string, rInt int, validUntil string, targetCapacity int) string {
+func testAccAWSSpotFleetRequestOnDemandTargetCapacityConfig(rName string, validUntil string, targetCapacity int) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName) +
 		fmt.Sprintf(`
 resource "aws_launch_template" "test" {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -357,6 +357,7 @@ func TestAccAWSSpotFleetRequest_onDemandTargetCapacity(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -399,6 +400,7 @@ func TestAccAWSSpotFleetRequest_onDemandMaxTotalPrice(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -427,6 +429,7 @@ func TestAccAWSSpotFleetRequest_onDemandAllocationStrategy(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -447,6 +447,34 @@ func TestAccAWSSpotFleetRequest_onDemandAllocationStrategy(t *testing.T) {
 	})
 }
 
+func TestAccAWSSpotFleetRequest_onDemandFulfilledCapacity(t *testing.T) {
+	var sfr ec2.SpotFleetRequestConfig
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestOnDemandFulfilledCapacityConfig(rName, validUntil, "2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_fulfilled_capacity", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
+		},
+	})
+}
+
 func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -2856,4 +2884,36 @@ resource "aws_spot_fleet_request" "test" {
   depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, rName, validUntil, strategy)
+}
+
+func testAccAWSSpotFleetRequestOnDemandFulfilledCapacityConfig(rName, validUntil, capacity string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) +
+		fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  key_name      = aws_key_pair.test.key_name
+}
+
+resource "aws_spot_fleet_request" "test" {
+  iam_fleet_role                      = aws_iam_role.test.arn
+  spot_price                          = "0.005"
+  target_capacity                     = 2
+  valid_until                         = %[2]q
+  terminate_instances_with_expiration = true
+  instance_interruption_behaviour     = "stop"
+  wait_for_fulfillment                = true
+  on_demand_fulfilled_capacity        = %[3]q
+
+  launch_template_config {
+    launch_template_specification {
+      name    = aws_launch_template.test.name
+      version = aws_launch_template.test.latest_version
+    }
+  }
+
+  depends_on = ["aws_iam_policy_attachment.test"]
+}
+`, rName, validUntil, capacity)
 }

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -2763,7 +2763,7 @@ resource "aws_spot_fleet_request" "test" {
 }
 
 func testAccAWSSpotFleetRequestOnDemandTargetCapacityConfig(rName string, rInt int, validUntil string, targetCapacity int) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) +
+	return testAccAWSSpotFleetRequestConfigBase(rName) +
 		fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[1]q

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -201,6 +201,10 @@ across different markets and instance types. Conflicts with `launch_template_con
 * `valid_from` - (Optional) The start date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). The default is to start fulfilling the request immediately.
 * `load_balancers` (Optional) A list of elastic load balancer names to add to the Spot fleet.
 * `target_group_arns` (Optional) A list of `aws_alb_target_group` ARNs, for use with Application Load Balancing.
+* `on_demand_allocation_strategy` - The order of the launch template overrides to use in fulfilling On-Demand capacity. the possible values are: `lowestPrice` and `prioritized`. the default is `lowestPrice`.
+* `on_demand_fulfilled_capacity` - The number of On-Demand units fulfilled by this request compared to the set target On-Demand capacity.
+* `on_demand_max_total_price` - The maximum amount per hour for On-Demand Instances that you're willing to pay. When the maximum amount you're willing to pay is reached, the fleet stops launching instances even if it hasn’t met the target capacity.
+* `on_demand_target_capacity` - The number of On-Demand units to request. If the request type is `maintain`, you can specify a target capacity of 0 and add capacity later.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Launch Template Configs

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -202,7 +202,6 @@ across different markets and instance types. Conflicts with `launch_template_con
 * `load_balancers` (Optional) A list of elastic load balancer names to add to the Spot fleet.
 * `target_group_arns` (Optional) A list of `aws_alb_target_group` ARNs, for use with Application Load Balancing.
 * `on_demand_allocation_strategy` - The order of the launch template overrides to use in fulfilling On-Demand capacity. the possible values are: `lowestPrice` and `prioritized`. the default is `lowestPrice`.
-* `on_demand_fulfilled_capacity` - The number of On-Demand units fulfilled by this request compared to the set target On-Demand capacity.
 * `on_demand_max_total_price` - The maximum amount per hour for On-Demand Instances that you're willing to pay. When the maximum amount you're willing to pay is reached, the fleet stops launching instances even if it hasn’t met the target capacity.
 * `on_demand_target_capacity` - The number of On-Demand units to request. If the request type is `maintain`, you can specify a target capacity of 0 and add capacity later.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7011
Closes #16607

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_spot_fleet_request: add `on_demand_allocation_strategy`, `on_demand_max_total_price`, and `on_demand_target_capacity` arguments
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSpotFleetRequest_onDemand'
--- PASS: TestAccAWSSpotFleetRequest_onDemandTargetCapacity (436.81s)
--- PASS: TestAccAWSSpotFleetRequest_onDemandMaxTotalPrice (282.42s)
--- PASS: TestAccAWSSpotFleetRequest_onDemandAllocationStrategy (349.56s)
```
