### PR TITLE
r/aws_ssm_document - support VersionName parameter

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -172,6 +172,12 @@ func resourceAwsSsmDocument() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"version_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -206,6 +212,9 @@ func resourceAwsSsmDocumentCreate(d *schema.ResourceData, meta interface{}) erro
 
 	if v, ok := d.GetOk("target_type"); ok {
 		docInput.TargetType = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("version_name"); ok {
+		docInput.VersionName = aws.String(v.(string))
 	}
 
 	resp, err := ssmconn.CreateDocument(docInput)
@@ -282,6 +291,7 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("hash", doc.Hash)
 	d.Set("hash_type", doc.HashType)
 	d.Set("latest_version", doc.LatestVersion)
+	d.Set("version_name", doc.VersionName)
 	d.Set("name", doc.Name)
 	d.Set("owner", doc.Owner)
 	d.Set("platform_types", flattenStringList(doc.PlatformTypes))

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -72,6 +72,37 @@ func TestAccAWSSSMDocument_target_type(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMDocument_version_name(t *testing.T) {
+	name := acctest.RandString(10)
+	resourceName := "aws_ssm_document.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMDocumentBasicConfigVersionName(name, "release-1.0.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "version_name", "release-1.0.0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMDocumentBasicConfigVersionName(name, "release-1.0.1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "version_name", "release-1.0.1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMDocument_update(t *testing.T) {
 	name := acctest.RandString(10)
 	resourceName := "aws_ssm_document.test"
@@ -622,6 +653,37 @@ resource "aws_ssm_document" "test" {
 DOC
 }
 `, rName, typ)
+}
+
+func testAccAWSSSMDocumentBasicConfigVersionName(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "test" {
+  name          = "%s"
+  document_type = "Command"
+  version_name   = "%s"
+
+  content = <<DOC
+    {
+       "schemaVersion": "2.0",
+       "description": "Sample version 2.0 document v2",
+       "parameters": {
+
+       },
+       "mainSteps": [
+          {
+             "action": "aws:runPowerShellScript",
+             "name": "runPowerShellScript",
+             "inputs": {
+                "runCommand": [
+                   "Get-Process"
+                ]
+             }
+          }
+       ]
+    }
+DOC
+}
+`, rName, version)
 }
 
 func testAccAWSSSMDocument20Config(rName string) string {

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -660,7 +660,7 @@ func testAccAWSSSMDocumentBasicConfigVersionName(rName, version string) string {
 resource "aws_ssm_document" "test" {
   name          = "%s"
   document_type = "Command"
-  version_name   = "%s"
+  version_name  = "%s"
 
   content = <<DOC
     {

--- a/website/docs/r/ssm_document.html.markdown
+++ b/website/docs/r/ssm_document.html.markdown
@@ -53,7 +53,8 @@ The following arguments are supported:
 * `document_format` - (Optional, defaults to JSON) The format of the document. Valid document types include: `JSON` and `YAML`
 * `document_type` - (Required) The type of the document. Valid document types include: `Automation`, `Command`, `Package`, `Policy`, and `Session`
 * `permissions` - (Optional) Additional Permissions to attach to the document. See [Permissions](#permissions) below for details.
-* `target_type` - (Optional) The target type which defines the kinds of resources the document can run on. For example, /AWS::EC2::Instance. For a list of valid resource types, see AWS Resource Types Reference (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
+* `target_type` - (Optional) The target type which defines the kinds of resources the document can run on. For example, /AWS::EC2::Instance. For a list of valid 
+* `version_name` - (Optional) A field specifying the version of the artifact you are creating with the document. For example, "Release 12, Update 6"
 * `tags` - (Optional) A map of tags to assign to the object.
 
 ## attachments_source

--- a/website/docs/r/ssm_document.html.markdown
+++ b/website/docs/r/ssm_document.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `document_format` - (Optional, defaults to JSON) The format of the document. Valid document types include: `JSON` and `YAML`
 * `document_type` - (Required) The type of the document. Valid document types include: `Automation`, `Command`, `Package`, `Policy`, and `Session`
 * `permissions` - (Optional) Additional Permissions to attach to the document. See [Permissions](#permissions) below for details.
-* `target_type` - (Optional) The target type which defines the kinds of resources the document can run on. For example, /AWS::EC2::Instance. For a list of valid 
+* `target_type` - (Optional) The target type which defines the kinds of resources the document can run on. For example, /AWS::EC2::Instance. For a list of valid resource types, see AWS Resource Types Reference (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
 * `version_name` - (Optional) A field specifying the version of the artifact you are creating with the document. For example, "Release 12, Update 6"
 * `tags` - (Optional) A map of tags to assign to the object.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14107 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Support VersionName parameter for aws_ssm_document resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMDocument'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSSMDocument -timeout 120m
=== RUN   TestAccAWSSSMDocument_basic
=== PAUSE TestAccAWSSSMDocument_basic
=== RUN   TestAccAWSSSMDocument_target_type
=== PAUSE TestAccAWSSSMDocument_target_type
=== RUN   TestAccAWSSSMDocument_version_name
=== PAUSE TestAccAWSSSMDocument_version_name
=== RUN   TestAccAWSSSMDocument_update
=== PAUSE TestAccAWSSSMDocument_update
=== RUN   TestAccAWSSSMDocument_permission_public
=== PAUSE TestAccAWSSSMDocument_permission_public
=== RUN   TestAccAWSSSMDocument_permission_private
=== PAUSE TestAccAWSSSMDocument_permission_private
=== RUN   TestAccAWSSSMDocument_permission_batching
=== PAUSE TestAccAWSSSMDocument_permission_batching
=== RUN   TestAccAWSSSMDocument_permission_change
=== PAUSE TestAccAWSSSMDocument_permission_change
=== RUN   TestAccAWSSSMDocument_params
=== PAUSE TestAccAWSSSMDocument_params
=== RUN   TestAccAWSSSMDocument_automation
=== PAUSE TestAccAWSSSMDocument_automation
=== RUN   TestAccAWSSSMDocument_package
=== PAUSE TestAccAWSSSMDocument_package
=== RUN   TestAccAWSSSMDocument_SchemaVersion_1
=== PAUSE TestAccAWSSSMDocument_SchemaVersion_1
=== RUN   TestAccAWSSSMDocument_session
=== PAUSE TestAccAWSSSMDocument_session
=== RUN   TestAccAWSSSMDocument_DocumentFormat_YAML
=== PAUSE TestAccAWSSSMDocument_DocumentFormat_YAML
=== RUN   TestAccAWSSSMDocument_Tags
=== PAUSE TestAccAWSSSMDocument_Tags
=== CONT  TestAccAWSSSMDocument_basic
=== CONT  TestAccAWSSSMDocument_params
=== CONT  TestAccAWSSSMDocument_Tags
=== CONT  TestAccAWSSSMDocument_DocumentFormat_YAML
=== CONT  TestAccAWSSSMDocument_session
=== CONT  TestAccAWSSSMDocument_SchemaVersion_1
=== CONT  TestAccAWSSSMDocument_package
=== CONT  TestAccAWSSSMDocument_automation
=== CONT  TestAccAWSSSMDocument_permission_public
=== CONT  TestAccAWSSSMDocument_permission_change
=== CONT  TestAccAWSSSMDocument_permission_batching
=== CONT  TestAccAWSSSMDocument_permission_private
=== CONT  TestAccAWSSSMDocument_version_name
=== CONT  TestAccAWSSSMDocument_target_type
=== CONT  TestAccAWSSSMDocument_update
--- PASS: TestAccAWSSSMDocument_session (29.82s)
--- PASS: TestAccAWSSSMDocument_permission_public (37.99s)
--- PASS: TestAccAWSSSMDocument_permission_private (44.34s)
--- PASS: TestAccAWSSSMDocument_permission_batching (47.99s)
--- PASS: TestAccAWSSSMDocument_params (51.48s)
--- PASS: TestAccAWSSSMDocument_automation (51.62s)
--- PASS: TestAccAWSSSMDocument_target_type (55.04s)
--- PASS: TestAccAWSSSMDocument_SchemaVersion_1 (61.63s)
--- PASS: TestAccAWSSSMDocument_Tags (63.34s)
--- PASS: TestAccAWSSSMDocument_package (64.46s)
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (64.82s)
--- PASS: TestAccAWSSSMDocument_update (74.92s)
--- PASS: TestAccAWSSSMDocument_permission_change (76.45s)
--- PASS: TestAccAWSSSMDocument_version_name (86.55s)
--- PASS: TestAccAWSSSMDocument_basic (118.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       119.068s

...
```
