### PR TITLE
cloudwatch metrics datasource

### DIFF
--- a/aws/data_source_aws_cloudwatch_metrics.go
+++ b/aws/data_source_aws_cloudwatch_metrics.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsCloudwatchMetrics() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCloudwatchMetricsRead,
+
+		Schema: map[string]*schema.Schema{
+			"namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"metric_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dimensions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"metrics": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"namespace": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"dimensions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"metric_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsCloudwatchMetricsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatchconn
+	params := &cloudwatch.ListMetricsInput{}
+
+	if v, ok := d.GetOk("namespace"); ok {
+		params.Namespace = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("metric_name"); ok {
+		params.MetricName = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("dimensions"); ok {
+		params.Dimensions = dataSourceAwsCloudwatchMetricsDimensionFilter(v.(*schema.Set))
+	}
+
+	metrics, err := dataSourceAwsCloudwatchMetricsLookup(conn, params)
+	if err != nil {
+		return err
+	}
+	if len(metrics) == 0 {
+		return fmt.Errorf("no metrics found with the current filters: %+v", params)
+	}
+
+	d.SetId(fmt.Sprintf("%d", hashcode.String(params.String())))
+
+	if err := d.Set("metrics", dataSourceAwsCloudwatchMetricsConvertMetricToTypeList(metrics)); err != nil {
+		return fmt.Errorf("Error settings metrics: %s", err)
+	}
+
+	return nil
+}
+
+func dataSourceAwsCloudwatchMetricsConvertMetricToTypeList(input []*cloudwatch.Metric) []map[string]interface{} {
+	metricsTypeList := make([]map[string]interface{}, len(input))
+	for k, metric := range input {
+		dimensionList := []map[string]string{}
+		for _, dimension := range metric.Dimensions {
+			dimensionList = append(dimensionList, map[string]string{
+				"name":  aws.StringValue(dimension.Name),
+				"value": aws.StringValue(dimension.Value),
+			})
+		}
+		metricsTypeList[k] = map[string]interface{}{
+			"namespace":   aws.StringValue(metric.Namespace),
+			"dimensions":  dimensionList,
+			"metric_name": aws.StringValue(metric.MetricName),
+		}
+	}
+
+	return metricsTypeList
+}
+
+func dataSourceAwsCloudwatchMetricsLookup(conn *cloudwatch.CloudWatch, params *cloudwatch.ListMetricsInput) ([]*cloudwatch.Metric, error) {
+	var metrics []*cloudwatch.Metric
+	err := conn.ListMetricsPages(params, func(page *cloudwatch.ListMetricsOutput, lastPage bool) bool {
+		metrics = append(metrics, page.Metrics...)
+		return !lastPage
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return metrics, nil
+}
+
+func dataSourceAwsCloudwatchMetricsDimensionFilter(set *schema.Set) []*cloudwatch.DimensionFilter {
+	var dimensionFilters []*cloudwatch.DimensionFilter
+	for _, v := range set.List() {
+		m := v.(map[string]interface{})
+		dimensionFilters = append(dimensionFilters, &cloudwatch.DimensionFilter{
+			Name:  aws.String(m["name"].(string)),
+			Value: aws.String(m["value"].(string)),
+		})
+	}
+	return dimensionFilters
+}

--- a/aws/data_source_aws_cloudwatch_metrics.go
+++ b/aws/data_source_aws_cloudwatch_metrics.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 )
 
 func dataSourceAwsCloudwatchMetrics() *schema.Resource {

--- a/aws/data_source_aws_cloudwatch_metrics_test.go
+++ b/aws/data_source_aws_cloudwatch_metrics_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSCloudwatchMetricsDataSource_basic(t *testing.T) {

--- a/aws/data_source_aws_cloudwatch_metrics_test.go
+++ b/aws/data_source_aws_cloudwatch_metrics_test.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSCloudwatchMetricsDataSource_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "data.aws_cloudwatch_metrics.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSCloudwatchMetricsPutConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloudwatchMetricsDataPut(rName),
+				),
+			},
+			{
+				Config: testAccCheckAWSCloudwatchMetricsDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "metrics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metrics.0.namespace", rName),
+					resource.TestCheckResourceAttr(resourceName, "metrics.0.metric_name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "metrics.0.dimensions.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "metrics.0.dimensions.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "metrics.0.dimensions.0.value", rName),
+					resource.TestCheckResourceAttr(resourceName, "metrics.0.dimensions.1.value", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCloudwatchMetricsDataPut(rName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
+
+		input := &cloudwatch.PutMetricDataInput{
+			Namespace: aws.String(rName),
+			MetricData: []*cloudwatch.MetricDatum{
+				{
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("test"),
+							Value: aws.String(rName),
+						},
+						{
+							Name:  aws.String("test2"),
+							Value: aws.String(rName),
+						},
+					},
+					MetricName: aws.String("test"),
+					Timestamp:  aws.Time(time.Now()),
+					Unit:       aws.String(cloudwatch.StandardUnitBytes),
+					Value:      aws.Float64(1),
+				},
+			},
+		}
+
+		_, err := conn.PutMetricData(input)
+		if err != nil {
+			return fmt.Errorf("Couldn't perform a PutMetricData: %s", err)
+		}
+
+		input2 := &cloudwatch.ListMetricsInput{
+			Namespace:  aws.String(rName),
+			MetricName: aws.String("test"),
+		}
+
+		// wait until metrics are visible
+		var metrics []*cloudwatch.Metric
+		for i := 0; i < 10; i++ {
+			metrics, err = dataSourceAwsCloudwatchMetricsLookup(conn, input2)
+
+			if err != nil {
+				return err
+			}
+			if len(metrics) > 0 {
+				break
+			}
+			time.Sleep(15 * time.Second)
+		}
+
+		if len(metrics) == 0 {
+			return fmt.Errorf("Couldn't retrieve metric after PutMetricData")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSCloudwatchMetricsPutConfig(rName string) string {
+	return `
+	`
+}
+
+func testAccCheckAWSCloudwatchMetricsDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+data aws_cloudwatch_metrics "test" {
+  namespace = "%s"
+  metric_name = "test"
+  dimensions {
+	  name  = "test"
+	  value = "%s"
+  }
+}
+`, rName, rName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -193,6 +193,7 @@ func Provider() *schema.Provider {
 			"aws_cloudhsm_v2_cluster":                        dataSourceCloudHsmV2Cluster(),
 			"aws_cloudtrail_service_account":                 dataSourceAwsCloudTrailServiceAccount(),
 			"aws_cloudwatch_log_group":                       dataSourceAwsCloudwatchLogGroup(),
+			"aws_cloudwatch_metrics":                         dataSourceAwsCloudwatchMetrics(),
 			"aws_cognito_user_pools":                         dataSourceAwsCognitoUserPools(),
 			"aws_codecommit_repository":                      dataSourceAwsCodeCommitRepository(),
 			"aws_cur_report_definition":                      dataSourceAwsCurReportDefinition(),

--- a/website/docs/d/cloudwatch_metrics.html.markdown
+++ b/website/docs/d/cloudwatch_metrics.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "CloudWatch"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_metrics"
+description: |-
+  Get metrics from CloudWatch.
+---
+
+# Data Source: aws_cloudwatch_metrics
+
+Use this data source to get metrics from CloudWatch
+
+## Example Usage
+
+```hcl
+data "aws_cloudwatch_metrics" "example" {
+  namespace   = "AWS/EC2"
+  metric_name = "NetworkPacketsIn"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Optional) The namespace of the CloudWatch Metric
+* `metric_name` - (Optional) The metric name of the CloudWatch Metric
+* `dimension` - (Optional) The dimension of the CloudWatch metric
+    * `dimension.#.name` - The dimension name.
+    * `dimension.#.value` - The dimension value.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `metrics` - A list of all Metrics matching the namespace, metric_name or dimension
+    * `metrics.#.namespace` - The namespace of the CloudWatch Metric.
+    * `metrics.#.metric_name` - The metric name of the CloudWatch Metric.
+    * `metrics.dimension` - The dimension of the CloudWatch metric
+        * `metrics.dimension.#.name` - The dimension name.
+        * `metrics.dimension.#.value` - The dimension value.


### PR DESCRIPTION
A few notes:
* There is no resource to create a metric, so the test includes a PutMetricData to create a custom metric. 
* The output of this datasource is a list of maps, because you typically want to retrieve more than one metric.
* One use-case is to retrieve all EC2 instances or RDS instances to create alarms for specific metrics.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3644

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
-->

```release-note
datasource/aws_cloudwatch_metrics: Get metrics from CloudWatch

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudwatchMetricsDataSource_basic'
-run=TestAccAWSCloudwatchMetricsDataSource_basic'==> Checking that code complies with gofmt requirements...TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudwatchMetricsDataSource_basic -timeout 120m
=== RUN   TestAccAWSCloudwatchMetricsDataSource_basic
=== PAUSE TestAccAWSCloudwatchMetricsDataSource_basic
=== CONT  TestAccAWSCloudwatchMetricsDataSource_basic
--- PASS: TestAccAWSCloudwatchMetricsDataSource_basic (159.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       161.487s
...
```
