### PR TITLE
added metadata_options for aws_launch_config

### DIFF
--- a/aws/data_source_aws_launch_configuration.go
+++ b/aws/data_source_aws_launch_configuration.go
@@ -156,6 +156,27 @@ func dataSourceAwsLaunchConfiguration() *schema.Resource {
 				},
 			},
 
+			"metadata_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"http_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"http_tokens": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"http_put_response_hop_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"root_block_device": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -243,6 +264,10 @@ func dataSourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface
 	}
 	if err := d.Set("security_groups", vpcSGs); err != nil {
 		return fmt.Errorf("error setting security_groups: %s", err)
+	}
+
+	if err := d.Set("metadata_options", flattenLaunchConfigInstanceMetadataOptions(lc.MetadataOptions)); err != nil {
+		return fmt.Errorf("error setting metadata_options: %s", err)
 	}
 
 	classicSGs := make([]string, 0, len(lc.ClassicLinkVPCSecurityGroups))

--- a/aws/data_source_aws_launch_configuration_test.go
+++ b/aws/data_source_aws_launch_configuration_test.go
@@ -77,6 +77,29 @@ func TestAccAWSLaunchConfigurationDataSource_ebsNoDevice(t *testing.T) {
 	})
 }
 
+func testAccLaunchConfigurationDataSource_metadataOptions(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_launch_configuration.test"
+	resourceName := "aws_launch_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfigurationDataSourceConfig_metadataOptions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.#", resourceName, "metadata_options.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.http_endpoint", resourceName, "metadata_options.0.http_endpoint"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.http_tokens", resourceName, "metadata_options.0.http_tokens"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.http_put_response_hop_limit", resourceName, "metadata_options.0.http_put_response_hop_limit"),
+				),
+			},
+		},
+	})
+}
+
 func testAccLaunchConfigurationDataSourceConfig_basic(rName string) string {
 	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
@@ -137,6 +160,24 @@ data "aws_launch_configuration" "foo" {
   name = aws_launch_configuration.test.name
 }
 `, rInt, rInt)
+}
+
+func testAccLaunchConfigurationDataSourceConfig_metadataOptions(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_configuration" "test" {
+  name = %[1]q
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
+data "aws_launch_configuration" "test" {
+  name = aws_launch_configuration.test.name
+}
+`, rName)
 }
 
 func testAccLaunchConfigurationDataSourceConfigEbsNoDevice(rName string) string {

--- a/aws/data_source_aws_launch_configuration_test.go
+++ b/aws/data_source_aws_launch_configuration_test.go
@@ -163,10 +163,13 @@ data "aws_launch_configuration" "foo" {
 }
 
 func testAccLaunchConfigurationDataSourceConfig_metadataOptions(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-  name = %[1]q
-
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = "t3.nano"
+  name          = %[1]q
   metadata_options {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
@@ -177,7 +180,7 @@ resource "aws_launch_configuration" "test" {
 data "aws_launch_configuration" "test" {
   name = aws_launch_configuration.test.name
 }
-`, rName)
+`, rName))
 }
 
 func testAccLaunchConfigurationDataSourceConfigEbsNoDevice(rName string) string {

--- a/aws/data_source_aws_launch_configuration_test.go
+++ b/aws/data_source_aws_launch_configuration_test.go
@@ -77,7 +77,7 @@ func TestAccAWSLaunchConfigurationDataSource_ebsNoDevice(t *testing.T) {
 	})
 }
 
