### PR TITLE
Fix for issue #13538

### DIFF
--- a/aws/resource_aws_eks_fargate_profile.go
+++ b/aws/resource_aws_eks_fargate_profile.go
@@ -110,7 +110,7 @@ func resourceAwsEksFargateProfileCreate(d *schema.ResourceData, meta interface{}
 		input.Tags = keyvaluetags.New(v).IgnoreAws().EksTags()
 	}
 
-  // Creation of profiles must be serialized, and can take a while, increase the timeout to a long time.
+	// Creation of profiles must be serialized, and can take a while, increase the timeout to a long time.
 	err := resource.Retry(30*time.Minute, func() *resource.RetryError {
 		_, err := conn.CreateFargateProfile(input)
 
@@ -238,18 +238,18 @@ func resourceAwsEksFargateProfileDelete(d *schema.ResourceData, meta interface{}
 		FargateProfileName: aws.String(fargateProfileName),
 	}
 
-  // Deletion of profiles must be serialized, and can take a while, increase the timeout to a long time.
+	// Deletion of profiles must be serialized, and can take a while, increase the timeout to a long time.
 	err = resource.Retry(30*time.Minute, func() *resource.RetryError {
-  	_, err := conn.DeleteFargateProfile(input)
-	  // Retry for ResourceInUse errors, creation needs to be serialized.
-  	if isAWSErr(err, eks.ErrCodeResourceInUseException, "") {
-  	  return resource.RetryableError(err)
-	  }
+		_, err := conn.DeleteFargateProfile(input)
+		// Retry for ResourceInUse errors, creation needs to be serialized.
+		if isAWSErr(err, eks.ErrCodeResourceInUseException, "") {
+			return resource.RetryableError(err)
+		}
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
-    return nil
-  })
+		return nil
+	})
 
 	if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
 		return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13538


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```NONE

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```

$ make testacc TESTARGS='-run=TestAccAWSEksFargateProfile_Multi_Profile'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSEksFargateProfile_Multi_Profile -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEksFargateProfile_Multi_Profile
=== PAUSE TestAccAWSEksFargateProfile_Multi_Profile
=== CONT  TestAccAWSEksFargateProfile_Multi_Profile
--- PASS: TestAccAWSEksFargateProfile_Multi_Profile (1252.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1252.966s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.002s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.013s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/naming       0.012s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/apigatewayv2/waiter  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency    0.006s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ecs/waiter   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token    0.006s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/guardduty/waiter     [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/waiter      [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kms/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/neptune/waiter       [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/secretsmanager/waiter        [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter      [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/workspaces/waiter    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource        0.013s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/awsproviderlint   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/awsproviderlint/helper/awsprovidertype/keyvaluetags       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes    0.012s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001   0.013s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001    0.003s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR002    0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr 0.003s [no tests to run]


```
