### PR TITLE
resource/aws_route53_traffic_policy: new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -776,6 +776,7 @@ func Provider() *schema.Provider {
 			"aws_route53_resolver_endpoint":                           resourceAwsRoute53ResolverEndpoint(),
 			"aws_route53_resolver_rule_association":                   resourceAwsRoute53ResolverRuleAssociation(),
 			"aws_route53_resolver_rule":                               resourceAwsRoute53ResolverRule(),
+			"aws_route53_traffic_policy":                              resourceAwsRoute53TrafficPolicy(),
 			"aws_route":                                               resourceAwsRoute(),
 			"aws_route_table":                                         resourceAwsRouteTable(),
 			"aws_default_route_table":                                 resourceAwsDefaultRouteTable(),

--- a/aws/resource_aws_route53_traffic_policy.go
+++ b/aws/resource_aws_route53_traffic_policy.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"

--- a/aws/resource_aws_route53_traffic_policy.go
+++ b/aws/resource_aws_route53_traffic_policy.go
@@ -77,7 +77,7 @@ func resourceAwsRoute53TrafficPolicyCreate(d *schema.ResourceData, meta interfac
 
 	d.SetId(*response.TrafficPolicy.Id)
 
-	err = d.Set("latest_version", *response.TrafficPolicy.Version)
+	err = d.Set("latest_version", response.TrafficPolicy.Version)
 	if err != nil {
 		return fmt.Errorf("Error assigning Id for Route53 Traffic Policy %s: %s", d.Get("name").(string), err)
 	}
@@ -109,17 +109,17 @@ func resourceAwsRoute53TrafficPolicyRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error getting Route53 Traffic Policy %s, version %d: %s", d.Get("name").(string), d.Get("latest_version").(int), err)
 	}
 
-	err = d.Set("document", *response.TrafficPolicy.Document)
+	err = d.Set("document", response.TrafficPolicy.Document)
 	if err != nil {
 		return fmt.Errorf("Error setting document for: %s, error: %#v", d.Id(), err)
 	}
 
-	err = d.Set("name", *response.TrafficPolicy.Name)
+	err = d.Set("name", response.TrafficPolicy.Name)
 	if err != nil {
 		return fmt.Errorf("Error setting name for: %s, error: %#v", d.Id(), err)
 	}
 
-	err = d.Set("comment", *response.TrafficPolicy.Comment)
+	err = d.Set("comment", response.TrafficPolicy.Comment)
 	if err != nil {
 		return fmt.Errorf("Error setting comment for: %s, error: %#v", d.Id(), err)
 	}
@@ -171,7 +171,7 @@ func resourceAwsRoute53TrafficPolicyUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error updating Route53 Traffic Policy: %s. %#v", d.Get("name").(string), err)
 	}
 
-	err = d.Set("latest_version", *response.TrafficPolicy.Version)
+	err = d.Set("latest_version", response.TrafficPolicy.Version)
 	if err != nil {
 		return fmt.Errorf("Error updating Route53 Traffic Policy %s and setting new policy version. %#v", d.Get("name").(string), err)
 	}

--- a/aws/resource_aws_route53_traffic_policy.go
+++ b/aws/resource_aws_route53_traffic_policy.go
@@ -176,7 +176,7 @@ func resourceAwsRoute53TrafficPolicyUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error updating Route53 Traffic Policy %s and setting new policy version. %#v", d.Get("name").(string), err)
 	}
 
-	return nil
+	return resourceAwsRoute53TrafficPolicyRead(d, meta)
 }
 
 func resourceAwsRoute53TrafficPolicyDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_route53_traffic_policy.go
