### PR TITLE
r/config_configuration_aggregator -remove toLower call when setting ID  + disappears test

### DIFF
--- a/.changelog/14247.txt
+++ b/.changelog/14247.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_config_configuration_aggregator: Allow name to have uppercase characters
+```

--- a/aws/resource_aws_config_configuration_aggregator.go
+++ b/aws/resource_aws_config_configuration_aggregator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/configservice"
@@ -115,35 +114,34 @@ func resourceAwsConfigConfigurationAggregator() *schema.Resource {
 func resourceAwsConfigConfigurationAggregatorPut(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).configconn
 
-	name := d.Get("name").(string)
-
 	req := &configservice.PutConfigurationAggregatorInput{
-		ConfigurationAggregatorName: aws.String(name),
+		ConfigurationAggregatorName: aws.String(d.Get("name").(string)),
 		Tags:                        keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().ConfigserviceTags(),
 	}
 
-	account_aggregation_sources := d.Get("account_aggregation_source").([]interface{})
-	if len(account_aggregation_sources) > 0 {
-		req.AccountAggregationSources = expandConfigAccountAggregationSources(account_aggregation_sources)
+	if v, ok := d.GetOk("account_aggregation_source"); ok && len(v.([]interface{})) > 0 {
+		req.AccountAggregationSources = expandConfigAccountAggregationSources(v.([]interface{}))
 	}
 
-	organization_aggregation_sources := d.Get("organization_aggregation_source").([]interface{})
-	if len(organization_aggregation_sources) > 0 {
-		req.OrganizationAggregationSource = expandConfigOrganizationAggregationSource(organization_aggregation_sources[0].(map[string]interface{}))
+	if v, ok := d.GetOk("organization_aggregation_source"); ok && len(v.([]interface{})) > 0 {
+		req.OrganizationAggregationSource = expandConfigOrganizationAggregationSource(v.([]interface{})[0].(map[string]interface{}))
 	}
 
-	_, err := conn.PutConfigurationAggregator(req)
+	log.Printf("[DEBUG] Putting Config Configuration Aggregator: %#v", req)
+	resp, err := conn.PutConfigurationAggregator(req)
 	if err != nil {
-		return fmt.Errorf("Error creating aggregator: %s", err)
+		return fmt.Errorf("error creating aggregator: %w", err)
 	}
 
-	d.SetId(strings.ToLower(name))
+	configAgg := resp.ConfigurationAggregator
+	d.SetId(aws.StringValue(configAgg.ConfigurationAggregatorName))
 
 	if !d.IsNewResource() && d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
-		if err := keyvaluetags.ConfigserviceUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Config Configuration Aggregator (%s) tags: %s", d.Get("arn").(string), err)
+		arn := aws.StringValue(configAgg.ConfigurationAggregatorArn)
+		if err := keyvaluetags.ConfigserviceUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Config Configuration Aggregator (%s) tags: %w", arn, err)
 		}
 	}
 
@@ -175,7 +173,8 @@ func resourceAwsConfigConfigurationAggregatorRead(d *schema.ResourceData, meta i
 	}
 
 	aggregator := res.ConfigurationAggregators[0]
-	d.Set("arn", aggregator.ConfigurationAggregatorArn)
+	arn := aws.StringValue(aggregator.ConfigurationAggregatorArn)
+	d.Set("arn", arn)
 	d.Set("name", aggregator.ConfigurationAggregatorName)
 
 	if err := d.Set("account_aggregation_source", flattenConfigAccountAggregationSources(aggregator.AccountAggregationSources)); err != nil {
@@ -186,14 +185,14 @@ func resourceAwsConfigConfigurationAggregatorRead(d *schema.ResourceData, meta i
 		return fmt.Errorf("error setting organization_aggregation_source: %s", err)
 	}
 
-	tags, err := keyvaluetags.ConfigserviceListTags(conn, d.Get("arn").(string))
+	tags, err := keyvaluetags.ConfigserviceListTags(conn, arn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Config Configuration Aggregator (%s): %s", d.Get("arn").(string), err)
+		return fmt.Errorf("error listing tags for Config Configuration Aggregator (%s): %w", arn, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil
@@ -206,10 +205,14 @@ func resourceAwsConfigConfigurationAggregatorDelete(d *schema.ResourceData, meta
 		ConfigurationAggregatorName: aws.String(d.Id()),
 	}
 	_, err := conn.DeleteConfigurationAggregator(req)
-	if err != nil {
-		return err
+
+	if isAWSErr(err, configservice.ErrCodeNoSuchConfigurationAggregatorException, "") {
+		return nil
 	}
 
-	d.SetId("")
+	if err != nil {
+		return fmt.Errorf("error deleting Config Configuration Aggregator (%s): %w", d.Id(), err)
+	}
+
 	return nil
 }

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -60,6 +60,7 @@ func testSweepConfigConfigurationAggregators(region string) error {
 
 func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 	var ca configservice.ConfigurationAggregator
+	//Name is upper case on purpose to test https://github.com/terraform-providers/terraform-provider-aws/issues/8432
 	rName := acctest.RandomWithPrefix("Tf-acc-test")
 	resourceName := "aws_config_configuration_aggregator.test"
 

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -60,7 +60,7 @@ func testSweepConfigConfigurationAggregators(region string) error {
 
 func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 	var ca configservice.ConfigurationAggregator
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("Tf-acc-test")
 	resourceName := "aws_config_configuration_aggregator.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -360,7 +360,7 @@ resource "aws_config_configuration_aggregator" "test" {
   }
 
   tags = {
-    %[2]s = %[3]q
+    %[2]q = %[3]q
   }
 }
 `, rName, tagKey1, tagValue1)
