### PR TITLE
r/elastic_transcoder_pipeline - add validations

### DIFF
--- a/.changelog/13973.txt
+++ b/.changelog/13973.txt
@@ -1,0 +1,5 @@
+```release-note:enhancement
+resource/aws_elastictranscoder_pipeline: Add plan time validations `content_config.storage_class`, `content_config_permissions.access`, `content_config_permissions.grantee`, `content_config_permissions.grantee_type`,
+`notifications.completed`, `notifications.error`, `notifications.progressing`, `notifications.warning`,
+`thumbnail_config.storage_class`, `thumbnail_config_permissions.access`, `thumbnail_config_permissions.grantee`, `thumbnail_config_permissions.grantee_type`
+```

--- a/.changelog/13973.txt
+++ b/.changelog/13973.txt
@@ -1,5 +1,5 @@
 ```release-note:enhancement
-resource/aws_elastictranscoder_pipeline: Add plan time validations to `content_config.storage_class`, `content_config_permissions.access`, `content_config_permissions.grantee`, `content_config_permissions.grantee_type`,
+resource/aws_elastictranscoder_pipeline: Add plan time validations to `content_config.storage_class`, `content_config_permissions.access`, `content_config_permissions.grantee_type`,
 `notifications.completed`, `notifications.error`, `notifications.progressing`, `notifications.warning`,
-`thumbnail_config.storage_class`, `thumbnail_config_permissions.access`, `thumbnail_config_permissions.grantee`, `thumbnail_config_permissions.grantee_type`
+`thumbnail_config.storage_class`, `thumbnail_config_permissions.access`, `thumbnail_config_permissions.grantee_type`
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,27 @@
 
 FEATURES:
 
+* **New Resource:** `aws_cloudfront_realtime_log_config` ([#14974](https://github.com/hashicorp/terraform-provider-aws/issues/14974))
 * **New Resource:** `aws_config_conformance_pack` ([#17313](https://github.com/hashicorp/terraform-provider-aws/issues/17313))
 * **New Resource:** `aws_sagemaker_model_package_group` ([#17366](https://github.com/hashicorp/terraform-provider-aws/issues/17366))
 * **New Resource:** `aws_securityhub_organization_admin_account` ([#17501](https://github.com/hashicorp/terraform-provider-aws/issues/17501))
 
 ENHANCEMENTS:
 
+* data-source/aws_customer_gateway: Add `device_name` attribute ([#14786](https://github.com/hashicorp/terraform-provider-aws/issues/14786))
 * data-source/aws_iam_policy_document: Support merging policy documents by adding `source_policy_documents` and `override_policy_documents` arguments ([#12055](https://github.com/hashicorp/terraform-provider-aws/issues/12055))
 * provider: Add terraform-provider-aws version to HTTP User-Agent header ([#17486](https://github.com/hashicorp/terraform-provider-aws/issues/17486))
+* resource/aws_cloudfront_distribution: Add `realtime_log_config_arn` attribute to `default_cache_behavior` and `ordered_cache_behavior` configuration blocks ([#14974](https://github.com/hashicorp/terraform-provider-aws/issues/14974))
 * resource/aws_cloudwatch_log_destination: Add plan time validation to `role_arn`, `name` and `target_arn`. ([#11687](https://github.com/hashicorp/terraform-provider-aws/issues/11687))
+* resource/aws_cloudwatch_log_group: Add plan time validation for `retention_in_days` argument ([#14673](https://github.com/hashicorp/terraform-provider-aws/issues/14673))
+* resource/aws_codebuild_report_group: Add `delete_reports` argument ([#17338](https://github.com/hashicorp/terraform-provider-aws/issues/17338))
+* resource/aws_customer_gateway: Add `device_name` argument ([#14786](https://github.com/hashicorp/terraform-provider-aws/issues/14786))
 * resource/aws_ec2_traffic_mirror_filter: Add `arn` attribute. ([#13948](https://github.com/hashicorp/terraform-provider-aws/issues/13948))
 * resource/aws_ec2_traffic_mirror_filter_rule: Add arn attribute. ([#13949](https://github.com/hashicorp/terraform-provider-aws/issues/13949))
 * resource/aws_ec2_traffic_mirror_filter_rule: Add plan time validation to `destination_port_range.from_port`, 
 `destination_port_range.to_port`, `source_port_range.from_port`, and `source_port_range.to_port`. ([#13949](https://github.com/hashicorp/terraform-provider-aws/issues/13949))
 * resource/aws_lambda_event_source_mapping: Add `topics` attribute to support Amazon MSK as an event source ([#14746](https://github.com/hashicorp/terraform-provider-aws/issues/14746))
+* resource/aws_lb_listener_certificate: Add import support ([#16474](https://github.com/hashicorp/terraform-provider-aws/issues/16474))
 * resource/aws_ses_active_receipt_rule_set: Add `arn` attribute ([#13962](https://github.com/hashicorp/terraform-provider-aws/issues/13962))
 * resource/aws_ses_active_receipt_rule_set: Add plan time validation for `rule_set_name` argument ([#13962](https://github.com/hashicorp/terraform-provider-aws/issues/13962))
 * resource/aws_ses_configuration_set: Add `arn` attribute. ([#13972](https://github.com/hashicorp/terraform-provider-aws/issues/13972))
@@ -31,8 +38,11 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * resource/aws_glue_catalog_database: Use Catalog Id when deleting Databases. ([#17489](https://github.com/hashicorp/terraform-provider-aws/issues/17489))
+* resource/aws_iam_instance_profile: Detach role when role doesn't exist + remove when deleted from state. ([#16188](https://github.com/hashicorp/terraform-provider-aws/issues/16188))
 * resource/aws_instance: Fix use of `throughput` and `iops` for `gp3` volumes at the same time ([#17380](https://github.com/hashicorp/terraform-provider-aws/issues/17380))
 * resource/aws_lambda_event_source_mapping: Wait for create and update operations to complete ([#14765](https://github.com/hashicorp/terraform-provider-aws/issues/14765))
+* resource/aws_lambda_function: Prevent crash when using `Image` package type ([#17082](https://github.com/hashicorp/terraform-provider-aws/issues/17082))
+* resource/aws_wafv2_web_acl_association: Increase creation timeout value from 2 to 5 minutes to prevent WAFUnavailableEntityException ([#17545](https://github.com/hashicorp/terraform-provider-aws/issues/17545))
 
 ## 3.27.0 (February 05, 2021)
 

--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -82,11 +82,6 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"grantee": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"AllUsers",
-								"AuthenticatedUsers",
-								"LogDelivery",
-							}, false),
 						},
 						"grantee_type": {
 							Type:     schema.TypeString,
@@ -211,11 +206,6 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"grantee": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"AllUsers",
-								"AuthenticatedUsers",
-								"LogDelivery",
-							}, false),
 						},
 						"grantee_type": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elastictranscoder"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsElasticTranscoderPipeline() *schema.Resource {
@@ -51,6 +52,10 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"storage_class": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"Standard",
+								"ReducedRedundancy",
+							}, false),
 						},
 					},
 				},
@@ -64,15 +69,33 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"access": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"Read",
+									"ReadAcp",
+									"WriteAcp",
+									"FullControl",
+								}, false),
+							},
 						},
 						"grantee": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"AllUsers",
+								"AuthenticatedUsers",
+								"LogDelivery",
+							}, false),
 						},
 						"grantee_type": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"Canonical",
+								"Email",
+								"Group",
+							}, false),
 						},
 					},
 				},
@@ -88,17 +111,11 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`^[.0-9A-Za-z-_]+$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"only alphanumeric characters, hyphens, underscores, and periods allowed in %q", k))
-					}
-					if len(value) > 40 {
-						errors = append(errors, fmt.Errorf("%q cannot be longer than 40 characters", k))
-					}
-					return
-				},
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[.0-9A-Za-z-_]+$`),
+						"only alphanumeric characters, hyphens, underscores, and periods allowed"),
+					validation.StringLenBetween(1, 40),
+				),
 			},
 
 			"notifications": {
@@ -108,20 +125,24 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"completed": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
 						},
 						"error": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
 						},
 						"progressing": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
 						},
 						"warning": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
 						},
 					},
 				},
@@ -160,6 +181,10 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"storage_class": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"Standard",
+								"ReducedRedundancy",
+							}, false),
 						},
 					},
 				},
@@ -173,15 +198,33 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"access": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"Read",
+									"ReadAcp",
+									"WriteAcp",
+									"FullControl",
+								}, false),
+							},
 						},
 						"grantee": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"AllUsers",
+								"AuthenticatedUsers",
+								"LogDelivery",
+							}, false),
 						},
 						"grantee_type": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"Canonical",
+								"Email",
+								"Group",
+							}, false),
 						},
 					},
 				},
@@ -408,7 +451,8 @@ func resourceAwsElasticTranscoderPipelineUpdate(d *schema.ResourceData, meta int
 	}
 
 	for _, w := range output.Warnings {
-		log.Printf("[WARN] Elastic Transcoder Pipeline %v: %v", *w.Code, *w.Message)
+		log.Printf("[WARN] Elastic Transcoder Pipeline %v: %v", aws.StringValue(w.Code),
+			aws.StringValue(w.Message))
 	}
 
 	return resourceAwsElasticTranscoderPipelineRead(d, meta)

--- a/aws/resource_aws_elastic_transcoder_pipeline_test.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -28,6 +29,7 @@ func TestAccAWSElasticTranscoderPipeline_basic(t *testing.T) {
 				Config: awsElasticTranscoderPipelineConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticTranscoderPipelineExists(resourceName, pipeline),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elastictranscoder", regexp.MustCompile(`pipeline/.+`)),
 				),
 			},
 			{

--- a/aws/resource_aws_elastic_transcoder_pipeline_test.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline_test.go
@@ -259,15 +259,15 @@ func testAccCheckElasticTranscoderPipelineDestroy(s *terraform.State) error {
 		out, err := conn.ReadPipeline(&elastictranscoder.ReadPipelineInput{
 			Id: aws.String(rs.Primary.ID),
 		})
-
-		if err == nil {
-			if out.Pipeline != nil && aws.StringValue(out.Pipeline.Id) == rs.Primary.ID {
-				return fmt.Errorf("Elastic Transcoder Pipeline still exists")
-			}
+		if isAWSErr(err, elastictranscoder.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("unexpected error: %w", err)
 		}
 
-		if !isAWSErr(err, elastictranscoder.ErrCodeResourceNotFoundException, "") {
-			return fmt.Errorf("unexpected error: %s", err)
+		if out.Pipeline != nil && aws.StringValue(out.Pipeline.Id) == rs.Primary.ID {
+			return fmt.Errorf("Elastic Transcoder Pipeline still exists")
 		}
 	}
 	return nil

--- a/website/docs/r/elastictranscoder_pipeline.html.markdown
+++ b/website/docs/r/elastictranscoder_pipeline.html.markdown
@@ -57,11 +57,11 @@ you specify values for `content_config`, you must also specify values for
 The `content_config` object supports the following:
 
 * `bucket` - The Amazon S3 bucket in which you want Elastic Transcoder to save transcoded files and playlists.
-* `storage_class` - The Amazon S3 storage class, Standard or ReducedRedundancy, that you want Elastic Transcoder to assign to the files and playlists that it stores in your Amazon S3 bucket.
+* `storage_class` - The Amazon S3 storage class, `Standard` or `ReducedRedundancy`, that you want Elastic Transcoder to assign to the files and playlists that it stores in your Amazon S3 bucket.
 
 The `content_config_permissions` object supports the following:
 
-* `access` - The permission that you want to give to the AWS user that you specified in `content_config_permissions.grantee`
+* `access` - The permission that you want to give to the AWS user that you specified in `content_config_permissions.grantee`. Valid values are `Read`, `ReadAcp`, `WriteAcp` or `FullControl`.
 * `grantee` - The AWS user or group that you want to have access to transcoded files and playlists.
 * `grantee_type` - Specify the type of value that appears in the `content_config_permissions.grantee` object. Valid values are `Canonical`, `Email` or `Group`.
 
@@ -90,10 +90,16 @@ The `thumbnail_config` object supports the following:
 
 The `thumbnail_config_permissions` object supports the following:
 
-* `access` - The permission that you want to give to the AWS user that you specified in `thumbnail_config_permissions.grantee`.
+* `access` - The permission that you want to give to the AWS user that you specified in `thumbnail_config_permissions.grantee`. Valid values are `Read`, `ReadAcp`, `WriteAcp` or `FullControl`.
 * `grantee` - The AWS user or group that you want to have access to thumbnail files.
-* `grantee_type` - Specify the type of value that appears in the `thumbnail_config_permissions.grantee` object.
+* `grantee_type` - Specify the type of value that appears in the `thumbnail_config_permissions.grantee` object. Valid values are `Canonical`, `Email` or `Group`.
 
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Elastictranscoder pipeline.
+* `arn` - The ARN of the Elastictranscoder pipeline.
 ## Import
 
 Elastic Transcoder pipelines can be imported using the `id`, e.g.

--- a/website/docs/r/elastictranscoder_pipeline.html.markdown
+++ b/website/docs/r/elastictranscoder_pipeline.html.markdown
@@ -100,6 +100,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the Elastictranscoder pipeline.
 * `arn` - The ARN of the Elastictranscoder pipeline.
+
 ## Import
 
 Elastic Transcoder pipelines can be imported using the `id`, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11872, #13820

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_elastic_transcoder_pipeline: add plan time validations `content_config.storage_class`, `content_config_permissions.access`, `content_config_permissions.grantee`, `content_config_permissions.grantee_type`,
`notifications.completed`, `notifications.error`, `notifications.progressing`, `notifications.warning`,
`thumbnail_config.storage_class`, `thumbnail_config_permissions.access`, `thumbnail_config_permissions.grantee`, `thumbnail_config_permissions.grantee_type`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticTranscoderPipeline_'
--- PASS: TestAccAWSElasticTranscoderPipeline_basic (151.20s)
--- PASS: TestAccAWSElasticTranscoderPipeline_kmsKey (263.72s)
--- PASS: TestAccAWSElasticTranscoderPipeline_notifications (384.76s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withContentConfig (278.10s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (137.67s)
--- PASS: TestAccAWSElasticTranscoderPipeline_disappears (175.47s)
```
