### PR TITLE
support CloudFront connection attempts & timeout origin properties

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -556,6 +556,12 @@ func expandOrigin(m map[string]interface{}) *cloudfront.Origin {
 		Id:         aws.String(m["origin_id"].(string)),
 		DomainName: aws.String(m["domain_name"].(string)),
 	}
+	if v, ok := m["connection_attempts"]; ok {
+		origin.ConnectionAttempts = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := m["connection_timeout"]; ok {
+		origin.ConnectionTimeout = aws.Int64(int64(v.(int)))
+	}
 	if v, ok := m["custom_header"]; ok {
 		origin.CustomHeaders = expandCustomHeaders(v.(*schema.Set))
 	}
@@ -588,6 +594,8 @@ func flattenOrigin(or *cloudfront.Origin) map[string]interface{} {
 	m := make(map[string]interface{})
 	m["origin_id"] = aws.StringValue(or.Id)
 	m["domain_name"] = aws.StringValue(or.DomainName)
+	m["connection_attempts"] = aws.Int64Value(or.ConnectionAttempts)
+	m["connection_timeout"] = aws.Int64Value(or.ConnectionTimeout)
 	if or.CustomHeaders != nil {
 		m["custom_header"] = flattenCustomHeaders(or.CustomHeaders)
 	}

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -540,6 +540,18 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Set:      originHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"connection_attempts": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      3,
+							ValidateFunc: validation.IntBetween(1, 3),
+						},
+						"connection_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      10,
+							ValidateFunc: validation.IntBetween(1, 10),
+						},
 						"custom_origin_config": {
 							Type:     schema.TypeList,
 							Optional: true,

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -409,6 +409,8 @@ argument is not required.
 
 #### Origin Arguments
 
+  * `connection_attempts` (Optional)- The number of times that CloudFront attempts to connect to the origin. The minimum number is 1, maximum is 3. If unspecified, it defaults to 3.
+  * `connection_timeout` (Optional) - The number of seconds that CloudFront waits when trying to establish a connection to the origin. The minimum timeout is 1 second, maximum is 10 seconds. If unspecified, it defaults to 10 seconds.
   * `custom_origin_config` - The [CloudFront custom
     origin](#custom-origin-config-arguments) configuration information. If an S3
     origin is required, use `s3_origin_config` instead.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13729

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
support CloudFront connection attempts & timeout origin properties
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudFrontDistribution_ConnectionAttemptAndTimeoutConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontDistribution_ConnectionAttemptAndTimeoutConfig -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_ConnectionAttemptAndTimeoutConfig
=== PAUSE TestAccAWSCloudFrontDistribution_ConnectionAttemptAndTimeoutConfig
=== CONT  TestAccAWSCloudFrontDistribution_ConnectionAttemptAndTimeoutConfig
--- PASS: TestAccAWSCloudFrontDistribution_ConnectionAttemptAndTimeoutConfig (538.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	538.171s

...
```
