### PR TITLE
Use multipart uploads for creating S3 objects

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/mitchellh/go-homedir"
@@ -196,8 +197,8 @@ func resourceAwsS3BucketObject() *schema.Resource {
 	}
 }
 
-func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) error {
-	s3conn := meta.(*AWSClient).s3conn
+func resourceAwsS3BucketObjectUpload(d *schema.ResourceData, meta interface{}) error {
+	uploader := s3manager.NewUploaderWithClient(meta.(*AWSClient).s3conn)
 
 	var body io.ReadSeeker
 
@@ -236,7 +237,7 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 
-	putInput := &s3.PutObjectInput{
+	uploadInput := &s3manager.UploadInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 		ACL:    aws.String(d.Get("acl").(string)),
@@ -244,65 +245,65 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := d.GetOk("storage_class"); ok {
-		putInput.StorageClass = aws.String(v.(string))
+		uploadInput.StorageClass = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("cache_control"); ok {
-		putInput.CacheControl = aws.String(v.(string))
+		uploadInput.CacheControl = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("content_type"); ok {
-		putInput.ContentType = aws.String(v.(string))
+		uploadInput.ContentType = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {
-		putInput.Metadata = stringMapToPointers(v.(map[string]interface{}))
+		uploadInput.Metadata = stringMapToPointers(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("content_encoding"); ok {
-		putInput.ContentEncoding = aws.String(v.(string))
+		uploadInput.ContentEncoding = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("content_language"); ok {
-		putInput.ContentLanguage = aws.String(v.(string))
+		uploadInput.ContentLanguage = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("content_disposition"); ok {
-		putInput.ContentDisposition = aws.String(v.(string))
+		uploadInput.ContentDisposition = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("server_side_encryption"); ok {
-		putInput.ServerSideEncryption = aws.String(v.(string))
+		uploadInput.ServerSideEncryption = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("kms_key_id"); ok {
-		putInput.SSEKMSKeyId = aws.String(v.(string))
-		putInput.ServerSideEncryption = aws.String(s3.ServerSideEncryptionAwsKms)
+		uploadInput.SSEKMSKeyId = aws.String(v.(string))
+		uploadInput.ServerSideEncryption = aws.String(s3.ServerSideEncryptionAwsKms)
 	}
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
 		// The tag-set must be encoded as URL Query parameters.
-		putInput.Tagging = aws.String(keyvaluetags.New(v).IgnoreAws().UrlEncode())
+		uploadInput.Tagging = aws.String(keyvaluetags.New(v).IgnoreAws().UrlEncode())
 	}
 
 	if v, ok := d.GetOk("website_redirect"); ok {
-		putInput.WebsiteRedirectLocation = aws.String(v.(string))
+		uploadInput.WebsiteRedirectLocation = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("object_lock_legal_hold_status"); ok {
-		putInput.ObjectLockLegalHoldStatus = aws.String(v.(string))
+		uploadInput.ObjectLockLegalHoldStatus = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("object_lock_mode"); ok {
-		putInput.ObjectLockMode = aws.String(v.(string))
+		uploadInput.ObjectLockMode = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("object_lock_retain_until_date"); ok {
-		putInput.ObjectLockRetainUntilDate = expandS3ObjectLockRetainUntilDate(v.(string))
+		uploadInput.ObjectLockRetainUntilDate = expandS3ObjectLockRetainUntilDate(v.(string))
 	}
 
-	if _, err := s3conn.PutObject(putInput); err != nil {
-		return fmt.Errorf("Error putting object in S3 bucket (%s): %s", bucket, err)
+	if _, err := uploader.Upload(uploadInput); err != nil {
+		return fmt.Errorf("Error uploading object to S3 bucket (%s): %s", bucket, err)
 	}
 
 	d.SetId(key)
@@ -310,7 +311,7 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceAwsS3BucketObjectCreate(d *schema.ResourceData, meta interface{}) error {
-	return resourceAwsS3BucketObjectPut(d, meta)
+	return resourceAwsS3BucketObjectUpload(d, meta)
 }
 
 func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) error {
@@ -421,7 +422,7 @@ func resourceAwsS3BucketObjectUpdate(d *schema.ResourceData, meta interface{}) e
 		"website_redirect",
 	} {
 		if d.HasChange(key) {
-			return resourceAwsS3BucketObjectPut(d, meta)
+			return resourceAwsS3BucketObjectUpload(d, meta)
 		}
 	}
 


### PR DESCRIPTION
This patch replaces the previous `s3.PutObject` call with an `Uploader` instance from the `s3manager` package.

This allows uploading S3 objects larger than 5GB (see bug report that this is closing).

I tested this locally, but did not run the acceptance test as I don't want to cover the cost for those.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #788

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
