### PR TITLE
making data source aws_ec2_transit_gateway_route_table able to return…

### DIFF
--- a/aws/data_source_aws_ec2_transit_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table.go
@@ -20,7 +20,6 @@ func dataSourceAwsEc2TransitGatewayRouteTable() *schema.Resource {
 				Type:     schema.TypeInt,
 				Default:  0,
 				Optional: true,
-				ForceNew: true,
 			},
 			"default_association_route_table": {
 				Type:     schema.TypeBool,

--- a/aws/data_source_aws_ec2_transit_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table.go
@@ -47,9 +47,10 @@ func dataSourceAwsEc2TransitGatewayRouteTable() *schema.Resource {
 func dataSourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
-	var index int = 0
 
 	input := &ec2.DescribeTransitGatewayRouteTablesInput{}
+
+	index := d.Get("index").(int)
 
 	if v, ok := d.GetOk("filter"); ok {
 		input.Filters = buildAwsDataSourceFilters(v.(*schema.Set))
@@ -69,8 +70,6 @@ func dataSourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta i
 	if output == nil || len(output.TransitGatewayRouteTables) == 0 {
 		return errors.New("error reading EC2 Transit Gateway Route Table: no results found")
 	}
-
-	index = d.Get("index").(int)
 
 	if index > len(output.TransitGatewayRouteTables) {
 		return errors.New("Index out of range")

--- a/aws/data_source_aws_ec2_transit_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table.go
@@ -16,6 +16,12 @@ func dataSourceAwsEc2TransitGatewayRouteTable() *schema.Resource {
 		Read: dataSourceAwsEc2TransitGatewayRouteTableRead,
 
 		Schema: map[string]*schema.Schema{
+			"index": {
+				Type: schema.TypeInt,
+				Default: 0,
+				Optional: true,
+				ForceNew: true,
+			},
 			"default_association_route_table": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -41,6 +47,7 @@ func dataSourceAwsEc2TransitGatewayRouteTable() *schema.Resource {
 func dataSourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+	var index int = 0
 
 	input := &ec2.DescribeTransitGatewayRouteTablesInput{}
 
@@ -63,11 +70,13 @@ func dataSourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta i
 		return errors.New("error reading EC2 Transit Gateway Route Table: no results found")
 	}
 
-	if len(output.TransitGatewayRouteTables) > 1 {
-		return errors.New("error reading EC2 Transit Gateway Route Table: multiple results found, try adjusting search criteria")
+	index = d.Get("index").(int)
+
+	if index > len(output.TransitGatewayRouteTables) {
+		return errors.New("Index out of range")
 	}
 
-	transitGatewayRouteTable := output.TransitGatewayRouteTables[0]
+	transitGatewayRouteTable := output.TransitGatewayRouteTables[index]
 
 	if transitGatewayRouteTable == nil {
 		return errors.New("error reading EC2 Transit Gateway Route Table: empty result")

--- a/aws/data_source_aws_ec2_transit_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table.go
@@ -17,8 +17,8 @@ func dataSourceAwsEc2TransitGatewayRouteTable() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"index": {
-				Type: schema.TypeInt,
-				Default: 0,
+				Type:     schema.TypeInt,
+				Default:  0,
 				Optional: true,
 				ForceNew: true,
 			},


### PR DESCRIPTION
… specific index so making it usable over more than one result

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data source aws_ec2_transit_gateway_route_table now returns indexed results so it could provide information for multiple routing tables.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
