### PR TITLE
New resource: aws_cloudfront_cache_policy

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -462,6 +462,7 @@ func Provider() *schema.Provider {
 			"aws_cloudformation_stack":                                resourceAwsCloudFormationStack(),
 			"aws_cloudformation_stack_set":                            resourceAwsCloudFormationStackSet(),
 			"aws_cloudformation_stack_set_instance":                   resourceAwsCloudFormationStackSetInstance(),
+			"aws_cloudfront_cache_policy":                             resourceAwsCloudFrontCachePolicy(),
 			"aws_cloudfront_distribution":                             resourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_origin_access_identity":                   resourceAwsCloudFrontOriginAccessIdentity(),
 			"aws_cloudfront_public_key":                               resourceAwsCloudFrontPublicKey(),

--- a/aws/resource_aws_cloudfront_cache_policy.go
+++ b/aws/resource_aws_cloudfront_cache_policy.go
@@ -43,6 +43,11 @@ func resourceAwsCloudFrontCachePolicy() *schema.Resource {
 				Default:      86400,
 				ValidateFunc: validation.IntAtLeast(0),
 			},
+			"enable_accept_encoding_brotli": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"enable_accept_encoding_gzip": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -238,7 +243,8 @@ func expandAwsCloudFrontCachePolicyConfig(d *schema.ResourceData) *cloudfront.Ca
 				CookieBehavior: aws.String(d.Get("cookie_behavior").(string)),
 				Cookies:        nil,
 			},
-			EnableAcceptEncodingGzip: aws.Bool(d.Get("enable_accept_encoding_gzip").(bool)),
+			EnableAcceptEncodingBrotli: aws.Bool(d.Get("enable_accept_encoding_brotli").(bool)),
+			EnableAcceptEncodingGzip:   aws.Bool(d.Get("enable_accept_encoding_gzip").(bool)),
 			HeadersConfig: &cloudfront.CachePolicyHeadersConfig{
 				HeaderBehavior: aws.String(d.Get("header_behavior").(string)),
 				Headers:        nil,
@@ -299,6 +305,7 @@ func flattenAwsCloudFrontCachePolicyConfig(d *schema.ResourceData, config *cloud
 			}
 		}
 
