### PR TITLE
d/security_groups - add `arns` attribute

### DIFF
--- a/.changelog/13944.txt
+++ b/.changelog/13944.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_security_groups: Adds `arns` attribute
+```

--- a/aws/data_source_aws_ami.go
+++ b/aws/data_source_aws_ami.go
@@ -321,7 +321,7 @@ func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image, meta int
 		Partition: meta.(*AWSClient).partition,
 		Region:    meta.(*AWSClient).region,
 		Resource:  fmt.Sprintf("image/%s", d.Id()),
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 	}.String()
 
 	d.Set("arn", imageArn)

--- a/aws/data_source_aws_customer_gateway.go
+++ b/aws/data_source_aws_customer_gateway.go
@@ -102,7 +102,7 @@ func dataSourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) 
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("customer-gateway/%s", d.Id()),

--- a/aws/data_source_aws_ebs_snapshot.go
+++ b/aws/data_source_aws_ebs_snapshot.go
@@ -162,7 +162,7 @@ func snapshotDescriptionAttributes(d *schema.ResourceData, snapshot *ec2.Snapsho
 		Partition: meta.(*AWSClient).partition,
 		Region:    meta.(*AWSClient).region,
 		Resource:  fmt.Sprintf("snapshot/%s", d.Id()),
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 	}.String()
 
 	d.Set("arn", snapshotArn)

--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -140,7 +140,7 @@ func volumeDescriptionAttributes(d *schema.ResourceData, client *AWSClient, volu
 	arn := arn.ARN{
 		Partition: client.partition,
 		Region:    client.region,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		AccountID: client.accountid,
 		Resource:  fmt.Sprintf("volume/%s", d.Id()),
 	}

--- a/aws/data_source_aws_ec2_transit_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table.go
@@ -92,7 +92,7 @@ func dataSourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta i
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("transit-gateway-route-table/%s", d.Id()),

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -425,7 +425,7 @@ func dataSourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Region:    meta.(*AWSClient).region,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("instance/%s", d.Id()),
 	}

--- a/aws/data_source_aws_internet_gateway.go
+++ b/aws/data_source_aws_internet_gateway.go
@@ -98,7 +98,7 @@ func dataSourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) 
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("internet-gateway/%s", d.Id()),

--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -457,7 +457,7 @@ func dataSourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) e
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("launch-template/%s", d.Id()),

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -90,7 +90,7 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 
 	sg := resp.SecurityGroups[0]
 
-	d.SetId(*sg.GroupId)
+	d.SetId(aws.StringValue(sg.GroupId))
 	d.Set("name", sg.GroupName)
 	d.Set("description", sg.Description)
 	d.Set("vpc_id", sg.VpcId)

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -101,7 +101,7 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: *sg.OwnerId,
 		Resource:  fmt.Sprintf("security-group/%s", *sg.GroupId),

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -103,8 +103,8 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 		Partition: meta.(*AWSClient).partition,
 		Service:   "ec2",
 		Region:    meta.(*AWSClient).region,
-		AccountID: *sg.OwnerId,
-		Resource:  fmt.Sprintf("security-group/%s", *sg.GroupId),
+		AccountID: aws.StringValue(sg.OwnerId),
+		Resource:  fmt.Sprintf("security-group/%s", aws.StringValue(sg.GroupId)),
 	}.String()
 	d.Set("arn", arn)
 

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -90,7 +90,7 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 
 	sg := resp.SecurityGroups[0]
 
-	d.SetId(aws.StringValue(sg.GroupId))
+	d.SetId(*sg.GroupId)
 	d.Set("name", sg.GroupName)
 	d.Set("description", sg.Description)
 	d.Set("vpc_id", sg.VpcId)
@@ -103,8 +103,8 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 		Partition: meta.(*AWSClient).partition,
 		Service:   "ec2",
 		Region:    meta.(*AWSClient).region,
-		AccountID: aws.StringValue(sg.OwnerId),
-		Resource:  fmt.Sprintf("security-group/%s", aws.StringValue(sg.GroupId)),
+		AccountID: *sg.OwnerId,
+		Resource:  fmt.Sprintf("security-group/%s", *sg.GroupId),
 	}.String()
 	d.Set("arn", arn)
 

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -83,11 +82,40 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_security_group" "test" {
-<<<<<<< HEAD
-  vpc_id = aws_vpc.test.id
-  name   = "test-%d"
-=======
   vpc_id = aws_vpc.test.id
   name   = %[1]q
->>>>>>> 5d0742b09 (use aws sdk wrappers, refactor tests)
 
+  tags = {
+    Name = %[1]q
+  }
+
+  description = "sg description"
+}
+
+data "aws_security_group" "by_id" {
+  id = aws_security_group.test.id
+}
+
+data "aws_security_group" "by_name" {
+  name = aws_security_group.test.name
+}
+
+data "aws_security_group" "default_by_name" {
+  vpc_id = aws_vpc.test.id
+  name   = "default"
+}
+
+data "aws_security_group" "by_tag" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_security_group" "by_filter" {
+  filter {
+    name   = "group-name"
+    values = [aws_security_group.test.name]
+  }
+}
+`, rName)
+}

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -2,57 +2,112 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceAwsSecurityGroup_basic(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_security_group.test"
+	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsSecurityGroupConfig(rName),
+				Config: testAccDataSourceAwsSecurityGroupConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "description", resourceName, "description"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "name", resourceName, "name"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "vpc_id", resourceName, "vpc_id"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "description", resourceName, "description"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "name", resourceName, "name"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "vpc_id", resourceName, "vpc_id"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "description", resourceName, "description"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "name", resourceName, "name"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "vpc_id", resourceName, "vpc_id"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "description", resourceName, "description"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "tags.%", resourceName, "tags.%"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "name", resourceName, "name"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "vpc_id", resourceName, "vpc_id"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.default_by_name", "vpc_id", "aws_vpc.test", "id"),
-					resource.TestCheckResourceAttrPair("data.aws_security_group.default_by_name", "id", "aws_vpc.test", "default_security_group_id"),
+					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_id"),
+					resource.TestCheckResourceAttr("data.aws_security_group.by_id", "description", "sg description"),
+					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_tag"),
+					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_filter"),
+					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_name"),
+					testAccDataSourceAwsSecurityGroupCheckDefault("data.aws_security_group.default_by_name"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsSecurityGroupConfig(rName string) string {
+func testAccDataSourceAwsSecurityGroupCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		SGRs, ok := s.RootModule().Resources["aws_security_group.test"]
+		if !ok {
+			return fmt.Errorf("can't find aws_security_group.test in state")
+		}
+		vpcRs, ok := s.RootModule().Resources["aws_vpc.test"]
+		if !ok {
+			return fmt.Errorf("can't find aws_vpc.test in state")
+		}
+		attr := rs.Primary.Attributes
+
+		if attr["id"] != SGRs.Primary.Attributes["id"] {
+			return fmt.Errorf(
+				"id is %s; want %s",
+				attr["id"],
+				SGRs.Primary.Attributes["id"],
+			)
+		}
+
+		if attr["vpc_id"] != vpcRs.Primary.Attributes["id"] {
+			return fmt.Errorf(
+				"vpc_id is %s; want %s",
+				attr["vpc_id"],
+				vpcRs.Primary.Attributes["id"],
+			)
+		}
+
+		if attr["tags.Name"] != "tf-acctest" {
+			return fmt.Errorf("bad Name tag %s", attr["tags.Name"])
+		}
+
+		if !strings.Contains(attr["arn"], attr["id"]) {
+			return fmt.Errorf("bad ARN %s", attr["arn"])
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsSecurityGroupCheckDefault(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		vpcRs, ok := s.RootModule().Resources["aws_vpc.test"]
+		if !ok {
+			return fmt.Errorf("can't find aws_vpc.test in state")
+		}
+		attr := rs.Primary.Attributes
+
+		if attr["id"] != vpcRs.Primary.Attributes["default_security_group_id"] {
+			return fmt.Errorf(
+				"id is %s; want %s",
+				attr["id"],
+				vpcRs.Primary.Attributes["default_security_group_id"],
+			)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsSecurityGroupConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags = {
-    Name = %[1]q
+    Name = "terraform-testacc-security-group-data-source"
   }
 }
 
@@ -61,8 +116,8 @@ resource "aws_security_group" "test" {
   name   = %[1]q
 
   tags = {
-    Name    = %[1]q
-    SomeTag = "SomeValue"
+    Name = "tf-acctest"
+    Seed = "%d"
   }
 
   description = "sg description"
@@ -83,7 +138,7 @@ data "aws_security_group" "default_by_name" {
 
 data "aws_security_group" "by_tag" {
   tags = {
-    Name = "${aws_security_group.test.tags["Name"]}"
+    Seed = "${aws_security_group.test.tags["Seed"]}"
   }
 }
 
@@ -93,5 +148,5 @@ data "aws_security_group" "by_filter" {
     values = [aws_security_group.test.name]
   }
 }
-`, rName)
+`, rInt, rInt)
 }

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -113,7 +113,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
-  name   = %[1]q
+  name   = "test-%d"
 
   tags = {
     Name = "tf-acctest"

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -11,69 +11,40 @@ import (
 )
 
 func TestAccDataSourceAwsSecurityGroup_basic(t *testing.T) {
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_security_group.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsSecurityGroupConfig(rInt),
+				Config: testAccDataSourceAwsSecurityGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_id"),
-					resource.TestCheckResourceAttr("data.aws_security_group.by_id", "description", "sg description"),
-					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_tag"),
-					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_filter"),
-					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_name"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_id", "vpc_id", resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_name", "vpc_id", resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_filter", "vpc_id", resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair("data.aws_security_group.by_tag", "vpc_id", resourceName, "vpc_id"),
 					testAccDataSourceAwsSecurityGroupCheckDefault("data.aws_security_group.default_by_name"),
 				),
 			},
 		},
 	})
-}
-
-func testAccDataSourceAwsSecurityGroupCheck(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		SGRs, ok := s.RootModule().Resources["aws_security_group.test"]
-		if !ok {
-			return fmt.Errorf("can't find aws_security_group.test in state")
-		}
-		vpcRs, ok := s.RootModule().Resources["aws_vpc.test"]
-		if !ok {
-			return fmt.Errorf("can't find aws_vpc.test in state")
-		}
-		attr := rs.Primary.Attributes
-
-		if attr["id"] != SGRs.Primary.Attributes["id"] {
-			return fmt.Errorf(
-				"id is %s; want %s",
-				attr["id"],
-				SGRs.Primary.Attributes["id"],
-			)
-		}
-
-		if attr["vpc_id"] != vpcRs.Primary.Attributes["id"] {
-			return fmt.Errorf(
-				"vpc_id is %s; want %s",
-				attr["vpc_id"],
-				vpcRs.Primary.Attributes["id"],
-			)
-		}
-
-		if attr["tags.Name"] != "tf-acctest" {
-			return fmt.Errorf("bad Name tag %s", attr["tags.Name"])
-		}
-
-		if !strings.Contains(attr["arn"], attr["id"]) {
-			return fmt.Errorf("bad ARN %s", attr["arn"])
-		}
-
-		return nil
-	}
 }
 
 func testAccDataSourceAwsSecurityGroupCheckDefault(name string) resource.TestCheckFunc {
@@ -101,52 +72,22 @@ func testAccDataSourceAwsSecurityGroupCheckDefault(name string) resource.TestChe
 	}
 }
 
