### PR TITLE
Removes carriage return characters from CF stacks during normalize

### DIFF
--- a/.changelog/14270.txt
+++ b/.changelog/14270.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack: CRLF line endings in `template_body` no longer cause erroneous diffs
+```

--- a/.changelog/14270.txt
+++ b/.changelog/14270.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_cloudformation_stack: CRLF line endings in `template_body` no longer cause erroneous diffs
 ```
+
+```release-note:note
+provider: When using YAML or JSON documents, such as in `template_body` of `aws_cloudformation_stack`, CRLF was previously treated as different from LF but these are now treated as equivalent in many situations
+```

--- a/internal/verify/json.go
+++ b/internal/verify/json.go
@@ -85,6 +85,9 @@ func SuppressEquivalentJSONOrYAMLDiffs(k, old, new string, d *schema.ResourceDat
 }
 
 func NormalizeJSONOrYAMLString(templateString interface{}) (string, error) {
+	if v, ok := templateString.(string); ok {
+		templateString = strings.ReplaceAll(v, "\r\n", "\n")
+	}
 	if looksLikeJSONString(templateString) {
 		return structure.NormalizeJsonString(templateString.(string))
 	}

--- a/internal/verify/json_test.go
+++ b/internal/verify/json_test.go
@@ -384,14 +384,25 @@ func TestNormalizeJSONOrYAMLString(t *testing.T) {
 		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, validNormalizedJSON)
 	}
 
-	validNormalizedYaml := `abc: 1
+	validNormalizedYAML := `abc: 1
 `
-	actual, err = NormalizeJSONOrYAMLString(validNormalizedYaml)
+	actual, err = NormalizeJSONOrYAMLString(validNormalizedYAML)
 	if err != nil {
 		t.Fatalf("Expected not to throw an error while parsing template, but got: %s", err)
 	}
-	if actual != validNormalizedYaml {
-		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, validNormalizedYaml)
+	if actual != validNormalizedYAML {
+		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, validNormalizedYAML)
+	}
+
+	validNormalizedYAMLWithCarriageReturn := "abc: 1\r\n"
+	expectedNormalizedYAML := `abc: 1
+`
+	actual, err = NormalizeJSONOrYAMLString(validNormalizedYAMLWithCarriageReturn)
+	if err != nil {
+		t.Fatalf("Expected not to throw an error while parsing template, but got: %s", err)
+	}
+	if actual != expectedNormalizedYAML {
+		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, expectedNormalizedYAML)
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #10382

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
NONE
```