-func testAccLaunchConfigurationDataSource_metadataOptions(t *testing.T) {
+func TestAccLaunchConfigurationDataSource_metadataOptions(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_launch_configuration.test"
 	resourceName := "aws_launch_configuration.test"
@@ -85,7 +85,7 @@ func testAccLaunchConfigurationDataSource_metadataOptions(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfigurationDataSourceConfig_metadataOptions(rName),

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -247,6 +247,35 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 				},
 			},
 
+			"metadata_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"http_endpoint": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{autoscaling.InstanceMetadataEndpointStateEnabled, autoscaling.InstanceMetadataEndpointStateDisabled}, false),
+						},
+						"http_tokens": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{autoscaling.InstanceMetadataHttpTokensStateOptional, autoscaling.InstanceMetadataHttpTokensStateRequired}, false),
+						},
+						"http_put_response_hop_limit": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntBetween(1, 64),
+						},
+					},
+				},
+			},
+
 			"root_block_device": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -347,6 +376,10 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 	if v, ok := d.GetOk("vpc_classic_link_id"); ok {
 		createLaunchConfigurationOpts.ClassicLinkVPCId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("metadata_options"); ok {
+		createLaunchConfigurationOpts.MetadataOptions = expandLaunchConfigInstanceMetadataOptions(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("vpc_classic_link_security_groups"); ok {
@@ -564,6 +597,10 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("error setting vpc_classic_link_security_groups: %s", err)
 	}
 
+	if err := d.Set("metadata_options", flattenLaunchConfigInstanceMetadataOptions(lc.MetadataOptions)); err != nil {
+		return fmt.Errorf("error setting metadata_options: %s", err)
+	}
+
 	if err := readLCBlockDevices(d, lc, ec2conn); err != nil {
 		return err
 	}
@@ -629,6 +666,46 @@ func readLCBlockDevices(d *schema.ResourceData, lc *autoscaling.LaunchConfigurat
 	}
 
 	return nil
+}
+
+func expandLaunchConfigInstanceMetadataOptions(l []interface{}) *autoscaling.InstanceMetadataOptions {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	opts := &autoscaling.InstanceMetadataOptions{
+		HttpEndpoint: aws.String(m["http_endpoint"].(string)),
+	}
+
+	if m["http_endpoint"].(string) == autoscaling.InstanceMetadataEndpointStateEnabled {
+		// These parameters are not allowed unless HttpEndpoint is enabled
+
+		if v, ok := m["http_tokens"].(string); ok && v != "" {
+			opts.HttpTokens = aws.String(v)
+		}
+
+		if v, ok := m["http_put_response_hop_limit"].(int); ok && v != 0 {
+			opts.HttpPutResponseHopLimit = aws.Int64(int64(v))
+		}
+	}
+
+	return opts
+}
+
+func flattenLaunchConfigInstanceMetadataOptions(opts *autoscaling.InstanceMetadataOptions) []interface{} {
+	if opts == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"http_endpoint":               aws.StringValue(opts.HttpEndpoint),
+		"http_put_response_hop_limit": aws.Int64Value(opts.HttpPutResponseHopLimit),
+		"http_tokens":                 aws.StringValue(opts.HttpTokens),
+	}
+
+	return []interface{}{m}
 }
 
 func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autoscaling.LaunchConfiguration, ec2conn *ec2.EC2) (

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -251,6 +251,7 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -258,18 +259,21 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
+							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice([]string{autoscaling.InstanceMetadataEndpointStateEnabled, autoscaling.InstanceMetadataEndpointStateDisabled}, false),
 						},
 						"http_tokens": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
+							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice([]string{autoscaling.InstanceMetadataHttpTokensStateOptional, autoscaling.InstanceMetadataHttpTokensStateRequired}, false),
 						},
 						"http_put_response_hop_limit": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Computed:     true,
