### PR TITLE
service/cloudformation: consider StackStatusUpdateRollbackComplete only as failure if updates were performed

### DIFF
--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -355,20 +355,14 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 
 func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cfconn
-	// Name must conform to regex: [a-zA-Z][-a-zA-Z0-9]*
-	changeSetName := fmt.Sprint("tf-", time.Now().UnixNano())
+	updatesPerformed := true
 	input := &cloudformation.UpdateStackInput{
 		StackName: aws.String(d.Id()),
-	}
-	changeSetInput := &cloudformation.CreateChangeSetInput{
-		StackName:     aws.String(d.Id()),
-		ChangeSetName: aws.String(changeSetName),
 	}
 
 	// Either TemplateBody, TemplateURL or UsePreviousTemplate are required
 	if v, ok := d.GetOk("template_url"); ok {
 		input.TemplateURL = aws.String(v.(string))
-		changeSetInput.TemplateURL = input.TemplateURL
 	}
 	if v, ok := d.GetOk("template_body"); ok && input.TemplateURL == nil {
 		template, err := normalizeCloudFormationTemplate(v)
@@ -376,29 +370,24 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 			return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 		}
 		input.TemplateBody = aws.String(template)
-		changeSetInput.TemplateBody = input.TemplateBody
 	}
 
 	// Capabilities must be present whether they are changed or not
 	if v, ok := d.GetOk("capabilities"); ok {
 		input.Capabilities = expandStringList(v.(*schema.Set).List())
-		changeSetInput.Capabilities = input.Capabilities
 	}
 
 	if d.HasChange("notification_arns") {
 		input.NotificationARNs = expandStringList(d.Get("notification_arns").(*schema.Set).List())
-		changeSetInput.NotificationARNs = input.NotificationARNs
 	}
 
 	// Parameters must be present whether they are changed or not
 	if v, ok := d.GetOk("parameters"); ok {
 		input.Parameters = expandCloudFormationParameters(v.(map[string]interface{}))
-		changeSetInput.Parameters = input.Parameters
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
 		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().CloudformationTags()
-		changeSetInput.Tags = input.Tags
 	}
 
 	if d.HasChange("policy_body") {
@@ -414,42 +403,11 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 
 	if d.HasChange("iam_role_arn") {
 		input.RoleARN = aws.String(d.Get("iam_role_arn").(string))
-		changeSetInput.RoleARN = input.RoleARN
 	}
 
 	log.Printf("[DEBUG] Updating CloudFormation stack: %s", input)
-	_, err := conn.CreateChangeSet(changeSetInput)
-	if err != nil {
-		return err
-	}
 
-	defer func() {
-		// appease linter and catch error
-		_, err := conn.DeleteChangeSet(&cloudformation.DeleteChangeSetInput{
-			ChangeSetName: aws.String(changeSetName),
-			StackName:     aws.String(d.Id()),
-		})
-		if err != nil {
-			log.Printf("could not delete Cloudformation change set: %s", changeSetName)
-		}
-	}()
-
-	err = waitForCloudFormationStackChangeSetCreation(conn, d.Id(), changeSetName, 5*time.Minute)
-	if err != nil {
-		return err
-	}
-	describeResponse, err := conn.DescribeChangeSet(&cloudformation.DescribeChangeSetInput{
-		ChangeSetName: aws.String(changeSetName),
-		StackName:     aws.String(d.Id()),
-	})
-	if err != nil {
-		return err
-	}
-	if len(describeResponse.Changes) == 0 {
-		log.Printf("[DEBUG] Current CloudFormation update has an empty changeset")
-		return resourceAwsCloudFormationStackRead(d, meta)
-	}
-	_, err = conn.UpdateStack(input)
+	_, err := conn.UpdateStack(input)
 	if err != nil {
 		awsErr, ok := err.(awserr.Error)
 		// ValidationError: No updates are to be performed.
@@ -458,6 +416,7 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 			awsErr.Message() != "No updates are to be performed." {
 			return err
 		}
+		updatesPerformed = false
 		log.Printf("[DEBUG] Current CloudFormation stack has no updates")
 	}
 
@@ -507,7 +466,11 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	if lastStatus == cloudformation.StackStatusUpdateRollbackComplete || lastStatus == cloudformation.StackStatusUpdateRollbackFailed {
+	/*
+		Only consider StackStatusUpdateRollbackComplete as fail state if updates were performed.
+		To avoid the plan application to fail if nothing was updated.
+	*/
+	if (updatesPerformed && lastStatus == cloudformation.StackStatusUpdateRollbackComplete) || lastStatus == cloudformation.StackStatusUpdateRollbackFailed {
 		reasons, err := getCloudFormationRollbackReasons(stackId, lastUpdatedTime, conn)
 		if err != nil {
 			return fmt.Errorf("Failed getting details about rollback: %q", err.Error())
@@ -762,48 +725,6 @@ func waitForCloudFormationStackDeletion(conn *cloudformation.CloudFormation, sta
 	}
 
 	_, err := stateConf.WaitForState()
-
-	return err
-}
-
-func waitForCloudFormationStackChangeSetCreation(conn *cloudformation.CloudFormation, stackId string, changeSetName string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			cloudformation.ChangeSetStatusCreateInProgress,
-			cloudformation.ChangeSetStatusCreatePending,
-		},
-		Target: []string{
-			cloudformation.ChangeSetStatusCreateComplete,
-			cloudformation.ChangeSetStatusFailed,
-		},
-		Refresh: func() (interface{}, string, error) {
-			resp, err := conn.DescribeChangeSet(&cloudformation.DescribeChangeSetInput{
-				ChangeSetName: aws.String(changeSetName),
-				StackName:     aws.String(stackId),
-			})
-			if err != nil {
-				return nil, "", fmt.Errorf("error describing CloudFormation change set: %s", err)
-			}
-			return resp, *resp.Status, nil
-		},
-		Timeout: timeout,
-		//Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
-	}
-
-	lastResult, err := stateConf.WaitForState()
-	if err != nil {
-		return err
-	}
-
-	resp := lastResult.(*cloudformation.DescribeChangeSetOutput)
-
-	//log.Printf("[DEBUG] status: %s, reason: %s", *resp.Status, *resp.StatusReason)
-
-	if *resp.Status != cloudformation.ChangeSetStatusCreateComplete &&
-		"The submitted information didn't contain changes. Submit different information to create a change set." != *resp.StatusReason {
-		err = fmt.Errorf("change set for Cloudformation stack could not be created: %s", *resp.StatusReason)
-	}
 
 	return err
 }


### PR DESCRIPTION
A reason for #5194
is that after an completed rollback every successive update
with an "empty" change set will cause an error.
The logic is:
- initiate Update
- Wait for end state
- check for fail state

If there was no update performed on the stack the previous
fail state did not change and will also produce a fail state.
This causes that application of terraform plans will also fail
if they do not cause the stack to transitions to a success state. This usually involved a "dumb" update like introducing
or changing a tag and changing it back after a successful update.
The new implementation creates a change set and checks if the
list of changes is > 0. If there are no changes to be performed
the update function for the stack will be exited.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5194

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudformationStackUpdate_whenPreviousUpdateCaused_UpdateRollbackComplete_state'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudformationStackUpdate_whenPreviousUpdateCaused_UpdateRollbackComplete_state -timeout 120m
=== RUN   TestAccAWSCloudformationStackUpdate_whenPreviousUpdateCaused_UpdateRollbackComplete_state
=== PAUSE TestAccAWSCloudformationStackUpdate_whenPreviousUpdateCaused_UpdateRollbackComplete_state
=== CONT  TestAccAWSCloudformationStackUpdate_whenPreviousUpdateCaused_UpdateRollbackComplete_state
--- PASS: TestAccAWSCloudformationStackUpdate_whenPreviousUpdateCaused_UpdateRollbackComplete_state (158.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       159.901s
...
```
