### PR TITLE
Correct Route 53 import example

### DIFF
--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -171,19 +171,22 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Route53 Records can be imported using ID of the record. The ID is made up as ZONEID_RECORDNAME_TYPE_SET-IDENTIFIER
+Route53 Records can be imported using ID of the record. The ID is made up as `ZONEID_RECORDNAME_TYPE_SET-IDENTIFIER`
 
-e.g.
+For example, for a FQDN of `foo.bar.example.com`, a ZoneID `Z4KAPRWWNC7JR` for zone `example.com`, a `NS` Type record and a `dev` Set Identifier the ID would be
 
 ```
-Z4KAPRWWNC7JR_dev.example.com_NS_dev
+Z4KAPRWWNC7JR_foo.bar_NS_dev
 ```
 
-In this example, `Z4KAPRWWNC7JR` is the ZoneID, `dev.example.com` is the Record Name, `NS` is the Type and `dev` is the Set Identifier.
-Only the Set Identifier is actually optional in the ID
+or if the record does not have a set identifier:
+
+```
+Z4KAPRWWNC7JR_foo.bar_NS
+```
 
 To import the ID above, it would look as follows:
 
 ```
-$ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev.example.com_NS_dev
+$ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_foo.bar_NS_dev
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

The route53 import documentation uses the FQDN as the ID, this is not what I see in my instance and not what worked for me, there the id was without the hosted zone domain part.

I also tried to clarify it a bit by not overloading `dev` in the example by using `foo.bar` as the domain entry instead, and clarified the optionality of the set identifier.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
