### PR TITLE
r/aws_default_route_table: Refactor acceptance tests in preparation for future fixes/enhancements

### DIFF
--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -249,44 +249,11 @@ func TestAccAWSDefaultRouteTable_Route_TransitGatewayID(t *testing.T) {
 	})
 }
 
-func TestAccAWSDefaultRouteTable_Route_VpcEndpointId(t *testing.T) {
-	var routeTable1 ec2.RouteTable
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+func TestAccAWSDefaultRouteTable_VpcEndpointAssociation(t *testing.T) {
+	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRouteTableDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSDefaultRouteTableConfigRouteVpcEndpointId(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(resourceName, &routeTable1),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccAWSDefaultRouteTableImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
-			},
-			// Default route tables do not currently have a method to remove routes during deletion.
-			// VPC Endpoints will not delete unless the route is removed prior, otherwise will error:
-			// InvalidParameter: Endpoint must be removed from route table before deletion
-			{
-				Config: testAccAWSDefaultRouteTableConfigRouteVpcEndpointIdNoRoute(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(resourceName, &routeTable1),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSDefaultRouteTable_vpc_endpoint(t *testing.T) {
-	var v ec2.RouteTable
-	resourceName := "aws_default_route_table.foo"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.2.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -295,10 +262,15 @@ func TestAccAWSDefaultRouteTable_vpc_endpoint(t *testing.T) {
 		CheckDestroy:  testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDefaultRouteTable_vpc_endpoint,
+				Config: testAccDefaultRouteTableConfigVpcEndpointAssociation(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(
-						resourceName, &v),
+					testAccCheckRouteTableExists(resourceName, &routeTable),
+					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route.*", map[string]string{
+						"cidr_block":      destinationCidr,
+						"ipv6_cidr_block": "",
+					}),
 				),
 			},
 			{
@@ -635,172 +607,50 @@ resource "aws_default_route_table" "test" {
 `
 }
 
-func testAccAWSDefaultRouteTableConfigRouteVpcEndpointId(rName string) string {
-	return composeConfig(
-		testAccAvailableAZsNoOptInConfig(),
-		fmt.Sprintf(`
-data "aws_caller_identity" "current" {}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.10.10.0/25"
-
-  tags = {
-    Name = "tf-acc-test-load-balancer"
-  }
-}
-
-# Another route destination for update
-resource "aws_internet_gateway" "test" {
-  vpc_id = aws_vpc.test.id
-}
-
-resource "aws_subnet" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id            = aws_vpc.test.id
-
-  tags = {
-    Name = "tf-acc-test-load-balancer"
-  }
-}
-
-resource "aws_lb" "test" {
-  load_balancer_type = "gateway"
-  name               = %[1]q
-
-  subnet_mapping {
-    subnet_id = aws_subnet.test.id
-  }
-}
-
-resource "aws_vpc_endpoint_service" "test" {
-  acceptance_required        = false
-  allowed_principals         = [data.aws_caller_identity.current.arn]
-  gateway_load_balancer_arns = [aws_lb.test.arn]
-}
-
-resource "aws_vpc_endpoint" "test" {
-  service_name      = aws_vpc_endpoint_service.test.service_name
-  subnet_ids        = [aws_subnet.test.id]
-  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
-  vpc_id            = aws_vpc.test.id
-}
-
-resource "aws_default_route_table" "test" {
-  default_route_table_id = aws_vpc.test.default_route_table_id
-
-  route {
-    cidr_block      = "0.0.0.0/0"
-    vpc_endpoint_id = aws_vpc_endpoint.test.id
-  }
-}
-`, rName))
-}
-
-func testAccAWSDefaultRouteTableConfigRouteVpcEndpointIdNoRoute(rName string) string {
-	return composeConfig(
-		testAccAvailableAZsNoOptInConfig(),
-		fmt.Sprintf(`
-data "aws_caller_identity" "current" {}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.10.10.0/25"
-
-  tags = {
-    Name = "tf-acc-test-load-balancer"
-  }
-}
-
-# Another route destination for update
-resource "aws_internet_gateway" "test" {
-  vpc_id = aws_vpc.test.id
-}
-
-resource "aws_subnet" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id            = aws_vpc.test.id
-
-  tags = {
-    Name = "tf-acc-test-load-balancer"
-  }
-}
-
-resource "aws_lb" "test" {
-  load_balancer_type = "gateway"
-  name               = %[1]q
-
-  subnet_mapping {
-    subnet_id = aws_subnet.test.id
-  }
-}
-
-resource "aws_vpc_endpoint_service" "test" {
-  acceptance_required        = false
-  allowed_principals         = [data.aws_caller_identity.current.arn]
-  gateway_load_balancer_arns = [aws_lb.test.arn]
-}
-
-resource "aws_vpc_endpoint" "test" {
-  service_name      = aws_vpc_endpoint_service.test.service_name
-  subnet_ids        = [aws_subnet.test.id]
-  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
-  vpc_id            = aws_vpc.test.id
-}
-
-resource "aws_default_route_table" "test" {
-  default_route_table_id = aws_vpc.test.default_route_table_id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.test.id
-  }
-}
-`, rName))
-}
-
-const testAccDefaultRouteTable_vpc_endpoint = `
+func testAccDefaultRouteTableConfigVpcEndpointAssociation(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-default-route-table-vpc-endpoint"
+    Name = %[1]q
   }
 }
 
