### PR TITLE
r/ses_template - add arn attribute

### DIFF
--- a/.changelog/13963.txt
+++ b/.changelog/13963.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/ses_template: Add `arn` attribute.
+```
+

--- a/.changelog/13963.txt
+++ b/.changelog/13963.txt
@@ -1,4 +1,3 @@
 ```release-note:enhancement
-resource/ses_template: Add `arn` attribute.
+resource/aws_ses_template: Add `arn` attribute
 ```
-

--- a/aws/resource_aws_ses_template.go
+++ b/aws/resource_aws_ses_template.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -22,6 +23,10 @@ func resourceAwsSesTemplate() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -101,6 +106,15 @@ func resourceAwsSesTemplateRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("name", gto.Template.TemplateName)
 	d.Set("subject", gto.Template.SubjectPart)
 	d.Set("text", gto.Template.TextPart)
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ses",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("template/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
 
 	return nil
 }

--- a/aws/resource_aws_ses_template_test.go
+++ b/aws/resource_aws_ses_template_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -57,6 +56,7 @@ func TestAccAWSSesTemplate_Update(t *testing.T) {
 				Config: testAccCheckAwsSesTemplateResourceConfigBasic1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSesTemplateExists(resourceName, &template),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("template/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "html", "html"),
 					resource.TestCheckResourceAttr(resourceName, "subject", "subject"),
@@ -159,7 +159,7 @@ func testAccCheckSesTemplateDestroy(s *terraform.State) error {
 
 			gto, err := conn.GetTemplate(&input)
 			if err != nil {
-				if awsErr, ok := err.(awserr.Error); ok && (awsErr.Code() == "TemplateDoesNotExist") {
+				if isAWSErr(err, ses.ErrCodeTemplateDoesNotExistException, "") {
 					return nil
 				}
 				return resource.NonRetryableError(err)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -319,6 +319,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
     - [`aws_ses_domain_identity_verification` resource](/docs/providers/aws/r/ses_domain_identity_verification.html)
     - [`aws_ses_email_identity` resource](/docs/providers/aws/r/ses_email_identity.html)
     - [`aws_ses_receipt_filter` resource](/docs/providers/aws/r/ses_receipt_filter.html)
+    - [`aws_ses_template` resource](/docs/providers/aws/r/ses_template.html)  
     - [`aws_ssm_document` data source](/docs/providers/aws/d/ssm_document.html)
     - [`aws_ssm_document` resource](/docs/providers/aws/r/ssm_document.html)
     - [`aws_ssm_parameter` data source](/docs/providers/aws/d/ssm_parameter.html)

--- a/website/docs/r/ses_template.html.markdown
+++ b/website/docs/r/ses_template.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the SES template
 * `id` - The name of the SES template
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ses_template: add arn attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSesTemplate_'
--- PASS: TestAccAWSSesTemplate_Basic (48.88s)
--- PASS: TestAccAWSSesTemplate_disappears (41.06s)
```
