### PR TITLE
Add aws_devicefarm_testgrid_project resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -506,6 +506,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_db_snapshot":                                         resourceAwsDbSnapshot(),
 			"aws_db_subnet_group":                                     resourceAwsDbSubnetGroup(),
 			"aws_devicefarm_project":                                  resourceAwsDevicefarmProject(),
+			"aws_devicefarm_testgrid_project":                         resourceAwsDevicefarmTestgridProject(),
 			"aws_directory_service_directory":                         resourceAwsDirectoryServiceDirectory(),
 			"aws_directory_service_conditional_forwarder":             resourceAwsDirectoryServiceConditionalForwarder(),
 			"aws_directory_service_log_subscription":                  resourceAwsDirectoryServiceLogSubscription(),

--- a/aws/resource_aws_devicefarm_testgrid_project.go
+++ b/aws/resource_aws_devicefarm_testgrid_project.go
@@ -1,0 +1,120 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAwsDevicefarmTestgridProject() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDevicefarmTestgridProjectCreate,
+		Read:   resourceAwsDevicefarmTestgridProjectRead,
+		Update: resourceAwsDevicefarmTestgridProjectUpdate,
+		Delete: resourceAwsDevicefarmTestgridProjectDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDevicefarmTestgridProjectCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).devicefarmconn
+	region := meta.(*AWSClient).region
+
+	//	We need to ensure that DeviceFarm is only being run against us-west-2
+	//	As this is the only place that AWS currently supports it
+	if region != "us-west-2" {
+		return fmt.Errorf("DeviceFarm can only be used with us-west-2. You are trying to use it on %s", region)
+	}
+
+	input := &devicefarm.CreateTestGridProjectInput{
+		Name: aws.String(d.Get("name").(string)),
+	}
+
+	log.Printf("[DEBUG] Creating DeviceFarm TestGrid Project: %s", d.Get("name").(string))
+	out, err := conn.CreateTestGridProject(input)
+	if err != nil {
+		return fmt.Errorf("Error creating DeviceFarm TestGrid Project: %s", err)
+	}
+
+	log.Printf("[DEBUG] Successsfully Created DeviceFarm TestGrid Project: %s", *out.TestGridProject.Arn)
+	d.SetId(*out.TestGridProject.Arn)
+
+	return resourceAwsDevicefarmTestgridProjectRead(d, meta)
+}
+
+func resourceAwsDevicefarmTestgridProjectRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).devicefarmconn
+
+	input := &devicefarm.GetTestGridProjectInput{
+		ProjectArn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading DeviceFarm TestGrid Project: %s", d.Id())
+	out, err := conn.GetTestGridProject(input)
+	if err != nil {
+		if isAWSErr(err, devicefarm.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] DeviceFarm TestGrid Project (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading DeviceFarm TestGrid Project: %s", err)
+	}
+
+	d.Set("name", out.TestGridProject.Name)
+	d.Set("arn", out.TestGridProject.Arn)
+
+	return nil
+}
+
+func resourceAwsDevicefarmTestgridProjectUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).devicefarmconn
+
+	if d.HasChange("name") {
+		input := &devicefarm.UpdateTestGridProjectInput{
+			ProjectArn: aws.String(d.Id()),
+			Name:       aws.String(d.Get("name").(string)),
+		}
+
+		log.Printf("[DEBUG] Updating DeviceFarm TestGrid Project: %s", d.Id())
+		_, err := conn.UpdateTestGridProject(input)
+		if err != nil {
+			return fmt.Errorf("Error Updating DeviceFarm TestGrid Project: %s", err)
+		}
+
+	}
+
+	return resourceAwsDevicefarmTestgridProjectRead(d, meta)
+}
+
+func resourceAwsDevicefarmTestgridProjectDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).devicefarmconn
+
+	input := &devicefarm.DeleteTestGridProjectInput{
+		ProjectArn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting DeviceFarm TestGrid Project: %s", d.Id())
+	_, err := conn.DeleteTestGridProject(input)
+	if err != nil {
+		return fmt.Errorf("Error deleting DeviceFarm TestGrid Project: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_devicefarm_testgrid_project_test.go
+++ b/aws/resource_aws_devicefarm_testgrid_project_test.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSDeviceFarmTestGridProject_basic(t *testing.T) {
+	var proj devicefarm.TestGridProject
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_devicefarm_testgrid_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDeviceFarmTestGridProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmTestGridProjectConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmTestGridProjectExists(resourceName, &proj),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`testgrid-project:.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDeviceFarmTestGridProject_disappears(t *testing.T) {
+	var proj devicefarm.TestGridProject
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_devicefarm_testgrid_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDeviceFarmTestGridProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmTestGridProjectConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmTestGridProjectExists(resourceName, &proj),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsDevicefarmTestgridProject(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDeviceFarmTestGridProjectExists(n string, v *devicefarm.TestGridProject) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).devicefarmconn
+		resp, err := conn.GetTestGridProject(
+			&devicefarm.GetTestGridProjectInput{ProjectArn: aws.String(rs.Primary.ID)})
+		if err != nil {
+			return err
+		}
+		if resp.TestGridProject == nil {
+			return fmt.Errorf("DeviceFarmTestGridProject not found")
+		}
+
+		*v = *resp.TestGridProject
+
+		return nil
+	}
+}
+
+func testAccCheckDeviceFarmTestGridProjectDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).devicefarmconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_devicefarm_testgrid_project" {
+			continue
+		}
+
+		// Try to find the resource
+		resp, err := conn.GetTestGridProject(
+			&devicefarm.GetTestGridProjectInput{ProjectArn: aws.String(rs.Primary.ID)})
+		if err == nil {
+			if resp.TestGridProject != nil {
+				return fmt.Errorf("still exist.")
+			}
+
+			return nil
+		}
+
+		if isAWSErr(err, devicefarm.ErrCodeNotFoundException, "") {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func testAccDeviceFarmTestGridProjectConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_devicefarm_testgrid_project" "test" {
+  name = %[1]q
+}
+`, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -917,6 +917,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/devicefarm_project.html">aws_devicefarm_project</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/devicefarm_testgrid_project.html">devicefarm_testgrid_project</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>

--- a/website/docs/r/devicefarm_testgrid_project.html.markdown
+++ b/website/docs/r/devicefarm_testgrid_project.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Device Farm"
+layout: "aws"
+page_title: "AWS: aws_devicefarm_testgrid_project"
+description: |-
+  Provides a Devicefarm TestGrid project
+---
+
+# Resource: aws_devicefarm_testgrid_project
+
+Provides a resource to manage AWS Device Farm TestGrid Projects.
+Please keep in mind that this feature is only supported on the "us-west-2" region.
+This resource will error if you try to create a project in another region.
+
+For more information about Device Farm Projects, see the AWS Documentation on
+[Device Farm Projects][aws-get-testgrid-project].
+
+## Basic Example Usage
+
+
+```hcl
+resource "aws_devicefarm_testgrid_project" "selenium_project" {
+  name = "my-device-farm"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the project
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name of this project
+
+[aws-get-testgrid-project]: http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_GetTestGridProject.html
+
+## Import
+
+DeviceFarm TestGrid Projects can be imported by their arn:
+
+```
+$ terraform import aws_devicefarm_testgrid_project.example arn:aws:devicefarm:us-west-2:123456789012:testgrid-project:4fa784c7-ccb4-4dbf-ba4f-02198320daa1
+```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Added aws_devicefarm_testgrid_project resource
```

Output from acceptance testing:

```
C:\Workspaces\terraform-provider-aws>go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDeviceFarmTestGridProject -timeout=120m
=== RUN   TestAccAWSDeviceFarmTestGridProject_basic
=== PAUSE TestAccAWSDeviceFarmTestGridProject_basic
=== RUN   TestAccAWSDeviceFarmTestGridProject_disappears
=== PAUSE TestAccAWSDeviceFarmTestGridProject_disappears
=== CONT  TestAccAWSDeviceFarmTestGridProject_basic
=== CONT  TestAccAWSDeviceFarmTestGridProject_disappears
--- PASS: TestAccAWSDeviceFarmTestGridProject_disappears (9.82s)
--- PASS: TestAccAWSDeviceFarmTestGridProject_basic (12.42s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       14.357s
```