-resource "aws_internet_gateway" "igw" {
+resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-default-route-table-vpc-endpoint"
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc_endpoint" "s3" {
+resource "aws_vpc_endpoint" "test" {
   vpc_id          = aws_vpc.test.id
   service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
   route_table_ids = [aws_vpc.test.default_route_table_id]
 
   tags = {
-    Name = "terraform-testacc-default-route-table-vpc-endpoint"
+    Name = %[1]q
   }
 }
 
-resource "aws_default_route_table" "foo" {
+resource "aws_default_route_table" "test" {
   default_route_table_id = aws_vpc.test.default_route_table_id
 
   tags = {
-    Name = "test"
+    Name = %[1]q
   }
 
   route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.igw.id
+    cidr_block = %[2]q
+    gateway_id = aws_internet_gateway.test.id
   }
 }
-`
+`, rName, destinationCidr)
+}
 
 func testAccDefaultRouteTableConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -431,7 +431,7 @@ func testAccCheckDefaultRouteTableRoute(resourceName, destinationAttr, destinati
 			return fmt.Errorf("Not found: %s.%s", targetResourceName, targetResourceAttr)
 		}
 
-		return tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route.*", map[string]string{
+		return resource.TestCheckTypeSetElemNestedAttrs(resourceName, "route.*", map[string]string{
 			destinationAttr: destination,
 			targetAttr:      target,
 		})(s)

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -242,6 +242,41 @@ func TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway(t *testing.T) {
 	})
 }
 
