### PR TITLE
Add support for WorkspaceCreationProperties

### DIFF
--- a/website/docs/r/workspaces_directory.html.markdown
+++ b/website/docs/r/workspaces_directory.html.markdown
@@ -57,6 +57,7 @@ The following arguments are supported:
 * `subnet_ids` - (Optional) The identifiers of the subnets where the directory resides.
 * `tags` – (Optional) A map of tags assigned to the WorkSpaces directory.
 * `self_service_permissions` – (Optional) The permissions to enable or disable self-service capabilities.
+* `creation_properties` - (Optional) Default attributes to set upon the creation of a WorkSpaces WorkSpace.
 
 `self_service_permissions` supports the following:
 
@@ -65,6 +66,14 @@ The following arguments are supported:
 * `rebuild_workspace` – (Optional) Whether WorkSpaces directory users can rebuild the operating system of a workspace to its original state. Default `false`.
 * `restart_workspace` – (Optional) Whether WorkSpaces directory users can restart their workspace. Default `true`.
 * `switch_running_mode` – (Optional) Whether WorkSpaces directory users can switch the running mode of their workspace. Default `false`.
+
+`creation_properties` supports the following:
+
+* `security_group` – (Optional) The id of the security group to associate with a newly created WorkSpace. Defaults to the empty string.
+* `default_ou` – (Optional) The OU in the associated Directory under which newly created workspaces are registered. Defaults to the empty string.
+* `internet_access` – (Optional) Indicates whether internet access is enabled for the WorkSpace. Default `false`.
+* `maintenance_mode` – (Optional) Controls if maintenance windows are enabled for workspaces in the directory. Default `true`.
+* `local_admin` – (Optional) Controls if the workspace owner is given local administrator permissions on their workspace. Default `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Implements a fix for #12737, but acceptance tests fail due to aws/aws-sdk-go#3439 . Otherwise ready for review.

* aws/resource_aws_workspaces_directory.go (resourceAwsWorkspacesDirectory()): Add optional `creation_properties` structure to definition.
  (resourceAwsWorkspacesDirectoryCreate(*schema.ResourceData, interface{})): Set WorkspaceCreationProperties during object creation.
  (resourceAwsWorkspacesDirectoryRead(*schema.ResourceData, interface{})): Process WorkspaceCreationProperties and add to object.
  (resourceAwsWorkspacesDirectoryUpdate(*schema.ResourceData, interface{})): Update WorkspaceCreationProperties if a delta exists.
  (expandCreationProperties([]interface{})): Add helper function for packing the creation_properties struct.
  (flattenCreationProperties(*workspaces.DefaultWorkspaceCreationProperties)): Add helper function for unpacking the DefaultWorkspaceCreationProperties structure
* resource_aws_workspaces_directory_test.go (TestAccAwsWorkspacesDirectory_basic(*testing.T)): Add additional attribute checks.
  (TestExpandCreationProperties(*testing.T)): Add unit test for expandCreationProperties().
  (TestFlattenCreationProperties(*testing.T)): Add unit test for flattenCreationProperties().
  (testAccWorkspacesDirectoryConfigB(string)): Add additional resource (aws_security_group.outbound) and use in aws_workspaces_directory.main definition.
  (testAccWorkspacesDirectoryConfigC(string)): Add additional properties to aws_workspaces_directory.main.
* workspaces_directory.html.markdown: Add documentation on new creation_properties structure.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12737

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_workspaces_directory: Add `creation_properties` attribute [GH-12737]
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
