### PR TITLE
Fix DescribeClientVpnTargetNetworks

### DIFF
--- a/aws/internal/service/ec2/waiter/status.go
+++ b/aws/internal/service/ec2/waiter/status.go
@@ -120,7 +120,12 @@ func ClientVpnNetworkAssociationStatus(conn *ec2.EC2, cvnaID string, cvepID stri
 	return func() (interface{}, string, error) {
 		result, err := conn.DescribeClientVpnTargetNetworks(&ec2.DescribeClientVpnTargetNetworksInput{
 			ClientVpnEndpointId: aws.String(cvepID),
-			AssociationIds:      []*string{aws.String(cvnaID)},
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("association-id"),
+					Values: []*string{aws.String(cvnaID)},
+				},
+			},
 		})
 
 		if tfec2.ErrCodeEquals(err, tfec2.ErrCodeClientVpnAssociationIdNotFound) || tfec2.ErrCodeEquals(err, tfec2.ErrCodeClientVpnEndpointIdNotFound) {

--- a/aws/resource_aws_ec2_client_vpn_network_association.go
+++ b/aws/resource_aws_ec2_client_vpn_network_association.go
@@ -119,7 +119,12 @@ func resourceAwsEc2ClientVpnNetworkAssociationRead(d *schema.ResourceData, meta 
 
 	result, err := conn.DescribeClientVpnTargetNetworks(&ec2.DescribeClientVpnTargetNetworksInput{
 		ClientVpnEndpointId: aws.String(d.Get("client_vpn_endpoint_id").(string)),
-		AssociationIds:      []*string{aws.String(d.Id())},
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("association-id"),
+				Values: []*string{aws.String(d.Id())},
+			},
+		},
 	})
 
 	if isAWSErr(err, tfec2.ErrCodeClientVpnAssociationIdNotFound, "") || isAWSErr(err, tfec2.ErrCodeClientVpnEndpointIdNotFound, "") {

--- a/aws/resource_aws_ec2_client_vpn_network_association_test.go
+++ b/aws/resource_aws_ec2_client_vpn_network_association_test.go
@@ -207,7 +207,12 @@ func testAccCheckAwsEc2ClientVpnNetworkAssociationDestroy(s *terraform.State) er
 
 		resp, _ := conn.DescribeClientVpnTargetNetworks(&ec2.DescribeClientVpnTargetNetworksInput{
 			ClientVpnEndpointId: aws.String(rs.Primary.Attributes["client_vpn_endpoint_id"]),
-			AssociationIds:      []*string{aws.String(rs.Primary.ID)},
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("association-id"),
+					Values: []*string{aws.String(rs.Primary.ID)},
+				},
+			},
 		})
 
 		for _, v := range resp.ClientVpnTargetNetworks {
@@ -235,7 +240,12 @@ func testAccCheckAwsEc2ClientVpnNetworkAssociationExists(name string, assoc *ec2
 
 		resp, err := conn.DescribeClientVpnTargetNetworks(&ec2.DescribeClientVpnTargetNetworksInput{
 			ClientVpnEndpointId: aws.String(rs.Primary.Attributes["client_vpn_endpoint_id"]),
-			AssociationIds:      []*string{aws.String(rs.Primary.ID)},
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("association-id"),
+					Values: []*string{aws.String(rs.Primary.ID)},
+				},
+			},
 		})
 
 		if err != nil {


### PR DESCRIPTION
Amazon API doesn't return the correct results when using
"AssociationIds" but works correctly when using a filter for the same
thing

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11586

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix Client Access VPN network association refresh
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsEc2ClientVpn_serial/NetworkAssociation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsEc2ClientVpn_serial/NetworkAssociation -timeout 120m
=== RUN   TestAccAwsEc2ClientVpn_serial
=== PAUSE TestAccAwsEc2ClientVpn_serial
=== CONT  TestAccAwsEc2ClientVpn_serial
=== RUN   TestAccAwsEc2ClientVpn_serial/NetworkAssociation_basic
=== PAUSE TestAccAwsEc2ClientVpn_serial/NetworkAssociation_basic
=== RUN   TestAccAwsEc2ClientVpn_serial/NetworkAssociation_disappears
=== PAUSE TestAccAwsEc2ClientVpn_serial/NetworkAssociation_disappears
=== RUN   TestAccAwsEc2ClientVpn_serial/NetworkAssociation_securityGroups
=== PAUSE TestAccAwsEc2ClientVpn_serial/NetworkAssociation_securityGroups
=== CONT  TestAccAwsEc2ClientVpn_serial/NetworkAssociation_basic
=== CONT  TestAccAwsEc2ClientVpn_serial/NetworkAssociation_securityGroups
=== CONT  TestAccAwsEc2ClientVpn_serial/NetworkAssociation_disappears
    resource_aws_ec2_client_vpn_network_association_test.go:148: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAwsEc2ClientVpn_serial (0.86s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_securityGroups (613.89s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_basic (755.98s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_disappears (832.45s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       833.015s

...
```

We submitted an AWS ticket about this back in February and they said "Use filter attribute". I've reopened it and will update if they admit this is a bug
