### PR TITLE
resource/aws_autoscaling_group: add instance_refresh block

### DIFF
--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -4409,10 +4409,10 @@ func TestAccAWSAutoScalingGroup_InstanceRefresh_Triggers(t *testing.T) {
 		UsePlacementGroup       bool
 		ExpectRefreshCount      int
 	}{
-		{2, 0, "t3.nano", true, false, false, false, 0},  // create asg
-		{1, 0, "t3.nano", true, false, false, false, 1},  // drop 1 subnet
-		{0, 2, "t3.nano", true, false, false, false, 2},  // add 2 vpcs, drop subnets
-		{0, 1, "t3.nano", true, false, false, false, 3},  // drop 1 vpc
+		{2, 0, "t3.nano", true, false, false, false, 0},  // create asg with 2 az-s
+		{1, 0, "t3.nano", true, false, false, false, 1},  // drop 1 az
+		{0, 2, "t3.nano", true, false, false, false, 2},  // add 2 subnets, drop az-s
+		{0, 1, "t3.nano", true, false, false, false, 3},  // drop 1 subnet
 		{0, 1, "t3.nano", false, true, false, false, 4},  // drop launch config, add template
 		{0, 1, "t3.micro", false, true, false, false, 5}, // update template
 		{0, 1, "t3.micro", false, false, true, false, 6}, // drop template, add mixed policy


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13785

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* resource/aws_autoscaling_group: add `instance_refresh` block
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAutoScalingGroup_'
--- PASS: TestAccAWSAutoScalingGroup_launchTempPartitionNum (57.76s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (88.14s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (96.66s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (104.83s)
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (116.14s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (116.58s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (117.32s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity (120.95s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (123.72s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (379.68s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (425.49s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (141.26s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (86.65s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (57.79s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (119.12s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (174.51s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (88.72s)
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (95.30s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (58.22s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (59.49s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (210.73s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (232.50s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (89.84s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (244.34s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (53.03s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (90.53s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (269.89s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (89.34s)
--- PASS: TestAccAWSAutoScalingGroup_basic (277.90s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (162.21s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (296.46s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (180.03s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (116.18s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (185.73s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (348.21s)
--- PASS: TestAccAWSAutoScalingGroup_tags (276.82s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Enabled (452.57s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Triggers (477.33s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (786.57s)
```

The following block will be added to `aws_autoscaling_group`:

```hcl
resource "aws_autoscaling_group" "default" {
  instance_refresh {
    instance_warmup_seconds = 300
    min_healthy_percentage = 90
    strategy = "Rolling"
  }
}
```

If the block is present, start an [ASG Instance Refresh](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html) with the given parameters when the ASG is updated. The refresh is started only when a property is changed that would need a rollout to take effect (e.g. `launch_template`). If there is already an active refresh during an update, it is cancelled.

The instance refresh is "fire and forget": the resource does not wait for the refresh to complete. This comes partly down to the difficulty of choosing a sensible timeout (highly dependent on ASG size, warmup settings, healthy percentages), and partly down to difficulties related to the representation of a rollout in Terraform state. Since the ASG update and Instance Refresh are separate operations, the resource might initially fail the apply, but then report a misleading success on the second run. Workarounds would require an opinionated solution, such as using a separate resource so that the identity of an Instance Refresh could be tracked individually.
