### PR TITLE
Add conflicts between cidr_blocks and self in docs

### DIFF
--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `type` - (Required) The type of rule being created. Valid options are `ingress` (inbound)
 or `egress` (outbound).
-* `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be specified with `source_security_group_id`.
+* `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be specified with `source_security_group_id` or `self`.
 * `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
 * `prefix_list_ids` - (Optional) List of prefix list IDs (for allowing access to VPC endpoints).
 Only valid with `egress`.
@@ -53,7 +53,7 @@ Only valid with `egress`.
 * `source_security_group_id` - (Optional) The security group id to allow access to/from,
      depending on the `type`. Cannot be specified with `cidr_blocks` and `self`.
 * `self` - (Optional) If true, the security group itself will be added as
-     a source to this ingress rule. Cannot be specified with `source_security_group_id`.
+     a source to this ingress rule. Cannot be specified with `source_security_group_id`, `cidr_blocks`, or `ipv6_cidr_blocks`.
 * `to_port` - (Required) The end port (or ICMP code if protocol is "icmp").
 * `description` - (Optional) Description of the rule.
 


### PR DESCRIPTION
When reading the docs, it suggested that you could use `cidr_blocks` and `self` together. I tried that and got this error:

```
Error: 'self': conflicts with 'cidr_blocks' ([]interface {}{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"})
```

This change updates the docs to mention that cidr_blocks and self are not allowed to be used with each other.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A, docs update
```
