### PR TITLE
r/sns_topic_policy - add disappears + refactor tests

### DIFF
--- a/.changelog/14123.txt
+++ b/.changelog/14123.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_sns_topic_policy: Add plan time validation to `arn`
+```
+
+```release-note:enhancement
+resource/aws_sns_topic_policy: Add `owner` attribute
+```

--- a/aws/resource_aws_sns_topic_policy_test.go
+++ b/aws/resource_aws_sns_topic_policy_test.go
@@ -155,7 +155,7 @@ resource "aws_sns_topic" "test" {
 }
 
 resource "aws_sns_topic_policy" "test" {
-  arn = aws_sns_topic.test.arn
+  arn    = aws_sns_topic.test.arn
   policy = <<POLICY
 {
   "Version":"2012-10-17",
@@ -189,7 +189,7 @@ resource "aws_sns_topic" "test" {
 }
 
 resource "aws_sns_topic_policy" "test" {
-  arn = "${aws_sns_topic.test.arn}"
+  arn    = aws_sns_topic.test.arn
   policy = <<POLICY
 {
   "Version":"2012-10-17",

--- a/aws/resource_aws_sns_topic_policy_test.go
+++ b/aws/resource_aws_sns_topic_policy_test.go
@@ -49,6 +49,7 @@ func TestAccAWSSNSTopicPolicy_updated(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSNSTopicPolicyDestroy,
 		Steps: []resource.TestStep{
@@ -86,6 +87,7 @@ func TestAccAWSSNSTopicPolicy_disappears_topic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSNSTopicPolicyDestroy,
 		Steps: []resource.TestStep{
@@ -108,6 +110,7 @@ func TestAccAWSSNSTopicPolicy_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSNSTopicPolicyDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_sns_topic_policy_test.go
+++ b/aws/resource_aws_sns_topic_policy_test.go
@@ -1,29 +1,36 @@
 package aws
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccAWSSNSTopicPolicy_basic(t *testing.T) {
 	attributes := make(map[string]string)
-	resourceName := "aws_sns_topic_policy.custom"
+	resourceName := "aws_sns_topic_policy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
+		CheckDestroy: testAccCheckAWSSNSTopicPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSNSTopicConfig_withPolicy,
+				Config: testAccAWSSNSTopicPolicyBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test", attributes),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_sns_topic.test", "arn"),
 					resource.TestMatchResourceAttr(resourceName, "policy",
 						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
+					testAccCheckResourceAttrAccountID(resourceName, "owner"),
 				),
 			},
 			{
@@ -35,36 +42,175 @@ func TestAccAWSSNSTopicPolicy_basic(t *testing.T) {
 	})
 }
 
-const testAccAWSSNSTopicConfig_withPolicy = `
-resource "aws_sns_topic" "test" {
-  name = "tf-acc-test-topic-with-policy"
+func TestAccAWSSNSTopicPolicy_updated(t *testing.T) {
+	attributes := make(map[string]string)
+	resourceName := "aws_sns_topic_policy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSNSTopicPolicyBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicExists("aws_sns_topic.test", attributes),
+					resource.TestMatchResourceAttr(resourceName, "policy",
+						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSNSTopicPolicyUpdatedConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicExists("aws_sns_topic.test", attributes),
+					resource.TestMatchResourceAttr(resourceName, "policy",
+						regexp.MustCompile("SNS:DeleteTopic")),
+				),
+			},
+		},
+	})
 }
 
