### PR TITLE
d/aws_prefix_list: fixes and enhancements

### DIFF
--- a/aws/data_source_aws_prefix_list.go
+++ b/aws/data_source_aws_prefix_list.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -68,10 +69,8 @@ func dataSourceAwsPrefixListRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(*pl.PrefixListId)
 	d.Set("name", pl.PrefixListName)
 
-	cidrs := make([]string, len(pl.Cidrs))
-	for i, v := range pl.Cidrs {
-		cidrs[i] = *v
-	}
+	cidrs := aws.StringValueSlice(pl.Cidrs)
+	sort.Strings(cidrs)
 	d.Set("cidr_blocks", cidrs)
 
 	return nil

--- a/aws/data_source_aws_prefix_list.go
+++ b/aws/data_source_aws_prefix_list.go
@@ -71,7 +71,9 @@ func dataSourceAwsPrefixListRead(d *schema.ResourceData, meta interface{}) error
 
 	cidrs := aws.StringValueSlice(pl.Cidrs)
 	sort.Strings(cidrs)
-	d.Set("cidr_blocks", cidrs)
+	if err := d.Set("cidr_blocks", cidrs); err != nil {
+		return fmt.Errorf("failed to set cidr blocks of prefix list %s: %s", d.Id(), err)
+	}
 
 	return nil
 }

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC"
 layout: "aws"
-page_title: "AWS: aws_prefix-list"
+page_title: "AWS: aws_prefix_list"
 description: |-
     Provides details about a specific prefix list
 ---
@@ -41,6 +41,15 @@ resource "aws_network_acl_rule" "private_s3" {
   cidr_block     = "${data.aws_prefix_list.private_s3.cidr_blocks[0]}"
   from_port      = 443
   to_port        = 443
+}
+```
+
+### Find the regional DynamoDB prefix list
+
+```hcl
+data "aws_region" "current" {}
+data "aws_prefix_list" "dynamo" {
+  name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14068, #13986

Contains bugfixes and enhancements to the `aws_prefix_list` data source discovered while implementing support for Managed Prefix Lists.

Users may be affected by the following changes in behavior:

- Where no criteria have been provided to the data source, the data source currently produces an arbitrary prefix list. After this PR, it will raise an error.
- Where a resource depends on the API ordering of CIDR blocks (such as by selecting `cidr_blocks[0]`), the result may now be a different CIDR block.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:
- data-source/aws_prefix_list: The `cidr_blocks` attribute is now lexically sorted
- data-source/aws_prefix_list: Add documentation example about finding a prefix list by name

BUG FIXES:
- data-source/aws_prefix_list: Raise error when criteria match more than one prefix list
- data-source/aws_prefix_list: Specifying the `name` attribute no longer overwrites all filters
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS=-run=TestAccDataSourceAwsPrefixList_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsPrefixList_ -timeout 120m
--- PASS: TestAccDataSourceAwsPrefixList_matchesTooMany (7.09s)
--- PASS: TestAccDataSourceAwsPrefixList_nameDoesNotOverrideFilter (7.10s)
--- PASS: TestAccDataSourceAwsPrefixList_basic (27.39s)
--- PASS: TestAccDataSourceAwsPrefixList_filter (28.37s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       29.752s
...
```
