### PR TITLE
New resource: aws_imagebuilder_infrastracture_configuration

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -654,6 +654,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_user_ssh_key":                                    resourceAwsIamUserSshKey(),
 			"aws_iam_user":                                            resourceAwsIamUser(),
 			"aws_iam_user_login_profile":                              resourceAwsIamUserLoginProfile(),
+			"aws_imagebuilder_infrastructure_configuration":           resourceAwsImageBuilderInfrastructureConfiguration(),
 			"aws_inspector_assessment_target":                         resourceAWSInspectorAssessmentTarget(),
 			"aws_inspector_assessment_template":                       resourceAWSInspectorAssessmentTemplate(),
 			"aws_inspector_resource_group":                            resourceAWSInspectorResourceGroup(),

--- a/aws/resource_aws_imagebuilder_infrastructure_configuration.go
+++ b/aws/resource_aws_imagebuilder_infrastructure_configuration.go
@@ -129,6 +129,7 @@ func resourceAwsImageBuilderInfrastructureConfigurationCreate(d *schema.Resource
 		InstanceProfileName: aws.String(d.Get("instance_profile_name").(string)),
 		SecurityGroupIds:    securityIds,
 		InstanceTypes:       instanceIds,
+		Logging:             expandAwsImageBuilderLogsConfig(d),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -136,9 +137,6 @@ func resourceAwsImageBuilderInfrastructureConfigurationCreate(d *schema.Resource
 	}
 	if v, ok := d.GetOk("key_pair"); ok {
 		input.SetKeyPair(v.(string))
-	}
-	if v, ok := d.GetOk("logging"); ok {
-		input.SetLogging(v.(*imagebuilder.Logging))
 	}
 	if v, ok := d.GetOk("sns_topic_arn"); ok {
 		input.SetSnsTopicArn(v.(string))

--- a/aws/resource_aws_imagebuilder_infrastructure_configuration.go
+++ b/aws/resource_aws_imagebuilder_infrastructure_configuration.go
@@ -1,0 +1,335 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"log"
+)
+
+func resourceAwsImageBuilderInfrastructureConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsImageBuilderInfrastructureConfigurationCreate,
+		Read:   resourceAwsImageBuilderInfrastructureConfigurationRead,
+		Update: resourceAwsImageBuilderInfrastructureConfigurationUpdate,
+		Delete: resourceAwsImageBuilderInfrastructureConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"datecreated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dateupdated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+			},
+			"instance_profile_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+			},
+			"instance_types": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"key_pair": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+			},
+			"logging": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"s3_logs": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"s3_bucket_name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringLenBetween(1, 1024),
+									},
+									"s3_key_prefix": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringLenBetween(1, 1024),
+										Default:      "/",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"sns_topic_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+			},
+			"subnet_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+			},
+			"terminate_instance_on_failure": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsImageBuilderInfrastructureConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).imagebuilderconn
+
+	securityIdSet := d.Get("security_group_ids").(*schema.Set)
+	securityIds := expandStringList(securityIdSet.List())
+	instanceIdSet := d.Get("instance_types").(*schema.Set)
+	instanceIds := expandStringList(instanceIdSet.List())
+
+	input := &imagebuilder.CreateInfrastructureConfigurationInput{
+		ClientToken:         aws.String(resource.UniqueId()),
+		Name:                aws.String(d.Get("name").(string)),
+		InstanceProfileName: aws.String(d.Get("instance_profile_name").(string)),
+		SecurityGroupIds:    securityIds,
+		InstanceTypes:       instanceIds,
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.SetDescription(v.(string))
+	}
+	if v, ok := d.GetOk("key_pair"); ok {
+		input.SetKeyPair(v.(string))
+	}
+	if v, ok := d.GetOk("logging"); ok {
+		input.SetLogging(v.(*imagebuilder.Logging))
+	}
+	if v, ok := d.GetOk("sns_topic_arn"); ok {
+		input.SetSnsTopicArn(v.(string))
+	}
+	if v, ok := d.GetOk("subnet_id"); ok {
+		input.SetSubnetId(v.(string))
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		input.SetTags(keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().ImagebuilderTags())
+	}
+
+	log.Printf("[DEBUG] Creating Infrastructure Configuration: %#v", input)
+
+	resp, err := conn.CreateInfrastructureConfiguration(input)
+	if err != nil {
+		return fmt.Errorf("error creating Component: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.InfrastructureConfigurationArn))
+
+	return resourceAwsImageBuilderInfrastructureConfigurationRead(d, meta)
+}
+
+func resourceAwsImageBuilderInfrastructureConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).imagebuilderconn
+
+	resp, err := conn.GetInfrastructureConfiguration(&imagebuilder.GetInfrastructureConfigurationInput{
+		InfrastructureConfigurationArn: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Infrastructure Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Infrastructure Configuration (%s): %s", d.Id(), err)
+	}
+
+	d.Set("arn", resp.InfrastructureConfiguration.Arn)
+	d.Set("datecreated", resp.InfrastructureConfiguration.DateCreated)
+	d.Set("dateupdated", resp.InfrastructureConfiguration.DateUpdated)
+	d.Set("description", resp.InfrastructureConfiguration.Description)
+	d.Set("instance_profile_name", resp.InfrastructureConfiguration.InstanceProfileName)
+	d.Set("instance_types", resp.InfrastructureConfiguration.InstanceTypes)
+	d.Set("key_pair", resp.InfrastructureConfiguration.KeyPair)
+	d.Set("logging", flattenAwsImageBuilderLogsConfig(resp.InfrastructureConfiguration.Logging))
+	d.Set("name", resp.InfrastructureConfiguration.Name)
+	d.Set("security_group_ids", resp.InfrastructureConfiguration.SecurityGroupIds)
+	d.Set("sns_topic_arn", resp.InfrastructureConfiguration.SnsTopicArn)
+	d.Set("subnet_id", resp.InfrastructureConfiguration.SubnetId)
+	d.Set("terminate_instance_on_failure", resp.InfrastructureConfiguration.TerminateInstanceOnFailure)
+
+	tags, err := keyvaluetags.ImagebuilderListTags(conn, d.Get("arn").(string))
+	if err != nil {
+		return fmt.Errorf("error listing tags for Infrastructure Configuration (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsImageBuilderInfrastructureConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).imagebuilderconn
+
+	// Despite not being required by the API, if it's not sent then certain things get wiped to null
+	upd := imagebuilder.UpdateInfrastructureConfigurationInput{
+		InfrastructureConfigurationArn: aws.String(d.Id()),
+		InstanceProfileName:            aws.String(d.Get("instance_profile_name").(string)),
+		Description:                    aws.String(d.Get("description").(string)),
+		KeyPair:                        aws.String(d.Get("key_pair").(string)),
+		SubnetId:                       aws.String(d.Get("subnet_id").(string)),
+		Logging:                        expandAwsImageBuilderLogsConfig(d),
+	}
+
+	if d.HasChange("instance_types") {
+		if attr := d.Get("instance_types").(*schema.Set); attr.Len() > 0 {
+			upd.InstanceTypes = expandStringList(attr.List())
+		}
+	}
+	if d.HasChange("instance_profile_name") {
+		upd.InstanceProfileName = aws.String(d.Get("instance_profile_name").(string))
+	}
+	if v, ok := d.GetOk("security_group_ids"); ok {
+		if attr := v.(*schema.Set); attr.Len() > 0 {
+			upd.SecurityGroupIds = expandStringList(attr.List())
+		}
+	}
+	if d.HasChange("sns_topic_arn") {
+		upd.SnsTopicArn = aws.String(d.Get("sns_topic_arn").(string))
+	}
+	if d.HasChange("terminate_instance_on_failure") {
+		upd.TerminateInstanceOnFailure = aws.Bool(d.Get("terminate_instance_on_failure").(bool))
+	}
+
+	if d.HasChange("security_group_ids") {
+		if attr := d.Get("security_group_ids").(*schema.Set); attr.Len() > 0 {
+			upd.SecurityGroupIds = expandStringList(attr.List())
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.ImagebuilderUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags for Infrastructure Configuration (%s): %s", d.Id(), err)
+		}
+	}
+
+	_, err := conn.UpdateInfrastructureConfiguration(&upd)
+	if err != nil {
+		return fmt.Errorf("error updating Infrastructure Configuration (%s): %s", d.Id(), err)
+	}
+
+	return resourceAwsImageBuilderInfrastructureConfigurationRead(d, meta)
+}
+
+func resourceAwsImageBuilderInfrastructureConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).imagebuilderconn
+
+	_, err := conn.DeleteInfrastructureConfiguration(&imagebuilder.DeleteInfrastructureConfigurationInput{
+		InfrastructureConfigurationArn: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, imagebuilder.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Infrastructure Configuration (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func flattenAwsImageBuilderLogsConfig(logsConfig *imagebuilder.Logging) []interface{} {
+	if logsConfig == nil {
+		return []interface{}{}
+	}
+
+	values := map[string]interface{}{}
+
+	// If more logging options are added, add more ifs!
+	if v := logsConfig.S3Logs; v != nil {
+		values["s3_logs"] = flattenAwsImageBuilderS3Logs(v)
+	}
+
+	return []interface{}{values}
+}
+
+func flattenAwsImageBuilderS3Logs(s3LogsConfig *imagebuilder.S3Logs) []interface{} {
+	values := map[string]interface{}{}
+
+	values["s3_key_prefix"] = aws.StringValue(s3LogsConfig.S3KeyPrefix)
+	values["s3_bucket_name"] = aws.StringValue(s3LogsConfig.S3BucketName)
+
+	return []interface{}{values}
+}
+
+func expandAwsImageBuilderLogsConfig(d *schema.ResourceData) *imagebuilder.Logging {
+	logsConfig := &imagebuilder.Logging{}
+
+	if v, ok := d.GetOk("logging"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		configList := v.([]interface{})
+		data := configList[0].(map[string]interface{})
+
+		if v, ok := data["s3_logs"]; ok {
+			logsConfig.S3Logs = expandAwsImageBuilderS3LogsConfig(v.([]interface{}))
+		}
+	}
+
+	return logsConfig
+}
+
+func expandAwsImageBuilderS3LogsConfig(configList []interface{}) *imagebuilder.S3Logs {
+	if len(configList) == 0 || configList[0] == nil {
+		return nil
+	}
+
+	data := configList[0].(map[string]interface{})
+
+	s3LogsConfig := &imagebuilder.S3Logs{}
+
+	if v, ok := data["s3_bucket_name"]; ok {
+		s3LogsConfig.S3BucketName = aws.String(v.(string))
+	}
+	if v, ok := data["s3_key_prefix"]; ok {
+		s3LogsConfig.S3KeyPrefix = aws.String(v.(string))
+	}
+
+	return s3LogsConfig
+}

--- a/aws/resource_aws_imagebuilder_infrastructure_configuration.go
+++ b/aws/resource_aws_imagebuilder_infrastructure_configuration.go
@@ -27,11 +27,11 @@ func resourceAwsImageBuilderInfrastructureConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"datecreated": {
+			"date_created": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"dateupdated": {
+			"date_updated": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -109,6 +109,7 @@ func resourceAwsImageBuilderInfrastructureConfiguration() *schema.Resource {
 			"terminate_instance_on_failure": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  false,
 			},
 			"tags": tagsSchema(),
 		},
@@ -162,6 +163,7 @@ func resourceAwsImageBuilderInfrastructureConfigurationCreate(d *schema.Resource
 
 func resourceAwsImageBuilderInfrastructureConfigurationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).imagebuilderconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	resp, err := conn.GetInfrastructureConfiguration(&imagebuilder.GetInfrastructureConfigurationInput{
 		InfrastructureConfigurationArn: aws.String(d.Id()),
@@ -178,8 +180,8 @@ func resourceAwsImageBuilderInfrastructureConfigurationRead(d *schema.ResourceDa
 	}
 
 	d.Set("arn", resp.InfrastructureConfiguration.Arn)
-	d.Set("datecreated", resp.InfrastructureConfiguration.DateCreated)
-	d.Set("dateupdated", resp.InfrastructureConfiguration.DateUpdated)
+	d.Set("date_created", resp.InfrastructureConfiguration.DateCreated)
+	d.Set("date_updated", resp.InfrastructureConfiguration.DateUpdated)
 	d.Set("description", resp.InfrastructureConfiguration.Description)
 	d.Set("instance_profile_name", resp.InfrastructureConfiguration.InstanceProfileName)
 	d.Set("instance_types", resp.InfrastructureConfiguration.InstanceTypes)
@@ -195,7 +197,7 @@ func resourceAwsImageBuilderInfrastructureConfigurationRead(d *schema.ResourceDa
 	if err != nil {
 		return fmt.Errorf("error listing tags for Infrastructure Configuration (%s): %s", d.Id(), err)
 	}
-	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -209,30 +211,41 @@ func resourceAwsImageBuilderInfrastructureConfigurationUpdate(d *schema.Resource
 	upd := imagebuilder.UpdateInfrastructureConfigurationInput{
 		InfrastructureConfigurationArn: aws.String(d.Id()),
 		InstanceProfileName:            aws.String(d.Get("instance_profile_name").(string)),
-		Description:                    aws.String(d.Get("description").(string)),
-		KeyPair:                        aws.String(d.Get("key_pair").(string)),
-		SubnetId:                       aws.String(d.Get("subnet_id").(string)),
 		Logging:                        expandAwsImageBuilderLogsConfig(d),
 	}
 
-	if d.HasChange("instance_types") {
-		if attr := d.Get("instance_types").(*schema.Set); attr.Len() > 0 {
-			upd.InstanceTypes = expandStringList(attr.List())
-		}
+	if description, ok := d.GetOk("description"); ok {
+		upd.Description = aws.String(description.(string))
 	}
+
+	if key_pair, ok := d.GetOk("key_pair"); ok {
+		upd.KeyPair = aws.String(key_pair.(string))
+	}
+
+	if subnet_id, ok := d.GetOk("subnet_id"); ok {
+		upd.SubnetId = aws.String(subnet_id.(string))
+	}
+
+	if attr := d.Get("instance_types").(*schema.Set); attr.Len() > 0 {
+		upd.InstanceTypes = expandStringList(attr.List())
+	}
+
 	if d.HasChange("instance_profile_name") {
 		upd.InstanceProfileName = aws.String(d.Get("instance_profile_name").(string))
 	}
+
 	if v, ok := d.GetOk("security_group_ids"); ok {
 		if attr := v.(*schema.Set); attr.Len() > 0 {
 			upd.SecurityGroupIds = expandStringList(attr.List())
 		}
 	}
-	if d.HasChange("sns_topic_arn") {
-		upd.SnsTopicArn = aws.String(d.Get("sns_topic_arn").(string))
+
+	if sns_topic_arn, ok := d.GetOk("sns_topic_arn"); ok {
+		upd.SnsTopicArn = aws.String(sns_topic_arn.(string))
 	}
-	if d.HasChange("terminate_instance_on_failure") {
-		upd.TerminateInstanceOnFailure = aws.Bool(d.Get("terminate_instance_on_failure").(bool))
+
+	if terminate_instance_on_failure, ok := d.GetOk("terminate_instance_on_failure"); ok {
+		upd.TerminateInstanceOnFailure = aws.Bool(terminate_instance_on_failure.(bool))
 	}
 
 	if d.HasChange("security_group_ids") {
@@ -275,16 +288,14 @@ func resourceAwsImageBuilderInfrastructureConfigurationDelete(d *schema.Resource
 }
 
 func flattenAwsImageBuilderLogsConfig(logsConfig *imagebuilder.Logging) []interface{} {
-	if logsConfig == nil {
+	if logsConfig == nil || logsConfig.S3Logs == nil {
 		return []interface{}{}
 	}
 
 	values := map[string]interface{}{}
 
 	// If more logging options are added, add more ifs!
-	if v := logsConfig.S3Logs; v != nil {
-		values["s3_logs"] = flattenAwsImageBuilderS3Logs(v)
-	}
+	values["s3_logs"] = flattenAwsImageBuilderS3Logs(logsConfig.S3Logs)
 
 	return []interface{}{values}
 }

--- a/aws/resource_aws_imagebuilder_infrastructure_configuration_test.go
+++ b/aws/resource_aws_imagebuilder_infrastructure_configuration_test.go
@@ -1,0 +1,355 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+//Check the minimal configuration
+func TestAccAWSImageBuilderInfrastructureConfiguration_basic(t *testing.T) {
+	var conf imagebuilder.InfrastructureConfiguration
+	RandomString := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
+	resource.ParallelTest(t, resource.TestCase{
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSImageBuilderInfrastructureConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSImageBuilderInfrastructureConfiguration_basic(RandomString),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSImageBuilderInfrastructureConfigurationExist(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_profile_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+//Check the configuration with everything
+func TestAccAWSImageBuilderInfrastructureConfiguration_advanced(t *testing.T) {
+	var conf imagebuilder.InfrastructureConfiguration
+	RandomString := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSImageBuilderInfrastructureConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSImageBuilderInfrastructureConfiguration_advanced(RandomString),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSImageBuilderInfrastructureConfigurationExist(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "instance_profile_name", RandomString),
+					resource.TestCheckResourceAttr(resourceName, "name", RandomString),
+					resource.TestCheckResourceAttr(resourceName, "description", "example desc"),
+					resource.TestCheckResourceAttr(resourceName, "key_pair", RandomString),
+					resource.TestCheckResourceAttrSet(resourceName, "sns_topic_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
+					resource.TestCheckResourceAttr(resourceName, "terminate_instance_on_failure", "false"),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging.0.s3_logs.0.s3_bucket_name", RandomString),
+					resource.TestCheckResourceAttr(resourceName, "logging.0.s3_logs.0.s3_key_prefix", "logs"),
+				),
+			},
+		},
+	})
+}
+
+//Test the tags work
+func TestAccAWSImageBuilderInfrastructureConfiguration_tags(t *testing.T) {
+	var conf imagebuilder.InfrastructureConfiguration
+	RandomString := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSImageBuilderInfrastructureConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSImageBuilderInfrastructureConfiguration_tags1(RandomString),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSImageBuilderInfrastructureConfigurationExist(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_profile_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				Config: testAccAWSImageBuilderInfrastructureConfiguration_tags2(RandomString),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSImageBuilderInfrastructureConfigurationExist(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_profile_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSImageBuilderInfrastructureConfigurationExist(n string, res *imagebuilder.InfrastructureConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No ImageBuilderInfrastructureConfiguration ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).imagebuilderconn
+
+		resp, err := conn.GetInfrastructureConfiguration(&imagebuilder.GetInfrastructureConfigurationInput{
+			InfrastructureConfigurationArn: aws.String(rs.Primary.Attributes["arn"]),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || resp.InfrastructureConfiguration == nil {
+			return fmt.Errorf("Infrastructure configuration (%s) not found", rs.Primary.Attributes["name"])
+		}
+		*res = *resp.InfrastructureConfiguration
+		return nil
+	}
+}
+
+func testAccCheckAWSImageBuilderInfrastructureConfigurationDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_imagebuilder_infrastructure_configuration" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).imagebuilderconn
+
+		resp, err := conn.GetInfrastructureConfiguration(&imagebuilder.GetInfrastructureConfigurationInput{
+			InfrastructureConfigurationArn: aws.String(rs.Primary.Attributes["arn"]),
+		})
+
+		if err == nil {
+			if resp.InfrastructureConfiguration != nil {
+				return fmt.Errorf("ImageBuilderInfrastructureConfiguration %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "ResourceNotFoundException" {
+				return nil
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSImageBuilderInfrastructureConfiguration_basic(ConfigurationName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test_profile.name
+  name = "%[1]s"
+}
+
+resource "aws_iam_instance_profile" "test_profile" {
+  name = "%[1]s"
+  role = aws_iam_role.role.name
+}
+
+resource "aws_iam_role" "role" {
+  name = "%[1]s"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+`, ConfigurationName)
+}
+
+func testAccAWSImageBuilderInfrastructureConfiguration_advanced(ConfigurationName string) string {
+	return fmt.Sprintf(`
+resource "aws_key_pair" "test" {
+  key_name   = "%[1]s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 example@example.com"
+}
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test_profile.name
+  name = "%[1]s"
+  description = "example desc"
+  instance_types = ["t3.micro"]
+  key_pair = aws_key_pair.test.key_name
+  logging  {
+    s3_logs  {
+      s3_bucket_name = aws_s3_bucket.example.bucket
+      s3_key_prefix = "logs"
+    }
+  }
+  security_group_ids = [aws_security_group.example.id]
+  sns_topic_arn = aws_sns_topic.example.arn
+  subnet_id = aws_subnet.main.id
+  terminate_instance_on_failure = false
+}
+
+resource "aws_iam_instance_profile" "test_profile" {
+  name = "%[1]s"
+  role = aws_iam_role.role.name
+}
+
+resource "aws_iam_role" "role" {
+  name = "%[1]s"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_sns_topic" "example" {
+  name = "%[1]s"
+}
+
+
+resource "aws_subnet" "main" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = "10.0.1.0/24"
+}
+
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_security_group" "example" {
+  name        = "%[1]s"
+  vpc_id      = aws_vpc.main.id
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket = %[1]q
+  acl    = "private"
+}
+
+`, ConfigurationName)
+}
+
+func testAccAWSImageBuilderInfrastructureConfiguration_tags1(ConfigurationName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test_profile.name
+  name = "%[1]s"
+  tags = {
+    Name = "tf-test",
+  }
+}
+
+resource "aws_iam_instance_profile" "test_profile" {
+  name = "%[1]s"
+  role = aws_iam_role.role.name
+}
+
+resource "aws_iam_role" "role" {
+  name = "%[1]s"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+`, ConfigurationName)
+}
+
+func testAccAWSImageBuilderInfrastructureConfiguration_tags2(ConfigurationName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test_profile.name
+  name = "%[1]s"
+  tags = {
+    Name = "tf-test",
+    ExtraName = "tf-test"
+  }
+}
+
+resource "aws_iam_instance_profile" "test_profile" {
+  name = "%[1]s"
+  role = aws_iam_role.role.name
+}
+
+resource "aws_iam_role" "role" {
+  name = "%[1]s"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+       {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+`, ConfigurationName)
+}

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -57,6 +57,7 @@ Global Accelerator
 Glue
 GuardDuty
 IAM
+Image Builder
 Inspector
 IoT
 KMS

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1972,6 +1972,20 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">Image Builder</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/imagebuilder_infrastructure_configuration.html">aws_imagebuilder_infrastructure_configuration</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                <li>
                     <a href="#">IoT</a>
                     <ul class="nav">
                         <li>

--- a/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Image Builder"
+layout: "aws"
+page_title: "AWS: aws_imagebuilder_infrastructure_configuration"
+description: |-
+  Provides AWS Image Builder infrasctracture configuration 
+---
+
+# Resource: aws_imagebuilder_infrastructure_configuration
+Provides AWS Image Builder infrasctracture configuration
+
+## Example Usage
+
+```hcl
+# Create new infrastructure configuration
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test_profile.name
+  name                  = "example"
+  description           = "example desc"
+  instance_types        = ["t2.nano", "t3.micro"]
+  key_pair              = aws_key_pair.example.key_name
+  logging {
+    s3_logs {
+      s3_bucket_name = aws_s3_bucket.example.bucket
+      s3_key_prefix  = "logs"
+    }
+  }
+  security_group_ids            = [aws_security_group.example.id]
+  sns_topic_arn                 = aws_sns_topic.example.arn
+  subnet_id                     = aws_subnet.main.id
+  terminate_instance_on_failure = true
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_profile_name` - (Required) The name of iam instance profile.
+* `name` - (Required) The name of the imgage builder infrastructure configuration.
+* `description` - (Optional) The description of the imgage builder infrastructure configuration.
+* `instance_types` - (Optional) A list of instance to use.
+* `key_pair` - (Optional) The name of your key pair
+* `logging` - (Optional) The logging configuration, see below for details.
+* `security_group_ids` - (Optional) A list of security groups to assign to resource, mandatory if subnet provider.
+* `sns_topic_arn` - (Optional) The ARN of sns topic to use.
+* `subnet_id` - (Optional) The id of subnet to use, if provided requires that security groups also be provided. 
+* `tags` - (Optional) A map of tags to assign to the resource.
+* `terminate_instance_on_failure` - (Optional) should the instance be terminated when the pipeline fails (Default: false).
+
+### Logging
+The logging object support the following blocks:
+* s3_logs
+
+The s3_logs block supports the following arguments:
+* `s3_bucket_name` - (Required) The name of the bucket to use.
+* `s3_key_prefix` - (Optional) The prefix to use for logs (Default: "/").
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The ARN of the configuration (matches `arn`).
+* `arn` - The ARN of the configuration  (matches `id`).
+* `date_created` - The timestamp when the configuration was created.
+* `date_updated` - The timestamp when the configuration was updated.
+
+## Import
+
+Infrastructure configuration can be imported using the ARN , e.g.
+
+```
+$ terraform import aws_imagebuilder_infrastructure_configuration.test '<ARN>'
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

New resource as part of image builder work, based on work by @dogers

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Part of #11084
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws/aws_imagebuilder_infrastracture_configuration: New resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSImageBuilderInfrastructureConfiguration_tags -timeout 120m
=== RUN   TestAccAWSImageBuilderInfrastructureConfiguration_tags
=== PAUSE TestAccAWSImageBuilderInfrastructureConfiguration_tags
=== CONT  TestAccAWSImageBuilderInfrastructureConfiguration_tags
--- PASS: TestAccAWSImageBuilderInfrastructureConfiguration_tags (58.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	58.288s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSImageBuilderInfrastructureConfiguration_advanced -timeout 120m
=== RUN   TestAccAWSImageBuilderInfrastructureConfiguration_advanced
=== PAUSE TestAccAWSImageBuilderInfrastructureConfiguration_advanced
=== CONT  TestAccAWSImageBuilderInfrastructureConfiguration_advanced
--- PASS: TestAccAWSImageBuilderInfrastructureConfiguration_advanced (39.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.678s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSImageBuilderInfrastructureConfiguration_basic -timeout 120m
=== RUN   TestAccAWSImageBuilderInfrastructureConfiguration_basic
=== PAUSE TestAccAWSImageBuilderInfrastructureConfiguration_basic
=== CONT  TestAccAWSImageBuilderInfrastructureConfiguration_basic

--- PASS: TestAccAWSImageBuilderInfrastructureConfiguration_basic (33.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	33.973s

...
```
