### PR TITLE
Support CodeBuild BuildBatchConfig

### DIFF
--- a/.changelog/14534.txt
+++ b/.changelog/14534.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codebuild_project: Add `build_batch_config` argument
+```

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -623,6 +623,10 @@ func TestAccAWSCodeBuildProject_BuildBatchConfig(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codebuild_project.test"
 
+	if testAccGetPartition() == "aws-us-gov" {
+		t.Skip("CodeBuild Project build batch config is not supported in GovCloud partition")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
 		ErrorCheck:   testAccErrorCheck(t, codebuild.EndpointsID),

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -230,6 +230,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `badge_enabled` - (Optional) Generates a publicly-accessible URL for the projects build badge. Available as `badge_url` attribute when enabled.
+* `build_batch_config` - (Optional) Defines the batch build options for the project.
 * `build_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.
 * `cache` - (Optional) Configuration block. Detailed below.
 * `description` - (Optional) Short description of the project.
@@ -254,6 +255,18 @@ The following arguments are optional:
 * `packaging` - (Optional) Type of build output artifact to create. If `type` is set to `S3`, valid values are `NONE`, `ZIP`
 * `path` - (Optional) If `type` is set to `S3`, this is the path to the output artifact.
 * `type` - (Required) Build output artifact's type. Valid values: `CODEPIPELINE`, `NO_ARTIFACTS`, `S3`.
