### PR TITLE
feat(dms_endpoint): add DataFormat, EncryptionMode, and KmsKeyId to the S3 settings block

### DIFF
--- a/aws/resource_aws_dms_endpoint_test.go
+++ b/aws/resource_aws_dms_endpoint_test.go
@@ -60,7 +60,7 @@ func TestAccAwsDmsEndpoint_S3(t *testing.T) {
 		CheckDestroy: dmsEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: dmsEndpointS3Config(randId),
+				Config: composeConfig(dmsEndpointS3Config(randId), dmsEndpointS3ConfigBase(randId)),
 				Check: resource.ComposeTestCheckFunc(
 					checkDmsEndpointExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
@@ -90,6 +90,74 @@ func TestAccAwsDmsEndpoint_S3(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_folder", "new-bucket_folder"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_name", "new-bucket_name"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.compression_type", "GZIP"),
+				),
+			},
+		},
+	})
+}
+
+// NOTE because of the change from s3_settings.0.encryption_mode from SSE_S3 to SSE_KMS this test will invoke a
+// forced destruction and recreation of the resource. Only add to this test case if you're okay with that (i.e. NOT an update)
+func TestAccAwsDmsEndpoint_S3Encrypted(t *testing.T) {
+	resourceName := "aws_dms_endpoint.dms_endpoint"
+	randId := acctest.RandString(8) + "-s3"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: dmsEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: composeConfig(dmsEndpointS3ConfigEncrypted(randId), dmsEndpointS3ConfigBase(randId)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDmsEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.external_table_definition", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_row_delimiter", "\\n"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_folder", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_name", "bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.compression_type", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.data_format", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.encryption_mode", "SSE_S3"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+			{
+				Config: composeConfig(dmsEndpointS3ConfigEncryptedUpdate(randId), dmsEndpointS3ConfigBase(randId)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDmsEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", "key=value;"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.external_table_definition", "new-external_table_definition"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_row_delimiter", "\\r"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_delimiter", "."),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_folder", "new-bucket_folder"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_name", "new-bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.compression_type", "GZIP"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.data_format", "parquet"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.encryption_mode", "SSE_KMS"),
+				),
+			},
+			{
+				Config: composeConfig(dmsEndpointS3ConfigEncryptedUpdateMaintainKms(randId), dmsEndpointS3ConfigBase(randId)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDmsEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", "key=value;"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.external_table_definition", "new-external_table_definition"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_row_delimiter", "\\r"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_delimiter", "."),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_folder", "new-bucket_folder"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_name", "new-bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.compression_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.data_format", "parquet"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.encryption_mode", "SSE_KMS"),
 				),
 			},
 		},