+		d.Set("enable_accept_encoding_brotli", forwarded.EnableAcceptEncodingBrotli)
 		d.Set("enable_accept_encoding_gzip", forwarded.EnableAcceptEncodingGzip)
 
 		if headers := forwarded.HeadersConfig; headers != nil {

--- a/aws/resource_aws_cloudfront_cache_policy.go
+++ b/aws/resource_aws_cloudfront_cache_policy.go
@@ -1,0 +1,326 @@
+package aws
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsCloudFrontCachePolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAwsCloudFrontCachePolicyCreate,
+		ReadContext:   resourceAwsCloudFrontCachePolicyRead,
+		UpdateContext: resourceAwsCloudFrontCachePolicyUpdate,
+		DeleteContext: resourceAwsCloudFrontCachePolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"comment": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cookie_behavior": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      cloudfront.CachePolicyCookieBehaviorNone,
+				ValidateFunc: validation.StringInSlice(cloudfront.CachePolicyCookieBehavior_Values(), false),
+			},
+			"cookie_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"default_ttl": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      86400,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"enable_accept_encoding_gzip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"header_behavior": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      cloudfront.CachePolicyHeaderBehaviorNone,
+				ValidateFunc: validation.StringInSlice(cloudfront.CachePolicyHeaderBehavior_Values(), false),
+			},
+			"header_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"max_ttl": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      31536000,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"min_ttl": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"query_string_behavior": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      cloudfront.CachePolicyQueryStringBehaviorNone,
+				ValidateFunc: validation.StringInSlice(cloudfront.CachePolicyQueryStringBehavior_Values(), false),
+			},
+			"query_string_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceAwsCloudFrontCachePolicyCreate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	input := cloudfront.CreateCachePolicyInput{
+		CachePolicyConfig: expandAwsCloudFrontCachePolicyConfig(d),
+	}
+
+	output, err := conn.CreateCachePolicyWithContext(ctx, &input)
+	if err != nil {
+		return diag.Errorf("create cache policy: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.CachePolicy.Id))
+	d.Set("etag", aws.StringValue(output.ETag))
+
+	return resourceAwsCloudFrontCachePolicyRead(ctx, d, meta)
+}
+
+func resourceAwsCloudFrontCachePolicyRead(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	conn := meta.(*AWSClient).cloudfrontconn
+	id := d.Id()
+
+	cachePolicy, etag, ok, err := getAwsCloudFrontCachePolicy(ctx, conn, id)
+	switch {
+	case err != nil:
+		return diag.Errorf("get cache policy %s: %s", id, err)
+	case !ok:
+		log.Printf("[WARN] Cache Policy %s not found; removing from state", id)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("etag", etag)
+
+	if err := flattenAwsCloudFrontCachePolicyConfig(d, cachePolicy.CachePolicyConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsCloudFrontCachePolicyUpdate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	conn := meta.(*AWSClient).cloudfrontconn
+	id := d.Id()
+
+	_, etag, ok, err := getAwsCloudFrontCachePolicy(ctx, conn, id)
+	switch {
+	case err != nil:
+		return diag.Errorf("get cache policy: %s", err)
+	case !ok:
+		return diag.Errorf("cache policy %s not found", id)
+	}
+
+	input := cloudfront.UpdateCachePolicyInput{
+		CachePolicyConfig: expandAwsCloudFrontCachePolicyConfig(d),
+		Id:                aws.String(id),
+		IfMatch:           aws.String(etag),
+	}
+
+	output, err := conn.UpdateCachePolicyWithContext(ctx, &input)
+	if err != nil {
+		return diag.Errorf("update failed: %s", err)
+	}
+
+	d.Set("etag", output.ETag)
+
+	return resourceAwsCloudFrontCachePolicyRead(ctx, d, meta)
+}
+
+func resourceAwsCloudFrontCachePolicyDelete(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	conn := meta.(*AWSClient).cloudfrontconn
+	id := d.Id()
+
+	_, etag, ok, err := getAwsCloudFrontCachePolicy(ctx, conn, id)
+	switch {
+	case !ok:
+		log.Printf("[WARN] Cache Policy %s does not exist", id)
+		return nil
+	case err != nil:
+		return diag.Errorf("failed to get etag of cache policy %s: %s", id, err)
+	}
+
+	input := cloudfront.DeleteCachePolicyInput{
+		Id:      aws.String(id),
+		IfMatch: aws.String(etag),
+	}
+
+	_, err = conn.DeleteCachePolicyWithContext(ctx, &input)
+	switch {
+	case isAWSErr(err, "NoSuchCachePolicy", ""):
+		log.Printf("[WARN] Cache Policy %s does not exist", id)
+		return nil
+	case err != nil:
+		return diag.Errorf("failed to delete: %s", err)
+	}
+
+	return nil
+}
+
+func getAwsCloudFrontCachePolicy(
+	ctx context.Context,
+	conn *cloudfront.CloudFront,
+	id string,
+) (cachePolicy *cloudfront.CachePolicy, etag string, ok bool, err error) {
+	input := cloudfront.GetCachePolicyInput{Id: aws.String(id)}
+	output, err := conn.GetCachePolicyWithContext(ctx, &input)
+	switch {
+	case isAWSErr(err, "NoSuchCachePolicy", ""):
+		return nil, "", false, nil
+	case err != nil:
+		return nil, "", false, err
+	}
+
+	return output.CachePolicy, aws.StringValue(output.ETag), true, nil
+}
+
+func expandAwsCloudFrontCachePolicyConfig(d *schema.ResourceData) *cloudfront.CachePolicyConfig {
+	output := &cloudfront.CachePolicyConfig{
+		Comment:    nil,
+		DefaultTTL: aws.Int64(int64(d.Get("default_ttl").(int))),
+		MaxTTL:     aws.Int64(int64(d.Get("max_ttl").(int))),
+		MinTTL:     aws.Int64(int64(d.Get("min_ttl").(int))),
+		Name:       aws.String(d.Get("name").(string)),
+		ParametersInCacheKeyAndForwardedToOrigin: &cloudfront.ParametersInCacheKeyAndForwardedToOrigin{
+			CookiesConfig: &cloudfront.CachePolicyCookiesConfig{
+				CookieBehavior: aws.String(d.Get("cookie_behavior").(string)),
+				Cookies:        nil,
+			},
+			EnableAcceptEncodingGzip: aws.Bool(d.Get("enable_accept_encoding_gzip").(bool)),
+			HeadersConfig: &cloudfront.CachePolicyHeadersConfig{
+				HeaderBehavior: aws.String(d.Get("header_behavior").(string)),
+				Headers:        nil,
+			},
+			QueryStringsConfig: &cloudfront.CachePolicyQueryStringsConfig{
+				QueryStringBehavior: aws.String(d.Get("query_string_behavior").(string)),
+				QueryStrings:        nil,
+			},
+		},
+	}
+
+	if v, ok := d.GetOk("comment"); ok && v.(string) != "" {
+		output.Comment = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("cookie_names"); ok {
+		s := v.(*schema.Set)
+		output.ParametersInCacheKeyAndForwardedToOrigin.CookiesConfig.Cookies = &cloudfront.CookieNames{
+			Items:    expandStringList(s.List()),
+			Quantity: aws.Int64(int64(s.Len())),
+		}
+	}
+
+	if v, ok := d.GetOk("header_names"); ok {
+		s := v.(*schema.Set)
+		output.ParametersInCacheKeyAndForwardedToOrigin.HeadersConfig.Headers = &cloudfront.Headers{
+			Items:    expandStringList(s.List()),
+			Quantity: aws.Int64(int64(s.Len())),
+		}
+	}
+
+	if v, ok := d.GetOk("query_string_names"); ok {
+		s := v.(*schema.Set)
+		output.ParametersInCacheKeyAndForwardedToOrigin.QueryStringsConfig.QueryStrings = &cloudfront.QueryStringNames{
+			Items:    expandStringList(s.List()),
+			Quantity: aws.Int64(int64(s.Len())),
+		}
+	}
+
+	return output
+}
+
+func flattenAwsCloudFrontCachePolicyConfig(d *schema.ResourceData, config *cloudfront.CachePolicyConfig) diag.Diagnostics {
+	d.Set("comment", config.Comment)
+	d.Set("default_ttl", config.DefaultTTL)
+	d.Set("max_ttl", config.MaxTTL)
+	d.Set("min_ttl", config.MinTTL)
+	d.Set("name", config.Name)
+
+	if forwarded := config.ParametersInCacheKeyAndForwardedToOrigin; forwarded != nil {
+		if cookies := forwarded.CookiesConfig; cookies != nil {
+			d.Set("cookie_behavior", cookies.CookieBehavior)
+			if list := cookies.Cookies; list != nil {
+				value := schema.NewSet(schema.HashString, flattenStringList(list.Items))
+				if err := d.Set("cookie_names", value); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+
+		d.Set("enable_accept_encoding_gzip", forwarded.EnableAcceptEncodingGzip)
+
+		if headers := forwarded.HeadersConfig; headers != nil {
+			d.Set("header_behavior", headers.HeaderBehavior)
+			if list := headers.Headers; list != nil {
+				value := schema.NewSet(schema.HashString, flattenStringList(list.Items))
+				if err := d.Set("header_names", value); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+
+		if qs := forwarded.QueryStringsConfig; qs != nil {
+			d.Set("query_string_behavior", qs.QueryStringBehavior)
+			if list := qs.QueryStrings; list != nil {
+				value := schema.NewSet(schema.HashString, flattenStringList(list.Items))
+				if err := d.Set("query_string_names", value); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/aws/resource_aws_cloudfront_cache_policy_test.go
+++ b/aws/resource_aws_cloudfront_cache_policy_test.go
@@ -100,7 +100,8 @@ func TestAccAwsCloudFrontCachePolicy_basic(t *testing.T) {
 						Quantity: aws.Int64(2),
 					},
 				},
-				EnableAcceptEncodingGzip: aws.Bool(true),
+				EnableAcceptEncodingBrotli: aws.Bool(true),
+				EnableAcceptEncodingGzip:   aws.Bool(true),
 				HeadersConfig: &cloudfront.CachePolicyHeadersConfig{
 					HeaderBehavior: aws.String("whitelist"),
 					Headers: &cloudfront.Headers{
@@ -139,6 +140,7 @@ func TestAccAwsCloudFrontCachePolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cookie_behavior", "none"),
 					resource.TestCheckResourceAttr(resourceName, "cookie_names.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "enable_accept_encoding_brotli", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enable_accept_encoding_gzip", "false"),
 					resource.TestCheckResourceAttrPtr(resourceName, "etag", &etag),
 					resource.TestCheckResourceAttr(resourceName, "header_behavior", "none"),
@@ -165,6 +167,7 @@ func TestAccAwsCloudFrontCachePolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cookie_behavior", "whitelist"),
 					resource.TestCheckResourceAttr(resourceName, "cookie_names.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "default_ttl", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "enable_accept_encoding_brotli", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enable_accept_encoding_gzip", "true"),
 					resource.TestCheckResourceAttrPtr(resourceName, "etag", &etag),
 					resource.TestCheckResourceAttr(resourceName, "header_behavior", "whitelist"),
@@ -194,18 +197,19 @@ resource "aws_cloudfront_cache_policy" "test" {
 func testAccAwsCloudFrontCachePolicyConfig_basic_update(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudfront_cache_policy" "test" {
-	comment                     = "Greetings, programs!"
-	cookie_behavior             = "whitelist"
-	cookie_names                = ["Cookie1", "Cookie2"]
-	default_ttl                 = 3600
-	enable_accept_encoding_gzip = true
-	header_behavior             = "whitelist"
-	header_names                = ["X-Header-1", "X-Header-2"]
-	max_ttl                     = 86400
-	min_ttl                     = 0
-	name                        = %[1]q
-	query_string_behavior       = "whitelist"
-	query_string_names          = ["test"]
+	comment                       = "Greetings, programs!"
+	cookie_behavior               = "whitelist"
+	cookie_names                  = ["Cookie1", "Cookie2"]
+	default_ttl                   = 3600
+	enable_accept_encoding_brotli = true
+	enable_accept_encoding_gzip   = true
+	header_behavior               = "whitelist"
+	header_names                  = ["X-Header-1", "X-Header-2"]
+	max_ttl                       = 86400
+	min_ttl                       = 0
+	name                          = %[1]q
+	query_string_behavior         = "whitelist"
+	query_string_names            = ["test"]
 }
 `, name)
 }

--- a/aws/resource_aws_cloudfront_cache_policy_test.go
+++ b/aws/resource_aws_cloudfront_cache_policy_test.go
@@ -1,0 +1,255 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func testAccCheckAwsCloudFrontCachePolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cloudfrontconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudfront_cache_policy" {
+			continue
+		}
+
+		id := rs.Primary.ID
+
+		switch _, _, ok, err := getAwsCloudFrontCachePolicy(context.Background(), conn, id); {
+		case err != nil:
+			return err
+		case ok:
+			return fmt.Errorf("cache policy %s still exists", id)
+		}
+	}
+
+	return nil
+}
+
+func testAccAwsCloudFrontCachePolicyExists(
+	name string,
+	out *cloudfront.CachePolicy,
+	etag *string,
+) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		switch {
+		case !ok:
+			return fmt.Errorf("resource %s not found", name)
+		case rs.Primary.ID == "":
+			return fmt.Errorf("resource %s has not set its id", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudfrontconn
+		id := rs.Primary.ID
+
+		cachePolicy, et, ok, err := getAwsCloudFrontCachePolicy(context.Background(), conn, id)
+		switch {
+		case err != nil:
+			return err
+		case !ok:
+			return fmt.Errorf("resource %s (%s) has not been created", name, id)
+		}
+
+		if out != nil {
+			*out = *cachePolicy
+			*etag = et
+		}
+
+		return nil
+	}
+}
+
+func TestAccAwsCloudFrontCachePolicy_basic(t *testing.T) {
+	resourceName := "aws_cloudfront_cache_policy.test"
+	randomName := "Terraform-AccTest-" + acctest.RandString(8)
+	cachePolicy, etag := cloudfront.CachePolicy{}, ""
+
+	checkAttributes := func(*terraform.State) error {
+		sortStringPtrs := func(slice []*string) {
+			sort.Slice(slice, func(i, j int) bool {
+				return *slice[i] < *slice[j]
+			})
+		}
+
+		actual := *cachePolicy.CachePolicyConfig
+		sortStringPtrs(actual.ParametersInCacheKeyAndForwardedToOrigin.CookiesConfig.Cookies.Items)
+		sortStringPtrs(actual.ParametersInCacheKeyAndForwardedToOrigin.HeadersConfig.Headers.Items)
+		sortStringPtrs(actual.ParametersInCacheKeyAndForwardedToOrigin.QueryStringsConfig.QueryStrings.Items)
+
+		expect := cloudfront.CachePolicyConfig{
+			Comment:    aws.String("Greetings, programs!"),
+			DefaultTTL: aws.Int64(3600),
+			MaxTTL:     aws.Int64(86400),
+			MinTTL:     aws.Int64(0),
+			Name:       aws.String(randomName + "-Suffix"),
+			ParametersInCacheKeyAndForwardedToOrigin: &cloudfront.ParametersInCacheKeyAndForwardedToOrigin{
+				CookiesConfig: &cloudfront.CachePolicyCookiesConfig{
+					CookieBehavior: aws.String("whitelist"),
+					Cookies: &cloudfront.CookieNames{
+						Items:    aws.StringSlice([]string{"Cookie1", "Cookie2"}),
+						Quantity: aws.Int64(2),
+					},
+				},
+				EnableAcceptEncodingGzip: aws.Bool(true),
+				HeadersConfig: &cloudfront.CachePolicyHeadersConfig{
+					HeaderBehavior: aws.String("whitelist"),
+					Headers: &cloudfront.Headers{
+						Items:    aws.StringSlice([]string{"X-Header-1", "X-Header-2"}),
+						Quantity: aws.Int64(2),
+					},
+				},
+				QueryStringsConfig: &cloudfront.CachePolicyQueryStringsConfig{
+					QueryStringBehavior: aws.String("whitelist"),
+					QueryStrings: &cloudfront.QueryStringNames{
+						Items:    aws.StringSlice([]string{"test"}),
+						Quantity: aws.Int64(1),
+					},
+				},
+			},
+		}
+
+		if !reflect.DeepEqual(actual, expect) {
+			return fmt.Errorf("Expected CachePolicyConfig:\n%#v\nGot:\n%#v", expect, actual)
+		}
+
+		return nil
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudFrontCachePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:       testAccAwsCloudFrontCachePolicyConfig_basic_create(randomName),
+				ResourceName: resourceName,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAwsCloudFrontCachePolicyExists(resourceName, &cachePolicy, &etag),
+					resource.TestCheckResourceAttr(resourceName, "comment", "Greetings, programs!"),
+					resource.TestCheckResourceAttr(resourceName, "cookie_behavior", "none"),
+					resource.TestCheckResourceAttr(resourceName, "cookie_names.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "enable_accept_encoding_gzip", "false"),
+					resource.TestCheckResourceAttrPtr(resourceName, "etag", &etag),
+					resource.TestCheckResourceAttr(resourceName, "header_behavior", "none"),
+					resource.TestCheckResourceAttr(resourceName, "header_names.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_ttl", "31536000"),
+					resource.TestCheckResourceAttr(resourceName, "min_ttl", "5"),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName),
+					resource.TestCheckResourceAttr(resourceName, "query_string_behavior", "none"),
+					resource.TestCheckResourceAttr(resourceName, "query_string_names.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:       testAccAwsCloudFrontCachePolicyConfig_basic_update(randomName + "-Suffix"),
+				ResourceName: resourceName,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAwsCloudFrontCachePolicyExists(resourceName, &cachePolicy, &etag),
+					checkAttributes,
+					resource.TestCheckResourceAttr(resourceName, "comment", "Greetings, programs!"),
+					resource.TestCheckResourceAttr(resourceName, "cookie_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "cookie_names.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "default_ttl", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "enable_accept_encoding_gzip", "true"),
+					resource.TestCheckResourceAttrPtr(resourceName, "etag", &etag),
+					resource.TestCheckResourceAttr(resourceName, "header_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "header_names.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "max_ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "min_ttl", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName+"-Suffix"),
+					resource.TestCheckResourceAttr(resourceName, "query_string_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "query_string_names.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsCloudFrontCachePolicyConfig_basic_create(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_cache_policy" "test" {
+	comment = "Greetings, programs!"
+	min_ttl = 5
+	name    = %[1]q
+}
+`, name)
+
+}
+
+func testAccAwsCloudFrontCachePolicyConfig_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_cache_policy" "test" {
+	comment                     = "Greetings, programs!"
+	cookie_behavior             = "whitelist"
+	cookie_names                = ["Cookie1", "Cookie2"]
+	default_ttl                 = 3600
+	enable_accept_encoding_gzip = true
+	header_behavior             = "whitelist"
+	header_names                = ["X-Header-1", "X-Header-2"]
+	max_ttl                     = 86400
+	min_ttl                     = 0
+	name                        = %[1]q
+	query_string_behavior       = "whitelist"
+	query_string_names          = ["test"]
+}
+`, name)
+}
+
+func TestAccAwsCloudFrontCachePolicy_disappears(t *testing.T) {
+	resourceName := "aws_cloudfront_cache_policy.test"
+	randomName := "Terraform-AccTest-" + acctest.RandString(8)
+	cachePolicy, etag := cloudfront.CachePolicy{}, ""
+
+	checkDisappears := func(*terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cloudfrontconn
+		input := cloudfront.DeleteCachePolicyInput{
+			Id:      aws.String(*cachePolicy.Id),
+			IfMatch: aws.String(etag),
+		}
+		_, err := conn.DeleteCachePolicy(&input)
+		return err
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudFrontCachePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:       testAccAwsCloudFrontCachePolicyConfig_disappears(randomName),
+				ResourceName: resourceName,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAwsCloudFrontCachePolicyExists(resourceName, &cachePolicy, &etag),
+					checkDisappears,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccAwsCloudFrontCachePolicyConfig_disappears(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_cache_policy" "test" {
+	comment = "Greetings, programs!"
+	min_ttl = 5
+	name    = %[1]q
+}
+`, name)
+
+}

--- a/infrastructure/repository/labels-workflow.tf
+++ b/infrastructure/repository/labels-workflow.tf
@@ -7,7 +7,7 @@ variable "workflow_labels" {
     "terraform-plugin-sdk-migration" = "fad8c7",
     "terraform-plugin-sdk-v1"        = "fad8c7",
     "terraform-0.11"                 = "cccccc",
-    "terraform-0.12"                 = "cccccc",    
+    "terraform-0.12"                 = "cccccc",
     "terraform-0.13"                 = "cccccc",
     "terraform-0.14"                 = "cccccc",
   }

--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -1,0 +1,71 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_cache_policy"
+description: |-
+  Provides a CloudFront Cache Policy resource.
+---
+
+# Resource: aws_cloudfront_cache_policy
+
+Provides a CloudFront Cache Policy resource, which allows for fine-grained control of the query string parameters, headers, and cookies that are included in the cache key by CloudFront.
+
+Read more about cache policies in [Controlling the cache key](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html).
+
+## Example Usage
+
+### Basic usage
+
+```hcl
+resource "aws_cloudfront_cache_policy" "example" {
+  default_ttl     = 3600
+  header_behavior = "whitelist"
+  header_names    = ["Authorization", "Host"]
+  max_ttl         = 86400
+  min_ttl         = 0
+  name            = "Example-CachePolicy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `comment` - (Optional) A comment to describe the cache policy.
+
+* `cookie_behavior` - (Optional) Determines whether any cookies in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none` (default), `whitelist`, `allExcept`, `all`. 
+
+* `cookie_names` - (Optional) Specifies the cookies to be handled in accordance with the cookie behavior.
+ 
+* `default_ttl` - (Optional) The default amount of time, in seconds, that you want objects to stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated. CloudFront uses this value as the object’s time to live (TTL) only when the origin does not send `Cache-Control` or `Expires` headers with the object. [See here for more information.](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html) The default value for this field is 86400 seconds (1 day). If the value of `min_ttl` is more than 86400 seconds, then the default value for this field is the same as the value of `min_ttl`. 
+
+* `enable_accept_encoding_gzip` - (Optional) A flag that determines whether the `Accept-Encoding` HTTP header is included in the cache key and included in requests that CloudFront sends to the origin. [See here for more information](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-policy-compressed-objects). The default value of this field is `false`.
+
+* `header_behavior` - (Optional) Determines whether any HTTP headers are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none` (default) and `whitelist`.
+
+* `header_names` - (Optional) Specifies the headers to be handled in accordance with the header behavior.
+
+* `max_ttl` - (Optional) The maximum amount of time, in seconds, that objects stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated. CloudFront uses this value only when the origin sends `Cache-Control` or `Expires` headers with the object. [See here for more information.](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html) The default value for this field is 31536000 seconds (1 year). If the value of `min_ttl` or `default_ttl` is more than 31536000 seconds, then the default value for this field is the same as the value of `default_ttl`.
+
+* `min_ttl` - (Required) The minimum amount of time, in seconds, that you want objects to stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated. [See here for more information.](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html)
+
+* `name` - (Required) A unique name to identify the cache policy.
+
+* `query_string_behavior` - (Optional) Determines whether any URL query strings in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none` (default), `whitelist`, `allExcept`, `all`.
+
+* `query_string_names` - (Optional) Specifies the query string parameters to be handled in accordance with the query string behavior.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the cache policy.
+* `etag` - The ETag of the latest version of the cache policy.
+
+## Import
+
+Cache Policies can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_cloudfront_cache_policy.default 486631b3-a60c-413e-82c4-f445871fb970
+```

--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -39,6 +39,8 @@ The following arguments are supported:
  
 * `default_ttl` - (Optional) The default amount of time, in seconds, that you want objects to stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated. CloudFront uses this value as the object’s time to live (TTL) only when the origin does not send `Cache-Control` or `Expires` headers with the object. [See here for more information.](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html) The default value for this field is 86400 seconds (1 day). If the value of `min_ttl` is more than 86400 seconds, then the default value for this field is the same as the value of `min_ttl`. 
 
+* `enable_accept_encoding_brotli` - (Optional) A flag that determines whether the `Accept-Encoding` HTTP header is included in the cache key and included in requests that CloudFront sends to the origin. [See here for more information](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-policy-compressed-objects). The default value of this field is `false`.
+
 * `enable_accept_encoding_gzip` - (Optional) A flag that determines whether the `Accept-Encoding` HTTP header is included in the cache key and included in requests that CloudFront sends to the origin. [See here for more information](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-policy-compressed-objects). The default value of this field is `false`.
 
 * `header_behavior` - (Optional) Determines whether any HTTP headers are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none` (default) and `whitelist`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14373
Closes #15172

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:
- **New Resource:** `aws_cloudfront_cache_policy`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsCloudFrontCachePolicy_'
==> Checking that code complies with gofmt requirements...
--- PASS: TestAccAwsCloudFrontCachePolicy_disappears (11.96s)
--- PASS: TestAccAwsCloudFrontCachePolicy_basic (29.12s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       30.577s
```
