### PR TITLE
r/aws_appsync_resolver: Support direct resolver

### DIFF
--- a/aws/resource_aws_appsync_resolver.go
+++ b/aws/resource_aws_appsync_resolver.go
@@ -45,11 +45,11 @@ func resourceAwsAppsyncResolver() *schema.Resource {
 			},
 			"request_template": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"response_template": {
 				Type:     schema.TypeString,
-				Required: true, // documentation bug, the api returns 400 if this is not specified.
+				Optional: true,
 			},
 			"kind": {
 				Type:     schema.TypeString,
@@ -110,12 +110,10 @@ func resourceAwsAppsyncResolverCreate(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*AWSClient).appsyncconn
 
 	input := &appsync.CreateResolverInput{
-		ApiId:                   aws.String(d.Get("api_id").(string)),
-		TypeName:                aws.String(d.Get("type").(string)),
-		FieldName:               aws.String(d.Get("field").(string)),
-		RequestMappingTemplate:  aws.String(d.Get("request_template").(string)),
-		ResponseMappingTemplate: aws.String(d.Get("response_template").(string)),
-		Kind:                    aws.String(d.Get("kind").(string)),
+		ApiId:     aws.String(d.Get("api_id").(string)),
+		TypeName:  aws.String(d.Get("type").(string)),
+		FieldName: aws.String(d.Get("field").(string)),
+		Kind:      aws.String(d.Get("kind").(string)),
 	}
 
 	if v, ok := d.GetOk("data_source"); ok {
@@ -127,6 +125,14 @@ func resourceAwsAppsyncResolverCreate(d *schema.ResourceData, meta interface{}) 
 		input.PipelineConfig = &appsync.PipelineConfig{
 			Functions: expandStringList(config["functions"].([]interface{})),
 		}
+	}
+
+	if v, ok := d.GetOk("request_template"); ok {
+		input.RequestMappingTemplate = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("response_template"); ok {
+		input.ResponseMappingTemplate = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("caching_config"); ok {

--- a/aws/resource_aws_appsync_resolver_test.go
+++ b/aws/resource_aws_appsync_resolver_test.go
@@ -98,6 +98,32 @@ func TestAccAwsAppsyncResolver_DataSource(t *testing.T) {
 	})
 }
 
+func TestAccAwsAppsyncResolver_DataSource_lambda(t *testing.T) {
+	var resolver appsync.Resolver
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_resolver.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncResolver_DataSource_lambda(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncResolverExists(resourceName, &resolver),
+					resource.TestCheckResourceAttr(resourceName, "data_source", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAwsAppsyncResolver_RequestTemplate(t *testing.T) {
 	var resolver1, resolver2 appsync.Resolver
 	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
@@ -469,6 +495,53 @@ EOF
 EOF
 }
 `, rName, dataSource)
+}
+
+func testAccAppsyncResolver_DataSource_lambda(rName string) string {
+	return testAccAppsyncDatasourceConfig_base_Lambda(rName) + fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+
+  schema = <<EOF
+type Mutation {
+	putPost(id: ID!, title: String!): Post
+}
+
+type Post {
+	id: ID!
+	title: String!
+}
+
+type Query {
+	singlePost(id: ID!): Post
+}
+
+schema {
+	query: Query
+	mutation: Mutation
+}
+EOF
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id           = "${aws_appsync_graphql_api.test.id}"
+  name             = %q
+  service_role_arn = "${aws_iam_role.test.arn}"
+  type             = "AWS_LAMBDA"
+
+  lambda_config {
+    function_arn = "${aws_lambda_function.test.arn}"
+  }
+}
+
+resource "aws_appsync_resolver" "test" {
+  api_id      = aws_appsync_graphql_api.test.id
+  field       = "singlePost"
+  type        = "Query"
+  data_source = aws_appsync_datasource.test.name
+}
+`, rName, rName)
 }
 
 func testAccAppsyncResolver_RequestTemplate(rName, resourcePath string) string {

--- a/aws/resource_aws_appsync_resolver_test.go
+++ b/aws/resource_aws_appsync_resolver_test.go
@@ -105,6 +105,7 @@ func TestAccAwsAppsyncResolver_DataSource_lambda(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
+		ErrorCheck:   testAccErrorCheck(t, appsync.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
 		Steps: []resource.TestStep{

--- a/website/docs/r/appsync_resolver.html.markdown
+++ b/website/docs/r/appsync_resolver.html.markdown
@@ -108,8 +108,8 @@ The following arguments are supported:
 * `api_id` - (Required) The API ID for the GraphQL API.
 * `type` - (Required) The type name from the schema defined in the GraphQL API.
 * `field` - (Required) The field name from the schema defined in the GraphQL API.
-* `request_template` - (Required) The request mapping template for UNIT resolver or 'before mapping template' for PIPELINE resolver.
-* `response_template` - (Required) The response mapping template for UNIT resolver or 'after mapping template' for PIPELINE resolver.
+* `request_template` - (Optional) The request mapping template for UNIT resolver or 'before mapping template' for PIPELINE resolver.
+* `response_template` - (Optional) The response mapping template for UNIT resolver or 'after mapping template' for PIPELINE resolver.
 * `data_source` - (Optional) The DataSource name.
 * `kind`  - (Optional) The resolver type. Valid values are `UNIT` and `PIPELINE`.
 * `pipeline_config` - (Optional) The PipelineConfig.

--- a/website/docs/r/appsync_resolver.html.markdown
+++ b/website/docs/r/appsync_resolver.html.markdown
@@ -108,8 +108,8 @@ The following arguments are supported:
 * `api_id` - (Required) The API ID for the GraphQL API.
 * `type` - (Required) The type name from the schema defined in the GraphQL API.
 * `field` - (Required) The field name from the schema defined in the GraphQL API.
-* `request_template` - (Optional) The request mapping template for UNIT resolver or 'before mapping template' for PIPELINE resolver.
-* `response_template` - (Optional) The response mapping template for UNIT resolver or 'after mapping template' for PIPELINE resolver.
+* `request_template` - (Optional) The request mapping template for UNIT resolver or 'before mapping template' for PIPELINE resolver. Required for non-Lambda resolvers.
+* `response_template` - (Optional) The response mapping template for UNIT resolver or 'after mapping template' for PIPELINE resolver. Required for non-Lambda resolvers.
 * `data_source` - (Optional) The DataSource name.
 * `kind`  - (Optional) The resolver type. Valid values are `UNIT` and `PIPELINE`.
 * `pipeline_config` - (Optional) The PipelineConfig.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14488

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/aws_appsync_resolver: Support direct resolver
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsAppsyncResolver'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAppsyncResolver -timeout 120m
=== RUN   TestAccAwsAppsyncResolver_basic
=== PAUSE TestAccAwsAppsyncResolver_basic
=== RUN   TestAccAwsAppsyncResolver_disappears
=== PAUSE TestAccAwsAppsyncResolver_disappears
=== RUN   TestAccAwsAppsyncResolver_DataSource
=== PAUSE TestAccAwsAppsyncResolver_DataSource
=== RUN   TestAccAwsAppsyncResolver_DataSource_lambda
=== PAUSE TestAccAwsAppsyncResolver_DataSource_lambda
=== RUN   TestAccAwsAppsyncResolver_RequestTemplate
=== PAUSE TestAccAwsAppsyncResolver_RequestTemplate
=== RUN   TestAccAwsAppsyncResolver_ResponseTemplate
=== PAUSE TestAccAwsAppsyncResolver_ResponseTemplate
=== RUN   TestAccAwsAppsyncResolver_multipleResolvers
=== PAUSE TestAccAwsAppsyncResolver_multipleResolvers
=== RUN   TestAccAwsAppsyncResolver_PipelineConfig
=== PAUSE TestAccAwsAppsyncResolver_PipelineConfig
=== RUN   TestAccAwsAppsyncResolver_CachingConfig
=== PAUSE TestAccAwsAppsyncResolver_CachingConfig
=== CONT  TestAccAwsAppsyncResolver_basic
=== CONT  TestAccAwsAppsyncResolver_ResponseTemplate
=== CONT  TestAccAwsAppsyncResolver_disappears
=== CONT  TestAccAwsAppsyncResolver_CachingConfig
=== CONT  TestAccAwsAppsyncResolver_DataSource_lambda
=== CONT  TestAccAwsAppsyncResolver_RequestTemplate
=== CONT  TestAccAwsAppsyncResolver_PipelineConfig
=== CONT  TestAccAwsAppsyncResolver_multipleResolvers
=== CONT  TestAccAwsAppsyncResolver_DataSource
    TestAccAwsAppsyncResolver_disappears: resource_aws_appsync_resolver_test.go:50: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAwsAppsyncResolver_disappears (44.45s)
--- PASS: TestAccAwsAppsyncResolver_CachingConfig (49.63s)
--- PASS: TestAccAwsAppsyncResolver_basic (58.12s)
--- PASS: TestAccAwsAppsyncResolver_multipleResolvers (71.85s)
--- PASS: TestAccAwsAppsyncResolver_DataSource_lambda (77.05s)
--- PASS: TestAccAwsAppsyncResolver_DataSource (81.25s)
--- PASS: TestAccAwsAppsyncResolver_ResponseTemplate (88.90s)
--- PASS: TestAccAwsAppsyncResolver_PipelineConfig (92.33s)
--- PASS: TestAccAwsAppsyncResolver_RequestTemplate (94.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	95.983s
...
```

Thank you for your review! 👍 
