### PR TITLE
aws_workspaces_bundle: Fix empty (private) owner

### DIFF
--- a/aws/data_source_aws_workspaces_bundle.go
+++ b/aws/data_source_aws_workspaces_bundle.go
@@ -97,10 +97,13 @@ func dataSourceAwsWorkspaceBundleRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if name, ok := d.GetOk("name"); ok {
-		name := name.(string)
-		input := &workspaces.DescribeWorkspaceBundlesInput{
-			Owner: aws.String(d.Get("owner").(string)),
+		input := &workspaces.DescribeWorkspaceBundlesInput{}
+
+		if owner, ok := d.GetOk("owner"); ok {
+			input.Owner = aws.String(owner.(string))
 		}
+
+		name := name.(string)
 		err := conn.DescribeWorkspaceBundlesPages(input, func(out *workspaces.DescribeWorkspaceBundlesOutput, lastPage bool) bool {
 			for _, b := range out.Bundles {
 				if aws.StringValue(b.Name) == name {

--- a/aws/data_source_aws_workspaces_bundle_test.go
+++ b/aws/data_source_aws_workspaces_bundle_test.go
@@ -131,7 +131,7 @@ data "aws_workspaces_bundle" "test" {
 func testAccDataSourceAwsWorkspaceBundleConfig_privateOwner(name string) string {
 	return fmt.Sprintf(`
 data "aws_workspaces_bundle" "test" {
-  name  = %q
+  name = %q
 }
 `, name)
 }

--- a/aws/data_source_aws_workspaces_bundle_test.go
+++ b/aws/data_source_aws_workspaces_bundle_test.go
@@ -103,7 +103,7 @@ func testAccWorkspacesBundlePreCheck(t *testing.T) {
 
 func testAccDataSourceAwsWorkspaceBundleConfig(bundleID string) string {
 	return fmt.Sprintf(`
-data aws_workspaces_bundle test {
+data "aws_workspaces_bundle" "test" {
   bundle_id = %q
 }
 `, bundleID)
@@ -111,7 +111,7 @@ data aws_workspaces_bundle test {
 
 func testAccDataSourceAwsWorkspaceBundleConfig_byOwnerName(owner, name string) string {
 	return fmt.Sprintf(`
-data aws_workspaces_bundle test {
+data "aws_workspaces_bundle" "test" {
   owner = %q
   name  = %q
 }
@@ -120,7 +120,7 @@ data aws_workspaces_bundle test {
 
 func testAccDataSourceAwsWorkspaceBundleConfig_bundleIDAndOwnerNameConflict(bundleID, owner, name string) string {
 	return fmt.Sprintf(`
-data aws_workspaces_bundle test {
+data "aws_workspaces_bundle" "test" {
   bundle_id = %q
   owner     = %q
   name      = %q
@@ -130,7 +130,7 @@ data aws_workspaces_bundle test {
 
 func testAccDataSourceAwsWorkspaceBundleConfig_privateOwner(name string) string {
 	return fmt.Sprintf(`
-data aws_workspaces_bundle test {
+data "aws_workspaces_bundle" "test" {
   name  = %q
 }
 `, name)

--- a/aws/data_source_aws_workspaces_bundle_test.go
+++ b/aws/data_source_aws_workspaces_bundle_test.go
@@ -103,7 +103,7 @@ func testAccWorkspacesBundlePreCheck(t *testing.T) {
 
 func testAccDataSourceAwsWorkspaceBundleConfig(bundleID string) string {
 	return fmt.Sprintf(`
-data "aws_workspaces_bundle" "test" {
+data aws_workspaces_bundle test {
   bundle_id = %q
 }
 `, bundleID)
@@ -111,7 +111,7 @@ data "aws_workspaces_bundle" "test" {
 
 func testAccDataSourceAwsWorkspaceBundleConfig_byOwnerName(owner, name string) string {
 	return fmt.Sprintf(`
-data "aws_workspaces_bundle" "test" {
+data aws_workspaces_bundle test {
   owner = %q
   name  = %q
 }
@@ -120,7 +120,7 @@ data "aws_workspaces_bundle" "test" {
 
 func testAccDataSourceAwsWorkspaceBundleConfig_bundleIDAndOwnerNameConflict(bundleID, owner, name string) string {
 	return fmt.Sprintf(`
-data "aws_workspaces_bundle" "test" {
+data aws_workspaces_bundle test {
   bundle_id = %q
   owner     = %q
   name      = %q
@@ -130,7 +130,7 @@ data "aws_workspaces_bundle" "test" {
 
 func testAccDataSourceAwsWorkspaceBundleConfig_privateOwner(name string) string {
 	return fmt.Sprintf(`
-data "aws_workspaces_bundle" "test" {
+data aws_workspaces_bundle test {
   name  = %q
 }
 `, name)

--- a/aws/data_source_aws_workspaces_bundle_test.go
+++ b/aws/data_source_aws_workspaces_bundle_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -73,6 +74,33 @@ func TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsWorkspaceBundle_privateOwner(t *testing.T) {
+	dataSourceName := "data.aws_workspaces_bundle.test"
+	bundleName := os.Getenv("AWS_WORKSPACES_BUNDLE_NAME")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccWorkspacesBundlePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsWorkspaceBundleConfig_privateOwner(bundleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name", bundleName),
+				),
+			},
+		},
+	})
+}
+
+func testAccWorkspacesBundlePreCheck(t *testing.T) {
+	if os.Getenv("AWS_WORKSPACES_BUNDLE_NAME") == "" {
+		t.Skip("AWS_WORKSPACES_BUNDLE_NAME env var must be set for AWS WorkSpaces private bundle acceptance test. This is required until AWS provides bundle creation API.")
+	}
+}
+
 func testAccDataSourceAwsWorkspaceBundleConfig(bundleID string) string {
 	return fmt.Sprintf(`
 data "aws_workspaces_bundle" "test" {
@@ -98,4 +126,12 @@ data "aws_workspaces_bundle" "test" {
   name      = %q
 }
 `, bundleID, owner, name)
+}
+
+func testAccDataSourceAwsWorkspaceBundleConfig_privateOwner(name string) string {
+	return fmt.Sprintf(`
+data "aws_workspaces_bundle" "test" {
+  name  = %q
+}
+`, name)
 }

--- a/website/docs/d/workspaces_bundle.html.markdown
+++ b/website/docs/d/workspaces_bundle.html.markdown
@@ -12,12 +12,18 @@ Retrieve information about an AWS WorkSpaces bundle.
 
 ## Example Usage
 
+### By ID
+
 ```hcl
-data "aws_workspaces_bundle" "by_id" {
+data aws_workspaces_bundle example {
   bundle_id = "wsb-b0s22j3d7"
 }
+```
 
-data "aws_workspaces_bundle" "by_owner_and_name" {
+### By Owner & Name
+
+```hcl
+data aws_workspaces_bundle example {
   owner = "AMAZON"
   name  = "Value with Windows 10 and Office 2016"
 }

--- a/website/docs/d/workspaces_bundle.html.markdown
+++ b/website/docs/d/workspaces_bundle.html.markdown
@@ -15,7 +15,7 @@ Retrieve information about an AWS WorkSpaces bundle.
 ### By ID
 
 ```hcl
-data aws_workspaces_bundle example {
+data "aws_workspaces_bundle" "example" {
   bundle_id = "wsb-b0s22j3d7"
 }
 ```
@@ -23,7 +23,7 @@ data aws_workspaces_bundle example {
 ### By Owner & Name
 
 ```hcl
-data aws_workspaces_bundle example {
+data "aws_workspaces_bundle" "example" {
   owner = "AMAZON"
   name  = "Value with Windows 10 and Office 2016"
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
aws_workspaces_bundle: Fix empty (private) owner
```

Closes #14206.

### Acceptance Tests

For private bundles test I've implemented the kind of the same trick (`AWS_WORKSPACES_BUNDLE_NAME`) as in `aws_workspaces_image` [test](https://github.com/terraform-providers/terraform-provider-aws/pull/11428/files#diff-ec54e665b3caeccdbc381156fade156cR37).

```
$ AWS_WORKSPACES_BUNDLE_NAME=PerformanceLinuxBaseline AWS_DEFAULT_REGION=us-east-1 make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsWorkspaceBundle'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWorkspaceBundle -timeout 120m
=== RUN   TestAccDataSourceAwsWorkspaceBundle_basic
=== PAUSE TestAccDataSourceAwsWorkspaceBundle_basic
=== RUN   TestAccDataSourceAwsWorkspaceBundle_byOwnerName
=== PAUSE TestAccDataSourceAwsWorkspaceBundle_byOwnerName
=== RUN   TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict
=== PAUSE TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict
=== RUN   TestAccDataSourceAwsWorkspaceBundle_privateOwner
=== PAUSE TestAccDataSourceAwsWorkspaceBundle_privateOwner
=== CONT  TestAccDataSourceAwsWorkspaceBundle_basic
=== CONT  TestAccDataSourceAwsWorkspaceBundle_privateOwner
=== CONT  TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict
=== CONT  TestAccDataSourceAwsWorkspaceBundle_byOwnerName
--- PASS: TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict (2.23s)
--- PASS: TestAccDataSourceAwsWorkspaceBundle_basic (20.44s)
--- PASS: TestAccDataSourceAwsWorkspaceBundle_privateOwner (20.51s)
--- PASS: TestAccDataSourceAwsWorkspaceBundle_byOwnerName (25.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	28.444s
```