### PR TITLE
Resource/lb_listener:  Add alpn policy argument

### DIFF
--- a/.changelog/14462.txt
+++ b/.changelog/14462.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_lb_listener: Add `alpn_policy` argument
+```
+
+```release-note:enhancement
+data-source/aws_lb_listener: Add `alpn_policy` argument
+```

--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -49,6 +49,11 @@ func dataSourceAwsLbListener() *schema.Resource {
 				Computed: true,
 			},
 
+			"alpn_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"default_action": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -14,46 +14,20 @@ func dataSourceAwsLbListener() *schema.Resource {
 		Read: dataSourceAwsLbListenerRead,
 
 		Schema: map[string]*schema.Schema{
+			"alpn_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"arn": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"load_balancer_arn", "port"},
 			},
-
-			"load_balancer_arn": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"arn"},
-			},
-			"port": {
-				Type:          schema.TypeInt,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"arn"},
-			},
-
-			"protocol": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"ssl_policy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"certificate_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"alpn_policy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"default_action": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -174,6 +148,46 @@ func dataSourceAwsLbListener() *schema.Resource {
 								},
 							},
 						},
+						"forward": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"stickiness": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"duration": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"enabled": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"target_group": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"arn": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"weight": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						"order": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -218,48 +232,28 @@ func dataSourceAwsLbListener() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"forward": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"target_group": {
-										Type:     schema.TypeSet,
-										Computed: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"arn": {
-													Type:     schema.TypeString,
-													Computed: true,
-												},
-												"weight": {
-													Type:     schema.TypeInt,
-													Computed: true,
-												},
-											},
-										},
-									},
-									"stickiness": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"enabled": {
-													Type:     schema.TypeBool,
-													Computed: true,
-												},
-												"duration": {
-													Type:     schema.TypeInt,
-													Computed: true,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
 					},
 				},
+			},
+			"load_balancer_arn": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"arn"},
+			},
+			"port": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"arn"},
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ssl_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 func TestAccDataSourceAWSLBListener_basic(t *testing.T) {
-	lbName := fmt.Sprintf("testlistener-basic-%s", acctest.RandString(13))
-	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_lb_listener.test"
+	dataSourceName2 := "data.aws_lb_listener.from_lb_and_port"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
@@ -19,22 +20,22 @@ func TestAccDataSourceAWSLBListener_basic(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSLBListenerConfigBasic(lbName, targetGroupName),
+				Config: testAccDataSourceAWSLBListenerConfigBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "load_balancer_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "default_action.0.target_group_arn"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "protocol", "HTTP"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "port", "80"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.0.type", "forward"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "load_balancer_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "default_action.0.target_group_arn"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "protocol", "HTTP"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "port", "80"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "default_action.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(dataSourceName, "port", "80"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttr(dataSourceName2, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(dataSourceName2, "port", "80"),
+					resource.TestCheckResourceAttr(dataSourceName2, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName2, "default_action.0.type", "forward"),
 				),
 			},
 		},
@@ -42,8 +43,9 @@ func TestAccDataSourceAWSLBListener_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAWSLBListener_BackwardsCompatibility(t *testing.T) {
-	lbName := fmt.Sprintf("testlistener-basic-%s", acctest.RandString(13))
-	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_alb_listener.test"
+	dataSourceName2 := "data.aws_alb_listener.from_lb_and_port"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
@@ -51,22 +53,22 @@ func TestAccDataSourceAWSLBListener_BackwardsCompatibility(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSLBListenerConfigBackwardsCompatibility(lbName, targetGroupName),
+				Config: testAccDataSourceAWSLBListenerConfigBackwardsCompatibility(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "load_balancer_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "arn"),
-					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "default_action.0.target_group_arn"),
-					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "protocol", "HTTP"),
-					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "port", "80"),
-					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "default_action.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "default_action.0.type", "forward"),
-					resource.TestCheckResourceAttrSet("data.aws_alb_listener.from_lb_and_port", "load_balancer_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_alb_listener.from_lb_and_port", "arn"),
-					resource.TestCheckResourceAttrSet("data.aws_alb_listener.from_lb_and_port", "default_action.0.target_group_arn"),
-					resource.TestCheckResourceAttr("data.aws_alb_listener.from_lb_and_port", "protocol", "HTTP"),
-					resource.TestCheckResourceAttr("data.aws_alb_listener.from_lb_and_port", "port", "80"),
-					resource.TestCheckResourceAttr("data.aws_alb_listener.from_lb_and_port", "default_action.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_alb_listener.from_lb_and_port", "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(dataSourceName, "port", "80"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttr(dataSourceName2, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(dataSourceName2, "port", "80"),
+					resource.TestCheckResourceAttr(dataSourceName2, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName2, "default_action.0.type", "forward"),
 				),
 			},
 		},
@@ -74,10 +76,11 @@ func TestAccDataSourceAWSLBListener_BackwardsCompatibility(t *testing.T) {
 }
 
 func TestAccDataSourceAWSLBListener_https(t *testing.T) {
-	lbName := fmt.Sprintf("testlistener-https-%s", acctest.RandString(13))
-	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	key := tlsRsaPrivateKeyPem(2048)
 	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
+	dataSourceName := "data.aws_lb_listener.test"
+	dataSourceName2 := "data.aws_lb_listener.from_lb_and_port"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
@@ -85,26 +88,26 @@ func TestAccDataSourceAWSLBListener_https(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSLBListenerConfigHTTPS(lbName, targetGroupName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key)),
+				Config: testAccDataSourceAWSLBListenerConfigHTTPS(rName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "load_balancer_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "default_action.0.target_group_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "certificate_arn"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "protocol", "HTTPS"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "port", "443"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.0.type", "forward"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "ssl_policy", "ELBSecurityPolicy-2016-08"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "load_balancer_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "default_action.0.target_group_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "certificate_arn"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "protocol", "HTTPS"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "port", "443"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "default_action.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "default_action.0.type", "forward"),
-					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "ssl_policy", "ELBSecurityPolicy-2016-08"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "certificate_arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(dataSourceName, "port", "443"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttr(dataSourceName, "ssl_policy", "ELBSecurityPolicy-2016-08"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName2, "certificate_arn"),
+					resource.TestCheckResourceAttr(dataSourceName2, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(dataSourceName2, "port", "443"),
+					resource.TestCheckResourceAttr(dataSourceName2, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName2, "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttr(dataSourceName2, "ssl_policy", "ELBSecurityPolicy-2016-08"),
 				),
 			},
 		},
@@ -132,10 +135,10 @@ func TestAccDataSourceAWSLBListener_DefaultAction_Forward(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAWSLBListenerConfigBasic(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
-resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = aws_lb.alb_test.id
+func testAccDataSourceAWSLBListenerConfigBasic(rName string) string {
+	return composeConfig(testAccAWSLBListenerConfigBase(rName), fmt.Sprintf(`
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
   protocol          = "HTTP"
   port              = "80"
 
