### PR TITLE
Only pass Workspace AutoStopTimeout when running mode is AutoStop

### DIFF
--- a/aws/resource_aws_workspaces_workspace.go
+++ b/aws/resource_aws_workspaces_workspace.go
@@ -366,13 +366,19 @@ func expandWorkspaceProperties(properties []interface{}) *workspaces.WorkspacePr
 
 	p := properties[0].(map[string]interface{})
 
-	return &workspaces.WorkspaceProperties{
-		ComputeTypeName:                     aws.String(p["compute_type_name"].(string)),
-		RootVolumeSizeGib:                   aws.Int64(int64(p["root_volume_size_gib"].(int))),
-		RunningMode:                         aws.String(p["running_mode"].(string)),
-		RunningModeAutoStopTimeoutInMinutes: aws.Int64(int64(p["running_mode_auto_stop_timeout_in_minutes"].(int))),
-		UserVolumeSizeGib:                   aws.Int64(int64(p["user_volume_size_gib"].(int))),
+	ret := &workspaces.WorkspaceProperties{
+		ComputeTypeName:   aws.String(p["compute_type_name"].(string)),
+		RootVolumeSizeGib: aws.Int64(int64(p["root_volume_size_gib"].(int))),
+		RunningMode:       aws.String(p["running_mode"].(string)),
+		UserVolumeSizeGib: aws.Int64(int64(p["user_volume_size_gib"].(int))),
 	}
+
+	// aws-sdk-go only accepts SetRunningModeAutoStopTimeoutInMinutes when mode is RunningModeAutoStop
+	if p["running_mode"] == workspaces.RunningModeAutoStop {
+		ret.SetRunningModeAutoStopTimeoutInMinutes(int64(p["running_mode_auto_stop_timeout_in_minutes"].(int)))
+	}
+
+	return ret
 }
 
 func flattenWorkspaceProperties(properties *workspaces.WorkspaceProperties) []map[string]interface{} {

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -372,7 +372,7 @@ resource "aws_workspaces_workspace" "test" {
   # NOTE: WorkSpaces API doesn't allow creating users in the directory.
   # However, "Administrator"" user is always present in a bare directory.
   user_name = "Administrator"
-  
+
   workspace_properties {
     # NOTE: Compute type and volume size update not allowed within 6 hours after creation.
     running_mode = "AUTO_STOP"
@@ -394,13 +394,13 @@ resource "aws_workspaces_workspace" "test" {
 
   # NOTE: WorkSpaces API doesn't allow creating users in the directory.
   # However, "Administrator"" user is always present in a bare directory.
-  user_name = "Administrator" 
+  user_name = "Administrator"
 
   workspace_properties {
     # NOTE: Compute type and volume size update not allowed within 6 hours after creation.
     running_mode = "ALWAYS_ON"
   }
-  
+
   tags = {
     TerraformProviderAwsTest = true
   }
@@ -432,8 +432,8 @@ resource "aws_workspaces_workspace" "test" {
 
   # NOTE: WorkSpaces API doesn't allow creating users in the directory.
   # However, "Administrator"" user is always present in a bare directory.
-  user_name = "Administrator" 
- 
+  user_name = "Administrator"
+
   workspace_properties {
     root_volume_size_gib = 90
     user_volume_size_gib = 50
@@ -454,8 +454,8 @@ resource "aws_workspaces_workspace" "test" {
 
   # NOTE: WorkSpaces API doesn't allow creating users in the directory.
   # However, "Administrator"" user is always present in a bare directory.
-  user_name = "Administrator" 
- 
+  user_name = "Administrator"
+
   workspace_properties {
     root_volume_size_gib = 80
     user_volume_size_gib = 60
@@ -468,7 +468,7 @@ resource "aws_workspaces_workspace" "test" {
 `)
 }
 
-func TestExpandWorkspaceProperties(t *testing.T) {
+func TestExpandWorkspacePropertiesForAutoStop(t *testing.T) {
 	cases := []struct {
 		input    []interface{}
 		expected *workspaces.WorkspaceProperties
@@ -495,6 +495,44 @@ func TestExpandWorkspaceProperties(t *testing.T) {
 				RunningMode:                         aws.String(workspaces.RunningModeAutoStop),
 				RunningModeAutoStopTimeoutInMinutes: aws.Int64(60),
 				UserVolumeSizeGib:                   aws.Int64(10),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := expandWorkspaceProperties(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
+		}
+	}
+}
+
+func TestExpandWorkspacePropertiesForAlwaysOn(t *testing.T) {
+	cases := []struct {
+		input    []interface{}
+		expected *workspaces.WorkspaceProperties
+	}{
+		// Empty
+		{
+			input:    []interface{}{},
+			expected: nil,
+		},
+		// Full
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"compute_type_name":                         workspaces.ComputeValue,
+					"root_volume_size_gib":                      80,
+					"running_mode":                              workspaces.RunningModeAlwaysOn,
+					"running_mode_auto_stop_timeout_in_minutes": 60,
+					"user_volume_size_gib":                      10,
+				},
+			},
+			expected: &workspaces.WorkspaceProperties{
+				ComputeTypeName:   aws.String(workspaces.ComputeValue),
+				RootVolumeSizeGib: aws.Int64(80),
+				RunningMode:       aws.String(workspaces.RunningModeAlwaysOn),
+				UserVolumeSizeGib: aws.Int64(10),
 			},
 		},
 	}


### PR DESCRIPTION
When specifying RunningMode as RunningModeAlwaysOn, aws-sdk-go throws an error when the property RunningModeAutoStopTimeoutInMinutes is passed, causing "terraform apply" to fail, passing up the error from aws-sdk-go:


```
workspace creation failed: RunningModeAutoStopTimeoutInMinutes is not applicable for WorkSpace with running mode set to ALWAYS_ON
```

This happens even if you have not explicitly specified the timeout property in Terraform config.

While aws-sdk-go could arguably ignore the irrelevant property, this change simply omits it from the properties struct unless the running mode is AutoStop.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_workspaces_workspace: Do not specify auto-stop timeout when creating always-on Workspace
```

Output from acceptance testing:

I did not add any acceptance tests as Workspaces are _quite_ expensive to spin up. 😐 