### PR TITLE
Add import support for resource_aws_iam_group_membership

### DIFF
--- a/aws/resource_aws_iam_group_membership.go
+++ b/aws/resource_aws_iam_group_membership.go
@@ -6,6 +6,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -15,6 +17,9 @@ func resourceAwsIamGroupMembership() *schema.Resource {
 		Read:   resourceAwsIamGroupMembershipRead,
 		Update: resourceAwsIamGroupMembershipUpdate,
 		Delete: resourceAwsIamGroupMembershipDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsIamGroupMembershipImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -163,4 +168,16 @@ func addUsersToGroup(conn *iam.IAM, users []*string, group string) error {
 		}
 	}
 	return nil
+}
+
+func resourceAwsIamGroupMembershipImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	groupName := d.Id()
+	if len(groupName) == 0 {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <group-name>", d.Id())
+	}
+
+	d.Set("group", groupName)
+	d.SetId(resource.UniqueId())
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/iam_group_membership.html.markdown
+++ b/website/docs/r/iam_group_membership.html.markdown
@@ -62,3 +62,11 @@ The following arguments are supported:
 [1]: /docs/providers/aws/r/iam_group.html
 [2]: /docs/providers/aws/r/iam_user.html
 [3]: /docs/providers/aws/r/iam_user_group_membership.html
+
+## Import
+
+IAM group membership can be imported using the group name.
+
+```
+$ terraform import aws_iam_group_membership.example1 group1
+```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
resource/aws_iam_group_membership: Import is now supported
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSGroupMembership_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGroupMembership_basic -timeout 120m
=== RUN   TestAccAWSGroupMembership_basic
=== PAUSE TestAccAWSGroupMembership_basic
=== CONT  TestAccAWSGroupMembership_basic
--- PASS: TestAccAWSGroupMembership_basic (64.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	64.974s
```
