### PR TITLE
Ensure changes to S3 lifecycle rules with AbortIncompleteMultipartUpload converge 

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -2256,11 +2256,12 @@ func resourceAwsS3BucketLifecycleUpdate(s3conn *s3.S3, d *schema.ResourceData) e
 			}
 		}
 
-		// As a lifecycle rule requires 1 or more transition/expiration actions,
+		// As a lifecycle rule requires 1 or more transition/expiration/abortincompletemultipartupload actions
 		// we explicitly pass a default ExpiredObjectDeleteMarker value to be able to create
 		// the rule while keeping the policy unaffected if the conditions are not met.
 		if rule.Expiration == nil && rule.NoncurrentVersionExpiration == nil &&
-			rule.Transitions == nil && rule.NoncurrentVersionTransitions == nil {
+			rule.Transitions == nil && rule.NoncurrentVersionTransitions == nil &&
+			rule.AbortIncompleteMultipartUpload == nil {
 			rule.Expiration = &s3.LifecycleExpiration{ExpiredObjectDeleteMarker: aws.Bool(false)}
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14280

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Prevent `AbortIncompleteMultipartUpload` S3 lifecycle rules being modified unexpectedly during terraform apply
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Note: this is a new test
This PR incorporates the test proposed in https://github.com/terraform-providers/terraform-provider-aws/pull/14283
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_Lifecycle_AbortIncompleteMultipartUploadOnly'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket_Lifecycle_AbortIncompleteMultipartUploadOnly -timeout 120m
=== RUN   TestAccAWSS3Bucket_Lifecycle_AbortIncompleteMultipartUploadOnly
=== PAUSE TestAccAWSS3Bucket_Lifecycle_AbortIncompleteMultipartUploadOnly
=== CONT  TestAccAWSS3Bucket_Lifecycle_AbortIncompleteMultipartUploadOnly
--- PASS: TestAccAWSS3Bucket_Lifecycle_AbortIncompleteMultipartUploadOnly (465.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	468.349s
```
