### PR TITLE
service/apigateway: added `operation_name` attribute to API G. method

### DIFF
--- a/aws/resource_aws_api_gateway_method.go
+++ b/aws/resource_aws_api_gateway_method.go
@@ -100,6 +100,11 @@ func resourceAwsApiGatewayMethod() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"operation_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -145,6 +150,10 @@ func resourceAwsApiGatewayMethodCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("request_validator_id"); ok {
 		input.RequestValidatorId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("operation_name"); ok {
+		input.OperationName = aws.String(v.(string))
 	}
 
 	_, err := conn.PutMethod(&input)
@@ -195,6 +204,8 @@ func resourceAwsApiGatewayMethodRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("request_validator_id", out.RequestValidatorId)
+
+	d.Set("operation_name", out.OperationName)
 
 	return nil
 }
@@ -301,6 +312,20 @@ func resourceAwsApiGatewayMethodUpdate(d *schema.ResourceData, meta interface{})
 			Op:    aws.String("replace"),
 			Path:  aws.String("/requestValidatorId"),
 			Value: request_validator_id,
+		})
+	}
+
+	if d.HasChange("operation_name") {
+		var operation_name *string
+		if v, ok := d.GetOk("operation_name"); ok {
+			if s := v.(string); len(s) > 0 {
+				operation_name = &s
+			}
+		}
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/operationName"),
+			Value: operation_name,
 		})
 	}
 

--- a/website/docs/r/api_gateway_method.html.markdown
+++ b/website/docs/r/api_gateway_method.html.markdown
@@ -88,6 +88,7 @@ The following arguments are supported:
 * `request_validator_id` - (Optional) The ID of a `aws_api_gateway_request_validator`
 * `request_parameters` - (Optional) A map of request parameters (from the path, query string and headers) that should be passed to the integration. The boolean value indicates whether the parameter is required (`true`) or optional (`false`).
   For example: `request_parameters = {"method.request.header.X-Some-Header" = true "method.request.querystring.some-query-param" = true}` would define that the header `X-Some-Header` and the query string `some-query-param` must be provided in the request.
+* `operation_name` - (Optional) The function name that will be given to the method when generating an SDK through API Gateway. If omitted, API Gateway will generate a function name based on the resource path and HTTP verb.
 
 ## Import
 


### PR DESCRIPTION
This commit adds the `operation_name` attribute to the `aws_api_gateway_method`
resource. This attribute allows users to specify a custom function name to be
used when using API Gateway to generate an SDK. The attribute is already
supported by the AWS API and SDKs so there was really no reason not to include
it. It also made it a pretty straight forward change. This commit also includes:

* test cases for the new attribute
* updated documentation for the resource

Closes #13232

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
added support for custom operation name on API Gateway methods
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayMethod_customoperationname'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayMethod_customoperationname -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAPIGatewayMethod_customoperationname
=== PAUSE TestAccAWSAPIGatewayMethod_customoperationname
=== CONT  TestAccAWSAPIGatewayMethod_customoperationname
--- PASS: TestAccAWSAPIGatewayMethod_customoperationname (56.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	56.089s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.025s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.077s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/apigatewayv2/waiter	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.033s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/guardduty/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kms/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/neptune/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/helper/awsprovidertype/keyvaluetags	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.050s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.039s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR002	0.052s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.032s [no tests to run]
...
```