@@ -381,8 +381,8 @@ resource "aws_config_configuration_aggregator" "test" {
   }
 
   tags = {
-	%[2]s = %[3]q
-	%[4]s = %[5]q
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -49,7 +50,8 @@ func testSweepConfigConfigurationAggregators(region string) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error deleting config configuration aggregator %s: %s", *agg.ConfigurationAggregatorName, err)
+			return fmt.Errorf("error deleting config configuration aggregator %s: %w",
+				aws.StringValue(agg.ConfigurationAggregatorName), err)
 		}
 	}
 
@@ -59,7 +61,7 @@ func testSweepConfigConfigurationAggregators(region string) error {
 func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 	var ca configservice.ConfigurationAggregator
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_config_configuration_aggregator.example"
+	resourceName := "aws_config_configuration_aggregator.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -72,11 +74,13 @@ func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 					testAccCheckAWSConfigConfigurationAggregatorExists(resourceName, &ca),
 					testAccCheckAWSConfigConfigurationAggregatorName(resourceName, rName, &ca),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "config", regexp.MustCompile(`config-aggregator/config-aggregator-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.account_ids.#", "1"),
 					testAccCheckResourceAttrAccountID(resourceName, "account_aggregation_source.0.account_ids.0"),
 					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.regions.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "account_aggregation_source.0.regions.0", "data.aws_region.current", "name"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -91,7 +95,7 @@ func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 func TestAccAWSConfigConfigurationAggregator_organization(t *testing.T) {
 	var ca configservice.ConfigurationAggregator
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_config_configuration_aggregator.example"
+	resourceName := "aws_config_configuration_aggregator.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
@@ -120,7 +124,7 @@ func TestAccAWSConfigConfigurationAggregator_organization(t *testing.T) {
 
 func TestAccAWSConfigConfigurationAggregator_switch(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_config_configuration_aggregator.example"
+	resourceName := "aws_config_configuration_aggregator.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
@@ -148,7 +152,7 @@ func TestAccAWSConfigConfigurationAggregator_switch(t *testing.T) {
 func TestAccAWSConfigConfigurationAggregator_tags(t *testing.T) {
 	var ca configservice.ConfigurationAggregator
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_config_configuration_aggregator.example"
+	resourceName := "aws_config_configuration_aggregator.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -156,25 +160,22 @@ func TestAccAWSConfigConfigurationAggregator_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSConfigConfigurationAggregatorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSConfigConfigurationAggregatorConfig_tags(rName, "foo", "bar", "fizz", "buzz"),
+				Config: testAccAWSConfigConfigurationAggregatorConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSConfigConfigurationAggregatorExists(resourceName, &ca),
 					testAccCheckAWSConfigConfigurationAggregatorName(resourceName, rName, &ca),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
-				Config: testAccAWSConfigConfigurationAggregatorConfig_tags(rName, "foo", "bar2", "fizz2", "buzz2"),
+				Config: testAccAWSConfigConfigurationAggregatorConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSConfigConfigurationAggregatorExists(resourceName, &ca),
 					testAccCheckAWSConfigConfigurationAggregatorName(resourceName, rName, &ca),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.fizz2", "buzz2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
@@ -183,12 +184,35 @@ func TestAccAWSConfigConfigurationAggregator_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSConfigConfigurationAggregatorConfig_account(rName),
+				Config: testAccAWSConfigConfigurationAggregatorConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSConfigConfigurationAggregatorExists(resourceName, &ca),
 					testAccCheckAWSConfigConfigurationAggregatorName(resourceName, rName, &ca),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSConfigConfigurationAggregator_disappears(t *testing.T) {
+	var ca configservice.ConfigurationAggregator
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_config_configuration_aggregator.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSConfigConfigurationAggregatorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSConfigConfigurationAggregatorConfig_account(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSConfigConfigurationAggregatorExists(resourceName, &ca),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsConfigConfigurationAggregator(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -200,8 +224,8 @@ func testAccCheckAWSConfigConfigurationAggregatorName(n, desired string, obj *co
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
-		if rs.Primary.Attributes["name"] != *obj.ConfigurationAggregatorName {
-			return fmt.Errorf("Expected name: %q, given: %q", desired, *obj.ConfigurationAggregatorName)
+		if rs.Primary.Attributes["name"] != aws.StringValue(obj.ConfigurationAggregatorName) {
+			return fmt.Errorf("expected name: %q, given: %q", desired, aws.StringValue(obj.ConfigurationAggregatorName))
 		}
 		return nil
 	}
@@ -250,7 +274,7 @@ func testAccCheckAWSConfigConfigurationAggregatorDestroy(s *terraform.State) err
 
 		if err == nil {
 			if len(resp.ConfigurationAggregators) != 0 &&
-				*resp.ConfigurationAggregators[0].ConfigurationAggregatorName == rs.Primary.Attributes["name"] {
+				aws.StringValue(resp.ConfigurationAggregators[0].ConfigurationAggregatorName) == rs.Primary.Attributes["name"] {
 				return fmt.Errorf("config configuration aggregator still exists: %s", rs.Primary.Attributes["name"])
 			}
 		}
@@ -261,18 +285,17 @@ func testAccCheckAWSConfigConfigurationAggregatorDestroy(s *terraform.State) err
 
 func testAccAWSConfigConfigurationAggregatorConfig_account(rName string) string {
 	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
 data "aws_region" "current" {}
 
-resource "aws_config_configuration_aggregator" "example" {
-  name = %q
+resource "aws_config_configuration_aggregator" "test" {
+  name = %[1]q
 
   account_aggregation_source {
     account_ids = [data.aws_caller_identity.current.account_id]
     regions     = [data.aws_region.current.name]
   }
-}
-
-data "aws_caller_identity" "current" {
 }
 `, rName)
 }