-func testAccDataSourceAwsSecurityGroupConfig(rInt int) string {
+func testAccDataSourceAwsSecurityGroupConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-security-group-data-source"
+    Name = %[1]q
   }
 }
 
 resource "aws_security_group" "test" {
+<<<<<<< HEAD
   vpc_id = aws_vpc.test.id
   name   = "test-%d"
-
-  tags = {
-    Name = "tf-acctest"
-    Seed = "%d"
-  }
-
-  description = "sg description"
-}
-
-data "aws_security_group" "by_id" {
-  id = aws_security_group.test.id
-}
-
-data "aws_security_group" "by_name" {
-  name = aws_security_group.test.name
-}
-
-data "aws_security_group" "default_by_name" {
+=======
   vpc_id = aws_vpc.test.id
-  name   = "default"
-}
+  name   = %[1]q
+>>>>>>> 5d0742b09 (use aws sdk wrappers, refactor tests)
 
-data "aws_security_group" "by_tag" {
-  tags = {
-    Seed = aws_security_group.test.tags["Seed"]
-  }
-}
-
-data "aws_security_group" "by_filter" {
-  filter {
-    name   = "group-name"
-    values = [aws_security_group.test.name]
-  }
-}
-`, rInt, rInt)
-}

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -138,7 +138,7 @@ data "aws_security_group" "default_by_name" {
 
 data "aws_security_group" "by_tag" {
   tags = {
-    Seed = "${aws_security_group.test.tags["Seed"]}"
+    Seed = aws_security_group.test.tags["Seed"]
   }
 }
 

--- a/aws/data_source_aws_security_groups.go
+++ b/aws/data_source_aws_security_groups.go
@@ -102,6 +102,13 @@ func dataSourceAwsSecurityGroupsRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	err = d.Set("vpcIds", vpcIds)
-	return err
+	if err = d.Set("vpc_ids", vpcIds); err != nil {
+		return fmt.Errorf("error setting vpc_ids: %s", err)
+	}
+
+	if err = d.Set("arns", arns); err != nil {
+		return fmt.Errorf("error setting arns: %s", err)
+	}
+
+	return nil
 }

--- a/aws/data_source_aws_security_groups.go
+++ b/aws/data_source_aws_security_groups.go
@@ -74,7 +74,7 @@ func dataSourceAwsSecurityGroupsRead(d *schema.ResourceData, meta interface{}) e
 
 			arn := arn.ARN{
 				Partition: meta.(*AWSClient).partition,
-				Service:   "ec2",
+				Service:   ec2.ServiceName,
 				Region:    meta.(*AWSClient).region,
 				AccountID: aws.StringValue(sg.OwnerId),
 				Resource:  fmt.Sprintf("security-group/%s", aws.StringValue(sg.GroupId)),

--- a/aws/data_source_aws_security_groups.go
+++ b/aws/data_source_aws_security_groups.go
@@ -61,7 +61,7 @@ func dataSourceAwsSecurityGroupsRead(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Reading Security Groups with request: %s", req)
 
-	var ids, vpc_ids, arns []string
+	var ids, vpcIds, arns []string
 	for {
 		resp, err := conn.DescribeSecurityGroups(req)
 		if err != nil {
@@ -70,7 +70,7 @@ func dataSourceAwsSecurityGroupsRead(d *schema.ResourceData, meta interface{}) e
 
 		for _, sg := range resp.SecurityGroups {
 			ids = append(ids, aws.StringValue(sg.GroupId))
-			vpc_ids = append(vpc_ids, aws.StringValue(sg.VpcId))
+			vpcIds = append(vpcIds, aws.StringValue(sg.VpcId))
 
 			arn := arn.ARN{
 				Partition: meta.(*AWSClient).partition,
@@ -102,6 +102,6 @@ func dataSourceAwsSecurityGroupsRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	err = d.Set("vpc_ids", vpc_ids)
+	err = d.Set("vpcIds", vpcIds)
 	return err
 }

--- a/aws/data_source_aws_security_groups.go
+++ b/aws/data_source_aws_security_groups.go
@@ -29,6 +29,11 @@ func dataSourceAwsSecurityGroups() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"arns": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }

--- a/aws/data_source_aws_security_groups.go
+++ b/aws/data_source_aws_security_groups.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"

--- a/aws/data_source_aws_security_groups_test.go
+++ b/aws/data_source_aws_security_groups_test.go
@@ -19,6 +19,7 @@ func TestAccDataSourceAwsSecurityGroups_tag(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_security_groups.by_tag", "ids.#", "3"),
 					resource.TestCheckResourceAttr("data.aws_security_groups.by_tag", "vpc_ids.#", "3"),
+					resource.TestCheckResourceAttr("data.aws_security_groups.by_tag", "arns.#", "3"),
 				),
 			},
 		},
@@ -36,6 +37,7 @@ func TestAccDataSourceAwsSecurityGroups_filter(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_security_groups.by_filter", "ids.#", "3"),
 					resource.TestCheckResourceAttr("data.aws_security_groups.by_filter", "vpc_ids.#", "3"),
+					resource.TestCheckResourceAttr("data.aws_security_groups.by_filter", "arns.#", "3"),
 				),
 			},
 		},

--- a/aws/data_source_aws_security_groups_test.go
+++ b/aws/data_source_aws_security_groups_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccDataSourceAwsSecurityGroups_tag(t *testing.T) {
 	rInt := acctest.RandInt()
+	dataSourceName := "data.aws_security_groups.by_tag"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -17,9 +18,9 @@ func TestAccDataSourceAwsSecurityGroups_tag(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsSecurityGroupsConfig_tag(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_security_groups.by_tag", "ids.#", "3"),
-					resource.TestCheckResourceAttr("data.aws_security_groups.by_tag", "vpc_ids.#", "3"),
-					resource.TestCheckResourceAttr("data.aws_security_groups.by_tag", "arns.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "vpc_ids.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "3"),
 				),
 			},
 		},
@@ -28,6 +29,7 @@ func TestAccDataSourceAwsSecurityGroups_tag(t *testing.T) {
 
 func TestAccDataSourceAwsSecurityGroups_filter(t *testing.T) {
 	rInt := acctest.RandInt()
+	dataSourceName := "data.aws_security_groups.by_filter"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -35,9 +37,9 @@ func TestAccDataSourceAwsSecurityGroups_filter(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsSecurityGroupsConfig_filter(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_security_groups.by_filter", "ids.#", "3"),
-					resource.TestCheckResourceAttr("data.aws_security_groups.by_filter", "vpc_ids.#", "3"),
-					resource.TestCheckResourceAttr("data.aws_security_groups.by_filter", "arns.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "vpc_ids.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "3"),
 				),
 			},
 		},

--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -191,7 +191,7 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpc/%s", d.Id()),

--- a/aws/data_source_aws_vpc_dhcp_options.go
+++ b/aws/data_source_aws_vpc_dhcp_options.go
@@ -136,7 +136,7 @@ func dataSourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) e
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("dhcp-options/%s", d.Id()),

--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -161,7 +161,7 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpc-endpoint/%s", d.Id()),

--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -164,7 +164,7 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpc-endpoint-service/%s", serviceId),

--- a/aws/data_source_aws_vpn_gateway.go
+++ b/aws/data_source_aws_vpn_gateway.go
@@ -126,7 +126,7 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpn-gateway/%s", d.Id()),

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -420,7 +420,7 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 		Partition: meta.(*AWSClient).partition,
 		Region:    meta.(*AWSClient).region,
 		Resource:  fmt.Sprintf("image/%s", d.Id()),
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 	}.String()
 
 	d.Set("arn", imageArn)

--- a/aws/resource_aws_customer_gateway.go
+++ b/aws/resource_aws_customer_gateway.go
@@ -246,7 +246,7 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("customer-gateway/%s", d.Id()),

--- a/aws/resource_aws_ebs_snapshot.go
+++ b/aws/resource_aws_ebs_snapshot.go
@@ -157,7 +157,7 @@ func resourceAwsEbsSnapshotRead(d *schema.ResourceData, meta interface{}) error 
 		Partition: meta.(*AWSClient).partition,
 		Region:    meta.(*AWSClient).region,
 		Resource:  fmt.Sprintf("snapshot/%s", d.Id()),
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 	}.String()
 
 	d.Set("arn", snapshotArn)

--- a/aws/resource_aws_ebs_snapshot_copy.go
+++ b/aws/resource_aws_ebs_snapshot_copy.go
@@ -145,7 +145,7 @@ func resourceAwsEbsSnapshotCopyRead(d *schema.ResourceData, meta interface{}) er
 		Partition: meta.(*AWSClient).partition,
 		Region:    meta.(*AWSClient).region,
 		Resource:  fmt.Sprintf("snapshot/%s", d.Id()),
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 	}.String()
 
 	d.Set("arn", snapshotArn)

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -273,7 +273,7 @@ func resourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		Partition: meta.(*AWSClient).partition,
 		Region:    meta.(*AWSClient).region,
 		Resource:  fmt.Sprintf("volume/%s", d.Id()),
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 	}
 	d.Set("arn", arn.String())
 	d.Set("availability_zone", volume.AvailabilityZone)

--- a/aws/resource_aws_ec2_carrier_gateway.go
+++ b/aws/resource_aws_ec2_carrier_gateway.go
@@ -97,7 +97,7 @@ func resourceAwsEc2CarrierGatewayRead(d *schema.ResourceData, meta interface{}) 
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("carrier-gateway/%s", d.Id()),

--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -255,7 +255,7 @@ func resourceAwsEc2ClientVpnEndpointRead(d *schema.ResourceData, meta interface{
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("client-vpn-endpoint/%s", d.Id()),

--- a/aws/resource_aws_ec2_traffic_mirror_filter.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter.go
@@ -157,7 +157,7 @@ func resourceAwsEc2TrafficMirrorFilterRead(d *schema.ResourceData, meta interfac
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("traffic-mirror-filter/%s", d.Id()),

--- a/aws/resource_aws_ec2_traffic_mirror_session.go
+++ b/aws/resource_aws_ec2_traffic_mirror_session.go
@@ -219,7 +219,7 @@ func resourceAwsEc2TrafficMirrorSessionRead(d *schema.ResourceData, meta interfa
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("traffic-mirror-session/%s", d.Id()),

--- a/aws/resource_aws_ec2_traffic_mirror_target.go
+++ b/aws/resource_aws_ec2_traffic_mirror_target.go
@@ -135,7 +135,7 @@ func resourceAwsEc2TrafficMirrorTargetRead(d *schema.ResourceData, meta interfac
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("traffic-mirror-target/%s", d.Id()),

--- a/aws/resource_aws_ec2_transit_gateway_route_table.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table.go
@@ -108,7 +108,7 @@ func resourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta int
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("transit-gateway-route-table/%s", d.Id()),

--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -240,7 +240,7 @@ func resourceAwsLogFlowRead(d *schema.ResourceData, meta interface{}) error {
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpc-flow-log/%s", d.Id()),

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -951,7 +951,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Region:    meta.(*AWSClient).region,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("instance/%s", d.Id()),
 	}

--- a/aws/resource_aws_internet_gateway.go
+++ b/aws/resource_aws_internet_gateway.go
@@ -121,7 +121,7 @@ func resourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) er
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("internet-gateway/%s", d.Id()),

--- a/aws/resource_aws_key_pair.go
+++ b/aws/resource_aws_key_pair.go
@@ -142,7 +142,7 @@ func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("key-pair/%s", d.Id()),

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -737,7 +737,7 @@ func resourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) err
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("launch-template/%s", d.Id()),

--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -273,7 +273,7 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("network-acl/%s", d.Id()),

--- a/aws/resource_aws_placement_group.go
+++ b/aws/resource_aws_placement_group.go
@@ -138,7 +138,7 @@ func resourceAwsPlacementGroupRead(d *schema.ResourceData, meta interface{}) err
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("placement-group/%s", d.Id()),

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -250,7 +250,7 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	// ARN
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpc/%s", d.Id()),

--- a/aws/resource_aws_vpc_dhcp_options.go
+++ b/aws/resource_aws_vpc_dhcp_options.go
@@ -193,7 +193,7 @@ func resourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) err
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("dhcp-options/%s", d.Id()),

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -226,7 +226,7 @@ func resourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) error 
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpc-endpoint/%s", d.Id()),

--- a/aws/resource_aws_vpc_endpoint_service.go
+++ b/aws/resource_aws_vpc_endpoint_service.go
@@ -195,7 +195,7 @@ func resourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{})
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpc-endpoint-service/%s", d.Id()),

--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -731,7 +731,7 @@ func resourceAwsVpnConnectionRead(d *schema.ResourceData, meta interface{}) erro
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpn-connection/%s", d.Id()),

--- a/aws/resource_aws_vpn_gateway.go
+++ b/aws/resource_aws_vpn_gateway.go
@@ -135,7 +135,7 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("vpn-gateway/%s", d.Id()),

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -49,6 +49,7 @@ several valid keys, for a full reference, check out
 
 * `id` - AWS Region.
 * `ids` - IDs of the matches security groups.
+* `arns` - ARNs of the matched security groups.
 * `vpc_ids` - The VPC IDs of the matched security groups. The data source's tag or filter *will span VPCs*
 unless the `vpc-id` filter is also used.
 

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -8,8 +8,7 @@ description: |-
 
 # Data Source: aws_security_groups
 
-Use this data source to get IDs and VPC membership of Security Groups that are created
-outside of Terraform.
+Use this data source to get IDs and VPC membership of Security Groups that are created outside of Terraform.
 
 ## Example Usage
 
@@ -38,19 +37,14 @@ data "aws_security_groups" "test" {
 
 ## Argument Reference
 
-* `tags` - (Optional) A map of tags, each pair of which must exactly match for
-desired security groups.
-
-* `filter` - (Optional) One or more name/value pairs to use as filters. There are
-several valid keys, for a full reference, check out
-[describe-security-groups in the AWS CLI reference][1].
+* `tags` - (Optional) A map of tags, each pair of which must exactly match for desired security groups.
+* `filter` - (Optional) One or more name/value pairs to use as filters. There are several valid keys, for a full reference, check out [describe-security-groups in the AWS CLI reference][1].
 
 ## Attributes Reference
 
+* `arns` - ARNs of the matched security groups.
 * `id` - AWS Region.
 * `ids` - IDs of the matches security groups.
-* `arns` - ARNs of the matched security groups.
-* `vpc_ids` - The VPC IDs of the matched security groups. The data source's tag or filter *will span VPCs*
-unless the `vpc-id` filter is also used.
+* `vpc_ids` - The VPC IDs of the matched security groups. The data source's tag or filter *will span VPCs* unless the `vpc-id` filter is also used.
 
 [1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-groups.html

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -20,7 +20,7 @@ resource "aws_vpc" "example" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "example" {
-  name        = "example.terraform.internal"
+  name        = "example.terraform.local"
   description = "example"
   vpc         = aws_vpc.example.id
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_security_groups: add `arns` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsSecurityGroups_'
--- PASS: TestAccDataSourceAwsSecurityGroups_tag (65.16s)
--- PASS: TestAccDataSourceAwsSecurityGroups_filter (65.36s)
```
