### PR TITLE
d/aws_route: Refactor acceptance tests in preparation for future fixes/enhancements

### DIFF
--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -5,23 +5,42 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSRouteDataSource_basic(t *testing.T) {
+	instanceRouteResourceName := "aws_route.instance"
+	pcxRouteResourceName := "aws_route.vpc_peering_connection"
+	rtResourceName := "aws_route_table.test"
+	instanceResourceName := "aws_instance.test"
+	pcxResourceName := "aws_vpc_peering_connection.test"
+	datasource1Name := "data.aws_route.by_destination_cidr_block"
+	datasource2Name := "data.aws_route.by_instance_id"
+	datasource3Name := "data.aws_route.by_peering_connection_id"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRouteGroupConfig(),
+				Config: testAccDataSourceAwsRouteConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRouteCheck("data.aws_route.by_destination_cidr_block"),
-					testAccDataSourceAwsRouteCheck("data.aws_route.by_instance_id"),
-					testAccDataSourceAwsRouteCheck("data.aws_route.by_peering_connection_id"),
+					// By destination CIDR.
+					resource.TestCheckResourceAttrPair(datasource1Name, "destination_cidr_block", instanceRouteResourceName, "destination_cidr_block"),
+					resource.TestCheckResourceAttrPair(datasource1Name, "route_table_id", rtResourceName, "id"),
+
+					// By instance ID.
+					resource.TestCheckResourceAttrPair(datasource2Name, "destination_cidr_block", instanceRouteResourceName, "destination_cidr_block"),
+					resource.TestCheckResourceAttrPair(datasource2Name, "instance_id", instanceResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource2Name, "route_table_id", rtResourceName, "id"),
+
+					// By VPC peering connection ID.
+					resource.TestCheckResourceAttrPair(datasource3Name, "destination_cidr_block", pcxRouteResourceName, "destination_cidr_block"),
+					resource.TestCheckResourceAttrPair(datasource3Name, "route_table_id", rtResourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasource3Name, "vpc_peering_connection_id", pcxResourceName, "id"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -31,6 +50,7 @@ func TestAccAWSRouteDataSource_TransitGatewayID(t *testing.T) {
 	var route ec2.Route
 	dataSourceName := "data.aws_route.test"
 	resourceName := "aws_route.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -38,7 +58,7 @@ func TestAccAWSRouteDataSource_TransitGatewayID(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteDataSourceConfigTransitGatewayID(),
+				Config: testAccAWSRouteDataSourceConfigIpv4TransitGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_cidr_block", dataSourceName, "destination_cidr_block"),
@@ -50,10 +70,32 @@ func TestAccAWSRouteDataSource_TransitGatewayID(t *testing.T) {
 	})
 }
 
+func TestAccAWSRouteDataSource_IPv6DestinationCidr(t *testing.T) {
+	dataSourceName := "data.aws_route.test"
+	resourceName := "aws_route.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteDataSourceConfigIpv6EgressOnlyInternetGateway(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "destination_ipv6_cidr_block", dataSourceName, "destination_ipv6_cidr_block"),
+					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", dataSourceName, "route_table_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRouteDataSource_LocalGatewayID(t *testing.T) {
 	var route ec2.Route
 	dataSourceName := "data.aws_route.by_local_gateway_id"
 	resourceName := "aws_route.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
@@ -61,7 +103,7 @@ func TestAccAWSRouteDataSource_LocalGatewayID(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteDataSourceConfigLocalGatewayID(),
+				Config: testAccAWSRouteDataSourceConfigIpv4LocalGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_cidr_block", dataSourceName, "destination_cidr_block"),
@@ -73,69 +115,36 @@ func TestAccAWSRouteDataSource_LocalGatewayID(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAwsRouteCheck(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		r, ok := s.RootModule().Resources["aws_route.test"]
-		if !ok {
-			return fmt.Errorf("can't find aws_route.test in state")
-		}
-		rts, ok := s.RootModule().Resources["aws_route_table.test"]
-		if !ok {
-			return fmt.Errorf("can't find aws_route_table.test in state")
-		}
-
-		attr := rs.Primary.Attributes
-
-		if attr["route_table_id"] != r.Primary.Attributes["route_table_id"] {
-			return fmt.Errorf(
-				"route_table_id is %s; want %s",
-				attr["route_table_id"],
-				r.Primary.Attributes["route_table_id"],
-			)
-		}
-
-		if attr["route_table_id"] != rts.Primary.Attributes["id"] {
-			return fmt.Errorf(
-				"route_table_id is %s; want %s",
-				attr["route_table_id"],
-				rts.Primary.Attributes["id"],
-			)
-		}
-
-		return nil
-	}
-}
-
-func testAccDataSourceAwsRouteGroupConfig() string {
+func testAccDataSourceAwsRouteConfigBasic(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableAZsNoOptInDefaultExcludeConfig(), `
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-route-table-data-source"
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc" "dest" {
+resource "aws_vpc" "target" {
   cidr_block = "172.17.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-route-table-data-source"
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_peering_connection" "test" {
-  peer_vpc_id = aws_vpc.dest.id
+  peer_vpc_id = aws_vpc.target.id
   vpc_id      = aws_vpc.test.id
   auto_accept = true
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_subnet" "test" {
@@ -144,7 +153,7 @@ resource "aws_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "tf-acc-route-table-data-source"
+    Name = %[1]q
   }
 }
 
@@ -152,11 +161,11 @@ resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-routetable-data-source"
+    Name = %[1]q
   }
 }
 
-resource "aws_route" "pcx" {
+resource "aws_route" "vpc_peering_connection" {
   route_table_id            = aws_route_table.test.id
   vpc_peering_connection_id = aws_vpc_peering_connection.test.id
   destination_cidr_block    = "10.0.2.0/24"
@@ -167,54 +176,48 @@ resource "aws_route_table_association" "a" {
   route_table_id = aws_route_table.test.id
 }
 
-resource "aws_instance" "web" {
+resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "t2.micro"
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
   subnet_id     = aws_subnet.test.id
 
   tags = {
-    Name = "HelloWorld"
+    Name = %[1]q
   }
 }
 
-resource "aws_route" "test" {
+resource "aws_route" "instance" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = "10.0.1.0/24"
-  instance_id            = aws_instance.web.id
-
-  timeouts {
-    create = "5m"
-  }
+  instance_id            = aws_instance.test.id
 }
 
 data "aws_route" "by_peering_connection_id" {
   route_table_id            = aws_route_table.test.id
-  vpc_peering_connection_id = aws_route.pcx.vpc_peering_connection_id
+  vpc_peering_connection_id = aws_route.vpc_peering_connection.vpc_peering_connection_id
 }
 
 data "aws_route" "by_destination_cidr_block" {
   route_table_id         = aws_route_table.test.id
-  destination_cidr_block = "10.0.1.0/24"
-  depends_on             = [aws_route.test]
+  destination_cidr_block = aws_route.instance.destination_cidr_block
 }
 
 data "aws_route" "by_instance_id" {
   route_table_id = aws_route_table.test.id
-  instance_id    = aws_instance.web.id
-  depends_on     = [aws_route.test]
+  instance_id    = aws_route.instance.instance_id
 }
-`)
+`, rName))
 }
 
-func testAccAWSRouteDataSourceConfigTransitGatewayID() string {
-	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
-# IncorrectState: Transit Gateway is not available in some availability zones
-
+func testAccAWSRouteDataSourceConfigIpv4TransitGateway(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "tf-acc-test-ec2-route-datasource-transit-gateway-id"
+    Name = %[1]q
   }
 }
 
@@ -224,16 +227,24 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-test-ec2-route-datasource-transit-gateway-id"
+    Name = %[1]q
   }
 }
 
-resource "aws_ec2_transit_gateway" "test" {}
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
   subnet_ids         = [aws_subnet.test.id]
   transit_gateway_id = aws_ec2_transit_gateway.test.id
   vpc_id             = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_route" "test" {
@@ -246,32 +257,85 @@ data "aws_route" "test" {
   route_table_id     = aws_route.test.route_table_id
   transit_gateway_id = aws_route.test.transit_gateway_id
 }
-`
+`, rName))
 }
 
-func testAccAWSRouteDataSourceConfigLocalGatewayID() string {
-	return `
+func testAccAWSRouteDataSourceConfigIpv6EgressOnlyInternetGateway(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_egress_only_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id              = aws_route_table.test.id
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.test.id
+}
+
+data "aws_route" "test" {
+  route_table_id              = aws_route.test.route_table_id
+  destination_ipv6_cidr_block = aws_route.test.destination_ipv6_cidr_block
+}
+`, rName)
+}
+
+func testAccAWSRouteDataSourceConfigIpv4LocalGateway(rName string) string {
+	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "all" {}
+
 data "aws_ec2_local_gateway" "first" {
   id = tolist(data.aws_ec2_local_gateways.all.ids)[0]
 }
 
 data "aws_ec2_local_gateway_route_tables" "all" {}
+
 data "aws_ec2_local_gateway_route_table" "first" {
   local_gateway_route_table_id = tolist(data.aws_ec2_local_gateway_route_tables.all.ids)[0]
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_ec2_local_gateway_route_table_vpc_association" "example" {
   local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.first.id
   vpc_id                       = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_route" "test" {
@@ -286,5 +350,5 @@ data "aws_route" "by_local_gateway_id" {
   local_gateway_id = data.aws_ec2_local_gateway.first.id
   depends_on       = [aws_route.test]
 }
-`
+`, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Refactoring `aws_route` data source acceptance tests in preparation for future fixes/enhancements.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSRouteDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSRouteDataSource_ -timeout 120m
=== RUN   TestAccAWSRouteDataSource_basic
=== PAUSE TestAccAWSRouteDataSource_basic
=== RUN   TestAccAWSRouteDataSource_TransitGatewayID
=== PAUSE TestAccAWSRouteDataSource_TransitGatewayID
=== RUN   TestAccAWSRouteDataSource_IPv6DestinationCidr
=== PAUSE TestAccAWSRouteDataSource_IPv6DestinationCidr
=== CONT  TestAccAWSRouteDataSource_TransitGatewayID
=== CONT  TestAccAWSRouteDataSource_basic
--- PASS: TestAccAWSRouteDataSource_basic (131.62s)
=== CONT  TestAccAWSRouteDataSource_IPv6DestinationCidr
--- PASS: TestAccAWSRouteDataSource_IPv6DestinationCidr (54.91s)
--- PASS: TestAccAWSRouteDataSource_TransitGatewayID (338.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	338.691s
```
