### PR TITLE
r/wafv2_web_acl_logging_configuration: update redacted_fields schema definition

### DIFF
--- a/.changelog/14319.txt
+++ b/.changelog/14319.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_wafv2_web_acl_logging_configuration: Ensure `redacted_fields` are applied to the resource
+```
+
+```release-note:note
+resource/aws_wafv2_web_acl_logging_configuration: The `redacted_fields` configuration block `all_query_arguments`, `body`, and `single_query_argument` arguments have been deprecated to match the WAF API documentation
+```

--- a/aws/resource_aws_wafv2_rule_group.go
+++ b/aws/resource_aws_wafv2_rule_group.go
@@ -120,15 +120,9 @@ func resourceAwsWafv2RuleGroupCreate(d *schema.ResourceData, meta interface{}) e
 		Name:             aws.String(d.Get("name").(string)),
 		Scope:            aws.String(d.Get("scope").(string)),
 		Capacity:         aws.Int64(int64(d.Get("capacity").(int))),
+		Rules:            expandWafv2Rules(d.Get("rule").(*schema.Set).List()),
 		VisibilityConfig: expandWafv2VisibilityConfig(d.Get("visibility_config").([]interface{})),
 	}
-
-	rules, err := expandWafv2Rules(d.Get("rule").(*schema.Set).List())
-	if err != nil {
-		return err
-	}
-
-	params.Rules = rules
 
 	if v, ok := d.GetOk("description"); ok {
 		params.Description = aws.String(v.(string))
@@ -138,7 +132,7 @@ func resourceAwsWafv2RuleGroupCreate(d *schema.ResourceData, meta interface{}) e
 		params.Tags = keyvaluetags.New(v).IgnoreAws().Wafv2Tags()
 	}
 
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		var err error
 		resp, err = conn.CreateRuleGroup(params)
 		if err != nil {
@@ -228,21 +222,15 @@ func resourceAwsWafv2RuleGroupUpdate(d *schema.ResourceData, meta interface{}) e
 		Name:             aws.String(d.Get("name").(string)),
 		Scope:            aws.String(d.Get("scope").(string)),
 		LockToken:        aws.String(d.Get("lock_token").(string)),
+		Rules:            expandWafv2Rules(d.Get("rule").(*schema.Set).List()),
 		VisibilityConfig: expandWafv2VisibilityConfig(d.Get("visibility_config").([]interface{})),
 	}
-
-	rules, err := expandWafv2Rules(d.Get("rule").(*schema.Set).List())
-	if err != nil {
-		return err
-	}
-
-	u.Rules = rules
 
 	if v, ok := d.GetOk("description"); ok {
 		u.Description = aws.String(v.(string))
 	}
 
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.UpdateRuleGroup(u)
 		if err != nil {
 			if isAWSErr(err, wafv2.ErrCodeWAFUnavailableEntityException, "") {

--- a/aws/resource_aws_wafv2_web_acl_logging_configuration.go
+++ b/aws/resource_aws_wafv2_web_acl_logging_configuration.go
@@ -69,6 +69,7 @@ func resourceAwsWafv2WebACLLoggingConfiguration() *schema.Resource {
 											// Trying to solve it with StateFunc and/or DiffSuppressFunc resulted in hash problem of the rule field or didn't work.
 											validation.StringMatch(regexp.MustCompile(`^[a-z0-9-_]+$`), "must contain only lowercase alphanumeric characters, underscores, and hyphens"),
 										),
+										Deprecated: "Not supported by WAFv2 API",
 									},
 								},
 							},

--- a/aws/resource_aws_wafv2_web_acl_logging_configuration.go
+++ b/aws/resource_aws_wafv2_web_acl_logging_configuration.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/wafv2"
@@ -34,11 +35,66 @@ func resourceAwsWafv2WebACLLoggingConfiguration() *schema.Resource {
 				Description: "AWS Kinesis Firehose Delivery Stream ARNs",
 			},
 			"redacted_fields": {
-				Type:        schema.TypeSet,
-				Optional:    true,
-				MaxItems:    100,
-				Elem:        wafv2FieldToMatchBaseSchema(),
-				Description: "Parts of the request to exclude from logs",
+				// To allow this argument and its nested fields with Empty Schemas (e.g. "method")
+				// to be correctly interpreted, this argument must be of type List,
+				// otherwise, at apply-time a field configured as an empty block
+				// (e.g. body {}) will result in a nil redacted_fields attribute
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 100,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// TODO: remove attributes marked as Deprecated
+						// as they are not supported by the WAFv2 API
+						// in the context of WebACL Logging Configurations
+						"all_query_arguments": wafv2EmptySchemaDeprecated(),
+						"body":                wafv2EmptySchemaDeprecated(),
+						"method":              wafv2EmptySchema(),
+						"query_string":        wafv2EmptySchema(),
+						"single_header": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.All(
+											validation.StringLenBetween(1, 40),
+											// The value is returned in lower case by the API.
+											// Trying to solve it with StateFunc and/or DiffSuppressFunc resulted in hash problem of the rule field or didn't work.
+											validation.StringMatch(regexp.MustCompile(`^[a-z0-9-_]+$`), "must contain only lowercase alphanumeric characters, underscores, and hyphens"),
+										),
+									},
+								},
+							},
+						},
+						"single_query_argument": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.All(
+											validation.StringLenBetween(1, 30),
+											// The value is returned in lower case by the API.
+											// Trying to solve it with StateFunc and/or DiffSuppressFunc resulted in hash problem of the rule field or didn't work.
+											validation.StringMatch(regexp.MustCompile(`^[a-z0-9-_]+$`), "must contain only lowercase alphanumeric characters, underscores, and hyphens"),
+										),
+									},
+								},
+							},
+							Deprecated: "Not supported by WAFv2 API",
+						},
+						"uri_path": wafv2EmptySchema(),
+					},
+				},
+				Description:      "Parts of the request to exclude from logs",
+				DiffSuppressFunc: suppressEquivalentRedactedFields,
 			},
 			"resource_arn": {
 				Type:         schema.TypeString,
@@ -51,6 +107,62 @@ func resourceAwsWafv2WebACLLoggingConfiguration() *schema.Resource {
 	}
 }
 
+// suppressEquivalentRedactedFields is required to
+// handle shifts in List ordering returned from the API
+func suppressEquivalentRedactedFields(k, old, new string, d *schema.ResourceData) bool {
+	o, n := d.GetChange("redacted_fields")
+	if o != nil && n != nil {
+		oldFields := o.([]interface{})
+		newFields := n.([]interface{})
+		if len(oldFields) != len(newFields) {
+			// account for case where the empty block {} is used as input
+			return !d.IsNewResource() && len(oldFields) == 0 && len(newFields) == 1 && newFields[0] == nil
+		}
+
+		for _, oldField := range oldFields {
+			om := oldField.(map[string]interface{})
+			found := false
+			for _, newField := range newFields {
+				nm := newField.(map[string]interface{})
+				if len(om) != len(nm) {
+					continue
+				}
+				for k, newVal := range nm {
+					if oldVal, ok := om[k]; ok {
+						if k == "method" || k == "query_string" || k == "uri_path" {
+							if len(oldVal.([]interface{})) == len(newVal.([]interface{})) {
+								found = true
+								break
+							}
+						} else if k == "single_header" {
+							oldHeader := oldVal.([]interface{})
+							newHeader := newVal.([]interface{})
+							if len(oldHeader) > 0 && oldHeader[0] != nil {
+								if len(newHeader) > 0 && newHeader[0] != nil {
+									oldName := oldVal.([]interface{})[0].(map[string]interface{})["name"].(string)
+									newName := newVal.([]interface{})[0].(map[string]interface{})["name"].(string)
+									if oldName == newName {
+										found = true
+										break
+									}
+								}
+							}
+						}
+					}
+				}
+				if found {
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
 func resourceAwsWafv2WebACLLoggingConfigurationPut(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafv2conn
 
@@ -60,8 +172,12 @@ func resourceAwsWafv2WebACLLoggingConfigurationPut(d *schema.ResourceData, meta 
 		ResourceArn:           aws.String(resourceArn),
 	}
 
-	if v, ok := d.GetOk("redacted_fields"); ok && v.(*schema.Set).Len() > 0 {
-		config.RedactedFields = expandWafv2RedactedFields(v.(*schema.Set).List())
+	if v, ok := d.GetOk("redacted_fields"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		fields, err := expandWafv2RedactedFields(v.([]interface{}))
+		if err != nil {
+			return err
+		}
+		config.RedactedFields = fields
 	} else {
 		config.RedactedFields = []*wafv2.FieldToMatch{}
 	}
@@ -126,18 +242,84 @@ func resourceAwsWafv2WebACLLoggingConfigurationDelete(d *schema.ResourceData, me
 	return nil
 }
 
+func expandWafv2RedactedFields(fields []interface{}) ([]*wafv2.FieldToMatch, error) {
+	redactedFields := make([]*wafv2.FieldToMatch, 0, len(fields))
+	for _, field := range fields {
+		f, err := expandWafv2RedactedField(field)
+		if err != nil {
+			return nil, err
+		}
+		redactedFields = append(redactedFields, f)
+	}
+	return redactedFields, nil
+}
+
+func expandWafv2RedactedField(field interface{}) (*wafv2.FieldToMatch, error) {
+	m := field.(map[string]interface{})
+
+	f := &wafv2.FieldToMatch{}
+
+	// While the FieldToMatch struct allows more than 1 of its fields to be set,
+	// the WAFv2 API does not. In addition, in the context of Logging Configuration requests,
+	// the WAFv2 API only supports the following redacted fields.
+	// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/14244
+	nFields := 0
+	for _, v := range m {
+		if len(v.([]interface{})) > 0 {
+			nFields++
+		}
+		if nFields > 1 {
+			return nil, fmt.Errorf(`error expanding redacted_field: only one of "method", "query_string",
+							"single_header", or "uri_path" is valid`)
+		}
+	}
+
+	if v, ok := m["method"]; ok && len(v.([]interface{})) > 0 {
+		f.Method = &wafv2.Method{}
+	} else if v, ok := m["query_string"]; ok && len(v.([]interface{})) > 0 {
+		f.QueryString = &wafv2.QueryString{}
+	} else if v, ok := m["single_header"]; ok && len(v.([]interface{})) > 0 {
+		f.SingleHeader = expandWafv2SingleHeader(m["single_header"].([]interface{}))
+	} else if v, ok := m["uri_path"]; ok && len(v.([]interface{})) > 0 {
+		f.UriPath = &wafv2.UriPath{}
+	}
+
+	return f, nil
+}
+
 func flattenWafv2RedactedFields(fields []*wafv2.FieldToMatch) []map[string]interface{} {
 	redactedFields := make([]map[string]interface{}, 0, len(fields))
 	for _, field := range fields {
-		redactedFields = append(redactedFields, flattenWafv2FieldToMatch(field).([]interface{})[0].(map[string]interface{}))
+		redactedFields = append(redactedFields, flattenWafv2RedactedField(field))
 	}
 	return redactedFields
 }
 
-func expandWafv2RedactedFields(fields []interface{}) []*wafv2.FieldToMatch {
-	redactedFields := make([]*wafv2.FieldToMatch, 0, len(fields))
-	for _, field := range fields {
-		redactedFields = append(redactedFields, expandWafv2FieldToMatch([]interface{}{field}))
+func flattenWafv2RedactedField(f *wafv2.FieldToMatch) map[string]interface{} {
+	m := map[string]interface{}{}
+
+	if f == nil {
+		return m
 	}
-	return redactedFields
+
+	// In the context of Logging Configuration requests,
+	// the WAFv2 API only supports the following redacted fields.
+	// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/14244
+	if f.Method != nil {
+		m["method"] = make([]map[string]interface{}, 1)
+	}
+
+	if f.QueryString != nil {
+		m["query_string"] = make([]map[string]interface{}, 1)
+	}
+
+	if f.SingleHeader != nil {
+		m["single_header"] = flattenWafv2SingleHeader(f.SingleHeader)
+	}
+
+	if f.UriPath != nil {
+		m["uri_path"] = make([]map[string]interface{}, 1)
+	}
+
+	return m
 }

--- a/aws/resource_aws_wafv2_web_acl_logging_configuration.go
+++ b/aws/resource_aws_wafv2_web_acl_logging_configuration.go
@@ -42,9 +42,9 @@ func resourceAwsWafv2WebACLLoggingConfiguration() *schema.Resource {
 				// to be correctly interpreted, this argument must be of type List,
 				// otherwise, at apply-time a field configured as an empty block
 				// (e.g. body {}) will result in a nil redacted_fields attribute
-				Type:             schema.TypeList,
-				Optional:         true,
-				MaxItems:         100,
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 100,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						// TODO: remove attributes marked as Deprecated
@@ -98,7 +98,7 @@ func resourceAwsWafv2WebACLLoggingConfiguration() *schema.Resource {
 						"uri_path": wafv2EmptySchema(),
 					},
 				},
-				Description: "Parts of the request to exclude from logs",
+				Description:      "Parts of the request to exclude from logs",
 				DiffSuppressFunc: suppressRedactedFieldsDiff,
 			},
 			"resource_arn": {

--- a/aws/resource_aws_wafv2_web_acl_logging_configuration_test.go
+++ b/aws/resource_aws_wafv2_web_acl_logging_configuration_test.go
@@ -40,7 +40,7 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACLLoggingConfiguration_update(t *testing.T) {
+func TestAccAwsWafv2WebACLLoggingConfiguration_updateSingleHeaderRedactedField(t *testing.T) {
 	var v wafv2.LoggingConfiguration
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl_logging_configuration.test"
@@ -61,7 +61,7 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateTwoRedactedFields(rName),
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateTwoSingleHeaderRedactedFields(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
@@ -76,13 +76,206 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateOneRedactedField(rName),
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateSingleHeaderRedactedField(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"single_header.0.name": "user-agent",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/14248
+func TestAccAwsWafv2WebACLLoggingConfiguration_updateMethodRedactedField(t *testing.T) {
+	var v wafv2.LoggingConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_web_acl_logging_configuration.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2WebACLLoggingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "0"),
+				),
+			},
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateRedactedField(rName, "method"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"method.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/14248
+func TestAccAwsWafv2WebACLLoggingConfiguration_updateQueryStringRedactedField(t *testing.T) {
+	var v wafv2.LoggingConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_web_acl_logging_configuration.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2WebACLLoggingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "0"),
+				),
+			},
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateRedactedField(rName, "query_string"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"query_string.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/14248
+func TestAccAwsWafv2WebACLLoggingConfiguration_updateUriPathRedactedField(t *testing.T) {
+	var v wafv2.LoggingConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_web_acl_logging_configuration.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2WebACLLoggingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "0"),
+				),
+			},
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateRedactedField(rName, "uri_path"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"uri_path.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/14248
+func TestAccAwsWafv2WebACLLoggingConfiguration_updateMultipleRedactedFields(t *testing.T) {
+	var v wafv2.LoggingConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_web_acl_logging_configuration.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2WebACLLoggingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateRedactedField(rName, "uri_path"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"uri_path.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateTwoRedactedFields(rName, "uri_path", "method"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "2"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"uri_path.#": "1",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"method.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateThreeRedactedFields(rName, "uri_path", "query_string"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "3"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"uri_path.#": "1",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"query_string.#": "1",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"single_header.0.name": "user-agent",
 					}),
 				),
@@ -201,6 +394,76 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAwsWafv2WebACLLoggingConfiguration_emptyRedactedFields(t *testing.T) {
+	var v wafv2.LoggingConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_web_acl_logging_configuration.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2WebACLLoggingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_emptyRedactedField(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsWafv2WebACLLoggingConfiguration_updateEmptyRedactedFields(t *testing.T) {
+	var v wafv2.LoggingConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_web_acl_logging_configuration.test"
+	webACLResourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2WebACLLoggingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_emptyRedactedField(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "0"),
+				),
+			},
+			{
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateRedactedField(rName, "uri_path"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+						"uri_path.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAwsWafv2WebACLLoggingConfiguration_disappears_WebAcl(t *testing.T) {
 	var v wafv2.LoggingConfiguration
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -295,8 +558,7 @@ data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
 resource "aws_iam_role" "firehose" {
-  name = "%[1]s"
-
+  name               = "%[1]s"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -405,7 +667,15 @@ resource "aws_wafv2_web_acl_logging_configuration" "test" {
 }
 `
 