@@ -145,11 +148,11 @@ resource "aws_lb_listener" "front_end" {
   }
 }
 
-resource "aws_lb" "alb_test" {
-  name            = "%s"
+resource "aws_lb" "test" {
+  name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -160,10 +163,10 @@ resource "aws_lb" "alb_test" {
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 8080
   protocol = "HTTP"
-  vpc_id   = aws_vpc.alb_test.id
+  vpc_id   = aws_vpc.test.id
 
   health_check {
     path                = "/health"
@@ -177,91 +180,21 @@ resource "aws_lb_target_group" "test" {
   }
 }
 
-variable "subnets" {
-  default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = list(string)
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "alb_test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-lb-listener-data-source-basic"
-  }
-}
-
-resource "aws_subnet" "alb_test" {
-  count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
-  cidr_block              = element(var.subnets, count.index)
-  map_public_ip_on_launch = true
-  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
-
-  tags = {
-    Name = "tf-acc-lb-listener-data-source-basic"
-  }
-}
-
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
-  description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
-
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    self      = true
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    TestName = "TestAccAWSALB_basic"
-  }
-}
-
-data "aws_lb_listener" "front_end" {
-  arn = aws_lb_listener.front_end.arn
+data "aws_lb_listener" "test" {
+  arn = aws_lb_listener.test.arn
 }
 
 data "aws_lb_listener" "from_lb_and_port" {
-  load_balancer_arn = aws_lb.alb_test.arn
-  port              = aws_lb_listener.front_end.port
+  load_balancer_arn = aws_lb.test.arn
+  port              = aws_lb_listener.test.port
+}
+`, rName))
 }
 
-output "front_end_load_balancer_arn" {
-  value = data.aws_lb_listener.front_end.load_balancer_arn
-}
-
-output "front_end_port" {
-  value = data.aws_lb_listener.front_end.port
-}
-
-output "from_lb_and_port_arn" {
-  value = data.aws_lb_listener.from_lb_and_port.arn
-}
-`, lbName, targetGroupName)
-}
-
-func testAccDataSourceAWSLBListenerConfigBackwardsCompatibility(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
-resource "aws_alb_listener" "front_end" {
-  load_balancer_arn = aws_alb.alb_test.id
+func testAccDataSourceAWSLBListenerConfigBackwardsCompatibility(rName string) string {
+	return composeConfig(testAccAWSLBListenerConfigBase(rName), fmt.Sprintf(`
+resource "aws_alb_listener" "test" {
+  load_balancer_arn = aws_alb.test.id
   protocol          = "HTTP"
   port              = "80"
 
@@ -271,11 +204,11 @@ resource "aws_alb_listener" "front_end" {
   }
 }
 
-resource "aws_alb" "alb_test" {
-  name            = "%s"
+resource "aws_alb" "test" {
+  name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -286,10 +219,10 @@ resource "aws_alb" "alb_test" {
 }
 
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 8080
   protocol = "HTTP"
-  vpc_id   = aws_vpc.alb_test.id
+  vpc_id   = aws_vpc.test.id
 
   health_check {
     path                = "/health"
@@ -303,83 +236,25 @@ resource "aws_alb_target_group" "test" {
   }
 }
 
-variable "subnets" {
-  default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = list(string)
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "alb_test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-lb-listener-data-source-bc"
-  }
-}
-
-resource "aws_subnet" "alb_test" {
-  count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
-  cidr_block              = element(var.subnets, count.index)
-  map_public_ip_on_launch = true
-  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
-
-  tags = {
-    Name = "tf-acc-lb-listener-data-source-bc"
-  }
-}
-
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
-  description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
-
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    self      = true
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    TestName = "TestAccAWSALB_basic"
-  }
-}
-
-data "aws_alb_listener" "front_end" {
-  arn = aws_alb_listener.front_end.arn
+data "aws_alb_listener" "test" {
+  arn = aws_alb_listener.test.arn
 }
 
 data "aws_alb_listener" "from_lb_and_port" {
-  load_balancer_arn = aws_alb.alb_test.arn
-  port              = aws_alb_listener.front_end.port
+  load_balancer_arn = aws_alb.test.arn
+  port              = aws_alb_listener.test.port
 }
-`, lbName, targetGroupName)
+`, rName))
 }
 
-func testAccDataSourceAWSLBListenerConfigHTTPS(lbName, targetGroupName, certificate, key string) string {
-	return fmt.Sprintf(`
-resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = aws_lb.alb_test.id
+func testAccDataSourceAWSLBListenerConfigHTTPS(rName, certificate, key string) string {
+	return composeConfig(testAccAWSLBListenerConfigBase(rName), fmt.Sprintf(`
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
   protocol          = "HTTPS"
   port              = "443"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = aws_iam_server_certificate.test_cert.arn
+  certificate_arn   = aws_iam_server_certificate.test.arn
 
   default_action {
     target_group_arn = aws_lb_target_group.test.id
@@ -387,11 +262,11 @@ resource "aws_lb_listener" "front_end" {
   }
 }
 
-resource "aws_lb" "alb_test" {
-  name            = "%[1]s"
+resource "aws_lb" "test" {
+  name            = %[1]q
   internal        = false
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -404,10 +279,10 @@ resource "aws_lb" "alb_test" {
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%[2]s"
+  name     = %[1]q
   port     = 8080
   protocol = "HTTP"
-  vpc_id   = aws_vpc.alb_test.id
+  vpc_id   = aws_vpc.test.id
 
   health_check {
     path                = "/health"
@@ -421,88 +296,30 @@ resource "aws_lb_target_group" "test" {
   }
 }
 
-variable "subnets" {
-  default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = list(string)
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "alb_test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-lb-listener-data-source-https"
-  }
-}
-
 resource "aws_internet_gateway" "gw" {
-  vpc_id = aws_vpc.alb_test.id
+  vpc_id = aws_vpc.test.id
 
   tags = {
-    Name     = "terraform-testacc-lb-listener-data-source-https"
+    Name     = %[1]q
     TestName = "TestAccAWSALB_basic"
   }
 }
 
-resource "aws_subnet" "alb_test" {
-  count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
-  cidr_block              = element(var.subnets, count.index)
-  map_public_ip_on_launch = true
-  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
-
-  tags = {
-    Name = "tf-acc-lb-listener-data-source-https"
-  }
+resource "aws_iam_server_certificate" "test" {
+  name             = %[1]q
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
 }
 
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
-  description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
-
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    self      = true
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    TestName = "TestAccAWSALB_basic"
-  }
-}
-
-resource "aws_iam_server_certificate" "test_cert" {
-  name             = "terraform-test-cert-%[3]d"
-  certificate_body = "%[4]s"
-  private_key      = "%[5]s"
-}
-
-data "aws_lb_listener" "front_end" {
-  arn = aws_lb_listener.front_end.arn
+data "aws_lb_listener" "test" {
+  arn = aws_lb_listener.test.arn
 }
 
 data "aws_lb_listener" "from_lb_and_port" {
-  load_balancer_arn = aws_lb.alb_test.arn
-  port              = aws_lb_listener.front_end.port
+  load_balancer_arn = aws_lb.test.arn
+  port              = aws_lb_listener.test.port
 }
-`, lbName, targetGroupName, acctest.RandInt(), certificate, key)
+`, rName, certificate, key))
 }
 
 func testAccDataSourceAWSLBListenerConfigDefaultActionForward(rName string) string {
@@ -513,7 +330,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "tf-acc-test-load-balancer"
+    Name = %[1]q
   }
 }
 
@@ -525,7 +342,7 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-test-load-balancer"
+    Name = %[1]q
   }
 }
 

--- a/aws/internal/service/elbv2/waiter/waiter.go
+++ b/aws/internal/service/elbv2/waiter/waiter.go
@@ -25,6 +25,9 @@ const (
 
 	// Default maximum amount of time to wait for network interfaces to propagate
 	LoadBalancerNetworkInterfaceDetachTimeout = 5 * time.Minute
+
+	LoadBalancerListenerCreateTimeout = 5 * time.Minute
+	LoadBalancedListenerReadTimeout   = 2 * time.Minute
 )
 
 // LoadBalancerActive waits for a Load Balancer to return active

--- a/aws/internal/service/elbv2/waiter/waiter.go
+++ b/aws/internal/service/elbv2/waiter/waiter.go
@@ -27,7 +27,8 @@ const (
 	LoadBalancerNetworkInterfaceDetachTimeout = 5 * time.Minute
 
 	LoadBalancerListenerCreateTimeout = 5 * time.Minute
-	LoadBalancedListenerReadTimeout   = 2 * time.Minute
+	LoadBalancerListenerReadTimeout   = 2 * time.Minute
+	LoadBalancerListenerUpdateTimeout = 5 * time.Minute
 )
 
 // LoadBalancerActive waits for a Load Balancer to return active

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -75,6 +75,13 @@ func resourceAwsLbListener() *schema.Resource {
 			"alpn_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"HTTP1Only",
+					"HTTP2Only",
+					"HTTP2Optional",
+					"HTTP2Preferred",
+					"None",
+				}, true),
 			},
 
 			"default_action": {

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -566,7 +566,7 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating ELBv2 Listener: %s", err)
+		return fmt.Errorf("error creating ELBv2 Listener (%s): %w", d.Get("load_balancer_arn").(string), err)
 	}
 
 	if output == nil || len(output.Listeners) == 0 {
@@ -751,7 +751,7 @@ func resourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
 		defaultActions[i] = defaultActionMap
 	}
 	if err := d.Set("default_action", defaultActions); err != nil {
-		return fmt.Errorf("error setting default_action: %s", err)
+		return fmt.Errorf("error setting default_action for ELBv2 listener (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -935,7 +935,7 @@ func resourceAwsLbListenerUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error modifying LB Listener: %s", err)
+		return fmt.Errorf("error modifying ELBv2 Listener (%s): %w", d.Id(), err)
 	}
 
 	return resourceAwsLbListenerRead(d, meta)
@@ -948,7 +948,7 @@ func resourceAwsLbListenerDelete(d *schema.ResourceData, meta interface{}) error
 		ListenerArn: aws.String(d.Id()),
 	})
 	if err != nil {
-		return fmt.Errorf("Error deleting Listener: %s", err)
+		return fmt.Errorf("error deleting Listener (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -1421,7 +1421,7 @@ resource "aws_lb_listener" "test" {
       user_pool_client_id = aws_cognito_user_pool_client.test.id
       user_pool_domain    = aws_cognito_user_pool_domain.test.domain
 
-      authentication_request_extra_params = { 
+      authentication_request_extra_params = {
         param = "test"
       }
     }

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -841,8 +841,8 @@ resource "aws_lb_listener" "test" {
       }
 
       stickiness {
-        enabled  = true
-        duration = 3600
+	enabled  = true
+	duration = 3600
       }
     }
   }
@@ -1231,7 +1231,7 @@ resource "aws_lb" "test" {
 resource "aws_lb_target_group" "test" {
   name     = %[1]q
   port     = 443
-  protocol = "TCP"
+  protocol = "TLS"
   vpc_id   = aws_vpc.test.id
 
   health_check {
@@ -1253,6 +1253,7 @@ resource "aws_lb_listener" "test" {
   port              = "443"
   protocol          = "TLS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
+  alpn_policy       = "HTTP2Preferred"
 
   default_action {
     target_group_arn = aws_lb_target_group.test.arn
@@ -1421,7 +1422,7 @@ resource "aws_lb_listener" "test" {
       user_pool_domain    = aws_cognito_user_pool_domain.test.domain
 
       authentication_request_extra_params = {
-        param = "test"
+	param = "test"
       }
     }
   }
@@ -1503,7 +1504,7 @@ resource "aws_lb_listener" "test" {
       user_info_endpoint     = "https://example.com/user_info_endpoint"
 
       authentication_request_extra_params = {
-        param = "test"
+	param = "test"
       }
     }
   }
@@ -1538,7 +1539,7 @@ resource "aws_lb_listener" "test" {
       user_info_endpoint     = "https://example.com/user_info_endpoint"
 
       authentication_request_extra_params = {
-        param = "test"
+	param = "test"
       }
     }
   }

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -841,8 +841,8 @@ resource "aws_lb_listener" "test" {
       }
 
       stickiness {
-	enabled  = true
-	duration = 3600
+       enabled  = true
+       duration = 3600
       }
     }
   }
@@ -1504,7 +1504,7 @@ resource "aws_lb_listener" "test" {
       user_info_endpoint     = "https://example.com/user_info_endpoint"
 
       authentication_request_extra_params = {
-	param = "test"
+       param = "test"
       }
     }
   }
@@ -1539,7 +1539,7 @@ resource "aws_lb_listener" "test" {
       user_info_endpoint     = "https://example.com/user_info_endpoint"
 
       authentication_request_extra_params = {
-	param = "test"
+       param = "test"
       }
     }
   }

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -841,8 +841,8 @@ resource "aws_lb_listener" "test" {
       }
 
       stickiness {
-       enabled  = true
-       duration = 3600
+        enabled  = true
+        duration = 3600
       }
     }
   }
@@ -1421,8 +1421,8 @@ resource "aws_lb_listener" "test" {
       user_pool_client_id = aws_cognito_user_pool_client.test.id
       user_pool_domain    = aws_cognito_user_pool_domain.test.domain
 
-      authentication_request_extra_params = {
-	param = "test"
+      authentication_request_extra_params = { 
+        param = "test"
       }
     }
   }
@@ -1504,7 +1504,7 @@ resource "aws_lb_listener" "test" {
       user_info_endpoint     = "https://example.com/user_info_endpoint"
 
       authentication_request_extra_params = {
-       param = "test"
+        param = "test"
       }
     }
   }
@@ -1539,7 +1539,7 @@ resource "aws_lb_listener" "test" {
       user_info_endpoint     = "https://example.com/user_info_endpoint"
 
       authentication_request_extra_params = {
-       param = "test"
+        param = "test"
       }
     }
   }

--- a/website/docs/d/lb_listener.html.markdown
+++ b/website/docs/d/lb_listener.html.markdown
@@ -12,9 +12,7 @@ description: |-
 
 Provides information about a Load Balancer Listener.
 
-This data source can prove useful when a module accepts an LB Listener as an
-input variable and needs to know the LB it is attached to, or other
-information specific to the listener in question.
+This data source can prove useful when a module accepts an LB Listener as an input variable and needs to know the LB it is attached to, or other information specific to the listener in question.
 
 ## Example Usage
 
@@ -45,11 +43,10 @@ data "aws_lb_listener" "selected443" {
 
 The following arguments are supported:
 
-* `arn` - (Optional) The arn of the listener. Required if `load_balancer_arn` and `port` is not set.
-* `load_balancer_arn` - (Optional) The arn of the load balancer. Required if `arn` is not set.
-* `port` - (Optional) The port of the listener. Required if `arn` is not set.
+* `arn` - (Optional) ARN of the listener. Required if `load_balancer_arn` and `port` is not set.
+* `load_balancer_arn` - (Optional) ARN of the load balancer. Required if `arn` is not set.
+* `port` - (Optional) Port of the listener. Required if `arn` is not set.
 
 ## Attributes Reference
 
-See the [LB Listener Resource](/docs/providers/aws/r/lb_listener.html) for details
-on the returned attributes - they are identical.
+See the [LB Listener Resource](/docs/providers/aws/r/lb_listener.html) for details on the returned attributes - they are identical.

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -245,7 +245,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `authenticate_cognito` - (Optional) Configuration block for using Amazon Cognito to authenticate users. Specify only when `type` is `authenticate-cognito`. Detailed below.
-* `authenticate_oidc` - (Optional)
+* `authenticate_oidc` - (Optional) Configuration block for an identity provider that is compliant with OpenID Connect (OIDC). Specify only when `type` is `authenticate-oidc`. Detailed below.
 * `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
 * `forward` - (Optional) Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
 * `order` - (Optional) Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -39,6 +39,23 @@ resource "aws_lb_listener" "front_end" {
 }
 ```
 
+To a NLB:
+
+```hcl
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = aws_lb.front_end.arn
+  port              = "443"
+  protocol          = "TLS"
+  certificate_arn   = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
+  alpn_policy       = "HTTP2Preferred"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.front_end.arn
+  }
+}
+```
+
 ### Redirect Action
 
 ```terraform
@@ -211,6 +228,7 @@ The following arguments are supported:
 * `protocol` - (Optional) The protocol for connections from clients to the load balancer. For Application Load Balancers, valid values are `HTTP` and `HTTPS`, with a default of `HTTP`. For Network Load Balancers, valid values are `TCP`, `TLS`, `UDP`, and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled. Not valid for Gateway Load Balancers.
 * `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS` or `TLS`.
 * `certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
+* `alpn_policy` - (Optional)  The name of the Application-Layer Protocol Negotiation (ALPN) policy. Can be set if `protocol` is `TLS`. Valid values are `HTTP1Only`, `HTTP2Only`, `HTTP2Optional`, `HTTP2Preferred`, and `None`.
 * `default_action` - (Required) An Action block. Action blocks are documented below.
 
 ~> **NOTE::** Please note that listeners that are attached to Application Load Balancers must use either `HTTP` or `HTTPS` protocols while listeners that are attached to Network Load Balancers must use the `TCP` protocol.

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -149,7 +149,7 @@ resource "aws_lb_listener" "front_end" {
 }
 ```
 
-### Authenticate-oidc Action
+### Authenticate-OIDC Action
 
 ```terraform
 resource "aws_lb" "front_end" {
@@ -221,95 +221,140 @@ resource "aws_lb_listener" "example" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `load_balancer_arn` - (Required, Forces New Resource) The ARN of the load balancer.
-* `port` - (Optional) The port on which the load balancer is listening. Not valid for Gateway Load Balancers.
-* `protocol` - (Optional) The protocol for connections from clients to the load balancer. For Application Load Balancers, valid values are `HTTP` and `HTTPS`, with a default of `HTTP`. For Network Load Balancers, valid values are `TCP`, `TLS`, `UDP`, and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled. Not valid for Gateway Load Balancers.
-* `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS` or `TLS`.
-* `certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
-* `alpn_policy` - (Optional)  The name of the Application-Layer Protocol Negotiation (ALPN) policy. Can be set if `protocol` is `TLS`. Valid values are `HTTP1Only`, `HTTP2Only`, `HTTP2Optional`, `HTTP2Preferred`, and `None`.
-* `default_action` - (Required) An Action block. Action blocks are documented below.
+* `default_action` - (Required) Configuration block for default actions. Detailed below.
+* `load_balancer_arn` - (Required, Forces New Resource) ARN of the load balancer.
+
+The following arguments are optional:
+
+* `alpn_policy` - (Optional)  Name of the Application-Layer Protocol Negotiation (ALPN) policy. Can be set if `protocol` is `TLS`. Valid values are `HTTP1Only`, `HTTP2Only`, `HTTP2Optional`, `HTTP2Preferred`, and `None`.
+* `certificate_arn` - (Optional) ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
+* `port` - (Optional) Port on which the load balancer is listening. Not valid for Gateway Load Balancers.
+* `protocol` - (Optional) Protocol for connections from clients to the load balancer. For Application Load Balancers, valid values are `HTTP` and `HTTPS`, with a default of `HTTP`. For Network Load Balancers, valid values are `TCP`, `TLS`, `UDP`, and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled. Not valid for Gateway Load Balancers.
+* `ssl_policy` - (Optional) Name of the SSL Policy for the listener. Required if `protocol` is `HTTPS` or `TLS`.
 
 ~> **NOTE::** Please note that listeners that are attached to Application Load Balancers must use either `HTTP` or `HTTPS` protocols while listeners that are attached to Network Load Balancers must use the `TCP` protocol.
 
-Action Blocks (for `default_action`) support the following:
+### default_action
 
-* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
-* `target_group_arn` - (Optional) The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
-* `forward` - (Optional) Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
-* `redirect` - (Optional) Information for creating a redirect action. Required if `type` is `redirect`.
+The following arguments are required:
+
+* `type` - (Required) Type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
+
+The following arguments are optional:
+
+* `authenticate_cognito` - (Optional) Configuration block for using Amazon Cognito to authenticate users. Specify only when `type` is `authenticate-cognito`. Detailed below.
+* `authenticate_oidc` - (Optional)
 * `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
+* `forward` - (Optional) Configuration block for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`. Detailed below.
+* `order` - (Optional) Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between `1` and `50000`.
+* `redirect` - (Optional) Configuration block for creating a redirect action. Required if `type` is `redirect`. Detailed below.
+* `target_group_arn` - (Optional) ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
 
-Forward Blocks (for `forward`) support the following:
+#### authenticate_cognito
 
-* `target_group` - (Required) One or more target groups block.
-* `stickiness` - (Optional) The target group stickiness for the rule.
+The following arguments are required:
 
-Target Group Blocks (for `target_group`) supports the following:
+* `user_pool_arn` - (Required) ARN of the Cognito user pool.
+* `user_pool_client_id` - (Required) ID of the Cognito user pool client.
+* `user_pool_domain` - (Required) Domain prefix or fully-qualified domain name of the Cognito user pool.
 
-* `arn` - (Required) The Amazon Resource Name (ARN) of the target group.
-* `weight` - (Optional) The weight. The range is 0 to 999.
+The following arguments are optional:
 
-Target Group Stickiness Config Blocks (for `stickiness`) supports the following:
+* `authentication_request_extra_params` - (Optional) Query parameters to include in the redirect request to the authorization endpoint. Max: 10. Detailed below.
+* `on_unauthenticated_request` - (Optional) Behavior if the user is not authenticated. Valid values are `deny`, `allow` and `authenticate`.
+* `scope` - (Optional) Set of user claims to be requested from the IdP.
+* `session_cookie_name` - (Optional) Name of the cookie used to maintain session information.
+* `session_timeout` - (Optional) Maximum duration of the authentication session, in seconds.
 
-* `enabled` - (Required) Indicates whether target group stickiness is enabled.
-* `duration` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target group. The range is 1-604800 seconds (7 days).
+##### authentication_request_extra_params
 
+* `key` - (Required) Key of query parameter.
+* `value` - (Required) Value of query parameter.
 
-Redirect Blocks (for `redirect`) support the following:
+#### authenticate_oidc
+
+The following arguments are required:
+
+* `authorization_endpoint` - (Required) Authorization endpoint of the IdP.
+* `client_id` - (Required) OAuth 2.0 client identifier.
+* `client_secret` - (Required) OAuth 2.0 client secret.
+* `issuer` - (Required) OIDC issuer identifier of the IdP.
+* `token_endpoint` - (Required) Token endpoint of the IdP.
+* `user_info_endpoint` - (Required) User info endpoint of the IdP.
+
+The following arguments are optional:
+
+* `authentication_request_extra_params` - (Optional) Query parameters to include in the redirect request to the authorization endpoint. Max: 10.
+* `on_unauthenticated_request` - (Optional) Behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
+* `scope` - (Optional) Set of user claims to be requested from the IdP.
+* `session_cookie_name` - (Optional) Name of the cookie used to maintain session information.
+* `session_timeout` - (Optional) Maximum duration of the authentication session, in seconds.
+
+#### fixed_response
+
+The following arguments are required:
+
+* `content_type` - (Required) Content type. Valid values are `text/plain`, `text/css`, `text/html`, `application/javascript` and `application/json`.
+
+The following arguments are optional:
+
+* `message_body` - (Optional) Message body.
+* `status_code` - (Optional) HTTP response code. Valid values are `2XX`, `4XX`, or `5XX`.
+
+#### forward
+
+The following arguments are required:
+
+* `target_group` - (Required) Set of 1-5 target group blocks. Detailed below.
+
+The following arguments are optional:
+
+* `stickiness` - (Optional) Configuration block for target group stickiness for the rule. Detailed below.
+
+##### target_group
+
+The following arguments are required:
+
+* `arn` - (Required) ARN of the target group.
+
+The following arguments are optional:
+
+* `weight` - (Optional) Weight. The range is 0 to 999.
+
+##### stickiness
+
+The following arguments are required:
+
+* `duration` - (Required) Time period, in seconds, during which requests from a client should be routed to the same target group. The range is 1-604800 seconds (7 days).
+
+The following arguments are optional:
+
+* `enabled` - (Optional) Whether target group stickiness is enabled. Default is `false`.
+
+#### redirect
 
 ~> **NOTE::** You can reuse URI components using the following reserved keywords: `#{protocol}`, `#{host}`, `#{port}`, `#{path}` (the leading "/" is removed) and `#{query}`.
 
-* `host` - (Optional) The hostname. This component is not percent-encoded. The hostname can contain `#{host}`. Defaults to `#{host}`.
-* `path` - (Optional) The absolute path, starting with the leading "/". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}. Defaults to `/#{path}`.
-* `port` - (Optional) The port. Specify a value from `1` to `65535` or `#{port}`. Defaults to `#{port}`.
-* `protocol` - (Optional) The protocol. Valid values are `HTTP`, `HTTPS`, or `#{protocol}`. Defaults to `#{protocol}`.
-* `query` - (Optional) The query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading "?". Defaults to `#{query}`.
-* `status_code` - (Required) The HTTP redirect code. The redirect is either permanent (`HTTP_301`) or temporary (`HTTP_302`).
+The following arguments are required:
 
-Fixed-response Blocks (for `fixed_response`) support the following:
+* `status_code` - (Required) HTTP redirect code. The redirect is either permanent (`HTTP_301`) or temporary (`HTTP_302`).
 
-* `content_type` - (Required) The content type. Valid values are `text/plain`, `text/css`, `text/html`, `application/javascript` and `application/json`.
-* `message_body` - (Optional) The message body.
-* `status_code` - (Optional) The HTTP response code. Valid values are `2XX`, `4XX`, or `5XX`.
+The following arguments are optional:
 
-Authenticate Cognito Blocks (for `authenticate_cognito`) supports the following:
-
-* `authentication_request_extra_params` - (Optional) The query parameters to include in the redirect request to the authorization endpoint. Max: 10.
-* `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
-* `scope` - (Optional) The set of user claims to be requested from the IdP.
-* `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
-* `session_timeout` - (Optional) The maximum duration of the authentication session, in seconds.
-* `user_pool_arn` - (Required) The ARN of the Cognito user pool.
-* `user_pool_client_id` - (Required) The ID of the Cognito user pool client.
-* `user_pool_domain` - (Required) The domain prefix or fully-qualified domain name of the Cognito user pool.
-
-Authenticate OIDC Blocks (for `authenticate_oidc`) supports the following:
-
-* `authentication_request_extra_params` - (Optional) The query parameters to include in the redirect request to the authorization endpoint. Max: 10.
-* `authorization_endpoint` - (Required) The authorization endpoint of the IdP.
-* `client_id` - (Required) The OAuth 2.0 client identifier.
-* `client_secret` - (Required) The OAuth 2.0 client secret.
-* `issuer` - (Required) The OIDC issuer identifier of the IdP.
-* `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
-* `scope` - (Optional) The set of user claims to be requested from the IdP.
-* `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
-* `session_timeout` - (Optional) The maximum duration of the authentication session, in seconds.
-* `token_endpoint` - (Required) The token endpoint of the IdP.
-* `user_info_endpoint` - (Required) The user info endpoint of the IdP.
-
-Authentication Request Extra Params Blocks (for `authentication_request_extra_params`) supports the following:
-
-* `key` - (Required) The key of query parameter
-* `value` - (Required) The value of query parameter
+* `host` - (Optional) Hostname. This component is not percent-encoded. The hostname can contain `#{host}`. Defaults to `#{host}`.
+* `path` - (Optional) Absolute path, starting with the leading "/". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}. Defaults to `/#{path}`.
+* `port` - (Optional) Port. Specify a value from `1` to `65535` or `#{port}`. Defaults to `#{port}`.
+* `protocol` - (Optional) Protocol. Valid values are `HTTP`, `HTTPS`, or `#{protocol}`. Defaults to `#{protocol}`.
+* `query` - (Optional) Query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading "?". Defaults to `#{query}`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ARN of the listener (matches `arn`)
-* `arn` - The ARN of the listener (matches `id`)
+* `arn` - ARN of the listener (matches `id`).
+* `id` - ARN of the listener (matches `arn`).
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13532

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/lb_listener: Adds `alpn_policy` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
