### PR TITLE
r/api_gateway_rest_api_policy - add new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -391,6 +391,7 @@ func Provider() *schema.Provider {
 			"aws_api_gateway_request_validator":                       resourceAwsApiGatewayRequestValidator(),
 			"aws_api_gateway_resource":                                resourceAwsApiGatewayResource(),
 			"aws_api_gateway_rest_api":                                resourceAwsApiGatewayRestApi(),
+			"aws_api_gateway_rest_api_policy":                         resourceAwsApiGatewayRestApiPolicy(),
 			"aws_api_gateway_stage":                                   resourceAwsApiGatewayStage(),
 			"aws_api_gateway_usage_plan":                              resourceAwsApiGatewayUsagePlan(),
 			"aws_api_gateway_usage_plan_key":                          resourceAwsApiGatewayUsagePlanKey(),

--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -49,6 +49,7 @@ func resourceAwsApiGatewayRestApi() *schema.Resource {
 			"policy": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Computed:         true,
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},

--- a/aws/resource_aws_api_gateway_rest_api_policy.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy.go
@@ -59,7 +59,7 @@ func resourceAwsApiGatewayRestApiPolicyPut(d *schema.ResourceData, meta interfac
 	})
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error setting API Gateway REST API Policy %w", err)
 	}
 
 	log.Printf("[DEBUG] API Gateway REST API Policy Set: %s", restApiId)
@@ -83,16 +83,16 @@ func resourceAwsApiGatewayRestApiPolicyRead(d *schema.ResourceData, meta interfa
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("error reading API Gateway REST API Policy (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway REST API Policy (%s): %w", d.Id(), err)
 	}
 
 	normalizedPolicy, err := structure.NormalizeJsonString(`"` + aws.StringValue(api.Policy) + `"`)
 	if err != nil {
-		fmt.Printf("error normalizing policy JSON: %s\n", err)
+		fmt.Errorf("error normalizing API Gateway REST API policy JSON: %w", err)
 	}
 	policy, err := strconv.Unquote(normalizedPolicy)
 	if err != nil {
-		return fmt.Errorf("error unescaping policy: %s", err)
+		return fmt.Errorf("error unescaping API Gateway REST API policy: %w", err)
 	}
 	d.Set("policy", policy)
 	d.Set("rest_api_id", api.Id)
@@ -120,7 +120,7 @@ func resourceAwsApiGatewayRestApiPolicyDelete(d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting API Gateway REST API policy: %w", err)
 	}
 
 	log.Printf("[DEBUG] API Gateway REST API Policy Deleted: %s", restApiId)

--- a/aws/resource_aws_api_gateway_rest_api_policy.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy.go
@@ -1,0 +1,129 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsApiGatewayRestApiPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsApiGatewayRestApiPolicyPut,
+		Read:   resourceAwsApiGatewayRestApiPolicyRead,
+		Update: resourceAwsApiGatewayRestApiPolicyPut,
+		Delete: resourceAwsApiGatewayRestApiPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"rest_api_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"policy": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+		},
+	}
+}
+
+func resourceAwsApiGatewayRestApiPolicyPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayconn
+
+	restApiId := d.Get("rest_api_id").(string)
+	log.Printf("[DEBUG] Setting API Gateway REST API Policy: %s", restApiId)
+
+	operations := make([]*apigateway.PatchOperation, 0)
+
+	operations = append(operations, &apigateway.PatchOperation{
+		Op:    aws.String(apigateway.OpReplace),
+		Path:  aws.String("/policy"),
+		Value: aws.String(d.Get("policy").(string)),
+	})
+
+	res, err := conn.UpdateRestApi(&apigateway.UpdateRestApiInput{
+		RestApiId:       aws.String(restApiId),
+		PatchOperations: operations,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] API Gateway REST API Policy Set: %s", restApiId)
+
+	d.SetId(aws.StringValue(res.Id))
+
+	return resourceAwsApiGatewayRestApiPolicyRead(d, meta)
+}
+
+func resourceAwsApiGatewayRestApiPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayconn
+
+	log.Printf("[DEBUG] Reading API Gateway REST API Policy %s", d.Id())
+
+	api, err := conn.GetRestApi(&apigateway.GetRestApiInput{
+		RestApiId: aws.String(d.Id()),
+	})
+	if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] API Gateway REST API Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading API Gateway REST API Policy (%s): %s", d.Id(), err)
+	}
+
+	normalizedPolicy, err := structure.NormalizeJsonString(`"` + aws.StringValue(api.Policy) + `"`)
+	if err != nil {
+		fmt.Printf("error normalizing policy JSON: %s\n", err)
+	}
+	policy, err := strconv.Unquote(normalizedPolicy)
+	if err != nil {
+		return fmt.Errorf("error unescaping policy: %s", err)
+	}
+	d.Set("policy", policy)
+	d.Set("rest_api_id", api.Id)
+
+	return nil
+}
+
+func resourceAwsApiGatewayRestApiPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayconn
+
+	restApiId := d.Get("rest_api_id").(string)
+	log.Printf("[DEBUG] Deleting API Gateway REST API Policy: %s", restApiId)
+
+	operations := make([]*apigateway.PatchOperation, 0)
+
+	operations = append(operations, &apigateway.PatchOperation{
+		Op:    aws.String(apigateway.OpRemove),
+		Path:  aws.String("/policy"),
+		Value: aws.String(d.Get("policy").(string)),
+	})
+
+	_, err := conn.UpdateRestApi(&apigateway.UpdateRestApiInput{
+		RestApiId:       aws.String(restApiId),
+		PatchOperations: operations,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] API Gateway REST API Policy Deleted: %s", restApiId)
+
+	return nil
+}

