### PR TITLE
Add resource: aws_rds_cluster_activity_stream

### DIFF
--- a/aws/internal/service/rds/waiter/status.go
+++ b/aws/internal/service/rds/waiter/status.go
@@ -1,7 +1,13 @@
 package waiter
 
 import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds/finder"
@@ -57,4 +63,46 @@ func DBProxyEndpointStatus(conn *rds.RDS, id string) resource.StateRefreshFunc {
 
 		return output, aws.StringValue(output.Status), nil
 	}
+}
+
+// ActivityStreamStatus fetches the RDS Cluster Activity Stream Status
+func ActivityStreamStatus(conn *rds.RDS, dbClusterIdentifier string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		emptyResp := &rds.DescribeDBClustersInput{}
+
+		resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+			DBClusterIdentifier: aws.String(dbClusterIdentifier),
+		})
+
+		if err != nil {
+			log.Printf("[DEBUG] Refreshing RDS Cluster Activity Stream State. Occur error: %s", err)
+			if isAWSErr(err, rds.ErrCodeDBClusterNotFoundFault, "") {
+				return emptyResp, rds.ActivityStreamStatusStopped, nil
+			} else if resp != nil && len(resp.DBClusters) == 0 {
+				return emptyResp, rds.ActivityStreamStatusStopped, nil
+			} else {
+				return emptyResp, "", fmt.Errorf("error on refresh: %+v", err)
+			}
+		}
+
+		if resp == nil || resp.DBClusters == nil || len(resp.DBClusters) == 0 {
+			log.Printf("[DEBUG] Refreshing RDS Cluster Activity Stream State. Invalid resp: %s", resp)
+			return emptyResp, rds.ActivityStreamStatusStopped, nil
+		}
+
+		cluster := resp.DBClusters[0]
+		status := aws.StringValue(cluster.ActivityStreamStatus)
+		log.Printf("[DEBUG] Refreshing RDS Cluster Activity Stream State... %s", status)
+		return cluster, status, nil
+	}
+}
+
+// Similar to isAWSErr from aws/awserr.go
+// TODO: Add and export in shared package
+func isAWSErr(err error, code string, message string) bool {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code() == code && strings.Contains(awsErr.Message(), message)
+	}
+	return false
 }

--- a/aws/internal/service/rds/waiter/waiter.go
+++ b/aws/internal/service/rds/waiter/waiter.go
@@ -13,7 +13,6 @@ const (
 	// Maximum amount of time to wait for an EventSubscription to return Deleted
 	EventSubscriptionDeletedTimeout  = 10 * time.Minute
 	RdsClusterInitiateUpgradeTimeout = 5 * time.Minute
-	EventSubscriptionDeletedTimeout = 10 * time.Minute
 
 	// Delay time to retry fetch RDS Cluster Activity Stream Status
 	ActivityStreamRetryDelay = 5 * time.Second

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -912,6 +912,7 @@ func Provider() *schema.Provider {
 			"aws_rds_cluster_endpoint":                                resourceAwsRDSClusterEndpoint(),
 			"aws_rds_cluster_instance":                                resourceAwsRDSClusterInstance(),
 			"aws_rds_cluster_parameter_group":                         resourceAwsRDSClusterParameterGroup(),
+			"aws_rds_cluster_activity_stream":                         resourceAwsRDSClusterActivityStream(),
 			"aws_rds_global_cluster":                                  resourceAwsRDSGlobalCluster(),
 			"aws_redshift_cluster":                                    resourceAwsRedshiftCluster(),
 			"aws_redshift_security_group":                             resourceAwsRedshiftSecurityGroup(),

--- a/aws/resource_aws_rds_cluster_activity_stream.go
+++ b/aws/resource_aws_rds_cluster_activity_stream.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds/waiter"
 )
 

--- a/aws/resource_aws_rds_cluster_activity_stream.go
+++ b/aws/resource_aws_rds_cluster_activity_stream.go
@@ -146,7 +146,7 @@ func resourceAwsRDSClusterActivityStreamRead(d *schema.ResourceData, meta interf
 }
 
 func resourceAwsRDSClusterActivityStreamUpdate(d *schema.ResourceData, meta interface{}) error {
-	if d.HasChange("arn") || d.HasChange("kms_key_id") || d.HasChange("mode") {
+	if d.HasChanges("arn", "kms_key_id", "mode") {
 		log.Printf("[DEBUG] Stopping RDS Cluster Activity Stream before updating")
 		if err := resourceAwsRDSClusterActivityStreamDelete(d, meta); err != nil {
 			return err

--- a/aws/resource_aws_rds_cluster_activity_stream.go
+++ b/aws/resource_aws_rds_cluster_activity_stream.go
@@ -34,9 +34,10 @@ func resourceAwsRDSClusterActivityStream() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"resource_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 			"apply_immediately": {
 				Type:     schema.TypeBool,

--- a/aws/resource_aws_rds_cluster_activity_stream.go
+++ b/aws/resource_aws_rds_cluster_activity_stream.go
@@ -1,0 +1,255 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+const (
+	AWSRDSClusterActivityStreamRetryDelay      = 5 * time.Second
+	AWSRDSClusterActivityStreamRetryMinTimeout = 3 * time.Second
+)
+
+func resourceAwsRDSClusterActivityStream() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRDSClusterActivityStreamCreate,
+		Read:   resourceAwsRDSClusterActivityStreamRead,
+		Update: resourceAwsRDSClusterActivityStreamUpdate,
+		Delete: resourceAwsRDSClusterActivityStreamDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(120 * time.Minute),
+			Delete: schema.DefaultTimeout(120 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"apply_immediately": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"mode": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"sync",
+					"async",
+				}, false),
+			},
+			"kinesis_stream_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsRDSClusterActivityStreamCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	resourceArn := d.Get("arn").(string)
+	applyImmediately := d.Get("apply_immediately").(bool)
+	kmsKeyId := d.Get("kms_key_id").(string)
+	mode := d.Get("mode").(string)
+
+	startActivityStreamInput := &rds.StartActivityStreamInput{
+		ResourceArn:      aws.String(resourceArn),
+		ApplyImmediately: aws.Bool(applyImmediately),
+		KmsKeyId:         aws.String(kmsKeyId),
+		Mode:             aws.String(mode),
+	}
+
+	log.Printf("[DEBUG] RDS Cluster start activity stream input: %s", startActivityStreamInput)
+
+	resp, err := conn.StartActivityStream(startActivityStreamInput)
+	if err != nil {
+		return fmt.Errorf("error creating RDS Cluster Activity Stream: %s", err)
+	}
+
+	log.Printf("[DEBUG]: RDS Cluster start activity stream response: %s", resp)
+
+	d.SetId(resourceArn)
+
+	err = resourceAwsRDSClusterActivityStreamWaitForStarted(d.Timeout(schema.TimeoutCreate), d.Id(), conn)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsRDSClusterActivityStreamRead(d, meta)
+}
+
+func resourceAwsRDSClusterActivityStreamRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	input := &rds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Describing RDS Cluster: %s", input)
+	resp, err := conn.DescribeDBClusters(input)
+
+	if isAWSErr(err, rds.ErrCodeDBClusterNotFoundFault, "") {
+		log.Printf("[WARN] RDS Cluster (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing RDS Cluster (%s): %s", d.Id(), err)
+	}
+
+	if resp == nil {
+		return fmt.Errorf("error retrieving RDS cluster: empty response for: %s", input)
+	}
+
+	var dbc *rds.DBCluster
+	for _, c := range resp.DBClusters {
+		if aws.StringValue(c.DBClusterArn) == d.Id() {
+			dbc = c
+			break
+		}
+	}
+
+	if dbc == nil {
+		log.Printf("[WARN] RDS Cluster (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("arn", dbc.DBClusterArn)
+	d.Set("kms_key_id", dbc.ActivityStreamKmsKeyId)
+	d.Set("kinesis_stream_name", dbc.ActivityStreamKinesisStreamName)
+	d.Set("mode", dbc.ActivityStreamMode)
+
+	return nil
+}
+
+func resourceAwsRDSClusterActivityStreamUpdate(d *schema.ResourceData, meta interface{}) error {
+	if d.HasChange("arn") || d.HasChange("kms_key_id") || d.HasChange("mode") {
+		log.Printf("[DEBUG] Stopping RDS Cluster Activity Stream before updating")
+		if err := resourceAwsRDSClusterActivityStreamDelete(d, meta); err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Starting RDS Cluster Activity Stream")
+		if err := resourceAwsRDSClusterActivityStreamCreate(d, meta); err != nil {
+			return err
+		}
+	}
+
+	return resourceAwsRDSClusterActivityStreamRead(d, meta)
+}
+
+func resourceAwsRDSClusterActivityStreamDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	stopActivityStreamInput := &rds.StopActivityStreamInput{
+		ApplyImmediately: aws.Bool(true),
+		ResourceArn:      aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] RDS Cluster stop activity stream input: %s", stopActivityStreamInput)
+
+	resp, err := conn.StopActivityStream(stopActivityStreamInput)
+	if err != nil {
+		return fmt.Errorf("error stopping RDS Cluster Activity Stream: %s", err)
+	}
+
+	log.Printf("[DEBUG] RDS Cluster stop activity stream response: %s", resp)
+
+	if err := resourceAwsRDSClusterActivityStreamWaitForStopped(d.Timeout(schema.TimeoutDelete), d.Id(), conn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsRDSClusterActivityStreamWaitForStarted(timeout time.Duration, id string, conn *rds.RDS) error {
+	log.Printf("[DEBUG] Waiting for RDS Cluster Activity Stream %s to become started...", id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{rds.ActivityStreamStatusStarting},
+		Target:     []string{rds.ActivityStreamStatusStarted},
+		Refresh:    resourceAwsRDSClusterActivityStreamStateRefreshFunc(conn, id),
+		Timeout:    timeout,
+		Delay:      AWSRDSClusterActivityStreamRetryDelay,
+		MinTimeout: AWSRDSClusterActivityStreamRetryMinTimeout,
+	}
+
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for RDS Cluster Activity Stream (%s) to be started: %v", id, err)
+	}
+	return nil
+}
+
+func resourceAwsRDSClusterActivityStreamWaitForStopped(timeout time.Duration, id string, conn *rds.RDS) error {
+	log.Printf("[DEBUG] Waiting for RDS Cluster Activity Stream %s to become stopped...", id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{rds.ActivityStreamStatusStopping},
+		Target:     []string{rds.ActivityStreamStatusStopped},
+		Refresh:    resourceAwsRDSClusterActivityStreamStateRefreshFunc(conn, id),
+		Timeout:    timeout,
+		Delay:      AWSRDSClusterActivityStreamRetryDelay,
+		MinTimeout: AWSRDSClusterActivityStreamRetryMinTimeout,
+	}
+
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for RDS Cluster Activity Stream (%s) to be stopped: %v", id, err)
+	}
+	return nil
+}
+
+func resourceAwsRDSClusterActivityStreamStateRefreshFunc(conn *rds.RDS, dbClusterIdentifier string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		emptyResp := &rds.DescribeDBClustersInput{}
+
+		resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+			DBClusterIdentifier: aws.String(dbClusterIdentifier),
+		})
+
+		if err != nil {
+			log.Printf("[DEBUG] Refreshing RDS Cluster Activity Stream State. Occur error: %s", err)
+			if isAWSErr(err, rds.ErrCodeDBClusterNotFoundFault, "") {
+				return emptyResp, rds.ActivityStreamStatusStopped, nil
+			} else if resp != nil && len(resp.DBClusters) == 0 {
+				return emptyResp, rds.ActivityStreamStatusStopped, nil
+			} else {
+				return emptyResp, "", fmt.Errorf("error on refresh: %+v", err)
+			}
+		}
+
+		if resp == nil || resp.DBClusters == nil || len(resp.DBClusters) == 0 {
+			log.Printf("[DEBUG] Refreshing RDS Cluster Activity Stream State. Invalid resp: %s", resp)
+			return emptyResp, rds.ActivityStreamStatusStopped, nil
+		}
+
+		cluster := resp.DBClusters[0]
+		status := aws.StringValue(cluster.ActivityStreamStatus)
+		log.Printf("[DEBUG] Refreshing RDS Cluster Activity Stream State... %s", status)
+		return cluster, status, nil
+	}
+}

