### PR TITLE
on lambda updates, output the returned values to ensure consistency

### DIFF
--- a/.changelog/14578.txt
+++ b/.changelog/14578.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_function: Handle eventual consistency issues after publishing a version
+```

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -1193,7 +1193,9 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 			}
 
 			// Return the newly published values as the read is eventually consistent
-			d.Set("arn", result.FunctionArn)
+			// Return the newly published values as the read is eventually consistent
+			re := regexp.MustCompile(`:[0-9]+$`)
+			d.Set("arn", re.ReplaceAllString(*result.FunctionArn, ""))
 			d.Set("description", result.Description)
 			d.Set("handler", result.Handler)
 			d.Set("memory_size", result.MemorySize)


### PR DESCRIPTION
On lambda updates that publish new versions, output the returned values to ensure consistency as the read is eventually consistent.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #14210
Closes #13099

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction_versioned'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunction_versioned -timeout 120m
=== RUN   TestAccAWSLambdaFunction_versioned
=== PAUSE TestAccAWSLambdaFunction_versioned
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
=== PAUSE TestAccAWSLambdaFunction_versionedUpdate
=== CONT  TestAccAWSLambdaFunction_versioned
=== CONT  TestAccAWSLambdaFunction_versionedUpdate
--- PASS: TestAccAWSLambdaFunction_versioned (37.82s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (64.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	65.540s
```
