### PR TITLE
[WIP] add configuration_set to aws_cognito_user_pool

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -169,6 +169,9 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							Optional: true,
 							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 								value := v.(string)
+								if value == "" {
+									return
+								}
 								validPattern := "^[A-Za-z0-9_-]{1,64}$"
 								valid, matchErr := regexp.MatchString(validPattern, value)
 								if !valid || matchErr != nil {

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -164,6 +164,20 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 								cognitoidentityprovider.EmailSendingAccountTypeDeveloper,
 							}, false),
 						},
+						"configuration_set": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								value := v.(string)
+								validPattern := "^[A-Za-z0-9_-]{1,64}$"
+								valid, matchErr := regexp.MatchString(validPattern, value)
+								if !valid || matchErr != nil {
+									errors = append(errors, fmt.Errorf(
+										"%q must match regex '%v'", k, validPattern))
+								}
+								return
+							},
+						},
 					},
 				},
 			},
@@ -594,6 +608,10 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 
 			if v, ok := config["email_sending_account"]; ok && v.(string) != "" {
 				emailConfigurationType.EmailSendingAccount = aws.String(v.(string))
+			}
+
+			if v, ok := config["configuration_set"]; ok && v.(string) != "" {
+				emailConfigurationType.ConfigurationSet = aws.String(v.(string))
 			}
 
 			params.EmailConfiguration = emailConfigurationType

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -704,12 +704,13 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, "", "", "", "COGNITO_DEFAULT"),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, "", "", "", "","COGNITO_DEFAULT"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", ""),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.email_sending_account", "COGNITO_DEFAULT"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.from_email_address", ""),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.configuration_set", ""),
 				),
 			},
 			{
@@ -718,13 +719,14 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, replyTo, sourceARN, "John Smith <john@smith.com>", "DEVELOPER"),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, replyTo, sourceARN, "John Smith <john@smith.com>", "config-set","DEVELOPER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", replyTo),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.email_sending_account", "DEVELOPER"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.source_arn", sourceARN),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.from_email_address", "John Smith <john@smith.com>"),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.configuration_set", "config-set"),
 				),
 			},
 		},
@@ -1509,7 +1511,7 @@ resource "aws_cognito_user_pool" "test" {
 `, name, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, email, arn, from, account string) string {
+func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, email, arn, from, configSet, account string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
     name = "terraform-test-pool-%[1]s"
@@ -1519,9 +1521,10 @@ resource "aws_cognito_user_pool" "test" {
       reply_to_email_address = %[2]q
       source_arn = %[3]q
       from_email_address = %[4]q
-      email_sending_account = %[5]q
+      configuration_set = %[5]q
+      email_sending_account = %[6]q
     }
-  }`, name, email, arn, from, account)
+  }`, name, email, arn, from, configSet, account)
 }
 
 func testAccAWSCognitoUserPoolConfig_withAliasAttributes(name string) string {

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -704,7 +704,7 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, "", "", "", "","COGNITO_DEFAULT"),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, "", "", "", "", "COGNITO_DEFAULT"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", ""),
@@ -719,7 +719,7 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, replyTo, sourceARN, "John Smith <john@smith.com>", "config-set","DEVELOPER"),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, replyTo, sourceARN, "John Smith <john@smith.com>", "config-set", "DEVELOPER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", replyTo),

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -92,6 +92,7 @@ The following arguments are supported:
   * `source_arn` (Optional) - The ARN of the email source.
   * `from_email_address` (Optional) - Sender’s email address or sender’s name with their email address (e.g. `john@smith.com` or `John Smith <john@smith.com>`)
   * `email_sending_account` (Optional) - Instruct Cognito to either use its built-in functional or Amazon SES to send out emails.
+  * `configuration_set` (Optional) - The set of configuration rules to be applied to emails sent using Amazon SES.
 
 #### Lambda Configuration
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13154

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cognito_user_pool: Add `configuration_set` to `email_configuration`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPool_withEmailConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserPool_withEmailConfiguration -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withEmailConfiguration
=== CONT  TestAccAWSCognitoUserPool_withEmailConfiguration
--- FAIL: TestAccAWSCognitoUserPool_withEmailConfiguration (34.17s)
    testing.go:669: Step 2 error: errors during apply:
        
        Error: Error updating Cognito User pool: NotAuthorizedException: Email arn does not belong to your account.
        
          on /tmp/tf-test527427261/main.tf line 2:
          (source code not available)
        
        
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       34.209s
```

### Questions

This is my first code contribution and a work in progress with some open questions.

- The `ValidateFunc` is fully defined in the schema, should this be defined in `validators.go`?
- The validation func returns if the value is an empty string, is this necessary for an "optional" value?
- I can't figure out what I need to add to get the acceptance tests to run.