+func TestAccAWSDefaultRouteTable_Route_VpcEndpointId(t *testing.T) {
+	var routeTable1 ec2.RouteTable
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_default_route_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDefaultRouteTableConfigRouteVpcEndpointId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists(resourceName, &routeTable1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSDefaultRouteTableImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			// Default route tables do not currently have a method to remove routes during deletion.
+			// VPC Endpoints will not delete unless the route is removed prior, otherwise will error:
+			// InvalidParameter: Endpoint must be removed from route table before deletion
+			{
+				Config: testAccAWSDefaultRouteTableConfigRouteVpcEndpointIdNoRoute(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists(resourceName, &routeTable1),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDefaultRouteTable_VpcEndpointAssociation(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
@@ -278,8 +313,6 @@ func TestAccAWSDefaultRouteTable_tags(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	destinationCidr := "10.2.0.0/16"
-	destinationIpv6Cidr := "::/0"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -320,6 +353,8 @@ func TestAccAWSDefaultRouteTable_ConditionalCidrBlock(t *testing.T) {
 	resourceName := "aws_default_route_table.test"
 	igwResourceName := "aws_internet_gateway.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.2.0.0/16"
+	destinationIpv6Cidr := "::/0"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -615,6 +650,130 @@ resource "aws_default_route_table" "test" {
   }
 }
 `, rName, destinationCidr))
+}
+
+func testAccAWSDefaultRouteTableConfigRouteVpcEndpointId(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+# Another route destination for update
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  load_balancer_type = "gateway"
+  name               = %[1]q
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  allowed_principals         = [data.aws_caller_identity.current.arn]
+  gateway_load_balancer_arns = [aws_lb.test.arn]
+}
+
+resource "aws_vpc_endpoint" "test" {
+  service_name      = aws_vpc_endpoint_service.test.service_name
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
+  vpc_id            = aws_vpc.test.id
+}
+
+resource "aws_default_route_table" "test" {
+  default_route_table_id = aws_vpc.test.default_route_table_id
+
+  route {
+    cidr_block      = "0.0.0.0/0"
+    vpc_endpoint_id = aws_vpc_endpoint.test.id
+  }
+}
+`, rName))
+}
+
+func testAccAWSDefaultRouteTableConfigRouteVpcEndpointIdNoRoute(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+# Another route destination for update
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  load_balancer_type = "gateway"
+  name               = %[1]q
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  allowed_principals         = [data.aws_caller_identity.current.arn]
+  gateway_load_balancer_arns = [aws_lb.test.arn]
+}
+
+resource "aws_vpc_endpoint" "test" {
+  service_name      = aws_vpc_endpoint_service.test.service_name
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
+  vpc_id            = aws_vpc.test.id
+}
+
+resource "aws_default_route_table" "test" {
+  default_route_table_id = aws_vpc.test.default_route_table_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+}
+`, rName))
 }
 
 func testAccDefaultRouteTableConfigVpcEndpointAssociation(rName, destinationCidr string) string {

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -54,7 +54,7 @@ func TestAccAWSDefaultRouteTable_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSDefaultRouteTable_vpcDisappears(t *testing.T) {
+func TestAccAWSDefaultRouteTable_disappears_Vpc(t *testing.T) {
 	var routeTable ec2.RouteTable
 	var vpc ec2.Vpc
 	resourceName := "aws_default_route_table.test"

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -567,18 +567,7 @@ resource "aws_main_route_table_association" "test" {
 }
 
 func testAccDefaultRouteTableConfigIpv4TransitGateway(rName, destinationCidr string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(testAccAvailableAZsNoOptInExcludeConfig("usw2-az4"), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -625,7 +614,7 @@ resource "aws_default_route_table" "test" {
     Name = %[1]q
   }
 }
-`, rName, destinationCidr)
+`, rName, destinationCidr))
 }
 
 func testAccDefaultRouteTableConfigVpcEndpointAssociation(rName, destinationCidr string) string {

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -224,9 +224,11 @@ func TestAccAWSDefaultRouteTable_swap(t *testing.T) {
 	})
 }
 
-func TestAccAWSDefaultRouteTable_Route_TransitGatewayID(t *testing.T) {
-	var routeTable1 ec2.RouteTable
+func TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway(t *testing.T) {
+	var routeTable ec2.RouteTable
 	resourceName := "aws_default_route_table.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.2.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -234,9 +236,15 @@ func TestAccAWSDefaultRouteTable_Route_TransitGatewayID(t *testing.T) {
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDefaultRouteTableConfigRouteTransitGatewayID(),
+				Config: testAccDefaultRouteTableConfigIpv4TransitGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(resourceName, &routeTable1),
+					testAccCheckRouteTableExists(resourceName, &routeTable),
+					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route.*", map[string]string{
+						"cidr_block":      destinationCidr,
+						"ipv6_cidr_block": "",
+					}),
 				),
 			},
 			{
@@ -561,28 +569,40 @@ resource "aws_main_route_table_association" "test" {
 `, rName, destinationCidr1, destinationCidr2)
 }
 
