### PR TITLE
Support multiple baselines on SSM Patch Group

### DIFF
--- a/aws/resource_aws_ssm_patch_group.go
+++ b/aws/resource_aws_ssm_patch_group.go
@@ -43,7 +43,7 @@ func resourceAwsSsmPatchGroupCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	d.SetId(*resp.PatchGroup)
+	d.SetId(fmt.Sprintf("%s:%s", *resp.PatchGroup, *resp.BaselineId))
 	return resourceAwsSsmPatchGroupRead(d, meta)
 }
 
@@ -59,7 +59,7 @@ func resourceAwsSsmPatchGroupRead(d *schema.ResourceData, meta interface{}) erro
 
 	found := false
 	for _, t := range resp.Mappings {
-		if *t.PatchGroup == d.Id() {
+		if fmt.Sprintf("%s:%s", *t.PatchGroup, *t.BaselineIdentity.BaselineId) == d.Id() {
 			found = true
 
 			d.Set("patch_group", t.PatchGroup)

--- a/aws/resource_aws_ssm_patch_group_test.go
+++ b/aws/resource_aws_ssm_patch_group_test.go
@@ -47,7 +47,7 @@ func testAccCheckAWSSSMPatchGroupExists(n string) resource.TestCheckFunc {
 		}
 
 		for _, i := range resp.Mappings {
-			if *i.BaselineIdentity.BaselineId == rs.Primary.Attributes["baseline_id"] && *i.PatchGroup == rs.Primary.ID {
+			if *i.BaselineIdentity.BaselineId == rs.Primary.Attributes["baseline_id"] && fmt.Sprintf("%s:%s", *i.PatchGroup, *i.BaselineIdentity.BaselineId) == rs.Primary.ID {
 				return nil
 			}
 		}

--- a/aws/resource_aws_ssm_patch_group_test.go
+++ b/aws/resource_aws_ssm_patch_group_test.go
@@ -47,7 +47,7 @@ func testAccCheckAWSSSMPatchGroupExists(n string) resource.TestCheckFunc {
 		}
 
 		for _, i := range resp.Mappings {
-			if *i.BaselineIdentity.BaselineId == rs.Primary.Attributes["baseline_id"] && fmt.Sprintf("%s:%s", *i.PatchGroup, *i.BaselineIdentity.BaselineId) == rs.Primary.ID {
+			if testAccAWSSSMPatchGroupStateCompare(i, rs) {
 				return nil
 			}
 		}
@@ -75,7 +75,7 @@ func testAccCheckAWSSSMPatchGroupDestroy(s *terraform.State) error {
 		}
 
 		for _, i := range resp.Mappings {
-			if *i.BaselineIdentity.BaselineId == rs.Primary.Attributes["baseline_id"] && *i.PatchGroup == rs.Primary.ID {
+			if testAccAWSSSMPatchGroupStateCompare(i, rs) {
 				return fmt.Errorf("Expected AWS SSM Patch Group to be gone, but was still found")
 			}
 		}
@@ -98,4 +98,15 @@ resource "aws_ssm_patch_group" "patchgroup" {
   patch_group = "patch-group"
 }
 `, rName)
+}
+
+func testAccAWSSSMPatchGroupStateCompare(mapping *ssm.PatchGroupPatchBaselineMapping, rs *terraform.ResourceState) bool {
+	id := fmt.Sprintf("%s:%s", *mapping.PatchGroup, *mapping.BaselineIdentity.BaselineId)
+
+	if *mapping.BaselineIdentity.BaselineId == rs.Primary.Attributes["baseline_id"] && id == rs.Primary.ID {
+
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
This commit modifies the Id for an SSM Patch Group to be the Patch Group Name joined to the BaselineId by a ":". This allows an SSM Patch Group to support multiple baselines.

Please note that pre-existing patch groups will be recreated due to the change in Id (this happens without issue in my testing as the AWS API call succeeds even if the patch group already has that baseline applied). 

If necessary, I can look into State Migration to handle that, but it looked quite complicated compared to my very beginner level of Go knowledge. 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9603

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ssm_patch_group: Support multiple baselines (one per OS) on an SSM patch group 
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMPatchGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSSMPatchGroup -timeout 120m
=== RUN   TestAccAWSSSMPatchGroup_basic
=== PAUSE TestAccAWSSSMPatchGroup_basic
=== CONT  TestAccAWSSSMPatchGroup_basic
--- PASS: TestAccAWSSSMPatchGroup_basic (29.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       30.406s
```
