### PR TITLE
[WIP] Cloudsearch

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -415,6 +415,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudfront_distribution":                             resourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_origin_access_identity":                   resourceAwsCloudFrontOriginAccessIdentity(),
 			"aws_cloudfront_public_key":                               resourceAwsCloudFrontPublicKey(),
+			"aws_cloudsearch_domain":                                  resourceAwsCloudSearchDomain(),
 			"aws_cloudtrail":                                          resourceAwsCloudTrail(),
 			"aws_cloudwatch_event_permission":                         resourceAwsCloudWatchEventPermission(),
 			"aws_cloudwatch_event_rule":                               resourceAwsCloudWatchEventRule(),

--- a/aws/resource_aws_cloudsearch_domain.go
+++ b/aws/resource_aws_cloudsearch_domain.go
@@ -1,0 +1,597 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudsearch"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"log"
+	"reflect"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+func resourceAwsCloudSearchDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudSearchDomainCreate,
+		Read:   resourceAwsCloudSearchDomainRead,
+		Update: resourceAwsCloudSearchDomainUpdate,
+		Delete: resourceAwsCloudSearchDomainDelete,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateDomainNameRegex,
+			},
+			"instance_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "search.m1.small",
+			},
+			"replication_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"partition_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+			},
+			"indexes": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"search": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"facet": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"return": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"sort": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"highlight": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"analysis_scheme": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"default_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"access_policy": {
+				Type:             schema.TypeString,
+				ValidateFunc:     validateIAMPolicyJson,
+				Required:         true,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+			"docservice": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"searchservice": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"wait_for_endpoints": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+		},
+	}
+}
+
+func resourceAwsCloudSearchDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudsearchconn
+
+	input := cloudsearch.CreateDomainInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+
+	output, err := conn.CreateDomain(&input)
+	if err != nil {
+		log.Printf("[DEBUG] Creating CloudWatch Domain: %#v", input)
+		return fmt.Errorf("%s %q", err, d.Get("domain_name").(string))
+	}
+
+	d.SetId(*output.DomainStatus.ARN)
+	return resourceAwsCloudSearchDomainUpdate(d, meta)
+}
+
+func resourceAwsCloudSearchDomainRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudsearchconn
+
+	domainlist := cloudsearch.DescribeDomainsInput{
+		DomainNames: []*string{
+			aws.String(d.Get("domain_name").(string)),
+		},
+	}
+
+	resp, err1 := conn.DescribeDomains(&domainlist)
+	if err1 != nil {
+		return err1
+	}
+	domain := resp.DomainStatusList[0]
+	d.Set("domain_id", domain.DomainId)
+
+	if domain.DocService.Endpoint != nil {
+		d.Set("docservice", domain.DocService.Endpoint)
+	}
+	if domain.SearchService.Endpoint != nil {
+		d.Set("searchservice", domain.SearchService.Endpoint)
+	}
+
+	input := cloudsearch.DescribeIndexFieldsInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+
+	_, err := conn.DescribeIndexFields(&input)
+	// if err != nil {
+	// 	log.Printf("[DEBUG] Reading CloudWatch Index fields: %#v", input)
+	// 	return fmt.Errorf("%s %q", err, d.Get("domain_name").(string))
+	// }
+
+	return err
+}
+
+func waitForSearchDomainToBeAvailable(d *schema.ResourceData, conn *cloudsearch.CloudSearch, domainlist cloudsearch.DescribeDomainsInput) error {
+	log.Printf("[INFO] cloudserach (%#v) waiting for SearchDomain endpoint. This usually takes 10 minutes.", domainlist.DomainNames[0])
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"Waiting"},
+		Target:     []string{"OK"},
+		Timeout:    30 * time.Minute,
+		MinTimeout: 5 * time.Second,
+		Refresh: func() (interface{}, string, error) {
+			resp, err := conn.DescribeDomains(&domainlist)
+			log.Printf("[DEBUG] Checking %v", domainlist.DomainNames[0])
+			if err != nil {
+				log.Printf("[ERROR] Could not find domain (%v).  %s", domainlist.DomainNames[0], err)
+				return nil, "", err
+			}
+			// Not good enough to wait for processing, have to check for serach end point.
+			domain := resp.DomainStatusList[0]
+			log.Printf("[DEBUG] GLEN: Domain = %s", domain)
+			processing := strconv.FormatBool(*domain.Processing)
+			log.Printf("[DEBUG] GLEN: Processing = %s", processing)
+			if domain.SearchService.Endpoint != nil {
+				log.Printf("[DEBUG] GLEN: type: %T", domain.SearchService.Endpoint)
+				log.Printf("[DEBUG] GLEN: SearchServiceEndPoint = %s", *domain.SearchService.Endpoint)
+			}
+			if domain.SearchService.Endpoint == nil || *domain.SearchService.Endpoint == "" {
+				return resp, "Waiting", nil
+			}
+			return resp, "OK", nil
+
+		},
+	}
+
+	log.Printf("[DEBUG] Waiting for CloudSearch domain to finish processing: %v", domainlist.DomainNames[0])
+	_, err := stateConf.WaitForState()
+
+	// Search service was blank.
+	resp, err1 := conn.DescribeDomains(&domainlist)
+	if err1 != nil {
+		return err1
+	}
+	domain := resp.DomainStatusList[0]
+	d.Set("domain_id", domain.DomainId)
+	d.Set("docservice", domain.DocService.Endpoint)
+	d.Set("searchservice", domain.SearchService.Endpoint)
+
+	if err != nil {
+		return fmt.Errorf("Error waiting for CloudSearch domain (%#v) to finish processing: %s", domainlist.DomainNames[0], err)
+	}
+	return err
+}
+
+func resourceAwsCloudSearchDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudsearchconn
+
+	err := updateScalingParameters(d, meta, conn)
+	if err != nil {
+		return err
+	}
+
+	updated, err := defineIndexFields(d, meta, conn)
+	if err != nil {
+		return err
+	}
+
+	err = updateAccessPolicy(d, meta, conn)
+	if err != nil {
+		return err
+	}
+
+	// When you add fields or modify existing fields, you must explicitly issue a request to re-index your data
+	// when you are done making configuration changes.
+	// https://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-index-fields.html
+	if updated {
+		_, err := conn.IndexDocuments(&cloudsearch.IndexDocumentsInput{
+			DomainName: aws.String(d.Get("domain_name").(string)),
+		})
+		if err != nil {
+			return err
+		}
+	}
+	if d.Get("wait_for_endpoints").(bool) {
+		domainlist := cloudsearch.DescribeDomainsInput{
+			DomainNames: []*string{
+				aws.String(d.Get("domain_name").(string)),
+			},
+		}
+		err2 := waitForSearchDomainToBeAvailable(d, conn, domainlist)
+		if err2 != nil {
+			fmt.Errorf("%s %q", err2, d.Get("domain_name").(string))
+		}
+	}
+	return nil
+}
+
+func updateScalingParameters(d *schema.ResourceData, meta interface{}, conn *cloudsearch.CloudSearch) error {
+	input := cloudsearch.UpdateScalingParametersInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+		ScalingParameters: &cloudsearch.ScalingParameters{
+			DesiredInstanceType:     aws.String(d.Get("instance_type").(string)),
+			DesiredReplicationCount: aws.Int64(int64(d.Get("replication_count").(int))),
+		},
+	}
+
+	if d.Get("instance_type").(string) == "search.m3.2xlarge" {
+		input.ScalingParameters.DesiredPartitionCount = aws.Int64(int64(d.Get("partition_count").(int)))
+	}
+
+	_, err := conn.UpdateScalingParameters(&input)
+	// if err != nil {
+	// 	log.Printf("[DEBUG] Updating Scaling Parameters: %#v", input)
+	// 	return fmt.Errorf("%s %q", err, d.Get("domain_name").(string))
+	// }
+	return err
+}
+
+func defineIndexFields(d *schema.ResourceData, meta interface{}, conn *cloudsearch.CloudSearch) (bool, error) {
+	if d.HasChange("indexes") {
+		old := make(map[string]interface{})
+		new := make(map[string]interface{})
+
+		o, n := d.GetChange("indexes")
+
+		for _, ot := range o.([]interface{}) {
+			os := ot.(map[string]interface{})
+			old[os["name"].(string)] = os
+		}
+
+		for _, nt := range n.([]interface{}) {
+			ns := nt.(map[string]interface{})
+			new[ns["name"].(string)] = ns
+		}
+
+		// Handle Removal
+		for k := range old {
+			if _, ok := new[k]; !ok {
+				deleteIndexField(d.Get("domain_name").(string), k, conn)
+			}
+		}
+
+		for _, v := range new {
+			// Handle replaces & additions
+			err := defineIndexField(d.Get("domain_name").(string), v.(map[string]interface{}), conn)
+			if err != nil {
+				return true, err
+			}
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func defineIndexField(domainName string, index map[string]interface{}, conn *cloudsearch.CloudSearch) error {
+	i, err := genIndexFieldInput(index)
+	if err != nil {
+		return err
+	}
+
+	input := cloudsearch.DefineIndexFieldInput{
+		DomainName: aws.String(domainName),
+		IndexField: i,
+	}
+
+	_, err = conn.DefineIndexField(&input)
+	return err
+}
+
+func deleteIndexField(domainName string, indexName string, conn *cloudsearch.CloudSearch) error {
+	input := cloudsearch.DeleteIndexFieldInput{
+		DomainName:     aws.String(domainName),
+		IndexFieldName: aws.String(indexName),
+	}
+
+	_, err := conn.DeleteIndexField(&input)
+	return err
+}
+
+var parseError = func(d string, t string) error {
+	return fmt.Errorf("can't convert default_value '%s' of type '%s' to int", d, t)
+}
+
+/*
+extractFromMapToType extracts a specific value from map[string]interface{} into an interface of type
+expects: map[string]interface{}, string, interface{}
+returns: error
+*/
+func extractFromMapToType(index map[string]interface{}, prop string, t interface{}) error {
+	v, ok := index[prop]
+	if !ok {
+		return fmt.Errorf("%s is not a valid propery of an index", prop)
+	}
+
+	if "default_value" == prop {
+		switch t.(type) {
+		case *int:
+			{
+				d, err := strconv.Atoi(v.(string))
+				if err != nil {
+					return parseError(v.(string), "int")
+				}
+
+				reflect.ValueOf(t).Elem().Set(reflect.ValueOf(d))
+			}
+		case *float64:
+			{
+				f, err := strconv.ParseFloat(v.(string), 64)
+				if err != nil {
+					return parseError(v.(string), "double")
+				}
+
+				reflect.ValueOf(t).Elem().Set(reflect.ValueOf(f))
+			}
+		default:
+			{
+				if v.(string) != "" {
+					reflect.ValueOf(t).Elem().Set(reflect.ValueOf(v))
+				}
+			}
+		}
+		return nil
+	}
+
+	reflect.ValueOf(t).Elem().Set(reflect.ValueOf(v))
+	return nil
+}
+
+func genIndexFieldInput(index map[string]interface{}) (*cloudsearch.IndexField, error) {
+	input := &cloudsearch.IndexField{
+		IndexFieldName: aws.String(index["name"].(string)),
+		IndexFieldType: aws.String(index["type"].(string)),
+	}
+
+	var facet bool
+	var returnV bool
+	var search bool
+	var sort bool
+	var highlight bool
+	var analysisScheme string
+
+	extractFromMapToType(index, "facet", &facet)
+	extractFromMapToType(index, "return", &returnV)
+	extractFromMapToType(index, "search", &search)
+	extractFromMapToType(index, "sort", &sort)
+	extractFromMapToType(index, "highlight", &highlight)
+	extractFromMapToType(index, "analysis_scheme", &analysisScheme)
+
+	switch index["type"] {
+	case "int":
+		{
+			input.IntOptions = &cloudsearch.IntOptions{
+				FacetEnabled:  aws.Bool(facet),
+				ReturnEnabled: aws.Bool(returnV),
+				SearchEnabled: aws.Bool(search),
+				SortEnabled:   aws.Bool(sort),
+			}
+
+			if index["default_value"].(string) != "" {
+				var defaultValue int
+				extractFromMapToType(index, "default_value", &defaultValue)
+				input.IntOptions.DefaultValue = aws.Int64(int64(defaultValue))
+			}
+		}
+	case "int-array":
+		{
+			input.IntArrayOptions = &cloudsearch.IntArrayOptions{
+				FacetEnabled:  aws.Bool(facet),
+				ReturnEnabled: aws.Bool(returnV),
+				SearchEnabled: aws.Bool(search),
+			}
+
+			if index["default_value"].(string) != "" {
+				var defaultValue int
+				extractFromMapToType(index, "default_value", &defaultValue)
+				input.IntArrayOptions.DefaultValue = aws.Int64(int64(defaultValue))
+			}
+		}
+	case "double":
+		{
+			input.DoubleOptions = &cloudsearch.DoubleOptions{
+				FacetEnabled:  aws.Bool(facet),
+				ReturnEnabled: aws.Bool(returnV),
+				SearchEnabled: aws.Bool(search),
+				SortEnabled:   aws.Bool(sort),
+			}
+
+			if index["default_value"].(string) != "" {
+				var defaultValue float64
+				extractFromMapToType(index, "default_value", &defaultValue)
+				input.DoubleOptions.DefaultValue = aws.Float64(float64(defaultValue))
+			}
+		}
+	case "double-array":
+		{
+			input.DoubleArrayOptions = &cloudsearch.DoubleArrayOptions{
+				FacetEnabled:  aws.Bool(facet),
+				ReturnEnabled: aws.Bool(returnV),
+				SearchEnabled: aws.Bool(search),
+			}
+
+			if index["default_value"].(string) != "" {
+				var defaultValue float64
+				extractFromMapToType(index, "default_value", &defaultValue)
+				input.DoubleArrayOptions.DefaultValue = aws.Float64(float64(defaultValue))
+			}
+		}
+	case "literal":
+		{
+			input.LiteralOptions = &cloudsearch.LiteralOptions{
+				FacetEnabled:  aws.Bool(facet),
+				ReturnEnabled: aws.Bool(returnV),
+				SearchEnabled: aws.Bool(search),
+				SortEnabled:   aws.Bool(sort),
+			}
+
+			if index["default_value"].(string) != "" {
+				input.LiteralOptions.DefaultValue = aws.String(index["default_value"].(string))
+			}
+		}
+	case "literal-array":
+		{
+			input.LiteralArrayOptions = &cloudsearch.LiteralArrayOptions{
+				FacetEnabled:  aws.Bool(facet),
+				ReturnEnabled: aws.Bool(returnV),
+				SearchEnabled: aws.Bool(search),
+			}
+
+			if index["default_value"].(string) != "" {
+				input.LiteralArrayOptions.DefaultValue = aws.String(index["default_value"].(string))
+			}
+		}
+	case "text":
+		{
+			input.TextOptions = &cloudsearch.TextOptions{
+				SortEnabled:      aws.Bool(sort),
+				ReturnEnabled:    aws.Bool(returnV),
+				HighlightEnabled: aws.Bool(highlight),
+				AnalysisScheme:   aws.String(analysisScheme),
+			}
+
+			if index["default_value"].(string) != "" {
+				input.TextOptions.DefaultValue = aws.String(index["default_value"].(string))
+			}
+		}
+	case "text-array":
+		{
+			input.TextArrayOptions = &cloudsearch.TextArrayOptions{
+				ReturnEnabled:    aws.Bool(returnV),
+				HighlightEnabled: aws.Bool(highlight),
+				AnalysisScheme:   aws.String(analysisScheme),
+			}
+
+			if index["default_value"].(string) != "" {
+				input.TextArrayOptions.DefaultValue = aws.String(index["default_value"].(string))
+			}
+		}
+	case "date":
+		{
+			input.DateOptions = &cloudsearch.DateOptions{
+				FacetEnabled:  aws.Bool(facet),
+				ReturnEnabled: aws.Bool(returnV),
+				SearchEnabled: aws.Bool(search),
+				SortEnabled:   aws.Bool(sort),
+			}
+
+			if index["default_value"].(string) != "" {
+				input.DateOptions.DefaultValue = aws.String(index["default_value"].(string))
+			}
+		}
+	case "date-aray":
+		{
+			input.DateArrayOptions = &cloudsearch.DateArrayOptions{
+				FacetEnabled:  aws.Bool(facet),
+				ReturnEnabled: aws.Bool(returnV),
+				SearchEnabled: aws.Bool(search),
+			}
+
+			if index["default_value"].(string) != "" {
+				input.DateArrayOptions.DefaultValue = aws.String(index["default_value"].(string))
+			}
+		}
+	case "latlon":
+		{
+			input.LatLonOptions = &cloudsearch.LatLonOptions{
+				FacetEnabled:  aws.Bool(facet),
+				ReturnEnabled: aws.Bool(returnV),
+				SearchEnabled: aws.Bool(search),
+				SortEnabled:   aws.Bool(sort),
+			}
+
+			if index["default_value"].(string) != "" {
+				input.LatLonOptions.DefaultValue = aws.String(index["default_value"].(string))
+			}
+		}
+	default:
+		return input, fmt.Errorf("invalid index field type %s", index["type"])
+	}
+
+	return input, nil
+}
+
+func updateAccessPolicy(d *schema.ResourceData, meta interface{}, conn *cloudsearch.CloudSearch) error {
+	input := cloudsearch.UpdateServiceAccessPoliciesInput{
+		DomainName:     aws.String(d.Get("domain_name").(string)),
+		AccessPolicies: aws.String(d.Get("access_policy").(string)),
+	}
+
+	_, err := conn.UpdateServiceAccessPolicies(&input)
+	return err
+}
+
+func resourceAwsCloudSearchDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudsearchconn
+
+	dm := d.Get("domain_name").(string)
+	input := cloudsearch.DeleteDomainInput{
+		DomainName: aws.String(dm),
+	}
+
+	_, err := conn.DeleteDomain(&input)
+
+	return err
+}
+
+func validateDomainNameRegex(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-z]([a-z0-9-]){2,27}$`).MatchString(value) {
+		es = append(es, fmt.Errorf(
+			"%q must begin with a lower-case letter, contain only [a-z0-9-] and be at least 3 and at most 28 characters", k))
+	}
+	return
+}

--- a/aws/resource_aws_cloudsearch_domain_test.go
+++ b/aws/resource_aws_cloudsearch_domain_test.go
@@ -1,0 +1,130 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudsearch"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"testing"
+)
+
+func TestAccAWSCloudSearchDomain_basic(t *testing.T) {
+	var domains cloudsearch.DescribeDomainsOutput
+	resourceName := "aws_cloudsearch_domain.test"
+	rString := acctest.RandString(8)
+	domainName := fmt.Sprintf("tf-acc-%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudSearchDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudSearchDomainConfig_basic(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloudSearchDomainExists(resourceName, &domains),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "search.m1.small"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       false,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCloudSearchDomainExists(n string, domains *cloudsearch.DescribeDomainsOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudsearchconn
+
+		domainlist := cloudsearch.DescribeDomainsInput{
+			DomainNames: []*string{
+				aws.String(rs.Primary.ID),
+			},
+		}
+
+		resp, err := conn.DescribeDomains(&domainlist)
+		if err != nil {
+			return err
+		}
+
+		*domains = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAWSCloudSearchDomainDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudsearch_domain" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudsearchconn
+
+		domainlist := cloudsearch.DescribeDomainsInput{
+			DomainNames: []*string{
+				aws.String(rs.Primary.ID),
+			},
+		}
+
+		resp, err := conn.DescribeDomains(&domainlist)
+		if err != nil {
+			return err
+		}
+		domain := resp.DomainStatusList[0]
+
+		if domain.Deleted != nil || *domain.Deleted != true {
+			return fmt.Errorf("Expected Cloudsearch domain to be deleted/destroyed, %s found with Deleted != true", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSCloudSearchDomainConfig_basic(domainName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudsearch_domain" "test" {
+	domain_name   = "%s"
+	wait_for_endpoints = "false"
+	indexes {
+		name            = "headline"
+		type            = "text"
+		search          = true
+		return          = true
+		sort            = true
+		highlight       = false
+		analysis_scheme = "_en_default_"
+		}
+	
+	access_policy = <<EOF
+	{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Effect": "Allow",
+		"Principal": {
+			"AWS": [
+			"*"
+			]
+		},
+		"Action": [
+			"cloudsearch:*"
+		]
+		}
+	]
+	}
+	EOF
+	}
+`, domainName)
+}

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -16,6 +16,7 @@ Cloud9
 CloudFormation
 CloudFront
 CloudHSM v2
