### PR TITLE
resource/aws_eks_node_group: add support for node_group_name prefixes

### DIFF
--- a/.changelog/13938.txt
+++ b/.changelog/13938.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_node_group: Add `node_group_name_prefix` argument
+```

--- a/aws/internal/service/eks/id.go
+++ b/aws/internal/service/eks/id.go
@@ -1,0 +1,25 @@
+package eks
+
+import (
+	"fmt"
+	"strings"
+)
+
+const nodeGroupResourceIDSeparator = ":"
+
+func NodeGroupCreateResourceID(clusterName, nodeGroupName string) string {
+	parts := []string{clusterName, nodeGroupName}
+	id := strings.Join(parts, nodeGroupResourceIDSeparator)
+
+	return id
+}
+
+func NodeGroupParseResourceID(id string) (string, string, error) {
+	parts := strings.Split(id, nodeGroupResourceIDSeparator)
+
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1], nil
+	}
+
+	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected cluster-name%[2]snode-group-name", id, nodeGroupResourceIDSeparator)
+}

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
+	tfeks "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks"
 )
 
 func resourceAwsEksNodeGroup() *schema.Resource {
@@ -288,13 +289,11 @@ func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) err
 
 	_, err := conn.CreateNodegroup(input)
 
-	id := resourceAwsEksNodeGroupCreateId(clusterName, nodeGroupName)
-
 	if err != nil {
-		return fmt.Errorf("error creating EKS Node Group (%s): %s", id, err)
+		return fmt.Errorf("error creating EKS Node Group (%s/%s): %w", clusterName, nodeGroupName, err)
 	}
 
-	d.SetId(id)
+	d.SetId(tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName))
 
 	stateConf := resource.StateChangeConf{
 		Pending: []string{eks.NodegroupStatusCreating},
@@ -304,7 +303,7 @@ func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("error waiting for EKS Node Group (%s) creation: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for EKS Node Group (%s) creation: %w", d.Id(), err)
 	}
 
 	return resourceAwsEksNodeGroupRead(d, meta)
@@ -315,7 +314,8 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(d.Id())
+	clusterName, nodeGroupName, err := tfeks.NodeGroupParseResourceID(d.Id())
+
 	if err != nil {
 		return err
 	}
@@ -334,7 +334,7 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading EKS Node Group (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading EKS Node Group (%s): %w", d.Id(), err)
 	}
 
 	nodeGroup := output.Nodegroup
@@ -351,38 +351,38 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("disk_size", nodeGroup.DiskSize)
 
 	if err := d.Set("instance_types", aws.StringValueSlice(nodeGroup.InstanceTypes)); err != nil {
-		return fmt.Errorf("error setting instance_types: %s", err)
+		return fmt.Errorf("error setting instance_types: %w", err)
 	}
 
 	if err := d.Set("labels", aws.StringValueMap(nodeGroup.Labels)); err != nil {
-		return fmt.Errorf("error setting labels: %s", err)
+		return fmt.Errorf("error setting labels: %w", err)
 	}
 
 	if err := d.Set("launch_template", flattenEksLaunchTemplateSpecification(nodeGroup.LaunchTemplate)); err != nil {
-		return fmt.Errorf("error setting launch_template: %s", err)
+		return fmt.Errorf("error setting launch_template: %w", err)
 	}
 
 	d.Set("node_group_name", nodeGroup.NodegroupName)
-	d.Set("name_prefix", naming.NamePrefixFromName(aws.StringValue(nodeGroup.NodegroupName)))
+	d.Set("node_group_name_prefix", naming.NamePrefixFromName(aws.StringValue(nodeGroup.NodegroupName)))
 	d.Set("node_role_arn", nodeGroup.NodeRole)
 	d.Set("release_version", nodeGroup.ReleaseVersion)
 
 	if err := d.Set("remote_access", flattenEksRemoteAccessConfig(nodeGroup.RemoteAccess)); err != nil {
-		return fmt.Errorf("error setting remote_access: %s", err)
+		return fmt.Errorf("error setting remote_access: %w", err)
 	}
 
 	if err := d.Set("resources", flattenEksNodeGroupResources(nodeGroup.Resources)); err != nil {
-		return fmt.Errorf("error setting resources: %s", err)
+		return fmt.Errorf("error setting resources: %w", err)
 	}
 
 	if err := d.Set("scaling_config", flattenEksNodeGroupScalingConfig(nodeGroup.ScalingConfig)); err != nil {
-		return fmt.Errorf("error setting scaling_config: %s", err)
+		return fmt.Errorf("error setting scaling_config: %w", err)
 	}
 
 	d.Set("status", nodeGroup.Status)
 
 	if err := d.Set("subnet_ids", aws.StringValueSlice(nodeGroup.Subnets)); err != nil {
-		return fmt.Errorf("error setting subnets: %s", err)
+		return fmt.Errorf("error setting subnets: %w", err)
 	}
 
 	tags := keyvaluetags.EksKeyValueTags(nodeGroup.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig)
@@ -404,7 +404,8 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).eksconn
 
-	clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(d.Id())
+	clusterName, nodeGroupName, err := tfeks.NodeGroupParseResourceID(d.Id())
+
 	if err != nil {
 		return err
 	}
@@ -426,7 +427,7 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 		output, err := conn.UpdateNodegroupConfig(input)
 
 		if err != nil {
-			return fmt.Errorf("error updating EKS Node Group (%s) config: %s", d.Id(), err)
+			return fmt.Errorf("error updating EKS Node Group (%s) config: %w", d.Id(), err)
 		}
 
 		if output == nil || output.Update == nil || output.Update.Id == nil {
@@ -437,7 +438,7 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 
 		err = waitForEksNodeGroupUpdate(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf("error waiting for EKS Node Group (%s) config update (%s): %s", d.Id(), updateID, err)
+			return fmt.Errorf("error waiting for EKS Node Group (%s) config update (%s): %w", d.Id(), updateID, err)
 		}
 	}
 
@@ -480,7 +481,7 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 		output, err := conn.UpdateNodegroupVersion(input)
 
 		if err != nil {
-			return fmt.Errorf("error updating EKS Node Group (%s) version: %s", d.Id(), err)
+			return fmt.Errorf("error updating EKS Node Group (%s) version: %w", d.Id(), err)
 		}
 
 		if output == nil || output.Update == nil || output.Update.Id == nil {
@@ -491,14 +492,14 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 
 		err = waitForEksNodeGroupUpdate(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf("error waiting for EKS Node Group (%s) version update (%s): %s", d.Id(), updateID, err)
+			return fmt.Errorf("error waiting for EKS Node Group (%s) version update (%s): %w", d.Id(), updateID, err)
 		}
 	}
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 		if err := keyvaluetags.EksUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+			return fmt.Errorf("error updating tags: %w", err)
 		}
 	}
 
@@ -508,7 +509,8 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 func resourceAwsEksNodeGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).eksconn
 
-	clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(d.Id())
+	clusterName, nodeGroupName, err := tfeks.NodeGroupParseResourceID(d.Id())
+
 	if err != nil {
 		return err
 	}
@@ -525,11 +527,11 @@ func resourceAwsEksNodeGroupDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting EKS Node Group (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting EKS Node Group (%s): %w", d.Id(), err)
 	}
 
 	if err := waitForEksNodeGroupDeletion(conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutDelete)); err != nil {
-		return fmt.Errorf("error waiting for EKS Node Group (%s) deletion: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for EKS Node Group (%s) deletion: %w", d.Id(), err)
 	}
 
 	return nil
@@ -724,7 +726,7 @@ func refreshEksNodeGroupStatus(conn *eks.EKS, clusterName string, nodeGroupName 
 		nodeGroup := output.Nodegroup
 
 		if nodeGroup == nil {
-			return nodeGroup, "", fmt.Errorf("EKS Node Group (%s) missing", resourceAwsEksNodeGroupCreateId(clusterName, nodeGroupName))
+			return nodeGroup, "", fmt.Errorf("EKS Node Group (%s) missing", tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName))
 		}
 
 		status := aws.StringValue(nodeGroup.Status)
@@ -733,7 +735,7 @@ func refreshEksNodeGroupStatus(conn *eks.EKS, clusterName string, nodeGroupName 
 		// unexpected state 'CREATE_FAILED', wanted target 'ACTIVE'. last error: %!s(<nil>)
 		if status == eks.NodegroupStatusCreateFailed || status == eks.NodegroupStatusDeleteFailed {
 			if nodeGroup.Health == nil || len(nodeGroup.Health.Issues) == 0 || nodeGroup.Health.Issues[0] == nil {
-				return nodeGroup, status, fmt.Errorf("unable to find additional information about %s status, check EKS Node Group (%s) health", status, resourceAwsEksNodeGroupCreateId(clusterName, nodeGroupName))
+				return nodeGroup, status, fmt.Errorf("unable to find additional information about %s status, check EKS Node Group (%s) health", status, tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName))
 			}
 
 			issue := nodeGroup.Health.Issues[0]
@@ -760,7 +762,7 @@ func refreshEksNodeGroupUpdateStatus(conn *eks.EKS, clusterName string, nodeGrou
 		}
 
 		if output == nil || output.Update == nil {
-			return nil, "", fmt.Errorf("EKS Node Group (%s) update (%s) missing", resourceAwsEksNodeGroupCreateId(clusterName, nodeGroupName), updateID)
+			return nil, "", fmt.Errorf("EKS Node Group (%s) update (%s) missing", tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName), updateID)
 		}
 
 		return output.Update, aws.StringValue(output.Update.Status), nil
@@ -817,20 +819,4 @@ func waitForEksNodeGroupUpdate(conn *eks.EKS, clusterName, nodeGroupName string,
 	}
 
 	return fmt.Errorf("EKS Node Group (%s) update (%s) status (%s) not successful: Errors:\n%s", clusterName, updateID, aws.StringValue(update.Status), strings.Join(detailedErrors, "\n"))
-}
-
-func resourceAwsEksNodeGroupParseId(id string) (string, string, error) {
-	// inverse of resourceAwsEksNodeGroupCreateId()
-	parts := strings.Split(id, ":")
-
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("unexpected format of ID (%s), expected cluster-name:node-group-name", id)
-	}
-
-	return parts[0], parts[1], nil
-}
-
-func resourceAwsEksNodeGroupCreateId(clusterName, nodeGroupName string) string {
-	// inverse of resourceAwsEksNodeGroupParseId()
-	return fmt.Sprintf("%s:%s", clusterName, nodeGroupName)
 }

--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
+	tfeks "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks"
 )
 
 func init() {
@@ -54,7 +55,7 @@ func testSweepEksNodeGroups(region string) error {
 
 					d.Set("cluster_name", clusterName)
 					d.Set("node_group_name", nodeGroupName)
-					d.SetId(resourceAwsEksNodeGroupCreateId(clusterName, nodeGroupName))
+					d.SetId(tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName))
 
 					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 				}
@@ -869,7 +870,7 @@ func testAccCheckAWSEksNodeGroupExists(resourceName string, nodeGroup *eks.Nodeg
 			return fmt.Errorf("No EKS Node Group ID is set")
 		}
 
-		clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(rs.Primary.ID)
+		clusterName, nodeGroupName, err := tfeks.NodeGroupParseResourceID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -913,7 +914,7 @@ func testAccCheckAWSEksNodeGroupDestroy(s *terraform.State) error {
 			continue
 		}
 
-		clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(rs.Primary.ID)
+		clusterName, nodeGroupName, err := tfeks.NodeGroupParseResourceID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -122,14 +122,14 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `ami_type` - (Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64`. Terraform will only perform drift detection if a configuration value is provided.
+* `ami_type` - (Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64`, `CUSTOM`. Terraform will only perform drift detection if a configuration value is provided.
 * `capacity_type` - (Optional) Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. Terraform will only perform drift detection if a configuration value is provided.
 * `disk_size` - (Optional) Disk size in GiB for worker nodes. Defaults to `20`. Terraform will only perform drift detection if a configuration value is provided.
 * `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
 * `instance_types` - (Optional) List of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
 * `labels` - (Optional) Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
 * `launch_template` - (Optional) Configuration block with Launch Template settings. Detailed below.
-* `node_group_name` – (Optional) Name of the EKS Node Group. If omitted, Terraform will assign a random, unique name.
+* `node_group_name` – (Optional) Name of the EKS Node Group. If omitted, Terraform will assign a random, unique name. Conflicts with `node_group_name_prefix`.
 * `node_group_name_prefix` – (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `node_group_name`.
 * `release_version` – (Optional) AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
 * `remote_access` - (Optional) Configuration block with remote access settings. Detailed below.

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -116,7 +116,6 @@ resource "aws_subnet" "example" {
 The following arguments are required:
 
 * `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
-* `node_group_name` – (Required) Name of the EKS Node Group.
 * `node_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Node Group.
 * `scaling_config` - (Required) Configuration block with scaling settings. Detailed below.
 * `subnet_ids` – (Required) Identifiers of EC2 Subnets to associate with the EKS Node Group. These subnets must have the following resource tag: `kubernetes.io/cluster/CLUSTER_NAME` (where `CLUSTER_NAME` is replaced with the name of the EKS Cluster).
@@ -130,6 +129,8 @@ The following arguments are optional:
 * `instance_types` - (Optional) List of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
 * `labels` - (Optional) Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
 * `launch_template` - (Optional) Configuration block with Launch Template settings. Detailed below.
+* `node_group_name` – (Optional) Name of the EKS Node Group. If omitted, Terraform will assign a random, unique name.
+* `node_group_name_prefix` – (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `node_group_name`.
 * `release_version` – (Optional) AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
 * `remote_access` - (Optional) Configuration block with remote access settings. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_eks_node_group: Add `node_group_name_prefix`.
resource/aws_eks_node_group: `node_group_name` is optional.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEksNodeGroup_NamePrefix'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksNodeGroup_NamePrefix -timeout 120m
=== RUN   TestAccAWSEksNodeGroup_NamePrefix
=== PAUSE TestAccAWSEksNodeGroup_NamePrefix
=== CONT  TestAccAWSEksNodeGroup_NamePrefix
--- PASS: TestAccAWSEksNodeGroup_NamePrefix (1331.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1331.894s
...
```

This PR adds functionality to use prefixes for naming EKS node groups which allows you to use life cycle arguments such as create_before_destroy. `node_group_name` is moved to optional with with a random unique value if omitted.