### PR TITLE
aws_workspaces_directory: Assign IP Group

### DIFF
--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -283,6 +283,45 @@ func TestAccAwsWorkspacesDirectory_workspaceCreationProperties(t *testing.T) {
 	})
 }
 
+func TestAccAwsWorkspacesDirectory_ipGroupIds(t *testing.T) {
+	var v workspaces.WorkspaceDirectory
+	rName := acctest.RandString(8)
+
+	resourceName := "aws_workspaces_directory.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspacesDirectoryConfig_ipGroupIds_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ip_group_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccWorkspacesDirectoryConfig_ipGroupIds_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ip_group_ids.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccPreCheckHasIAMRole(t *testing.T, roleName string) {
 	conn := testAccProvider.Meta().(*AWSClient).iamconn
 
@@ -615,6 +654,47 @@ resource "aws_workspaces_directory" "main" {
     enable_maintenance_mode             = false
     user_enabled_as_local_administrator = false
   }
+}
+`, rName))
+}
+
+func testAccWorkspacesDirectoryConfig_ipGroupIds_create(rName string) string {
+	return composeConfig(
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		fmt.Sprintf(`
+resource "aws_workspaces_ip_group" "test_alpha" {
+  name = "%[1]s-alpha"
+}
+
+resource "aws_workspaces_directory" "test" {
+  directory_id = aws_directory_service_directory.main.id
+
+  ip_group_ids = [
+    aws_workspaces_ip_group.test_alpha.id
+  ]
+}
+`, rName))
+}
+
+func testAccWorkspacesDirectoryConfig_ipGroupIds_update(rName string) string {
+	return composeConfig(
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		fmt.Sprintf(`
+resource "aws_workspaces_ip_group" "test_beta" {
+  name = "%[1]s-beta"
+}
+
+resource "aws_workspaces_ip_group" "test_gamma" {
+  name = "%[1]s-gamma"
+}
+
+resource "aws_workspaces_directory" "test" {
+  directory_id = aws_directory_service_directory.main.id
+
+  ip_group_ids = [
+    aws_workspaces_ip_group.test_beta.id,
+    aws_workspaces_ip_group.test_gamma.id
+  ]
 }
 `, rName))
 }

--- a/website/docs/r/workspaces_directory.html.markdown
+++ b/website/docs/r/workspaces_directory.html.markdown
@@ -116,12 +116,29 @@ resource "aws_subnet" "example_d" {
 }
 ```
 
+### IP Groups
+
+```hcl
+resource "aws_workspaces_directory" "example" {
+  directory_id = aws_directory_service_directory.example.id
+
+  ip_group_ids = [
+    aws_workspaces_ip_group.example.id,
+  ]
+}
+
+resource "aws_workspaces_ip_group" "example" {
+  name = "example"
+}
+```
+
 ## Arguments Reference
 
 The following arguments are supported:
 
 * `directory_id` - (Required) The directory identifier for registration in WorkSpaces service.
-* `subnet_ids` - (Optional) The subnets identifiers where the workspaces are created.
+* `subnet_ids` - (Optional) The identifiers of the subnets where the directory resides.
+* `ip_group_ids` - The identifiers of the IP access control groups associated with the directory.
 * `tags` – (Optional) A map of tags assigned to the WorkSpaces directory.
 * `self_service_permissions` – (Optional) Permissions to enable or disable self-service capabilities. Defined below.
 * `workspace_creation_properties` – (Optional) Default properties that are used for creating WorkSpaces. Defined below.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates  #434
Closes #14669

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
aws_workspaces_directory: Assign IP group
```

### Acceptance Test

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsWorkspacesDirectory_ipGroupIds'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWorkspacesDirectory_ipGroupIds -timeout 120m
=== RUN   TestAccAwsWorkspacesDirectory_ipGroupIds
=== PAUSE TestAccAwsWorkspacesDirectory_ipGroupIds
=== CONT  TestAccAwsWorkspacesDirectory_ipGroupIds
--- PASS: TestAccAwsWorkspacesDirectory_ipGroupIds (903.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	906.724s
```