### PR TITLE
New resource: aws_securityhub_standards_control

### DIFF
--- a/.changelog/14714.txt
+++ b/.changelog/14714.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_securityhub_standards_control
+```

--- a/aws/internal/service/securityhub/arn.go
+++ b/aws/internal/service/securityhub/arn.go
@@ -1,0 +1,44 @@
+package securityhub
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+const (
+	ARNSeparator = "/"
+	ARNService   = "securityhub"
+)
+
+// StandardsControlARNToStandardsSubscriptionARN converts a security standard control ARN to a subscription ARN.
+func StandardsControlARNToStandardsSubscriptionARN(inputARN string) (string, error) {
+	parsedARN, err := arn.Parse(inputARN)
+
+	if err != nil {
+		return "", fmt.Errorf("error parsing ARN (%s): %w", inputARN, err)
+	}
+
+	if actual, expected := parsedARN.Service, ARNService; actual != expected {
+		return "", fmt.Errorf("expected service %s in ARN (%s), got: %s", expected, inputARN, actual)
+	}
+
+	inputResourceParts := strings.Split(parsedARN.Resource, ARNSeparator)
+
+	if actual, expected := len(inputResourceParts), 3; actual < expected {
+		return "", fmt.Errorf("expected at least %d resource parts in ARN (%s), got: %d", expected, inputARN, actual)
+	}
+
+	outputResourceParts := append([]string{"subscription"}, inputResourceParts[1:len(inputResourceParts)-1]...)
+
+	outputARN := arn.ARN{
+		Partition: parsedARN.Partition,
+		Service:   parsedARN.Service,
+		Region:    parsedARN.Region,
+		AccountID: parsedARN.AccountID,
+		Resource:  strings.Join(outputResourceParts, ARNSeparator),
+	}.String()
+
+	return outputARN, nil
+}

--- a/aws/internal/service/securityhub/arn_test.go
+++ b/aws/internal/service/securityhub/arn_test.go
@@ -1,0 +1,65 @@
+package securityhub_test
+
+import (
+	"regexp"
+	"testing"
+
+	tfsecurityhub "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/securityhub"
+)
+
+func TestStandardsControlARNToStandardsSubscriptionARN(t *testing.T) {
+	testCases := []struct {
+		TestName      string
+		InputARN      string
+		ExpectedError *regexp.Regexp
+		ExpectedARN   string
+	}{
+		{
+			TestName:      "empty ARN",
+			InputARN:      "",
+			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+		},
+		{
+			TestName:      "unparsable ARN",
+			InputARN:      "test",
+			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+		},
+		{
+			TestName:      "invalid ARN service",
+			InputARN:      "arn:aws:ec2:us-west-2:1234567890:control/cis-aws-foundations-benchmark/v/1.2.0/1.1",
+			ExpectedError: regexp.MustCompile(`expected service securityhub`),
+		},
+		{
+			TestName:      "invalid ARN resource parts",
+			InputARN:      "arn:aws:securityhub:us-west-2:1234567890:control/cis-aws-foundations-benchmark",
+			ExpectedError: regexp.MustCompile(`expected at least 3 resource parts`),
+		},
+		{
+			TestName:    "valid ARN",
+			InputARN:    "arn:aws:securityhub:us-west-2:1234567890:control/cis-aws-foundations-benchmark/v/1.2.0/1.1",
+			ExpectedARN: "arn:aws:securityhub:us-west-2:1234567890:subscription/cis-aws-foundations-benchmark/v/1.2.0",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := tfsecurityhub.StandardsControlARNToStandardsSubscriptionARN(testCase.InputARN)
+
+			if err == nil && testCase.ExpectedError != nil {
+				t.Fatalf("expected error %s, got no error", testCase.ExpectedError.String())
+			}
+
+			if err != nil && testCase.ExpectedError == nil {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if err != nil && !testCase.ExpectedError.MatchString(err.Error()) {
+				t.Fatalf("expected error %s, got: %s", testCase.ExpectedError.String(), err)
+			}
+
+			if got != testCase.ExpectedARN {
+				t.Errorf("got %s, expected %s", got, testCase.ExpectedARN)
+			}
+		})
+	}
+}

--- a/aws/internal/service/securityhub/finder/finder.go
+++ b/aws/internal/service/securityhub/finder/finder.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func AdminAccount(conn *securityhub.SecurityHub, adminAccountID string) (*securityhub.AdminAccount, error) {
@@ -50,4 +52,83 @@ func Insight(ctx context.Context, conn *securityhub.SecurityHub, arn string) (*s
 	}
 
 	return output.Insights[0], nil
+}
+
+func StandardsControlByStandardsSubscriptionARNAndStandardsControlARN(ctx context.Context, conn *securityhub.SecurityHub, standardsSubscriptionARN, standardsControlARN string) (*securityhub.StandardsControl, error) {
+	input := &securityhub.DescribeStandardsControlsInput{
+		StandardsSubscriptionArn: aws.String(standardsSubscriptionARN),
+	}
+	var output *securityhub.StandardsControl
+
+	err := conn.DescribeStandardsControlsPagesWithContext(ctx, input, func(page *securityhub.DescribeStandardsControlsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, control := range page.Controls {
+			if aws.StringValue(control.StandardsControlArn) == standardsControlARN {
+				output = control
+
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	if tfawserr.ErrCodeEquals(err, securityhub.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}
+
+func StandardsSubscriptionByARN(conn *securityhub.SecurityHub, arn string) (*securityhub.StandardsSubscription, error) {
+	input := &securityhub.GetEnabledStandardsInput{
+		StandardsSubscriptionArns: aws.StringSlice([]string{arn}),
+	}
+
+	output, err := conn.GetEnabledStandards(input)
+
+	if tfawserr.ErrCodeEquals(err, securityhub.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if output == nil || len(output.StandardsSubscriptions) == 0 || output.StandardsSubscriptions[0] == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	// TODO Check for multiple results.
+	// TODO https://github.com/hashicorp/terraform-provider-aws/pull/17613.
+
+	subscription := output.StandardsSubscriptions[0]
+
+	if status := aws.StringValue(subscription.StandardsStatus); status == securityhub.StandardsStatusFailed {
+		return nil, &resource.NotFoundError{
+			Message:     status,
+			LastRequest: input,
+		}
+	}
+
+	return subscription, nil
 }

--- a/aws/internal/service/securityhub/waiter/waiter.go
+++ b/aws/internal/service/securityhub/waiter/waiter.go
@@ -13,6 +13,9 @@ const (
 
 	// Maximum amount of time to wait for an AdminAccount to return NotFound
 	AdminAccountNotFoundTimeout = 5 * time.Minute
+
+	StandardsSubscriptionCreateTimeout = 3 * time.Minute
+	StandardsSubscriptionDeleteTimeout = 3 * time.Minute
 )
 
 // AdminAccountEnabled waits for an AdminAccount to return Enabled
@@ -45,6 +48,40 @@ func AdminAccountNotFound(conn *securityhub.SecurityHub, adminAccountID string) 
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*securityhub.AdminAccount); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func StandardsSubscriptionCreated(conn *securityhub.SecurityHub, arn string) (*securityhub.StandardsSubscription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{securityhub.StandardsStatusPending},
+		Target:  []string{securityhub.StandardsStatusReady, securityhub.StandardsStatusIncomplete},
+		Refresh: StandardsSubscriptionStatus(conn, arn),
+		Timeout: StandardsSubscriptionCreateTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*securityhub.StandardsSubscription); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func StandardsSubscriptionDeleted(conn *securityhub.SecurityHub, arn string) (*securityhub.StandardsSubscription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{securityhub.StandardsStatusDeleting},
+		Target:  []string{StandardsStatusNotFound, securityhub.StandardsStatusIncomplete},
+		Refresh: StandardsSubscriptionStatus(conn, arn),
+		Timeout: StandardsSubscriptionDeleteTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*securityhub.StandardsSubscription); ok {
 		return output, err
 	}
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1056,6 +1056,7 @@ func Provider() *schema.Provider {
 			"aws_securityhub_member":                                  resourceAwsSecurityHubMember(),
 			"aws_securityhub_organization_admin_account":              resourceAwsSecurityHubOrganizationAdminAccount(),
 			"aws_securityhub_product_subscription":                    resourceAwsSecurityHubProductSubscription(),
+			"aws_securityhub_standards_control":                       resourceAwsSecurityHubStandardsControl(),
 			"aws_securityhub_standards_subscription":                  resourceAwsSecurityHubStandardsSubscription(),
 			"aws_servicecatalog_budget_resource_association":          resourceAwsServiceCatalogBudgetResourceAssociation(),
 			"aws_servicecatalog_constraint":                           resourceAwsServiceCatalogConstraint(),

--- a/aws/resource_aws_securityhub_standards_control.go
+++ b/aws/resource_aws_securityhub_standards_control.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/securityhub"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/aws/resource_aws_securityhub_standards_control.go
+++ b/aws/resource_aws_securityhub_standards_control.go
@@ -1,0 +1,139 @@
+package aws
+
+import (
+	"context"
+	"log"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/securityhub"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsSecurityHubStandardsControl() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAwsSecurityHubStandardsControlPut,
+		ReadContext:   resourceAwsSecurityHubStandardsControlRead,
+		UpdateContext: resourceAwsSecurityHubStandardsControlPut,
+		DeleteContext: resourceAwsSecurityHubStandardsControlDelete,
+
+		Schema: map[string]*schema.Schema{
+			"standards_control_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"control_status": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(securityhub.ControlStatus_Values(), false),
+			},
+			"disabled_reason": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"control_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"control_status_updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"related_requirements": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"remediation_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"severity_rating": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"title": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSecurityHubStandardsControlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).securityhubconn
+
+	a := d.Get("standards_control_arn").(string)
+	controlArn, err := arn.Parse(a)
+	if err != nil {
+		return diag.Errorf("error parsing standards control ARN %q", controlArn)
+	}
+
+	subscriptionArn := path.Dir(strings.ReplaceAll(controlArn.String(), "control", "subscription"))
+
+	log.Printf("[DEBUG] Read Security Hub standard control %s", controlArn)
+
+	resp, err := conn.DescribeStandardsControls(&securityhub.DescribeStandardsControlsInput{
+		StandardsSubscriptionArn: aws.String(subscriptionArn),
+	})
+	if err != nil {
+		return diag.Errorf("error reading Security Hub standard controls within %q subscription: %s", subscriptionArn, err)
+	}
+
+	for _, c := range resp.Controls {
+		if aws.StringValue(c.StandardsControlArn) != controlArn.String() {
+			continue
+		}
+
+		d.Set("control_status", c.ControlStatus)
+		d.Set("control_status_updated_at", c.ControlStatusUpdatedAt.Format(time.RFC3339))
+		d.Set("description", c.Description)
+		d.Set("disabled_reason", c.DisabledReason)
+		d.Set("severity_rating", c.SeverityRating)
+		d.Set("title", c.Title)
+
+		if err := d.Set("related_requirements", flattenStringList(c.RelatedRequirements)); err != nil {
+			return diag.Errorf("error setting related_requirements: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsSecurityHubStandardsControlPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).securityhubconn
+
+	d.SetId(d.Get("standards_control_arn").(string))
+
+	log.Printf("[DEBUG] Update Security Hub standard control %s", d.Id())
+
+	_, err := conn.UpdateStandardsControl(&securityhub.UpdateStandardsControlInput{
+		StandardsControlArn: aws.String(d.Get("standards_control_arn").(string)),
+		ControlStatus:       aws.String(d.Get("control_status").(string)),
+		DisabledReason:      aws.String(d.Get("disabled_reason").(string)),
+	})
+	if err != nil {
+		d.SetId("")
+		return diag.Errorf("error updating Security Hub standard control %q: %s", d.Id(), err)
+	}
+
+	return resourceAwsSecurityHubStandardsControlRead(ctx, d, meta)
+}
+
+func resourceAwsSecurityHubStandardsControlDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[WARN] Cannot delete Security Hub standard control. Terraform will remove this resource from the state.")
+	return nil
+}

--- a/aws/resource_aws_securityhub_standards_control_test.go
+++ b/aws/resource_aws_securityhub_standards_control_test.go
@@ -18,9 +18,10 @@ func testAccAWSSecurityHubStandardsControl_basic(t *testing.T) {
 	resourceName := "aws_securityhub_standards_control.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:   func() { testAccPreCheck(t) },
-		ErrorCheck: testAccErrorCheck(t, securityhub.EndpointsID),
-		Providers:  testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil, //lintignore:AT001
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityHubStandardsControlConfig_basic(),
@@ -46,9 +47,10 @@ func testAccAWSSecurityHubStandardsControl_disabledControlStatus(t *testing.T) {
 	resourceName := "aws_securityhub_standards_control.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:   func() { testAccPreCheck(t) },
-		ErrorCheck: testAccErrorCheck(t, securityhub.EndpointsID),
-		Providers:  testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil, //lintignore:AT001
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityHubStandardsControlConfig_disabledControlStatus(),
@@ -64,9 +66,10 @@ func testAccAWSSecurityHubStandardsControl_disabledControlStatus(t *testing.T) {
 
 func testAccAWSSecurityHubStandardsControl_enabledControlStatusAndDisabledReason(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:   func() { testAccPreCheck(t) },
-		ErrorCheck: testAccErrorCheck(t, securityhub.EndpointsID),
-		Providers:  testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil, //lintignore:AT001
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSSecurityHubStandardsControlConfig_enabledControlStatus(),

--- a/aws/resource_aws_securityhub_standards_control_test.go
+++ b/aws/resource_aws_securityhub_standards_control_test.go
@@ -1,0 +1,154 @@
+package aws
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSSecurityHubStandardsControl_basic(t *testing.T) {
+	var standardsControl *securityhub.StandardsControl
+
+	resourceName := "aws_securityhub_standards_control.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityHubStandardsControlExists(resourceName, standardsControl),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityHubStandardsControlConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSecurityHubStandardsControlExists(resourceName, standardsControl),
+					resource.TestCheckResourceAttr(resourceName, "control_status", "ENABLED"),
+					resource.TestMatchResourceAttr(resourceName, "control_status_updated_at", regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z`)),
+					resource.TestCheckResourceAttr(resourceName, "description", "IAM password policies can prevent the reuse of a given password by the same user. It is recommended that the password policy prevent the reuse of passwords."),
+					resource.TestCheckResourceAttr(resourceName, "disabled_reason", ""),
+					resource.TestCheckResourceAttr(resourceName, "related_requirements.0", "CIS AWS Foundations 1.10"),
+					resource.TestCheckResourceAttr(resourceName, "severity_rating", "LOW"),
+					resource.TestCheckResourceAttr(resourceName, "title", "Ensure IAM password policy prevents password reuse"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityHubStandardsControl_disabledControlStatus(t *testing.T) {
+	var standardsControl *securityhub.StandardsControl
+
+	resourceName := "aws_securityhub_standards_control.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityHubStandardsControlExists(resourceName, standardsControl),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityHubStandardsControlConfig_disabledControlStatus(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSecurityHubStandardsControlExists(resourceName, standardsControl),
+					resource.TestCheckResourceAttr(resourceName, "control_status", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "disabled_reason", "We handle password policies within Okta"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityHubStandardsControl_enabledControlStatusAndDisabledReason(t *testing.T) {
+	var standardsControl *securityhub.StandardsControl
+
+	resourceName := "aws_securityhub_standards_control.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityHubStandardsControlExists(resourceName, standardsControl),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSSecurityHubStandardsControlConfig_enabledControlStatus(),
+				ExpectError: regexp.MustCompile("InvalidInputException: DisabledReason should not be given for action other than disabling control"),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSecurityHubStandardsControlExists(n string, control *securityhub.StandardsControl) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).securityhubconn
+
+		arn := rs.Primary.ID
+		subscription_arn := path.Dir(strings.ReplaceAll(arn, "control", "subscription"))
+
+		resp, err := conn.DescribeStandardsControls(&securityhub.DescribeStandardsControlsInput{
+			StandardsSubscriptionArn: aws.String(subscription_arn),
+		})
+		if err != nil {
+			return fmt.Errorf("error reading Security Hub %s standard controls: %s", subscription_arn, err)
+		}
+
+		controlNotFound := true
+
+		for _, c := range resp.Controls {
+			if aws.StringValue(c.StandardsControlArn) != arn {
+				continue
+			}
+
+			controlNotFound = false
+			control = c
+		}
+
+		if controlNotFound {
+			return fmt.Errorf("Security Hub %s standard control %s not found", subscription_arn, arn)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSSecurityHubStandardsControlConfig_basic() string {
+	return composeConfig(
+		testAccAWSSecurityHubStandardsSubscriptionConfig_basic,
+		`
+resource aws_securityhub_standards_control test {
+  standards_control_arn = format("%s/1.10", replace(aws_securityhub_standards_subscription.test.id, "subscription", "control"))
+  control_status        = "ENABLED"
+}
+`)
+}
+
+func testAccAWSSecurityHubStandardsControlConfig_disabledControlStatus() string {
+	return composeConfig(
+		testAccAWSSecurityHubStandardsSubscriptionConfig_basic,
+		`
+resource aws_securityhub_standards_control test {
+  standards_control_arn = format("%s/1.11", replace(aws_securityhub_standards_subscription.test.id, "subscription", "control"))
+  control_status        = "DISABLED"
+  disabled_reason       = "We handle password policies within Okta"
+}
+`)
+}
+
+func testAccAWSSecurityHubStandardsControlConfig_enabledControlStatus() string {
+	return composeConfig(
+		testAccAWSSecurityHubStandardsSubscriptionConfig_basic,
+		`
+resource aws_securityhub_standards_control test {
+  standards_control_arn = format("%s/1.12", replace(aws_securityhub_standards_subscription.test.id, "subscription", "control"))
+  control_status        = "ENABLED"
+  disabled_reason       = "We handle password policies within Okta"
+}
+`)
+}

--- a/aws/resource_aws_securityhub_standards_control_test.go
+++ b/aws/resource_aws_securityhub_standards_control_test.go
@@ -20,6 +20,7 @@ func TestAccAWSSecurityHubStandardsControl_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSecurityHubStandardsControlExists(resourceName, standardsControl),
 		Steps: []resource.TestStep{
@@ -47,6 +48,7 @@ func TestAccAWSSecurityHubStandardsControl_disabledControlStatus(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSecurityHubStandardsControlExists(resourceName, standardsControl),
 		Steps: []resource.TestStep{
@@ -69,6 +71,7 @@ func TestAccAWSSecurityHubStandardsControl_enabledControlStatusAndDisabledReason
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSecurityHubStandardsControlExists(resourceName, standardsControl),
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_securityhub_standards_subscription.go
+++ b/aws/resource_aws_securityhub_standards_subscription.go
@@ -7,6 +7,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/securityhub"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/securityhub/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/securityhub/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsSecurityHubStandardsSubscription() *schema.Resource {
@@ -14,6 +17,7 @@ func resourceAwsSecurityHubStandardsSubscription() *schema.Resource {
 		Create: resourceAwsSecurityHubStandardsSubscriptionCreate,
 		Read:   resourceAwsSecurityHubStandardsSubscriptionRead,
 		Delete: resourceAwsSecurityHubStandardsSubscriptionDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -31,23 +35,30 @@ func resourceAwsSecurityHubStandardsSubscription() *schema.Resource {
 
 func resourceAwsSecurityHubStandardsSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).securityhubconn
-	log.Printf("[DEBUG] Enabling Security Hub standard %s", d.Get("standards_arn"))
 
-	resp, err := conn.BatchEnableStandards(&securityhub.BatchEnableStandardsInput{
+	standardsARN := d.Get("standards_arn").(string)
+	input := &securityhub.BatchEnableStandardsInput{
 		StandardsSubscriptionRequests: []*securityhub.StandardsSubscriptionRequest{
 			{
-				StandardsArn: aws.String(d.Get("standards_arn").(string)),
+				StandardsArn: aws.String(standardsARN),
 			},
 		},
-	})
-
-	if err != nil {
-		return fmt.Errorf("Error enabling Security Hub standard: %s", err)
 	}
 
-	standardsSubscription := resp.StandardsSubscriptions[0]
+	log.Printf("[DEBUG] Creating Security Hub Standards Subscription: %s", input)
+	output, err := conn.BatchEnableStandards(input)
 
-	d.SetId(aws.StringValue(standardsSubscription.StandardsSubscriptionArn))
+	if err != nil {
+		return fmt.Errorf("error enabling Security Hub Standard (%s): %w", standardsARN, err)
+	}
+
+	d.SetId(aws.StringValue(output.StandardsSubscriptions[0].StandardsSubscriptionArn))
+
+	_, err = waiter.StandardsSubscriptionCreated(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error waiting for Security Hub Standards Subscription (%s) to create: %w", d.Id(), err)
+	}
 
 	return resourceAwsSecurityHubStandardsSubscriptionRead(d, meta)
 }
@@ -55,38 +66,35 @@ func resourceAwsSecurityHubStandardsSubscriptionCreate(d *schema.ResourceData, m
 func resourceAwsSecurityHubStandardsSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).securityhubconn
 
-	log.Printf("[DEBUG] Reading Security Hub standard %s", d.Id())
-	resp, err := conn.GetEnabledStandards(&securityhub.GetEnabledStandardsInput{
-		StandardsSubscriptionArns: []*string{aws.String(d.Id())},
-	})
+	output, err := finder.StandardsSubscriptionByARN(conn, d.Id())
 
-	if err != nil {
-		return fmt.Errorf("Error reading Security Hub standard %s: %s", d.Id(), err)
-	}
-
-	if len(resp.StandardsSubscriptions) == 0 {
-		log.Printf("[WARN] Security Hub standard (%s) not found, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Security Hub Standards Subscription (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	standardsSubscription := resp.StandardsSubscriptions[0]
-
-	d.Set("standards_arn", standardsSubscription.StandardsArn)
+	d.Set("standards_arn", output.StandardsArn)
 
 	return nil
 }
 
 func resourceAwsSecurityHubStandardsSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).securityhubconn
-	log.Printf("[DEBUG] Disabling Security Hub standard %s", d.Id())
 
+	log.Printf("[DEBUG] Deleting Security Hub Standards Subscription: %s", d.Id())
 	_, err := conn.BatchDisableStandards(&securityhub.BatchDisableStandardsInput{
-		StandardsSubscriptionArns: []*string{aws.String(d.Id())},
+		StandardsSubscriptionArns: aws.StringSlice([]string{d.Id()}),
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error disabling Security Hub standard %s: %s", d.Id(), err)
+		return fmt.Errorf("error disabling Security Hub Standard (%s): %w", d.Id(), err)
+	}
+
+	_, err = waiter.StandardsSubscriptionDeleted(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error waiting for Security Hub Standards Subscription (%s) to delete: %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_securityhub_standards_subscription_test.go
+++ b/aws/resource_aws_securityhub_standards_subscription_test.go
@@ -19,7 +19,7 @@ func testAccAWSSecurityHubStandardsSubscription_basic(t *testing.T) {
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSecurityHubAccountDestroy,
+		CheckDestroy: testAccCheckAWSSecurityHubStandardsSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityHubStandardsSubscriptionConfig_basic,
@@ -44,7 +44,7 @@ func testAccAWSSecurityHubStandardsSubscription_disappears(t *testing.T) {
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSecurityHubAccountDestroy,
+		CheckDestroy: testAccCheckAWSSecurityHubStandardsSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityHubStandardsSubscriptionConfig_basic,
@@ -106,10 +106,6 @@ func testAccCheckAWSSecurityHubStandardsSubscriptionDestroy(s *terraform.State) 
 
 	return nil
 }
-
-const testAccAWSSecurityHubStandardsSubscriptionConfig_empty = `
-resource "aws_securityhub_account" "test" {}
-`
 
 const testAccAWSSecurityHubStandardsSubscriptionConfig_basic = `
 resource "aws_securityhub_account" "test" {}

--- a/aws/resource_aws_securityhub_standards_subscription_test.go
+++ b/aws/resource_aws_securityhub_standards_subscription_test.go
@@ -13,6 +13,8 @@ import (
 func testAccAWSSecurityHubStandardsSubscription_basic(t *testing.T) {
 	var standardsSubscription *securityhub.StandardsSubscription
 
+	resourceName := "aws_securityhub_standards_subscription.test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
@@ -22,11 +24,11 @@ func testAccAWSSecurityHubStandardsSubscription_basic(t *testing.T) {
 			{
 				Config: testAccAWSSecurityHubStandardsSubscriptionConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSecurityHubStandardsSubscriptionExists("aws_securityhub_standards_subscription.example", standardsSubscription),
+					testAccCheckAWSSecurityHubStandardsSubscriptionExists(resourceName, standardsSubscription),
 				),
 			},
 			{
-				ResourceName:      "aws_securityhub_standards_subscription.example",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -95,16 +97,16 @@ func testAccCheckAWSSecurityHubStandardsSubscriptionDestroy(s *terraform.State) 
 }
 
 const testAccAWSSecurityHubStandardsSubscriptionConfig_empty = `
-resource "aws_securityhub_account" "example" {}
+resource "aws_securityhub_account" "test" {}
 `
 
 const testAccAWSSecurityHubStandardsSubscriptionConfig_basic = `
-resource "aws_securityhub_account" "example" {}
+resource "aws_securityhub_account" "test" {}
 
 data "aws_partition" "current" {}
 
-resource "aws_securityhub_standards_subscription" "example" {
-  depends_on    = [aws_securityhub_account.example]
+resource "aws_securityhub_standards_subscription" "test" {
   standards_arn = "arn:${data.aws_partition.current.partition}:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+  depends_on    = [aws_securityhub_account.test]
 }
 `

--- a/aws/resource_aws_securityhub_standards_subscription_test.go
+++ b/aws/resource_aws_securityhub_standards_subscription_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/securityhub"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -91,7 +92,7 @@ func testAccCheckAWSSecurityHubStandardsSubscriptionDestroy(s *terraform.State) 
 			continue
 		}
 
-		_, err := finder.StandardsSubscriptionByARN(conn, rs.Primary.ID)
+		output, err := finder.StandardsSubscriptionByARN(conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -99,6 +100,11 @@ func testAccCheckAWSSecurityHubStandardsSubscriptionDestroy(s *terraform.State) 
 
 		if err != nil {
 			return err
+		}
+
+		// INCOMPLETE subscription status => deleted.
+		if aws.StringValue(output.StandardsStatus) == securityhub.StandardsStatusIncomplete {
+			continue
 		}
 
 		return fmt.Errorf("Security Hub Standards Subscription %s still exists", rs.Primary.ID)

--- a/aws/resource_aws_securityhub_test.go
+++ b/aws/resource_aws_securityhub_test.go
@@ -43,8 +43,14 @@ func TestAccAWSSecurityHub_serial(t *testing.T) {
 		"ProductSubscription": {
 			"basic": testAccAWSSecurityHubProductSubscription_basic,
 		},
+		"StandardsControl": {
+			"basic":                                 testAccAWSSecurityHubStandardsControl_basic,
+			"DisabledControlStatus":                 testAccAWSSecurityHubStandardsControl_disabledControlStatus,
+			"EnabledControlStatusAndDisabledReason": testAccAWSSecurityHubStandardsControl_enabledControlStatusAndDisabledReason,
+		},
 		"StandardsSubscription": {
-			"basic": testAccAWSSecurityHubStandardsSubscription_basic,
+			"basic":      testAccAWSSecurityHubStandardsSubscription_basic,
+			"disappears": testAccAWSSecurityHubStandardsSubscription_disappears,
 		},
 	}
 

--- a/website/docs/r/securityhub_standards_control.markdown
+++ b/website/docs/r/securityhub_standards_control.markdown
@@ -32,7 +32,7 @@ resource aws_securityhub_standards_control ensure_iam_password_policy_prevents_p
 }
 ```
 
-## Arguments Reference
+## Argument Reference
 
 The following arguments are supported:
 

--- a/website/docs/r/securityhub_standards_control.markdown
+++ b/website/docs/r/securityhub_standards_control.markdown
@@ -16,7 +16,7 @@ into management. When you _delete_ this resource configuration, Terraform "aband
 
 ## Example Usage
 
-```hcl
+```terraform
 resource aws_securityhub_account example {}
 
 resource aws_securityhub_standards_subscription cis_aws_foundations_benchmark {

--- a/website/docs/r/securityhub_standards_control.markdown
+++ b/website/docs/r/securityhub_standards_control.markdown
@@ -25,10 +25,11 @@ resource aws_securityhub_standards_subscription cis_aws_foundations_benchmark {
 }
 
 resource aws_securityhub_standards_control ensure_iam_password_policy_prevents_password_reuse {
-  arn             = "arn:aws:securityhub:us-east-1:111111111111:control/cis-aws-foundations-benchmark/v/1.2.0/1.10"
-  control_status  = "DISABLED"
-  disabled_reason = "We handle password policies within Okta"
-  depends_on      = [aws_securityhub_standards_subscription.cis_aws_foundations_benchmark]
+  standards_control_arn = "arn:aws:securityhub:us-east-1:111111111111:control/cis-aws-foundations-benchmark/v/1.2.0/1.10"
+  control_status        = "DISABLED"
+  disabled_reason       = "We handle password policies within Okta"
+
+  depends_on = [aws_securityhub_standards_subscription.cis_aws_foundations_benchmark]
 }
 ```
 

--- a/website/docs/r/securityhub_standards_control.markdown
+++ b/website/docs/r/securityhub_standards_control.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported in addition to the arguments listed above:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The standard control ARN.
 * `control_id` – The identifier of the security standard control.

--- a/website/docs/r/securityhub_standards_control.markdown
+++ b/website/docs/r/securityhub_standards_control.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "Security Hub"
+layout: "aws"
+page_title: "AWS: aws_securityhub_standards_control"
+description: |-
+  Enable/disable Security Hub standards controls.
+---
+
+# Resource: aws_securityhub_standards_control
+
+Disable/enable Security Hub standards control in the current region.
+
+The `aws_securityhub_standards_control` behaves differently from normal resources, in that
+Terraform does not _create_ this resource, but instead "adopts" it
+into management. When you _delete_ this resource configuration, Terraform "abandons" resource as is and just removes it from the state.
+
+## Example Usage
+
+```hcl
+resource aws_securityhub_account example {}
+
+resource aws_securityhub_standards_subscription cis_aws_foundations_benchmark {
+  standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+  depends_on    = [aws_securityhub_account.example]
+}
+
+resource aws_securityhub_standards_control ensure_iam_password_policy_prevents_password_reuse {
+  arn             = "arn:aws:securityhub:us-east-1:111111111111:control/cis-aws-foundations-benchmark/v/1.2.0/1.10"
+  control_status  = "DISABLED"
+  disabled_reason = "We handle password policies within Okta"
+  depends_on      = [aws_securityhub_standards_subscription.cis_aws_foundations_benchmark]
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `standards_control_arn` - (Required) The standards control ARN.
+* `control_status` – (Required) The control status could be `ENABLED` or `DISABLED`. You have to specify `disabled_reason` argument for `DISABLED` control status.
+* `disabled_reason` – (Optional) A description of the reason why you are disabling a security standard control. If you specify this attribute, `control_status` will be set to `DISABLED` automatically.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The standard control ARN.
+* `control_id` – The identifier of the security standard control.
+* `control_status_updated_at` – The date and time that the status of the security standard control was most recently updated.
+* `description` – The standard control longer description. Provides information about what the control is checking for.
+* `related_requirements` – The list of requirements that are related to this control.
+* `remediation_url` – A link to remediation information for the control in the Security Hub user documentation.
+* `severity_rating` – The severity of findings generated from this security standard control.
+* `title` – The standard control title.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11624

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
New resource: aws_securityhub_standards_control
```

### Example Usage

```hcl
resource "aws_securityhub_account" "example" {}

resource "aws_securityhub_standards_subscription" "cis_aws_foundations_benchmark" {
  standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
  depends_on    = [aws_securityhub_account.example]
}

resource "aws_securityhub_standards_control" "ensure_iam_password_policy_prevents_password_reuse" {
  arn             = "arn:aws:securityhub:us-east-1:078884324539:control/cis-aws-foundations-benchmark/v/1.2.0/1.10"
  control_status  = "DISABLED"
  disabled_reason = "We handle password policies within Okta" 
  depends_on      = [aws_securityhub_standards_subscription.cis_aws_foundations_benchmark]
}
```

### Acceptance Tests

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSecurityHubStandardsControl'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSecurityHubStandardsControl -timeout 120m
=== RUN   TestAccAWSSecurityHubStandardsControl_basic
--- PASS: TestAccAWSSecurityHubStandardsControl_basic (19.31s)
=== RUN   TestAccAWSSecurityHubStandardsControl_disabledControlStatus
--- PASS: TestAccAWSSecurityHubStandardsControl_disabledControlStatus (18.76s)
=== RUN   TestAccAWSSecurityHubStandardsControl_enabledControlStatusAndDisabledReason
--- PASS: TestAccAWSSecurityHubStandardsControl_enabledControlStatusAndDisabledReason (6.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.379s
```

### Notes

1. This is my first attempt to make `terraform-plugin-sdk/v2` compatible resource. Please don't hesitate to refer me to the best practices according to this shift.
1. I don't' know what is a standard approach for `time.Time` attribute type in this provider and chose a simple `String()` conversion. 
1. Standard control resource has an "adoption" lifecycle – resource already exists in the cloud and Terraform provider calls `Create()` to accept it into the management and `Delete()` just removes from the state.
1. I noticed some resource have `Read()` func call at the end of `Update()` func and some not. I do believe if a resource has computed attributes any update (for synchronous API) should re-read them to the state. Please correct me if I'm wrong.