+
+### build_batch_config
+
+* `combine_artifacts` - (Optional) Specifies if the build artifacts for the batch build should be combined into a single artifact location.
+* `restrictions` - (Optional) Specifies the restrictions for the batch build.
+* `service_role` - (Required) Specifies the service role ARN for the batch build project.
+* `timeout_in_mins` - (Optional) Specifies the maximum amount of time, in minutes, that the batch build must be completed in.
+
+#### restrictions
+
+* `compute_types_allowed` - (Optional) An array of strings that specify the compute types that are allowed for the batch build. See [Build environment compute types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html) in the AWS CodeBuild User Guide for these values.
+* `maximum_builds_allowed` - (Optional) Specifies the maximum number of builds allowed.
 
 ### cache
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14472

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeBuildProject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeBuildProject_ -timeout 180m
=== RUN   TestAccAWSCodeBuildProject_basic
=== PAUSE TestAccAWSCodeBuildProject_basic
=== RUN   TestAccAWSCodeBuildProject_BadgeEnabled
=== PAUSE TestAccAWSCodeBuildProject_BadgeEnabled
=== RUN   TestAccAWSCodeBuildProject_BuildTimeout
=== PAUSE TestAccAWSCodeBuildProject_BuildTimeout
=== RUN   TestAccAWSCodeBuildProject_QueuedTimeout
=== PAUSE TestAccAWSCodeBuildProject_QueuedTimeout
=== RUN   TestAccAWSCodeBuildProject_Cache
=== PAUSE TestAccAWSCodeBuildProject_Cache
=== RUN   TestAccAWSCodeBuildProject_Description
=== PAUSE TestAccAWSCodeBuildProject_Description
=== RUN   TestAccAWSCodeBuildProject_SourceVersion
=== PAUSE TestAccAWSCodeBuildProject_SourceVersion
=== RUN   TestAccAWSCodeBuildProject_EncryptionKey
=== PAUSE TestAccAWSCodeBuildProject_EncryptionKey
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value
=== RUN   TestAccAWSCodeBuildProject_Environment_Certificate
=== PAUSE TestAccAWSCodeBuildProject_Environment_Certificate
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== RUN   TestAccAWSCodeBuildProject_BuildBatchConfig
=== PAUSE TestAccAWSCodeBuildProject_BuildBatchConfig
=== RUN   TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== PAUSE TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== RUN   TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub
=== PAUSE TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub
=== RUN   TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub
=== PAUSE TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub
=== RUN   TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_InsecureSSL
=== PAUSE TestAccAWSCodeBuildProject_Source_InsecureSSL
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== RUN   TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_S3
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_S3
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSource
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSource
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== RUN   TestAccAWSCodeBuildProject_Tags
=== PAUSE TestAccAWSCodeBuildProject_Tags
=== RUN   TestAccAWSCodeBuildProject_VpcConfig
=== PAUSE TestAccAWSCodeBuildProject_VpcConfig
=== RUN   TestAccAWSCodeBuildProject_WindowsServer2019Container
=== PAUSE TestAccAWSCodeBuildProject_WindowsServer2019Container
=== RUN   TestAccAWSCodeBuildProject_ARMContainer
=== PAUSE TestAccAWSCodeBuildProject_ARMContainer
=== RUN   TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== RUN   TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Location
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Location
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Name
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Name
=== RUN   TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== RUN   TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Packaging
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Packaging
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Path
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Path
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Type
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Type
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Name
    provider_test.go:55: Currently no solution to allow updates on name attribute
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== RUN   TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== PAUSE TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_basic
=== CONT  TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Packaging
=== CONT  TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_VpcConfig
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Path
=== CONT  TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Name
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Location
=== CONT  TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== CONT  TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== CONT  TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== CONT  TestAccAWSCodeBuildProject_ARMContainer
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== CONT  TestAccAWSCodeBuildProject_WindowsServer2019Container
=== CONT  TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== CONT  TestAccAWSCodeBuildProject_WindowsServer2019Container
    resource_aws_codebuild_project_test.go:1326: Step 1/2 error: Error running apply: exit status 1

        Error: Error creating CodeBuild project: InvalidInputException: Region ap-northeast-1 is not supported for WINDOWS_SERVER_2019_CONTAINER

          on terraform_plugin_test.tf line 64, in resource "aws_codebuild_project" "test":
          64: resource "aws_codebuild_project" "test" {


--- FAIL: TestAccAWSCodeBuildProject_WindowsServer2019Container (69.43s)
=== CONT  TestAccAWSCodeBuildProject_Tags
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (155.49s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
--- PASS: TestAccAWSCodeBuildProject_ARMContainer (156.02s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSource
--- PASS: TestAccAWSCodeBuildProject_basic (156.03s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_S3
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (156.53s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (156.53s)
=== CONT  TestAccAWSCodeBuildProject_BuildBatchConfig
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (177.31s)
=== CONT  TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (236.69s)
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_S3Logs
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (104.18s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (273.23s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (273.24s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (273.28s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (274.43s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (274.74s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (275.41s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (275.42s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (275.42s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (275.57s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== CONT  TestAccAWSCodeBuildProject_Environment_Certificate
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (275.58s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (277.86s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Type
--- PASS: TestAccAWSCodeBuildProject_Tags (234.66s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (149.20s)
=== CONT  TestAccAWSCodeBuildProject_BuildTimeout
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (150.51s)
=== CONT  TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (156.23s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (365.63s)
=== CONT  TestAccAWSCodeBuildProject_EncryptionKey
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (142.62s)
=== CONT  TestAccAWSCodeBuildProject_SourceVersion
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (157.95s)
=== CONT  TestAccAWSCodeBuildProject_Description
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (158.31s)
=== CONT  TestAccAWSCodeBuildProject_QueuedTimeout
--- PASS: TestAccAWSCodeBuildProject_BuildBatchConfig (286.34s)
=== CONT  TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (321.73s)
=== CONT  TestAccAWSCodeBuildProject_Source_InsecureSSL
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (256.39s)
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (254.13s)
=== CONT  TestAccAWSCodeBuildProject_BadgeEnabled
--- PASS: TestAccAWSCodeBuildProject_SourceVersion (127.72s)
=== CONT  TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (252.45s)
=== CONT  TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (257.22s)
=== CONT  TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (255.16s)
=== CONT  TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (174.37s)
=== CONT  TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (265.46s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (270.65s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (275.56s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (245.06s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (337.40s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (290.72s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value (332.82s)
--- PASS: TestAccAWSCodeBuildProject_Description (218.17s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (218.30s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub (209.70s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (390.40s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (137.75s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (189.19s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (180.57s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit (179.71s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise (179.99s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit (180.29s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub (180.45s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise (170.95s)
--- PASS: TestAccAWSCodeBuildProject_Cache (438.06s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	746.670s
FAIL
make: *** [testacc] Error 1
```

`TestAccAWSCodeBuildProject_WindowsServer2019Container` fails due to the environmental problem but except that all the tests passed. Thank you for your review! 👍 