+CloudSearch
 CloudTrail
 CloudWatch
 CodeBuild

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -580,6 +580,19 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">CloudSearch</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudsearch_domain.html">aws_cloudsearch_domain</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                 </li>
+                 <li>
                     <a href="#">CloudWatch</a>
                     <ul class="nav">
                         <li>

--- a/website/docs/r/cloudsearch_domain.html.markdown
+++ b/website/docs/r/cloudsearch_domain.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "CloudSearch Domain"
+subcategory: "CloudSearch"
 layout: "aws"
 page_title: "AWS: aws_cloudsearch_domain"
 description: |-

--- a/website/docs/r/cloudsearch_domain.html.markdown
+++ b/website/docs/r/cloudsearch_domain.html.markdown
@@ -1,0 +1,100 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cloudsearch_domain"
+sidebar_current: "docs-aws-resource-cloudsearch"
+description: |-
+  Provides an CloudSearch domain resource. 
+---
+
+# Resource: aws_cloudsearch_domain
+
+Provides an CloudSearch domain resource.
+
+## Example Usage
+
+```hcl
+resource "aws_cloudsearch_domain" "my_domain" {
+  domain_name   = "test-domain"
+  instance_type = "search.m3.medium"
+
+  indexes {
+      name            = "headline"
+      type            = "text"
+      search          = true
+      return          = true
+      sort            = true
+      highlight       = false
+      analysis_scheme = "_de_default_"
+    }
+  indexes {
+      name   = "price"
+      type   = "double"
+      search = true
+      facet  = true
+      return = true
+      sort   = true
+    }
+  access_policy = data.aws_iam_policy_document.cloudsearch-access-policy.json
+}
+
+data "aws_iam_policy_document" "cloudsearch-access-policy" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "cloudsearch:search",
+      "cloudsearch:suggest"
+    ]
+  }
+}
+```
+
+
+## Using aws_cloudsearch_domain with API gateway.
+
+When you are using a cloudsearch domain with an aws_api_gateway_integration you need to set uri of the AWS cloudsearch service, to a speically formatted uri, that includes the first part of the search endpoint that is returned from this provider.  The below will help.
+```
+data "aws_region" "current" {}
+resource "aws_api_gateway_integration" "sample" {
+  ...
+  type        = "AWS"
+  uri         = "arn:aws:apigateway:${data.aws_region.current.name}:${replace(aws_cloudsearch_domain.my_domain.searchservice, ".${data.aws_region.current.name}.cloudsearch.amazonaws.com", "")}.cloudsearch:path/2013-01-01/search"
+  ...
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required) Domain name
+* `instance_type` - (Optional) The type of instance to start
+* `replication_count` - (Optional) The amount of replicas.
+* `partition_count` - (Optional) The amount of partitions on each instance. Currently only supported by `search.m3.2xlarge`
+* `indexes` - (Required) See [Indexes](#indexes) below for details.
+* `access_policy` - (Required) The iam access policy.
+* `wait_for_endpoints` = (Optional) - Default true, wait for the search service end point.  If you set this to false, the search and doc endpoints won't be available to use as an attribute during the first run.
+
+### Indexes
+
+Each of the `indexes` entities represents an index field of the domain.
+
+* `name` - (Required) Represents the property field name.
+* `type` - (Required) Represents the property type. It can be one of `int,int-array,double,double-array,literal,literal-array,text,text-array,date,date-array,lation` [AWS's Docs](http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-index-fields.html)
+* `search` - (Required) You can set whether this index should be searchable or not. (index of type text ist always searchable)
+* `facet` - (Optional) You can get facet information by enabling this.
+* `return` - (Required) You can enable returning the value of all searchable fields.
+* `sort` - (Optional) You can enable the property to be sortable.
+* `highlight` - (Optional) You can highlight information.
+* `analysis_scheme` - (Optional) Only needed with type `text`. [AWS's Docs - supported languages](http://docs.aws.amazon.com/cloudsearch/latest/developerguide/text-processing.html)
+* `default_value` - (Optional) The default value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `docservice` - The doc service end point - see wait_for_endpoints parameter
+* `searchservice` - The search service end point - see wait_for_endpoints parameter
+* `domain_id` - The domain id

--- a/website/docs/r/cloudsearch_domain.html.markdown
+++ b/website/docs/r/cloudsearch_domain.html.markdown
@@ -24,7 +24,7 @@ resource "aws_cloudsearch_domain" "my_domain" {
       return          = true
       sort            = true
       highlight       = false
-      analysis_scheme = "_de_default_"
+      analysis_scheme = "_en_default_"
     }
   indexes {
       name   = "price"

--- a/website/docs/r/cloudsearch_domain.html.markdown
+++ b/website/docs/r/cloudsearch_domain.html.markdown
@@ -1,7 +1,7 @@
 ---
+subcategory: "CloudSearch Domain"
 layout: "aws"
 page_title: "AWS: aws_cloudsearch_domain"
-sidebar_current: "docs-aws-resource-cloudsearch"
 description: |-
   Provides an CloudSearch domain resource. 
 ---

--- a/website/docs/r/cloudsearch_domain.html.markdown
+++ b/website/docs/r/cloudsearch_domain.html.markdown
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "cloudsearch-access-policy" {
 
 ## Using aws_cloudsearch_domain with API gateway.
 
-When you are using a cloudsearch domain with an aws_api_gateway_integration you need to set uri of the AWS cloudsearch service, to a speically formatted uri, that includes the first part of the search endpoint that is returned from this provider.  The below will help.
+When you are using a cloudsearch domain with an aws_api_gateway_integration you need to set uri of the AWS cloudsearch service, to a specially formatted uri, that includes the first part of the search endpoint that is returned from this provider.  The below will help.
 ```
 data "aws_region" "current" {}
 resource "aws_api_gateway_integration" "sample" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

