### PR TITLE
r/ec2_traffic_mirror_filter_rule - add arn attribute

### DIFF
--- a/.changelog/13949.txt
+++ b/.changelog/13949.txt
@@ -1,0 +1,8 @@
+```release-note:enhancement
+resource/aws_ec2_traffic_mirror_filter_rule: Add arn attribute.
+```
+
+```release-note:enhancement
+resource/aws_ec2_traffic_mirror_filter_rule: Add plan time validation to `destination_port_range.from_port`, 
+`destination_port_range.to_port`, `source_port_range.from_port`, and `source_port_range.to_port`.
+```

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
@@ -49,12 +49,12 @@ func resourceAwsEc2TrafficMirrorFilterRule() *schema.Resource {
 						"from_port": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IsPortNumber,
+							ValidateFunc: validation.IsPortNumberOrZero,
 						},
 						"to_port": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IsPortNumber,
+							ValidateFunc: validation.IsPortNumberOrZero,
 						},
 					},
 				},
@@ -89,12 +89,12 @@ func resourceAwsEc2TrafficMirrorFilterRule() *schema.Resource {
 						"from_port": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IsPortNumber,
+							ValidateFunc: validation.IsPortNumberOrZero,
 						},
 						"to_port": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IsPortNumber,
+							ValidateFunc: validation.IsPortNumberOrZero,
 						},
 					},
 				},

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
@@ -171,7 +171,7 @@ func resourceAwsEc2TrafficMirrorFilterRuleRead(d *schema.ResourceData, meta inte
 	}
 
 	if nil == rule {
-		log.Printf("[WARN] EC2 Traffic Mirror Filter (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] EC2 Traffic Mirror Filter Rule (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -210,15 +210,16 @@ func resourceAwsEc2TrafficMirrorFilterRuleRead(d *schema.ResourceData, meta inte
 func findEc2TrafficMirrorFilterRule(ruleId string, filters []*ec2.TrafficMirrorFilter) (rule *ec2.TrafficMirrorFilterRule) {
 	log.Printf("[DEBUG] searching %s in %d filters", ruleId, len(filters))
 	for _, v := range filters {
-		log.Printf("[DEBUG]: searching filter %s, ingress rule count = %d, egress rule count = %d", *v.TrafficMirrorFilterId, len(v.IngressFilterRules), len(v.EgressFilterRules))
+		log.Printf("[DEBUG]: searching filter %s, ingress rule count = %d, egress rule count = %d",
+			aws.StringValue(v.TrafficMirrorFilterId), len(v.IngressFilterRules), len(v.EgressFilterRules))
 		for _, r := range v.IngressFilterRules {
-			if *r.TrafficMirrorFilterRuleId == ruleId {
+			if aws.StringValue(r.TrafficMirrorFilterRuleId) == ruleId {
 				rule = r
 				break
 			}
 		}
 		for _, r := range v.EgressFilterRules {
-			if *r.TrafficMirrorFilterRuleId == ruleId {
+			if aws.StringValue(r.TrafficMirrorFilterRuleId) == ruleId {
 				rule = r
 				break
 			}
@@ -226,7 +227,7 @@ func findEc2TrafficMirrorFilterRule(ruleId string, filters []*ec2.TrafficMirrorF
 	}
 
 	if nil != rule {
-		log.Printf("[DEBUG]: Found %s in %s", ruleId, *rule.TrafficDirection)
+		log.Printf("[DEBUG]: Found %s in %s", ruleId, aws.StringValue(rule.TrafficDirection))
 	}
 
 	return rule

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
@@ -196,7 +196,7 @@ func resourceAwsEc2TrafficMirrorFilterRuleRead(d *schema.ResourceData, meta inte
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("traffic-mirror-filter-rule/%s", d.Id()),

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -21,6 +22,10 @@ func resourceAwsEc2TrafficMirrorFilterRule() *schema.Resource {
 			State: resourceAwsEc2TrafficMirrorFilterRuleImport,
 		},
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -42,12 +47,14 @@ func resourceAwsEc2TrafficMirrorFilterRule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": {
-							Type:     schema.TypeInt,
-							Optional: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IsPortNumber,
 						},
 						"to_port": {
-							Type:     schema.TypeInt,
-							Optional: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IsPortNumber,
 						},
 					},
 				},
@@ -80,12 +87,14 @@ func resourceAwsEc2TrafficMirrorFilterRule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": {
-							Type:     schema.TypeInt,
-							Optional: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IsPortNumber,
 						},
 						"to_port": {
-							Type:     schema.TypeInt,
-							Optional: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IsPortNumber,
 						},
 					},
 				},
@@ -184,6 +193,16 @@ func resourceAwsEc2TrafficMirrorFilterRuleRead(d *schema.ResourceData, meta inte
 	if err := d.Set("source_port_range", buildTrafficMirrorFilterRulePortRangeSchema(rule.SourcePortRange)); err != nil {
 		return fmt.Errorf("error setting source_port_range: %s", err)
 	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ec2",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("traffic-mirror-filter-rule/%s", d.Id()),
+	}.String()
+
+	d.Set("arn", arn)
 
 	return nil
 }

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccAWSEc2TrafficMirrorFilterRule_basic(t *testing.T) {
-	resourceName := "aws_ec2_traffic_mirror_filter_rule.rule"
+	resourceName := "aws_ec2_traffic_mirror_filter_rule.test"
 	dstCidr := "10.0.0.0/8"
 	srcCidr := "0.0.0.0/0"
 	ruleNum := 1
@@ -39,6 +39,7 @@ func TestAccAWSEc2TrafficMirrorFilterRule_basic(t *testing.T) {
 				Config: testAccEc2TrafficMirrorFilterRuleConfig(dstCidr, srcCidr, action, direction, ruleNum),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TrafficMirrorFilterRuleExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`traffic-mirror-filter-rule/tmfr-.+`)),
 					resource.TestMatchResourceAttr(resourceName, "traffic_mirror_filter_id", regexp.MustCompile("tmf-.*")),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", dstCidr),
 					resource.TestCheckResourceAttr(resourceName, "rule_action", action),
@@ -99,6 +100,34 @@ func TestAccAWSEc2TrafficMirrorFilterRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSEc2TrafficMirrorFilterRule_disappears(t *testing.T) {
+	resourceName := "aws_ec2_traffic_mirror_session_rule.test"
+	dstCidr := "10.0.0.0/8"
+	srcCidr := "0.0.0.0/0"
+	ruleNum := 1
+	action := "accept"
+	direction := "ingress"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TrafficMirrorFilterRule(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TrafficMirrorFilterRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEc2TrafficMirrorFilterRuleConfig(dstCidr, srcCidr, action, direction, ruleNum),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TrafficMirrorFilterRuleExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEc2TrafficMirrorFilterRule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEc2TrafficMirrorFilterRuleExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -150,6 +179,7 @@ func testAccCheckAWSEc2TrafficMirrorFilterRuleExists(name string) resource.TestC
 
 func testAccEc2TrafficMirrorFilterRuleConfig(dstCidr, srcCidr, action, dir string, num int) string {
 	return fmt.Sprintf(`
+<<<<<<< HEAD
 resource "aws_ec2_traffic_mirror_filter" "filter" {
 }
 
@@ -160,15 +190,26 @@ resource "aws_ec2_traffic_mirror_filter_rule" "rule" {
   rule_number              = %d
   source_cidr_block        = "%s"
   traffic_direction        = "%s"
+=======
+resource "aws_ec2_traffic_mirror_filter" "test" {}
+
+resource "aws_ec2_traffic_mirror_filter_rule" "test" {
+	traffic_mirror_filter_id = "${aws_ec2_traffic_mirror_filter.test.id}"
+	destination_cidr_block   = "%s"
+	rule_action              = "%s"
+	rule_number              = %d
+	source_cidr_block        = "%s"
+	traffic_direction        = "%s"
+>>>>>>> fd1c1723b... add arn attribute + disappears
 }
 `, dstCidr, action, num, srcCidr, dir)
 }
 
 func testAccEc2TrafficMirrorFilterRuleConfigFull(dstCidr, srcCidr, action, dir, description string, ruleNum, srcPortFrom, srcPortTo, dstPortFrom, dstPortTo, protocol int) string {
 	return fmt.Sprintf(`
-resource "aws_ec2_traffic_mirror_filter" "filter" {
-}
+resource "aws_ec2_traffic_mirror_filter" "test" {}
 
+<<<<<<< HEAD
 resource "aws_ec2_traffic_mirror_filter_rule" "rule" {
   traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
   destination_cidr_block   = "%s"
@@ -186,6 +227,27 @@ resource "aws_ec2_traffic_mirror_filter_rule" "rule" {
     from_port = %d
     to_port   = %d
   }
+=======
+resource "aws_ec2_traffic_mirror_filter_rule" "test" {
+	traffic_mirror_filter_id = "${aws_ec2_traffic_mirror_filter.test.id}"
+	destination_cidr_block = "%s"
+	rule_action            = "%s"
+	rule_number            = %d
+	source_cidr_block      = "%s"
+	traffic_direction      = "%s"
+	description            = "%s"
+	protocol               = %d
+
+	source_port_range {
+		from_port = %d
+		to_port   = %d
+	}
+
+	destination_port_range {
+		from_port = %d
+		to_port   = %d
+	}
+>>>>>>> fd1c1723b... add arn attribute + disappears
 }
 `, dstCidr, action, ruleNum, srcCidr, dir, description, protocol, srcPortFrom, srcPortTo, dstPortFrom, dstPortTo)
 }
@@ -239,7 +301,7 @@ func testAccCheckAWSEc2TrafficMirrorFilterRuleDestroy(s *terraform.State) error 
 		ruleList = append(ruleList, filter.EgressFilterRules...)
 
 		for _, rule := range ruleList {
-			if *rule.TrafficMirrorFilterRuleId == ruleId {
+			if aws.StringValue(rule.TrafficMirrorFilterRuleId) == ruleId {
 				return fmt.Errorf("Rule %s still exists in filter %s", ruleId, filterId)
 			}
 		}

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
@@ -182,8 +182,8 @@ func testAccEc2TrafficMirrorFilterRuleConfig(dstCidr, srcCidr, action, dir strin
 resource "aws_ec2_traffic_mirror_filter" "test" {
 }
 
-resource "aws_ec2_traffic_mirror_filter_rule" "rule" {
-  traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
+resource "aws_ec2_traffic_mirror_filter_rule" "test" {
+  traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.test.id
   destination_cidr_block   = "%s"
   rule_action              = "%s"
   rule_number              = %d
@@ -198,7 +198,7 @@ func testAccEc2TrafficMirrorFilterRuleConfigFull(dstCidr, srcCidr, action, dir, 
 resource "aws_ec2_traffic_mirror_filter" "test" {}
 
 resource "aws_ec2_traffic_mirror_filter_rule" "test" {
-  traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
+  traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.test.id
   destination_cidr_block   = "%s"
   rule_action              = "%s"
   rule_number              = %d

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
@@ -39,7 +39,7 @@ func TestAccAWSEc2TrafficMirrorFilterRule_basic(t *testing.T) {
 				Config: testAccEc2TrafficMirrorFilterRuleConfig(dstCidr, srcCidr, action, direction, ruleNum),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TrafficMirrorFilterRuleExists(resourceName),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`traffic-mirror-filter-rule/tmfr-.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", ec2.ServiceName, regexp.MustCompile(`traffic-mirror-filter-rule/tmfr-.+`)),
 					resource.TestMatchResourceAttr(resourceName, "traffic_mirror_filter_id", regexp.MustCompile("tmf-.*")),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", dstCidr),
 					resource.TestCheckResourceAttr(resourceName, "rule_action", action),

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
@@ -179,7 +179,6 @@ func testAccCheckAWSEc2TrafficMirrorFilterRuleExists(name string) resource.TestC
 
 func testAccEc2TrafficMirrorFilterRuleConfig(dstCidr, srcCidr, action, dir string, num int) string {
 	return fmt.Sprintf(`
-<<<<<<< HEAD
 resource "aws_ec2_traffic_mirror_filter" "filter" {
 }
 
@@ -190,17 +189,6 @@ resource "aws_ec2_traffic_mirror_filter_rule" "rule" {
   rule_number              = %d
   source_cidr_block        = "%s"
   traffic_direction        = "%s"
-=======
-resource "aws_ec2_traffic_mirror_filter" "test" {}
-
-resource "aws_ec2_traffic_mirror_filter_rule" "test" {
-	traffic_mirror_filter_id = "${aws_ec2_traffic_mirror_filter.test.id}"
-	destination_cidr_block   = "%s"
-	rule_action              = "%s"
-	rule_number              = %d
-	source_cidr_block        = "%s"
-	traffic_direction        = "%s"
->>>>>>> fd1c1723b... add arn attribute + disappears
 }
 `, dstCidr, action, num, srcCidr, dir)
 }
@@ -209,7 +197,6 @@ func testAccEc2TrafficMirrorFilterRuleConfigFull(dstCidr, srcCidr, action, dir, 
 	return fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_filter" "test" {}
 
-<<<<<<< HEAD
 resource "aws_ec2_traffic_mirror_filter_rule" "rule" {
   traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
   destination_cidr_block   = "%s"
@@ -227,27 +214,6 @@ resource "aws_ec2_traffic_mirror_filter_rule" "rule" {
     from_port = %d
     to_port   = %d
   }
-=======
-resource "aws_ec2_traffic_mirror_filter_rule" "test" {
-	traffic_mirror_filter_id = "${aws_ec2_traffic_mirror_filter.test.id}"
-	destination_cidr_block = "%s"
-	rule_action            = "%s"
-	rule_number            = %d
-	source_cidr_block      = "%s"
-	traffic_direction      = "%s"
-	description            = "%s"
-	protocol               = %d
-
-	source_port_range {
-		from_port = %d
-		to_port   = %d
-	}
-
-	destination_port_range {
-		from_port = %d
-		to_port   = %d
-	}
->>>>>>> fd1c1723b... add arn attribute + disappears
 }
 `, dstCidr, action, ruleNum, srcCidr, dir, description, protocol, srcPortFrom, srcPortTo, dstPortFrom, dstPortTo)
 }

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
@@ -179,7 +179,7 @@ func testAccCheckAWSEc2TrafficMirrorFilterRuleExists(name string) resource.TestC
 
 func testAccEc2TrafficMirrorFilterRuleConfig(dstCidr, srcCidr, action, dir string, num int) string {
 	return fmt.Sprintf(`
-resource "aws_ec2_traffic_mirror_filter" "filter" {
+resource "aws_ec2_traffic_mirror_filter" "test" {
 }
 
 resource "aws_ec2_traffic_mirror_filter_rule" "rule" {
@@ -197,7 +197,7 @@ func testAccEc2TrafficMirrorFilterRuleConfigFull(dstCidr, srcCidr, action, dir, 
 	return fmt.Sprintf(`
 resource "aws_ec2_traffic_mirror_filter" "test" {}
 
-resource "aws_ec2_traffic_mirror_filter_rule" "rule" {
+resource "aws_ec2_traffic_mirror_filter_rule" "test" {
   traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
   destination_cidr_block   = "%s"
   rule_action              = "%s"

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
@@ -163,7 +163,7 @@ func testAccCheckAWSEc2TrafficMirrorFilterRuleExists(name string) resource.TestC
 
 		var exists bool
 		for _, rule := range ruleList {
-			if *rule.TrafficMirrorFilterRuleId == ruleId {
+			if aws.StringValue(rule.TrafficMirrorFilterRuleId) == ruleId {
 				exists = true
 				break
 			}

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule_test.go
@@ -101,7 +101,7 @@ func TestAccAWSEc2TrafficMirrorFilterRule_basic(t *testing.T) {
 }
 
 func TestAccAWSEc2TrafficMirrorFilterRule_disappears(t *testing.T) {
-	resourceName := "aws_ec2_traffic_mirror_session_rule.test"
+	resourceName := "aws_ec2_traffic_mirror_filter_rule.test"
 	dstCidr := "10.0.0.0/8"
 	srcCidr := "0.0.0.0/0"
 	ruleNum := 1

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -265,6 +265,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
     - [`aws_ebs_volume` data source](/docs/providers/aws/d/ebs_volume.html)
     - [`aws_ec2_capacity_reservation` resource](/docs/providers/aws/r/ec2_capacity_reservation.html)
     - [`aws_ec2_client_vpn_endpoint` resource](/docs/providers/aws/r/ec2_client_vpn_endpoint.html)
+    - [`aws_ec2_traffic_mirror_filter_rule` resource](/docs/providers/aws/r/ec2_traffic_mirror_filter_rule.html)    
     - [`aws_ec2_traffic_mirror_session` resource](/docs/providers/aws/r/ec2_traffic_mirror_session.html)
     - [`aws_ec2_traffic_mirror_target` resource](/docs/providers/aws/r/ec2_traffic_mirror_target.html)
     - [`aws_ec2_transit_gateway_route_table` data source](/docs/providers/aws/d/ec2_transit_gateway_route_table.html)  

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -265,7 +265,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
     - [`aws_ebs_volume` data source](/docs/providers/aws/d/ebs_volume.html)
     - [`aws_ec2_capacity_reservation` resource](/docs/providers/aws/r/ec2_capacity_reservation.html)
     - [`aws_ec2_client_vpn_endpoint` resource](/docs/providers/aws/r/ec2_client_vpn_endpoint.html)
-    - [`aws_ec2_traffic_mirror_filter_rule` resource](/docs/providers/aws/r/ec2_traffic_mirror_filter_rule.html)    
+    - [`aws_ec2_traffic_mirror_filter_rule` resource](/docs/providers/aws/r/ec2_traffic_mirror_filter_rule.html)
     - [`aws_ec2_traffic_mirror_session` resource](/docs/providers/aws/r/ec2_traffic_mirror_session.html)
     - [`aws_ec2_traffic_mirror_target` resource](/docs/providers/aws/r/ec2_traffic_mirror_target.html)
     - [`aws_ec2_transit_gateway_route_table` data source](/docs/providers/aws/d/ec2_transit_gateway_route_table.html)  

--- a/website/docs/r/ec2_traffic_mirror_filter_rule.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_filter_rule.html.markdown
@@ -77,6 +77,7 @@ Traffic mirror port range support following attributes:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the traffic mirror filter rule.
 * `id` - The name of the traffic mirror filter rule.
 
 ## Import

--- a/website/docs/r/ec2_traffic_mirror_filter_rule.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_filter_rule.html.markdown
@@ -57,16 +57,16 @@ resource "aws_ec2_traffic_mirror_filter_rule" "rulein" {
 
 The following arguments are supported:
 
-* `description` - (Optional) A description of the traffic mirror filter rule.
+* `description` - (Optional) Description of the traffic mirror filter rule.
 * `traffic_mirror_filter_id`  - (Required) ID of the traffic mirror filter to which this rule should be added
-* `destination_cidr_block` - (Required) The destination CIDR block to assign to the Traffic Mirror rule.
-* `destination_port_range` - (Optional) The destination port range. Supported only when the protocol is set to TCP(6) or UDP(17). See Traffic mirror port range documented below
-* `protocol` - (Optional) The protocol number, for example 17 (UDP), to assign to the Traffic Mirror rule. For information about the protocol value, see [Protocol Numbers](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml) on the Internet Assigned Numbers Authority (IANA) website.
-* `rule_action` - (Required) The action to take (accept | reject) on the filtered traffic. Valid values are `accept` and `reject`
-* `rule_number` - (Required) The number of the Traffic Mirror rule. This number must be unique for each Traffic Mirror rule in a given direction. The rules are processed in ascending order by rule number.
-* `source_cidr_block` - (Required) The source CIDR block to assign to the Traffic Mirror rule.
-* `source_port_range` - (Optional) The source port range. Supported only when the protocol is set to TCP(6) or UDP(17). See Traffic mirror port range documented below
-* `traffic_direction` - (Required) The direction of traffic to be captured. Valid values are `ingress` and `egress`
+* `destination_cidr_block` - (Required) Destination CIDR block to assign to the Traffic Mirror rule.
+* `destination_port_range` - (Optional) Destination port range. Supported only when the protocol is set to TCP(6) or UDP(17). See Traffic mirror port range documented below
+* `protocol` - (Optional) Protocol number, for example 17 (UDP), to assign to the Traffic Mirror rule. For information about the protocol value, see [Protocol Numbers](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml) on the Internet Assigned Numbers Authority (IANA) website.
+* `rule_action` - (Required) Action to take (accept | reject) on the filtered traffic. Valid values are `accept` and `reject`
+* `rule_number` - (Required) Number of the Traffic Mirror rule. This number must be unique for each Traffic Mirror rule in a given direction. The rules are processed in ascending order by rule number.
+* `source_cidr_block` - (Required) Source CIDR block to assign to the Traffic Mirror rule.
+* `source_port_range` - (Optional) Source port range. Supported only when the protocol is set to TCP(6) or UDP(17). See Traffic mirror port range documented below
+* `traffic_direction` - (Required) Direction of traffic to be captured. Valid values are `ingress` and `egress`
 
 Traffic mirror port range support following attributes:
 
@@ -77,8 +77,8 @@ Traffic mirror port range support following attributes:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the traffic mirror filter rule.
-* `id` - The name of the traffic mirror filter rule.
+* `arn` - ARN of the traffic mirror filter rule.
+* `id` - Name of the traffic mirror filter rule.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624
Relates #13527
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ec2_traffic_mirror_filter_rule: add arn attribute
resource_aws_ec2_traffic_mirror_filter_rule: plan time validation for `destination_port_range.from_port`, `destination_port_range.to_port`, `source_port_range.from_port` and `source_port_range.to_port`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2TrafficMirrorFilterRule_'
--- PASS: TestAccAWSEc2TrafficMirrorFilterRule_basic (103.98s)
--- PASS: TestAccAWSEc2TrafficMirrorFilterRule_disappears (37.14s)
```