@@ -692,6 +760,112 @@ EOF
 `, randId)
 }
 
+func dmsEndpointS3ConfigEncrypted(randId string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                 = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type               = "target"
+  engine_name                 = "s3"
+  ssl_mode                    = "none"
+  extra_connection_attributes = ""
+
+  tags = {
+    Name   = "tf-test-s3-endpoint-%[1]s"
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+
+  s3_settings {
+    service_access_role_arn           = "${aws_iam_role.iam_role.arn}"
+    bucket_name                       = "bucket_name"
+    encryption_mode                   = "SSE_S3"
+  }
+
+  depends_on = ["aws_iam_role_policy.dms_s3_access"]
+}
+`, randId)
+}
+
+func dmsEndpointS3ConfigEncryptedUpdate(randId string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_kms_alias" "dms" {
+  name = "alias/aws/dms"
+}
+
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                 = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type               = "target"
+  engine_name                 = "s3"
+  ssl_mode                    = "none"
+  extra_connection_attributes = "key=value;"
+
+  tags = {
+    Name   = "tf-test-s3-endpoint-%[1]s"
+    Update = "updated"
+    Add    = "added"
+  }
+
+  s3_settings {
+    service_access_role_arn           = "${aws_iam_role.iam_role.arn}"
+    external_table_definition         = "new-external_table_definition"
+    csv_row_delimiter                 = "\\r"
+    csv_delimiter                     = "."
+    bucket_folder                     = "new-bucket_folder"
+    bucket_name                       = "new-bucket_name"
+    compression_type                  = "GZIP"
+    data_format                       = "parquet"
+    encryption_mode                   = "SSE_KMS"
+    server_side_encryption_kms_key_id = "${data.aws_kms_alias.dms.target_key_arn}"
+  }
+}
+`, randId)
+}
+
+// Designed to test the situation when an udpate needs to occur to the s3_settings block
+// but NOT the encryption_mode attribute. This tests we can update s3_settings without angering the AWS API
+// which refuses any modification with encryption_mode=SSE_KMS (even if it was set before) unless encryption_mode is
+// omitted from the modify request. We set here by removing GZIP compression.
+func dmsEndpointS3ConfigEncryptedUpdateMaintainKms(randId string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_kms_alias" "dms" {
+  name = "alias/aws/dms"
+}
+
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                 = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type               = "target"
+  engine_name                 = "s3"
+  ssl_mode                    = "none"
+  extra_connection_attributes = "key=value;"
+
+  tags = {
+    Name   = "tf-test-s3-endpoint-%[1]s"
+    Update = "updated"
+    Add    = "added"
+  }
+
+  s3_settings {
+    service_access_role_arn           = "${aws_iam_role.iam_role.arn}"
+    external_table_definition         = "new-external_table_definition"
+    csv_row_delimiter                 = "\\r"
+    csv_delimiter                     = "."
+    bucket_folder                     = "new-bucket_folder"
+    bucket_name                       = "new-bucket_name"
+    compression_type                  = ""
+    data_format                       = "parquet"
+    encryption_mode                   = "SSE_KMS"
+    server_side_encryption_kms_key_id = "${data.aws_kms_alias.dms.target_key_arn}"
+  }
+}
+`, randId)
+}
+
 func dmsEndpointS3Config(randId string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
@@ -716,7 +890,11 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 
   depends_on = [aws_iam_role_policy.dms_s3_access]
 }
+`, randId)
+}
 
+func dmsEndpointS3ConfigBase(randId string) string {
+	return fmt.Sprintf(`
 resource "aws_iam_role" "iam_role" {
   name = "tf-test-iam-s3-role-%[1]s"
 

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -125,6 +125,16 @@ The `s3_settings` configuration block supports the following arguments:
 * `csv_row_delimiter` - (Optional) Delimiter used to separate rows in the source files. Defaults to `\n`.
 * `external_table_definition` - (Optional) JSON document that describes how AWS DMS should interpret the data.
 * `service_access_role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM Role with permissions to read from or write to the S3 Bucket.
+* `data_format` - (Optional) Specify the data format. Valid values are `csv` and `parquet`.
+* `encryption_mode` - (Optional) Set to encrypt target files. Valid vaules are `SSE_S3` and `SSE_KMS`.
+* `server_side_encryption_kms_key_id` - (Optional) When using `encryption_mode` as `SSE_KMS`, provide the arn for the KMS key to use. 
+
+## Timeouts
+
+`aws_dms_endpoint` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `delete` - (Default `10 minutes`) Used for destroying endpoints.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This pull request adds three new attributes to the S3 settings block of the dms_endpoint resource.  This allows the user to specify S3 target endpoint in parquet format as well as specify the KMS key (or just server side sse-s3 encryption) to protect the exported data at rest.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->




Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `data_format`, `encryption_mode`, and `server_side_encryption_kms_key_id` to the S3 settings block of the aws_dms_endpoint resource.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAwsDmsEndpoint_S3 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsDmsEndpoint_S3
=== PAUSE TestAccAwsDmsEndpoint_S3
=== RUN   TestAccAwsDmsEndpoint_S3Encrypted
=== PAUSE TestAccAwsDmsEndpoint_S3Encrypted
=== CONT  TestAccAwsDmsEndpoint_S3
=== CONT  TestAccAwsDmsEndpoint_S3Encrypted
--- PASS: TestAccAwsDmsEndpoint_S3 (143.29s)
--- PASS: TestAccAwsDmsEndpoint_S3Encrypted (252.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	252.696s
```