WIP issues:
1. Can't get the delete test to pass.  Deletion takes a long time.  The provider returns when the resource is marked as deleted.  I'd like the test to check if the Deleted attributes is set to true, and if it is, to pass the test.

2. There is a known issue I've found, which I'd like to know how to fix.  If one creates a search domain, and has a resource that uses the searchsearch attribute, then manually delete the cloudsearch domain in AWS.  Then run terraform.   It will blow up with an error about rpc.

3. Possibly a separate terraform resource should exist to manage service-access-policies, ie to call update-service-access-policies when they change.  They don't seem to otherwise be replaced by terraform on change.

I am a beginner at programming in Golang, and have cobbled this together from https://github.com/terraform-providers/terraform-provider-aws/pull/1541  - so any help is appropriated, but please make your help beginner level.

The provider, as it stands, works good enough for us to use in our project!.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7833

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds support to create aws_cloudsearch_domain
```

Output from acceptance testing:
Can't get my tests to run properly yet.  - please help
```
    TestAccAWSCloudSearchDomain_basic: testing.go:669: Step 1 error: unknown test mode for step. Please see TestStep docs
        
        resource.TestStep{ResourceName:"aws_cloudsearch_domain.test", PreConfig:(func())(nil), Taint:[]string(nil), Config:"", Check:(resource.TestCheckFunc)(nil), Destroy:false, ExpectNonEmptyPlan:false, ExpectError:(*regexp.Regexp)(nil), PlanOnly:false, PreventDiskCleanup:false, PreventPostDestroyRefresh:false, SkipFunc:(func() (bool, error))(nil), ImportState:false, ImportStateId:"", ImportStateIdPrefix:"", ImportStateIdFunc:(resource.ImportStateIdFunc)(nil), ImportStateCheck:(resource.ImportStateCheckFunc)(nil), ImportStateVerify:false, ImportStateVerifyIgnore:[]string(nil), providers:map[string]terraform.ResourceProvider{"aws":(*schema.Provider)(0xc0000b6880)}}
    TestAccAWSCloudSearchDomain_basic: testing.go:730: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: couldn't find resource (21 retries)
        
        State: <no state>
--- FAIL: TestAccAWSCloudSearchDomain_basic (191.02s)
```

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudSearchDomain_basic'

...
```