--- a/aws/resource_aws_rds_cluster_activity_stream.go
+++ b/aws/resource_aws_rds_cluster_activity_stream.go
@@ -33,7 +33,7 @@ func resourceAwsRDSClusterActivityStream() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"arn": {
+			"resource_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -68,7 +68,7 @@ func resourceAwsRDSClusterActivityStream() *schema.Resource {
 func resourceAwsRDSClusterActivityStreamCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
-	resourceArn := d.Get("arn").(string)
+	resourceArn := d.Get("resource_arn").(string)
 	applyImmediately := d.Get("apply_immediately").(bool)
 	kmsKeyId := d.Get("kms_key_id").(string)
 	mode := d.Get("mode").(string)
@@ -137,7 +137,7 @@ func resourceAwsRDSClusterActivityStreamRead(d *schema.ResourceData, meta interf
 		return nil
 	}
 
-	d.Set("arn", dbc.DBClusterArn)
+	d.Set("resource_arn", dbc.DBClusterArn)
 	d.Set("kms_key_id", dbc.ActivityStreamKmsKeyId)
 	d.Set("kinesis_stream_name", dbc.ActivityStreamKinesisStreamName)
 	d.Set("mode", dbc.ActivityStreamMode)
@@ -146,7 +146,7 @@ func resourceAwsRDSClusterActivityStreamRead(d *schema.ResourceData, meta interf
 }
 
 func resourceAwsRDSClusterActivityStreamUpdate(d *schema.ResourceData, meta interface{}) error {
-	if d.HasChanges("arn", "kms_key_id", "mode") {
+	if d.HasChanges("resource_arn", "kms_key_id", "mode") {
 		log.Printf("[DEBUG] Stopping RDS Cluster Activity Stream before updating")
 		if err := resourceAwsRDSClusterActivityStreamDelete(d, meta); err != nil {
 			return err

--- a/aws/resource_aws_rds_cluster_activity_stream.go
+++ b/aws/resource_aws_rds_cluster_activity_stream.go
@@ -16,7 +16,6 @@ func resourceAwsRDSClusterActivityStream() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsRDSClusterActivityStreamCreate,
 		Read:   resourceAwsRDSClusterActivityStreamRead,
-		Update: resourceAwsRDSClusterActivityStreamUpdate,
 		Delete: resourceAwsRDSClusterActivityStreamDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -33,11 +32,6 @@ func resourceAwsRDSClusterActivityStream() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validateArn,
-			},
-			"apply_immediately": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
 			},
 			"kms_key_id": {
 				Type:     schema.TypeString,
@@ -65,13 +59,12 @@ func resourceAwsRDSClusterActivityStreamCreate(d *schema.ResourceData, meta inte
 	conn := meta.(*AWSClient).rdsconn
 
 	resourceArn := d.Get("resource_arn").(string)
-	applyImmediately := d.Get("apply_immediately").(bool)
 	kmsKeyId := d.Get("kms_key_id").(string)
 	mode := d.Get("mode").(string)
 
 	startActivityStreamInput := &rds.StartActivityStreamInput{
 		ResourceArn:      aws.String(resourceArn),
-		ApplyImmediately: aws.Bool(applyImmediately),
+		ApplyImmediately: aws.Bool(true),
 		KmsKeyId:         aws.String(kmsKeyId),
 		Mode:             aws.String(mode),
 	}
@@ -145,22 +138,6 @@ func resourceAwsRDSClusterActivityStreamRead(d *schema.ResourceData, meta interf
 	d.Set("mode", dbc.ActivityStreamMode)
 
 	return nil
-}
-
-func resourceAwsRDSClusterActivityStreamUpdate(d *schema.ResourceData, meta interface{}) error {
-	if d.HasChanges("resource_arn", "kms_key_id", "mode") {
-		log.Printf("[DEBUG] Stopping RDS Cluster Activity Stream before updating")
-		if err := resourceAwsRDSClusterActivityStreamDelete(d, meta); err != nil {
-			return err
-		}
-
-		log.Printf("[DEBUG] Starting RDS Cluster Activity Stream")
-		if err := resourceAwsRDSClusterActivityStreamCreate(d, meta); err != nil {
-			return err
-		}
-	}
-
-	return resourceAwsRDSClusterActivityStreamRead(d, meta)
 }
 
 func resourceAwsRDSClusterActivityStreamDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_rds_cluster_activity_stream.go
+++ b/aws/resource_aws_rds_cluster_activity_stream.go
@@ -54,8 +54,8 @@ func resourceAwsRDSClusterActivityStream() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"sync",
-					"async",
+					rds.ActivityStreamModeSync,
+					rds.ActivityStreamModeAsync,
 				}, false),
 			},
 			"kinesis_stream_name": {

--- a/aws/resource_aws_rds_cluster_activity_stream.go
+++ b/aws/resource_aws_rds_cluster_activity_stream.go
@@ -133,6 +133,12 @@ func resourceAwsRDSClusterActivityStreamRead(d *schema.ResourceData, meta interf
 		return nil
 	}
 
+	if aws.StringValue(dbc.ActivityStreamStatus) == rds.ActivityStreamStatusStopped {
+		log.Printf("[WARN] RDS Cluster (%s) Activity Stream already stopped, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("resource_arn", dbc.DBClusterArn)
 	d.Set("kms_key_id", dbc.ActivityStreamKmsKeyId)
 	d.Set("kinesis_stream_name", dbc.ActivityStreamKinesisStreamName)

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -322,14 +322,14 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_rds_cluster_instance" "test" {
   identifier         = "%[2]s"
-  cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
-  engine             = "${aws_rds_cluster.test.engine}"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
+  engine             = aws_rds_cluster.test.engine
   instance_class     = "db.r5.large"
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  resource_arn = "${aws_rds_cluster.test.arn}"
-  kms_key_id   = "${aws_kms_key.test.key_id}"
+  resource_arn = aws_rds_cluster.test.arn
+  kms_key_id   = aws_kms_key.test.key_id
   mode         = "async"
 
   depends_on = [aws_rds_cluster_instance.test]
@@ -363,14 +363,14 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_rds_cluster_instance" "test" {
   identifier         = "%[2]s"
-  cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
-  engine             = "${aws_rds_cluster.test.engine}"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
+  engine             = aws_rds_cluster.test.engine
   instance_class     = "db.r5.large"
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  resource_arn = "${aws_rds_cluster.test.arn}"
-  kms_key_id   = "${aws_kms_key.new_kms_key.key_id}"
+  resource_arn = aws_rds_cluster.test.arn
+  kms_key_id   = aws_kms_key.new_kms_key.key_id
   mode         = "async"
 
   depends_on = [aws_rds_cluster_instance.test]
@@ -404,14 +404,14 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_rds_cluster_instance" "test" {
   identifier         = "%[2]s"
-  cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
-  engine             = "${aws_rds_cluster.test.engine}"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
+  engine             = aws_rds_cluster.test.engine
   instance_class     = "db.r5.large"
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  resource_arn = "${aws_rds_cluster.test.arn}"
-  kms_key_id   = "${aws_kms_key.test.key_id}"
+  resource_arn = aws_rds_cluster.test.arn
+  kms_key_id   = aws_kms_key.test.key_id
   mode         = "sync"
 
   depends_on = [aws_rds_cluster_instance.test]
@@ -445,14 +445,14 @@ resource "aws_rds_cluster" "new_rds_cluster_test" {
 
 resource "aws_rds_cluster_instance" "new_rds_instance_test" {
   identifier         = "%[2]s"
-  cluster_identifier = "${aws_rds_cluster.new_rds_cluster_test.cluster_identifier}"
-  engine             = "${aws_rds_cluster.new_rds_cluster_test.engine}"
+  cluster_identifier = aws_rds_cluster.new_rds_cluster_test.cluster_identifier
+  engine             = aws_rds_cluster.new_rds_cluster_test.engine
   instance_class     = "db.r5.large"
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  resource_arn = "${aws_rds_cluster.new_rds_cluster_test.arn}"
-  kms_key_id   = "${aws_kms_key.test.key_id}"
+  resource_arn = aws_rds_cluster.new_rds_cluster_test.arn
+  kms_key_id   = aws_kms_key.test.key_id
   mode         = "async"
 
   depends_on = [aws_rds_cluster_instance.new_rds_instance_test]

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -42,7 +42,7 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-aurora-cluster-%s$", rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-aurora-cluster-%s$", rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "kinesis_stream_name"),
 					resource.TestCheckResourceAttr(resourceName, "mode", "async"),
@@ -153,7 +153,7 @@ func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
 	})
 }
 
-func TestAccAWSRDSClusterActivityStream_arn(t *testing.T) {
+func TestAccAWSRDSClusterActivityStream_resourceArn(t *testing.T) {
 	var dbCluster rds.DBCluster
 	rName := acctest.RandString(5)
 	resourceName := "aws_rds_cluster_activity_stream.test"
@@ -168,7 +168,7 @@ func TestAccAWSRDSClusterActivityStream_arn(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-aurora-cluster-%s$", rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-aurora-cluster-%s$", rName))),
 				),
 			},
 			{
@@ -182,7 +182,7 @@ func TestAccAWSRDSClusterActivityStream_arn(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-new-aurora-cluster-%s$", rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-new-aurora-cluster-%s$", rName))),
 				),
 			},
 		},
