### PR TITLE
Prevent spurious diffs in IAM policies

### DIFF
--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -37,8 +37,12 @@ func resourceAwsIamPolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
+				Type:     schema.TypeString,
+				Required: true,
+				StateFunc: func(v interface{}) string {
+					policy, _ := normalizeIAMPolicyDoc(v.(string))
+					return policy
+				},
 				ValidateFunc:     validateIAMPolicyJson,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
@@ -191,6 +195,11 @@ func resourceAwsIamPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		policy, err = url.QueryUnescape(aws.StringValue(getPolicyVersionResponse.PolicyVersion.Document))
 		if err != nil {
 			return fmt.Errorf("error parsing policy: %s", err)
+		}
+
+		policy, err = normalizeIAMPolicyDoc(policy)
+		if err != nil {
+			return fmt.Errorf("error normalizing IAM policy: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_s3_bucket_policy.go
+++ b/aws/resource_aws_s3_bucket_policy.go
@@ -31,8 +31,12 @@ func resourceAwsS3BucketPolicy() *schema.Resource {
 			},
 
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
+				Type:     schema.TypeString,
+				Required: true,
+				StateFunc: func(v interface{}) string {
+					policy, _ := normalizeIAMPolicyDoc(v.(string))
+					return policy
+				},
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
@@ -85,7 +89,7 @@ func resourceAwsS3BucketPolicyRead(d *schema.ResourceData, meta interface{}) err
 
 	v := ""
 	if err == nil && pol.Policy != nil {
-		v = *pol.Policy
+		v, _ = normalizeIAMPolicyDoc(*pol.Policy)
 	}
 	if err := d.Set("policy", v); err != nil {
 		return err


### PR DESCRIPTION
IAM policies have several fields that are treated as arrays by the AWS API and Terraform, but are actually sets with no meaningful order (examples: actions, principals, resources). As a result, the order of the results returned by the AWS API can vary from API call to API call. This provider makes liberal use of `diff_suppress_funcs.suppressEquivalentAwsPolicyDiffs` which can suppress such a diff **if the policy isn't changing for any other reason**. However, if the policy **is** changing, then we will (correctly) get a plan, but it will include spurious diffs due to the arbitrary ordering of these sets.

One solution, as in https://github.com/terraform-providers/terraform-provider-aws/pull/11463, is to normalize the policy document as it's read from AWS, and normalize it as it's serialized to Terraform state. This PR does that for several resources (the ones where I've noted the need, though this is probably not exhaustive).

Here's an example:

```
provider "aws" {
  region = "us-east-1"
}

resource "aws_iam_role" "test" {
  name = "test-role"

  assume_role_policy = jsonencode(
    {
      Version = "2012-10-17"
      Statement = [
        {
          Action = ["sts:AssumeRole"],
          Effect = "Allow",
          Principal = {
            AWS = [
              # NOTE: These account ids need to be replaced with valid ids for IAM to accept the policy
              "arn:aws:iam::111111111111:root",
              "arn:aws:iam::222222222222:root",
              "arn:aws:iam::333333333333:root",
              "arn:aws:iam::444444444444:root",
              "arn:aws:iam::555555555555:root",
            ]
          }
        }
      ]
    }
  )
}
```

Apply this, and then remove the middle principal and plan again. Without this patch, the plan has a random element to it, but it can look like:

```
~ Principal = {
    ~ AWS = [
        + "arn:aws:iam::111111111111:root",
        + "arn:aws:iam::222222222222:root",
          "arn:aws:iam::444444444444:root",
          "arn:aws:iam::555555555555:root",
        - "arn:aws:iam::333333333333:root",
        - "arn:aws:iam::222222222222:root",
        - "arn:aws:iam::111111111111:root",
      ]
  }
```

With this patch, the plan is:

```
~ Principal = {
    ~ AWS = [
          "arn:aws:iam::111111111111:root",
          "arn:aws:iam::222222222222:root",
        - "arn:aws:iam::333333333333:root",
          "arn:aws:iam::444444444444:root",
          "arn:aws:iam::555555555555:root",
      ]
  }
```

It would be ideal to centralize this logic, but I don't see a clear way to do that, and I'd appreciate suggestions.

Also, this PR actually doesn't touch actions and resources in the policy because they're not given any structure in `iam_policy_model.go` (i.e. just left as `interface{}`). With some guidance on how this should look, I'd be happy to make that change, as well.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* Suppress spurious diffs due to arbitrary ordering of IAM policies
```

Output from acceptance testing:

Unfortunately, as in https://github.com/terraform-providers/terraform-provider-aws/pull/11463, this doesn't fit the mold of most changes as far as testing goes. I think the most meaningful test would be one that inspects the contents of the plan, and I don't know how to do that with the testing framework.