--- a/aws/resource_aws_api_gateway_rest_api_policy.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy.go
@@ -109,9 +109,9 @@ func resourceAwsApiGatewayRestApiPolicyDelete(d *schema.ResourceData, meta inter
 	operations := make([]*apigateway.PatchOperation, 0)
 
 	operations = append(operations, &apigateway.PatchOperation{
-		Op:    aws.String(apigateway.OpRemove),
+		Op:    aws.String(apigateway.OpReplace),
 		Path:  aws.String("/policy"),
-		Value: aws.String(d.Get("policy").(string)),
+		Value: aws.String(""),
 	})
 
 	_, err := conn.UpdateRestApi(&apigateway.UpdateRestApiInput{

--- a/aws/resource_aws_api_gateway_rest_api_policy.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsApiGatewayRestApiPolicy() *schema.Resource {

--- a/aws/resource_aws_api_gateway_rest_api_policy.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy.go
@@ -88,7 +88,7 @@ func resourceAwsApiGatewayRestApiPolicyRead(d *schema.ResourceData, meta interfa
 
 	normalizedPolicy, err := structure.NormalizeJsonString(`"` + aws.StringValue(api.Policy) + `"`)
 	if err != nil {
-		fmt.Errorf("error normalizing API Gateway REST API policy JSON: %w", err)
+		return fmt.Errorf("error normalizing API Gateway REST API policy JSON: %w", err)
 	}
 	policy, err := strconv.Unquote(normalizedPolicy)
 	if err != nil {

--- a/aws/resource_aws_api_gateway_rest_api_policy_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy_test.go
@@ -1,0 +1,182 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"testing"
+)
+
+func TestAccAWSAPIGatewayRestApiPolicy_basic(t *testing.T) {
+	var v apigateway.RestApi
+	resourceName := "aws_api_gateway_rest_api_policy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayRestApiPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayRestApiPolicyConfigWithPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayRestApiPolicyExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAPIGatewayRestApiPolicyConfigUpdatePolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayRestApiPolicyExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayRestApiPolicy_disappears(t *testing.T) {
+	var v apigateway.RestApi
+	resourceName := "aws_api_gateway_rest_api_policy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayRestApiPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayRestApiPolicyConfigWithPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayRestApiPolicyExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsApiGatewayRestApiPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAPIGatewayRestApiPolicyExists(n string, res *apigateway.RestApi) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).apigatewayconn
+
+		req := &apigateway.GetRestApiInput{
+			RestApiId: aws.String(rs.Primary.ID),
+		}
+		describe, err := conn.GetRestApi(req)
+		if err != nil {
+			return err
+		}
+
+		if aws.StringValue(describe.Id) != rs.Primary.ID {
+			return fmt.Errorf("API Gateway REST API Policy not found")
+		}
+
+		*res = *describe
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayRestApiPolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).apigatewayconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_api_gateway_rest_api_policy" {
+			continue
+		}
+
+		req := &apigateway.GetRestApisInput{}
+		describe, err := conn.GetRestApis(req)
+
+		if err == nil {
+			if len(describe.Items) != 0 &&
+				aws.StringValue(describe.Items[0].Id) == rs.Primary.ID {
+				return fmt.Errorf("API Gateway REST API Policy still exists")
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSAPIGatewayRestApiPolicyConfigWithPolicy(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
+}
+
+resource "aws_api_gateway_rest_api_policy" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "execute-api:Invoke",
+      "Resource": "${aws_api_gateway_rest_api.test.arn}",
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": "123.123.123.123/32"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayRestApiPolicyConfigUpdatePolicy(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
+}
+
+resource "aws_api_gateway_rest_api_policy" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+   "Statement": [
+       {
+           "Effect": "Deny",
+           "Principal": {
+               "AWS": "*"
+           },
+           "Action": "execute-api:Invoke",
+           "Resource": "${aws_api_gateway_rest_api.test.arn}"
+       }
+   ]
+}
+EOF
+}
+`, rName)
+}

--- a/aws/resource_aws_api_gateway_rest_api_policy_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy_test.go
@@ -82,7 +82,7 @@ func TestAccAWSAPIGatewayRestApiPolicy_disappears_restApi(t *testing.T) {
 				Config: testAccAWSAPIGatewayRestApiPolicyConfigWithPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayRestApiPolicyExists(resourceName, &v),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsApiGatewayRestApi(), resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsApiGatewayRestApi(), "aws_api_gateway_rest_api.test"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -163,7 +163,7 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_rest_api_policy" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 
   policy = <<EOF
 {
@@ -196,7 +196,7 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_rest_api_policy" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 
   policy = <<EOF
 {

--- a/aws/resource_aws_api_gateway_rest_api_policy_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
-	
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"

--- a/aws/resource_aws_api_gateway_rest_api_policy_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy_test.go
@@ -2,14 +2,15 @@ package aws
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+	
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"strconv"
-	"testing"
 )
 
 func TestAccAWSAPIGatewayRestApiPolicy_basic(t *testing.T) {

--- a/aws/resource_aws_api_gateway_rest_api_policy_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_policy_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSAPIGatewayRestApiPolicy_basic(t *testing.T) {

--- a/website/docs/r/api_gateway_rest_api_policy.html.markdown
+++ b/website/docs/r/api_gateway_rest_api_policy.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "API Gateway (REST APIs)"
+layout: "aws"
+page_title: "AWS: aws_api_gateway_rest_api_policy"
+description: |-
+  Provides an API Gateway REST API Policy.
+---
+
+# Resource: aws_api_gateway_rest_api_policy
+
+Provides an API Gateway REST API Policy.
+
+-> **Note:** Amazon API Gateway Version 1 resources are used for creating and deploying REST APIs. To create and deploy WebSocket and HTTP APIs, use Amazon API Gateway Version 2 [resources](https://www.terraform.io/docs/providers/aws/r/apigatewayv2_api.html).
+
+## Example Usage
+
+### Basic
+
+```hcl
+resource "aws_api_gateway_rest_api" "test" {
+  name = "example-rest-api"
+}
+
+resource "aws_api_gateway_rest_api_policy" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "execute-api:Invoke",
+      "Resource": "${aws_api_gateway_rest_api.test.arn}",
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": "123.123.123.123/32"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `rest_api_id` - (Required) The ID of the REST API.
+* `policy` - (Required) JSON formatted policy document that controls access to the API Gateway. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy)
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the REST API
+
+## Import
+
+`aws_api_gateway_rest_api_policy` can be imported by using the REST API ID, e.g.
+
+```
+$ terraform import aws_api_gateway_rest_api_policy.example 12345abcde
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5834 
Relates #5549
Relates #10986

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_api_gateway_rest_api_policy: new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayRestApiPolicy_'
--- PASS: TestAccAWSAPIGatewayRestApiPolicy_basic (165.57s)
--- PASS: TestAccAWSAPIGatewayRestApiPolicy_disappears (68.53s)
--- PASS: TestAccAWSAPIGatewayRestApiPolicy_disappears_restApi (80.66s)
```
