### PR TITLE
resource/aws_route53_traffic_policy_instance: new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -776,6 +776,7 @@ func Provider() *schema.Provider {
 			"aws_route53_resolver_endpoint":                           resourceAwsRoute53ResolverEndpoint(),
 			"aws_route53_resolver_rule_association":                   resourceAwsRoute53ResolverRuleAssociation(),
 			"aws_route53_resolver_rule":                               resourceAwsRoute53ResolverRule(),
+			"aws_route53_traffic_policy_instance":                     resourceAwsRoute53TrafficPolicyInstance(),
 			"aws_route":                                               resourceAwsRoute(),
 			"aws_route_table":                                         resourceAwsRouteTable(),
 			"aws_default_route_table":                                 resourceAwsDefaultRouteTable(),

--- a/aws/resource_aws_route53_traffic_policy_instance.go
+++ b/aws/resource_aws_route53_traffic_policy_instance.go
@@ -1,0 +1,152 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsRoute53TrafficPolicyInstance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53TrafficPolicyInstanceCreate,
+		Read:   resourceAwsRoute53TrafficPolicyInstanceRead,
+		Update: resourceAwsRoute53TrafficPolicyInstanceUpdate,
+		Delete: resourceAwsRoute53TrafficPolicyInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"hosted_zone_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+				StateFunc: func(v interface{}) string {
+					value := strings.TrimSuffix(v.(string), ".")
+					return strings.ToLower(value)
+				},
+			},
+			"traffic_policy_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 36),
+			},
+			"traffic_policy_version": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtMost(1000),
+			},
+			"ttl": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtMost(2147483647),
+			},
+		},
+	}
+}
+
+func resourceAwsRoute53TrafficPolicyInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+
+	request := &route53.CreateTrafficPolicyInstanceInput{
+		HostedZoneId:         aws.String(d.Get("hosted_zone_id").(string)),
+		Name:                 aws.String(d.Get("name").(string)),
+		TrafficPolicyId:      aws.String(d.Get("traffic_policy_id").(string)),
+		TrafficPolicyVersion: aws.Int64(int64(d.Get("traffic_policy_version").(int))),
+		TTL:                  aws.Int64(int64(d.Get("ttl").(int))),
+	}
+
+	response, err := conn.CreateTrafficPolicyInstance(request)
+	if err != nil {
+		return fmt.Errorf("Error creating Route53 Traffic Policy Instance %s: %s", d.Get("name").(string), err)
+	}
+
+	d.SetId(*response.TrafficPolicyInstance.Id)
+
+	return resourceAwsRoute53TrafficPolicyInstanceRead(d, meta)
+}
+
+func resourceAwsRoute53TrafficPolicyInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+
+	request := &route53.GetTrafficPolicyInstanceInput{
+		Id: aws.String(d.Id()),
+	}
+
+	response, err := conn.GetTrafficPolicyInstance(request)
+	if err != nil {
+		return fmt.Errorf("Error reading Route53 Traffic Policy Instance %s: %s", d.Get("name").(string), err)
+	}
+
+	err = d.Set("name", strings.TrimSuffix(*response.TrafficPolicyInstance.Name, "."))
+	if err != nil {
+		return fmt.Errorf("Error setting name for: %s, error: %#v", d.Id(), err)
+	}
+
+	err = d.Set("hosted_zone_id", response.TrafficPolicyInstance.HostedZoneId)
+	if err != nil {
+		return fmt.Errorf("Error setting hosted_zone_id for: %s, error: %#v", d.Id(), err)
+	}
+
+	err = d.Set("traffic_policy_id", response.TrafficPolicyInstance.TrafficPolicyId)
+	if err != nil {
+		return fmt.Errorf("Error setting traffic_policy_id for: %s, error: %#v", d.Id(), err)
+	}
+
+	err = d.Set("traffic_policy_version", response.TrafficPolicyInstance.TrafficPolicyVersion)
+	if err != nil {
+		return fmt.Errorf("Error setting traffic_policy_version for: %s, error: %#v", d.Id(), err)
+	}
+
+	err = d.Set("ttl", response.TrafficPolicyInstance.TTL)
+	if err != nil {
+		return fmt.Errorf("Error setting ttl for: %s, error: %#v", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53TrafficPolicyInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+
+	request := &route53.UpdateTrafficPolicyInstanceInput{
+		Id:                   aws.String(d.Id()),
+		TrafficPolicyId:      aws.String(d.Get("traffic_policy_id").(string)),
+		TrafficPolicyVersion: aws.Int64(int64(d.Get("traffic_policy_version").(int))),
+		TTL:                  aws.Int64(int64(d.Get("ttl").(int))),
+	}
+
+	_, err := conn.UpdateTrafficPolicyInstance(request)
+	if err != nil {
+		return fmt.Errorf("Error updating Route53 Traffic Policy Instance %s: %s", d.Get("name").(string), err)
+	}
+
+	return resourceAwsRoute53TrafficPolicyInstanceRead(d, meta)
+}
+
+func resourceAwsRoute53TrafficPolicyInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53conn
+
+	request := &route53.DeleteTrafficPolicyInstanceInput{
+		Id: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteTrafficPolicyInstance(request)
+	if err != nil {
+		return fmt.Errorf("Error deleting Route53 Traffic Policy Instance %s: %s", d.Get("name").(string), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_route53_traffic_policy_instance_test.go
+++ b/aws/resource_aws_route53_traffic_policy_instance_test.go
@@ -1,0 +1,1 @@
+package aws

--- a/website/docs/r/route53_traffic_policy_instance.html.markdown
+++ b/website/docs/r/route53_traffic_policy_instance.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "Route53"
+layout: "aws"
+page_title: "AWS: aws_route53_traffic_policy_instance"
+description: |-
+  Provides a Route53 traffic policy instance resource.
+---
+
+# Resource: aws_route53_traffic_policy_instance
+
+Provides a Route53 traffic policy instance resource.
+
+## Example Usage
+
+```hcl
+resource "aws_route53_traffic_policy_instance" "test" {
+  name                   = "test.example.com"
+  traffic_policy_id      = "b3gb108f-ea6f-45a5-baab-9d112d8b4037"
+  traffic_policy_version = 1
+  hosted_zone_id         = "Z033120931TAQO548OGJC"
+  ttl                    = 360
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The domain name for which Amazon Route 53 responds to DNS queries by using the resource record sets that Route 53 creates for this traffic policy instance.
+* `traffic_policy_id` - (Required) The ID of the traffic policy that you want to use to create resource record sets in the specified hosted zone.
+* `traffic_policy_version` - (Required) The version of the traffic policy
+* `hosted_zone_id` - (Required) The ID of the hosted zone
+* `ttl` - (Optional) The TTL that you want Amazon Route 53 to assign to all of the resource record sets that it creates in the specified hosted zone.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Id of created traffic policy instance.
+
+## Import
+
+Route53 traffic policy instance can be imported using its id.
+
+```
+$ terraform import aws_route53_traffic_policy_instance.test df579d9a-6396-410e-ac22-e7ad60cf9e7e
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11256

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: aws_route53_traffic_policy_instance
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


### NOTE:

This is a draft PR. It doesn't have acc tests because #14331 is not yet merged so I cannot use that resource in test configs. But of course, I'm open to feedback from maintainers and the broader community. 