@@ -281,14 +304,14 @@ func testAccAWSConfigConfigurationAggregatorConfig_organization(rName string) st
 	return fmt.Sprintf(`
 resource "aws_organizations_organization" "test" {}
 
-resource "aws_config_configuration_aggregator" "example" {
-  depends_on = [aws_iam_role_policy_attachment.example]
+resource "aws_config_configuration_aggregator" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test]
 
   name = %[1]q
 
   organization_aggregation_source {
     all_regions = true
-    role_arn    = aws_iam_role.example.arn
+    role_arn    = aws_iam_role.test.arn
   }
 }
 
@@ -315,17 +338,19 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "example" {
-  role       = aws_iam_role.example.name
+  role       = aws_iam_role.test.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSConfigRoleForOrganizations"
 }
 `, rName)
 }
 
-func testAccAWSConfigConfigurationAggregatorConfig_tags(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAWSConfigConfigurationAggregatorConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
 data "aws_region" "current" {}
 
-resource "aws_config_configuration_aggregator" "example" {
+resource "aws_config_configuration_aggregator" "test" {
   name = %[1]q
 
   account_aggregation_source {
@@ -334,13 +359,30 @@ resource "aws_config_configuration_aggregator" "example" {
   }
 
   tags = {
-    Name = %[1]q
-
     %[2]s = %[3]q
-    %[4]s = %[5]q
   }
 }
+`, rName, tagKey1, tagValue1)
+}
 
+func testAccAWSConfigConfigurationAggregatorConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_config_configuration_aggregator" "test" {
+  name = %[1]q
+
+  account_aggregation_source {
+    account_ids = [data.aws_caller_identity.current.account_id]
+    regions     = [data.aws_region.current.name]
+  }
+
+  tags = {
+	%[2]s = %[3]q
+	%[4]s = %[5]q
+  }
+}
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11769
Closes #8432
Related #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_config_configuration_aggregator: allow name to have uppercase characters
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSConfigConfigurationAggregator_'

--- PASS: TestAccAWSConfigConfigurationAggregator_tags (111.49s)
--- PASS: TestAccAWSConfigConfigurationAggregator_account (43.38s)
--- PASS: TestAccAWSConfigConfigurationAggregator_disappears (36.07s)

    TestAccAWSConfigConfigurationAggregator_organization: provider_test.go:532: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- SKIP: TestAccAWSConfigConfigurationAggregator_organization (3.00s)
Test ignored.
    TestAccAWSConfigConfigurationAggregator_switch: provider_test.go:532: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- SKIP: TestAccAWSConfigConfigurationAggregator_switch (3.59s)
Test ignored.
```

Can't test org features
