### PR TITLE
r/secretsmanager_secret_policy - new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -835,6 +835,7 @@ func Provider() *schema.Provider {
 			"aws_sagemaker_notebook_instance_lifecycle_configuration": resourceAwsSagemakerNotebookInstanceLifeCycleConfiguration(),
 			"aws_sagemaker_notebook_instance":                         resourceAwsSagemakerNotebookInstance(),
 			"aws_secretsmanager_secret":                               resourceAwsSecretsManagerSecret(),
+			"aws_secretsmanager_secret_policy":                        resourceAwsSecretsManagerSecretPolicy(),
 			"aws_secretsmanager_secret_version":                       resourceAwsSecretsManagerSecretVersion(),
 			"aws_secretsmanager_secret_rotation":                      resourceAwsSecretsManagerSecretRotation(),
 			"aws_ses_active_receipt_rule_set":                         resourceAwsSesActiveReceiptRuleSet(),

--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -58,6 +58,7 @@ func resourceAwsSecretsManagerSecret() *schema.Resource {
 			"policy": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Computed:         true,
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},

--- a/aws/resource_aws_secretsmanager_secret_policy.go
+++ b/aws/resource_aws_secretsmanager_secret_policy.go
@@ -1,0 +1,162 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsSecretsManagerSecretPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSecretsManagerSecretPolicyCreate,
+		Read:   resourceAwsSecretsManagerSecretPolicyRead,
+		Update: resourceAwsSecretsManagerSecretPolicyUpdate,
+		Delete: resourceAwsSecretsManagerSecretPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"secret_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+		},
+	}
+}
+
+func resourceAwsSecretsManagerSecretPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).secretsmanagerconn
+
+	input := &secretsmanager.PutResourcePolicyInput{
+		ResourcePolicy: aws.String(d.Get("policy").(string)),
+		SecretId:       aws.String(d.Get("secret_arn").(string)),
+	}
+
+	log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %#v", input)
+	var res *secretsmanager.PutResourcePolicyOutput
+
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		res, err = conn.PutResourcePolicy(input)
+		if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,
+			"This resource policy contains an unsupported principal") {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if isResourceTimeoutError(err) {
+		res, err = conn.PutResourcePolicy(input)
+	}
+	if err != nil {
+		return fmt.Errorf("error setting Secrets Manager Secret %q policy: %w", d.Id(), err)
+	}
+
+	d.SetId(aws.StringValue(res.ARN))
+
+	return resourceAwsSecretsManagerSecretPolicyRead(d, meta)
+}
+
+func resourceAwsSecretsManagerSecretPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).secretsmanagerconn
+
+	input := &secretsmanager.GetResourcePolicyInput{
+		SecretId: aws.String(d.Id()),
+	}
+	log.Printf("[DEBUG] Reading Secrets Manager Secret Policy: %#v", input)
+	res, err := conn.GetResourcePolicy(input)
+	if err != nil {
+		if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] SecretsManager Secret Policy (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Secrets Manager Secret policy: %w", err)
+	}
+
+	if res.ResourcePolicy != nil {
+		policy, err := structure.NormalizeJsonString(aws.StringValue(res.ResourcePolicy))
+		if err != nil {
+			return fmt.Errorf("policy contains an invalid JSON: %w", err)
+		}
+		d.Set("policy", policy)
+	} else {
+		d.Set("policy", "")
+	}
+	d.Set("secret_arn", d.Id())
+
+	return nil
+}
+
+func resourceAwsSecretsManagerSecretPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).secretsmanagerconn
+
+	if d.HasChange("policy") {
+		policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+		if err != nil {
+			return fmt.Errorf("policy contains an invalid JSON: %s", err)
+		}
+		input := &secretsmanager.PutResourcePolicyInput{
+			ResourcePolicy: aws.String(policy),
+			SecretId:       aws.String(d.Id()),
+		}
+
+		log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %#v", input)
+		err = resource.Retry(2*time.Minute, func() *resource.RetryError {
+			var err error
+			_, err = conn.PutResourcePolicy(input)
+			if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,
+				"This resource policy contains an unsupported principal") {
+				return resource.RetryableError(err)
+			}
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.PutResourcePolicy(input)
+		}
+		if err != nil {
+			return fmt.Errorf("error setting Secrets Manager Secret %q policy: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsSecretsManagerSecretPolicyRead(d, meta)
+}
+
+func resourceAwsSecretsManagerSecretPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).secretsmanagerconn
+
+	input := &secretsmanager.DeleteResourcePolicyInput{
+		SecretId: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Removing Secrets Manager Secret policy: %#v", input)
+	_, err := conn.DeleteResourcePolicy(input)
+	if err != nil {
+		if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("error removing Secrets Manager Secret %q policy: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_secretsmanager_secret_policy.go
+++ b/aws/resource_aws_secretsmanager_secret_policy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
 func resourceAwsSecretsManagerSecretPolicy() *schema.Resource {
@@ -50,7 +51,7 @@ func resourceAwsSecretsManagerSecretPolicyCreate(d *schema.ResourceData, meta in
 	log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %#v", input)
 	var res *secretsmanager.PutResourcePolicyOutput
 
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 		var err error
 		res, err = conn.PutResourcePolicy(input)
 		if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,
@@ -119,7 +120,7 @@ func resourceAwsSecretsManagerSecretPolicyUpdate(d *schema.ResourceData, meta in
 		}
 
 		log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %#v", input)
-		err = resource.Retry(2*time.Minute, func() *resource.RetryError {
+		err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 			var err error
 			_, err = conn.PutResourcePolicy(input)
 			if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,

--- a/aws/resource_aws_secretsmanager_secret_policy.go
+++ b/aws/resource_aws_secretsmanager_secret_policy.go
@@ -119,7 +119,7 @@ func resourceAwsSecretsManagerSecretPolicyUpdate(d *schema.ResourceData, meta in
 		}
 
 		log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %#v", input)
-		err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		err = resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 			var err error
 			_, err = conn.PutResourcePolicy(input)
 			if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,

--- a/aws/resource_aws_secretsmanager_secret_policy.go
+++ b/aws/resource_aws_secretsmanager_secret_policy.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
@@ -25,9 +25,10 @@ func resourceAwsSecretsManagerSecretPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"secret_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 			"policy": {
 				Type:             schema.TypeString,

--- a/aws/resource_aws_secretsmanager_secret_policy.go
+++ b/aws/resource_aws_secretsmanager_secret_policy.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"

--- a/aws/resource_aws_secretsmanager_secret_policy_test.go
+++ b/aws/resource_aws_secretsmanager_secret_policy_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/secretsmanager/waiter"
 )
 

--- a/aws/resource_aws_secretsmanager_secret_policy_test.go
+++ b/aws/resource_aws_secretsmanager_secret_policy_test.go
@@ -1,0 +1,293 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/secretsmanager/waiter"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_secretsmanager_secret_policy", &resource.Sweeper{
+		Name: "aws_secretsmanager_secret_policy",
+		F:    testSweepSecretsManagerSecretPolicies,
+	})
+}
+
+func testSweepSecretsManagerSecretPolicies(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).secretsmanagerconn
+
+	err = conn.ListSecretsPages(&secretsmanager.ListSecretsInput{}, func(page *secretsmanager.ListSecretsOutput, isLast bool) bool {
+		if len(page.SecretList) == 0 {
+			log.Print("[DEBUG] No Secrets Manager Secrets to sweep")
+			return true
+		}
+
+		for _, secret := range page.SecretList {
+			name := aws.StringValue(secret.Name)
+
+			log.Printf("[INFO] Deleting Secrets Manager Secret: %s", name)
+			input := &secretsmanager.DeleteSecretInput{
+				ForceDeleteWithoutRecovery: aws.Bool(true),
+				SecretId:                   aws.String(name),
+			}
+
+			_, err := conn.DeleteSecret(input)
+			if err != nil {
+				if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") {
+					continue
+				}
+				log.Printf("[ERROR] Failed to delete Secrets Manager Secret (%s): %s", name, err)
+			}
+		}
+
+		return !isLast
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Secrets Manager Secret sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Secrets Manager Secrets: %s", err)
+	}
+	return nil
+}
+
+func TestAccAwsSecretsManagerSecretPolicy_basic(t *testing.T) {
+	var policy secretsmanager.GetResourcePolicyOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_secretsmanager_secret_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSecretsManagerSecretPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSecretsManagerSecretPolicyBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSecretsManagerSecretPolicyExists(resourceName, &policy),
+					resource.TestMatchResourceAttr(resourceName, "policy",
+						regexp.MustCompile(`{"Action":"secretsmanager:GetSecretValue".+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsSecretsManagerSecretPolicyUpdatedConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSecretsManagerSecretPolicyExists(resourceName, &policy),
+					resource.TestMatchResourceAttr(resourceName, "policy",
+						regexp.MustCompile(`{"Action":"secretsmanager:\*".+`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsSecretsManagerSecretPolicy_disappears(t *testing.T) {
+	var policy secretsmanager.GetResourcePolicyOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_secretsmanager_secret_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSecretsManagerSecretPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSecretsManagerSecretPolicyBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSecretsManagerSecretPolicyExists(resourceName, &policy),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSecretsManagerSecretPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsSecretsManagerSecretPolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).secretsmanagerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_secretsmanager_secret_policy" {
+			continue
+		}
+
+		secretInput := &secretsmanager.DescribeSecretInput{
+			SecretId: aws.String(rs.Primary.ID),
+		}
+
+		var output *secretsmanager.DescribeSecretOutput
+
+		err := resource.Retry(waiter.DeletionPropagationTimeout, func() *resource.RetryError {
+			var err error
+			output, err = conn.DescribeSecret(secretInput)
+
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			if output != nil && output.DeletedDate == nil {
+				return resource.RetryableError(fmt.Errorf("Secret %q still exists", rs.Primary.ID))
+			}
+
+			return nil
+		})
+
+		if isResourceTimeoutError(err) {
+			output, err = conn.DescribeSecret(secretInput)
+		}
+
+		if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if output != nil && output.DeletedDate == nil {
+			return fmt.Errorf("Secret %q still exists", rs.Primary.ID)
+		}
+
+		input := &secretsmanager.GetResourcePolicyInput{
+			SecretId: aws.String(rs.Primary.ID),
+		}
+
+		_, err = conn.GetResourcePolicy(input)
+
+		if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") ||
+			isAWSErr(err, secretsmanager.ErrCodeInvalidRequestException,
+				"You can't perform this operation on the secret because it was marked for deletion.") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+func testAccCheckAwsSecretsManagerSecretPolicyExists(resourceName string, policy *secretsmanager.GetResourcePolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).secretsmanagerconn
+		input := &secretsmanager.GetResourcePolicyInput{
+			SecretId: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.GetResourcePolicy(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil {
+			return fmt.Errorf("Secret Policy %q does not exist", rs.Primary.ID)
+		}
+
+		*policy = *output
+
+		return nil
+	}
+}
+
+func testAccAwsSecretsManagerSecretPolicyBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q 
+  assume_role_policy   = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+
+resource "aws_secretsmanager_secret_policy" "test" {
+  secret_arn = aws_secretsmanager_secret.test.arn
+  
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+	{
+	  "Sid": "EnableAllPermissions",
+	  "Effect": "Allow",
+	  "Principal": {
+		"AWS": "${aws_iam_role.test.arn}"
+	  },
+	  "Action": "secretsmanager:GetSecretValue",
+	  "Resource": "*"
+	}
+  ]
+}
+POLICY
+}
+`, rName)
+}
+
+func testAccAwsSecretsManagerSecretPolicyUpdatedConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+
+resource "aws_secretsmanager_secret_policy" "test" {
+  secret_arn = aws_secretsmanager_secret.test.arn
+  
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+	{
+	  "Sid": "EnableAllPermissions",
+	  "Effect": "Allow",
+	  "Principal": {
+		"AWS": "*"
+	  },
+	  "Action": "secretsmanager:*",
+	  "Resource": "*"
+	}
+  ]
+}
+POLICY
+}
+`, rName)
+}

--- a/aws/resource_aws_secretsmanager_secret_policy_test.go
+++ b/aws/resource_aws_secretsmanager_secret_policy_test.go
@@ -37,18 +37,17 @@ func testSweepSecretsManagerSecretPolicies(region string) error {
 		for _, secret := range page.SecretList {
 			name := aws.StringValue(secret.Name)
 
-			log.Printf("[INFO] Deleting Secrets Manager Secret: %s", name)
-			input := &secretsmanager.DeleteSecretInput{
-				ForceDeleteWithoutRecovery: aws.Bool(true),
-				SecretId:                   aws.String(name),
+			log.Printf("[INFO] Deleting Secrets Manager Secret Policy: %s", name)
+			input := &secretsmanager.DeleteResourcePolicyInput{
+				SecretId: aws.String(name),
 			}
 
-			_, err := conn.DeleteSecret(input)
+			_, err := conn.DeleteResourcePolicy(input)
 			if err != nil {
 				if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") {
 					continue
 				}
-				log.Printf("[ERROR] Failed to delete Secrets Manager Secret (%s): %s", name, err)
+				log.Printf("[ERROR] Failed to delete Secrets Manager Secret Policy (%s): %w", name, err)
 			}
 		}
 
@@ -56,10 +55,10 @@ func testSweepSecretsManagerSecretPolicies(region string) error {
 	})
 	if err != nil {
 		if testSweepSkipSweepError(err) {
-			log.Printf("[WARN] Skipping Secrets Manager Secret sweep for %s: %s", region, err)
+			log.Printf("[WARN] Skipping Secrets Manager Secret sweep for %s: %w", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error retrieving Secrets Manager Secrets: %s", err)
+		return fmt.Errorf("Error retrieving Secrets Manager Secrets: %w", err)
 	}
 	return nil
 }

--- a/aws/resource_aws_secretsmanager_secret_policy_test.go
+++ b/aws/resource_aws_secretsmanager_secret_policy_test.go
@@ -47,7 +47,7 @@ func testSweepSecretsManagerSecretPolicies(region string) error {
 				if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") {
 					continue
 				}
-				log.Printf("[ERROR] Failed to delete Secrets Manager Secret Policy (%s): %w", name, err)
+				log.Printf("[ERROR] Failed to delete Secrets Manager Secret Policy (%s): %s", name, err)
 			}
 		}
 
@@ -55,7 +55,7 @@ func testSweepSecretsManagerSecretPolicies(region string) error {
 	})
 	if err != nil {
 		if testSweepSkipSweepError(err) {
-			log.Printf("[WARN] Skipping Secrets Manager Secret sweep for %s: %w", region, err)
+			log.Printf("[WARN] Skipping Secrets Manager Secret sweep for %s: %s", region, err)
 			return nil
 		}
 		return fmt.Errorf("Error retrieving Secrets Manager Secrets: %w", err)

--- a/aws/resource_aws_secretsmanager_secret_policy_test.go
+++ b/aws/resource_aws_secretsmanager_secret_policy_test.go
@@ -312,7 +312,7 @@ resource "aws_secretsmanager_secret" "test" {
 
 resource "aws_secretsmanager_secret_policy" "test" {
   secret_arn = aws_secretsmanager_secret.test.arn
-  
+
   policy = <<POLICY
 {
   "Version": "2012-10-17",

--- a/aws/resource_aws_secretsmanager_secret_policy_test.go
+++ b/aws/resource_aws_secretsmanager_secret_policy_test.go
@@ -259,8 +259,8 @@ func testAccCheckAwsSecretsManagerSecretPolicyExists(resourceName string, policy
 func testAccAwsSecretsManagerSecretPolicyBasicConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = %[1]q 
-  assume_role_policy   = <<EOF
+  name               = %[1]q
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -283,7 +283,7 @@ resource "aws_secretsmanager_secret" "test" {
 
 resource "aws_secretsmanager_secret_policy" "test" {
   secret_arn = aws_secretsmanager_secret.test.arn
-  
+
   policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -336,8 +336,8 @@ POLICY
 func testAccAwsSecretsManagerSecretPolicyBlockConfig(rName string, block bool) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = %[1]q 
-  assume_role_policy   = <<EOF
+  name               = %[1]q
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -361,7 +361,7 @@ resource "aws_secretsmanager_secret" "test" {
 resource "aws_secretsmanager_secret_policy" "test" {
   secret_arn          = aws_secretsmanager_secret.test.arn
   block_public_policy = %[2]t
-  
+
   policy = <<POLICY
 {
   "Version": "2012-10-17",

--- a/website/docs/r/secretsmanager_secret_policy.html.markdown
+++ b/website/docs/r/secretsmanager_secret_policy.html.markdown
@@ -47,6 +47,7 @@ The following arguments are supported:
 
 * `secret_arn` - (Required) Secret ARN.
 * `policy` - (Required) A valid JSON document representing a [resource policy](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-based-policies.html). For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
+* `block_public_policy` - (Optional) Makes an optional API call to Zelkova to validate the Resource Policy to prevent broad access to your secret.
 
 ## Attribute Reference
 

--- a/website/docs/r/secretsmanager_secret_policy.html.markdown
+++ b/website/docs/r/secretsmanager_secret_policy.html.markdown
@@ -32,7 +32,7 @@ resource "aws_secretsmanager_secret_policy" "example" {
 	  "Principal": {
 		"AWS": "*"
 	  },
-	  "Action": "secretsmanager:*",
+	  "Action": "secretsmanager:GetSecretValue",
 	  "Resource": "*"
 	}
   ]

--- a/website/docs/r/secretsmanager_secret_policy.html.markdown
+++ b/website/docs/r/secretsmanager_secret_policy.html.markdown
@@ -21,7 +21,7 @@ resource "aws_secretsmanager_secret" "example" {
 
 resource "aws_secretsmanager_secret_policy" "example" {
   secret_arn = aws_secretsmanager_secret.example.arn
-  
+
   policy = <<POLICY
 {
   "Version": "2012-10-17",

--- a/website/docs/r/secretsmanager_secret_policy.html.markdown
+++ b/website/docs/r/secretsmanager_secret_policy.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "Secrets Manager"
+layout: "aws"
+page_title: "AWS: aws_secretsmanager_secret_policy"
+description: |-
+  Provides a resource to manage AWS Secrets Manager secret policy
+---
+
+# Resource: aws_secretsmanager_secret_policy
+
+Provides a resource to manage AWS Secrets Manager secret policy.
+
+## Example Usage
+
+### Basic
+
+```hcl
+resource "aws_secretsmanager_secret" "example" {
+  name = "example"
+}
+
+resource "aws_secretsmanager_secret_policy" "example" {
+  secret_arn = aws_secretsmanager_secret.example.arn
+  
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+	{
+	  "Sid": "EnableAllPermissions",
+	  "Effect": "Allow",
+	  "Principal": {
+		"AWS": "*"
+	  },
+	  "Action": "secretsmanager:*",
+	  "Resource": "*"
+	}
+  ]
+}
+POLICY
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `secret_arn` - (Required) Secret ARN.
+* `policy` - (Required) A valid JSON document representing a [resource policy](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-based-policies.html). For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
+
+## Attribute Reference
+
+* `id` - Amazon Resource Name (ARN) of the secret.
+
+## Import
+
+`aws_secretsmanager_secret_policy` can be imported by using the secret Amazon Resource Name (ARN), e.g.
+
+```
+$ terraform import aws_secretsmanager_secret_policy.example arn:aws:secretsmanager:us-east-1:123456789012:secret:example-123456
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14618
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_secretsmanager_secret_policy - new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsSecretsManagerSecretPolicy_'
--- PASS: TestAccAwsSecretsManagerSecretPolicy_basic (92.55s)
--- PASS: TestAccAwsSecretsManagerSecretPolicy_blockPublicPolicy (122.51s)
--- PASS: TestAccAwsSecretsManagerSecretPolicy_disappears (48.91s)
```
