### PR TITLE
r/aws_cloudfront_distribution: add support for cache policies

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -268,6 +268,11 @@ of several sub-resources - these resources are laid out below.
 * `allowed_methods` (Required) - Controls which HTTP methods CloudFront
     processes and forwards to your Amazon S3 bucket or your custom origin.
 
+* `cache_policy_id` (Optional) - Use a managed or customer-provided
+    [Cache Policy](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html).
+
+    Conflicts with `min_ttl`, `max_ttl`, `default_ttl`, `forwarded_values`.
+
 * `cached_methods` (Required) - Controls whether CloudFront caches the
     response to requests using the specified HTTP methods.
 
@@ -277,13 +282,21 @@ of several sub-resources - these resources are laid out below.
 
 * `default_ttl` (Optional) - The default amount of time (in seconds) that an
     object is in a CloudFront cache before CloudFront forwards another request
-    in the absence of an `Cache-Control max-age` or `Expires` header. Defaults to
-    1 day.
+    in the absence of an `Cache-Control max-age` or `Expires` header.
+
+    Conflicts with
+    `cache_policy_id`, `origin_request_policy_id`. Defaults to 1 day.
+
+    _This field has been deprecated by AWS in favor of Cache Policies._
 
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
-* `forwarded_values` (Required) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
+* `forwarded_values` (Optional) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
     handles query strings, cookies and headers (maximum one).
+
+    Conflicts with `cache_policy_id`, `origin_request_policy_id`.
+
+    _This field has been deprecated by AWS in favor of Cache Policies and Origin Request Policies._
 
 * `lambda_function_association` (Optional) - A config block that triggers a lambda function with
   specific actions. Defined below, maximum 4.
@@ -292,11 +305,26 @@ of several sub-resources - these resources are laid out below.
     object is in a CloudFront cache before CloudFront forwards another request
     to your origin to determine whether the object has been updated. Only
     effective in the presence of `Cache-Control max-age`, `Cache-Control
-    s-maxage`, and `Expires` headers. Defaults to 365 days.
+    s-maxage`, and `Expires` headers.
 
-* `min_ttl` (Optional) - The minimum amount of time that you want objects to
+    Conflicts with `cache_policy_id`,
+    `origin_request_policy_id`. Defaults to 365 days.
+
+    _This field has been deprecated by AWS in favor of Cache Policies._
+
+* `min_ttl` (Optional, Conflicts with `cache_policy_id`, `origin_request_policy_id`) - The minimum amount of time that you want objects to
     stay in CloudFront caches before CloudFront queries your origin to see
-    whether the object has been updated. Defaults to 0 seconds.
+    whether the object has been updated.
+
+    Conflicts with `cache_policy_id`,
+    `origin_request_policy_id`. Defaults to 0 seconds.
+
+    _This field has been deprecated by AWS in favor of Cache Policies._
+
+* `origin_request_policy_id` (Optional) - Use a managed or customer-provided
+    [Origin Request Policy](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html).
+
+    Conflicts with `min_ttl`, `max_ttl`, `default_ttl`, `forwarded_values`.
 
 * `path_pattern` (Required) - The pattern (for example, `images/*.jpg)` that
     specifies which requests you want this cache behavior to apply to.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14373

When a cache policy is in effect, CloudFront rejects the TTL and ForwardedValues properties. To preserve backwards compatibility, this change maintains the existing TTL defaults in state, but considers them no-ops when a cache policy is set.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS

* resource/aws_cloudfront_distribution: Add `cache_policy_id` and `origin_request_policy_id` attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc ACCTEST_PARALLELISM=4 TESTARGS=-run=TestAccAWSCloudFrontDistribution_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -run=TestAccAWSCloudFrontDistribution_ -timeout 120m
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (204.84s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (215.53s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (173.24s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (384.94s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (182.00s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (405.86s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (232.95s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (242.71s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_cachePolicies (246.81s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (369.60s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (157.33s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.41s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (192.37s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (564.85s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (401.08s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (392.60s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (503.96s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (391.32s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.54s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (409.02s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (409.74s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_cachePolicies (246.67s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (338.60s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (338.14s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (336.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1925.152s
```