-resource "aws_sns_topic_policy" "custom" {
-  arn = aws_sns_topic.test.arn
+func TestAccAWSSNSTopicPolicy_disappears_topic(t *testing.T) {
+	attributes := make(map[string]string)
+	topicResourceName := "aws_sns_topic.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSNSTopicPolicyBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicExists(topicResourceName, attributes),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSnsTopic(), topicResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSNSTopicPolicy_disappears(t *testing.T) {
+	attributes := make(map[string]string)
+	resourceName := "aws_sns_topic_policy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSNSTopicPolicyBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicExists("aws_sns_topic.test", attributes),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSnsTopicPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSNSTopicPolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).snsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sns_topic_policy" {
+			continue
+		}
+
+		// Check if the topic policy exists by fetching its attributes
+		params := &sns.GetTopicAttributesInput{
+			TopicArn: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetTopicAttributes(params)
+		if err != nil {
+			if isAWSErr(err, sns.ErrCodeNotFoundException, "") {
+				return nil
+			}
+			return err
+		}
+		return fmt.Errorf("SNS Topic Policy (%s) exists when it should be destroyed", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccAWSSNSTopicPolicyBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+resource "aws_sns_topic_policy" "test" {
+  arn = aws_sns_topic.test.arn
   policy = <<POLICY
 {
-  "Version": "2012-10-17",
-  "Id": "default",
-  "Statement": [
+  "Version":"2012-10-17",
+  "Id":"default",
+  "Statement":[
     {
-      "Sid": "default",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
+      "Sid":"default",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"*"
       },
-      "Action": [
+      "Action":[
+        "SNS:GetTopicAttributes",
+        "SNS:SetTopicAttributes",
+        "SNS:AddPermission",
+        "SNS:RemovePermission"
+      ],
+      "Resource":"${aws_sns_topic.test.arn}"
+    }
+  ]
+}
+POLICY
+}
+`, rName)
+}
+
+func testAccAWSSNSTopicPolicyUpdatedConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+resource "aws_sns_topic_policy" "test" {
+  arn = "${aws_sns_topic.test.arn}"
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Id":"default",
+  "Statement":[
+    {
+      "Sid":"default",
+      "Effect":"Allow",
+      "Principal":{
+        "AWS":"*"
+      },
+      "Action":[
         "SNS:GetTopicAttributes",
         "SNS:SetTopicAttributes",
         "SNS:AddPermission",
         "SNS:RemovePermission",
         "SNS:DeleteTopic"
       ],
-      "Resource": "${aws_sns_topic.test.arn}"
+      "Resource":"${aws_sns_topic.test.arn}"
     }
   ]
 }
 POLICY
 }
-`
+`, rName)
+}

--- a/aws/resource_aws_sns_topic_policy_test.go
+++ b/aws/resource_aws_sns_topic_policy_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSSNSTopicPolicy_basic(t *testing.T) {

--- a/aws/resource_aws_sns_topic_policy_test.go
+++ b/aws/resource_aws_sns_topic_policy_test.go
@@ -29,7 +29,7 @@ func TestAccAWSSNSTopicPolicy_basic(t *testing.T) {
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test", attributes),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_sns_topic.test", "arn"),
 					resource.TestMatchResourceAttr(resourceName, "policy",
-						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
+						regexp.MustCompile(fmt.Sprintf("\"Sid\":\"%[1]s\"", rName))),
 					testAccCheckResourceAttrAccountID(resourceName, "owner"),
 				),
 			},
@@ -57,7 +57,7 @@ func TestAccAWSSNSTopicPolicy_updated(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test", attributes),
 					resource.TestMatchResourceAttr(resourceName, "policy",
-						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
+						regexp.MustCompile(fmt.Sprintf("\"Sid\":\"%[1]s\"", rName))),
 				),
 			},
 			{
@@ -69,6 +69,8 @@ func TestAccAWSSNSTopicPolicy_updated(t *testing.T) {
 				Config: testAccAWSSNSTopicPolicyUpdatedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test", attributes),
+					resource.TestMatchResourceAttr(resourceName, "policy",
+						regexp.MustCompile(fmt.Sprintf("\"Sid\":\"%[1]s\"", rName))),
 					resource.TestMatchResourceAttr(resourceName, "policy",
 						regexp.MustCompile("SNS:DeleteTopic")),
 				),
@@ -160,7 +162,7 @@ resource "aws_sns_topic_policy" "test" {
   "Id":"default",
   "Statement":[
     {
-      "Sid":"default",
+      "Sid":"%[1]s",
       "Effect":"Allow",
       "Principal":{
         "AWS":"*"
@@ -194,7 +196,7 @@ resource "aws_sns_topic_policy" "test" {
   "Id":"default",
   "Statement":[
     {
-      "Sid":"default",
+      "Sid":"%[1]s",
       "Effect":"Allow",
       "Principal":{
         "AWS":"*"

--- a/website/docs/r/sns_topic_policy.html.markdown
+++ b/website/docs/r/sns_topic_policy.html.markdown
@@ -75,7 +75,9 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-No additional attributes are exported.
+In addition to all arguments above, the following attributes are exported:
+
+* `owner` - The AWS Account ID of the SNS topic owner
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sns_topic_policy: add `owner` attribute
resource_aws_sns_topic_policy: add plan time validation to `arn`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSNSTopicPolicy_'
--- PASS: TestAccAWSSNSTopicPolicy_basic (50.74s)
--- PASS: TestAccAWSSNSTopicPolicy_updated (73.65s)
--- PASS: TestAccAWSSNSTopicPolicy_disappears_topic (30.39s)
--- PASS: TestAccAWSSNSTopicPolicy_disappears (41.43s)
```
