### PR TITLE
d/aws_route_table: Refactor acceptance tests in preparation for future fixes/enhancements

### DIFF
--- a/aws/data_source_aws_route_table_test.go
+++ b/aws/data_source_aws_route_table_test.go
@@ -83,7 +83,6 @@ func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 					testAccCheckListHasSomeElementAttrPair(datasource5Name, "associations", "gateway_id", igwResourceName, "id"),
 					resource.TestCheckResourceAttr(datasource5Name, "tags.Name", rName),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/aws/data_source_aws_route_table_test.go
+++ b/aws/data_source_aws_route_table_test.go
@@ -1,134 +1,87 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 	rtResourceName := "aws_route_table.test"
 	snResourceName := "aws_subnet.test"
 	vpcResourceName := "aws_vpc.test"
-	gwResourceName := "aws_internet_gateway.test"
-	ds1ResourceName := "data.aws_route_table.by_tag"
-	ds2ResourceName := "data.aws_route_table.by_filter"
-	ds3ResourceName := "data.aws_route_table.by_subnet"
-	ds4ResourceName := "data.aws_route_table.by_id"
-	ds5ResourceName := "data.aws_route_table.by_gateway"
-	tagValue := "terraform-testacc-routetable-data-source"
+	igwResourceName := "aws_internet_gateway.test"
+	datasource1Name := "data.aws_route_table.by_tag"
+	datasource2Name := "data.aws_route_table.by_filter"
+	datasource3Name := "data.aws_route_table.by_subnet"
+	datasource4Name := "data.aws_route_table.by_id"
+	datasource5Name := "data.aws_route_table.by_gateway"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRouteTableGroupConfig,
+				Config: testAccDataSourceAwsRouteTableConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(
-						ds1ResourceName, "id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds1ResourceName, "route_table_id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds1ResourceName, "owner_id", rtResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds1ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckNoResourceAttr(
-						ds1ResourceName, "subnet_id"),
-					resource.TestCheckNoResourceAttr(
-						ds1ResourceName, "gateway_id"),
-					resource.TestCheckResourceAttr(
-						ds1ResourceName, "associations.#", "2"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds1ResourceName, "associations", "subnet_id", snResourceName, "id"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds1ResourceName, "associations", "gateway_id", gwResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds1ResourceName, "tags.Name", tagValue),
-
-					resource.TestCheckResourceAttrPair(
-						ds2ResourceName, "id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds2ResourceName, "route_table_id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds2ResourceName, "owner_id", rtResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds2ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckNoResourceAttr(
-						ds2ResourceName, "subnet_id"),
-					resource.TestCheckNoResourceAttr(
-						ds2ResourceName, "gateway_id"),
-					resource.TestCheckResourceAttr(
-						ds2ResourceName, "associations.#", "2"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds2ResourceName, "associations", "subnet_id", snResourceName, "id"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds2ResourceName, "associations", "gateway_id", gwResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds2ResourceName, "tags.Name", tagValue),
-
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "route_table_id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "owner_id", rtResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "subnet_id", snResourceName, "id"),
-					resource.TestCheckNoResourceAttr(
-						ds3ResourceName, "gateway_id"),
-					resource.TestCheckResourceAttr(
-						ds3ResourceName, "associations.#", "2"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds3ResourceName, "associations", "subnet_id", snResourceName, "id"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds3ResourceName, "associations", "gateway_id", gwResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds3ResourceName, "tags.Name", tagValue),
-
-					resource.TestCheckResourceAttrPair(
-						ds4ResourceName, "id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds4ResourceName, "route_table_id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds4ResourceName, "owner_id", rtResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds4ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckNoResourceAttr(
-						ds4ResourceName, "subnet_id"),
-					resource.TestCheckNoResourceAttr(
-						ds4ResourceName, "gateway_id"),
-					resource.TestCheckResourceAttr(
-						ds4ResourceName, "associations.#", "2"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds4ResourceName, "associations", "subnet_id", snResourceName, "id"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds4ResourceName, "associations", "gateway_id", gwResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds4ResourceName, "tags.Name", tagValue),
-
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "route_table_id", rtResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "owner_id", rtResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckNoResourceAttr(
-						ds5ResourceName, "subnet_id"),
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "gateway_id", gwResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds5ResourceName, "associations.#", "2"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds5ResourceName, "associations", "subnet_id", snResourceName, "id"),
-					testAccCheckListHasSomeElementAttrPair(
-						ds5ResourceName, "associations", "gateway_id", gwResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds5ResourceName, "tags.Name", tagValue),
+					// By tags.
+					resource.TestCheckResourceAttrPair(datasource1Name, "id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource1Name, "route_table_id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource1Name, "owner_id", rtResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(datasource1Name, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckNoResourceAttr(datasource1Name, "subnet_id"),
+					resource.TestCheckNoResourceAttr(datasource1Name, "gateway_id"),
+					resource.TestCheckResourceAttr(datasource1Name, "associations.#", "2"),
+					testAccCheckListHasSomeElementAttrPair(datasource1Name, "associations", "subnet_id", snResourceName, "id"),
+					testAccCheckListHasSomeElementAttrPair(datasource1Name, "associations", "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(datasource1Name, "tags.Name", rName),
+					// By filter.
+					resource.TestCheckResourceAttrPair(datasource2Name, "id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource2Name, "route_table_id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource2Name, "owner_id", rtResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(datasource2Name, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckNoResourceAttr(datasource2Name, "subnet_id"),
+					resource.TestCheckNoResourceAttr(datasource2Name, "gateway_id"),
+					resource.TestCheckResourceAttr(datasource2Name, "associations.#", "2"),
+					testAccCheckListHasSomeElementAttrPair(datasource2Name, "associations", "subnet_id", snResourceName, "id"),
+					testAccCheckListHasSomeElementAttrPair(datasource2Name, "associations", "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(datasource2Name, "tags.Name", rName),
+					// By subnet ID.
+					resource.TestCheckResourceAttrPair(datasource3Name, "id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource3Name, "route_table_id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource3Name, "owner_id", rtResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(datasource3Name, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource3Name, "subnet_id", snResourceName, "id"),
+					resource.TestCheckNoResourceAttr(datasource3Name, "gateway_id"),
+					resource.TestCheckResourceAttr(datasource3Name, "associations.#", "2"),
+					testAccCheckListHasSomeElementAttrPair(datasource3Name, "associations", "subnet_id", snResourceName, "id"),
+					testAccCheckListHasSomeElementAttrPair(datasource3Name, "associations", "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(datasource3Name, "tags.Name", rName),
+					// By route table ID.
+					resource.TestCheckResourceAttrPair(datasource4Name, "id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource4Name, "route_table_id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource4Name, "owner_id", rtResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(datasource4Name, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckNoResourceAttr(datasource4Name, "subnet_id"),
+					resource.TestCheckNoResourceAttr(datasource4Name, "gateway_id"),
+					resource.TestCheckResourceAttr(datasource4Name, "associations.#", "2"),
+					testAccCheckListHasSomeElementAttrPair(datasource4Name, "associations", "subnet_id", snResourceName, "id"),
+					testAccCheckListHasSomeElementAttrPair(datasource4Name, "associations", "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(datasource4Name, "tags.Name", rName),
+					// By gateway ID.
+					resource.TestCheckResourceAttrPair(datasource5Name, "id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource5Name, "route_table_id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource5Name, "owner_id", rtResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(datasource5Name, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckNoResourceAttr(datasource5Name, "subnet_id"),
+					resource.TestCheckResourceAttrPair(datasource5Name, "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(datasource5Name, "associations.#", "2"),
+					testAccCheckListHasSomeElementAttrPair(datasource5Name, "associations", "subnet_id", snResourceName, "id"),
+					testAccCheckListHasSomeElementAttrPair(datasource5Name, "associations", "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(datasource5Name, "tags.Name", rName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -158,12 +111,13 @@ func TestAccDataSourceAwsRouteTable_main(t *testing.T) {
 	})
 }
 
-const testAccDataSourceAwsRouteTableGroupConfig = `
+func testAccDataSourceAwsRouteTableConfigBasic(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-route-table-data-source"
+    Name = %[1]q
   }
 }
 
@@ -172,7 +126,7 @@ resource "aws_subnet" "test" {
   vpc_id     = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-route-table-data-source"
+    Name = %[1]q
   }
 }
 
@@ -180,7 +134,7 @@ resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-routetable-data-source"
+    Name = %[1]q
   }
 }
 
@@ -193,7 +147,7 @@ resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-routetable-data-source"
+    Name = %[1]q
   }
 }
 
@@ -204,14 +158,11 @@ resource "aws_route_table_association" "b" {
 
 data "aws_route_table" "by_filter" {
   filter {
-    name   = "association.route-table-association-id"
+    name = "association.route-table-association-id"
     values = [aws_route_table_association.a.id]
   }
 
-  depends_on = [
-    "aws_route_table_association.a",
-    "aws_route_table_association.b"
-  ]
+  depends_on = [aws_route_table_association.a, aws_route_table_association.b]
 }
 
 data "aws_route_table" "by_tag" {
@@ -219,36 +170,28 @@ data "aws_route_table" "by_tag" {
     Name = aws_route_table.test.tags["Name"]
   }
 
-  depends_on = [
-    "aws_route_table_association.a",
-    "aws_route_table_association.b"
-  ]
+  depends_on = [aws_route_table_association.a, aws_route_table_association.b]
 }
 
 data "aws_route_table" "by_subnet" {
   subnet_id = aws_subnet.test.id
-  depends_on = [
-    "aws_route_table_association.a",
-    "aws_route_table_association.b"
-  ]
+
+  depends_on = [aws_route_table_association.a, aws_route_table_association.b]
 }
 
 data "aws_route_table" "by_gateway" {
   gateway_id = aws_internet_gateway.test.id
-  depends_on = [
-    "aws_route_table_association.a",
-    "aws_route_table_association.b"
-  ]
+
+  depends_on = [aws_route_table_association.a, aws_route_table_association.b]
 }
 
 data "aws_route_table" "by_id" {
   route_table_id = aws_route_table.test.id
-  depends_on = [
-    "aws_route_table_association.a",
-    "aws_route_table_association.b"
-  ]
+
+  depends_on = [aws_route_table_association.a, aws_route_table_association.b]
 }
-`
+`, rName)
+}
 
 const testAccDataSourceAwsRouteTableMainRoute = `
 resource "aws_vpc" "test" {

--- a/aws/data_source_aws_route_table_test.go
+++ b/aws/data_source_aws_route_table_test.go
@@ -156,7 +156,7 @@ resource "aws_route_table_association" "b" {
 
 data "aws_route_table" "by_filter" {
   filter {
-    name = "association.route-table-association-id"
+    name   = "association.route-table-association-id"
     values = [aws_route_table_association.a.id]
   }
 

--- a/aws/data_source_aws_route_table_test.go
+++ b/aws/data_source_aws_route_table_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
@@ -90,21 +90,19 @@ func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAwsRouteTable_main(t *testing.T) {
-	dsResourceName := "data.aws_route_table.by_filter"
+	datasourceName := "data.aws_route_table.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRouteTableMainRoute,
+				Config: testAccDataSourceAwsRouteTableConfigMain(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						dsResourceName, "id"),
-					resource.TestCheckResourceAttrSet(
-						dsResourceName, "vpc_id"),
-					resource.TestCheckResourceAttr(
-						dsResourceName, "associations.0.main", "true"),
+					resource.TestCheckResourceAttrSet(datasourceName, "id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "vpc_id"),
+					resource.TestCheckResourceAttr(datasourceName, "associations.0.main", "true"),
 				),
 			},
 		},
@@ -193,16 +191,17 @@ data "aws_route_table" "by_id" {
 `, rName)
 }
 
-const testAccDataSourceAwsRouteTableMainRoute = `
+func testAccDataSourceAwsRouteTableConfigMain(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-route-table-data-source-main-route"
+    Name = %[1]q
   }
 }
 
-data "aws_route_table" "by_filter" {
+data "aws_route_table" "test" {
   filter {
     name   = "association.main"
     values = ["true"]
@@ -213,4 +212,5 @@ data "aws_route_table" "by_filter" {
     values = [aws_vpc.test.id]
   }
 }
-`
+`, rName)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Refactoring `aws_route_table` data source acceptance tests in preparation for future fixes/enhancements.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsRouteTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccDataSourceAwsRouteTable_ -timeout 120m
=== RUN   TestAccDataSourceAwsRouteTable_basic
=== PAUSE TestAccDataSourceAwsRouteTable_basic
=== RUN   TestAccDataSourceAwsRouteTable_main
=== PAUSE TestAccDataSourceAwsRouteTable_main
=== CONT  TestAccDataSourceAwsRouteTable_basic
=== CONT  TestAccDataSourceAwsRouteTable_main
--- PASS: TestAccDataSourceAwsRouteTable_main (37.24s)
--- PASS: TestAccDataSourceAwsRouteTable_basic (53.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	53.193s
```
