### PR TITLE
aws_msk_cluster: support in-place Kafka version upgrade

### DIFF
--- a/aws/resource_aws_msk_cluster_test.go
+++ b/aws/resource_aws_msk_cluster_test.go
@@ -514,6 +514,128 @@ func TestAccAWSMskCluster_LoggingInfo(t *testing.T) {
 	})
 }
 
+func TestAccAWSMskCluster_KafkaVersionUpgrade(t *testing.T) {
+	var cluster1, cluster2 kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskClusterConfigKafkaVersion(rName, "2.2.1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.2.1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
+				},
+			},
+			{
+				Config: testAccMskClusterConfigKafkaVersion(rName, "2.4.1.1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster2),
+					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.4.1.1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSMskCluster_KafkaVersionDowngrade(t *testing.T) {
+	var cluster1, cluster2 kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskClusterConfigKafkaVersion(rName, "2.4.1.1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.4.1.1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
+				},
+			},
+			{
+				Config: testAccMskClusterConfigKafkaVersion(rName, "2.2.1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster2),
+					testAccCheckMskClusterRecreated(&cluster1, &cluster2),
+					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.2.1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSMskCluster_KafkaVersionUpgradeWithConfigurationInfo(t *testing.T) {
+	var cluster1, cluster2 kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	configurationResourceName1 := "aws_msk_configuration.config1"
+	configurationResourceName2 := "aws_msk_configuration.config2"
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskClusterConfigKafkaVersionWithConfigurationInfo(rName, "2.2.1", "config1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.2.1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.arn", configurationResourceName1, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.revision", configurationResourceName1, "latest_revision"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
+				},
+			},
+			{
+				Config: testAccMskClusterConfigKafkaVersionWithConfigurationInfo(rName, "2.4.1.1", "config2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster2),
+					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.4.1.1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.arn", configurationResourceName2, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.revision", configurationResourceName2, "latest_revision"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSMskCluster_Tags(t *testing.T) {
 	var cluster kafka.ClusterInfo
 	var td kafka.ListTagsForResourceOutput
@@ -605,6 +727,16 @@ func testAccCheckMskClusterNotRecreated(i, j *kafka.ClusterInfo) resource.TestCh
 	return func(s *terraform.State) error {
 		if aws.StringValue(i.ClusterArn) != aws.StringValue(j.ClusterArn) {
 			return fmt.Errorf("MSK Cluster (%s) recreated", aws.StringValue(i.ClusterArn))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMskClusterRecreated(i, j *kafka.ClusterInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(i.ClusterArn) == aws.StringValue(j.ClusterArn) {
+			return fmt.Errorf("MSK Cluster (%s) was not recreated", aws.StringValue(i.ClusterArn))
 		}
 
 		return nil
@@ -1101,6 +1233,73 @@ resource "aws_msk_cluster" "test" {
   }
 }
 `, rName, cloudwatchLogsEnabled, cloudwatchLogsLogGroup, firehoseEnabled, firehoseDeliveryStream, s3Enabled, s3Bucket)
+}
+
+func testAccMskClusterConfigKafkaVersion(rName string, kafkaVersion string) string {
+	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = %[2]q
+  number_of_broker_nodes = 3
+
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
+    }
+  }
+
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+}
+`, rName, kafkaVersion)
+}
+
+func testAccMskClusterConfigKafkaVersionWithConfigurationInfo(rName string, kafkaVersion string, configResourceName string) string {
+	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_configuration" "config1" {
+  kafka_versions    = ["2.2.1"]
+  name              = "%[1]s-1"
+  server_properties = <<PROPERTIES
+log.cleaner.delete.retention.ms = 86400000
+PROPERTIES
+}
+
+resource "aws_msk_configuration" "config2" {
+  kafka_versions    = ["2.4.1.1"]
+  name              = "%[1]s-2"
+  server_properties = <<PROPERTIES
+log.cleaner.delete.retention.ms = 86400001
+PROPERTIES
+}
+
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = %[2]q
+  number_of_broker_nodes = 3
+
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
+    }
+  }
+
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+
+  configuration_info {
+    arn      = aws_msk_configuration.%[3]s.arn
+    revision = aws_msk_configuration.%[3]s.latest_revision
+  }
+}
+`, rName, kafkaVersion, configResourceName)
 }
 
 func testAccMskClusterConfigTags1(rName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13547

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_msk_cluster: support in-place Kafka version upgrade [GH-13547]
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMskCluster_KafkaVersionUpgrade'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMskCluster_KafkaVersionUpgrade -timeout 120m
=== RUN   TestAccAWSMskCluster_KafkaVersionUpgrade
=== PAUSE TestAccAWSMskCluster_KafkaVersionUpgrade
=== CONT  TestAccAWSMskCluster_KafkaVersionUpgrade
--- PASS: TestAccAWSMskCluster_KafkaVersionUpgrade (4734.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4736.762s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMskCluster_KafkaVersionUpgradeWithConfigurationInfo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMskCluster_KafkaVersionUpgradeWithConfigurationInfo -timeout 120m
=== RUN   TestAccAWSMskCluster_KafkaVersionUpgradeWithConfigurationInfo
=== PAUSE TestAccAWSMskCluster_KafkaVersionUpgradeWithConfigurationInfo
=== CONT  TestAccAWSMskCluster_KafkaVersionUpgradeWithConfigurationInfo
--- PASS: TestAccAWSMskCluster_KafkaVersionUpgradeWithConfigurationInfo (6143.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6145.800s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMskCluster_KafkaVersionDowngrade'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMskCluster_KafkaVersionDowngrade -timeout 120m
=== RUN   TestAccAWSMskCluster_KafkaVersionDowngrade
=== PAUSE TestAccAWSMskCluster_KafkaVersionDowngrade
=== CONT  TestAccAWSMskCluster_KafkaVersionDowngrade
--- PASS: TestAccAWSMskCluster_KafkaVersionDowngrade (3230.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3232.396s
```
