### PR TITLE
Add `tags` attribute to `aws_iam_user` data source.

### DIFF
--- a/aws/data_source_aws_iam_user.go
+++ b/aws/data_source_aws_iam_user.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -34,12 +36,14 @@ func dataSourceAwsIAMUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }
 
 func dataSourceAwsIAMUserRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 	userName := d.Get("user_name").(string)
 	req := &iam.GetUserInput{
 		UserName: aws.String(userName),
@@ -60,6 +64,7 @@ func dataSourceAwsIAMUserRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("permissions_boundary", user.PermissionsBoundary.PermissionsBoundaryArn)
 	}
 	d.Set("user_id", user.UserId)
+	d.Set("tags", keyvaluetags.IamKeyValueTags(user.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map())
 
 	return nil
 }

--- a/aws/data_source_aws_iam_user.go
+++ b/aws/data_source_aws_iam_user.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsIAMUser() *schema.Resource {
@@ -44,6 +43,7 @@ func dataSourceAwsIAMUser() *schema.Resource {
 func dataSourceAwsIAMUserRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
 	userName := d.Get("user_name").(string)
 	req := &iam.GetUserInput{
 		UserName: aws.String(userName),
@@ -64,7 +64,9 @@ func dataSourceAwsIAMUserRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("permissions_boundary", user.PermissionsBoundary.PermissionsBoundaryArn)
 	}
 	d.Set("user_id", user.UserId)
-	d.Set("tags", keyvaluetags.IamKeyValueTags(user.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map())
+	if err := d.Set("tags", keyvaluetags.IamKeyValueTags(user.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_iam_user_test.go
+++ b/aws/data_source_aws_iam_user_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestAccAWSDataSourceIAMUser_basic(t *testing.T) {
-	resourceName := "data.aws_iam_user.test"
+	resourceName := "aws_iam_user.test"
+	dataSourceName := "data.aws_iam_user.test"
 
 	userName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
 
@@ -20,12 +21,12 @@ func TestAccAWSDataSourceIAMUser_basic(t *testing.T) {
 			{
 				Config: testAccAwsDataSourceIAMUserConfig(userName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "user_id", "aws_iam_user.user", "unique_id"),
-					resource.TestCheckResourceAttr(resourceName, "path", "/"),
-					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
-					resource.TestCheckResourceAttr(resourceName, "user_name", userName),
-					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_iam_user.user", "arn"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "user_id", resourceName, "unique_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "path", resourceName, "path"),
+					resource.TestCheckResourceAttr(dataSourceName, "permissions_boundary", ""),
+					resource.TestCheckResourceAttrPair(dataSourceName, "user_name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
 				),
 			},
 		},
@@ -33,7 +34,8 @@ func TestAccAWSDataSourceIAMUser_basic(t *testing.T) {
 }
 
 func TestAccAWSDataSourceIAMUser_tags(t *testing.T) {
-	resourceName := "data.aws_iam_user.test"
+	resourceName := "aws_iam_user.test"
+	dataSourceName := "data.aws_iam_user.test"
 
 	userName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
 
@@ -44,14 +46,7 @@ func TestAccAWSDataSourceIAMUser_tags(t *testing.T) {
 			{
 				Config: testAccAwsDataSourceIAMUserConfig_tags(userName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "user_id", "aws_iam_user.user", "unique_id"),
-					resource.TestCheckResourceAttr(resourceName, "path", "/"),
-					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
-					resource.TestCheckResourceAttr(resourceName, "user_name", userName),
-					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_iam_user.user", "arn"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.tag1", "test-value1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.tag2", "test-value2"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
 				),
 			},
 		},
@@ -60,20 +55,20 @@ func TestAccAWSDataSourceIAMUser_tags(t *testing.T) {
 
 func testAccAwsDataSourceIAMUserConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_user" "user" {
+resource "aws_iam_user" "test" {
   name = "%s"
   path = "/"
 }
 
 data "aws_iam_user" "test" {
-  user_name = aws_iam_user.user.name
+  user_name = aws_iam_user.test.name
 }
 `, name)
 }
 
 func testAccAwsDataSourceIAMUserConfig_tags(name string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_user" "user" {
+resource "aws_iam_user" "test" {
   name = "%s"
   path = "/"
 
@@ -84,7 +79,7 @@ resource "aws_iam_user" "user" {
 }
 
 data "aws_iam_user" "test" {
-  user_name = "${aws_iam_user.user.name}"
+  user_name = aws_iam_user.test.name
 }
 `, name)
 }

--- a/website/docs/d/iam_user.html.markdown
+++ b/website/docs/d/iam_user.html.markdown
@@ -31,4 +31,4 @@ data "aws_iam_user" "example" {
 * `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the user.
 * `user_id` - The unique ID assigned by AWS for this user.
 * `user_name` - The name associated to this User
-* `tags` - The tags attached to the user.
+* `tags` - Map of key-value pairs associated with the user.

--- a/website/docs/d/iam_user.html.markdown
+++ b/website/docs/d/iam_user.html.markdown
@@ -31,3 +31,4 @@ data "aws_iam_user" "example" {
 * `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the user.
 * `user_id` - The unique ID assigned by AWS for this user.
 * `user_name` - The name associated to this User
+* `tags` - The tags attached to the user.


### PR DESCRIPTION
This adds the `tags` attribute to the `aws_iam_user` data source. This was copied from the `aws_iam_role` data source and updated to work with user.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
* data-source/aws_iam_user: Add `tags` attribute
```

Closes #13470 

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDataSourceIAMUser_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMUser_ -timeout 120m
...
--- PASS: TestAccAWSDataSourceIAMUser_basic (14.90s)
--- PASS: TestAccAWSDataSourceIAMUser_tags (14.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.446s
...
```