-func testAccAWSDefaultRouteTableConfigRouteTransitGatewayID() string {
-	return `
+func testAccDefaultRouteTableConfigIpv4TransitGateway(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "tf-acc-test-ec2-default-route-table-transit-gateway-id"
+    Name = %[1]q
   }
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-test-ec2-default-route-table-transit-gateway-id"
+    Name = %[1]q
   }
 }
 
 resource "aws_ec2_transit_gateway" "test" {
   tags = {
-    Name = "tf-acc-test-ec2-default-route-table-transit-gateway-id"
+    Name = %[1]q
   }
 }
 
@@ -592,7 +612,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
   vpc_id             = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-test-ec2-default-route-table-transit-gateway-id"
+    Name = %[1]q
   }
 }
 
@@ -600,11 +620,15 @@ resource "aws_default_route_table" "test" {
   default_route_table_id = aws_vpc.test.default_route_table_id
 
   route {
-    cidr_block         = "0.0.0.0/0"
+    cidr_block         = %[2]q
     transit_gateway_id = aws_ec2_transit_gateway_vpc_attachment.test.transit_gateway_id
   }
+
+  tags = {
+    Name = %[1]q
+  }
 }
-`
+`, rName, destinationCidr)
 }
 
 func testAccDefaultRouteTableConfigVpcEndpointAssociation(rName, destinationCidr string) string {

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -567,7 +567,7 @@ resource "aws_main_route_table_association" "test" {
 }
 
 func testAccDefaultRouteTableConfigIpv4TransitGateway(rName, destinationCidr string) string {
-	return composeConfig(testAccAvailableAZsNoOptInExcludeConfig("usw2-az4"), fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInDefaultExcludeConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -54,7 +54,7 @@ func TestAccAWSDefaultRouteTable_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSDefaultRouteTable_disappears_Vpc(t *testing.T) {
+func TestAccAWSDefaultRouteTable_vpcDisappears(t *testing.T) {
 	var routeTable ec2.RouteTable
 	var vpc ec2.Vpc
 	resourceName := "aws_default_route_table.test"

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -630,6 +630,16 @@ func TestAccAWSRouteTable_ConditionalCidrBlock(t *testing.T) {
 	})
 }
 
+func testAccCheckAWSRouteTableNumberOfRoutes(routeTable *ec2.RouteTable, n int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len := len(routeTable.Routes); len != n {
+			return fmt.Errorf("Route Table has incorrect number of routes (Expected=%d, Actual=%d)\n", n, len)
+		}
+
+		return nil
+	}
+}
+
 const testAccRouteTableConfig = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Refactoring `aws_default_route_table` resource acceptance tests in preparation for future fixes/enhancements.
Relates #13527.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDefaultRouteTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSDefaultRouteTable_ -timeout 120m
=== RUN   TestAccAWSDefaultRouteTable_basic
=== PAUSE TestAccAWSDefaultRouteTable_basic
=== RUN   TestAccAWSDefaultRouteTable_vpcDisappears
=== PAUSE TestAccAWSDefaultRouteTable_vpcDisappears
=== RUN   TestAccAWSDefaultRouteTable_Route_ConfigMode
=== PAUSE TestAccAWSDefaultRouteTable_Route_ConfigMode
=== RUN   TestAccAWSDefaultRouteTable_swap
=== PAUSE TestAccAWSDefaultRouteTable_swap
=== RUN   TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway
=== PAUSE TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway
=== RUN   TestAccAWSDefaultRouteTable_VpcEndpointAssociation
=== PAUSE TestAccAWSDefaultRouteTable_VpcEndpointAssociation
=== RUN   TestAccAWSDefaultRouteTable_tags
=== PAUSE TestAccAWSDefaultRouteTable_tags
=== RUN   TestAccAWSDefaultRouteTable_ConditionalCidrBlock
=== PAUSE TestAccAWSDefaultRouteTable_ConditionalCidrBlock
=== CONT  TestAccAWSDefaultRouteTable_basic
=== CONT  TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway
--- PASS: TestAccAWSDefaultRouteTable_basic (53.09s)
=== CONT  TestAccAWSDefaultRouteTable_ConditionalCidrBlock
--- PASS: TestAccAWSDefaultRouteTable_ConditionalCidrBlock (78.73s)
=== CONT  TestAccAWSDefaultRouteTable_tags
--- PASS: TestAccAWSDefaultRouteTable_tags (82.10s)
=== CONT  TestAccAWSDefaultRouteTable_VpcEndpointAssociation
--- PASS: TestAccAWSDefaultRouteTable_VpcEndpointAssociation (58.35s)
=== CONT  TestAccAWSDefaultRouteTable_Route_ConfigMode
--- PASS: TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway (318.88s)
=== CONT  TestAccAWSDefaultRouteTable_swap
--- PASS: TestAccAWSDefaultRouteTable_Route_ConfigMode (99.49s)
=== CONT  TestAccAWSDefaultRouteTable_vpcDisappears
--- PASS: TestAccAWSDefaultRouteTable_vpcDisappears (24.11s)
--- PASS: TestAccAWSDefaultRouteTable_swap (106.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	425.257s
```
