### PR TITLE
Fix hardcoded availability zone issues (VPC-WOR)

### DIFF
--- a/aws/data_source_aws_autoscaling_group_test.go
+++ b/aws/data_source_aws_autoscaling_group_test.go
@@ -41,7 +41,7 @@ func TestAccAwsAutoScalingGroupDataSource_basic(t *testing.T) {
 
 // Lookup based on AutoScalingGroupName
 func testAccAutoScalingGroupDataResourceConfig(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_ami" "ubuntu" {
   most_recent = true
 
@@ -56,15 +56,6 @@ data "aws_ami" "ubuntu" {
   }
 
   owners = ["099720109477"] # Canonical
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_launch_configuration" "data_source_aws_autoscaling_group_test" {

--- a/aws/data_source_aws_autoscaling_groups_test.go
+++ b/aws/data_source_aws_autoscaling_groups_test.go
@@ -81,7 +81,7 @@ func testAccCheckAwsAutoscalingGroupsAvailable(attrs map[string]string) ([]strin
 }
 
 func testAccCheckAwsAutoscalingGroupsConfig(rInt1, rInt2, rInt3 int) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_ami" "test_ami" {
   most_recent = true
   owners      = ["amazon"]
@@ -89,15 +89,6 @@ data "aws_ami" "test_ami" {
   filter {
     name   = "name"
     values = ["amzn-ami-hvm-*-x86_64-gp2"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -163,7 +154,7 @@ resource "aws_autoscaling_group" "barbaz" {
 }
 
 func testAccCheckAwsAutoscalingGroupsConfigWithDataSource(rInt1, rInt2, rInt3 int) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_ami" "test_ami" {
   most_recent = true
   owners      = ["amazon"]
@@ -171,15 +162,6 @@ data "aws_ami" "test_ami" {
   filter {
     name   = "name"
     values = ["amzn-ami-hvm-*-x86_64-gp2"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/data_source_aws_availability_zone_test.go
+++ b/aws/data_source_aws_availability_zone_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceAwsAvailabilityZone_AllAvailabilityZones(t *testing.T) {
-	availabilityZonesDataSourceName := "data.aws_availability_zones.test"
+	availabilityZonesDataSourceName := "data.aws_availability_zones.available"
 	dataSourceName := "data.aws_availability_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -32,7 +32,7 @@ func TestAccDataSourceAwsAvailabilityZone_AllAvailabilityZones(t *testing.T) {
 }
 
 func TestAccDataSourceAwsAvailabilityZone_Filter(t *testing.T) {
-	availabilityZonesDataSourceName := "data.aws_availability_zones.test"
+	availabilityZonesDataSourceName := "data.aws_availability_zones.available"
 	dataSourceName := "data.aws_availability_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -56,7 +56,7 @@ func TestAccDataSourceAwsAvailabilityZone_Filter(t *testing.T) {
 }
 
 func TestAccDataSourceAwsAvailabilityZone_Name(t *testing.T) {
-	availabilityZonesDataSourceName := "data.aws_availability_zones.test"
+	availabilityZonesDataSourceName := "data.aws_availability_zones.available"
 	dataSourceName := "data.aws_availability_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -80,7 +80,7 @@ func TestAccDataSourceAwsAvailabilityZone_Name(t *testing.T) {
 }
 
 func TestAccDataSourceAwsAvailabilityZone_ZoneId(t *testing.T) {
-	availabilityZonesDataSourceName := "data.aws_availability_zones.test"
+	availabilityZonesDataSourceName := "data.aws_availability_zones.available"
 	dataSourceName := "data.aws_availability_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/data_source_aws_availability_zone_test.go
+++ b/aws/data_source_aws_availability_zone_test.go
@@ -104,73 +104,37 @@ func TestAccDataSourceAwsAvailabilityZone_ZoneId(t *testing.T) {
 }
 
 func testAccDataSourceAwsAvailabilityZoneConfigAllAvailabilityZones() string {
-	return `
-data "aws_availability_zones" "test" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + `
 data "aws_availability_zone" "test" {
   all_availability_zones = true
-  name                   = data.aws_availability_zones.test.names[0]
+  name                   = data.aws_availability_zones.available.names[0]
 }
 `
 }
 
 func testAccDataSourceAwsAvailabilityZoneConfigFilter() string {
-	return `
-data "aws_availability_zones" "test" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + `
 data "aws_availability_zone" "test" {
   filter {
     name   = "zone-name"
-    values = [data.aws_availability_zones.test.names[0]]
+    values = [data.aws_availability_zones.available.names[0]]
   }
 }
 `
 }
 
 func testAccDataSourceAwsAvailabilityZoneConfigName() string {
-	return `
-data "aws_availability_zones" "test" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + `
 data "aws_availability_zone" "test" {
-  name = data.aws_availability_zones.test.names[0]
+  name = data.aws_availability_zones.available.names[0]
 }
 `
 }
 
 func testAccDataSourceAwsAvailabilityZoneConfigZoneId() string {
-	return `
-data "aws_availability_zones" "test" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + `
 data "aws_availability_zone" "test" {
-  zone_id = data.aws_availability_zones.test.zone_ids[0]
+  zone_id = data.aws_availability_zones.available.zone_ids[0]
 }
 `
 }

--- a/aws/data_source_aws_cloudhsm2_cluster_test.go
+++ b/aws/data_source_aws_cloudhsm2_cluster_test.go
@@ -31,19 +31,10 @@ func TestAccDataSourceCloudHsmV2Cluster_basic(t *testing.T) {
 	})
 }
 
-var testAccCheckCloudHsmV2ClusterDataSourceConfig = fmt.Sprintf(`
+var testAccCheckCloudHsmV2ClusterDataSourceConfig = testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "cloudhsm_v2_test_vpc" {

--- a/aws/data_source_aws_db_cluster_snapshot_test.go
+++ b/aws/data_source_aws_db_cluster_snapshot_test.go
@@ -117,16 +117,7 @@ func testAccCheckAwsDbClusterSnapshotDataSourceExists(dataSourceName string) res
 }
 
 func testAccCheckAwsDbClusterSnapshotDataSourceConfig_DbClusterSnapshotIdentifier(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
@@ -176,16 +167,7 @@ data "aws_db_cluster_snapshot" "test" {
 }
 
 func testAccCheckAwsDbClusterSnapshotDataSourceConfig_DbClusterIdentifier(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
@@ -235,16 +217,7 @@ data "aws_db_cluster_snapshot" "test" {
 }
 
 func testAccCheckAwsDbClusterSnapshotDataSourceConfig_MostRecent(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 

--- a/aws/data_source_aws_directory_service_directory_test.go
+++ b/aws/data_source_aws_directory_service_directory_test.go
@@ -115,16 +115,7 @@ data "aws_directory_service_directory" "test" {
 `
 
 func testAccDataSourceAwsDirectoryServiceDirectoryConfig_Prerequisites(adType string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 
@@ -204,16 +195,7 @@ data "aws_directory_service_directory" "test-microsoft-ad" {
 `, alias)
 }
 
-const testAccDataSourceDirectoryServiceDirectoryConfig_connector = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccDataSourceDirectoryServiceDirectoryConfig_connector = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_directory_service_directory" "test" {
   name     = "corp.notexample.com"
   password = "SuperSecretPassw0rd"

--- a/aws/data_source_aws_ebs_snapshot_test.go
+++ b/aws/data_source_aws_ebs_snapshot_test.go
@@ -88,16 +88,7 @@ func testAccCheckAwsEbsSnapshotDataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccCheckAwsEbsSnapshotDataSourceConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccCheckAwsEbsSnapshotDataSourceConfig = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"
@@ -113,16 +104,7 @@ data "aws_ebs_snapshot" "test" {
 }
 `
 
-const testAccCheckAwsEbsSnapshotDataSourceConfigFilter = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccCheckAwsEbsSnapshotDataSourceConfigFilter = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"
@@ -141,16 +123,7 @@ data "aws_ebs_snapshot" "test" {
 }
 `
 
-const testAccCheckAwsEbsSnapshotDataSourceConfigMostRecent = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccCheckAwsEbsSnapshotDataSourceConfigMostRecent = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -66,16 +66,7 @@ func testAccCheckAwsEbsVolumeDataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccCheckAwsEbsVolumeDataSourceConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccCheckAwsEbsVolumeDataSourceConfig = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"
@@ -101,16 +92,7 @@ data "aws_ebs_volume" "test" {
 }
 `
 
-const testAccCheckAwsEbsVolumeDataSourceConfigWithMultipleFilters = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccCheckAwsEbsVolumeDataSourceConfigWithMultipleFilters = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"

--- a/aws/data_source_aws_ebs_volumes_test.go
+++ b/aws/data_source_aws_ebs_volumes_test.go
@@ -45,17 +45,13 @@ data "aws_ebs_volumes" "subject_under_test" {
 }
 
 func testAccDataSourceAwsEbsVolumeIDsConfig(rInt int) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_region" "current" {}
-
-data "aws_availability_zones" "azs" {
-  state = "available"
-}
 
 resource "aws_ebs_volume" "volume" {
   count = 2
 
-  availability_zone = data.aws_availability_zones.azs.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
   size              = 1
 
   tags = {

--- a/aws/data_source_aws_ec2_instance_type_offering_test.go
+++ b/aws/data_source_aws_ec2_instance_type_offering_test.go
@@ -96,16 +96,7 @@ data "aws_ec2_instance_type_offering" "test" {
 }
 
 func testAccAWSEc2InstanceTypeOfferingDataSourceConfigLocationType() string {
-	return `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + `
 # Rather than hardcode an instance type in the testing,
 # use the first result from all available offerings.
 data "aws_ec2_instance_type_offerings" "test" {

--- a/aws/data_source_aws_ec2_instance_type_offerings_test.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings_test.go
@@ -91,16 +91,7 @@ data "aws_ec2_instance_type_offerings" "test" {
 }
 
 func testAccAWSEc2InstanceTypeOfferingsDataSourceConfigLocationType() string {
-	return `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + `
 data "aws_ec2_instance_type_offerings" "test" {
   filter {
     name   = "location"

--- a/aws/data_source_aws_ec2_spot_price_test.go
+++ b/aws/data_source_aws_ec2_spot_price_test.go
@@ -67,22 +67,13 @@ func testAccPreCheckAwsEc2SpotPrice(t *testing.T) {
 }
 
 func testAccAwsEc2SpotPriceDataSourceConfig() string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_region" "current" {}
 
 data "aws_ec2_instance_type_offering" "test" {
   filter {
     name   = "instance-type"
     values = ["m5.xlarge"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "region-name"
-    values = [data.aws_region.current.name]
   }
 }
 
@@ -100,22 +91,13 @@ data "aws_ec2_spot_price" "test" {
 }
 
 func testAccAwsEc2SpotPriceDataSourceFilterConfig() string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_region" "current" {}
 
 data "aws_ec2_instance_type_offering" "test" {
   filter {
     name   = "instance-type"
     values = ["m5.xlarge"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "region-name"
-    values = [data.aws_region.current.name]
   }
 }
 

--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -57,18 +57,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID(t *testing.T) {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentDataSourceConfigFilter() string {
-	return `
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -105,17 +94,8 @@ data "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentDataSourceConfigID() string {
-	return `
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
+# IncorrectState: Transit Gateway is not available in availability zone usw2-az4	
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/aws/data_source_aws_efs_mount_target_test.go
+++ b/aws/data_source_aws_efs_mount_target_test.go
@@ -37,16 +37,7 @@ func TestAccDataSourceAwsEfsMountTarget_basic(t *testing.T) {
 }
 
 func testAccAwsEfsMountTargetConfigByMountTargetId(ct string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = "%s"
 

--- a/aws/data_source_aws_eip_test.go
+++ b/aws/data_source_aws_eip_test.go
@@ -289,18 +289,7 @@ data "aws_eip" "test" {
 }
 `
 
-const testAccDataSourceAwsEipConfigInstance = `
-data "aws_availability_zones" "available" {
-  # Error launching source instance: Unsupported: Your requested instance type (t2.micro) is not supported in your requested Availability Zone (us-west-2d).
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccDataSourceAwsEipConfigInstance = testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.2.0.0/16"
 }

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -77,16 +77,7 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent(t *testing.T) {
 }
 
 func testAccDataSourceAwsElasticacheReplicationGroupConfig_basic(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "test description"

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -139,16 +139,7 @@ data "aws_elasticsearch_domain" "test" {
 }
 
 func testAccAWSElasticsearchDomainConfigAdvancedWithDataSource(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}

--- a/aws/data_source_aws_elb_test.go
+++ b/aws/data_source_aws_elb_test.go
@@ -37,7 +37,7 @@ func TestAccDataSourceAWSELB_basic(t *testing.T) {
 }
 
 func testAccDataSourceAWSELBConfigBasic(rName, testName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elb" "elb_test" {
   name            = "%[1]s"
   internal        = true
@@ -61,15 +61,6 @@ resource "aws_elb" "elb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "elb_test" {

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -108,7 +108,7 @@ func TestAccDataSourceAWSLBListener_https(t *testing.T) {
 }
 
 func testAccDataSourceAWSLBListenerConfigBasic(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = aws_lb.alb_test.id
   protocol          = "HTTP"
@@ -155,15 +155,6 @@ resource "aws_lb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -234,7 +225,7 @@ output "from_lb_and_port_arn" {
 }
 
 func testAccDataSourceAWSLBListenerConfigBackwardsCompatibility(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_alb_listener" "front_end" {
   load_balancer_arn = aws_alb.alb_test.id
   protocol          = "HTTP"
@@ -281,15 +272,6 @@ resource "aws_alb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -348,7 +330,7 @@ data "aws_alb_listener" "from_lb_and_port" {
 }
 
 func testAccDataSourceAWSLBListenerConfigHTTPS(lbName, targetGroupName, certificate, key string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = aws_lb.alb_test.id
   protocol          = "HTTPS"
@@ -399,15 +381,6 @@ resource "aws_lb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {

--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -128,7 +128,7 @@ func TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 }
 
 func testAccDataSourceAWSLBTargetGroupConfigBasic(lbName string, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = aws_lb.alb_test.id
   protocol          = "HTTP"
@@ -179,15 +179,6 @@ resource "aws_lb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -245,7 +236,7 @@ data "aws_lb_target_group" "alb_tg_test_with_name" {
 }
 
 func testAccDataSourceAWSLBTargetGroupConfigBackwardsCompatibility(lbName string, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_alb_listener" "front_end" {
   load_balancer_arn = aws_alb.alb_test.id
   protocol          = "HTTP"
@@ -296,15 +287,6 @@ resource "aws_alb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {

--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -94,7 +94,7 @@ func TestAccDataSourceAWSLB_BackwardsCompatibility(t *testing.T) {
 }
 
 func testAccDataSourceAWSLBConfigBasic(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
@@ -112,15 +112,6 @@ resource "aws_lb" "alb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -178,7 +169,7 @@ data "aws_lb" "alb_test_with_name" {
 }
 
 func testAccDataSourceAWSLBConfigBackardsCompatibility(albName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_alb" "alb_test" {
   name            = "%s"
   internal        = true
@@ -196,15 +187,6 @@ resource "aws_alb" "alb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {

--- a/aws/data_source_aws_mq_broker_test.go
+++ b/aws/data_source_aws_mq_broker_test.go
@@ -92,18 +92,9 @@ func TestAccDataSourceAWSMqBroker_basic(t *testing.T) {
 }
 
 func testAccDataSourceAWSMqBrokerConfig_base(brokerName, prefix string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "prefix" {
   default = "%s"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "acctest" {

--- a/aws/data_source_aws_network_interface_test.go
+++ b/aws/data_source_aws_network_interface_test.go
@@ -34,16 +34,7 @@ func TestAccDataSourceAwsNetworkInterface_basic(t *testing.T) {
 }
 
 func testAccDataSourceAwsNetworkInterface_basic(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -97,16 +88,7 @@ func TestAccDataSourceAwsNetworkInterface_filters(t *testing.T) {
 }
 
 func testAccDataSourceAwsNetworkInterface_filters(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -135,16 +135,7 @@ func TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock(t *testing.T) {
 }
 
 func testAccDataSourceAwsSubnetConfig(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
 
@@ -199,16 +190,7 @@ data "aws_subnet" "by_az_id" {
 }
 
 func testAccDataSourceAwsSubnetConfigIpv6(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "172.%d.0.0/16"
   assign_generated_ipv6_cidr_block = true
@@ -232,16 +214,7 @@ resource "aws_subnet" "test" {
 }
 
 func testAccDataSourceAwsSubnetConfigIpv6WithDataSourceFilter(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "172.%d.0.0/16"
   assign_generated_ipv6_cidr_block = true
@@ -272,16 +245,7 @@ data "aws_subnet" "by_ipv6_cidr" {
 }
 
 func testAccDataSourceAwsSubnetConfigIpv6WithDataSourceIpv6CidrBlock(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "172.%d.0.0/16"
   assign_generated_ipv6_cidr_block = true

--- a/aws/data_source_aws_vpc_endpoint_service_test.go
+++ b/aws/data_source_aws_vpc_endpoint_service_test.go
@@ -157,7 +157,7 @@ data "aws_vpc_endpoint_service" "test" {
 `
 
 func testAccDataSourceAwsVpcEndpointServiceCustomConfigBase(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -181,15 +181,6 @@ resource "aws_lb" "test" {
 
   tags = {
     Name = %[1]q
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/data_source_aws_vpc_endpoint_test.go
+++ b/aws/data_source_aws_vpc_endpoint_test.go
@@ -336,21 +336,12 @@ data "aws_vpc_endpoint" "test" {
 }
 
 func testAccDataSourceAwsVpcEndpointConfig_interface(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
     Name = %[1]q
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -212,15 +212,7 @@ func testAccCheckAWSAMICopyAttributes(image *ec2.Image, expectedName string) res
 }
 
 func testAccAWSAMICopyConfigBase(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_region" "current" {}
 
 resource "aws_ebs_volume" "test" {

--- a/aws/resource_aws_ami_test.go
+++ b/aws/resource_aws_ami_test.go
@@ -328,16 +328,7 @@ func testAccCheckAmiEbsBlockDevice(bd *ec2.BlockDeviceMapping, ed *ec2.EbsBlockD
 }
 
 func testAccAmiConfigBase(rName string, size int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = %d

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -717,18 +717,9 @@ resource "aws_api_gateway_integration" "test" {
 }
 
 func testAccAWSAPIGatewayIntegrationConfig_IntegrationTypeBase(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "name" {
   default = "%s"
-}
-
-data "aws_availability_zones" "test" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "test" {
@@ -742,7 +733,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "10.10.0.0/24"
-  availability_zone = "${data.aws_availability_zones.test.names[0]}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
 }
 
 resource "aws_api_gateway_rest_api" "test" {

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -677,7 +677,7 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 func testAccAWSAPIGatewayRestAPIConfig_VPCEndpointConfiguration(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "11.0.0.0/16"
   enable_dns_support   = true
@@ -691,15 +691,6 @@ resource "aws_vpc" "test" {
 data "aws_security_group" "test" {
   vpc_id = "${aws_vpc.test.id}"
   name   = "default"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_subnet" "test" {
@@ -741,7 +732,7 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 func testAccAWSAPIGatewayRestAPIConfig_VPCEndpointConfiguration2(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "11.0.0.0/16"
   enable_dns_support   = true
@@ -755,15 +746,6 @@ resource "aws_vpc" "test" {
 data "aws_security_group" "test" {
   vpc_id = "${aws_vpc.test.id}"
   name   = "default"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_subnet" "test" {

--- a/aws/resource_aws_api_gateway_vpc_link_test.go
+++ b/aws/resource_aws_api_gateway_vpc_link_test.go
@@ -219,7 +219,7 @@ func testAccCheckAwsAPIGatewayVpcLinkExists(name string) resource.TestCheckFunc 
 }
 
 func testAccAPIGatewayVpcLinkConfig_basis(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "test_a" {
   name               = "tf-lb-%s"
   internal           = true
@@ -234,19 +234,10 @@ resource "aws_vpc" "test" {
   }
 }
 
-data "aws_availability_zones" "test" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "10.10.0.0/21"
-  availability_zone = "${data.aws_availability_zones.test.names[0]}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
   tags = {
     Name = "tf-acc-api-gateway-vpc-link"

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -717,16 +717,7 @@ resource "aws_apigatewayv2_integration" "test" {
 func testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkWebSocket(rName string) string {
 	return composeConfig(
 		testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName),
-		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
 

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -717,7 +717,7 @@ resource "aws_apigatewayv2_integration" "test" {
 func testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkWebSocket(rName string) string {
 	return composeConfig(
 		testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName),
-		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
 

--- a/aws/resource_aws_apigatewayv2_vpc_link_test.go
+++ b/aws/resource_aws_apigatewayv2_vpc_link_test.go
@@ -254,21 +254,12 @@ func testAccCheckAWSAPIGatewayV2VpcLinkExists(n string, v *apigatewayv2.GetVpcLi
 }
 
 func testAccAWSAPIGatewayV2VpcLinkConfig_base(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
     Name = %[1]q
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -230,18 +230,7 @@ resource "aws_appautoscaling_scheduled_action" "hoge" {
 }
 
 func testAccAppautoscalingScheduledActionConfig_EMR(rName, ts string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # The requested instance type c4.large is not supported in the requested availability zone.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_emr_cluster" "hoge" {

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -341,18 +341,7 @@ resource "aws_appautoscaling_target" "bar" {
 }
 
 func testAccAWSAppautoscalingTargetEmrClusterConfig(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # The requested instance type m3.xlarge is not supported in the requested availability zone.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_emr_cluster" "tf-test-cluster" {

--- a/aws/resource_aws_autoscaling_attachment_test.go
+++ b/aws/resource_aws_autoscaling_attachment_test.go
@@ -176,16 +176,7 @@ func testAccCheckAWSAutocalingAlbAttachmentExists(asgname string, targetGroupCou
 }
 
 func testAccAWSAutoscalingAttachment_alb(rInt int) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-	state            = "available"
-	
-	filter {
-		name   = "opt-in-status"
-		values = ["opt-in-not-required"]
-	}
-}	
-	
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name     = "test-alb-%d"
   port     = 443
@@ -282,16 +273,7 @@ resource "aws_vpc" "test" {
 }
 
 func testAccAWSAutoscalingAttachment_elb(rInt int) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-	state            = "available"
-	
-	filter {
-		name   = "opt-in-status"
-		values = ["opt-in-not-required"]
-	}
-}	
-
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elb" "foo" {
   availability_zones = data.aws_availability_zones.available.names
 

--- a/aws/resource_aws_autoscaling_lifecycle_hook_test.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook_test.go
@@ -125,7 +125,7 @@ func testAccAWSAutoscalingLifecycleHookImportStateIdFunc(resourceName string) re
 }
 
 func testAccAWSAutoscalingLifecycleHookConfig(name string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -177,15 +177,6 @@ resource "aws_iam_role_policy" "foobar" {
 EOF
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_autoscaling_group" "foobar" {
   availability_zones        = [data.aws_availability_zones.available.names[1]]
   name                      = "%s"
@@ -224,7 +215,7 @@ EOF
 }
 
 func testAccAWSAutoscalingLifecycleHookConfig_omitDefaultResult(name string, rInt int) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -274,15 +265,6 @@ resource "aws_iam_role_policy" "foobar" {
     } ]
 }
 EOF
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_autoscaling_group" "foobar" {

--- a/aws/resource_aws_autoscaling_notification_test.go
+++ b/aws/resource_aws_autoscaling_notification_test.go
@@ -211,7 +211,7 @@ func testAccCheckAWSASGNotificationAttributes(n string, asgn *autoscaling.Descri
 }
 
 func testAccASGNotificationConfig_basic(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_sns_topic" "topic_example" {
   name = "user-updates-topic-%s"
 }
@@ -220,15 +220,6 @@ resource "aws_launch_configuration" "foobar" {
   name          = "foobarautoscaling-terraform-test-%s"
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t2.micro"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_autoscaling_group" "bar" {
@@ -258,7 +249,7 @@ resource "aws_autoscaling_notification" "example" {
 }
 
 func testAccASGNotificationConfig_update(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_sns_topic" "topic_example" {
   name = "user-updates-topic-%s"
 }
@@ -269,15 +260,6 @@ resource "aws_launch_configuration" "foobar" {
   instance_type = "t2.micro"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-  
 resource "aws_autoscaling_group" "bar" {
   availability_zones        = [data.aws_availability_zones.available.names[1]]
   name                      = "foobar1-terraform-test-%s"
@@ -322,7 +304,7 @@ resource "aws_autoscaling_notification" "example" {
 }
 
 func testAccASGNotificationConfig_pagination() string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_sns_topic" "user_updates" {
   name = "user-updates-topic"
 }
@@ -330,15 +312,6 @@ resource "aws_sns_topic" "user_updates" {
 resource "aws_launch_configuration" "foobar" {
   image_id = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t2.micro"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_autoscaling_group" "bar" {

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -337,7 +337,7 @@ func testAccAWSAutoscalingPolicyImportStateIdFunc(resourceName string) resource.
 }
 
 func testAccAWSAutoscalingPolicyConfig_base(name string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_ami" "amzn" {
   most_recent = true
   owners      = ["amazon"]
@@ -345,15 +345,6 @@ data "aws_ami" "amzn" {
   filter {
     name   = "name"
     values = ["amzn2-ami-hvm-*-x86_64-gp2"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/resource_aws_autoscaling_schedule_test.go
+++ b/aws/resource_aws_autoscaling_schedule_test.go
@@ -267,20 +267,11 @@ func testAccCheckScalingScheduleHasNoDesiredCapacity(
 }
 
 func testAccAWSAutoscalingScheduleConfig(r, start, end string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_autoscaling_group" "foobar" {
@@ -314,20 +305,11 @@ resource "aws_autoscaling_schedule" "foobar" {
 }
 
 func testAccAWSAutoscalingScheduleConfig_recurrence(r string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_autoscaling_group" "foobar" {
@@ -360,20 +342,11 @@ resource "aws_autoscaling_schedule" "foobar" {
 }
 
 func testAccAWSAutoscalingScheduleConfig_zeroValues(r, start, end string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_autoscaling_group" "foobar" {
@@ -407,20 +380,11 @@ resource "aws_autoscaling_schedule" "foobar" {
 }
 
 func testAccAWSAutoscalingScheduleConfig_negativeOne(r, start, end string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_autoscaling_group" "foobar" {

--- a/aws/resource_aws_backup_selection_test.go
+++ b/aws/resource_aws_backup_selection_test.go
@@ -327,16 +327,7 @@ resource "aws_backup_selection" "test" {
 func testAccBackupSelectionConfigWithResources(rName string) string {
 	return composeConfig(
 		testAccBackupSelectionConfigBase(rName),
-		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   count = 2
 

--- a/aws/resource_aws_backup_selection_test.go
+++ b/aws/resource_aws_backup_selection_test.go
@@ -327,7 +327,7 @@ resource "aws_backup_selection" "test" {
 func testAccBackupSelectionConfigWithResources(rName string) string {
 	return composeConfig(
 		testAccBackupSelectionConfigBase(rName),
-		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   count = 2
 

--- a/aws/resource_aws_cloud9_environment_ec2_test.go
+++ b/aws/resource_aws_cloud9_environment_ec2_test.go
@@ -290,18 +290,7 @@ func testAccPreCheckAWSCloud9(t *testing.T) {
 }
 
 func testAccAWSCloud9EnvironmentEc2ConfigBase() string {
-	return `
-data "aws_availability_zones" "available" {
-  # t2.micro instance type is not available in these Availability Zones
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_cloudhsm2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm2_cluster_test.go
@@ -157,19 +157,10 @@ func TestAccAWSCloudHsmV2Cluster_Tags(t *testing.T) {
 }
 
 func testAccAWSCloudHsmV2ClusterConfigBase() string {
-	return `
+	return testAccAvailableAZsNoOptInConfig() + `
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "cloudhsm_v2_test_vpc" {

--- a/aws/resource_aws_cloudhsm2_hsm_test.go
+++ b/aws/resource_aws_cloudhsm2_hsm_test.go
@@ -36,19 +36,10 @@ func TestAccAWSCloudHsmV2Hsm_basic(t *testing.T) {
 }
 
 func testAccAWSCloudHsmV2Hsm() string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "cloudhsm_v2_test_vpc" {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -3394,18 +3394,9 @@ resource "aws_codebuild_project" "test" {
 }
 
 func testAccAWSCodeBuildProjectConfig_VpcConfig1(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # InvalidInputException: CodeBuild currently doesn't support VPC in us-west-2d, please select subnets in other availability zones.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) +
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -3455,18 +3446,9 @@ resource "aws_codebuild_project" "test" {
 }
 
 func testAccAWSCodeBuildProjectConfig_VpcConfig2(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # InvalidInputException: CodeBuild currently doesn't support VPC in us-west-2d, please select subnets in other availability zones.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) +
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -2935,7 +2935,7 @@ resource "aws_codedeploy_deployment_group" "test" {
 }
 
 func test_config_blue_green_deployment_config_create_with_asg(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
   app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
@@ -2985,15 +2985,6 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   }
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 data "aws_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   default_for_az    = "true"
@@ -3027,7 +3018,7 @@ resource "aws_autoscaling_group" "test" {
 }
 
 func test_config_blue_green_deployment_config_update_with_asg(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
   app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
@@ -3073,15 +3064,6 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   filter {
     name   = "root-device-type"
     values = ["ebs"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -3261,16 +3243,7 @@ resource "aws_codedeploy_deployment_group" "test" {
 }
 
 func testAccAWSCodeDeployDeploymentGroupConfigEcsBase(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_db_cluster_snapshot_test.go
+++ b/aws/resource_aws_db_cluster_snapshot_test.go
@@ -225,16 +225,7 @@ func testAccCheckDbClusterSnapshotExists(resourceName string, dbClusterSnapshot 
 }
 
 func testAccAwsDbClusterSnapshotConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
@@ -276,16 +267,7 @@ resource "aws_db_cluster_snapshot" "test" {
 }
 
 func testAccAwsDbClusterSnapshotConfigTags1(rName, tagKey1, tagValue1 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
@@ -330,16 +312,7 @@ resource "aws_db_cluster_snapshot" "test" {
 }
 
 func testAccAwsDbClusterSnapshotConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -4611,16 +4611,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_DbSubnetGroupName(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -4747,16 +4738,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -4983,16 +4965,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_AvailabilityZone(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
@@ -5064,19 +5037,10 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName(rName string) string {
-	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "alternate" {
   provider = "awsalternate"
 
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-data "aws_availability_zones" "available" {
   state = "available"
 
   filter {
@@ -5304,19 +5268,10 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
-	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "alternate" {
   provider = "awsalternate"
 
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-data "aws_availability_zones" "available" {
   state = "available"
 
   filter {
@@ -5833,16 +5788,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_AvailabilityZone(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
   engine              = "mariadb"
@@ -5954,16 +5900,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DbSubnetGroupName(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -6114,16 +6051,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_db_subnet_group_test.go
+++ b/aws/resource_aws_db_subnet_group_test.go
@@ -263,16 +263,7 @@ func testAccCheckDBSubnetGroupExists(n string, v *rds.DBSubnetGroup) resource.Te
 }
 
 func testAccDBSubnetGroupConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -313,16 +304,7 @@ resource "aws_db_subnet_group" "test" {
 }
 
 func testAccDBSubnetGroupConfig_updatedDescription(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -363,16 +345,7 @@ resource "aws_db_subnet_group" "test" {
 `, rName)
 }
 
-const testAccDBSubnetGroupConfig_namePrefix = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccDBSubnetGroupConfig_namePrefix = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
@@ -403,16 +376,7 @@ resource "aws_db_subnet_group" "test" {
 	subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
 }`
 
-const testAccDBSubnetGroupConfig_generatedName = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccDBSubnetGroupConfig_generatedName = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
@@ -442,16 +406,7 @@ resource "aws_db_subnet_group" "test" {
 	subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
 }`
 
-const testAccDBSubnetGroupConfig_withUnderscoresAndPeriodsAndSpaces = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccDBSubnetGroupConfig_withUnderscoresAndPeriodsAndSpaces = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "main" {
     cidr_block = "192.168.0.0/16"
 	tags = {

--- a/aws/resource_aws_directory_service_conditional_forwarder_test.go
+++ b/aws/resource_aws_directory_service_conditional_forwarder_test.go
@@ -135,16 +135,7 @@ func testAccCheckAwsDirectoryServiceConditionalForwarderExists(name string, dnsI
 }
 
 func testAccDirectoryServiceConditionalForwarderConfig(ip1, ip2 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_directory_service_directory" "bar" {
   name     = "corp.notexample.com"
   password = "SuperSecretPassw0rd"

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -480,16 +480,7 @@ func testAccPreCheckAWSDirectoryServiceSimpleDirectory(t *testing.T) {
 	}
 }
 
-const testAccDirectoryServiceDirectoryConfigBase = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccDirectoryServiceDirectoryConfigBase = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags = {

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -506,7 +506,7 @@ resource "aws_subnet" "test2" {
 }
 `
 
-const testAccDirectoryServiceDirectoryConfig = testAccDirectoryServiceDirectoryConfigBase + `
+var testAccDirectoryServiceDirectoryConfig = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -519,7 +519,7 @@ resource "aws_directory_service_directory" "test" {
 }
 `
 
-const testAccDirectoryServiceDirectoryTagsConfig = testAccDirectoryServiceDirectoryConfigBase + `
+var testAccDirectoryServiceDirectoryTagsConfig = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -537,7 +537,7 @@ resource "aws_directory_service_directory" "test" {
 }
 `
 
-const testAccDirectoryServiceDirectoryUpdateTagsConfig = testAccDirectoryServiceDirectoryConfigBase + `
+var testAccDirectoryServiceDirectoryUpdateTagsConfig = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -556,7 +556,7 @@ resource "aws_directory_service_directory" "test" {
 }
 `
 
-const testAccDirectoryServiceDirectoryRemoveTagsConfig = testAccDirectoryServiceDirectoryConfigBase + `
+var testAccDirectoryServiceDirectoryRemoveTagsConfig = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -573,7 +573,7 @@ resource "aws_directory_service_directory" "test" {
 }
 `
 
-const testAccDirectoryServiceDirectoryConfig_connector = testAccDirectoryServiceDirectoryConfigBase + `
+var testAccDirectoryServiceDirectoryConfig_connector = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "base" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -600,7 +600,7 @@ resource "aws_directory_service_directory" "test" {
 }
 `
 
-const testAccDirectoryServiceDirectoryConfig_microsoft = testAccDirectoryServiceDirectoryConfigBase + `
+var testAccDirectoryServiceDirectoryConfig_microsoft = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -613,7 +613,7 @@ resource "aws_directory_service_directory" "test" {
 }
 `
 
-const testAccDirectoryServiceDirectoryConfig_microsoftStandard = testAccDirectoryServiceDirectoryConfigBase + `
+var testAccDirectoryServiceDirectoryConfig_microsoftStandard = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"

--- a/aws/resource_aws_directory_service_log_subscription_test.go
+++ b/aws/resource_aws_directory_service_log_subscription_test.go
@@ -102,16 +102,7 @@ func testAccCheckAwsDirectoryServiceLogSubscriptionExists(name string, logGroupN
 }
 
 func testAccDirectoryServiceLogSubscriptionConfig(logGroupName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_directory_service_directory" "bar" {
   name     = "corp.notexample.com"
   password = "SuperSecretPassw0rd"

--- a/aws/resource_aws_dms_event_subscription_test.go
+++ b/aws/resource_aws_dms_event_subscription_test.go
@@ -265,16 +265,7 @@ func testAccCheckDmsEventSubscriptionExists(n string, eventSubscription *dms.Eve
 }
 
 func testAccDmsEventSubscriptionConfigBase(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_vpc" "test" {

--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -683,16 +683,7 @@ resource "aws_dms_replication_instance" "test" {
 }
 
 func testAccAWSDmsReplicationInstanceConfig_AvailabilityZone(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_dms_replication_instance" "test" {
@@ -784,16 +775,7 @@ resource "aws_dms_replication_instance" "test" {
 }
 
 func testAccAWSDmsReplicationInstanceConfig_ReplicationSubnetGroupId(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_vpc" "test" {
@@ -865,16 +847,7 @@ resource "aws_dms_replication_instance" "test" {
 }
 
 func testAccAWSDmsReplicationInstanceConfig_VpcSecurityGroupIds(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_vpc" "test" {

--- a/aws/resource_aws_docdb_cluster_instance_test.go
+++ b/aws/resource_aws_docdb_cluster_instance_test.go
@@ -326,16 +326,7 @@ resource "aws_docdb_cluster_instance" "cluster_instances" {
 }
 
 func testAccAWSDocDBClusterInstanceConfig_az(n int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_docdb_cluster" "default" {
   cluster_identifier  = "tf-docdb-cluster-test-%d"
   availability_zones  = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]

--- a/aws/resource_aws_docdb_cluster_snapshot_test.go
+++ b/aws/resource_aws_docdb_cluster_snapshot_test.go
@@ -109,16 +109,7 @@ func testAccCheckDocDBClusterSnapshotExists(resourceName string, dbClusterSnapsh
 }
 
 func testAccAwsDocDBClusterSnapshotConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 

--- a/aws/resource_aws_docdb_cluster_test.go
+++ b/aws/resource_aws_docdb_cluster_test.go
@@ -782,16 +782,7 @@ resource "aws_docdb_cluster" "default" {
 }
 
 func testAccDocDBClusterConfig_Port(rInt, port int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_docdb_cluster" "test" {
   availability_zones              = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   cluster_identifier              = "tf-acc-test-%d"

--- a/aws/resource_aws_ebs_snapshot_copy_test.go
+++ b/aws/resource_aws_ebs_snapshot_copy_test.go
@@ -221,16 +221,7 @@ func testAccCheckEbsSnapshotCopyExists(n string, v *ec2.Snapshot) resource.TestC
 	}
 }
 
-const testAccAwsEbsSnapshotCopyConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsSnapshotCopyConfig = testAccAvailableAZsNoOptInConfig() + `
 data "aws_region" "current" {}
 
 resource "aws_ebs_volume" "test" {
@@ -253,16 +244,7 @@ resource "aws_ebs_snapshot_copy" "test" {
 `
 
 func testAccAwsEbsSnapshotCopyConfigTags1(tagKey1, tagValue1 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_region" "current" {}
 
 resource "aws_ebs_volume" "test" {
@@ -291,16 +273,7 @@ resource "aws_ebs_snapshot_copy" "test" {
 }
 
 func testAccAwsEbsSnapshotCopyConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_region" "current" {}
 
 resource "aws_ebs_volume" "test" {
@@ -329,16 +302,7 @@ resource "aws_ebs_snapshot_copy" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-const testAccAwsEbsSnapshotCopyConfigWithDescription = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsSnapshotCopyConfigWithDescription = testAccAvailableAZsNoOptInConfig() + `
 data "aws_region" "current" {}
 
 resource "aws_ebs_volume" "test" {
@@ -387,7 +351,7 @@ data "aws_region" "alternate" {
 
 resource "aws_ebs_volume" "test" {
   provider          = "awsalternate"
-  availability_zone = "${data.aws_availability_zones.alternate_available.names[0]}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
 
   tags = {
@@ -414,16 +378,7 @@ resource "aws_ebs_snapshot_copy" "test" {
 }
 `
 
-const testAccAwsEbsSnapshotCopyConfigWithKms = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsSnapshotCopyConfigWithKms = testAccAvailableAZsNoOptInConfig() + `
 data "aws_region" "current" {}
 
 resource "aws_kms_key" "test" {

--- a/aws/resource_aws_ebs_snapshot_test.go
+++ b/aws/resource_aws_ebs_snapshot_test.go
@@ -214,16 +214,7 @@ func testAccCheckAWSEbsSnapshotDestroy(s *terraform.State) error {
 }
 
 func testAccAwsEbsSnapshotConfigBasic(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
@@ -245,16 +236,7 @@ resource "aws_ebs_snapshot" "test" {
 }
 
 func testAccAwsEbsSnapshotConfigBasicTags1(rName, tagKey1, tagValue1 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
@@ -277,16 +259,7 @@ resource "aws_ebs_snapshot" "test" {
 }
 
 func testAccAwsEbsSnapshotConfigBasicTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
@@ -310,16 +283,7 @@ resource "aws_ebs_snapshot" "test" {
 }
 
 func testAccAwsEbsSnapshotConfigWithDescription(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ebs_volume" "description_test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
@@ -333,16 +297,7 @@ resource "aws_ebs_snapshot" "test" {
 }
 
 func testAccAwsEbsSnapshotConfigWithKms(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -464,16 +464,7 @@ func testAccCheckVolumeExists(n string, v *ec2.Volume) resource.TestCheckFunc {
 	}
 }
 
-const testAccAwsEbsVolumeConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsVolumeConfig = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "gp2"
@@ -481,7 +472,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsAttachedVolumeConfig = `
+var testAccAwsEbsAttachedVolumeConfig = testAccAvailableAZsNoOptInConfig() + `
 data "aws_ami" "debian_jessie_latest" {
   most_recent = true
 
@@ -520,15 +511,6 @@ resource "aws_instance" "test" {
 
   tags = {
     Name    = "test-terraform"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -604,16 +586,7 @@ resource "aws_volume_attachment" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigUpdateSize = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsVolumeConfigUpdateSize = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "gp2"
@@ -624,16 +597,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigUpdateType = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsVolumeConfigUpdateType = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "sc1"
@@ -644,16 +608,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigWithIops = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsVolumeConfigWithIops = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "io1"
@@ -665,16 +620,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigWithIopsUpdated = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsVolumeConfigWithIopsUpdated = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "io1"
@@ -686,7 +632,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigWithKmsKey = `
+var testAccAwsEbsVolumeConfigWithKmsKey = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_kms_key" "test" {
   description = "Terraform acc test %d"
   policy = <<POLICY
@@ -708,15 +654,6 @@ resource "aws_kms_key" "test" {
 POLICY
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
@@ -725,16 +662,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigWithTags = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsVolumeConfigWithTags = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size = 1
@@ -744,16 +672,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigWithNoIops = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsVolumeConfigWithNoIops = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size = 10
@@ -765,16 +684,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigWithInvalidIopsForType = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAwsEbsVolumeConfigWithInvalidIopsForType = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 10
@@ -805,16 +715,7 @@ resource "aws_ebs_volume" "test" {
 }
 
 func testAccAwsEbsVolumeConfigMultiAttach(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type                 = "io1"

--- a/aws/resource_aws_ec2_availability_zone_group_test.go
+++ b/aws/resource_aws_ec2_availability_zone_group_test.go
@@ -95,7 +95,7 @@ data "aws_availability_zones" "test" {
 
 resource "aws_ec2_availability_zone_group" "test" {
   # The above group-name filter should ensure one Availability Zone Group per Region
-  group_name    = tolist(data.aws_availability_zones.test.group_names)[0]
+  group_name    = tolist(data.aws_availability_zones.available.group_names)[0]
   opt_in_status = %[1]q
 }
 `, optInStatus)

--- a/aws/resource_aws_ec2_capacity_reservation_test.go
+++ b/aws/resource_aws_ec2_capacity_reservation_test.go
@@ -488,16 +488,7 @@ func testAccPreCheckAWSEc2CapacityReservation(t *testing.T) {
 	}
 }
 
-const testAccEc2CapacityReservationConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccEc2CapacityReservationConfig = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   instance_count    = 1
@@ -507,16 +498,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 `
 
 func testAccEc2CapacityReservationConfig_ebsOptimized(ebsOptimized bool) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   ebs_optimized     = %t
@@ -528,16 +510,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 func testAccEc2CapacityReservationConfig_endDate(endDate string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   end_date          = %q
@@ -550,16 +523,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 func testAccEc2CapacityReservationConfig_endDateType(endDateType string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   end_date_type     = %q
@@ -571,16 +535,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 func testAccEc2CapacityReservationConfig_ephemeralStorage(ephemeralStorage bool) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   ephemeral_storage = %t
@@ -592,16 +547,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 func testAccEc2CapacityReservationConfig_instanceCount(instanceCount int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   instance_count    = %d
@@ -612,16 +558,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 func testAccEc2CapacityReservationConfig_instanceMatchCriteria(instanceMatchCriteria string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone       = "${data.aws_availability_zones.available.names[0]}"
   instance_count          = 1
@@ -633,16 +570,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 func testAccEc2CapacityReservationConfig_instanceType(instanceType string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   instance_count    = 1
@@ -653,16 +581,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 func testAccEc2CapacityReservationConfig_tags_single(tag1Key, tag1Value string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   instance_count    = 1
@@ -677,16 +596,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 func testAccEc2CapacityReservationConfig_tags_multiple(tag1Key, tag1Value, tag2Key, tag2Value string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   instance_count    = 1
@@ -702,16 +612,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 func testAccEc2CapacityReservationConfig_tenancy(tenancy string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   instance_count    = 1

--- a/aws/resource_aws_ec2_client_vpn_authorization_rule_test.go
+++ b/aws/resource_aws_ec2_client_vpn_authorization_rule_test.go
@@ -335,18 +335,7 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 }
 
 func testAccEc2ClientVpnAuthorizationRuleVpcBase(rName string, subnetCount int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # InvalidParameterValue: AZ us-west-2d is not currently supported. Please choose another az in this region
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -431,16 +431,7 @@ resource "aws_acm_certificate" "test" {
 }
 
 func testAccEc2ClientVpnEndpointMsADBase() string {
-	return `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }

--- a/aws/resource_aws_ec2_client_vpn_network_association_test.go
+++ b/aws/resource_aws_ec2_client_vpn_network_association_test.go
@@ -136,18 +136,7 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 }
 
 func testAccEc2ClientVpnNetworkAssociationVpcBase(rName string, subnetCount int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # InvalidParameterValue: AZ us-west-2d is not currently supported. Please choose another az in this region
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/resource_aws_ec2_client_vpn_route_test.go
+++ b/aws/resource_aws_ec2_client_vpn_route_test.go
@@ -222,18 +222,7 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 }
 
 func testAccEc2ClientVpnRouteVpcBase(rName string, subnetCount int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # InvalidParameterValue: AZ us-west-2d is not currently supported. Please choose another az in this region
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/resource_aws_ec2_fleet_test.go
+++ b/aws/resource_aws_ec2_fleet_test.go
@@ -1473,16 +1473,7 @@ resource "aws_ec2_fleet" "test" {
 }
 
 func testAccAWSEc2FleetConfig_LaunchTemplateConfig_Override_AvailabilityZone(rName string, availabilityZoneIndex int) string {
-	return testAccAWSEc2FleetConfig_BaseLaunchTemplate(rName) + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAWSEc2FleetConfig_BaseLaunchTemplate(rName) + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_fleet" "test" {
   launch_template_config {
     launch_template_specification {

--- a/aws/resource_aws_ec2_traffic_mirror_session_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_session_test.go
@@ -183,16 +183,7 @@ func testAccCheckAWSEc2TrafficMirrorSessionExists(name string, session *ec2.Traf
 }
 
 func testAccTrafficMirrorSessionConfigBase(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "azs" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_ami" "amzn-linux" {
   most_recent = true
 
@@ -220,7 +211,7 @@ resource "aws_vpc" "vpc" {
 resource "aws_subnet" "sub1" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.0.0/24"
-  availability_zone = "${data.aws_availability_zones.azs.names[0]}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
   tags = {
     Name = %[1]q
@@ -230,7 +221,7 @@ resource "aws_subnet" "sub1" {
 resource "aws_subnet" "sub2" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.1.0/24"
-  availability_zone = "${data.aws_availability_zones.azs.names[1]}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_ec2_traffic_mirror_target_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_target_test.go
@@ -185,16 +185,7 @@ func testAccCheckAWSEc2TrafficMirrorTargetExists(name string, target *ec2.Traffi
 }
 
 func testAccTrafficMirrorTargetConfigBase(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "azs" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
 
@@ -206,7 +197,7 @@ resource "aws_vpc" "vpc" {
 resource "aws_subnet" "sub1" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.0.0/24"
-  availability_zone = "${data.aws_availability_zones.azs.names[0]}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
   tags = {
     Name = %[1]q
@@ -216,7 +207,7 @@ resource "aws_subnet" "sub1" {
 resource "aws_subnet" "sub2" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.1.0/24"
-  availability_zone = "${data.aws_availability_zones.azs.names[1]}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_ec2_transit_gateway_route_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_test.go
@@ -204,18 +204,7 @@ func testAccCheckAWSEc2TransitGatewayRouteDisappears(transitGateway *ec2.Transit
 }
 
 func testAccAWSEc2TransitGatewayRouteConfigDestinationCidrBlock() string {
-	return `
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
@@ -190,18 +190,9 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRoute
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentAccepterConfig_base(rName string) string {
-	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAlternateAccountProviderConfig() +
+		testAccAvailableAZsNoOptInDefaultExcludeConfig() +
+		fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -542,18 +542,7 @@ func testAccCheckAWSEc2TransitGatewayVpcAttachmentNotRecreated(i, j *ec2.Transit
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfig() string {
-	return `
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -583,18 +572,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigDnsSupport(dnsSupport string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -625,18 +603,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigIpv6Support(ipv6Support string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
   cidr_block                       = "10.0.0.0/16"
@@ -669,18 +636,9 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigSharedTransitGateway(rName string) string {
-	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAlternateAccountProviderConfig() +
+		testAccAvailableAZsNoOptInDefaultExcludeConfig() +
+		fmt.Sprintf(`
 data "aws_organizations_organization" "test" {}
 
 resource "aws_ec2_transit_gateway" "test" {
@@ -736,18 +694,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigSubnetIds1() string {
-	return `
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -779,18 +726,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigSubnetIds2() string {
-	return `
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -822,18 +758,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTags1(tagKey1, tagValue1 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -867,18 +792,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -913,18 +827,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTransitGatewayDefaultRouteTableAssociationAndPropagationDisabled() string {
-	return `
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -959,18 +862,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTransitGatewayDefaultRouteTableAssociation(transitGatewayDefaultRouteTableAssociation bool) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1001,18 +893,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTransitGatewayDefaultRouteTablePropagation(transitGatewayDefaultRouteTablePropagation bool) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_ecs_capacity_provider_test.go
+++ b/aws/resource_aws_ecs_capacity_provider_test.go
@@ -328,7 +328,7 @@ func testAccCheckAWSEcsCapacityProviderExists(resourceName string, provider *ecs
 }
 
 func testAccAWSEcsCapacityProviderConfigBase(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_ami" "test" {
   most_recent = true
   owners      = ["amazon"]
@@ -336,15 +336,6 @@ data "aws_ami" "test" {
   filter {
     name   = "name"
     values = ["amzn-ami-hvm-*-x86_64-gp2"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -1692,16 +1692,7 @@ resource "aws_ecs_service" "mongo" {
 }
 
 func testAccAWSEcsServiceWithPlacementConstraint(clusterName, tdName, svcName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
   name = "%s"
 }
@@ -1772,16 +1763,7 @@ resource "aws_ecs_service" "mongo" {
 }
 
 func testAccAWSEcsServiceWithLaunchTypeFargate(sg1Name, sg2Name, clusterName, tdName, svcName, assignPublicIP string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
 
@@ -1869,16 +1851,7 @@ resource "aws_ecs_service" "main" {
 }
 
 func testAccAWSEcsServiceWithLaunchTypeFargateAndPlatformVersion(sg1Name, sg2Name, clusterName, tdName, svcName, platformVersion string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
 
@@ -1968,16 +1941,7 @@ resource "aws_ecs_service" "main" {
 
 func testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName, roleName, policyName,
 	lbName, svcName string, healthCheckGracePeriodSeconds int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
 
@@ -2115,16 +2079,7 @@ resource "aws_ecs_service" "with_alb" {
 }
 
 func testAccAWSEcsService_withIamRole(clusterName, tdName, roleName, policyName, svcName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -2277,16 +2232,7 @@ resource "aws_ecs_service" "mongo" {
 func tpl_testAccAWSEcsService_withLbChanges(clusterName, tdName, image,
 	containerName string, containerPort, hostPort int, roleName, policyName string,
 	instancePort int, svcName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -2540,16 +2486,7 @@ resource "aws_ecs_service" "jenkins" {
 }
 
 func testAccAWSEcsServiceWithAlb(clusterName, tdName, roleName, policyName, lbName, svcName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
 
@@ -2685,16 +2622,7 @@ resource "aws_ecs_service" "with_alb" {
 }
 
 func testAccAWSEcsServiceWithMultipleTargetGroups(clusterName, tdName, lbName, svcName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
 
@@ -2825,16 +2753,7 @@ func testAccAWSEcsServiceWithNetworkConfiguration_modified(sg1Name, sg2Name, clu
 }
 
 func tpl_testAccAWSEcsServiceWithNetworkConfiguration(sg1Name, sg2Name, clusterName, tdName, svcName string, securityGroups string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
   tags = {
@@ -2912,16 +2831,7 @@ resource "aws_ecs_service" "main" {
 }
 
 func testAccAWSEcsService_withServiceRegistries(rName, clusterName, tdName, svcName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "test" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -2933,7 +2843,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   count             = 2
   cidr_block        = "${cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)}"
-  availability_zone = "${data.aws_availability_zones.test.names[count.index]}"
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
@@ -3013,16 +2923,7 @@ resource "aws_ecs_service" "test" {
 }
 
 func testAccAWSEcsService_withServiceRegistries_container(rName, clusterName, tdName, svcName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "test" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -3034,7 +2935,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   count             = 2
   cidr_block        = "${cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)}"
-  availability_zone = "${data.aws_availability_zones.test.names[count.index]}"
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
@@ -3180,16 +3081,7 @@ resource "aws_ecs_service" "ghost" {
 }
 
 func testAccAWSEcsServiceConfigDeploymentControllerTypeCodeDeploy(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -284,16 +284,7 @@ func testAccCheckEfsMountTarget(resourceID string, mount *efs.MountTargetDescrip
 }
 
 func testAccAWSEFSMountTargetConfig(ct string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = "%s"
 
@@ -328,16 +319,7 @@ resource "aws_subnet" "test" {
 }
 
 func testAccAWSEFSMountTargetConfigModified(ct string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = "%s"
 
@@ -387,16 +369,7 @@ resource "aws_subnet" "test2" {
 }
 
 func testAccAWSEFSMountTargetConfigIpAddress(ipAddress string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -281,16 +281,7 @@ func testAccCheckAWSEIPAssociationDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccAWSEIPAssociationConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSEIPAssociationConfig = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
 	cidr_block = "192.168.0.0/24"
 	tags = {
@@ -356,16 +347,7 @@ resource "aws_network_interface" "test" {
 }
 `
 
-const testAccAWSEIPAssociationConfigDisappears = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSEIPAssociationConfigDisappears = testAccAvailableAZsNoOptInConfig() + `
 data "aws_ami" "amzn-ami-minimal-pv" {
 	most_recent = true
 	owners      = ["amazon"]
@@ -407,21 +389,12 @@ resource "aws_eip_association" "by_allocation_id" {
 	instance_id = "${aws_instance.foo.id}"
 }`
 
-const testAccAWSEIPAssociationConfig_ec2Classic = `
+var testAccAWSEIPAssociationConfig_ec2Classic = testAccAvailableAZsNoOptInConfig() + `
 provider "aws" {
   region = "us-east-1"
 }
 
 resource "aws_eip" "test" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 
 data "aws_ami" "ubuntu" {
   most_recent = true

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -930,16 +930,7 @@ resource "aws_eip" "test" {
 }
 `
 
-const testAccAWSEIPNetworkInterfaceConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSEIPNetworkInterfaceConfig = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/24"
 	tags = {
@@ -973,16 +964,7 @@ resource "aws_eip" "test" {
 }
 `
 
-const testAccAWSEIPMultiNetworkInterfaceConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSEIPMultiNetworkInterfaceConfig = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/24"
 	tags = {

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -518,16 +518,7 @@ func testAccPreCheckAWSEks(t *testing.T) {
 }
 
 func testAccAWSEksClusterConfig_Base(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = "%s"
 

--- a/aws/resource_aws_eks_fargate_profile_test.go
+++ b/aws/resource_aws_eks_fargate_profile_test.go
@@ -349,16 +349,7 @@ https://docs.aws.amazon.com/eks/latest/userguide/fargate.html
 }
 
 func testAccAWSEksFargateProfileConfigBase(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "cluster" {

--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -687,16 +687,7 @@ func testAccCheckAWSEksNodeGroupDisappears(nodeGroup *eks.Nodegroup) resource.Te
 }
 
 func testAccAWSEksNodeGroupConfigBaseIamAndVpc(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "cluster" {

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -720,19 +720,10 @@ func describeBeanstalkEnv(conn *elasticbeanstalk.ElasticBeanstalk,
 }
 
 func testAccBeanstalkEnvConfigBase(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Default instance type of t2.micro is not available in this Availability Zone
-  # The failure will occur during Elastic Beanstalk CloudFormation Template handling
-  # after waiting upwards of one hour to initialize the Auto Scaling Group.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
+# Default instance type of t2.micro is not available in this Availability Zone
+# The failure will occur during Elastic Beanstalk CloudFormation Template handling
+# after waiting upwards of one hour to initialize the Auto Scaling Group.	
 
 data "aws_elastic_beanstalk_solution_stack" "test" {
   most_recent = true

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -992,16 +992,7 @@ func testAccAWSElasticacheClusterConfig_NumCacheNodesWithPreferredAvailabilityZo
 		preferredAvailabilityZones[i] = `"${data.aws_availability_zones.available.names[0]}"`
 	}
 
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
   apply_immediately            = true
   cluster_id                   = "%s"
@@ -1013,16 +1004,7 @@ resource "aws_elasticache_cluster" "test" {
 `, rName, numCacheNodes, strings.Join(preferredAvailabilityZones, ","))
 }
 
-var testAccAWSElasticacheClusterInVPCConfig = fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSElasticacheClusterInVPCConfig = testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
     cidr_block = "192.168.0.0/16"
     tags = {
@@ -1079,16 +1061,7 @@ resource "aws_sns_topic" "test" {
 }
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
-var testAccAWSElasticacheClusterMultiAZInVPCConfig = fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSElasticacheClusterMultiAZInVPCConfig = testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
     cidr_block = "192.168.0.0/16"
     tags = {
@@ -1282,16 +1255,7 @@ resource "aws_elasticache_cluster" "test" {
 }
 
 func testAccAWSElasticacheClusterConfig_ReplicationGroupID_AvailabilityZone(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
     replication_group_description = "Terraform Acceptance Testing"
     replication_group_id          = "%[1]s"

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -848,16 +848,7 @@ resource "aws_elasticache_replication_group" "test" {
 }
 
 func testAccAWSElasticacheReplicationGroupConfig_Uppercase(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
@@ -982,16 +973,7 @@ resource "aws_elasticache_replication_group" "test" {
 `, rName)
 }
 
-var testAccAWSElasticacheReplicationGroupInVPCConfig = fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSElasticacheReplicationGroupInVPCConfig = testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
     cidr_block = "192.168.0.0/16"
   tags = {
@@ -1039,15 +1021,7 @@ resource "aws_elasticache_replication_group" "test" {
 }
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
-var testAccAWSElasticacheReplicationGroupMultiAZInVPCConfig = fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
+var testAccAWSElasticacheReplicationGroupMultiAZInVPCConfig = testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
     cidr_block = "192.168.0.0/16"
   tags = {
@@ -1104,17 +1078,9 @@ resource "aws_elasticache_replication_group" "test" {
 }
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
-var testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig = fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # InvalidParameterValue: Specified node type cache.m3.medium is not available in AZ us-east-1b.
-  exclude_zone_ids = ["use1-az1"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
+var testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig = testAccAvailableAZsNoOptInExcludeConfig("usw2-az4", "usgw1-az2", "use1-az1") +
+	fmt.Sprintf(`
+# InvalidParameterValue: Specified node type cache.m3.medium is not available in AZ use1-az1.	
   resource "aws_vpc" "test" {
 	  cidr_block = "192.168.0.0/16"
 	tags = {
@@ -1174,16 +1140,7 @@ data "aws_availability_zones" "available" {
   `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
 func testAccAWSElasticacheReplicationGroupNativeRedisClusterErrorConfig(rInt int, rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
@@ -1255,16 +1212,7 @@ resource "aws_elasticache_replication_group" "test" {
 }
 
 func testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rName string, numNodeGroups, replicasPerNodeGroup int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
@@ -1334,16 +1282,7 @@ resource "aws_elasticache_replication_group" "test" {
 }
 
 func testAccAWSElasticacheReplicationGroup_UseCmkKmsKeyId(rInt int, rString string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "192.168.0.0/16"
 
@@ -1406,16 +1345,7 @@ resource "aws_elasticache_replication_group" "bar" {
 }
 
 func testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(rInt int, rString string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
@@ -1473,16 +1403,7 @@ resource "aws_elasticache_replication_group" "test" {
 }
 
 func testAccAWSElasticacheReplicationGroup_EnableAuthTokenTransitEncryptionConfig(rInt int, rString10 string, rString16 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
@@ -1541,17 +1462,9 @@ resource "aws_elasticache_replication_group" "test" {
 }
 
 func testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName string, numberCacheClusters int, autoFailover bool) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # InvalidParameterValue: Specified node type cache.m3.medium is not available in AZ us-east-1b.
-  exclude_zone_ids = ["use1-az1"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
+	return testAccAvailableAZsNoOptInExcludeConfig("usw2-az4", "usgw1-az2", "use1-az1") +
+		fmt.Sprintf(`
+# InvalidParameterValue: Specified node type cache.m3.medium is not available in AZ use1-az1.		
 
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -1645,16 +1645,7 @@ resource "aws_elasticsearch_domain" "test" {
 }
 
 func testAccESDomainConfig_vpc(randInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "elasticsearch_in_vpc" {
   cidr_block = "192.168.0.0/22"
 
@@ -1723,16 +1714,7 @@ func testAccESDomainConfig_vpc_update(randInt int, update bool) string {
 		subnet_string = "first"
 	}
 
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "elasticsearch_in_vpc" {
   cidr_block = "192.168.0.0/22"
 
@@ -1812,16 +1794,7 @@ resource "aws_elasticsearch_domain" "test" {
 }
 
 func testAccESDomainConfig_internetToVpcEndpoint(randInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "elasticsearch_in_vpc" {
   cidr_block = "192.168.0.0/22"
 

--- a/aws/resource_aws_elb_attachment_test.go
+++ b/aws/resource_aws_elb_attachment_test.go
@@ -122,16 +122,7 @@ func TestAccAWSELBAttachment_drift(t *testing.T) {
 
 // add one attachment
 func testAccAWSELBAttachmentConfig1() string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elb" "bar" {
   availability_zones = [
     data.aws_availability_zones.available.names[0],
@@ -161,16 +152,7 @@ resource "aws_elb_attachment" "foo1" {
 
 // add a second attachment
 func testAccAWSELBAttachmentConfig2() string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elb" "bar" {
   availability_zones = [
     data.aws_availability_zones.available.names[0],
@@ -210,16 +192,7 @@ resource "aws_elb_attachment" "foo2" {
 
 // swap attachments between resources
 func testAccAWSELBAttachmentConfig3() string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elb" "bar" {
   availability_zones = [
     data.aws_availability_zones.available.names[0],
@@ -259,16 +232,7 @@ resource "aws_elb_attachment" "foo2" {
 
 // destroy attachments
 func testAccAWSELBAttachmentConfig4() string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elb" "bar" {
   availability_zones = [
     data.aws_availability_zones.available.names[0],

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1121,16 +1121,7 @@ func testAccCheckAWSELBExists(n string, res *elb.LoadBalancerDescription) resour
 	}
 }
 
-const testAccAWSELBConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfig = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1146,16 +1137,7 @@ resource "aws_elb" "test" {
 `
 
 func testAccAWSELBConfigTags1(tagKey1, tagValue1 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1176,16 +1158,7 @@ resource "aws_elb" "test" {
 }
 
 func testAccAWSELBConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1206,16 +1179,7 @@ resource "aws_elb" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-const testAccAWSELBFullRangeOfCharacters = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBFullRangeOfCharacters = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   name = "%s"
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
@@ -1229,16 +1193,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBAccessLogs = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBAccessLogs = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1252,7 +1207,7 @@ resource "aws_elb" "test" {
 `
 
 func testAccAWSELBAccessLogsOn(r string) string {
-	return `
+	return testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1269,19 +1224,11 @@ resource "aws_elb" "test" {
   }
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 ` + testAccAWSELBAccessLogsCommon(r)
 }
 
 func testAccAWSELBAccessLogsDisabled(r string) string {
-	return `
+	return testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1299,14 +1246,6 @@ resource "aws_elb" "test" {
   }
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 ` + testAccAWSELBAccessLogsCommon(r)
 }
 
@@ -1342,16 +1281,7 @@ EOF
 `, r)
 }
 
-const testAccAWSELB_namePrefix = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELB_namePrefix = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   name_prefix = "test-"
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
@@ -1365,16 +1295,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBGeneratedName = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBGeneratedName = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1387,16 +1308,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELB_zeroValueName = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELB_zeroValueName = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   name               = ""
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
@@ -1415,16 +1327,7 @@ output "lb_name" {
 }
 `
 
-const testAccAWSELBConfig_AvailabilityZonesUpdate = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfig_AvailabilityZonesUpdate = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
 
@@ -1437,7 +1340,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigNewInstance = `
+var testAccAWSELBConfigNewInstance = testAccAvailableAZsNoOptInConfig() + `
 data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   most_recent = true
   owners      = ["amazon"]
@@ -1450,15 +1353,6 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   filter {
     name   = "root-device-type"
     values = ["ebs"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -1481,16 +1375,7 @@ resource "aws_instance" "test" {
 }
 `
 
-const testAccAWSELBConfigHealthCheck = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigHealthCheck = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1511,16 +1396,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigHealthCheck_update = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigHealthCheck_update = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
@@ -1541,16 +1417,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigListener_update = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigListener_update = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1563,16 +1430,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigListener_multipleListeners = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigListener_multipleListeners = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1592,16 +1450,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigIdleTimeout = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigIdleTimeout = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
@@ -1616,16 +1465,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigIdleTimeout_update = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigIdleTimeout_update = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
@@ -1640,16 +1480,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigConnectionDraining = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigConnectionDraining = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
@@ -1665,16 +1496,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigConnectionDraining_update_timeout = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigConnectionDraining_update_timeout = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
@@ -1690,16 +1512,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigConnectionDraining_update_disable = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigConnectionDraining_update_disable = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
@@ -1714,16 +1527,7 @@ resource "aws_elb" "test" {
 }
 `
 
-const testAccAWSELBConfigSecurityGroups = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfigSecurityGroups = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1752,16 +1556,7 @@ resource "aws_security_group" "test" {
 `
 
 func testAccELBConfig_Listener_IAMServerCertificate(certName, certificate, key, lbProtocol string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_iam_server_certificate" "test_cert" {
   name             = "%[1]s"
   certificate_body = "%[2]s"
@@ -1783,16 +1578,7 @@ resource "aws_elb" "test" {
 }
 
 func testAccELBConfig_Listener_IAMServerCertificate_AddInvalidListener(certName, certificate, key string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_iam_server_certificate" "test_cert" {
   name             = "%[1]s"
   certificate_body = "%[2]s"
@@ -1822,16 +1608,7 @@ resource "aws_elb" "test" {
 `, certName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
 }
 
-const testAccAWSELBConfig_subnets = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfig_subnets = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "azelb" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -1898,16 +1675,7 @@ resource "aws_internet_gateway" "gw" {
 }
 `
 
-const testAccAWSELBConfig_subnet_swap = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSELBConfig_subnet_swap = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "azelb" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -3000,17 +3000,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 }
 
 func testAccAWSEmrClusterConfigBaseVpc(mapPublicIPOnLaunch bool) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Many instance types are not available in this availability zone
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true

--- a/aws/resource_aws_emr_instance_group_test.go
+++ b/aws/resource_aws_emr_instance_group_test.go
@@ -341,18 +341,7 @@ func testAccAWSEMRInstanceGroupRecreated(t *testing.T, before, after *emr.Instan
 	}
 }
 
-const testAccAWSEmrInstanceGroupBase = `
-data "aws_availability_zones" "available" {
-  # Many instance types are not available in this availability zone
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSEmrInstanceGroupBase = testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 data "aws_partition" "current" {}
 
 resource "aws_security_group" "allow_all" {

--- a/aws/resource_aws_fsx_lustre_file_system_test.go
+++ b/aws/resource_aws_fsx_lustre_file_system_test.go
@@ -530,16 +530,7 @@ func testAccCheckFsxLustreFileSystemRecreated(i, j *fsx.FileSystem) resource.Tes
 }
 
 func testAccAwsFsxLustreFileSystemConfigBase() string {
-	return `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
   cidr_block  = "10.0.0.0/16"
 }

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -759,16 +759,7 @@ func testAccCheckFsxWindowsFileSystemRecreated(i, j *fsx.FileSystem) resource.Te
 }
 
 func testAccAwsFsxWindowsFileSystemConfigBase() string {
-	return `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
   cidr_block  = "10.0.0.0/16"
 }

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -407,16 +407,7 @@ resource "aws_glue_connection" "test" {
 }
 
 func testAccAWSGlueConnectionConfig_PhysicalConnectionRequirements(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -3280,6 +3280,19 @@ data "aws_availability_zones" "available" {
 `, strings.Join(excludeZoneIds, "\", \""))
 }
 
+func testAccAvailableAZsNoOptInConfig() string {
+	return `
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+`
+}
+
 func testAccInstanceConfigInDefaultVpcBySgName(rName string) string {
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		testAccLatestAmazonLinuxHvmEbsAmiConfig() +
@@ -4886,16 +4899,7 @@ resource "aws_subnet" "test" {
 }
 
 func testAccAwsInstanceVpcConfigBasic(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2186,16 +2186,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccKinesisFirehoseDeliveryStreamRedshiftConfigBase(rName string, rInt int) string {
 	return composeConfig(
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt),
-		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2186,7 +2186,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccKinesisFirehoseDeliveryStreamRedshiftConfigBase(rName string, rInt int) string {
 	return composeConfig(
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt),
-		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1973,17 +1973,8 @@ func createTempFile(prefix string) (string, *os.File, error) {
 }
 
 func baseAccAWSLambdaConfig(policyName, roleName, sgName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_partition" "current" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
   name = "%s"

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -1196,7 +1196,7 @@ resource "aws_launch_template" "test" {
 }
 
 func testAccAWSLaunchTemplateConfig_BlockDeviceMappings_EBS(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_ami" "test" {
   most_recent = true
   owners      = ["099720109477"] # Canonical
@@ -1209,15 +1209,6 @@ data "aws_ami" "test" {
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -1253,7 +1244,7 @@ resource "aws_autoscaling_group" "test" {
 }
 
 func testAccAWSLaunchTemplateConfig_BlockDeviceMappings_EBS_DeleteOnTermination(rName string, deleteOnTermination bool) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_ami" "test" {
   most_recent = true
   owners      = ["099720109477"] # Canonical
@@ -1266,15 +1257,6 @@ data "aws_ami" "test" {
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -1433,16 +1415,7 @@ resource "aws_launch_template" "test" {
 }
 
 func testAccAWSLaunchTemplateConfig_capacityReservation_target(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_ec2_capacity_reservation" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   instance_count    = 1
@@ -1641,7 +1614,7 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-const testAccAWSLaunchTemplateConfig_asg_basic = `
+var testAccAWSLaunchTemplateConfig_asg_basic = testAccAvailableAZsNoOptInConfig() + `
 data "aws_ami" "test_ami" {
   most_recent = true
   owners      = ["amazon"]
@@ -1658,15 +1631,6 @@ resource "aws_launch_template" "test" {
   instance_type = "t2.micro"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
   desired_capacity = 0
@@ -1679,7 +1643,7 @@ resource "aws_autoscaling_group" "bar" {
 }
 `
 
-const testAccAWSLaunchTemplateConfig_asg_update = `
+var testAccAWSLaunchTemplateConfig_asg_update = testAccAvailableAZsNoOptInConfig() + `
 data "aws_ami" "test_ami" {
   most_recent = true
   owners      = ["amazon"]
@@ -1696,15 +1660,6 @@ resource "aws_launch_template" "test" {
   instance_type = "t2.nano"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
   desired_capacity = 0
@@ -1717,7 +1672,7 @@ resource "aws_autoscaling_group" "bar" {
 }
 `
 
-const testAccAWSLaunchTemplateConfig_instanceMarketOptions_basic = `
+var testAccAWSLaunchTemplateConfig_instanceMarketOptions_basic = testAccAvailableAZsNoOptInConfig() + `
 data "aws_ami" "test" {
   most_recent = true
   owners      = ["amazon"]
@@ -1741,15 +1696,6 @@ resource "aws_launch_template" "test" {
   }
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_autoscaling_group" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
   desired_capacity = 0
@@ -1763,7 +1709,7 @@ resource "aws_autoscaling_group" "test" {
 }
 `
 
-const testAccAWSLaunchTemplateConfig_instanceMarketOptions_update = `
+var testAccAWSLaunchTemplateConfig_instanceMarketOptions_update = testAccAvailableAZsNoOptInConfig() + `
 data "aws_ami" "test" {
   most_recent = true
   owners      = ["amazon"]
@@ -1785,15 +1731,6 @@ resource "aws_launch_template" "test" {
       max_price          = "0.5"
       spot_instance_type = "one-time"
     }
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/resource_aws_lb_listener_certificate_test.go
+++ b/aws/resource_aws_lb_listener_certificate_test.go
@@ -161,16 +161,7 @@ func testAccCheckAwsLbListenerCertificateNotExists(name string) resource.TestChe
 }
 
 func testAccLbListenerCertificateConfigLbListenerBase(rName, key, certificate string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -1265,7 +1265,7 @@ func testAccCheckAWSLBListenerRuleDestroy(s *terraform.State) error {
 }
 
 func testAccAWSLBListenerRuleConfig_basic(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "static" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 100
@@ -1330,15 +1330,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1386,7 +1377,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_forwardWeighted(lbName, targetGroupName1 string, targetGroupName2 string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "weighted" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 100
@@ -1478,15 +1469,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1534,7 +1516,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_changeForwardWeightedStickiness(lbName, targetGroupName1 string, targetGroupName2 string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "weighted" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 100
@@ -1630,15 +1612,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1686,7 +1659,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_changeForwardWeightedToBasic(lbName, targetGroupName1 string, targetGroupName2 string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "weighted" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 100
@@ -1769,15 +1742,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1825,7 +1789,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfigBackwardsCompatibility(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_alb_listener_rule" "static" {
   listener_arn = "${aws_alb_listener.front_end.arn}"
   priority     = 100
@@ -1890,15 +1854,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1946,7 +1901,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_redirect(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "static" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 100
@@ -2003,15 +1958,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -2059,7 +2005,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_fixedResponse(lbName, response string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "static" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 100
@@ -2116,15 +2062,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -2172,7 +2109,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_updateRulePriority(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "static" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 101
@@ -2237,15 +2174,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -2293,7 +2221,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_changeRuleArn(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "static" {
   listener_arn = "${aws_lb_listener.front_end_ruleupdate.arn}"
   priority     = 101
@@ -2369,15 +2297,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -2425,7 +2344,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_priorityBase(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = "${aws_lb.alb_test.id}"
   protocol          = "HTTP"
@@ -2472,15 +2391,6 @@ resource "aws_lb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2687,7 +2597,7 @@ resource "aws_lb_listener_rule" "priority50000_in_use" {
 }
 
 func testAccAWSLBListenerRuleConfig_cognito(rName, key, certificate string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "cognito" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 100
@@ -2774,15 +2684,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -2851,7 +2752,7 @@ resource "aws_cognito_user_pool_domain" "test" {
 }
 
 func testAccAWSLBListenerRuleConfig_oidc(rName, key, certificate string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "oidc" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 100
@@ -2941,15 +2842,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -2997,18 +2889,9 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_Action_Order(rName, key, certificate string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "rName" {
   default = %[1]q
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_lb_listener_rule" "test" {
@@ -3219,7 +3102,7 @@ condition {
 }
 
 func testAccAWSLBListenerRuleConfig_condition_base(condition, name, lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "static" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 100
@@ -3270,15 +3153,6 @@ resource "aws_lb" "alb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -525,7 +525,7 @@ func testAccCheckAWSLBListenerDestroy(s *terraform.State) error {
 }
 
 func testAccAWSLBListenerConfig_basic(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = "${aws_lb.alb_test.id}"
   protocol          = "HTTP"
@@ -572,15 +572,6 @@ resource "aws_lb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -630,7 +621,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerConfig_forwardWeighted(lbName, targetGroupName1 string, targetGroupName2 string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "weighted" {
   load_balancer_arn = "${aws_lb.alb_test.id}"
   protocol          = "HTTP"
@@ -706,15 +697,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -762,7 +744,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerConfig_changeForwardWeightedStickiness(lbName, targetGroupName1 string, targetGroupName2 string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "weighted" {
   load_balancer_arn = "${aws_lb.alb_test.id}"
   protocol          = "HTTP"
@@ -842,15 +824,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -898,7 +871,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerConfig_changeForwardWeightedToBasic(lbName, targetGroupName1 string, targetGroupName2 string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "weighted" {
   load_balancer_arn = "${aws_lb.alb_test.id}"
   protocol          = "HTTP"
@@ -965,15 +938,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1021,7 +985,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerConfig_basicUdp(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = "${aws_lb.alb_test.id}"
   protocol          = "UDP"
@@ -1064,15 +1028,6 @@ variable "subnets" {
   type    = "list"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1104,7 +1059,7 @@ resource "aws_subnet" "alb_test" {
 }
 
 func testAccAWSLBListenerConfigBackwardsCompatibility(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_alb_listener" "front_end" {
   load_balancer_arn = "${aws_alb.alb_test.id}"
   protocol          = "HTTP"
@@ -1151,15 +1106,6 @@ resource "aws_alb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1209,7 +1155,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerConfig_https(rName, key, certificate string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = "${aws_lb.alb_test.id}"
   protocol          = "HTTPS"
@@ -1260,15 +1206,6 @@ resource "aws_lb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1332,16 +1269,7 @@ resource "aws_iam_server_certificate" "test_cert" {
 }
 
 func testAccAWSLBListenerConfig_Protocol_Tls(rName, key, certificate string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
   certificate_body = "%[2]s"
   private_key      = "%[3]s"
@@ -1413,7 +1341,7 @@ resource "aws_lb_listener" "test" {
 }
 
 func testAccAWSLBListenerConfig_redirect(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = "${aws_lb.alb_test.id}"
   protocol          = "HTTP"
@@ -1447,15 +1375,6 @@ resource "aws_lb" "alb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1505,7 +1424,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerConfig_fixedResponse(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = "${aws_lb.alb_test.id}"
   protocol          = "HTTP"
@@ -1539,15 +1458,6 @@ resource "aws_lb" "alb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1597,7 +1507,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerConfig_cognito(rName, key, certificate string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "test" {
   name                       = "%[1]s"
   internal                   = false
@@ -1627,15 +1537,6 @@ resource "aws_lb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "test" {
@@ -1731,7 +1632,7 @@ resource "aws_lb_listener" "test" {
 }
 
 func testAccAWSLBListenerConfig_oidc(rName, key, certificate string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "test" {
   name                       = "%[1]s"
   internal                   = false
@@ -1761,15 +1662,6 @@ resource "aws_lb_target_group" "test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "test" {
@@ -1847,18 +1739,9 @@ resource "aws_lb_listener" "test" {
 }
 
 func testAccAWSLBListenerConfig_DefaultAction_Order(rName, key, certificate string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "rName" {
   default = %[1]q
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_lb_listener" "test" {

--- a/aws/resource_aws_lb_ssl_negotiation_policy_test.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy_test.go
@@ -183,16 +183,7 @@ func policyAttributesToMap(attributes *[]*elb.PolicyAttributeDescription) map[st
 
 // Sets the SSL Negotiation policy with attributes.
 func testAccSslNegotiationPolicyConfig(rName, key, certificate string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_iam_server_certificate" "test" {
   name             = "%[1]s"
   certificate_body = "%[2]s"

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -238,18 +238,7 @@ func testAccCheckAWSLBTargetGroupAttachmentDestroy(s *terraform.State) error {
 }
 
 func testAccAWSLBTargetGroupAttachmentConfigInstanceBase() string {
-	return `
-data "aws_availability_zones" "available" {
-  # t2.micro instance type is not available in these Availability Zones
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   most_recent = true
   owners      = ["amazon"]

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1318,7 +1318,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBConfig_basic(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
@@ -1336,15 +1336,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1394,7 +1385,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBConfig_enableHttp2(lbName string, http2 bool) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
@@ -1414,15 +1405,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1472,7 +1454,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBConfig_enableDropInvalidHeaderFields(lbName string, dropInvalid bool) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
@@ -1492,15 +1474,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1550,7 +1523,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBConfig_enableDeletionProtection(lbName string, deletion_protection bool) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
@@ -1568,15 +1541,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1728,16 +1692,7 @@ resource "aws_subnet" "alb_test" {
 }
 
 func testAccAWSLBConfig_networkLoadBalancerEIP(lbName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
 
@@ -1800,16 +1755,7 @@ resource "aws_eip" "lb" {
 }
 
 func testAccAWSLBConfig_networkLoadBalancerPrivateIPV4Address(lbName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "test" {
   name                       = "%s"
   internal                   = true
@@ -1848,7 +1794,7 @@ resource "aws_subnet" "test" {
 }
 
 func testAccAWSLBConfigBackwardsCompatibility(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_alb" "lb_test" {
   name            = "%s"
   internal        = true
@@ -1866,15 +1812,6 @@ resource "aws_alb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1924,7 +1861,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBConfig_updateSubnets(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
@@ -1942,15 +1879,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2000,7 +1928,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBConfig_generatedName() string {
-	return `
+	return testAccAvailableAZsNoOptInConfig() + `
 resource "aws_lb" "lb_test" {
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
@@ -2017,15 +1945,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2082,7 +2001,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBConfig_zeroValueName() string {
-	return `
+	return testAccAvailableAZsNoOptInConfig() + `
 resource "aws_lb" "lb_test" {
   name            = ""
   internal        = true
@@ -2105,15 +2024,6 @@ output "lb_name" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2170,7 +2080,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBConfig_namePrefix() string {
-	return `
+	return testAccAvailableAZsNoOptInConfig() + `
 resource "aws_lb" "lb_test" {
   name_prefix     = "tf-lb-"
   internal        = true
@@ -2188,15 +2098,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2244,7 +2145,7 @@ resource "aws_security_group" "alb_test" {
 }`
 }
 func testAccAWSLBConfig_updatedTags(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
@@ -2263,15 +2164,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2321,16 +2213,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBConfigALBAccessLogsBase(bucketName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_elb_service_account" "current" {}
 
 resource "aws_vpc" "test" {
@@ -2405,16 +2288,7 @@ resource "aws_lb" "test" {
 }
 
 func testAccAWSLBConfigNLBAccessLogsBase(bucketName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_elb_service_account" "current" {}
 
 resource "aws_vpc" "test" {
@@ -2502,7 +2376,7 @@ resource "aws_lb" "test" {
 }
 
 func testAccAWSLBConfig_nosg(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name     = "%s"
   internal = true
@@ -2519,15 +2393,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2553,7 +2418,7 @@ resource "aws_subnet" "alb_test" {
 }
 
 func testAccAWSLBConfig_updateSecurityGroups(lbName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
@@ -2571,15 +2436,6 @@ resource "aws_lb" "lb_test" {
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_vpc" "alb_test" {

--- a/aws/resource_aws_lightsail_instance_test.go
+++ b/aws/resource_aws_lightsail_instance_test.go
@@ -294,16 +294,7 @@ func testAccPreCheckAWSLightsail(t *testing.T) {
 }
 
 func testAccAWSLightsailInstanceConfig_basic(lightsailName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lightsail_instance" "lightsail_instance_test" {
   name              = "%s"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
@@ -314,16 +305,7 @@ resource "aws_lightsail_instance" "lightsail_instance_test" {
 }
 
 func testAccAWSLightsailInstanceConfig_tags1(lightsailName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lightsail_instance" "lightsail_instance_test" {
   name              = "%s"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
@@ -337,16 +319,7 @@ resource "aws_lightsail_instance" "lightsail_instance_test" {
 }
 
 func testAccAWSLightsailInstanceConfig_tags2(lightsailName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lightsail_instance" "lightsail_instance_test" {
   name              = "%s"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"

--- a/aws/resource_aws_lightsail_static_ip_attachment_test.go
+++ b/aws/resource_aws_lightsail_static_ip_attachment_test.go
@@ -135,16 +135,7 @@ func testAccCheckAWSLightsailStaticIpAttachmentDestroy(s *terraform.State) error
 }
 
 func testAccAWSLightsailStaticIpAttachmentConfig_basic(staticIpName, instanceName, keypairName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_lightsail_static_ip_attachment" "test" {
   static_ip_name = "${aws_lightsail_static_ip.test.name}"
   instance_name  = "${aws_lightsail_instance.test.name}"

--- a/aws/resource_aws_load_balancer_backend_server_policy_test.go
+++ b/aws/resource_aws_load_balancer_backend_server_policy_test.go
@@ -141,16 +141,7 @@ func testAccCheckAWSLoadBalancerBackendServerPolicyState(loadBalancerName string
 }
 
 func testAccAWSLoadBalancerBackendServerPolicyConfig_basic0(rName, privateKey, publicKey, certificate string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_iam_server_certificate" "test-iam-cert0" {
   name_prefix      = "test_cert_"
   certificate_body = "%[2]s"
@@ -208,16 +199,7 @@ resource "aws_load_balancer_backend_server_policy" "test-backend-auth-policies-4
 }
 
 func testAccAWSLoadBalancerBackendServerPolicyConfig_basic1(rName, privateKey1, publicKey1, certificate1, publicKey2 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_iam_server_certificate" "test-iam-cert0" {
   name_prefix      = "test_cert_"
   certificate_body = "%[2]s"
@@ -286,16 +268,7 @@ resource "aws_load_balancer_backend_server_policy" "test-backend-auth-policies-4
 }
 
 func testAccAWSLoadBalancerBackendServerPolicyConfig_basic2(rName, privateKey, certificate string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_iam_server_certificate" "test-iam-cert0" {
   name_prefix      = "test_cert_"
   certificate_body = "%[2]s"

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -980,16 +980,7 @@ resource "aws_mq_broker" "test" {
 }
 
 func testAccMqBrokerConfig_allFieldsCustomVpc(sgName, cfgName, cfgBody, brokerName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.11.0.0/16"
 

--- a/aws/resource_aws_msk_cluster_test.go
+++ b/aws/resource_aws_msk_cluster_test.go
@@ -666,21 +666,12 @@ func testAccPreCheckAWSMsk(t *testing.T) {
 }
 
 func testAccMskClusterBaseConfig() string {
-	return `
+	return testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "example_vpc" {
   cidr_block = "192.168.0.0/22"
 
   tags = {
     Name = "tf-testacc-msk-cluster-vpc"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -570,16 +570,7 @@ func testAccCheckAWSNeptuneClusterSnapshot(rName string) resource.TestCheckFunc 
 	}
 }
 
-var testAccAWSNeptuneClusterConfigBase = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccAWSNeptuneClusterConfigBase = testAccAvailableAZsNoOptInConfig() + `
 locals {
 	availability_zone_names = slice(data.aws_availability_zones.available.names, 0, min(3, length(data.aws_availability_zones.available.names)))
 }

--- a/aws/resource_aws_network_interface_attachment_test.go
+++ b/aws/resource_aws_network_interface_attachment_test.go
@@ -40,7 +40,7 @@ func TestAccAWSNetworkInterfaceAttachment_basic(t *testing.T) {
 }
 
 func testAccAWSNetworkInterfaceAttachmentConfig_basic(rInt int) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
 
@@ -48,15 +48,6 @@ resource "aws_vpc" "foo" {
     Name = "terraform-testacc-network-iface-attachment-basic"
   }
 }
-
-data "aws_availability_zones" "available" {
-  state            = "available"
-  
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}	
 
 resource "aws_subnet" "foo" {
   vpc_id            = "${aws_vpc.foo.id}"

--- a/aws/resource_aws_network_interface_sg_attachment_test.go
+++ b/aws/resource_aws_network_interface_sg_attachment_test.go
@@ -334,16 +334,7 @@ resource "aws_network_interface_sg_attachment" "test" {
 }
 
 func testAccAwsNetworkInterfaceSGAttachmentConfigMultiple(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_subnet" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   default_for_az    = "true"

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -498,7 +498,7 @@ func testAccCheckAWSENIMakeExternalAttachment(n string, conf *ec2.NetworkInterfa
 }
 
 func testAccAWSENIConfig() string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
@@ -506,15 +506,6 @@ resource "aws_vpc" "foo" {
     Name = "terraform-testacc-network-interface"
   }
 }
-
-data "aws_availability_zones" "available" {
-   state = "available"
-
-   filter {
-     name   = "opt-in-status"
-     values = ["opt-in-not-required"]
-   }
- }
 
 resource "aws_subnet" "foo" {
   vpc_id            = "${aws_vpc.foo.id}"
@@ -551,21 +542,12 @@ resource "aws_network_interface" "bar" {
 }
 
 func testAccAWSENIConfigUpdatedDescription() string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
   tags = {
     Name = "terraform-testacc-network-interface-update-desc"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -604,21 +586,12 @@ resource "aws_network_interface" "bar" {
 }
 
 func testAccAWSENIConfigWithSourceDestCheck() string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
   tags = {
     Name = "terraform-testacc-network-interface-w-source-dest-check"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -640,21 +613,12 @@ resource "aws_network_interface" "bar" {
 }
 
 func testAccAWSENIConfigWithNoPrivateIPs() string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
   tags = {
     Name = "terraform-testacc-network-interface-w-no-private-ips"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -675,7 +639,7 @@ resource "aws_network_interface" "bar" {
 }
 
 func testAccAWSENIConfigWithAttachment() string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
@@ -683,15 +647,6 @@ resource "aws_vpc" "foo" {
     Name = "terraform-testacc-network-interface-w-attachment"
   }
 }
-
-data "aws_availability_zones" "available" {
-   state = "available"
-
-   filter {
-     name   = "opt-in-status"
-     values = ["opt-in-not-required"]
-   }
- }
 
 resource "aws_subnet" "foo" {
   vpc_id            = "${aws_vpc.foo.id}"
@@ -743,7 +698,7 @@ resource "aws_network_interface" "bar" {
 }
 
 func testAccAWSENIConfigExternalAttachment() string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
@@ -751,15 +706,6 @@ resource "aws_vpc" "foo" {
     Name = "terraform-testacc-network-interface-external-attachment"
   }
 }
-
-data "aws_availability_zones" "available" {
-   state = "available"
-
-   filter {
-     name   = "opt-in-status"
-     values = ["opt-in-not-required"]
-   }
- }
 
 resource "aws_subnet" "foo" {
   vpc_id            = "${aws_vpc.foo.id}"

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -947,16 +947,7 @@ resource "aws_db_parameter_group" "bar" {
 }
 
 func testAccAWSClusterInstanceConfig_az(n int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
   cluster_identifier  = "tf-aurora-cluster-test-%d"
   availability_zones  = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -2252,16 +2252,7 @@ resource "aws_rds_cluster" "test" {
 }
 
 func testAccAWSClusterConfig_AvailabilityZones(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
   apply_immediately   = true
   availability_zones  = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
@@ -2298,16 +2289,7 @@ resource "aws_rds_cluster" "test" {
 }
 
 func testAccAWSClusterConfig_DbSubnetGroupName(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
   cluster_identifier   = %[1]q
   master_username      = "root"
@@ -2352,16 +2334,7 @@ resource "aws_db_subnet_group" "test" {
 }
 
 func testAccAWSClusterConfig_s3Restore(bucketName string, bucketPrefix string, uniqueId string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_s3_bucket" "xtrabackup" {
   bucket = %[1]q
 }
@@ -3082,16 +3055,7 @@ resource "aws_rds_cluster" "test" {
 }
 
 func testAccAWSRDSClusterConfig_EngineMode_Multimaster(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -1552,16 +1552,7 @@ resource "aws_route53_record" "ap-northeast-1" {
 }
 `
 
-const testAccRoute53RecordConfigAliasElb = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccRoute53RecordConfigAliasElb = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
@@ -1591,16 +1582,7 @@ resource "aws_elb" "main" {
 }
 `
 
-const testAccRoute53RecordConfigAliasElbUppercase = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccRoute53RecordConfigAliasElbUppercase = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
@@ -1841,16 +1823,7 @@ resource "aws_route53_record" "test" {
 `
 }
 
-const testAccRoute53WeightedElbAliasRecord = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccRoute53WeightedElbAliasRecord = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
@@ -2058,16 +2031,7 @@ resource "aws_route53_record" "basic_to_weighted" {
 }
 `
 
-const testAccRoute53RecordAliasChangePre = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccRoute53RecordAliasChangePre = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_route53_zone" "main" {
 	name = "notexample.com"
 }

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -210,7 +210,7 @@ func testAccPreCheckAWSRoute53Resolver(t *testing.T) {
 }
 
 func testAccRoute53ResolverEndpointConfig_base(rInt int) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
@@ -218,15 +218,6 @@ resource "aws_vpc" "foo" {
 
   tags = {
     Name = "terraform-testacc-r53-resolver-vpc-%d"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -512,7 +512,7 @@ resource "aws_route53_resolver_rule" "example" {
 }
 
 func testAccRoute53ResolverRuleConfig_resolverVpc(name string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
@@ -520,15 +520,6 @@ resource "aws_vpc" "foo" {
 
   tags = {
     Name = %q
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -895,18 +895,7 @@ resource "aws_route_table" "test" {
 }
 
 func testAccAWSRouteTableConfigRouteTransitGatewayID() string {
-	return `
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -614,7 +614,7 @@ resource "aws_route" "igw" {
 func testAccAWSRouteConfigIpv6NetworkInterface() string {
 	return testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.router-network.availability_zone", "t2.small", "t3.small") +
 		testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "examplevpc" {
   cidr_block                       = "10.100.0.0/16"
   enable_dns_hostnames             = true
@@ -622,15 +622,6 @@ resource "aws_vpc" "examplevpc" {
   
   tags = {
     Name = "terraform-testacc-route-ipv6-network-interface"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -723,7 +714,7 @@ resource "aws_route" "internal-default-route-ipv6" {
 func testAccAWSRouteConfigIpv6Instance() string {
 	return testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.router-network.availability_zone", "t2.small", "t3.small") +
 		testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "examplevpc" {
   cidr_block                       = "10.100.0.0/16"
   enable_dns_hostnames             = true
@@ -731,15 +722,6 @@ resource "aws_vpc" "examplevpc" {
 
   tags = {
     Name = "terraform-testacc-route-ipv6-instance"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -821,7 +803,7 @@ resource "aws_route" "internal-default-route-ipv6" {
 func testAccAWSRouteConfigIpv6InstanceExpanded() string {
 	return testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.router-network.availability_zone", "t2.small", "t3.small") +
 		testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "examplevpc" {
   cidr_block                       = "10.100.0.0/16"
   enable_dns_hostnames             = true
@@ -829,15 +811,6 @@ resource "aws_vpc" "examplevpc" {
   
   tags = {
     Name = "terraform-testacc-route-ipv6-instance"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 
@@ -1035,18 +1008,10 @@ resource "aws_route" "bar" {
 }
 
 func testAccAWSRouteNoopChange() string {
-	return testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t2.nano", "t3.nano") +
+	return testAccAvailableAZsNoOptInConfig() +
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t2.nano", "t3.nano") +
 		testAccLatestAmazonLinuxHvmEbsAmiConfig() +
 		fmt.Sprint(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
   

--- a/aws/resource_aws_shield_protection_test.go
+++ b/aws/resource_aws_shield_protection_test.go
@@ -260,16 +260,7 @@ resource "aws_shield_protection" "acctest" {
 }
 
 func testAccShieldProtectionElbConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
@@ -331,16 +322,7 @@ resource "aws_shield_protection" "acctest" {
 }
 
 func testAccShieldProtectionAlbConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"
@@ -494,19 +476,11 @@ resource "aws_shield_protection" "acctest" {
 }
 
 func testAccShieldProtectionElasticIPAddressConfig(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "name" {
   default = "%s"
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 

--- a/aws/resource_aws_snapshot_create_volume_permission_test.go
+++ b/aws/resource_aws_snapshot_create_volume_permission_test.go
@@ -106,16 +106,7 @@ func testAccAWSSnapshotCreateVolumePermissionDestroyed(accountId, snapshotId *st
 }
 
 func testAccAWSSnapshotCreateVolumePermissionConfig(includeCreateVolumePermission bool, accountID string) string {
-	base := `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	base := testAccAvailableAZsNoOptInConfig() + `
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1312,7 +1312,7 @@ func testAccAWSSpotFleetRequestConfigBase(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1312,16 +1312,7 @@ func testAccAWSSpotFleetRequestConfigBase(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -661,17 +661,7 @@ func testAccAWSSpotInstanceRequestConfig_withBlockDuration(rInt int) string {
 }
 
 func testAccAWSSpotInstanceRequestConfigVPC(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo_VPC" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
@@ -719,17 +709,7 @@ tags = {
 }
 
 func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + fmt.Sprintf(`
 %v
 
 resource "aws_spot_instance_request" "foo" {

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -774,18 +774,9 @@ resource "aws_ssm_association" "test" {
 }
 
 func testAccAWSSSMAssociationBasicConfig(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "name" {
   default = "%s"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 data "aws_ami" "amzn" {

--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -702,7 +702,7 @@ func testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName stri
 	return composeConfig(
 		// Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test[0].availability_zone", "m5.xlarge", "m4.xlarge"),
-		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 # Directory Service Directories must be deployed across multiple EC2 Availability Zones
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -702,17 +702,8 @@ func testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName stri
 	return composeConfig(
 		// Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test[0].availability_zone", "m5.xlarge", "m4.xlarge"),
-		fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 # Directory Service Directories must be deployed across multiple EC2 Availability Zones
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -272,16 +272,7 @@ func testAccVolumeAttachmentInstanceOnlyConfigBase(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami               = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -272,7 +272,7 @@ func testAccVolumeAttachmentInstanceOnlyConfigBase(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
-		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+		testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami               = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"

--- a/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_test.go
@@ -34,7 +34,7 @@ func testSweepVpcDhcpOptions(region string) error {
 			var defaultDomainNameFound, defaultDomainNameServersFound bool
 
 			domainName := region + ".compute.internal"
-			if region == "us-east-1" {
+			if region == "us-east-1" { //lintignore:AWSAT003
 				domainName = "ec2.internal"
 			}
 
@@ -296,11 +296,11 @@ func testAccCheckDHCPOptionsDelete(n string) resource.TestCheckFunc {
 func testAccDHCPOptionsConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc_dhcp_options" "test" {
-	domain_name = "service.%s"
-	domain_name_servers = ["127.0.0.1", "10.0.0.2"]
-	ntp_servers = ["127.0.0.1"]
-	netbios_name_servers = ["127.0.0.1"]
-	netbios_node_type = 2
+  domain_name          = "service.%s"
+  domain_name_servers  = ["127.0.0.1", "10.0.0.2"]
+  ntp_servers          = ["127.0.0.1"]
+  netbios_name_servers = ["127.0.0.1"]
+  netbios_node_type    = 2
 }
 `, rName)
 }
@@ -308,11 +308,11 @@ resource "aws_vpc_dhcp_options" "test" {
 func testAccDHCPOptionsConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc_dhcp_options" "test" {
-	domain_name = "service.%[1]s"
-	domain_name_servers = ["127.0.0.1", "10.0.0.2"]
-	ntp_servers = ["127.0.0.1"]
-	netbios_name_servers = ["127.0.0.1"]
-	netbios_node_type = 2
+  domain_name          = "service.%[1]s"
+  domain_name_servers  = ["127.0.0.1", "10.0.0.2"]
+  ntp_servers          = ["127.0.0.1"]
+  netbios_name_servers = ["127.0.0.1"]
+  netbios_node_type    = 2
 
   tags = {
     %[2]q = %[3]q
@@ -324,11 +324,11 @@ resource "aws_vpc_dhcp_options" "test" {
 func testAccDHCPOptionsConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc_dhcp_options" "test" {
-	domain_name = "service.%[1]s"
-	domain_name_servers = ["127.0.0.1", "10.0.0.2"]
-	ntp_servers = ["127.0.0.1"]
-	netbios_name_servers = ["127.0.0.1"]
-	netbios_node_type = 2
+  domain_name          = "service.%[1]s"
+  domain_name_servers  = ["127.0.0.1", "10.0.0.2"]
+  ntp_servers          = ["127.0.0.1"]
+  netbios_name_servers = ["127.0.0.1"]
+  netbios_node_type    = 2
 
   tags = {
     %[2]q = %[3]q

--- a/aws/resource_aws_vpc_endpoint_connection_notification_test.go
+++ b/aws/resource_aws_vpc_endpoint_connection_notification_test.go
@@ -106,8 +106,7 @@ func testAccCheckVpcEndpointConnectionNotificationExists(n string) resource.Test
 }
 
 func testAccVpcEndpointConnectionNotificationBasicConfig(lbName string) string {
-	return fmt.Sprintf(
-		`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -120,8 +119,8 @@ resource "aws_lb" "nlb_test" {
   name = "%s"
 
   subnets = [
-    "${aws_subnet.nlb_test_1.id}",
-    "${aws_subnet.nlb_test_2.id}",
+    aws_subnet.nlb_test_1.id,
+    aws_subnet.nlb_test_2.id,
   ]
 
   load_balancer_type         = "network"
@@ -135,9 +134,9 @@ resource "aws_lb" "nlb_test" {
 }
 
 resource "aws_subnet" "nlb_test_1" {
-  vpc_id            = "${aws_vpc.nlb_test.id}"
+  vpc_id            = aws_vpc.nlb_test.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-vpc-endpoint-connection-notification-1"
@@ -145,9 +144,9 @@ resource "aws_subnet" "nlb_test_1" {
 }
 
 resource "aws_subnet" "nlb_test_2" {
-  vpc_id            = "${aws_vpc.nlb_test.id}"
+  vpc_id            = aws_vpc.nlb_test.id
   cidr_block        = "10.0.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-vpc-endpoint-connection-notification-2"
@@ -160,11 +159,11 @@ resource "aws_vpc_endpoint_service" "test" {
   acceptance_required = false
 
   network_load_balancer_arns = [
-    "${aws_lb.nlb_test.id}",
+    aws_lb.nlb_test.id,
   ]
 
   allowed_principals = [
-    "${data.aws_caller_identity.current.arn}"
+    data.aws_caller_identity.current.arn
   ]
 }
 
@@ -173,112 +172,115 @@ resource "aws_sns_topic" "topic" {
 
   policy = <<POLICY
 {
-    "Version":"2012-10-17",
-    "Statement":[{
-        "Effect": "Allow",
-        "Principal": {
-            "Service": "vpce.amazonaws.com"
-        },
-        "Action": "SNS:Publish",
-        "Resource": "arn:aws:sns:*:*:vpce-notification-topic"
-    }]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "vpce.amazonaws.com"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:*:*:vpce-notification-topic"
+    }
+  ]
 }
 POLICY
 }
 
 resource "aws_vpc_endpoint_connection_notification" "test" {
-  vpc_endpoint_service_id = "${aws_vpc_endpoint_service.test.id}"
-  connection_notification_arn = "${aws_sns_topic.topic.arn}"
-  connection_events = ["Accept", "Reject"]
+  vpc_endpoint_service_id     = aws_vpc_endpoint_service.test.id
+  connection_notification_arn = aws_sns_topic.topic.arn
+  connection_events           = ["Accept", "Reject"]
 }
 `, lbName)
 }
 
 func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) string {
-	return fmt.Sprintf(
-		`
-		resource "aws_vpc" "nlb_test" {
-			cidr_block = "10.0.0.0/16"
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+resource "aws_vpc" "nlb_test" {
+  cidr_block = "10.0.0.0/16"
 
-	tags = {
-				Name = "terraform-testacc-vpc-endpoint-connection-notification"
-			}
-		}
+  tags = {
+    Name = "terraform-testacc-vpc-endpoint-connection-notification"
+  }
+}
 
-		resource "aws_lb" "nlb_test" {
-			name = "%s"
+resource "aws_lb" "nlb_test" {
+  name = "%s"
 
-			subnets = [
-				"${aws_subnet.nlb_test_1.id}",
-				"${aws_subnet.nlb_test_2.id}",
-			]
+  subnets = [
+    aws_subnet.nlb_test_1.id,
+    aws_subnet.nlb_test_2.id,
+  ]
 
-			load_balancer_type         = "network"
-			internal                   = true
-			idle_timeout               = 60
-			enable_deletion_protection = false
+  load_balancer_type         = "network"
+  internal                   = true
+  idle_timeout               = 60
+  enable_deletion_protection = false
 
-	tags = {
-				Name = "testAccVpcEndpointConnectionNotificationBasicConfig_nlb"
-			}
-		}
+  tags = {
+    Name = "testAccVpcEndpointConnectionNotificationBasicConfig_nlb"
+  }
+}
 
-		resource "aws_subnet" "nlb_test_1" {
-			vpc_id            = "${aws_vpc.nlb_test.id}"
-			cidr_block        = "10.0.1.0/24"
-			availability_zone = "us-west-2a"
+resource "aws_subnet" "nlb_test_1" {
+  vpc_id            = aws_vpc.nlb_test.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
-	tags = {
-				Name = "tf-acc-vpc-endpoint-connection-notification-1"
-			}
-		}
+  tags = {
+    Name = "tf-acc-vpc-endpoint-connection-notification-1"
+  }
+}
 
-		resource "aws_subnet" "nlb_test_2" {
-			vpc_id            = "${aws_vpc.nlb_test.id}"
-			cidr_block        = "10.0.2.0/24"
-			availability_zone = "us-west-2b"
+resource "aws_subnet" "nlb_test_2" {
+  vpc_id            = aws_vpc.nlb_test.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
-	tags = {
-				Name = "tf-acc-vpc-endpoint-connection-notification-2"
-			}
-		}
+  tags = {
+    Name = "tf-acc-vpc-endpoint-connection-notification-2"
+  }
+}
 
-		data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {}
 
-		resource "aws_vpc_endpoint_service" "test" {
-			acceptance_required = false
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required = false
 
-			network_load_balancer_arns = [
-				"${aws_lb.nlb_test.id}",
-			]
+  network_load_balancer_arns = [
+    aws_lb.nlb_test.id,
+  ]
 
-			allowed_principals = [
-				"${data.aws_caller_identity.current.arn}"
-			]
-		}
+  allowed_principals = [
+    data.aws_caller_identity.current.arn
+  ]
+}
 
-		resource "aws_sns_topic" "topic" {
-			name = "vpce-notification-topic"
+resource "aws_sns_topic" "topic" {
+  name = "vpce-notification-topic"
 
-			policy = <<POLICY
-		{
-				"Version":"2012-10-17",
-				"Statement":[{
-						"Effect": "Allow",
-						"Principal": {
-								"Service": "vpce.amazonaws.com"
-						},
-						"Action": "SNS:Publish",
-						"Resource": "arn:aws:sns:*:*:vpce-notification-topic"
-				}]
-		}
-		POLICY
-		}
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "vpce.amazonaws.com"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:*:*:vpce-notification-topic"
+    }
+  ]
+}
+POLICY
+}
 
-		resource "aws_vpc_endpoint_connection_notification" "test" {
-			vpc_endpoint_service_id = "${aws_vpc_endpoint_service.test.id}"
-			connection_notification_arn = "${aws_sns_topic.topic.arn}"
-			connection_events = ["Accept"]
-		}
+resource "aws_vpc_endpoint_connection_notification" "test" {
+  vpc_endpoint_service_id     = aws_vpc_endpoint_service.test.id
+  connection_notification_arn = aws_sns_topic.topic.arn
+  connection_events           = ["Accept"]
+}
 `, lbName)
 }

--- a/aws/resource_aws_vpc_endpoint_service_allowed_principal_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_allowed_principal_test.go
@@ -95,8 +95,7 @@ func testAccCheckVpcEndpointServiceAllowedPrincipalExists(n string) resource.Tes
 }
 
 func testAccVpcEndpointServiceAllowedPrincipalBasicConfig(lbName string) string {
-	return fmt.Sprintf(
-		`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -109,8 +108,8 @@ resource "aws_lb" "nlb_test_1" {
   name = "%s"
 
   subnets = [
-    "${aws_subnet.nlb_test_1.id}",
-    "${aws_subnet.nlb_test_2.id}",
+    aws_subnet.nlb_test_1.id,
+    aws_subnet.nlb_test_2.id,
   ]
 
   load_balancer_type         = "network"
@@ -124,9 +123,9 @@ resource "aws_lb" "nlb_test_1" {
 }
 
 resource "aws_subnet" "nlb_test_1" {
-  vpc_id            = "${aws_vpc.nlb_test.id}"
+  vpc_id            = aws_vpc.nlb_test.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-vpc-endpoint-service-allowed-principal-1"
@@ -134,9 +133,9 @@ resource "aws_subnet" "nlb_test_1" {
 }
 
 resource "aws_subnet" "nlb_test_2" {
-  vpc_id            = "${aws_vpc.nlb_test.id}"
+  vpc_id            = aws_vpc.nlb_test.id
   cidr_block        = "10.0.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-vpc-endpoint-service-allowed-principal-2"
@@ -149,14 +148,14 @@ resource "aws_vpc_endpoint_service" "foo" {
   acceptance_required = false
 
   network_load_balancer_arns = [
-    "${aws_lb.nlb_test_1.id}",
+    aws_lb.nlb_test_1.id,
   ]
 }
 
 resource "aws_vpc_endpoint_service_allowed_principal" "foo" {
-	vpc_endpoint_service_id = "${aws_vpc_endpoint_service.foo.id}"
+  vpc_endpoint_service_id = aws_vpc_endpoint_service.foo.id
 
-  principal_arn = "${data.aws_caller_identity.current.arn}"
+  principal_arn = data.aws_caller_identity.current.arn
 }
 `, lbName)
 }

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -281,7 +281,7 @@ func testAccCheckVpcEndpointServiceExists(n string, svcCfg *ec2.ServiceConfigura
 }
 
 func testAccVpcEndpointServiceConfig_base(rName1, rName2 string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -323,15 +323,6 @@ resource "aws_lb" "test2" {
 
   tags = {
     Name = %[2]q
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
   }
 }
 

--- a/aws/resource_aws_vpc_endpoint_subnet_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association_test.go
@@ -125,7 +125,7 @@ func testAccCheckVpcEndpointSubnetAssociationExists(n string, vpce *ec2.VpcEndpo
 	}
 }
 
-const testAccVpcEndpointSubnetAssociationConfig_basic = `
+var testAccVpcEndpointSubnetAssociationConfig_basic = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
   tags = {
@@ -139,15 +139,6 @@ data "aws_security_group" "default" {
 }
 
 data "aws_region" "current" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 
 resource "aws_vpc_endpoint" "ec2" {
   vpc_id              = "${aws_vpc.foo.id}"
@@ -172,7 +163,7 @@ resource "aws_vpc_endpoint_subnet_association" "a" {
 }
 `
 
-const testAccVpcEndpointSubnetAssociationConfig_multiple = `
+var testAccVpcEndpointSubnetAssociationConfig_multiple = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
   tags = {
@@ -186,15 +177,6 @@ data "aws_security_group" "default" {
 }
 
 data "aws_region" "current" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 
 resource "aws_vpc_endpoint" "ec2" {
   vpc_id              = "${aws_vpc.foo.id}"

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -788,7 +788,7 @@ resource "aws_vpc_endpoint" "test" {
 }
 
 func testAccVpcEndpointConfig_interfaceWithSubnet(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
@@ -800,15 +800,6 @@ resource "aws_vpc" "test" {
 }
 
 data "aws_region" "current" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 
 resource "aws_subnet" "test1" {
   vpc_id            = "${aws_vpc.test.id}"
@@ -879,7 +870,7 @@ resource "aws_vpc_endpoint" "test" {
 }
 
 func testAccVpcEndpointConfig_interfaceWithSubnetModified(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
@@ -891,15 +882,6 @@ resource "aws_vpc" "test" {
 }
 
 data "aws_region" "current" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 
 resource "aws_subnet" "test1" {
   vpc_id            = "${aws_vpc.test.id}"
@@ -971,7 +953,7 @@ resource "aws_vpc_endpoint" "test" {
 }
 
 func testAccVpcEndpointConfig_interfaceNonAWSService(rName string, autoAccept bool) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -999,15 +981,6 @@ resource "aws_lb" "test" {
 }
 
 data "aws_region" "current" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 
 resource "aws_subnet" "test1" {
   vpc_id            = "${aws_vpc.test.id}"

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -159,6 +159,7 @@ func TestAccAWSVpnGateway_basic(t *testing.T) {
 func TestAccAWSVpnGateway_withAvailabilityZoneSetToState(t *testing.T) {
 	var v ec2.VpnGateway
 	resourceName := "aws_vpn_gateway.test"
+	availabilityZonesDataSourceName := "data.aws_availability_zones.available"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -169,7 +170,7 @@ func TestAccAWSVpnGateway_withAvailabilityZoneSetToState(t *testing.T) {
 				Config: testAccVpnGatewayConfigWithAZ,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpnGatewayExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", availabilityZonesDataSourceName, "names.0"),
 				),
 			},
 			{
@@ -475,6 +476,7 @@ func testAccCheckVpnGatewayExists(n string, ig *ec2.VpnGateway) resource.TestChe
 const testAccNoVpnGatewayConfig = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-removed"
   }
@@ -484,26 +486,29 @@ resource "aws_vpc" "test" {
 const testAccVpnGatewayConfig = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway"
   }
 }
 
 resource "aws_vpn_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 `
 
 const testAccVpnGatewayConfigChangeVPC = `
 resource "aws_vpc" "test2" {
   cidr_block = "10.2.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-change-vpc"
   }
 }
 
 resource "aws_vpn_gateway" "test" {
-  vpc_id = "${aws_vpc.test2.id}"
+  vpc_id = aws_vpc.test2.id
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-basic"
   }
@@ -514,13 +519,14 @@ func testAccCheckVpnGatewayConfigTags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-tags"
   }
 }
 
 resource "aws_vpn_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     %[1]q = %[2]q
@@ -533,13 +539,14 @@ func testAccCheckVpnGatewayConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 st
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-tags"
   }
 }
 
 resource "aws_vpn_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     %[1]q = %[2]q
@@ -552,6 +559,7 @@ resource "aws_vpn_gateway" "test" {
 const testAccCheckVpnGatewayConfigReattach = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-reattach-test"
   }
@@ -559,20 +567,23 @@ resource "aws_vpc" "test" {
 
 resource "aws_vpc" "test2" {
   cidr_block = "10.2.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-reattach-test2"
   }
 }
 
 resource "aws_vpn_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-reattach"
   }
 }
 
 resource "aws_vpn_gateway" "test2" {
-  vpc_id = "${aws_vpc.test2.id}"
+  vpc_id = aws_vpc.test2.id
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-reattach"
   }
@@ -582,6 +593,7 @@ resource "aws_vpn_gateway" "test2" {
 const testAccCheckVpnGatewayConfigReattachChange = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-reattach-test"
   }
@@ -589,20 +601,23 @@ resource "aws_vpc" "test" {
 
 resource "aws_vpc" "test2" {
   cidr_block = "10.2.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-reattach-test2"
   }
 }
 
 resource "aws_vpn_gateway" "test" {
-  vpc_id = "${aws_vpc.test2.id}"
+  vpc_id = aws_vpc.test2.id
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-reattach"
   }
 }
 
 resource "aws_vpn_gateway" "test2" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-reattach"
   }
@@ -612,14 +627,15 @@ resource "aws_vpn_gateway" "test2" {
 var testAccVpnGatewayConfigWithAZ = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-with-az"
   }
 }
 
 resource "aws_vpn_gateway" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "terraform-testacc-vpn-gateway-with-az"
@@ -630,13 +646,14 @@ resource "aws_vpn_gateway" "test" {
 const testAccVpnGatewayConfigWithASN = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-vpn-gateway-with-asn"
   }
 }
 
 resource "aws_vpn_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id          = aws_vpc.test.id
   amazon_side_asn = 4294967294
 }
 `

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -609,16 +609,7 @@ resource "aws_vpn_gateway" "test2" {
 }
 `
 
-const testAccVpnGatewayConfigWithAZ = `
-data "aws_availability_zones" "azs" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+var testAccVpnGatewayConfigWithAZ = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
   tags = {
@@ -628,7 +619,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_vpn_gateway" "test" {
   vpc_id            = "${aws_vpc.test.id}"
-  availability_zone = "${data.aws_availability_zones.azs.names[0]}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
   tags = {
     Name = "terraform-testacc-vpn-gateway-with-az"

--- a/aws/resource_aws_wafregional_web_acl_association_test.go
+++ b/aws/resource_aws_wafregional_web_acl_association_test.go
@@ -231,7 +231,7 @@ resource "aws_wafregional_web_acl_association" "foo" {
 }
 `
 
-const testAccCheckWafRegionalWebAclAssociationConfig_multipleAssociations = testAccCheckWafRegionalWebAclAssociationConfig_basic + `
+var testAccCheckWafRegionalWebAclAssociationConfig_multipleAssociations = testAccCheckWafRegionalWebAclAssociationConfig_basic + `
 resource "aws_alb" "bar" {
   internal = true
   subnets = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]

--- a/aws/resource_aws_wafregional_web_acl_association_test.go
+++ b/aws/resource_aws_wafregional_web_acl_association_test.go
@@ -183,7 +183,7 @@ func testAccCheckWafRegionalWebAclAssociationDisappears(resourceName string) res
 	}
 }
 
-const testAccCheckWafRegionalWebAclAssociationConfig_basic = `
+var testAccCheckWafRegionalWebAclAssociationConfig_basic = testAccAvailableAZsNoOptInConfig() + `
 resource "aws_wafregional_rule" "foo" {
   name = "foo"
   metric_name = "foo"
@@ -206,15 +206,6 @@ resource "aws_wafregional_web_acl" "foo" {
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 resource "aws_subnet" "foo" {

--- a/aws/resource_aws_worklink_fleet_test.go
+++ b/aws/resource_aws_worklink_fleet_test.go
@@ -385,16 +385,7 @@ resource "aws_worklink_fleet" "test" {
 }
 
 func testAccAWSWorkLinkFleetConfigNetwork_Base(rName, cidrBlock string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "%s"
 

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -377,17 +377,8 @@ func TestFlattenSelfServicePermissions(t *testing.T) {
 
 // Extract common infra
 func testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName string) string {
-	return fmt.Sprintf(`
+	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_region" "current" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 
 locals {
   region_workspaces_az_ids = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
NONE
```

This PR takes on 3 tasks:

1. Fix hardcoded AZs in 4 resources:
    * `resource_aws_vpc_dhcp_options_test`
    * `resource_aws_vpc_endpoint_connection_notification_test`
    * `resource_aws_vpc_endpoint_service_allowed_principal_test`
    * `resource_aws_vpn_gateway_test`.
2. Fix config formatting in 4 resources:
    * `resource_aws_vpc_dhcp_options_test`
    * `resource_aws_vpc_endpoint_connection_notification_test`
    * `resource_aws_vpc_endpoint_service_allowed_principal_test`
    * `resource_aws_vpn_gateway_test`.
3. Standardize use of `testAccAvailableAZsNoOptInConfig()` (defined in `resource_aws_instance_test`) to cut down on repetitive boilerplate of data source `data "aws_availability_zones" "available"`.

The output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDHCPOptions_disappears (9.26s)
--- PASS: TestAccAWSDHCPOptions_deleteOptions (9.28s)
--- PASS: TestAccAWSDHCPOptions_basic (12.75s)
--- PASS: TestAccAWSDHCPOptions_tags (28.80s)
```

The output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSDHCPOptions_deleteOptions (64.46s)
--- PASS: TestAccAWSDHCPOptions_disappears (64.68s)
--- PASS: TestAccAWSDHCPOptions_basic (71.05s)
--- PASS: TestAccAWSDHCPOptions_tags (93.62s)
--- SKIP: TestAccDataSourceAWSEIP_CustomerOwnedIpv4Pool (0.00s)
--- SKIP: TestAccAWSAPIGatewayRestApi_EndpointConfiguration (0.00s)
--- SKIP: TestAccDataSourceAWSDirectoryServiceDirectory_connector (0.00s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent (1.29s)
--- FAIL: TestAccAWSAPIGatewayIntegrationResponse_basic (1.42s)
--- FAIL: TestAccAWSAPIGatewayRestApi_api_key_source (1.83s)
--- FAIL: TestAccDataSourceAwsEip_PublicIP_EC2Classic (1.94s)
--- FAIL: TestAccAWSAPIGatewayRestApi_openapi (2.88s)
--- FAIL: TestAccAWSAPIGatewayIntegration_disappears (3.00s)
--- FAIL: TestAccAWSAPIGatewayIntegration_basic (3.85s)
--- FAIL: TestAccDataSourceAwsSubnetIDs_basic (4.04s)
--- FAIL: TestAccDataSourceAwsSubnetIDs_filter (4.05s)
--- FAIL: TestAccAWSAPIGatewayRestApi_tags (4.79s)
--- FAIL: TestAccAWSAPIGatewayIntegrationResponse_disappears (4.94s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingDataSource_PreferredInstanceTypes (5.18s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter (5.45s)
--- FAIL: TestAccAWSAPIGatewayIntegration_cache_key_parameters (5.48s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType (6.05s)
--- PASS: TestAccAwsEc2SpotPriceDataSource_basic (6.09s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (6.24s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (6.53s)
--- PASS: TestAccDataSourceAwsEip_Id (6.86s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingDataSource_LocationType (6.94s)
--- PASS: TestAccDataSourceAwsEip_PublicIP_VPC (7.10s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_NonExistent (7.12s)
--- PASS: TestAccDataSourceAwsEip_Filter (7.12s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingDataSource_Filter (7.12s)
--- PASS: TestAccDataSourceAwsEip_Tags (7.14s)
--- FAIL: TestAccAWSAPIGatewayRestApi_basic (7.39s)
--- FAIL: TestAccAwsAutoScalingGroupDataSource_basic (7.48s)
--- PASS: TestAccAwsEc2SpotPriceDataSource_Filter (7.68s)
--- FAIL: TestAccAWSAPIGatewayRestApi_disappears (8.01s)
--- PASS: TestAccDataSourceAwsSubnet_basic (8.17s)
--- PASS: TestAccDataSourceAwsNetworkInterfaces_Filter (8.90s)
--- PASS: TestAccDataSourceAwsNetworkInterfaces_Tags (9.29s)
--- PASS: TestAccDataSourceAwsNetworkInterface_basic (9.53s)
--- PASS: TestAccDataSourceAwsNetworkInterface_filters (9.96s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private (10.01s)
--- PASS: TestAccDataSourceAWSELB_basic (11.77s)
--- FAIL: TestAccAWSAPIGatewayIntegration_contentHandling (12.23s)
--- FAIL: TestAccAWSAPIGatewayRestApi_policy (13.56s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter (13.85s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock (14.59s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (17.03s)
--- FAIL: TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD (17.37s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayBasic (17.80s)
--- +PASS: TestAccDataSourceAwsAvailabilityZone_AllAvailabilityZones (18.16s)
--- +PASS: TestAccDataSourceAwsAvailabilityZone_ZoneId (18.20s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byFilter (18.21s)
--- +PASS: TestAccDataSourceAwsAvailabilityZone_Filter (18.23s)
--- +PASS: TestAccDataSourceAwsAvailabilityZone_Name (18.24s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byTags (18.32s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags (18.99s)
--- PASS: TestAccAWSEbsVolumeDataSource_multipleFilters (19.81s)
--- PASS: TestAccDataSourceAwsEip_NetworkInterface (20.93s)
--- PASS: TestAccAWSEbsVolumeDataSource_basic (22.88s)
--- PASS: TestAccDataSourceAwsEbsVolumes_basic (27.14s)
--- PASS: TestAccAWSAMI_disappears (41.77s)
--- PASS: TestAccAWSEbsSnapshotDataSource_Filter (41.99s)
--- PASS: TestAccAWSAMI_basic (42.06s)
--- PASS: TestAccAWSEbsSnapshotDataSource_basic (42.39s)
--- FAIL: TestAccDataSourceAWSMqBroker_basic (42.57s)
--- PASS: TestAccAWSAMI_snapshotSize (42.60s)
--- PASS: TestAccAWSAMI_description (45.27s)
--- PASS: TestAccAWSAMI_tags (48.98s)
--- PASS: TestAccAWSEbsSnapshotDataSource_MostRecent (82.41s)
--- PASS: TestAccDataSourceAwsEip_Instance (85.28s)
--- PASS: TestAccAWSAutoscalingGroups_basic (97.31s)
--- PASS: TestAccDataSourceAwsEfsMountTarget_basic (118.90s)
--- PASS: TestAccDataSourceAWSLBListener_BackwardsCompatibility (156.35s)
--- PASS: TestAccDataSourceAWSALBTargetGroup_basic (158.06s)
--- PASS: TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility (158.72s)
--- FAIL: TestAccDataSourceAWSLBListener_https (160.63s)
--- PASS: TestAccDataSourceAWSLB_basic (165.31s)
--- PASS: TestAccDataSourceAWSLB_BackwardsCompatibility (166.54s)
--- PASS: TestAccDataSourceAWSLBListener_basic (168.65s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_interface (170.21s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_DbClusterSnapshotIdentifier (224.84s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_DbClusterIdentifier (225.28s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (236.77s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter_tags (257.32s)
--- PASS: TestAccDataSourceCloudHsmV2Cluster_basic (267.01s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter (267.46s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VPCEndpoint (283.65s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_MostRecent (300.50s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (304.50s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID (304.84s)
--- PASS: TestAccAWSAMILaunchPermission_Disappears_LaunchPermission (318.66s)
--- PASS: TestAccAWSAMILaunchPermission_basic (328.17s)
--- PASS: TestAccAWSAMILaunchPermission_Disappears_LaunchPermission_Public (329.01s)
--- PASS: TestAccAWSAMILaunchPermission_Disappears_AMI (331.73s)
--- PASS: TestAccAWSAMIFromInstance_tags (361.72s)
--- PASS: TestAccAWSAMICopy_EnaSupport (363.92s)
--- PASS: TestAccAWSAMICopy_basic (364.52s)
--- PASS: TestAccAWSAMICopy_Description (367.34s)
--- PASS: TestAccAWSAMICopy_tags (369.70s)
--- PASS: TestAccAWSAMIFromInstance_basic (381.56s)
--- FAIL: TestAccAWSAPIGatewayIntegration_integrationType (680.00s)
--- PASS: TestAccAWSDataElasticsearchDomain_basic (754.57s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode (923.08s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_basic (953.80s)
--- PASS: TestAccAWSDataElasticsearchDomain_advanced (1092.71s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD (1710.99s)
```

\+ Originally failed on TC but fixed after