### PR TITLE
resource/aws_iot_greengrass_service_role: Resource for managing IoT Greengrass service role setting (incl. datasource)

### DIFF
--- a/aws/data_source_aws_iot_greengrass_service_role.go
+++ b/aws/data_source_aws_iot_greengrass_service_role.go
@@ -31,7 +31,6 @@ func dataSourceAwsIotGreengrassServiceRoleRead(d *schema.ResourceData, meta inte
 	}
 
 	roleArn := aws.StringValue(output.RoleArn)
-	associatedAt := aws.StringValue(output.AssociatedAt)
 
 	if err := d.Set("role_arn", roleArn); err != nil {
 		return fmt.Errorf("error setting role_arn: %s", err)

--- a/aws/data_source_aws_iot_greengrass_service_role.go
+++ b/aws/data_source_aws_iot_greengrass_service_role.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/greengrass"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsIotGreengrassServiceRole() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsIotGreengrassServiceRoleRead,
+		Schema: map[string]*schema.Schema{
+			"associated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsIotGreengrassServiceRoleRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).greengrassconn
+	input := &greengrass.GetServiceRoleForAccountInput{}
+
+	output, err := conn.GetServiceRoleForAccount(input)
+
+	if err != nil {
+		return fmt.Errorf("error while getting greengrass service role for account: %s", err)
+	}
+
+	roleArn := aws.StringValue(output.RoleArn)
+	associatedAt := aws.StringValue(output.AssociatedAt)
+
+	d.SetId(roleArn)
+	if err := d.Set("role_arn", roleArn); err != nil {
+		return fmt.Errorf("error setting role_arn: %s", err)
+	}
+	if err := d.Set("associated_at", associatedAt); err != nil {
+		return fmt.Errorf("error setting associated_at: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_iot_greengrass_service_role.go
+++ b/aws/data_source_aws_iot_greengrass_service_role.go
@@ -37,13 +37,14 @@ func dataSourceAwsIotGreengrassServiceRoleRead(d *schema.ResourceData, meta inte
 	roleArn := aws.StringValue(output.RoleArn)
 	associatedAt := aws.StringValue(output.AssociatedAt)
 
-	d.SetId(roleArn)
 	if err := d.Set("role_arn", roleArn); err != nil {
 		return fmt.Errorf("error setting role_arn: %s", err)
 	}
 	if err := d.Set("associated_at", associatedAt); err != nil {
 		return fmt.Errorf("error setting associated_at: %s", err)
 	}
+
+	d.SetId(roleArn)
 
 	return nil
 }

--- a/aws/data_source_aws_iot_greengrass_service_role.go
+++ b/aws/data_source_aws_iot_greengrass_service_role.go
@@ -12,10 +12,6 @@ func dataSourceAwsIotGreengrassServiceRole() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAwsIotGreengrassServiceRoleRead,
 		Schema: map[string]*schema.Schema{
-			"associated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"role_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -39,9 +35,6 @@ func dataSourceAwsIotGreengrassServiceRoleRead(d *schema.ResourceData, meta inte
 
 	if err := d.Set("role_arn", roleArn); err != nil {
 		return fmt.Errorf("error setting role_arn: %s", err)
-	}
-	if err := d.Set("associated_at", associatedAt); err != nil {
-		return fmt.Errorf("error setting associated_at: %s", err)
 	}
 
 	d.SetId(roleArn)

--- a/aws/data_source_aws_iot_greengrass_service_role_test.go
+++ b/aws/data_source_aws_iot_greengrass_service_role_test.go
@@ -19,10 +19,10 @@ func TestAccAWSIotGreengrassServiceRoleDataSource(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSIotGreengrassServiceRoleConfigResources(rInt),
+				Config: testAccAWSIotGreengrassServiceRoleDataSourceConfigResources(rInt),
 			},
 			{
-				Config: testAccAWSIotGreengrassServiceRoleConfig(rInt),
+				Config: testAccAWSIotGreengrassServiceRoleDataSourceConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "role_arn", resourceName, "arn"),
 				),
@@ -31,7 +31,7 @@ func TestAccAWSIotGreengrassServiceRoleDataSource(t *testing.T) {
 	})
 }
 
-func testAccAWSIotGreengrassServiceRoleConfigResources(rInt int) string {
+func testAccAWSIotGreengrassServiceRoleDataSourceConfigResources(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "greengrass_service_role" {
   name = "greengrass_service_role_test_%[1]d"
@@ -57,10 +57,10 @@ resource "aws_iot_greengrass_service_role" "test" {
 `, rInt)
 }
 
-func testAccAWSIotGreengrassServiceRoleConfig(rInt int) string {
+func testAccAWSIotGreengrassServiceRoleDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 %s
 
 data "aws_iot_greengrass_service_role" "test" {}
-`, testAccAWSIotGreengrassServiceRoleConfigResources(rInt))
+`, testAccAWSIotGreengrassServiceRoleDataSourceConfigResources(rInt))
 }

--- a/aws/data_source_aws_iot_greengrass_service_role_test.go
+++ b/aws/data_source_aws_iot_greengrass_service_role_test.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSIotGreengrassServiceRoleDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_iot_greengrass_service_role.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIotGreengrassServiceRoleConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "role_arn", "arn_of_some_service_role"),
+				),
+			},
+		},
+	})
+}
+
+const testAccAWSIotGreengrassServiceRoleConfig = `
+resource "aws_iam_role" "greengrass_service_role" {
+  name = "greengrass_service_role"
+  assume_role_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+	{
+	"Effect": "Allow",
+	"Principal": {
+		"Service": "greengrass.amazonaws.com"
+	},
+	"Action": "sts:AssumeRole"
+	}
+]
+}
+EOF
+}
+
+data "aws_iot_greengrass_service_role" "test" {}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -256,6 +256,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_user":                                  dataSourceAwsIAMUser(),
 			"aws_internet_gateway":                          dataSourceAwsInternetGateway(),
 			"aws_iot_endpoint":                              dataSourceAwsIotEndpoint(),
+			"aws_iot_greengrass_service_role":               dataSourceAwsIotGreengrassServiceRole(),
 			"aws_inspector_rules_packages":                  dataSourceAwsInspectorRulesPackages(),
 			"aws_instance":                                  dataSourceAwsInstance(),
 			"aws_instances":                                 dataSourceAwsInstances(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -635,6 +635,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_instance":                                            resourceAwsInstance(),
 			"aws_internet_gateway":                                    resourceAwsInternetGateway(),
 			"aws_iot_certificate":                                     resourceAwsIotCertificate(),
+			"aws_iot_greengrass_service_role":                         resourceAwsIotGreengrassServiceRole(),
 			"aws_iot_policy":                                          resourceAwsIotPolicy(),
 			"aws_iot_policy_attachment":                               resourceAwsIotPolicyAttachment(),
 			"aws_iot_thing":                                           resourceAwsIotThing(),

--- a/aws/resource_aws_iot_greengrass_service_role.go
+++ b/aws/resource_aws_iot_greengrass_service_role.go
@@ -55,7 +55,6 @@ func resourceAwsIotGreengrassServiceRoleRead(d *schema.ResourceData, meta interf
 	}
 
 	roleArn := aws.StringValue(output.RoleArn)
-	associatedAt := aws.StringValue(output.AssociatedAt)
 
 	if err := d.Set("role_arn", roleArn); err != nil {
 		return fmt.Errorf("error setting role_arn: %s", err)

--- a/aws/resource_aws_iot_greengrass_service_role.go
+++ b/aws/resource_aws_iot_greengrass_service_role.go
@@ -12,7 +12,6 @@ func resourceAwsIotGreengrassServiceRole() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsIotGreengrassServiceRoleCreate,
 		Read:   resourceAwsIotGreengrassServiceRoleRead,
-		Update: resourceAwsIotGreengrassServiceRoleUpdate,
 		Delete: resourceAwsIotGreengrassServiceRoleDelete,
 		Schema: map[string]*schema.Schema{
 			"associated_at": {
@@ -22,6 +21,7 @@ func resourceAwsIotGreengrassServiceRole() *schema.Resource {
 			"role_arn": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 		},
 	}
@@ -69,27 +69,6 @@ func resourceAwsIotGreengrassServiceRoleRead(d *schema.ResourceData, meta interf
 	}
 
 	return nil
-}
-
-func resourceAwsIotGreengrassServiceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-
-	if d.HasChange("role_arn") {
-		conn := meta.(*AWSClient).greengrassconn
-		roleArn := d.Get("role_arn").(string)
-		input := &greengrass.AssociateServiceRoleToAccountInput{
-			RoleArn: aws.String(roleArn),
-		}
-
-		_, err := conn.AssociateServiceRoleToAccount(input)
-
-		if err != nil {
-			return fmt.Errorf("greengrass service role could not be associated with account: %v", err)
-		}
-
-		d.SetId(roleArn)
-	}
-
-	return resourceAwsIotGreengrassServiceRoleRead(d, meta)
 }
 
 func resourceAwsIotGreengrassServiceRoleDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_iot_greengrass_service_role.go
+++ b/aws/resource_aws_iot_greengrass_service_role.go
@@ -1,0 +1,105 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/greengrass"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAwsIotGreengrassServiceRole() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsIotGreengrassServiceRoleCreate,
+		Read:   resourceAwsIotGreengrassServiceRoleRead,
+		Update: resourceAwsIotGreengrassServiceRoleUpdate,
+		Delete: resourceAwsIotGreengrassServiceRoleDelete,
+		Schema: map[string]*schema.Schema{
+			"associated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsIotGreengrassServiceRoleCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).greengrassconn
+	roleArn := d.Get("role_arn").(string)
+	input := &greengrass.AssociateServiceRoleToAccountInput{
+		RoleArn: aws.String(roleArn),
+	}
+
+	_, err := conn.AssociateServiceRoleToAccount(input)
+
+	if err != nil {
+		return fmt.Errorf("greengrass service role could not be associated with account: %v", err)
+	}
+
+	d.SetId(roleArn)
+
+	return resourceAwsIotGreengrassServiceRoleRead(d, meta)
+}
+
+func resourceAwsIotGreengrassServiceRoleRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).greengrassconn
+	input := &greengrass.GetServiceRoleForAccountInput{}
+
+	output, err := conn.GetServiceRoleForAccount(input)
+
+	if err != nil {
+		if isAWSErrRequestFailureStatusCode(err, 404) {
+			return fmt.Errorf("No greengrass service role is set for this account")
+		}
+		return fmt.Errorf("error while getting greengrass service role for account: %s", err)
+	}
+
+	roleArn := aws.StringValue(output.RoleArn)
+	associatedAt := aws.StringValue(output.AssociatedAt)
+
+	if err := d.Set("role_arn", roleArn); err != nil {
+		return fmt.Errorf("error setting role_arn: %s", err)
+	}
+	if err := d.Set("associated_at", associatedAt); err != nil {
+		return fmt.Errorf("error setting associated_at: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsIotGreengrassServiceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	if d.HasChange("role_arn") {
+		conn := meta.(*AWSClient).greengrassconn
+		roleArn := d.Get("role_arn").(string)
+		input := &greengrass.AssociateServiceRoleToAccountInput{
+			RoleArn: aws.String(roleArn),
+		}
+
+		_, err := conn.AssociateServiceRoleToAccount(input)
+
+		if err != nil {
+			return fmt.Errorf("greengrass service role could not be associated with account: %v", err)
+		}
+
+		d.SetId(roleArn)
+	}
+
+	return resourceAwsIotGreengrassServiceRoleRead(d, meta)
+}
+
+func resourceAwsIotGreengrassServiceRoleDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).greengrassconn
+	input := &greengrass.DisassociateServiceRoleFromAccountInput{}
+
+	_, err := conn.DisassociateServiceRoleFromAccount(input)
+	if err != nil {
+		return fmt.Errorf("error disassociating greengrass service role from account: %v", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_iot_greengrass_service_role.go
+++ b/aws/resource_aws_iot_greengrass_service_role.go
@@ -14,10 +14,6 @@ func resourceAwsIotGreengrassServiceRole() *schema.Resource {
 		Read:   resourceAwsIotGreengrassServiceRoleRead,
 		Delete: resourceAwsIotGreengrassServiceRoleDelete,
 		Schema: map[string]*schema.Schema{
-			"associated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"role_arn": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -63,9 +59,6 @@ func resourceAwsIotGreengrassServiceRoleRead(d *schema.ResourceData, meta interf
 
 	if err := d.Set("role_arn", roleArn); err != nil {
 		return fmt.Errorf("error setting role_arn: %s", err)
-	}
-	if err := d.Set("associated_at", associatedAt); err != nil {
-		return fmt.Errorf("error setting associated_at: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_iot_greengrass_service_role_test.go
+++ b/aws/resource_aws_iot_greengrass_service_role_test.go
@@ -59,17 +59,6 @@ func testAccCheckAwsIotGreengrassServiceRoleExists(name string) resource.TestChe
 	}
 }
 
-func testAccCheckAwsIotGreengrassServiceRoleNotExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
-		if !ok {
-			return nil
-		}
-
-		return fmt.Errorf("Not expecting but found: %s", name)
-	}
-}
-
 func testAccAWSIotGreengrassServiceRoleConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "greengrass_service_role" {

--- a/aws/resource_aws_iot_greengrass_service_role_test.go
+++ b/aws/resource_aws_iot_greengrass_service_role_test.go
@@ -1,0 +1,97 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/greengrass"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAwsIotGreengrassServiceRole_basic(t *testing.T) {
+	resourceName := "aws_iot_greengrass_service_role.test"
+	roleResourceName := "aws_iam_role.greengrass_service_role"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsIotGreengrassServiceRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIotGreengrassServiceRoleConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsIotGreengrassServiceRoleExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", roleResourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsIotGreengrassServiceRoleDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).greengrassconn
+	input := &greengrass.GetServiceRoleForAccountInput{}
+
+	_, err := conn.GetServiceRoleForAccount(input)
+
+	if err != nil {
+		if isAWSErrRequestFailureStatusCode(err, 404) {
+			//No greengrass service role is set for this account
+			return nil
+		}
+		return err
+	}
+	return errors.New("greengrass service role was not reset")
+}
+
+func testAccCheckAwsIotGreengrassServiceRoleExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAwsIotGreengrassServiceRoleNotExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return nil
+		}
+
+		return fmt.Errorf("Not expecting but found: %s", name)
+	}
+}
+
+func testAccAWSIotGreengrassServiceRoleConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "greengrass_service_role" {
+  name = "greengrass_service_role_test_%[1]d"
+  assume_role_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+	{
+	"Effect": "Allow",
+	"Principal": {
+		"Service": "greengrass.amazonaws.com"
+	},
+	"Action": "sts:AssumeRole"
+	}
+]
+}
+EOF
+}
+
+resource "aws_iot_greengrass_service_role" "test" {
+	role_arn    = aws_iam_role.greengrass_service_role.arn
+}
+`, rInt)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1935,6 +1935,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/d/iot_endpoint.html">aws_iot_endpoint</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/iot_greengrass_service_role.html">aws_iot_greengrass_service_role</a>
+                                </li>
                             </ul>
                         </li>
                         <li>
@@ -1942,6 +1945,9 @@
                             <ul class="nav nav-auto-expand">
                                 <li>
                                     <a href="/docs/providers/aws/r/iot_certificate.html">aws_iot_certificate</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iot_greengrass_service_role.html">aws_iot_greengrass_service_role</a>
                                 </li>
                                 <li>
                                     <a href="/docs/providers/aws/r/iot_policy.html">aws_iot_policy</a>

--- a/website/docs/d/iot_greengrass_service_role.html.markdown
+++ b/website/docs/d/iot_greengrass_service_role.html.markdown
@@ -1,0 +1,26 @@
+---
+subcategory: "IoT"
+layout: "aws"
+page_title: "AWS: aws_iot_greengrass_service_role"
+description: |-
+  Retrieves the greengrass service role that is attached to your account
+---
+
+# Data Source: aws_iot_greengrass_service_role
+
+Returns the greengrass service role that is attached to your account. See also https://docs.aws.amazon.com/greengrass/latest/apireference/-greengrass-servicerole.html
+
+## Example Usage
+
+```hcl
+data "aws_iot_greengrass_service_role" "example" {}
+
+output "greengrass_service_role" {
+  value = data.aws_iot_greengrass_service_role.example.role_arn
+}
+```
+
+## Attributes Reference
+
+* `associated_at` - The time when the service role was associated with the account.
+* `role_arn` - The ARN of the role which is associated with the account.

--- a/website/docs/d/iot_greengrass_service_role.html.markdown
+++ b/website/docs/d/iot_greengrass_service_role.html.markdown
@@ -22,5 +22,4 @@ output "greengrass_service_role" {
 
 ## Attributes Reference
 
-* `associated_at` - The time when the service role was associated with the account.
 * `role_arn` - The ARN of the role which is associated with the account.

--- a/website/docs/r/iot_greengrass_service_role.html.markdown
+++ b/website/docs/r/iot_greengrass_service_role.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_iot_greengrass_service_role
 
-Manages the Greengrass service role of the account.
+Manages the Greengrass service role of the account. See also https://docs.aws.amazon.com/greengrass/latest/apireference/-greengrass-servicerole.html
 
 ## Example Usage
 

--- a/website/docs/r/iot_greengrass_service_role.html.markdown
+++ b/website/docs/r/iot_greengrass_service_role.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "IoT"
+layout: "aws"
+page_title: "AWS: aws_iot_greengrass_service_role"
+description: |-
+    Manages the Greengrass service role of the account.
+---
+
+# Resource: aws_iot_greengrass_service_role
+
+Manages the Greengrass service role of the account.
+
+## Example Usage
+
+```hcl
+resource "aws_iam_role" "greengrass_service_role" {
+  name = "greengrass_service_role"
+  assume_role_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+	{
+	"Effect": "Allow",
+	"Principal": {
+		"Service": "greengrass.amazonaws.com"
+	},
+	"Action": "sts:AssumeRole"
+	}
+]
+}
+EOF
+}
+
+resource "aws_iot_greengrass_service_role" "example" {
+  role_arn    = aws_iam_role.greengrass_service_role.arn
+}
+```
+
+
+## Argument Reference
+
+* `role_arn` - (Required)  ARN of the IAM role to set as the Greengrass service role for the account 
+
+## Attributes Reference
+
+In addition to the arguments, the following attributes are exported:
+
+* `associated_at` - The time when the service role was associated with the account.
+

--- a/website/docs/r/iot_greengrass_service_role.html.markdown
+++ b/website/docs/r/iot_greengrass_service_role.html.markdown
@@ -17,16 +17,16 @@ resource "aws_iam_role" "greengrass_service_role" {
   name = "greengrass_service_role"
   assume_role_policy = <<EOF
 {
-"Version": "2012-10-17",
-"Statement": [
-	{
-	"Effect": "Allow",
-	"Principal": {
-		"Service": "greengrass.amazonaws.com"
-	},
-	"Action": "sts:AssumeRole"
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+	  "Effect": "Allow",
+	  "Principal": {
+        "Service": "greengrass.amazonaws.com"
+	  },
+	  "Action": "sts:AssumeRole"
 	}
-]
+  ]
 }
 EOF
 }

--- a/website/docs/r/iot_greengrass_service_role.html.markdown
+++ b/website/docs/r/iot_greengrass_service_role.html.markdown
@@ -41,9 +41,4 @@ resource "aws_iot_greengrass_service_role" "example" {
 
 * `role_arn` - (Required)  ARN of the IAM role to set as the Greengrass service role for the account 
 
-## Attributes Reference
-
-In addition to the arguments, the following attributes are exported:
-
-* `associated_at` - The time when the service role was associated with the account.
 

--- a/website/docs/r/iot_greengrass_service_role.html.markdown
+++ b/website/docs/r/iot_greengrass_service_role.html.markdown
@@ -14,7 +14,7 @@ Manages the Greengrass service role of the account. See also https://docs.aws.am
 
 ```hcl
 resource "aws_iam_role" "greengrass_service_role" {
-  name = "greengrass_service_role"
+  name               = "greengrass_service_role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -32,7 +32,7 @@ EOF
 }
 
 resource "aws_iot_greengrass_service_role" "example" {
-  role_arn    = aws_iam_role.greengrass_service_role.arn
+  role_arn = aws_iam_role.greengrass_service_role.arn
 }
 ```
 


### PR DESCRIPTION
This PR adds the resource "aws_iot_greengrass_service_role" that enables you to set the greengrass service role for the account. This PR also adds the datasource "aws_iot_greengrass_service_role" to read the currently set greengrass service role.

```
resource "aws_iam_role" "greengrass_service_role" {
  name = "greengrass_service_role"
  assume_role_policy = <<EOF
{
"Version": "2012-10-17",
"Statement": [
	{
	"Effect": "Allow",
	"Principal": {
		"Service": "greengrass.amazonaws.com"
	},
	"Action": "sts:AssumeRole"
	}
]
}
EOF
}

resource "aws_iot_greengrass_service_role" "example" {
  role_arn    = aws_iam_role.greengrass_service_role.arn
}

data "aws_iot_greengrass_service_role" "example" {}

```

see also [AWS Doc](https://docs.aws.amazon.com/greengrass/latest/apireference/-greengrass-servicerole.html)

so far this is not possible with the terraform-provider-aws and we have to run additional cli calls after terraform apply which is a bit ugly. 


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