-const testAccWebACLLoggingConfigurationResourceUpdateTwoRedactedFieldsConfig = `
+const testAccWebACLLoggingConfigurationResource_emptyRedactedFieldsConfig = `
+resource "aws_wafv2_web_acl_logging_configuration" "test" {
+  resource_arn            = aws_wafv2_web_acl.test.arn
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
+  redacted_fields {}
+}
+`
+
+const testAccWebACLLoggingConfigurationResource_updateTwoSingleHeaderRedactedFieldsConfig = `
 resource "aws_wafv2_web_acl_logging_configuration" "test" {
   resource_arn            = aws_wafv2_web_acl.test.arn
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
@@ -424,7 +694,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "test" {
 }
 `
 
-const testAccWebACLLoggingConfigurationResourceUpdateOneRedactedFieldConfig = `
+const testAccWebACLLoggingConfigurationResource_updateSingleHeaderRedactedFieldConfig = `
 resource "aws_wafv2_web_acl_logging_configuration" "test" {
   resource_arn            = aws_wafv2_web_acl.test.arn
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
@@ -436,6 +706,59 @@ resource "aws_wafv2_web_acl_logging_configuration" "test" {
   }
 }
 `
+
+func testAccWebACLLoggingConfigurationResource_updateRedactedFieldConfig(field string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl_logging_configuration" "test" {
+  resource_arn            = aws_wafv2_web_acl.test.arn
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
+
+  redacted_fields {
+    %s {}
+  }
+}
+`, field)
+}
+
+func testAccWebACLLoggingConfigurationResource_updateTwoRedactedFieldsConfig(field1, field2 string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl_logging_configuration" "test" {
+  resource_arn            = aws_wafv2_web_acl.test.arn
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
+
+  redacted_fields {
+    %s {}
+  }
+
+  redacted_fields {
+    %s {}
+  }
+}
+`, field1, field2)
+}
+
+func testAccWebACLLoggingConfigurationResource_updateThreeRedactedFieldsConfig(field1, field2 string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl_logging_configuration" "test" {
+  resource_arn            = aws_wafv2_web_acl.test.arn
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
+
+  redacted_fields {
+    %s {}
+  }
+
+  redacted_fields {
+    %s {}
+  }
+
+  redacted_fields {
+    single_header {
+      name = "user-agent"
+    }
+  }
+}
+`, field1, field2)
+}
 
 func testAccAwsWafv2WebACLLoggingConfiguration_basic(rName string) string {
 	return composeConfig(
@@ -451,16 +774,44 @@ func testAccAwsWafv2WebACLLoggingConfiguration_updateLogDestination(rName, rName
 		testAccWebACLLoggingConfigurationResourceConfig)
 }
 
-func testAccAwsWafv2WebACLLoggingConfiguration_updateTwoRedactedFields(rName string) string {
+func testAccAwsWafv2WebACLLoggingConfiguration_updateTwoSingleHeaderRedactedFields(rName string) string {
 	return composeConfig(
 		testAccWebACLLoggingConfigurationDependenciesConfig(rName),
 		testAccWebACLLoggingConfigurationKinesisDependencyConfig(rName),
-		testAccWebACLLoggingConfigurationResourceUpdateTwoRedactedFieldsConfig)
+		testAccWebACLLoggingConfigurationResource_updateTwoSingleHeaderRedactedFieldsConfig)
 }
 
-func testAccAwsWafv2WebACLLoggingConfiguration_updateOneRedactedField(rName string) string {
+func testAccAwsWafv2WebACLLoggingConfiguration_updateSingleHeaderRedactedField(rName string) string {
 	return composeConfig(
 		testAccWebACLLoggingConfigurationDependenciesConfig(rName),
 		testAccWebACLLoggingConfigurationKinesisDependencyConfig(rName),
-		testAccWebACLLoggingConfigurationResourceUpdateOneRedactedFieldConfig)
+		testAccWebACLLoggingConfigurationResource_updateSingleHeaderRedactedFieldConfig)
+}
+
+func testAccAwsWafv2WebACLLoggingConfiguration_updateRedactedField(rName, field string) string {
+	return composeConfig(
+		testAccWebACLLoggingConfigurationDependenciesConfig(rName),
+		testAccWebACLLoggingConfigurationKinesisDependencyConfig(rName),
+		testAccWebACLLoggingConfigurationResource_updateRedactedFieldConfig(field))
+}
+
+func testAccAwsWafv2WebACLLoggingConfiguration_updateTwoRedactedFields(rName, field1, field2 string) string {
+	return composeConfig(
+		testAccWebACLLoggingConfigurationDependenciesConfig(rName),
+		testAccWebACLLoggingConfigurationKinesisDependencyConfig(rName),
+		testAccWebACLLoggingConfigurationResource_updateTwoRedactedFieldsConfig(field1, field2))
+}
+
+func testAccAwsWafv2WebACLLoggingConfiguration_updateThreeRedactedFields(rName, field1, field2 string) string {
+	return composeConfig(
+		testAccWebACLLoggingConfigurationDependenciesConfig(rName),
+		testAccWebACLLoggingConfigurationKinesisDependencyConfig(rName),
+		testAccWebACLLoggingConfigurationResource_updateThreeRedactedFieldsConfig(field1, field2))
+}
+
+func testAccAwsWafv2WebACLLoggingConfiguration_emptyRedactedField(rName string) string {
+	return composeConfig(
+		testAccWebACLLoggingConfigurationDependenciesConfig(rName),
+		testAccWebACLLoggingConfigurationKinesisDependencyConfig(rName),
+		testAccWebACLLoggingConfigurationResource_emptyRedactedFieldsConfig)
 }

--- a/aws/resource_aws_wafv2_web_acl_logging_configuration_test.go
+++ b/aws/resource_aws_wafv2_web_acl_logging_configuration_test.go
@@ -263,7 +263,7 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_updateMultipleRedactedFields(t *t
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateThreeRedactedFields(rName, "uri_path", "query_string"),
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateThreeRedactedFields(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),

--- a/aws/resource_aws_wafv2_web_acl_logging_configuration_test.go
+++ b/aws/resource_aws_wafv2_web_acl_logging_configuration_test.go
@@ -82,7 +82,7 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_updateSingleHeaderRedactedField(t
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"single_header.0.name": "user-agent",
 					}),
 				),
@@ -124,7 +124,7 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_updateMethodRedactedField(t *test
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"method.#": "1",
 					}),
 				),
@@ -166,7 +166,7 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_updateQueryStringRedactedField(t 
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"query_string.#": "1",
 					}),
 				),
@@ -208,7 +208,7 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_updateUriPathRedactedField(t *tes
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"uri_path.#": "1",
 					}),
 				),
@@ -242,22 +242,21 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_updateMultipleRedactedFields(t *t
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"uri_path.#": "1",
 					}),
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateTwoRedactedFields(rName, "uri_path", "method"),
+				Config: testAccAwsWafv2WebACLLoggingConfiguration_updateTwoRedactedFields(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLLoggingConfigurationExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"uri_path.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"method.#": "1",
 					}),
 				),
@@ -269,13 +268,13 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_updateMultipleRedactedFields(t *t
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "3"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"uri_path.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"query_string.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"single_header.0.name": "user-agent",
 					}),
 				),
@@ -450,7 +449,7 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_updateEmptyRedactedFields(t *test
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"uri_path.#": "1",
 					}),
 				),
@@ -558,7 +557,8 @@ data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
 resource "aws_iam_role" "firehose" {
-  name               = "%[1]s"
+  name = "%[1]s"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -708,47 +708,53 @@ resource "aws_wafv2_web_acl_logging_configuration" "test" {
 `
 
 func testAccWebACLLoggingConfigurationResource_updateRedactedFieldConfig(field string) string {
+	var redactedField string
+	switch field {
+	case "method":
+		redactedField = `method {}`
+	case "query_string":
+		redactedField = `query_string {}`
+	case "uri_path":
+		redactedField = `uri_path {}`
+	}
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl_logging_configuration" "test" {
   resource_arn            = aws_wafv2_web_acl.test.arn
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
 
   redacted_fields {
-    %s {}
+    %s
   }
 }
