### PR TITLE
Fix suppressEquivalentSnsTopicSubscriptionDeliveryPolicy

### DIFF
--- a/.changelog/14255.txt
+++ b/.changelog/14255.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sns_topic_subscription: Fix to avoid `delivery_policy` always showing diff.
+```

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -36,6 +36,11 @@ func TestSuppressEquivalentSnsTopicSubscriptionDeliveryPolicy(t *testing.T) {
 			equivalent: true,
 		},
 		{
+			old:        `{"healthyRetryPolicy":{"minDelayTarget":5,"maxDelayTarget":20,"numRetries":5,"numMaxDelayRetries":null,"numNoDelayRetries":null,"numMinDelayRetries":null,"backoffFunction":null},"throttlePolicy":{}}`,
+			new:        `{"healthyRetryPolicy":{"minDelayTarget":5,"maxDelayTarget":20,"numRetries":5,"numMaxDelayRetries":null,"numNoDelayRetries":null,"numMinDelayRetries":null,"backoffFunction":null},"throttlePolicy":{}}`,
+			equivalent: true,
+		},
+		{
 			old:        `{"healthyRetryPolicy":{"minDelayTarget":5,"maxDelayTarget":20,"numRetries":5,"numMaxDelayRetries":null,"numNoDelayRetries":null,"numMinDelayRetries":null,"backoffFunction":null},"sicklyRetryPolicy":null,"throttlePolicy":null,"guaranteed":false}`,
 			new:        `{"healthyRetryPolicy":{"minDelayTarget":5,"maxDelayTarget":20,"numRetries":6}}`,
 			equivalent: false,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14041

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_sns_topic_subscription: Ensure `delivery_policy` is compared properly during plans (https://github.com/terraform-providers/terraform-provider-aws/pull/14255)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestSuppressEquivalentSnsTopicSubscriptionDeliveryPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestSuppressEquivalentSnsTopicSubscriptionDeliveryPolicy -timeout 120m
=== RUN   TestSuppressEquivalentSnsTopicSubscriptionDeliveryPolicy
--- PASS: TestSuppressEquivalentSnsTopicSubscriptionDeliveryPolicy (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.639s
...
```

`suppressEquivalentSnsTopicSubscriptionDeliveryPolicy` method compared a normalized `delivery_policy` with a "raw" `delivery_policy` and check if diffs existed. As a result,  unnecessary diffs showed up. So I fixed the method so that it always compare a normalized new `delivery_policy` with a normalized old `delivery_policy`.
