### PR TITLE
r/ecr_repository_policy - Read after update + validate `policy` + disappears test

### DIFF
--- a/.changelog/14193.txt
+++ b/.changelog/14193.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecr_repository_policy: Add plan time validation for `policy`
+```

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -90,7 +90,7 @@ func resourceAwsEcrRepositoryPolicyRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") ||
 			isAWSErr(err, ecr.ErrCodeRepositoryPolicyNotFoundException, "") {
-			log.Printf("[WARN] ECR Repositoy Policy %s not found, removing", d.Id())
+			log.Printf("[WARN] ECR Repository Policy %s not found, removing", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -115,7 +115,7 @@ func resourceAwsEcrRepositoryPolicyUpdate(d *schema.ResourceData, meta interface
 		PolicyText:     aws.String(d.Get("policy").(string)),
 	}
 
-	log.Printf("[DEBUG] Updating ECR resository policy: %#v", input)
+	log.Printf("[DEBUG] Updating ECR repository policy: %#v", input)
 
 	// Retry due to IAM eventual consistency
 	var err error

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -50,7 +50,7 @@ func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface
 		PolicyText:     aws.String(d.Get("policy").(string)),
 	}
 
-	log.Printf("[DEBUG] Creating ECR resository policy: %#v", input)
+	log.Printf("[DEBUG] Creating ECR repository policy: %#v", input)
 
 	// Retry due to IAM eventual consistency
 	var err error

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsEcrRepositoryPolicy() *schema.Resource {
@@ -31,6 +31,7 @@ func resourceAwsEcrRepositoryPolicy() *schema.Resource {
 			"policy": {
 				Type:             schema.TypeString,
 				Required:         true,
+				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 			"registry_id": {
@@ -49,7 +50,7 @@ func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface
 		PolicyText:     aws.String(d.Get("policy").(string)),
 	}
 
-	log.Printf("[DEBUG] Creating ECR resository policy: %s", input)
+	log.Printf("[DEBUG] Creating ECR resository policy: %#v", input)
 
 	// Retry due to IAM eventual consistency
 	var err error
@@ -57,7 +58,7 @@ func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface
 	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
 		out, err = conn.SetRepositoryPolicy(&input)
 
-		if isAWSErr(err, "InvalidParameterException", "Invalid repository policy provided") {
+		if isAWSErr(err, ecr.ErrCodeInvalidParameterException, "Invalid repository policy provided") {
 			return resource.RetryableError(err)
 		}
 		if err != nil {
@@ -69,15 +70,12 @@ func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface
 		out, err = conn.SetRepositoryPolicy(&input)
 	}
 	if err != nil {
-		return fmt.Errorf("Error creating ECR Repository Policy: %s", err)
+		return fmt.Errorf("error creating ECR Repository Policy: %w", err)
 	}
 
-	repositoryPolicy := *out
+	log.Printf("[DEBUG] ECR repository policy created: %s", aws.StringValue(out.RepositoryName))
 
-	log.Printf("[DEBUG] ECR repository policy created: %s", *repositoryPolicy.RepositoryName)
-
-	d.SetId(aws.StringValue(repositoryPolicy.RepositoryName))
-	d.Set("registry_id", repositoryPolicy.RegistryId)
+	d.SetId(aws.StringValue(out.RepositoryName))
 
 	return resourceAwsEcrRepositoryPolicyRead(d, meta)
 }
@@ -90,26 +88,20 @@ func resourceAwsEcrRepositoryPolicyRead(d *schema.ResourceData, meta interface{}
 		RepositoryName: aws.String(d.Id()),
 	})
 	if err != nil {
-		if ecrerr, ok := err.(awserr.Error); ok {
-			switch ecrerr.Code() {
-			case "RepositoryNotFoundException", "RepositoryPolicyNotFoundException":
-				d.SetId("")
-				return nil
-			default:
-				return err
-			}
+		if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") ||
+			isAWSErr(err, ecr.ErrCodeRepositoryPolicyNotFoundException, "") {
+			log.Printf("[WARN] ECR Repositoy Policy %s not found, removing", d.Id())
+			d.SetId("")
+			return nil
 		}
 		return err
 	}
 
-	log.Printf("[DEBUG] Received repository policy %s", out)
+	log.Printf("[DEBUG] Received repository policy %#v", out)
 
-	repositoryPolicy := out
-
-	d.SetId(aws.StringValue(repositoryPolicy.RepositoryName))
-	d.Set("repository", repositoryPolicy.RepositoryName)
-	d.Set("registry_id", repositoryPolicy.RegistryId)
-	d.Set("policy", repositoryPolicy.PolicyText)
+	d.Set("repository", out.RepositoryName)
+	d.Set("registry_id", out.RegistryId)
+	d.Set("policy", out.PolicyText)
 
 	return nil
 }
@@ -117,25 +109,20 @@ func resourceAwsEcrRepositoryPolicyRead(d *schema.ResourceData, meta interface{}
 func resourceAwsEcrRepositoryPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecrconn
 
-	if !d.HasChange("policy") {
-		return nil
-	}
-
 	input := ecr.SetRepositoryPolicyInput{
-		RepositoryName: aws.String(d.Get("repository").(string)),
+		RepositoryName: aws.String(d.Id()),
 		RegistryId:     aws.String(d.Get("registry_id").(string)),
 		PolicyText:     aws.String(d.Get("policy").(string)),
 	}
 
-	log.Printf("[DEBUG] Updating ECR resository policy: %s", input)
+	log.Printf("[DEBUG] Updating ECR resository policy: %#v", input)
 
 	// Retry due to IAM eventual consistency
 	var err error
-	var out *ecr.SetRepositoryPolicyOutput
 	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
-		out, err = conn.SetRepositoryPolicy(&input)
+		_, err = conn.SetRepositoryPolicy(&input)
 
-		if isAWSErr(err, "InvalidParameterException", "Invalid repository policy provided") {
+		if isAWSErr(err, ecr.ErrCodeInvalidParameterException, "Invalid repository policy provided") {
 			return resource.RetryableError(err)
 		}
 		if err != nil {
@@ -144,18 +131,13 @@ func resourceAwsEcrRepositoryPolicyUpdate(d *schema.ResourceData, meta interface
 		return nil
 	})
 	if isResourceTimeoutError(err) {
-		out, err = conn.SetRepositoryPolicy(&input)
+		_, err = conn.SetRepositoryPolicy(&input)
 	}
 	if err != nil {
-		return fmt.Errorf("Error updating ECR Repository Policy: %s", err)
+		return fmt.Errorf("error updating ECR Repository Policy: %w", err)
 	}
 
-	repositoryPolicy := *out
-
-	d.SetId(aws.StringValue(repositoryPolicy.RepositoryName))
-	d.Set("registry_id", repositoryPolicy.RegistryId)
-
-	return nil
+	return resourceAwsEcrRepositoryPolicyRead(d, meta)
 }
 
 func resourceAwsEcrRepositoryPolicyDelete(d *schema.ResourceData, meta interface{}) error {
@@ -166,13 +148,9 @@ func resourceAwsEcrRepositoryPolicyDelete(d *schema.ResourceData, meta interface
 		RegistryId:     aws.String(d.Get("registry_id").(string)),
 	})
 	if err != nil {
-		if ecrerr, ok := err.(awserr.Error); ok {
-			switch ecrerr.Code() {
-			case "RepositoryNotFoundException", "RepositoryPolicyNotFoundException":
-				return nil
-			default:
-				return err
-			}
+		if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") ||
+			isAWSErr(err, ecr.ErrCodeRepositoryPolicyNotFoundException, "") {
+			return nil
 		}
 		return err
 	}

--- a/aws/resource_aws_ecr_repository_policy_test.go
+++ b/aws/resource_aws_ecr_repository_policy_test.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccAWSEcrRepositoryPolicy_basic(t *testing.T) {
-	randString := acctest.RandString(10)
-	resourceName := "aws_ecr_repository_policy.default"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecr_repository_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,9 +22,48 @@ func TestAccAWSEcrRepositoryPolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcrRepositoryPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcrRepositoryPolicy(randString),
+				Config: testAccAWSEcrRepositoryPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcrRepositoryPolicyExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "repository", "aws_ecr_repository.test", "name"),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(rName)),
+					testAccCheckResourceAttrAccountID(resourceName, "registry_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEcrRepositoryPolicyConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryPolicyExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "repository", "aws_ecr_repository.test", "name"),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(rName)),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile("ecr:DescribeImages")),
+					testAccCheckResourceAttrAccountID(resourceName, "registry_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEcrRepositoryPolicy_iam(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecr_repository_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcrRepositoryPolicyWithIAMRoleConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryPolicyExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(rName)),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile("iam")),
 				),
 			},
 			{
@@ -36,9 +75,9 @@ func TestAccAWSEcrRepositoryPolicy_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcrRepositoryPolicy_iam(t *testing.T) {
-	randString := acctest.RandString(10)
-	resourceName := "aws_ecr_repository_policy.default"
+func TestAccAWSEcrRepositoryPolicy_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecr_repository_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -46,15 +85,33 @@ func TestAccAWSEcrRepositoryPolicy_iam(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcrRepositoryPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcrRepositoryPolicyWithIAMRole(randString),
+				Config: testAccAWSEcrRepositoryPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcrRepositoryPolicyExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEcrRepositoryPolicy(), resourceName),
 				),
+				ExpectNonEmptyPlan: true,
 			},
+		},
+	})
+}
+
+func TestAccAWSEcrRepositoryPolicy_disappears_repository(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecr_repository_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryPolicyDestroy,
+		Steps: []resource.TestStep{
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config: testAccAWSEcrRepositoryPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryPolicyExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEcrRepository(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -70,10 +127,11 @@ func testAccCheckAWSEcrRepositoryPolicyDestroy(s *terraform.State) error {
 
 		_, err := conn.GetRepositoryPolicy(&ecr.GetRepositoryPolicyInput{
 			RegistryId:     aws.String(rs.Primary.Attributes["registry_id"]),
-			RepositoryName: aws.String(rs.Primary.Attributes["repository"]),
+			RepositoryName: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
-			if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryNotFoundException" {
+			if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") ||
+				isAWSErr(err, ecr.ErrCodeRepositoryPolicyNotFoundException, "") {
 				return nil
 			}
 			return err
@@ -94,21 +152,21 @@ func testAccCheckAWSEcrRepositoryPolicyExists(name string) resource.TestCheckFun
 	}
 }
 
-func testAccAWSEcrRepositoryPolicy(randString string) string {
+func testAccAWSEcrRepositoryPolicyConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecr_repository" "foo" {
-  name = "tf-acc-test-ecr-%s"
+resource "aws_ecr_repository" "test" {
+  name = %[1]q
 }
 
-resource "aws_ecr_repository_policy" "default" {
-  repository = aws_ecr_repository.foo.name
+resource "aws_ecr_repository_policy" "test" {
+  repository = aws_ecr_repository.test.name
 
   policy = <<EOF
 {
     "Version": "2008-10-17",
     "Statement": [
         {
-            "Sid": "testpolicy",
+            "Sid": "%[1]s",
             "Effect": "Allow",
             "Principal": "*",
             "Action": [
@@ -119,21 +177,50 @@ resource "aws_ecr_repository_policy" "default" {
 }
 EOF
 }
-`, randString)
+`, rName)
 }
 
-// testAccAWSEcrRepositoryPolicyWithIAMRole creates a new IAM Role and tries
+func testAccAWSEcrRepositoryPolicyConfigUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecr_repository_policy" "test" {
+  repository = "${aws_ecr_repository.test.name}"
+
+  policy = <<EOF
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "%[1]s",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "ecr:ListImages",
+                "ecr:DescribeImages"
+            ]
+        }
+    ]
+}
+EOF
+}
+`, rName)
+}
+
+// testAccAWSEcrRepositoryPolicyWithIAMRoleConfig creates a new IAM Role and tries
 // to use it's ARN in an ECR Repository Policy. IAM changes need some time to
 // be propagated to other services - like ECR. So the following code should
 // exercise our retry logic, since we try to use the new resource instantly.