+++ b/aws/resource_aws_route53_traffic_policy.go
@@ -1,0 +1,224 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+func resourceAwsRoute53TrafficPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53TrafficPolicyCreate,
+		Read:   resourceAwsRoute53TrafficPolicyRead,
+		Update: resourceAwsRoute53TrafficPolicyUpdate,
+		Delete: resourceAwsRoute53TrafficPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected traffic-policy-id/traffic-policy-version", d.Id())
+				}
+				version, err := strconv.Atoi(idParts[1])
+				if err != nil {
+					return nil, fmt.Errorf("Cannot convert to int: %s", idParts[1])
+				}
+				d.Set("latest_version", version)
+				d.SetId(idParts[0])
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 512),
+			},
+			"comment": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
+			"document": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(0, 102400),
+			},
+			"latest_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsRoute53TrafficPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+
+	request := &route53.CreateTrafficPolicyInput{
+		Name:     aws.String(d.Get("name").(string)),
+		Comment:  aws.String(d.Get("comment").(string)),
+		Document: aws.String(d.Get("document").(string)),
+	}
+
+	response, err := conn.CreateTrafficPolicy(request)
+	if err != nil {
+		return fmt.Errorf("Error creating Route53 Traffic Policy %s: %s", d.Get("name").(string), err)
+	}
+
+	d.SetId(*response.TrafficPolicy.Id)
+
+	err = d.Set("latest_version", *response.TrafficPolicy.Version)
+	if err != nil {
+		return fmt.Errorf("Error assigning Id for Route53 Traffic Policy %s: %s", d.Get("name").(string), err)
+	}
+
+	return resourceAwsRoute53TrafficPolicyRead(d, meta)
+}
+
+func resourceAwsRoute53TrafficPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+
+	tp, err := getTrafficPolicyById(d.Id(), conn)
+	if err != nil {
+		return err
+	}
+
+	if tp == nil {
+		log.Printf("[WARN] Route53 Traffic Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	request := &route53.GetTrafficPolicyInput{
+		Id:      tp.Id,
+		Version: tp.LatestVersion,
+	}
+
+	response, err := conn.GetTrafficPolicy(request)
+	if err != nil {
+		return fmt.Errorf("Error getting Route53 Traffic Policy %s, version %d: %s", d.Get("name").(string), d.Get("latest_version").(int), err)
+	}
+
+	err = d.Set("document", *response.TrafficPolicy.Document)
+	if err != nil {
+		return fmt.Errorf("Error setting document for: %s, error: %#v", d.Id(), err)
+	}
+
+	err = d.Set("name", *response.TrafficPolicy.Name)
+	if err != nil {
+		return fmt.Errorf("Error setting name for: %s, error: %#v", d.Id(), err)
+	}
+
+	err = d.Set("comment", *response.TrafficPolicy.Comment)
+	if err != nil {
+		return fmt.Errorf("Error setting comment for: %s, error: %#v", d.Id(), err)
+	}
+
+	return nil
+}
+
+func getTrafficPolicyById(trafficPolicyId string, conn *route53.Route53) (*route53.TrafficPolicySummary, error) {
+	var idMarker *string
+
+	for allPoliciesListed := false; !allPoliciesListed; {
+		listRequest := &route53.ListTrafficPoliciesInput{}
+
+		if idMarker != nil {
+			listRequest.TrafficPolicyIdMarker = idMarker
+		}
+
+		listResponse, err := conn.ListTrafficPolicies(listRequest)
+		if err != nil {
+			return nil, fmt.Errorf("Error listing Route 53 Traffic Policies: %v", err)
+		}
+
+		for _, tp := range listResponse.TrafficPolicySummaries {
+			if *tp.Id == trafficPolicyId {
+				return tp, nil
+			}
+		}
+
+		if *listResponse.IsTruncated {
+			idMarker = listResponse.TrafficPolicyIdMarker
+		} else {
+			allPoliciesListed = true
+		}
+	}
+	return nil, nil
+}
+
+func resourceAwsRoute53TrafficPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+
+	request := &route53.CreateTrafficPolicyVersionInput{
+		Id:       aws.String(d.Id()),
+		Comment:  aws.String(d.Get("comment").(string)),
+		Document: aws.String(d.Get("document").(string)),
+	}
+
+	response, err := conn.CreateTrafficPolicyVersion(request)
+	if err != nil {
+		return fmt.Errorf("Error updating Route53 Traffic Policy: %s. %#v", d.Get("name").(string), err)
+	}
+
+	err = d.Set("latest_version", *response.TrafficPolicy.Version)
+	if err != nil {
+		return fmt.Errorf("Error updating Route53 Traffic Policy %s and setting new policy version. %#v", d.Get("name").(string), err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53TrafficPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+
+	var versionMarker *string
+
+	var trafficPolicies []*route53.TrafficPolicy
+
+	for allPoliciesListed := false; !allPoliciesListed; {
+		listRequest := &route53.ListTrafficPolicyVersionsInput{
+			Id: aws.String(d.Id()),
+		}
+		if versionMarker != nil {
+			listRequest.TrafficPolicyVersionMarker = versionMarker
+		}
+
+		listResponse, err := conn.ListTrafficPolicyVersions(listRequest)
+		if err != nil {
+			return fmt.Errorf("Error listing Route 53 Traffic Policy versions: %v", err)
+		}
+
+		trafficPolicies = append(trafficPolicies, listResponse.TrafficPolicies...)
+
+		if *listResponse.IsTruncated {
+			versionMarker = listResponse.TrafficPolicyVersionMarker
+		} else {
+			allPoliciesListed = true
+		}
+	}
+
+	for _, trafficPolicy := range trafficPolicies {
+		deleteRequest := &route53.DeleteTrafficPolicyInput{
+			Id:      trafficPolicy.Id,
+			Version: trafficPolicy.Version,
+		}
+
+		_, err := conn.DeleteTrafficPolicy(deleteRequest)
+		if err != nil {
+			return fmt.Errorf("Error deleting Route53 Traffic Policy %s, version %d: %s", *trafficPolicy.Id, *trafficPolicy.Version, err)
+		}
+	}
+
+	return nil
+}

--- a/aws/resource_aws_route53_traffic_policy_test.go
+++ b/aws/resource_aws_route53_traffic_policy_test.go
@@ -1,0 +1,61 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSRoute53TrafficPolicy_basic(t *testing.T) {
+	policyName := fmt.Sprintf("policy-%s", acctest.RandString(8))
+	resourceName := "aws_route53_traffic_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53TrafficPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53TrafficPolicyConfig(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRoute53TrafficPolicyConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_traffic_policy" "test" {
+	name     = "%s"
+	comment  = "comment"
+	document = "{\"AWSPolicyFormatVersion\":\"2015-10-01\",\"RecordType\":\"A\",\"Endpoints\":{\"endpoint-start-NkPh\":{\"Type\":\"value\",\"Value\":\"10.0.0.1\"}},\"StartEndpoint\":\"endpoint-start-NkPh\"}"
+}
+`, name)
+}
+
+func testAccCheckRoute53TrafficPolicyDestroy(s *terraform.State) error {
+	return testAccCheckRoute53TrafficPolicyDestroyWithProvider(s, testAccProvider)
+}
+
+func testAccCheckRoute53TrafficPolicyDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	conn := provider.Meta().(*AWSClient).r53conn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_traffic_policy" {
+			continue
+		}
+		tp, err := getTrafficPolicyById(rs.Primary.ID, conn)
+		if err != nil {
+			return fmt.Errorf("Error during check if traffic policy still exists, %#v", err)
+		}
+		if tp != nil {
+			return fmt.Errorf("Traffic Policy still exists")
+		}
+	}
+	return nil
+}

--- a/aws/resource_aws_route53_traffic_policy_test.go
+++ b/aws/resource_aws_route53_traffic_policy_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSRoute53TrafficPolicy_basic(t *testing.T) {

--- a/website/docs/r/route53_traffic_policy.html.markdown
+++ b/website/docs/r/route53_traffic_policy.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Route53"
+layout: "aws"
+page_title: "AWS: aws_route53_traffic_policy"
+description: |-
+  Manages a Route53 Traffic Policy
+---
+
+# Resource: aws_route53_traffic_policy
+
+Manages a Route53 Traffic Policy.
+
+## Example Usage
+
+```hcl
+resource "aws_route53_traffic_policy" "example" {
+  name     = "example"
+  comment  = "example comment"
+  document = <<EOF
+{
+  "AWSPolicyFormatVersion": "2015-10-01",
+  "RecordType": "A",
+  "Endpoints": {
+    "endpoint-start-NkPh": {
+      "Type": "value",
+      "Value": "10.0.0.2"
+    }
+  },
+  "StartEndpoint": "endpoint-start-NkPh"
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) This is the name of the traffic policy.
+* `comment` - (Optional) A comment for the traffic policy.
+* `document` - (Required) The policy document. This is a JSON formatted string. For more information about building Route53 traffic policy documents, see the [AWS Route53 Traffic Policy document format](https://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html)
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the traffic policy
+* `latest_version` - The latest version number of the traffic policy. This value is automatically incremented by AWS after each update of this resource.
+
+
+## Import
+
+Route53 Traffic Policy can be imported using the `id` and `latest_version`, e.g.
+
+```
+$ terraform import aws_route53_traffic_policy.example 01a52019-d16f-422a-ae72-c306d2b6df7e/1
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11256 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: aws_route53_traffic_policy
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAWSRoute53TrafficPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRoute53TrafficPolicy_basic -timeout 120m
=== RUN   TestAccAWSRoute53TrafficPolicy_basic
=== PAUSE TestAccAWSRoute53TrafficPolicy_basic
=== CONT  TestAccAWSRoute53TrafficPolicy_basic
--- PASS: TestAccAWSRoute53TrafficPolicy_basic (17.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       17.574s

...
```
