### PR TITLE
r/aws_eip -  support NetworkBorderGroup attribute

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -108,6 +108,12 @@ func resourceAwsEip() *schema.Resource {
 				Computed: true,
 			},
 
+			"network_border_group": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -132,6 +138,10 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("customer_owned_ipv4_pool"); ok {
 		allocOpts.CustomerOwnedIpv4Pool = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("network_border_group"); ok {
+		allocOpts.NetworkBorderGroup = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] EIP create configuration: %#v", allocOpts)
@@ -274,6 +284,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("public_ipv4_pool", address.PublicIpv4Pool)
 	d.Set("customer_owned_ipv4_pool", address.CustomerOwnedIpv4Pool)
 	d.Set("customer_owned_ip", address.CustomerOwnedIp)
+	d.Set("network_border_group", address.NetworkBorderGroup)
 
 	// On import (domain never set, which it must've been if we created),
 	// set the 'vpc' attribute depending on if we're in a VPC.

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -112,6 +112,7 @@ func resourceAwsEip() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"tags": tagsSchema(),

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -441,7 +441,7 @@ func TestAccAWSEIP_NetworkBorderGroup(t *testing.T) {
 					testAccCheckAWSEIPExists(resourceName, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 					resource.TestCheckResourceAttr(resourceName, "public_ipv4_pool", "amazon"),
-					resource.TestCheckResourceAttr(resourceName, "network_border_group", "us-west-2"),
+					resource.TestCheckResourceAttr(resourceName, "network_border_group", testAccGetRegion()),
 				),
 			},
 			{

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -1204,7 +1204,7 @@ const testAccAWSEIPConfigNetworkBorderGroup = `
 data "aws_region" current {}
 
 resource "aws_eip" "test" {
-  vpc  				   = "true"
+  vpc                  = true
   network_border_group = data.aws_region.current.name
 }
 `

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -106,6 +106,7 @@ The following arguments are supported:
 * `tags` - (Optional) A map of tags to assign to the resource.
 * `public_ipv4_pool` - (Optional) EC2 IPv4 address pool identifier or `amazon`. This option is only available for VPC EIPs.
 * `customer_owned_ipv4_pool` - The  ID  of a customer-owned address pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing)
+* `network_border_group` - The location from which the IP address is advertised. Use this parameter to limit the address to this location.
 
 ~> **NOTE:** You can specify either the `instance` ID or the `network_interface` ID,
 but not both. Including both will **not** return an error from the AWS API, but will


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13998

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
support NetworkBorderGroup attribute for aws_eip resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP_NetworkBorderGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEIP_NetworkBorderGroup -timeout 120m
=== RUN   TestAccAWSEIP_NetworkBorderGroup
=== PAUSE TestAccAWSEIP_NetworkBorderGroup
=== CONT  TestAccAWSEIP_NetworkBorderGroup
--- PASS: TestAccAWSEIP_NetworkBorderGroup (22.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       22.843s

...
```