-func testAccAWSEcrRepositoryPolicyWithIAMRole(randString string) string {
+func testAccAWSEcrRepositoryPolicyWithIAMRoleConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecr_repository" "foo" {
-  name = "tf-acc-test-ecr-%s"
+resource "aws_ecr_repository" "test" {
+  name = %[1]q
 }
 
-resource "aws_iam_role" "foo" {
-  name = "tf-acc-test-ecr-%s"
+resource "aws_iam_role" "test" {
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -151,18 +238,18 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
-resource "aws_ecr_repository_policy" "default" {
-  repository = aws_ecr_repository.foo.name
+resource "aws_ecr_repository_policy" "test" {
+  repository = aws_ecr_repository.test.name
 
   policy = <<EOF
 {
     "Version": "2008-10-17",
     "Statement": [
         {
-            "Sid": "testpolicy",
+            "Sid": "%[1]s",
             "Effect": "Allow",
             "Principal": {
-              "AWS": "${aws_iam_role.foo.arn}"
+              "AWS": "${aws_iam_role.test.arn}"
             },
             "Action": [
                 "ecr:ListImages"
@@ -172,5 +259,5 @@ resource "aws_ecr_repository_policy" "default" {
 }
 EOF
 }
-`, randString, randString)
+`, rName)
 }

--- a/aws/resource_aws_ecr_repository_policy_test.go
+++ b/aws/resource_aws_ecr_repository_policy_test.go
@@ -187,7 +187,7 @@ resource "aws_ecr_repository" "test" {
 }
 
 resource "aws_ecr_repository_policy" "test" {
-  repository = "${aws_ecr_repository.test.name}"
+  repository = aws_ecr_repository.test.name
 
   policy = <<EOF
 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13826
Closes #3924
Closes #545

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_ecr_repository_policy: add plan time validation for `policy`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcrRepositoryPolicy_'
--- PASS: TestAccAWSEcrRepositoryPolicy_basic (63.26s)
--- PASS: TestAccAWSEcrRepositoryPolicy_iam (54.24s)
--- PASS: TestAccAWSEcrRepositoryPolicy_disappears (33.63s)
--- PASS: TestAccAWSEcrRepositoryPolicy_disappears_repository (28.06s)
```