@@ -318,7 +318,7 @@ resource "aws_rds_cluster_instance" "test" {
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  arn  								= "${aws_rds_cluster.test.arn}"
+  resource_arn        = "${aws_rds_cluster.test.arn}"
   apply_immediately  	= true
   kms_key_id 					= "${aws_kms_key.test.key_id}"
   mode         				= "async"
@@ -407,7 +407,7 @@ resource "aws_rds_cluster_instance" "test" {
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  arn  								= "${aws_rds_cluster.test.arn}"
+  resource_arn        = "${aws_rds_cluster.test.arn}"
   apply_immediately  	= true
   kms_key_id 					= "${aws_kms_key.new_kms_key.key_id}"
   mode         				= "async"
@@ -449,7 +449,7 @@ resource "aws_rds_cluster_instance" "test" {
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  arn  								= "${aws_rds_cluster.test.arn}"
+  resource_arn        = "${aws_rds_cluster.test.arn}"
   apply_immediately  	= true
   kms_key_id 					= "${aws_kms_key.test.key_id}"
   mode         				= "sync"
@@ -491,7 +491,7 @@ resource "aws_rds_cluster_instance" "new_rds_instance_test" {
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  arn  								= "${aws_rds_cluster.new_rds_cluster_test.arn}"
+  resource_arn        = "${aws_rds_cluster.new_rds_cluster_test.arn}"
   apply_immediately  	= true
   kms_key_id 					= "${aws_kms_key.test.key_id}"
   mode         				= "async"

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -27,7 +27,8 @@ func init() {
 
 func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 	var dbCluster rds.DBCluster
-	rName := acctest.RandString(5)
+	clusterName := acctest.RandomWithPrefix("tf-testacc-aurora-cluster")
+	instanceName := acctest.RandomWithPrefix("tf-testacc-aurora-instance")
 	resourceName := "aws_rds_cluster_activity_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -36,11 +37,11 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Config: testAccAWSClusterActivityStreamConfig(clusterName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-aurora-cluster-%s$", rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile("cluster:"+clusterName)),
 					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "kinesis_stream_name"),
 					resource.TestCheckResourceAttr(resourceName, "mode", rds.ActivityStreamModeAsync),
@@ -59,7 +60,8 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 
 func TestAccAWSRDSClusterActivityStream_disappears(t *testing.T) {
 	var dbCluster rds.DBCluster
-	rName := acctest.RandString(5)
+	clusterName := acctest.RandomWithPrefix("tf-testacc-aurora-cluster")
+	instanceName := acctest.RandomWithPrefix("tf-testacc-aurora-instance")
 	resourceName := "aws_rds_cluster_activity_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -68,7 +70,7 @@ func TestAccAWSRDSClusterActivityStream_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Config: testAccAWSClusterActivityStreamConfig(clusterName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsRDSClusterActivityStream(), resourceName),
@@ -81,7 +83,8 @@ func TestAccAWSRDSClusterActivityStream_disappears(t *testing.T) {
 
 func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
 	var dbCluster rds.DBCluster
-	rName := acctest.RandString(5)
+	clusterName := acctest.RandomWithPrefix("tf-testacc-aurora-cluster")
+	instanceName := acctest.RandomWithPrefix("tf-testacc-aurora-instance")
 	resourceName := "aws_rds_cluster_activity_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -90,7 +93,7 @@ func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Config: testAccAWSClusterActivityStreamConfig(clusterName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
@@ -104,7 +107,7 @@ func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 			{
-				Config: testAccAWSClusterActivityStreamConfig_kmsKeyId(rName),
+				Config: testAccAWSClusterActivityStreamConfig_kmsKeyId(clusterName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
@@ -117,7 +120,8 @@ func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
 
 func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
 	var dbCluster rds.DBCluster
-	rName := acctest.RandString(5)
+	clusterName := acctest.RandomWithPrefix("tf-testacc-aurora-cluster")
+	instanceName := acctest.RandomWithPrefix("tf-testacc-aurora-instance")
 	resourceName := "aws_rds_cluster_activity_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -126,7 +130,7 @@ func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Config: testAccAWSClusterActivityStreamConfig(clusterName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
@@ -140,7 +144,7 @@ func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 			{
-				Config: testAccAWSClusterActivityStreamConfig_modeSync(rName),
+				Config: testAccAWSClusterActivityStreamConfig_modeSync(clusterName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
@@ -153,7 +157,10 @@ func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
 
 func TestAccAWSRDSClusterActivityStream_resourceArn(t *testing.T) {
 	var dbCluster rds.DBCluster
-	rName := acctest.RandString(5)
+	clusterName := acctest.RandomWithPrefix("tf-testacc-aurora-cluster")
+	instanceName := acctest.RandomWithPrefix("tf-testacc-aurora-instance")
+	newClusterName := acctest.RandomWithPrefix("tf-testacc-new-aurora-cluster")
+	newInstanceName := acctest.RandomWithPrefix("tf-testacc-new-aurora-instance")
 	resourceName := "aws_rds_cluster_activity_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -162,11 +169,11 @@ func TestAccAWSRDSClusterActivityStream_resourceArn(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Config: testAccAWSClusterActivityStreamConfig(clusterName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-aurora-cluster-%s$", rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile("cluster:"+clusterName)),
 				),
 			},
 			{
@@ -176,11 +183,11 @@ func TestAccAWSRDSClusterActivityStream_resourceArn(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 			{
-				Config: testAccAWSClusterActivityStreamConfig_arn(rName),
+				Config: testAccAWSClusterActivityStreamConfig_resourceArn(newClusterName, newInstanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-new-aurora-cluster-%s$", rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile("cluster:"+newClusterName)),
 				),
 			},
 		},
@@ -284,19 +291,19 @@ func testAccCheckAWSClusterActivityStreamDestroyWithProvider(s *terraform.State,
 	return nil
 }
 
-func testAccAWSClusterActivityStreamConfig(rName string) string {
+func testAccAWSClusterActivityStreamConfig(clusterName, instanceName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 }
 
 resource "aws_kms_key" "test" {
-	description             = "tf-testacc-kms-key-%[1]s"
+	description             = "Testing for AWS RDS Cluster Activity Stream"
   deletion_window_in_days = 7
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier              = "tf-testacc-aurora-cluster-%[1]s"
+  cluster_identifier              = "%[1]s"
   engine                  				= "aurora-postgresql"
   engine_version                  = "10.11"
 	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
@@ -309,7 +316,7 @@ resource "aws_rds_cluster" "test" {
 }
 
 resource "aws_rds_cluster_instance" "test" {
-	identifier         = "tf-testacc-aurora-instance-%[1]s"
+	identifier         = "%[2]s"
   cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
   engine             = "${aws_rds_cluster.test.engine}"
   instance_class     = "db.r5.large"
@@ -323,22 +330,22 @@ resource "aws_rds_cluster_activity_stream" "test" {
 	
 	depends_on = [aws_rds_cluster_instance.test]
 }
-`, rName)
+`, clusterName, instanceName)
 }
 
-func testAccAWSClusterActivityStreamConfig_kmsKeyId(rName string) string {
+func testAccAWSClusterActivityStreamConfig_kmsKeyId(clusterName, instanceName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 }
 
 resource "aws_kms_key" "new_kms_key" {
-	description             = "tf-testacc-new-kms-key-%[1]s"
+	description             = "Testing for AWS RDS Cluster Activity Stream"
   deletion_window_in_days = 7
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier              = "tf-testacc-aurora-cluster-%[1]s"
+  cluster_identifier              = "%[1]s"
   engine                  				= "aurora-postgresql"
   engine_version                  = "10.11"
 	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
@@ -351,7 +358,7 @@ resource "aws_rds_cluster" "test" {
 }
 
 resource "aws_rds_cluster_instance" "test" {
-	identifier         = "tf-testacc-aurora-instance-%[1]s"
+	identifier         = "%[2]s"
   cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
   engine             = "${aws_rds_cluster.test.engine}"
   instance_class     = "db.r5.large"
@@ -365,22 +372,22 @@ resource "aws_rds_cluster_activity_stream" "test" {
 	
 	depends_on = [aws_rds_cluster_instance.test]
 }
-`, rName)
+`, clusterName, instanceName)
 }
 
-func testAccAWSClusterActivityStreamConfig_modeSync(rName string) string {
+func testAccAWSClusterActivityStreamConfig_modeSync(clusterName, instanceName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 }
 
 resource "aws_kms_key" "test" {
-	description             = "tf-testacc-kms-key-%[1]s"
+	description             = "Testing for AWS RDS Cluster Activity Stream"
   deletion_window_in_days = 7
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier              = "tf-testacc-aurora-cluster-%[1]s"
+  cluster_identifier              = "%[1]s"
   engine                  				= "aurora-postgresql"
   engine_version                  = "10.11"
 	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
@@ -393,7 +400,7 @@ resource "aws_rds_cluster" "test" {
 }
 
 resource "aws_rds_cluster_instance" "test" {
-	identifier         = "tf-testacc-aurora-instance-%[1]s"
+	identifier         = "%[2]s"
   cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
   engine             = "${aws_rds_cluster.test.engine}"
   instance_class     = "db.r5.large"
@@ -407,22 +414,22 @@ resource "aws_rds_cluster_activity_stream" "test" {
 	
 	depends_on = [aws_rds_cluster_instance.test]
 }
-`, rName)
+`, clusterName, instanceName)
 }
 
-func testAccAWSClusterActivityStreamConfig_arn(rName string) string {
+func testAccAWSClusterActivityStreamConfig_resourceArn(clusterName, instanceName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 }
 
 resource "aws_kms_key" "test" {
-	description             = "tf-testacc-kms-key-%[1]s"
+	description             = "Testing for AWS RDS Cluster Activity Stream"
   deletion_window_in_days = 7
 }
 
 resource "aws_rds_cluster" "new_rds_cluster_test" {
-  cluster_identifier              = "tf-testacc-new-aurora-cluster-%[1]s"
+  cluster_identifier              = "%[1]s"
   engine                  				= "aurora-postgresql"
   engine_version                  = "10.11"
 	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
@@ -435,7 +442,7 @@ resource "aws_rds_cluster" "new_rds_cluster_test" {
 }
 
 resource "aws_rds_cluster_instance" "new_rds_instance_test" {
-	identifier         = "tf-testacc-new-aurora-instance-%[1]s"
+	identifier         = "%[2]s"
   cluster_identifier = "${aws_rds_cluster.new_rds_cluster_test.cluster_identifier}"
   engine             = "${aws_rds_cluster.new_rds_cluster_test.engine}"
   instance_class     = "db.r5.large"
@@ -449,5 +456,5 @@ resource "aws_rds_cluster_activity_stream" "test" {
 	
 	depends_on = [aws_rds_cluster_instance.new_rds_instance_test]
 }
-`, rName)
+`, clusterName, instanceName)
 }

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -45,7 +45,7 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-aurora-cluster-%s$", rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "kinesis_stream_name"),
-					resource.TestCheckResourceAttr(resourceName, "mode", "async"),
+					resource.TestCheckResourceAttr(resourceName, "mode", rds.ActivityStreamModeAsync),
 					resource.TestCheckResourceAttr(resourceName, "apply_immediately", "true"),
 				),
 			},
@@ -132,7 +132,7 @@ func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "mode", "async"),
+					resource.TestCheckResourceAttr(resourceName, "mode", rds.ActivityStreamModeAsync),
 				),
 			},
 			{
@@ -146,7 +146,7 @@ func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "mode", "sync"),
+					resource.TestCheckResourceAttr(resourceName, "mode", rds.ActivityStreamModeSync),
 				),
 			},
 		},
@@ -242,7 +242,7 @@ func testAccCheckAWSRDSClusterActivityStreamAttributes(v *rds.DBCluster) resourc
 			return fmt.Errorf("incorrect activity stream status: expected: %s, got: %s", rds.ActivityStreamStatusStarted, aws.StringValue(v.ActivityStreamStatus))
 		}
 
-		if aws.StringValue(v.ActivityStreamMode) != "sync" && aws.StringValue(v.ActivityStreamMode) != "async" {
+		if aws.StringValue(v.ActivityStreamMode) != rds.ActivityStreamModeSync && aws.StringValue(v.ActivityStreamMode) != rds.ActivityStreamModeAsync {
 			return fmt.Errorf("incorrect activity stream mode: expected: sync or async, got: %s", aws.StringValue(v.ActivityStreamMode))
 		}
 

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -48,14 +48,12 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "kinesis_stream_name"),
 					resource.TestCheckResourceAttr(resourceName, "mode", rds.ActivityStreamModeAsync),
-					resource.TestCheckResourceAttr(resourceName, "apply_immediately", "true"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -106,10 +104,9 @@ func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSClusterActivityStreamConfig_kmsKeyId(clusterName, instanceName),
@@ -143,10 +140,9 @@ func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSClusterActivityStreamConfig_modeSync(clusterName, instanceName),
@@ -186,10 +182,9 @@ func TestAccAWSRDSClusterActivityStream_resourceArn(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSClusterActivityStreamConfig_resourceArn(newClusterName, newInstanceName),
@@ -334,7 +329,6 @@ resource "aws_rds_cluster_instance" "test" {
 
 resource "aws_rds_cluster_activity_stream" "test" {
   resource_arn        = "${aws_rds_cluster.test.arn}"
-  apply_immediately  	= true
   kms_key_id 					= "${aws_kms_key.test.key_id}"
   mode         				= "async"
 	
@@ -376,7 +370,6 @@ resource "aws_rds_cluster_instance" "test" {
 
 resource "aws_rds_cluster_activity_stream" "test" {
   resource_arn        = "${aws_rds_cluster.test.arn}"
-  apply_immediately  	= true
   kms_key_id 					= "${aws_kms_key.new_kms_key.key_id}"
   mode         				= "async"
 	
@@ -418,7 +411,6 @@ resource "aws_rds_cluster_instance" "test" {
 
 resource "aws_rds_cluster_activity_stream" "test" {
   resource_arn        = "${aws_rds_cluster.test.arn}"
-  apply_immediately  	= true
   kms_key_id 					= "${aws_kms_key.test.key_id}"
   mode         				= "sync"
 	
@@ -460,7 +452,6 @@ resource "aws_rds_cluster_instance" "new_rds_instance_test" {
 
 resource "aws_rds_cluster_activity_stream" "test" {
   resource_arn        = "${aws_rds_cluster.new_rds_cluster_test.arn}"
-  apply_immediately  	= true
   kms_key_id 					= "${aws_kms_key.test.key_id}"
   mode         				= "async"
 	

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -35,6 +35,7 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
@@ -67,6 +68,7 @@ func TestAccAWSRDSClusterActivityStream_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
@@ -92,6 +94,7 @@ func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
@@ -128,6 +131,7 @@ func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{
@@ -169,6 +173,7 @@ func TestAccAWSRDSClusterActivityStream_resourceArn(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -303,15 +303,15 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_kms_key" "test" {
-	description             = "Testing for AWS RDS Cluster Activity Stream"
+  description             = "Testing for AWS RDS Cluster Activity Stream"
   deletion_window_in_days = 7
 }
 
 resource "aws_rds_cluster" "test" {
   cluster_identifier              = "%[1]s"
-  engine                  				= "aurora-postgresql"
+  engine                          = "aurora-postgresql"
   engine_version                  = "10.11"
-	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
+  availability_zones              = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   database_name                   = "mydb"
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
@@ -321,18 +321,18 @@ resource "aws_rds_cluster" "test" {
 }
 
 resource "aws_rds_cluster_instance" "test" {
-	identifier         = "%[2]s"
+  identifier         = "%[2]s"
   cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
   engine             = "${aws_rds_cluster.test.engine}"
   instance_class     = "db.r5.large"
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  resource_arn        = "${aws_rds_cluster.test.arn}"
-  kms_key_id 					= "${aws_kms_key.test.key_id}"
-  mode         				= "async"
-	
-	depends_on = [aws_rds_cluster_instance.test]
+  resource_arn = "${aws_rds_cluster.test.arn}"
+  kms_key_id   = "${aws_kms_key.test.key_id}"
+  mode         = "async"
+
+  depends_on = [aws_rds_cluster_instance.test]
 }
 `, clusterName, instanceName)
 }
@@ -344,15 +344,15 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_kms_key" "new_kms_key" {
-	description             = "Testing for AWS RDS Cluster Activity Stream"
+  description             = "Testing for AWS RDS Cluster Activity Stream"
   deletion_window_in_days = 7
 }
 
 resource "aws_rds_cluster" "test" {
   cluster_identifier              = "%[1]s"
-  engine                  				= "aurora-postgresql"
+  engine                          = "aurora-postgresql"
   engine_version                  = "10.11"
-	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
+  availability_zones              = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   database_name                   = "mydb"
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
@@ -362,18 +362,18 @@ resource "aws_rds_cluster" "test" {
 }
 
 resource "aws_rds_cluster_instance" "test" {
-	identifier         = "%[2]s"
+  identifier         = "%[2]s"
   cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
   engine             = "${aws_rds_cluster.test.engine}"
   instance_class     = "db.r5.large"
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  resource_arn        = "${aws_rds_cluster.test.arn}"
-  kms_key_id 					= "${aws_kms_key.new_kms_key.key_id}"
-  mode         				= "async"
-	
-	depends_on = [aws_rds_cluster_instance.test]
+  resource_arn = "${aws_rds_cluster.test.arn}"
+  kms_key_id   = "${aws_kms_key.new_kms_key.key_id}"
+  mode         = "async"
+
+  depends_on = [aws_rds_cluster_instance.test]
 }
 `, clusterName, instanceName)
 }
@@ -385,15 +385,15 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_kms_key" "test" {
-	description             = "Testing for AWS RDS Cluster Activity Stream"
+  description             = "Testing for AWS RDS Cluster Activity Stream"
   deletion_window_in_days = 7
 }
 
 resource "aws_rds_cluster" "test" {
   cluster_identifier              = "%[1]s"
-  engine                  				= "aurora-postgresql"
+  engine                          = "aurora-postgresql"
   engine_version                  = "10.11"
-	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
+  availability_zones              = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   database_name                   = "mydb"
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
@@ -403,18 +403,18 @@ resource "aws_rds_cluster" "test" {
 }
 
 resource "aws_rds_cluster_instance" "test" {
-	identifier         = "%[2]s"
+  identifier         = "%[2]s"
   cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
   engine             = "${aws_rds_cluster.test.engine}"
   instance_class     = "db.r5.large"
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  resource_arn        = "${aws_rds_cluster.test.arn}"
-  kms_key_id 					= "${aws_kms_key.test.key_id}"
-  mode         				= "sync"
-	
-	depends_on = [aws_rds_cluster_instance.test]
+  resource_arn = "${aws_rds_cluster.test.arn}"
+  kms_key_id   = "${aws_kms_key.test.key_id}"
+  mode         = "sync"
+
+  depends_on = [aws_rds_cluster_instance.test]
 }
 `, clusterName, instanceName)
 }
@@ -426,15 +426,15 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_kms_key" "test" {
-	description             = "Testing for AWS RDS Cluster Activity Stream"
+  description             = "Testing for AWS RDS Cluster Activity Stream"
   deletion_window_in_days = 7
 }
 
 resource "aws_rds_cluster" "new_rds_cluster_test" {
   cluster_identifier              = "%[1]s"
-  engine                  				= "aurora-postgresql"
+  engine                          = "aurora-postgresql"
   engine_version                  = "10.11"
-	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
+  availability_zones              = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   database_name                   = "mydb"
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
@@ -444,18 +444,18 @@ resource "aws_rds_cluster" "new_rds_cluster_test" {
 }
 
 resource "aws_rds_cluster_instance" "new_rds_instance_test" {
-	identifier         = "%[2]s"
+  identifier         = "%[2]s"
   cluster_identifier = "${aws_rds_cluster.new_rds_cluster_test.cluster_identifier}"
   engine             = "${aws_rds_cluster.new_rds_cluster_test.engine}"
   instance_class     = "db.r5.large"
 }
 
 resource "aws_rds_cluster_activity_stream" "test" {
-  resource_arn        = "${aws_rds_cluster.new_rds_cluster_test.arn}"
-  kms_key_id 					= "${aws_kms_key.test.key_id}"
-  mode         				= "async"
-	
-	depends_on = [aws_rds_cluster_instance.new_rds_instance_test]
+  resource_arn = "${aws_rds_cluster.new_rds_cluster_test.arn}"
+  kms_key_id   = "${aws_kms_key.test.key_id}"
+  mode         = "async"
+
+  depends_on = [aws_rds_cluster_instance.new_rds_instance_test]
 }
 `, clusterName, instanceName)
 }

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -1,0 +1,502 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_rds_cluster_activity_stream", &resource.Sweeper{
+		Name: "aws_rds_cluster_activity_stream",
+		F:    func(region string) error { return nil },
+		Dependencies: []string{
+			"aws_kms_key",
+			"aws_kinesis_stream",
+			"aws_rds_cluster",
+		},
+	})
+}
+
+func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
+	var dbCluster rds.DBCluster
+	rName := acctest.RandString(5)
+	resourceName := "aws_rds_cluster_activity_stream.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
+					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-aurora-cluster-%s$", rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "kinesis_stream_name"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "async"),
+					resource.TestCheckResourceAttr(resourceName, "apply_immediately", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterActivityStream_disappears(t *testing.T) {
+	var dbCluster rds.DBCluster
+	rName := acctest.RandString(5)
+	resourceName := "aws_rds_cluster_activity_stream.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
+					testAccCheckAWSRDSClusterActivityStreamDisappears(&dbCluster),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
+	var dbCluster rds.DBCluster
+	rName := acctest.RandString(5)
+	resourceName := "aws_rds_cluster_activity_stream.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
+					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSClusterActivityStreamConfig_kmsKeyId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
+					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterActivityStream_mode(t *testing.T) {
+	var dbCluster rds.DBCluster
+	rName := acctest.RandString(5)
+	resourceName := "aws_rds_cluster_activity_stream.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
+					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "mode", "async"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSClusterActivityStreamConfig_modeSync(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
+					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "mode", "sync"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterActivityStream_arn(t *testing.T) {
+	var dbCluster rds.DBCluster
+	rName := acctest.RandString(5)
+	resourceName := "aws_rds_cluster_activity_stream.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterActivityStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterActivityStreamConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
+					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-aurora-cluster-%s$", rName))),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSClusterActivityStreamConfig_arn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
+					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster:tf-testacc-new-aurora-cluster-%s$", rName))),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSRDSClusterActivityStreamExists(resourceName string, dbCluster *rds.DBCluster) resource.TestCheckFunc {
+	return testAccCheckAWSRDSClusterActivityStreamExistsWithProvider(resourceName, dbCluster, testAccProvider)
+}
+
+func testAccCheckAWSRDSClusterActivityStreamExistsWithProvider(resourceName string, dbCluster *rds.DBCluster, provider *schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("DBCluster ID is not set")
+		}
+
+		conn := provider.Meta().(*AWSClient).rdsconn
+
+		response, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+			DBClusterIdentifier: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if len(response.DBClusters) != 1 || *response.DBClusters[0].DBClusterArn != rs.Primary.ID {
+			return fmt.Errorf("DBCluster not found")
+		}
+
+		*dbCluster = *response.DBClusters[0]
+		return nil
+	}
+}
+
+func testAccCheckAWSRDSClusterActivityStreamAttributes(v *rds.DBCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if aws.StringValue(v.DBClusterArn) == "" {
+			return fmt.Errorf("empty RDS Cluster arn")
+		}
+
+		if aws.StringValue(v.ActivityStreamKmsKeyId) == "" {
+			return fmt.Errorf("empty RDS Cluster activity stream kms key id")
+		}
+
+		if aws.StringValue(v.ActivityStreamKinesisStreamName) == "" {
+			return fmt.Errorf("empty RDS Cluster activity stream kinesis stream name")
+		}
+
+		if aws.StringValue(v.ActivityStreamStatus) != rds.ActivityStreamStatusStarted {
+			return fmt.Errorf("incorrect activity stream status: expected: %s, got: %s", rds.ActivityStreamStatusStarted, aws.StringValue(v.ActivityStreamStatus))
+		}
+
+		if aws.StringValue(v.ActivityStreamMode) != "sync" && aws.StringValue(v.ActivityStreamMode) != "async" {
+			return fmt.Errorf("incorrect activity stream mode: expected: sync or async, got: %s", aws.StringValue(v.ActivityStreamMode))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSClusterActivityStreamDestroy(s *terraform.State) error {
+	return testAccCheckAWSClusterActivityStreamDestroyWithProvider(s, testAccProvider)
+}
+
+func testAccCheckAWSClusterActivityStreamDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	conn := provider.Meta().(*AWSClient).rdsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_rds_cluster_activity_stream" {
+			continue
+		}
+
+		var err error
+		resp, err := conn.DescribeDBClusters(
+			&rds.DescribeDBClustersInput{
+				DBClusterIdentifier: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if len(resp.DBClusters) != 0 &&
+				*resp.DBClusters[0].ActivityStreamStatus != rds.ActivityStreamStatusStopped {
+				return fmt.Errorf("DB Cluster %s Activity Stream still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the cluster is already destroyed
+		if isAWSErr(err, rds.ErrCodeDBClusterNotFoundFault, "") {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSClusterActivityStreamConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_kms_key" "test" {
+	description             = "tf-testacc-kms-key-%[1]s"
+  deletion_window_in_days = 7
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier              = "tf-testacc-aurora-cluster-%[1]s"
+  engine                  				= "aurora-postgresql"
+  engine_version                  = "10.11"
+	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
+  database_name                   = "mydb"
+  master_username                 = "foo"
+  master_password                 = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora-postgresql10"
+  skip_final_snapshot             = true
+  deletion_protection             = false
+}
+
+resource "aws_rds_cluster_instance" "test" {
+	identifier         = "tf-testacc-aurora-instance-%[1]s"
+  cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
+  engine             = "${aws_rds_cluster.test.engine}"
+  instance_class     = "db.r5.large"
+}
+
+resource "aws_rds_cluster_activity_stream" "test" {
+  arn  								= "${aws_rds_cluster.test.arn}"
+  apply_immediately  	= true
+  kms_key_id 					= "${aws_kms_key.test.key_id}"
+  mode         				= "async"
+	
+	depends_on = [aws_rds_cluster_instance.test]
+}
+`, rName)
+}
+
+func testAccCheckAWSRDSClusterActivityStreamDisappears(v *rds.DBCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+		// delete db instances
+		for _, dbi := range v.DBClusterMembers {
+			log.Printf("[DEBUG] Deleting DB instance: %s", *dbi.DBInstanceIdentifier)
+
+			_, err := conn.DeleteDBInstance(&rds.DeleteDBInstanceInput{
+				DBInstanceIdentifier: dbi.DBInstanceIdentifier,
+				SkipFinalSnapshot:    aws.Bool(true),
+			})
+
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete DB instance %s: %s", *dbi.DBInstanceIdentifier, err)
+				return err
+			}
+
+			if err := waitUntilAwsDbInstanceIsDeleted(*dbi.DBInstanceIdentifier, conn, 40*time.Minute); err != nil {
+				log.Printf("[ERROR] Failure while waiting for DB instance %s to be deleted: %s", *dbi.DBInstanceIdentifier, err)
+				return err
+			}
+		}
+
+		// delete db cluster
+		clusterId := aws.StringValue(v.DBClusterIdentifier)
+		log.Printf("[DEBUG] Deleting RDS DB Cluster: %s", clusterId)
+
+		_, err := conn.DeleteDBCluster(&rds.DeleteDBClusterInput{
+			DBClusterIdentifier: v.DBClusterIdentifier,
+			SkipFinalSnapshot:   aws.Bool(true),
+		})
+
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete RDS DB Cluster (%s): %s", clusterId, err)
+			return err
+		}
+
+		if err := waitForRDSClusterDeletion(conn, clusterId, 40*time.Minute); err != nil {
+			log.Printf("[ERROR] Failure while waiting for RDS DB Cluster (%s) to be deleted: %s", clusterId, err)
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSClusterActivityStreamConfig_kmsKeyId(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_kms_key" "new_kms_key" {
+	description             = "tf-testacc-new-kms-key-%[1]s"
+  deletion_window_in_days = 7
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier              = "tf-testacc-aurora-cluster-%[1]s"
+  engine                  				= "aurora-postgresql"
+  engine_version                  = "10.11"
+	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
+  database_name                   = "mydb"
+  master_username                 = "foo"
+  master_password                 = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora-postgresql10"
+  skip_final_snapshot             = true
+  deletion_protection             = false
+}
+
+resource "aws_rds_cluster_instance" "test" {
+	identifier         = "tf-testacc-aurora-instance-%[1]s"
+  cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
+  engine             = "${aws_rds_cluster.test.engine}"
+  instance_class     = "db.r5.large"
+}
+
+resource "aws_rds_cluster_activity_stream" "test" {
+  arn  								= "${aws_rds_cluster.test.arn}"
+  apply_immediately  	= true
+  kms_key_id 					= "${aws_kms_key.new_kms_key.key_id}"
+  mode         				= "async"
+	
+	depends_on = [aws_rds_cluster_instance.test]
+}
+`, rName)
+}
+
+func testAccAWSClusterActivityStreamConfig_modeSync(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_kms_key" "test" {
+	description             = "tf-testacc-kms-key-%[1]s"
+  deletion_window_in_days = 7
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier              = "tf-testacc-aurora-cluster-%[1]s"
+  engine                  				= "aurora-postgresql"
+  engine_version                  = "10.11"
+	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
+  database_name                   = "mydb"
+  master_username                 = "foo"
+  master_password                 = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora-postgresql10"
+  skip_final_snapshot             = true
+  deletion_protection             = false
+}
+
+resource "aws_rds_cluster_instance" "test" {
+	identifier         = "tf-testacc-aurora-instance-%[1]s"
+  cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
+  engine             = "${aws_rds_cluster.test.engine}"
+  instance_class     = "db.r5.large"
+}
+
+resource "aws_rds_cluster_activity_stream" "test" {
+  arn  								= "${aws_rds_cluster.test.arn}"
+  apply_immediately  	= true
+  kms_key_id 					= "${aws_kms_key.test.key_id}"
+  mode         				= "sync"
+	
+	depends_on = [aws_rds_cluster_instance.test]
+}
+`, rName)
+}
+
+func testAccAWSClusterActivityStreamConfig_arn(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_kms_key" "test" {
+	description             = "tf-testacc-kms-key-%[1]s"
+  deletion_window_in_days = 7
+}
+
+resource "aws_rds_cluster" "new_rds_cluster_test" {
+  cluster_identifier              = "tf-testacc-new-aurora-cluster-%[1]s"
+  engine                  				= "aurora-postgresql"
+  engine_version                  = "10.11"
+	availability_zones  						= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
+  database_name                   = "mydb"
+  master_username                 = "foo"
+  master_password                 = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora-postgresql10"
+  skip_final_snapshot             = true
+  deletion_protection             = false
+}
+
+resource "aws_rds_cluster_instance" "new_rds_instance_test" {
+	identifier         = "tf-testacc-new-aurora-instance-%[1]s"
+  cluster_identifier = "${aws_rds_cluster.new_rds_cluster_test.cluster_identifier}"
+  engine             = "${aws_rds_cluster.new_rds_cluster_test.engine}"
+  instance_class     = "db.r5.large"
+}
+
+resource "aws_rds_cluster_activity_stream" "test" {
+  arn  								= "${aws_rds_cluster.new_rds_cluster_test.arn}"
+  apply_immediately  	= true
+  kms_key_id 					= "${aws_kms_key.test.key_id}"
+  mode         				= "async"
+	
+	depends_on = [aws_rds_cluster_instance.new_rds_instance_test]
+}
+`, rName)
+}

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func init() {

--- a/aws/resource_aws_rds_cluster_activity_stream_test.go
+++ b/aws/resource_aws_rds_cluster_activity_stream_test.go
@@ -30,6 +30,8 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 	clusterName := acctest.RandomWithPrefix("tf-testacc-aurora-cluster")
 	instanceName := acctest.RandomWithPrefix("tf-testacc-aurora-instance")
 	resourceName := "aws_rds_cluster_activity_stream.test"
+	rdsClusterResourceName := "aws_rds_cluster.test"
+	kmsKeyResourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -42,7 +44,8 @@ func TestAccAWSRDSClusterActivityStream_basic(t *testing.T) {
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
 					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile("cluster:"+clusterName)),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", rdsClusterResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "kinesis_stream_name"),
 					resource.TestCheckResourceAttr(resourceName, "mode", rds.ActivityStreamModeAsync),
 					resource.TestCheckResourceAttr(resourceName, "apply_immediately", "true"),
@@ -86,6 +89,8 @@ func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
 	clusterName := acctest.RandomWithPrefix("tf-testacc-aurora-cluster")
 	instanceName := acctest.RandomWithPrefix("tf-testacc-aurora-instance")
 	resourceName := "aws_rds_cluster_activity_stream.test"
+	kmsKeyResourceName := "aws_kms_key.test"
+	newKmsKeyResourceName := "aws_kms_key.new_kms_key"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,7 +102,7 @@ func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "key_id"),
 				),
 			},
 			{
@@ -111,7 +116,7 @@ func TestAccAWSRDSClusterActivityStream_kmsKeyId(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", newKmsKeyResourceName, "key_id"),
 				),
 			},
 		},
@@ -161,7 +166,10 @@ func TestAccAWSRDSClusterActivityStream_resourceArn(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf-testacc-aurora-instance")
 	newClusterName := acctest.RandomWithPrefix("tf-testacc-new-aurora-cluster")
 	newInstanceName := acctest.RandomWithPrefix("tf-testacc-new-aurora-instance")
+
 	resourceName := "aws_rds_cluster_activity_stream.test"
+	rdsClusterResourceName := "aws_rds_cluster.test"
+	newRdsClusterResourceName := "aws_rds_cluster.new_rds_cluster_test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -174,6 +182,7 @@ func TestAccAWSRDSClusterActivityStream_resourceArn(t *testing.T) {
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
 					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile("cluster:"+clusterName)),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", rdsClusterResourceName, "arn"),
 				),
 			},
 			{
@@ -188,6 +197,7 @@ func TestAccAWSRDSClusterActivityStream_resourceArn(t *testing.T) {
 					testAccCheckAWSRDSClusterActivityStreamExists(resourceName, &dbCluster),
 					testAccCheckAWSRDSClusterActivityStreamAttributes(&dbCluster),
 					testAccMatchResourceAttrRegionalARN(resourceName, "resource_arn", "rds", regexp.MustCompile("cluster:"+newClusterName)),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", newRdsClusterResourceName, "arn"),
 				),
 			},
 		},

--- a/website/docs/r/rds_cluster_activity_stream.html.markdown
+++ b/website/docs/r/rds_cluster_activity_stream.html.markdown
@@ -12,9 +12,8 @@ Manages RDS Aurora Cluster Database Activity Streams.
 
 Database Activity Streams have some limits and requirements, You can refer to the [User Guide][1].
 
-~> **Note:** using `apply_immediately` can result in a
-brief downtime as the server reboots. See the AWS Docs on [RDS Maintenance][2]
-for more information.
+~> **Note:** `apply_immediately` always is true, cannot be modified. 
+Because when apply_immediately=false, terraform cannot get activity stream associated attributes.
 
 ~> **Note:** This resource depends on having one `aws_rds_cluster_instance` created.
 To avoid race conditions when all resources are being created together, you need to add explicit resource
@@ -66,7 +65,6 @@ The following arguments are supported:
 * `resource_arn` - (Required, Forces new resources) The Amazon Resource Name (ARN) of the DB cluster.
 * `mode` - (Required, Forces new resources) Specifies the mode of the database activity stream. One of: `sync` , `async` .
 * `kms_key_id` - (Required, Forces new resources) The AWS KMS key identifier used for encrypting messages in the database activity stream.
-* `apply_immediately` - (Optional) Specifies whether or not the database activity stream is to start immediately, or during the next maintenance window. Default is `false`.
 
 
 ## Attributes Reference

--- a/website/docs/r/rds_cluster_activity_stream.html.markdown
+++ b/website/docs/r/rds_cluster_activity_stream.html.markdown
@@ -1,0 +1,89 @@
+---
+subcategory: "RDS"
+layout: "aws"
+page_title: "AWS: aws_rds_cluster_activity_stream"
+description: |-
+  Manages RDS Aurora Cluster Database Activity Streams
+---
+
+# Resource: aws_rds_cluster_activity_stream
+
+Manages RDS Aurora Cluster Database Activity Streams.
+
+Database Activity Streams have some limits and requirements, You can refer to the [User Guide][1].
+
+~> **Note:** using `apply_immediately` can result in a
+brief downtime as the server reboots. See the AWS Docs on [RDS Maintenance][2]
+for more information.
+
+~> **Note:** This resource depends on having one `aws_rds_cluster_instance` created.
+To avoid race conditions when all resources are being created together, you need to add explicit resource
+references using the [resource `depends_on` meta-argument](/docs/configuration/resources.html#depends_on-explicit-resource-dependencies).
+ 
+
+## Example Usage
+
+```hcl
+resource "aws_rds_cluster" "default" {
+  cluster_identifier      = "aurora-cluster-demo"
+  availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  database_name           = "mydb"
+  master_username         = "foo"
+  master_password         = "mustbeeightcharaters"
+  engine                  = "aurora-postgresql"
+  engine_version          = "10.11"
+}
+
+resource "aws_rds_cluster_instance" "default" {
+  identifier         = "aurora-instance-demo"
+  cluster_identifier = aws_rds_cluster.default.cluster_identifier
+  engine             = aws_rds_cluster.default.engine
+  instance_class     = "db.r5.large"
+}
+
+resource "aws_kms_key" "default" {
+  description = "aws kms key"
+}
+
+resource "aws_rds_cluster_activity_stream" "default" {
+  arn               = aws_rds_cluster.default.arn
+  mode              = "async"
+  kms_key_id        = aws_kms_key.default.key_id
+  apply_immediately = true
+
+  depends_on = [aws_rds_cluster_instance.default]
+}
+```
+
+
+## Argument Reference
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/start-activity-stream.html).
+
+The following arguments are supported:
+
+* `arn` - (Required, Forces new resources) The Amazon Resource Name (ARN) of the DB cluster.
+* `mode` - (Required, Forces new resources) Specifies the mode of the database activity stream. One of: `sync` , `async` .
+* `kms_key_id` - (Required, Forces new resources) The AWS KMS key identifier used for encrypting messages in the database activity stream.
+* `apply_immediately` - (Optional) Specifies whether or not the database activity stream is to start immediately, or during the next maintenance window. Default is `false`.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The Amazon Resource Name (ARN) of the DB cluster.
+* `kinesis_stream_name` - The name of the Amazon Kinesis data stream to be used for the database activity stream.
+
+
+## Import
+
+RDS Aurora Cluster Database Activity Streams can be imported using the `arn`, e.g.
+
+```
+$ terraform import aws_rds_cluster_activity_stream.default arn:aws:rds:us-west-2:123456789012:cluster:aurora-cluster-demo
+```
+
+[1]: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.html
+[2]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html

--- a/website/docs/r/rds_cluster_activity_stream.html.markdown
+++ b/website/docs/r/rds_cluster_activity_stream.html.markdown
@@ -25,13 +25,13 @@ references using the [resource `depends_on` meta-argument](/docs/configuration/r
 
 ```hcl
 resource "aws_rds_cluster" "default" {
-  cluster_identifier      = "aurora-cluster-demo"
-  availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
-  database_name           = "mydb"
-  master_username         = "foo"
-  master_password         = "mustbeeightcharaters"
-  engine                  = "aurora-postgresql"
-  engine_version          = "10.11"
+  cluster_identifier = "aurora-cluster-demo"
+  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "mustbeeightcharaters"
+  engine             = "aurora-postgresql"
+  engine_version     = "10.11"
 }
 
 resource "aws_rds_cluster_instance" "default" {

--- a/website/docs/r/rds_cluster_activity_stream.html.markdown
+++ b/website/docs/r/rds_cluster_activity_stream.html.markdown
@@ -46,7 +46,7 @@ resource "aws_kms_key" "default" {
 }
 
 resource "aws_rds_cluster_activity_stream" "default" {
-  arn               = aws_rds_cluster.default.arn
+  resource_arn      = aws_rds_cluster.default.arn
   mode              = "async"
   kms_key_id        = aws_kms_key.default.key_id
   apply_immediately = true
@@ -63,7 +63,7 @@ the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/referenc
 
 The following arguments are supported:
 
-* `arn` - (Required, Forces new resources) The Amazon Resource Name (ARN) of the DB cluster.
+* `resource_arn` - (Required, Forces new resources) The Amazon Resource Name (ARN) of the DB cluster.
 * `mode` - (Required, Forces new resources) Specifies the mode of the database activity stream. One of: `sync` , `async` .
 * `kms_key_id` - (Required, Forces new resources) The AWS KMS key identifier used for encrypting messages in the database activity stream.
 * `apply_immediately` - (Optional) Specifies whether or not the database activity stream is to start immediately, or during the next maintenance window. Default is `false`.
@@ -79,7 +79,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-RDS Aurora Cluster Database Activity Streams can be imported using the `arn`, e.g.
+RDS Aurora Cluster Database Activity Streams can be imported using the `resource_arn`, e.g.
 
 ```
 $ terraform import aws_rds_cluster_activity_stream.default arn:aws:rds:us-west-2:123456789012:cluster:aurora-cluster-demo

--- a/website/docs/r/rds_cluster_activity_stream.html.markdown
+++ b/website/docs/r/rds_cluster_activity_stream.html.markdown
@@ -12,13 +12,13 @@ Manages RDS Aurora Cluster Database Activity Streams.
 
 Database Activity Streams have some limits and requirements, You can refer to the [User Guide][1].
 
-~> **Note:** `apply_immediately` always is true, cannot be modified. 
+~> **Note:** `apply_immediately` always is true, cannot be modified.
 Because when apply_immediately=false, terraform cannot get activity stream associated attributes.
 
 ~> **Note:** This resource depends on having one `aws_rds_cluster_instance` created.
 To avoid race conditions when all resources are being created together, you need to add explicit resource
 references using the [resource `depends_on` meta-argument](/docs/configuration/resources.html#depends_on-explicit-resource-dependencies).
- 
+
 
 ## Example Usage
 

--- a/website/docs/r/rds_cluster_activity_stream.html.markdown
+++ b/website/docs/r/rds_cluster_activity_stream.html.markdown
@@ -22,7 +22,7 @@ references using the [resource `depends_on` meta-argument](/docs/configuration/r
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "aurora-cluster-demo"
   availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Description: This PR adds support for the Amazon Aurora Database Activity Streams.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: `aws_rds_cluster_activity_stream`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRDSClusterActivityStream_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSRDSClusterActivityStream_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRDSClusterActivityStream_basic
=== PAUSE TestAccAWSRDSClusterActivityStream_basic
=== RUN   TestAccAWSRDSClusterActivityStream_disappears
=== PAUSE TestAccAWSRDSClusterActivityStream_disappears
=== RUN   TestAccAWSRDSClusterActivityStream_kmsKeyId
=== PAUSE TestAccAWSRDSClusterActivityStream_kmsKeyId
=== RUN   TestAccAWSRDSClusterActivityStream_mode
=== PAUSE TestAccAWSRDSClusterActivityStream_mode
=== RUN   TestAccAWSRDSClusterActivityStream_arn
=== PAUSE TestAccAWSRDSClusterActivityStream_arn
=== CONT  TestAccAWSRDSClusterActivityStream_basic
=== CONT  TestAccAWSRDSClusterActivityStream_mode
=== CONT  TestAccAWSRDSClusterActivityStream_arn
=== CONT  TestAccAWSRDSClusterActivityStream_kmsKeyId
=== CONT  TestAccAWSRDSClusterActivityStream_disappears
--- PASS: TestAccAWSRDSClusterActivityStream_disappears (1152.28s)
--- PASS: TestAccAWSRDSClusterActivityStream_basic (1283.99s)
--- PASS: TestAccAWSRDSClusterActivityStream_mode (1692.51s)
--- PASS: TestAccAWSRDSClusterActivityStream_kmsKeyId (1838.95s)
--- PASS: TestAccAWSRDSClusterActivityStream_arn (2066.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       2068.890s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.847s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.647s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/naming       0.517s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/apigatewayv2/waiter  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency    0.382s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token    0.749s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/guardduty/waiter     [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/waiter      [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kms/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/neptune/waiter       [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/secretsmanager/waiter        [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter      [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/workspaces/waiter    [no test files]
?       github.com/terraform-providers/terraform-provider-aws/awsproviderlint   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/awsproviderlint/helper/awsprovidertype/keyvaluetags       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes    0.654s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001   0.877s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001    0.521s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR002    1.037s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr 0.502s [no tests to run]
...
```
