### PR TITLE
New data source: aws_iam_openid_connect_provider

### DIFF
--- a/aws/data_source_aws_iam_openid_connect_provider.go
+++ b/aws/data_source_aws_iam_openid_connect_provider.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceAwsIamOpenIDConnectProvider() *schema.Resource {

--- a/aws/data_source_aws_iam_openid_connect_provider.go
+++ b/aws/data_source_aws_iam_openid_connect_provider.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsIamOpenIDConnectProvider() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsIamOpenIDConnectProviderRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"client_id_list": {
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Computed: true,
+			},
+			"thumbprint_list": {
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsIamOpenIDConnectProviderRead(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	arn := d.Get("arn").(string)
+	input := &iam.GetOpenIDConnectProviderInput{
+		OpenIDConnectProviderArn: aws.String(arn),
+	}
+	out, err := iamconn.GetOpenIDConnectProvider(input)
+	if err != nil {
+		return fmt.Errorf("error reading IAM OIDC Provider (%s): %w", arn, err)
+	}
+
+	d.SetId(arn)
+	d.Set("url", out.Url)
+	d.Set("client_id_list", flattenStringList(out.ClientIDList))
+	d.Set("thumbprint_list", flattenStringList(out.ThumbprintList))
+
+	return nil
+}

--- a/aws/data_source_aws_iam_openid_connect_provider_test.go
+++ b/aws/data_source_aws_iam_openid_connect_provider_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccAWSDataSourceIamOpenIDConnectProvider_basic(t *testing.T) {

--- a/aws/data_source_aws_iam_openid_connect_provider_test.go
+++ b/aws/data_source_aws_iam_openid_connect_provider_test.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSDataSourceIamOpenIDConnectProvider_basic(t *testing.T) {
+	resourceName := "data.aws_iam_openid_connect_provider.test"
+	rString := acctest.RandString(5)
+	url := "accounts.testle.com/" + rString
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceAwsIamOpenIDConnectProviderConfig(url),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_iam_openid_connect_provider.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "url", url),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.0",
+						"266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com"),
+					resource.TestCheckResourceAttr(resourceName, "thumbprint_list.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "thumbprint_list.0", "cf23df2207d99a74fbe169e3eba035e633b65d94"),
+					resource.TestCheckResourceAttr(resourceName, "thumbprint_list.1", "c784713d6f9cb67b55dd84f4e4af7832d42b8f55"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceAwsIamOpenIDConnectProviderConfig(url string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_openid_connect_provider" "test" {
+	url = "https://%s"
+	
+	client_id_list = [
+		"266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com",
+	]
+	
+	thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94", "c784713d6f9cb67b55dd84f4e4af7832d42b8f55"]
+}
+
+data "aws_iam_openid_connect_provider" "test" {
+	arn = aws_iam_openid_connect_provider.test.arn
+}
+`, url)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -256,6 +256,7 @@ func Provider() *schema.Provider {
 			"aws_iam_account_alias":                          dataSourceAwsIamAccountAlias(),
 			"aws_iam_group":                                  dataSourceAwsIAMGroup(),
 			"aws_iam_instance_profile":                       dataSourceAwsIAMInstanceProfile(),
+			"aws_iam_openid_connect_provider":                dataSourceAwsIamOpenIDConnectProvider(),
 			"aws_iam_policy":                                 dataSourceAwsIAMPolicy(),
 			"aws_iam_policy_document":                        dataSourceAwsIamPolicyDocument(),
 			"aws_iam_role":                                   dataSourceAwsIAMRole(),

--- a/website/docs/d/iam_openid_connect_provider.html.markdown
+++ b/website/docs/d/iam_openid_connect_provider.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "IAM"
+layout: "aws"
+page_title: "AWS: aws_iam_openid_connect_provider"
+description: |-
+  Retrieve an IAM OpenID Connect provider.
+---
+
+# Data Source: aws_iam_openid_connect_provider
+
+Retrieve an IAM OpenID Connect provider.
+
+## Example Usage
+
+```hcl
+data "aws_iam_openid_connect_provider" "default" {
+  arn = "arn:aws:iam::123456789012:oidc-provider/server.example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `arn` - (Required) The ARN assigned by AWS for this provider.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `url` - The URL of the identity provider. Corresponds to the _iss_ claim.
+* `client_id_list` - A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)
+* `thumbprint_list` - A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s). 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New data source: aws_iam_openid_connect_provider (#14375)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDataSourceIamOpenIDConnectProvider_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIamOpenIDConnectProvider_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIamOpenIDConnectProvider_basic
=== PAUSE TestAccAWSDataSourceIamOpenIDConnectProvider_basic
=== CONT  TestAccAWSDataSourceIamOpenIDConnectProvider_basic
--- PASS: TestAccAWSDataSourceIamOpenIDConnectProvider_basic (33.10s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       33.135s
```