### PR TITLE
add data source aws_db_parameter_group

### DIFF
--- a/aws/data_source_aws_db_parameter_group.go
+++ b/aws/data_source_aws_db_parameter_group.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsDbParameterGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsDbParameterGroupRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"family": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) error {
+	rdsconn := meta.(*AWSClient).rdsconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	groupName := d.Get("name").(string)
+
+	describeOpts := rds.DescribeDBParameterGroupsInput{
+		DBParameterGroupName: aws.String(groupName),
+	}
+
+	describeResp, err := rdsconn.DescribeDBParameterGroups(&describeOpts)
+	if err != nil {
+		return fmt.Errorf("Error getting DB Parameter Groups: %v", err)
+	}
+
+	if len(describeResp.DBParameterGroups) != 1 ||
+		*describeResp.DBParameterGroups[0].DBParameterGroupName != groupName {
+		return fmt.Errorf("Unable to find Parameter Group: %#v", describeResp.DBParameterGroups)
+	}
+
+	d.SetId(aws.StringValue(describeResp.DBParameterGroups[0].DBParameterGroupName))
+	d.Set("name", describeResp.DBParameterGroups[0].DBParameterGroupName)
+	d.Set("arn", describeResp.DBParameterGroups[0].DBParameterGroupArn)
+	d.Set("family", describeResp.DBParameterGroups[0].DBParameterGroupFamily)
+	d.Set("description", describeResp.DBParameterGroups[0].Description)
+
+	tags, err := keyvaluetags.RdsListTags(rdsconn, d.Get("arn").(string))
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for RDS DB Parameter Group (%s): %s", d.Get("arn").(string), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_db_parameter_group_test.go
+++ b/aws/data_source_aws_db_parameter_group_test.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSDbParameterGroupDataSource_basic(t *testing.T) {
+	datasourceName := "data.aws_db_parameter_group.test"
+	resourceName := "aws_db_parameter_group.test"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAwsDbParameterGroupDataSourceConfig_nonExistent,
+				ExpectError: regexp.MustCompile(`Error getting DB Parameter Groups`),
+			},
+			{
+				Config: testAccAwsDbParameterGroupDataSourceConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "family", resourceName, "family"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+const testAccAwsDbParameterGroupDataSourceConfig_nonExistent = `
+data "aws_db_parameter_group" "test" {
+	name = "tf-acc-test-does-not-exist"
+}
+`
+
+func testAccAwsDbParameterGroupDataSourceConfig_basic(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_db_parameter_group" "test" {
+	name   = "tf-acc-test-%d"
+	family = "postgres12"
+  
+	parameter {
+	  name         = "client_encoding"
+	  value        = "UTF8"
+	  apply_method = "pending-reboot"
+	}
+}
+
+data "aws_db_parameter_group" "test" {
+  name = aws_db_parameter_group.test.name
+}
+`, rInt)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -199,6 +199,7 @@ func Provider() *schema.Provider {
 			"aws_db_cluster_snapshot":                        dataSourceAwsDbClusterSnapshot(),
 			"aws_db_event_categories":                        dataSourceAwsDbEventCategories(),
 			"aws_db_instance":                                dataSourceAwsDbInstance(),
+			"aws_db_parameter_group":                         dataSourceAwsDbParameterGroup(),
 			"aws_db_snapshot":                                dataSourceAwsDbSnapshot(),
 			"aws_db_subnet_group":                            dataSourceAwsDbSubnetGroup(),
 			"aws_directory_service_directory":                dataSourceAwsDirectoryServiceDirectory(),

--- a/website/docs/d/db_parameter_group.html.markdown
+++ b/website/docs/d/db_parameter_group.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "RDS"
+layout: "aws"
+page_title: "AWS: aws_db_parameter_group"
+description: |-
+  Provides details about an RDS Database Parameter Group.
+---
+
+# Data Source: aws_backup_vault
+
+Use this data source to get information on an existing database parameter group.
+
+## Example Usage
+
+```hcl
+data "aws_db_parameter_group" "example" {
+  name = "name-of-parameter"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the database parameter group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the DB parameter group.
+* `family` - The name of the DB parameter group family that this DB parameter is compatible with.
+* `description` - The customer specified description for the DB parameter group.
+* `tags` - Metadata that you can assign to help organize the resources that you create.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6970

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
add data source aws_db_parameter_group
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDbParameterGroupDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDbParameterGroupDataSource_basic -timeout 120m
=== RUN   TestAccAWSDbParameterGroupDataSource_basic
=== PAUSE TestAccAWSDbParameterGroupDataSource_basic
=== CONT  TestAccAWSDbParameterGroupDataSource_basic
--- PASS: TestAccAWSDbParameterGroupDataSource_basic (33.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	33.859s

...
```