-`, field)
+`, redactedField)
 }
 
-func testAccWebACLLoggingConfigurationResource_updateTwoRedactedFieldsConfig(field1, field2 string) string {
-	return fmt.Sprintf(`
+const testAccWebACLLoggingConfigurationResource_updateTwoRedactedFieldsConfig = `
 resource "aws_wafv2_web_acl_logging_configuration" "test" {
   resource_arn            = aws_wafv2_web_acl.test.arn
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
 
   redacted_fields {
-    %s {}
+    method {}
   }
 
   redacted_fields {
-    %s {}
+    uri_path {}
   }
 }
-`, field1, field2)
-}
+`
 
-func testAccWebACLLoggingConfigurationResource_updateThreeRedactedFieldsConfig(field1, field2 string) string {
-	return fmt.Sprintf(`
+const testAccWebACLLoggingConfigurationResource_updateThreeRedactedFieldsConfig = `
 resource "aws_wafv2_web_acl_logging_configuration" "test" {
   resource_arn            = aws_wafv2_web_acl.test.arn
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.test.arn]
 
   redacted_fields {
-    %s {}
+    uri_path {}
   }
 
   redacted_fields {
-    %s {}
+    query_string {}
   }
 
   redacted_fields {
@@ -757,8 +763,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "test" {
     }
   }
 }
-`, field1, field2)
-}
+`
 
 func testAccAwsWafv2WebACLLoggingConfiguration_basic(rName string) string {
 	return composeConfig(
@@ -795,18 +800,18 @@ func testAccAwsWafv2WebACLLoggingConfiguration_updateRedactedField(rName, field 
 		testAccWebACLLoggingConfigurationResource_updateRedactedFieldConfig(field))
 }
 
-func testAccAwsWafv2WebACLLoggingConfiguration_updateTwoRedactedFields(rName, field1, field2 string) string {
+func testAccAwsWafv2WebACLLoggingConfiguration_updateTwoRedactedFields(rName string) string {
 	return composeConfig(
 		testAccWebACLLoggingConfigurationDependenciesConfig(rName),
 		testAccWebACLLoggingConfigurationKinesisDependencyConfig(rName),
-		testAccWebACLLoggingConfigurationResource_updateTwoRedactedFieldsConfig(field1, field2))
+		testAccWebACLLoggingConfigurationResource_updateTwoRedactedFieldsConfig)
 }
 
-func testAccAwsWafv2WebACLLoggingConfiguration_updateThreeRedactedFields(rName, field1, field2 string) string {
+func testAccAwsWafv2WebACLLoggingConfiguration_updateThreeRedactedFields(rName string) string {
 	return composeConfig(
 		testAccWebACLLoggingConfigurationDependenciesConfig(rName),
 		testAccWebACLLoggingConfigurationKinesisDependencyConfig(rName),
-		testAccWebACLLoggingConfigurationResource_updateThreeRedactedFieldsConfig(field1, field2))
+		testAccWebACLLoggingConfigurationResource_updateThreeRedactedFieldsConfig)
 }
 
 func testAccAwsWafv2WebACLLoggingConfiguration_emptyRedactedField(rName string) string {

--- a/aws/wafv2_helper.go
+++ b/aws/wafv2_helper.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"math"
 	"regexp"
 
@@ -418,9 +417,9 @@ func wafv2VisibilityConfigSchema() *schema.Schema {
 	}
 }
 
-func expandWafv2Rules(l []interface{}) ([]*wafv2.Rule, error) {
+func expandWafv2Rules(l []interface{}) []*wafv2.Rule {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	rules := make([]*wafv2.Rule, 0)
@@ -429,35 +428,24 @@ func expandWafv2Rules(l []interface{}) ([]*wafv2.Rule, error) {
 		if rule == nil {
 			continue
 		}
-		r, err := expandWafv2Rule(rule.(map[string]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		rules = append(rules, r)
+		rules = append(rules, expandWafv2Rule(rule.(map[string]interface{})))
 	}
 
-	return rules, nil
+	return rules
 }
 
-func expandWafv2Rule(m map[string]interface{}) (*wafv2.Rule, error) {
+func expandWafv2Rule(m map[string]interface{}) *wafv2.Rule {
 	if m == nil {
-		return nil, nil
+		return nil
 	}
 
-	rule := &wafv2.Rule{
+	return &wafv2.Rule{
 		Name:             aws.String(m["name"].(string)),
 		Priority:         aws.Int64(int64(m["priority"].(int))),
 		Action:           expandWafv2RuleAction(m["action"].([]interface{})),
+		Statement:        expandWafv2RootStatement(m["statement"].([]interface{})),
 		VisibilityConfig: expandWafv2VisibilityConfig(m["visibility_config"].([]interface{})),
 	}
-	s, err := expandWafv2RootStatement(m["statement"].([]interface{}))
-	if err != nil {
-		return nil, err
-	}
-
-	rule.Statement = s
-
-	return rule, nil
 }
 
 func expandWafv2RuleAction(l []interface{}) *wafv2.RuleAction {
@@ -507,9 +495,9 @@ func expandWafv2VisibilityConfig(l []interface{}) *wafv2.VisibilityConfig {
 	return configuration
 }
 
-func expandWafv2RootStatement(l []interface{}) (*wafv2.Statement, error) {
+func expandWafv2RootStatement(l []interface{}) *wafv2.Statement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
@@ -517,9 +505,9 @@ func expandWafv2RootStatement(l []interface{}) (*wafv2.Statement, error) {
 	return expandWafv2Statement(m)
 }
 
-func expandWafv2Statements(l []interface{}) ([]*wafv2.Statement, error) {
+func expandWafv2Statements(l []interface{}) []*wafv2.Statement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	statements := make([]*wafv2.Statement, 0)
@@ -528,37 +516,25 @@ func expandWafv2Statements(l []interface{}) ([]*wafv2.Statement, error) {
 		if statement == nil {
 			continue
 		}
-		s, err := expandWafv2Statement(statement.(map[string]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		statements = append(statements, s)
+		statements = append(statements, expandWafv2Statement(statement.(map[string]interface{})))
 	}
 
-	return statements, nil
+	return statements
 }
 
-func expandWafv2Statement(m map[string]interface{}) (*wafv2.Statement, error) {
+func expandWafv2Statement(m map[string]interface{}) *wafv2.Statement {
 	if m == nil {
-		return nil, nil
+		return nil
 	}
 
 	statement := &wafv2.Statement{}
 
 	if v, ok := m["and_statement"]; ok {
-		s, err := expandWafv2AndStatement(v.([]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		statement.AndStatement = s
+		statement.AndStatement = expandWafv2AndStatement(v.([]interface{}))
 	}
 
 	if v, ok := m["byte_match_statement"]; ok {
-		s, err := expandWafv2ByteMatchStatement(v.([]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		statement.ByteMatchStatement = s
+		statement.ByteMatchStatement = expandWafv2ByteMatchStatement(v.([]interface{}))
 	}
 
 	if v, ok := m["ip_set_reference_statement"]; ok {
@@ -570,133 +546,96 @@ func expandWafv2Statement(m map[string]interface{}) (*wafv2.Statement, error) {
 	}
 
 	if v, ok := m["not_statement"]; ok {
-		s, err := expandWafv2NotStatement(v.([]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		statement.NotStatement = s
+		statement.NotStatement = expandWafv2NotStatement(v.([]interface{}))
 	}
 
 	if v, ok := m["or_statement"]; ok {
-		s, err := expandWafv2OrStatement(v.([]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		statement.OrStatement = s
+		statement.OrStatement = expandWafv2OrStatement(v.([]interface{}))
 	}
 
 	if v, ok := m["regex_pattern_set_reference_statement"]; ok {
-		s, err := expandWafv2RegexPatternSetReferenceStatement(v.([]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		statement.RegexPatternSetReferenceStatement = s
+		statement.RegexPatternSetReferenceStatement = expandWafv2RegexPatternSetReferenceStatement(v.([]interface{}))
 	}
 
 	if v, ok := m["size_constraint_statement"]; ok {
-		s, err := expandWafv2SizeConstraintStatement(v.([]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		statement.SizeConstraintStatement = s
+		statement.SizeConstraintStatement = expandWafv2SizeConstraintStatement(v.([]interface{}))
 	}
 
 	if v, ok := m["sqli_match_statement"]; ok {
-		s, err := expandWafv2SqliMatchStatement(v.([]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		statement.SqliMatchStatement = s
+		statement.SqliMatchStatement = expandWafv2SqliMatchStatement(v.([]interface{}))
 	}
 
 	if v, ok := m["xss_match_statement"]; ok {
-		s, err := expandWafv2XssMatchStatement(v.([]interface{}))
-		if err != nil {
-			return nil, err
-		}
-		statement.XssMatchStatement = s
+		statement.XssMatchStatement = expandWafv2XssMatchStatement(v.([]interface{}))
 	}
 
-	return statement, nil
+	return statement
 }
 
-func expandWafv2AndStatement(l []interface{}) (*wafv2.AndStatement, error) {
+func expandWafv2AndStatement(l []interface{}) *wafv2.AndStatement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	s, err := expandWafv2Statements(m["statement"].([]interface{}))
-	if err != nil {
-		return nil, err
+	return &wafv2.AndStatement{
+		Statements: expandWafv2Statements(m["statement"].([]interface{})),
 	}
-
-	return &wafv2.AndStatement{Statements: s}, nil
 }
 
-func expandWafv2ByteMatchStatement(l []interface{}) (*wafv2.ByteMatchStatement, error) {
+func expandWafv2ByteMatchStatement(l []interface{}) *wafv2.ByteMatchStatement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	s := &wafv2.ByteMatchStatement{
+	return &wafv2.ByteMatchStatement{
+		FieldToMatch:         expandWafv2FieldToMatch(m["field_to_match"].([]interface{})),
 		PositionalConstraint: aws.String(m["positional_constraint"].(string)),
 		SearchString:         []byte(m["search_string"].(string)),
 		TextTransformations:  expandWafv2TextTransformations(m["text_transformation"].(*schema.Set).List()),
 	}
-
-	fieldToMatch, err := expandWafv2FieldToMatch(m["field_to_match"].([]interface{}))
-	if err != nil {
-		return nil, err
-	}
-
-	s.FieldToMatch = fieldToMatch
-
-	return s, nil
 }
 
-func expandWafv2FieldToMatch(l []interface{}) (*wafv2.FieldToMatch, error) {
+func expandWafv2FieldToMatch(l []interface{}) *wafv2.FieldToMatch {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 	f := &wafv2.FieldToMatch{}
 
-	// While the FieldToMatch struct allows more than 1 of its fields to be set,
-	// the WAFv2 API does not.
-	// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/14248
-	nFields := 0
-	for _, v := range m {
-		if len(v.([]interface{})) > 0 {
-			nFields++
-		}
-		if nFields > 1 {
-			return nil, fmt.Errorf(`error expanding field_to_match: only one of "all_query_arguments", "body", method", 
-							"query_string", "single_header", "single_query_argument", or "uri_path" is valid`)
-		}
-	}
-
 	if v, ok := m["all_query_arguments"]; ok && len(v.([]interface{})) > 0 {
 		f.AllQueryArguments = &wafv2.AllQueryArguments{}
-	} else if v, ok := m["body"]; ok && len(v.([]interface{})) > 0 {
+	}
+
+	if v, ok := m["body"]; ok && len(v.([]interface{})) > 0 {
 		f.Body = &wafv2.Body{}
-	} else if v, ok := m["method"]; ok && len(v.([]interface{})) > 0 {
+	}
+
+	if v, ok := m["method"]; ok && len(v.([]interface{})) > 0 {
 		f.Method = &wafv2.Method{}
-	} else if v, ok := m["query_string"]; ok && len(v.([]interface{})) > 0 {
+	}
+
+	if v, ok := m["query_string"]; ok && len(v.([]interface{})) > 0 {
 		f.QueryString = &wafv2.QueryString{}
-	} else if v, ok := m["single_header"]; ok && len(v.([]interface{})) > 0 {
+	}
+
+	if v, ok := m["single_header"]; ok && len(v.([]interface{})) > 0 {
 		f.SingleHeader = expandWafv2SingleHeader(m["single_header"].([]interface{}))
-	} else if v, ok := m["single_query_argument"]; ok && len(v.([]interface{})) > 0 {
+	}
+
+	if v, ok := m["single_query_argument"]; ok && len(v.([]interface{})) > 0 {
 		f.SingleQueryArgument = expandWafv2SingleQueryArgument(m["single_query_argument"].([]interface{}))
-	} else if v, ok := m["uri_path"]; ok && len(v.([]interface{})) > 0 {
+	}
+
+	if v, ok := m["uri_path"]; ok && len(v.([]interface{})) > 0 {
 		f.UriPath = &wafv2.UriPath{}
 	}
 
-	return f, nil
+	return f
 }
 
 func expandWafv2ForwardedIPConfig(l []interface{}) *wafv2.ForwardedIPConfig {
@@ -814,127 +753,90 @@ func expandWafv2GeoMatchStatement(l []interface{}) *wafv2.GeoMatchStatement {
 	return statement
 }
 
-func expandWafv2NotStatement(l []interface{}) (*wafv2.NotStatement, error) {
+func expandWafv2NotStatement(l []interface{}) *wafv2.NotStatement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 	s := m["statement"].([]interface{})
 
 	if len(s) == 0 || s[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m = s[0].(map[string]interface{})
 
-	statement, err := expandWafv2Statement(m)
-	if err != nil {
-		return nil, err
+	return &wafv2.NotStatement{
+		Statement: expandWafv2Statement(m),
 	}
-	return &wafv2.NotStatement{Statement: statement}, nil
 }
 
-func expandWafv2OrStatement(l []interface{}) (*wafv2.OrStatement, error) {
+func expandWafv2OrStatement(l []interface{}) *wafv2.OrStatement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	s, err := expandWafv2Statements(m["statement"].([]interface{}))
-	if err != nil {
-		return nil, err
+	return &wafv2.OrStatement{
+		Statements: expandWafv2Statements(m["statement"].([]interface{})),
 	}
-
-	return &wafv2.OrStatement{Statements: s}, nil
 }
 
-func expandWafv2RegexPatternSetReferenceStatement(l []interface{}) (*wafv2.RegexPatternSetReferenceStatement, error) {
+func expandWafv2RegexPatternSetReferenceStatement(l []interface{}) *wafv2.RegexPatternSetReferenceStatement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	s := &wafv2.RegexPatternSetReferenceStatement{
+	return &wafv2.RegexPatternSetReferenceStatement{
 		ARN:                 aws.String(m["arn"].(string)),
+		FieldToMatch:        expandWafv2FieldToMatch(m["field_to_match"].([]interface{})),
 		TextTransformations: expandWafv2TextTransformations(m["text_transformation"].(*schema.Set).List()),
 	}
-
-	fieldToMatch, err := expandWafv2FieldToMatch(m["field_to_match"].([]interface{}))
-	if err != nil {
-		return nil, err
-	}
-
-	s.FieldToMatch = fieldToMatch
-
-	return s, nil
 }
 
-func expandWafv2SizeConstraintStatement(l []interface{}) (*wafv2.SizeConstraintStatement, error) {
+func expandWafv2SizeConstraintStatement(l []interface{}) *wafv2.SizeConstraintStatement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	s := &wafv2.SizeConstraintStatement{
+	return &wafv2.SizeConstraintStatement{
 		ComparisonOperator:  aws.String(m["comparison_operator"].(string)),
+		FieldToMatch:        expandWafv2FieldToMatch(m["field_to_match"].([]interface{})),
 		Size:                aws.Int64(int64(m["size"].(int))),
 		TextTransformations: expandWafv2TextTransformations(m["text_transformation"].(*schema.Set).List()),
 	}
-
-	fieldToMatch, err := expandWafv2FieldToMatch(m["field_to_match"].([]interface{}))
-	if err != nil {
-		return nil, err
-	}
-
-	s.FieldToMatch = fieldToMatch
-
-	return s, nil
 }
 
-func expandWafv2SqliMatchStatement(l []interface{}) (*wafv2.SqliMatchStatement, error) {
+func expandWafv2SqliMatchStatement(l []interface{}) *wafv2.SqliMatchStatement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	s := &wafv2.SqliMatchStatement{
+	return &wafv2.SqliMatchStatement{
+		FieldToMatch:        expandWafv2FieldToMatch(m["field_to_match"].([]interface{})),
 		TextTransformations: expandWafv2TextTransformations(m["text_transformation"].(*schema.Set).List()),
 	}
-
-	fieldToMatch, err := expandWafv2FieldToMatch(m["field_to_match"].([]interface{}))
-	if err != nil {
-		return nil, err
-	}
-
-	s.FieldToMatch = fieldToMatch
-
-	return s, nil
 }
 
-func expandWafv2XssMatchStatement(l []interface{}) (*wafv2.XssMatchStatement, error) {
+func expandWafv2XssMatchStatement(l []interface{}) *wafv2.XssMatchStatement {
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})
 
-	s := &wafv2.XssMatchStatement{
+	return &wafv2.XssMatchStatement{
+		FieldToMatch:        expandWafv2FieldToMatch(m["field_to_match"].([]interface{})),
 		TextTransformations: expandWafv2TextTransformations(m["text_transformation"].(*schema.Set).List()),
 	}
-
-	fieldToMatch, err := expandWafv2FieldToMatch(m["field_to_match"].([]interface{}))
-	if err != nil {
-		return nil, err
-	}
-
-	s.FieldToMatch = fieldToMatch
-
-	return s, nil
 }
 
 func flattenWafv2Rules(r []*wafv2.Rule) interface{} {

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -307,7 +307,7 @@ Each `rule` supports the following arguments:
 
 The `action` block supports the following arguments:
 
-~> **NOTE**: One of `allow`, `block`, or `count`, expressed as an empty configuration block `{}`, is required when specifying an `action`
+~> **NOTE:** One of `allow`, `block`, or `count`, expressed as an empty configuration block `{}`, is required when specifying an `action`
 
 * `allow` - (Optional) Instructs AWS WAF to allow the web request.
 * `block` - (Optional) Instructs AWS WAF to block the web request.
@@ -429,7 +429,8 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE**: An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes
+~> **NOTE:** Only one of `all_query_arguments`, `body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. 
+An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
 * `body` - (Optional) Inspect the request body, which immediately follows the request headers.

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -429,7 +429,7 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE:** Only one of `all_query_arguments`, `body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. 
+~> **NOTE:** Only one of `all_query_arguments`, `body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
 An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -267,14 +267,14 @@ The following arguments are supported:
 
 The `default_action` block supports the following arguments:
 
-~> **NOTE**: One of `allow` or `block`, expressed as an empty configuration block `{}`, is required when specifying a `default_action`
+~> **NOTE:** One of `allow` or `block`, expressed as an empty configuration block `{}`, is required when specifying a `default_action`
 
 * `allow` - (Optional) Specifies that AWS WAF should allow requests by default.
 * `block` - (Optional) Specifies that AWS WAF should block requests by default.
 
 ### Rules
 
-~> **NOTE**: One of `action` or `override_action` is required when specifying a rule
+~> **NOTE:** One of `action` or `override_action` is required when specifying a rule
 
 Each `rule` supports the following arguments:
 
@@ -289,7 +289,7 @@ Each `rule` supports the following arguments:
 
 The `action` block supports the following arguments:
 
-~> **NOTE**: One of `allow`, `block`, or `count`, expressed as an empty configuration block `{}`, is required when specifying an `action`
+~> **NOTE:** One of `allow`, `block`, or `count`, expressed as an empty configuration block `{}`, is required when specifying an `action`
 
 * `allow` - (Optional) Instructs AWS WAF to allow the web request. Configure as an empty block `{}`.
 * `block` - (Optional) Instructs AWS WAF to block the web request. Configure as an empty block `{}`.
@@ -299,7 +299,7 @@ The `action` block supports the following arguments:
 
 The `override_action` block supports the following arguments:
 
-~> **NOTE**: One of `count` or `none`, expressed as an empty configuration block `{}`, is required when specifying an `override_action`
+~> **NOTE:** One of `count` or `none`, expressed as an empty configuration block `{}`, is required when specifying an `override_action`
 
 * `count` - (Optional) Override the rule action setting to count (i.e. only count matches). Configured as an empty block `{}`.
 * `none` - (Optional) Don't override the rule action setting. Configured as an empty block `{}`.
@@ -466,7 +466,8 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE**: An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, `query_string`, or `uri_path` attributes
+~> **NOTE:** Only one of `all_query_arguments`, `body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. 
+An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
 * `body` - (Optional) Inspect the request body, which immediately follows the request headers.

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -466,7 +466,7 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE:** Only one of `all_query_arguments`, `body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. 
+~> **NOTE:** Only one of `all_query_arguments`, `body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
 An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.

--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -38,12 +38,14 @@ The following arguments are supported:
 
 The `redacted_fields` block supports the following arguments:
 
-* `all_query_arguments` - (Optional) Redact all query arguments.
-* `body` - (Optional) Redact the request body, which immediately follows the request headers.
+~> **NOTE:** Only one of `method`, `query_string`, `single_header` or `uri_path` can be specified.
+
+* `all_query_arguments` - (Optional, **DEPRECATED**) Redact all query arguments.
+* `body` - (Optional, **DEPRECATED**) Redact the request body, which immediately follows the request headers.
 * `method` - (Optional) Redact the HTTP method. The method indicates the type of operation that the request is asking the origin to perform.
 * `query_string` - (Optional) Redact the query string. This is the part of a URL that appears after a `?` character, if any.
 * `single_header` - (Optional) Redact a single header. See [Single Header](#single-header) below for details.
-* `single_query_argument` - (Optional) Redact a single query argument. See [Single Query Argument](#single-query-argument) below for details.
+* `single_query_argument` - (Optional, **DEPRECATED**) Redact a single query argument. See [Single Query Argument](#single-query-argument) below for details.
 * `uri_path` - (Optional) Redact the request URI path. This is the part of a web request that identifies a resource, for example, `/images/daily-ad.jpg`.
 
 ### Single Header
@@ -54,7 +56,7 @@ The `single_header` block supports the following arguments:
 
 * `name` - (Optional) The name of the query header to redact. This setting must be provided as lower case characters.
 
-### Single Query Argument
+### Single Query Argument (**DEPRECATED**)
 
 Redact a single query argument. Provide the name of the query argument to redact, such as `UserName` or `SalesRegion` (provided as lowercase strings).
 

--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -42,11 +42,11 @@ The `redacted_fields` block supports the following arguments:
 
 * `all_query_arguments` - (Optional, **DEPRECATED**) Redact all query arguments.
 * `body` - (Optional, **DEPRECATED**) Redact the request body, which immediately follows the request headers.
-* `method` - (Optional) Redact the HTTP method. The method indicates the type of operation that the request is asking the origin to perform.
-* `query_string` - (Optional) Redact the query string. This is the part of a URL that appears after a `?` character, if any.
+* `method` - (Optional) Redact the HTTP method. Must be specified as an empty configuration block `{}`. The method indicates the type of operation that the request is asking the origin to perform.
+* `query_string` - (Optional) Redact the query string. Must be specified as an empty configuration block `{}`. This is the part of a URL that appears after a `?` character, if any.
 * `single_header` - (Optional) Redact a single header. See [Single Header](#single-header) below for details.
 * `single_query_argument` - (Optional, **DEPRECATED**) Redact a single query argument. See [Single Query Argument](#single-query-argument) below for details.
-* `uri_path` - (Optional) Redact the request URI path. This is the part of a web request that identifies a resource, for example, `/images/daily-ad.jpg`.
+* `uri_path` - (Optional) Redact the request URI path. Must be specified as an empty configuration block `{}`. This is the part of a web request that identifies a resource, for example, `/images/daily-ad.jpg`.
 
 ### Single Header
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14248 
Closes #14244 

### Notes: 
The linked GH-Issues brought to light the following:
* `redacted_fields` blocks in the context of a `LoggingConfiguration` only permits a subset of the fields documented in https://docs.aws.amazon.com/waf/latest/APIReference/API_FieldToMatch.html and the API will error when an unsupported field (e.g. single_query_argument) is provided --> to account for this behavior, a custom schema is made for this argument instead of using the shared one in `waf_helper.go`; fields that are not supported have been marked as `Deprecated` until they can officially be removed

* only 1 nested attribute is valid in the `redacted_fields` configuration block of `aws_wafv2_web_acl_logging_configuration` and the `field_to_match` block in the `wafv2_web_acl` and `wafv2_rule_group` resources --> to account for this, the documentation has been updated to prevent users from setting multiple attributes

* the previous `Set` type used for `redacted_fields` would be evaluated as an empty object when fields with empty schemas (e.g. `body`) were configured --> to address this, the field argument has been changed to type `List`

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/wafv2_logging_configuration: update redacted_fields handling
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
🏃‍♀️ 🏃‍♂️ 🏃‍♀️ 🏃‍♂️ sooo fast, terraform 0.14 💪  
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_disappears (88.40s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_webACLDisappears (97.98s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateQueryStringRedactedField (102.55s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateEmptyRedactedFields (118.02s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateUriPathRedactedField (123.19s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_emptyRedactedFields (124.89s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_basic (132.33s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateMethodRedactedField (140.09s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateMultipleRedactedFields (147.57s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateSingleHeaderRedactedField (154.22s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_changeResourceARNForceNew (199.44s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_changeLogDestinationConfigsForceNew (200.19s)
```