+							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(1, 64),
 						},
 					},

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -715,19 +715,20 @@ resource "aws_launch_configuration" "test" {
 }
 
 func testAccAWSLaunchConfigurationConfigMetadataOptions(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-  name = %[1]q
-  image_id = "${data.aws_ami.ubuntu.id}"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t3.nano"
-
+  name          = %[1]q
   metadata_options {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSLaunchConfigurationConfig() string {

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -389,6 +389,35 @@ func TestAccAWSLaunchConfiguration_updateEbsBlockDevices(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchConfiguration_metadataOptions(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_launch_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationConfigMetadataOptions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "required"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchConfiguration_ebs_noDevice(t *testing.T) {
 	var conf autoscaling.LaunchConfiguration
 	rInt := acctest.RandInt()
@@ -683,6 +712,20 @@ resource "aws_launch_configuration" "test" {
   }
 }
 `, rInt))
+}
+
+func testAccAWSLaunchConfigurationConfigMetadataOptions(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_configuration" "test" {
+  name = %[1]q
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+`, rName)
 }
 
 func testAccAWSLaunchConfigurationConfig() string {

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -718,6 +718,8 @@ func testAccAWSLaunchConfigurationConfigMetadataOptions(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
   name = %[1]q
+  image_id = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t3.nano"
 
   metadata_options {
     http_endpoint               = "enabled"

--- a/website/docs/d/launch_configuration.html.markdown
+++ b/website/docs/d/launch_configuration.html.markdown
@@ -35,6 +35,10 @@ In addition to all arguments above, the following attributes are exported:
 * `instance_type` - The Instance Type of the instance to launch.
 * `iam_instance_profile` - The IAM Instance Profile to associate with launched instances.
 * `key_name` - The Key Name that should be used for the instance.
+* `metadata_options` - The metadata options for the instance.
+    * `http_endpoint` - The state of the metadata service: `enabled`, `disabled`.
+    * `http_tokens` - If session tokens are required: `optional`, `required`.
+    * `http_put_response_hop_limit` - The desired HTTP PUT response hop limit for instance metadata requests.
 * `security_groups` - A list of associated Security Group IDS.
 * `associate_public_ip_address` - Whether a Public IP address is associated with the instance.
 * `vpc_classic_link_id` - The ID of a ClassicLink-enabled VPC.

--- a/website/docs/r/launch_configuration.html.markdown
+++ b/website/docs/r/launch_configuration.html.markdown
@@ -144,6 +144,10 @@ The following arguments are supported:
 * `iam_instance_profile` - (Optional) The name attribute of the IAM instance profile to associate
      with launched instances.
 * `key_name` - (Optional) The key name that should be used for the instance.
+* `metadata_options` - The metadata options for the instance.
+    * `http_endpoint` - The state of the metadata service: `enabled`, `disabled`.
+    * `http_tokens` - If session tokens are required: `optional`, `required`.
+    * `http_put_response_hop_limit` - The desired HTTP PUT response hop limit for instance metadata requests.
 * `security_groups` - (Optional) A list of associated security group IDS.
 * `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.
 * `vpc_classic_link_id` - (Optional) The ID of a ClassicLink-enabled VPC. Only applies to EC2-Classic instances. (eg. `vpc-2730681a`)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #[14621](https://github.com/terraform-providers/terraform-provider-aws/issues/14621)

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_launch_config: Add metadata_options attribute
resource/aws_launch_template: Add metadata_options configuration block (support IMDSv2)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchConfiguration_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchConfiguration_metadataOptions -timeout 120m
=== RUN   TestAccAWSLaunchConfiguration_metadataOptions
=== PAUSE TestAccAWSLaunchConfiguration_metadataOptions
=== CONT  TestAccAWSLaunchConfiguration_metadataOptions
--- PASS: TestAccAWSLaunchConfiguration_metadataOptions (14.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       15.007s

$ make testacc TEST=./aws/ TESTARGS='-run=TestAccLaunchConfigurationDataSource_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccLaunchConfigurationDataSource_metadataOptions -timeout 120m
=== RUN   TestAccLaunchConfigurationDataSource_metadataOptions
=== PAUSE TestAccLaunchConfigurationDataSource_metadataOptions
=== CONT  TestAccLaunchConfigurationDataSource_metadataOptions
--- PASS: TestAccLaunchConfigurationDataSource_metadataOptions (13.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       13.978s

...
```
