### PR TITLE
aws_elb & aws_lb: Add desync_mitigation_mode

### DIFF
--- a/.changelog/14764.txt
+++ b/.changelog/14764.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+data-source/aws_elb: Add `desync_mitigation_mode` attribute
+```
+
+```release-note:enhancement
+data-source/aws_lb: Add `desync_mitigation_mode` attribute
+```
+
+```release-note:enhancement
+resource/aws_elb: Add `desync_mitigation_mode` argument
+```
+
+```release-note:enhancement
+resource/aws_lb: Add `desync_mitigation_mode` argument
+```

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -15,7 +15,7 @@ import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -15,7 +15,7 @@ import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -255,6 +255,17 @@ func ResourceLoadBalancer() *schema.Resource {
 				Computed: true,
 			},
 
+			"desync_mitigation_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "defensive",
+				ValidateFunc: validation.StringInSlice([]string{
+					"monitor",
+					"defensive",
+					"strictest",
+				}, false),
+			},
+
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
@@ -453,6 +464,13 @@ func flattenLoadBalancerEResource(d *schema.ResourceData, ec2conn *ec2.EC2, elbc
 		}
 	}
 
+	for _, attr := range lbAttrs.AdditionalAttributes {
+		switch aws.StringValue(attr.Key) {
+		case "elb.http.desyncmitigationmode":
+			d.Set("desync_mitigation_mode", aws.StringValue(attr.Value))
+		}
+	}
+
 	tags, err := ListTags(elbconn, d.Id())
 
 	if err != nil {
@@ -580,10 +598,16 @@ func resourceLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	if d.HasChanges("cross_zone_load_balancing", "idle_timeout", "access_logs") {
+	if d.HasChanges("cross_zone_load_balancing", "idle_timeout", "access_logs", "desync_mitigation_mode") {
 		attrs := elb.ModifyLoadBalancerAttributesInput{
 			LoadBalancerName: aws.String(d.Get("name").(string)),
 			LoadBalancerAttributes: &elb.LoadBalancerAttributes{
+				AdditionalAttributes: []*elb.AdditionalAttribute{
+					{
+						Key:   aws.String("elb.http.desyncmitigationmode"),
+						Value: aws.String(d.Get("desync_mitigation_mode").(string)),
+					},
+				},
 				CrossZoneLoadBalancing: &elb.CrossZoneLoadBalancing{
 					Enabled: aws.Bool(d.Get("cross_zone_load_balancing").(bool)),
 				},

--- a/internal/service/elb/load_balancer_data_source.go
+++ b/internal/service/elb/load_balancer_data_source.go
@@ -188,6 +188,11 @@ func DataSourceLoadBalancer() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
+			"desync_mitigation_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tftags.TagsSchemaComputed(),
 
 			"zone_id": {
@@ -301,6 +306,13 @@ func dataSourceLoadBalancerRead(d *schema.ResourceData, meta interface{}) error 
 		}
 		if err := d.Set("access_logs", flattenAccessLog(elbal)); err != nil {
 			return err
+		}
+	}
+
+	for _, attr := range lbAttrs.AdditionalAttributes {
+		switch aws.StringValue(attr.Key) {
+		case "elb.http.desyncmitigationmode":
+			d.Set("desync_mitigation_mode", aws.StringValue(attr.Value))
 		}
 	}
 

--- a/internal/service/elb/load_balancer_data_source_test.go
+++ b/internal/service/elb/load_balancer_data_source_test.go
@@ -29,6 +29,7 @@ func TestAccELBLoadBalancerDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "internal", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "subnets.#", "2"),
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "desync_mitigation_mode", "defensive"),
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(dataSourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(dataSourceName, "tags.TestName", t.Name()),

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -1907,71 +1907,70 @@ resource "aws_internet_gateway" "gw" {
 `
 
 const testAccLoadBalancerConfigDesyncMitigationMode = `
- data "aws_availability_zones" "available" {
-   state = "available"
+data "aws_availability_zones" "available" {
+  state = "available"
 
-   filter {
-     name   = "opt-in-status"
-     values = ["opt-in-not-required"]
-   }
- }
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
- resource "aws_elb" "test" {
-   availability_zones = [data.aws_availability_zones.available.names[0]]
+resource "aws_elb" "test" {
+  availability_zones = [data.aws_availability_zones.available.names[0]]
+  listener {
+    instance_port     = 8000
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
 
-   listener {
-     instance_port     = 8000
-     instance_protocol = "http"
-     lb_port           = 80
-     lb_protocol       = "http"
-   }
-
-   desync_mitigation_mode = "strictest"
- }
- `
+  desync_mitigation_mode = "strictest"
+}
+`
 
 const testAccLoadBalancerConfigDesyncMitigationMode_update_default = `
- data "aws_availability_zones" "available" {
-   state = "available"
+data "aws_availability_zones" "available" {
+  state = "available"
 
-   filter {
-     name   = "opt-in-status"
-     values = ["opt-in-not-required"]
-   }
- }
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
- resource "aws_elb" "test" {
-   availability_zones = [data.aws_availability_zones.available.names[0]]
+resource "aws_elb" "test" {
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
-   listener {
-     instance_port     = 8000
-     instance_protocol = "http"
-     lb_port           = 80
-     lb_protocol       = "http"
-   }
- }
- `
+  listener {
+    instance_port     = 8000
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+}
+`
 
 const testAccLoadBalancerConfigDesyncMitigationMode_update_monitor = `
- data "aws_availability_zones" "available" {
-   state = "available"
+data "aws_availability_zones" "available" {
+  state = "available"
 
-   filter {
-     name   = "opt-in-status"
-     values = ["opt-in-not-required"]
-   }
- }
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
- resource "aws_elb" "test" {
-   availability_zones = [data.aws_availability_zones.available.names[0]]
+resource "aws_elb" "test" {
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
-   listener {
-     instance_port     = 8000
-     instance_protocol = "http"
-     lb_port           = 80
-     lb_protocol       = "http"
-   }
+  listener {
+    instance_port     = 8000
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
 
-   desync_mitigation_mode = "monitor"
- }
- `
+  desync_mitigation_mode = "monitor"
+}
+`

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -44,6 +44,7 @@ func TestAccELBLoadBalancer_basic(t *testing.T) {
 						"lb_protocol":       "http",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "cross_zone_load_balancing", "true"),
+					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "defensive"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -661,6 +662,71 @@ func TestAccELBLoadBalancer_securityGroups(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Count should still be one as we swap in a custom security group
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccELBLoadBalancer_desyncMitigationMode(t *testing.T) {
+	resourceName := "aws_elb.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, elb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerConfigDesyncMitigationMode,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "strictest"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccELBLoadBalancer_desyncMitigationMode_update(t *testing.T) {
+	resourceName := "aws_elb.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, elb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerConfigDesyncMitigationMode_update_default,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "defensive"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoadBalancerConfigDesyncMitigationMode_update_monitor,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "monitor"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoadBalancerConfigDesyncMitigationMode_update_default,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "defensive"),
 				),
 			},
 		},
@@ -1839,3 +1905,73 @@ resource "aws_internet_gateway" "gw" {
   }
 }
 `
+
+const testAccLoadBalancerConfigDesyncMitigationMode = `
+ data "aws_availability_zones" "available" {
+   state = "available"
+
+   filter {
+     name   = "opt-in-status"
+     values = ["opt-in-not-required"]
+   }
+ }
+
+ resource "aws_elb" "test" {
+   availability_zones = [data.aws_availability_zones.available.names[0]]
+
+   listener {
+     instance_port     = 8000
+     instance_protocol = "http"
+     lb_port           = 80
+     lb_protocol       = "http"
+   }
+
+   desync_mitigation_mode = "strictest"
+ }
+ `
+
+const testAccLoadBalancerConfigDesyncMitigationMode_update_default = `
+ data "aws_availability_zones" "available" {
+   state = "available"
+
+   filter {
+     name   = "opt-in-status"
+     values = ["opt-in-not-required"]
+   }
+ }
+
+ resource "aws_elb" "test" {
+   availability_zones = [data.aws_availability_zones.available.names[0]]
+
+   listener {
+     instance_port     = 8000
+     instance_protocol = "http"
+     lb_port           = 80
+     lb_protocol       = "http"
+   }
+ }
+ `
+
+const testAccLoadBalancerConfigDesyncMitigationMode_update_monitor = `
+ data "aws_availability_zones" "available" {
+   state = "available"
+
+   filter {
+     name   = "opt-in-status"
+     values = ["opt-in-not-required"]
+   }
+ }
+
+ resource "aws_elb" "test" {
+   availability_zones = [data.aws_availability_zones.available.names[0]]
+
+   listener {
+     instance_port     = 8000
+     instance_protocol = "http"
+     lb_port           = 80
+     lb_protocol       = "http"
+   }
+
+   desync_mitigation_mode = "monitor"
+ }
+ `

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -251,6 +251,18 @@ func ResourceLoadBalancer() *schema.Resource {
 				Computed: true,
 			},
 
+			"desync_mitigation_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "defensive",
+				ValidateFunc: validation.StringInSlice([]string{
+					"monitor",
+					"defensive",
+					"strictest",
+				}, false),
+				DiffSuppressFunc: suppressIfLBTypeNot(elbv2.LoadBalancerTypeEnumApplication),
+			},
+
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
@@ -260,6 +272,12 @@ func ResourceLoadBalancer() *schema.Resource {
 func suppressIfLBType(t string) schema.SchemaDiffSuppressFunc {
 	return func(k string, old string, new string, d *schema.ResourceData) bool {
 		return d.Get("load_balancer_type").(string) == t
+	}
+}
+
+func suppressIfLBTypeNot(t string) schema.SchemaDiffSuppressFunc {
+	return func(k string, old string, new string, d *schema.ResourceData) bool {
+		return d.Get("load_balancer_type").(string) != t
 	}
 }
 
@@ -465,6 +483,13 @@ func resourceLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error 
 			attributes = append(attributes, &elbv2.LoadBalancerAttribute{
 				Key:   aws.String("routing.http.drop_invalid_header_fields.enabled"),
 				Value: aws.String(strconv.FormatBool(d.Get("drop_invalid_header_fields").(bool))),
+			})
+		}
+
+		if d.HasChange("desync_mitigation_mode") || d.IsNewResource() {
+			attributes = append(attributes, &elbv2.LoadBalancerAttribute{
+				Key:   aws.String("routing.http.desync_mitigation_mode"),
+				Value: aws.String(d.Get("desync_mitigation_mode").(string)),
 			})
 		}
 
@@ -805,6 +830,10 @@ func flattenResource(d *schema.ResourceData, meta interface{}, lb *elbv2.LoadBal
 			crossZoneLbEnabled := aws.StringValue(attr.Value) == "true"
 			log.Printf("[DEBUG] Setting NLB Cross Zone Load Balancing Enabled: %t", crossZoneLbEnabled)
 			d.Set("enable_cross_zone_load_balancing", crossZoneLbEnabled)
+		case "routing.http.desync_mitigation_mode":
+			desyncMitigationMode := aws.StringValue(attr.Value)
+			log.Printf("[DEBUG] Setting ALB Desync Mitigation Mode: %s", desyncMitigationMode)
+			d.Set("desync_mitigation_mode", desyncMitigationMode)
 		}
 	}
 

--- a/internal/service/elbv2/load_balancer_data_source.go
+++ b/internal/service/elbv2/load_balancer_data_source.go
@@ -153,6 +153,11 @@ func DataSourceLoadBalancer() *schema.Resource {
 				Computed: true,
 			},
 
+			"desync_mitigation_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
@@ -290,6 +295,9 @@ func dataSourceLoadBalancerRead(d *schema.ResourceData, meta interface{}) error 
 		case "load_balancing.cross_zone.enabled":
 			crossZoneLbEnabled := aws.StringValue(attr.Value) == "true"
 			d.Set("enable_cross_zone_load_balancing", crossZoneLbEnabled)
+		case "routing.http.desync_mitigation_mode":
+			desyncMitigationMode := aws.StringValue(attr.Value)
+			d.Set("desync_mitigation_mode", desyncMitigationMode)
 		}
 	}
 

--- a/internal/service/elbv2/load_balancer_data_source_test.go
+++ b/internal/service/elbv2/load_balancer_data_source_test.go
@@ -40,6 +40,7 @@ func TestAccELBV2LoadBalancerDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "ip_address_type", resourceName, "ip_address_type"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_mapping.#", resourceName, "subnet_mapping.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "desync_mitigation_mode", resourceName, "desync_mitigation_mode"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "internal", resourceName, "internal"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "subnets.#", resourceName, "subnets.#"),
@@ -55,6 +56,7 @@ func TestAccELBV2LoadBalancerDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName2, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "ip_address_type", resourceName, "ip_address_type"),
 					resource.TestCheckResourceAttrPair(dataSourceName2, "subnet_mapping.#", resourceName, "subnet_mapping.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "desync_mitigation_mode", resourceName, "desync_mitigation_mode"),
 					resource.TestCheckResourceAttrPair(dataSourceName3, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName3, "internal", resourceName, "internal"),
 					resource.TestCheckResourceAttrPair(dataSourceName3, "subnets.#", resourceName, "subnets.#"),
@@ -70,6 +72,7 @@ func TestAccELBV2LoadBalancerDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName3, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName3, "ip_address_type", resourceName, "ip_address_type"),
 					resource.TestCheckResourceAttrPair(dataSourceName3, "subnet_mapping.#", resourceName, "subnet_mapping.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "desync_mitigation_mode", resourceName, "desync_mitigation_mode"),
 				),
 			},
 		},
@@ -196,6 +199,8 @@ resource "aws_lb" "test" {
 
   idle_timeout               = 30
   enable_deletion_protection = false
+
+  desync_mitigation_mode = "defensive"
 
   tags = {
     Name   = %[1]q

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -2906,78 +2906,78 @@ resource "aws_security_group" "alb_test" {
 
 func testAccAWSLBConfig_desyncMitigationMode(lbName string, mode string) string {
 	return fmt.Sprintf(`
- resource "aws_lb" "lb_test" {
-   name            = "%s"
-   internal        = true
-   security_groups = ["${aws_security_group.alb_test.id}"]
-   subnets         = "${aws_subnet.alb_test.*.id}"
+resource "aws_lb" "lb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = aws_subnet.alb_test.*.id
 
-   idle_timeout               = 30
-   enable_deletion_protection = false
+  idle_timeout               = 30
+  enable_deletion_protection = false
 
-   desync_mitigation_mode = %q
+  desync_mitigation_mode = %q
 
-   tags = {
-     Name = "TestAccAWSALB_desync"
-   }
- }
+  tags = {
+    Name = "TestAccAWSALB_desync"
+  }
+}
 
- variable "subnets" {
-   default = ["10.0.1.0/24", "10.0.2.0/24"]
-   type    = list
- }
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = list
+}
 
- data "aws_availability_zones" "available" {
-   state = "available"
+data "aws_availability_zones" "available" {
+  state = "available"
 
-   filter {
-     name   = "opt-in-status"
-     values = ["opt-in-not-required"]
-   }
- }
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
- resource "aws_vpc" "alb_test" {
-   cidr_block = "10.0.0.0/16"
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
 
-   tags = {
-     Name = "terraform-testacc-lb-desync"
-   }
- }
+  tags = {
+    Name = "terraform-testacc-lb-desync"
+  }
+}
 
- resource "aws_subnet" "alb_test" {
-   count                   = 2
-   vpc_id                  = "${aws_vpc.alb_test.id}"
-   cidr_block              = "${element(var.subnets, count.index)}"
-   map_public_ip_on_launch = true
-   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = aws_vpc.alb_test.id
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-   tags = {
-     Name = "tf-acc-lb-desync-${count.index}"
-   }
- }
+  tags = {
+    Name = "tf-acc-lb-desync-${count.index}"
+  }
+}
 
- resource "aws_security_group" "alb_test" {
-   name        = "allow_all_alb_test_desync"
-   description = "Used for ALB Testing"
-   vpc_id      = "${aws_vpc.alb_test.id}"
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test_desync"
+  description = "Used for ALB Testing"
+  vpc_id      = aws_vpc.alb_test.id
 
-   ingress {
-     from_port   = 0
-     to_port     = 0
-     protocol    = "-1"
-     cidr_blocks = ["0.0.0.0/0"]
-   }
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-   egress {
-     from_port   = 0
-     to_port     = 0
-     protocol    = "-1"
-     cidr_blocks = ["0.0.0.0/0"]
-   }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-   tags = {
-     Name = "TestAccAWSALB_desync"
-   }
- }
- `, lbName, mode)
+  tags = {
+    Name = "TestAccAWSALB_desync"
+  }
+}
+`, lbName, mode)
 }

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -92,6 +92,7 @@ func TestAccELBV2LoadBalancer_ALB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSALB_basic"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "zone_id"),
+					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "defensive"),
 				),
 			},
 		},
@@ -1102,6 +1103,55 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "testAccLoadBalancerConfig_networkLoadbalancer_subnets"),
 					resource.TestCheckResourceAttr(resourceName, "load_balancer_type", "network"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLB_applicationLoadBalancer_updateDesyncMitigationMode(t *testing.T) {
+	var pre, mid, post elbv2.LoadBalancer
+	lbName := fmt.Sprintf("testaccawsalb-desync-%s", sdkacctest.RandString(4))
+	resourceName := "aws_lb.lb_test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, elbv2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBConfig_desyncMitigationMode(lbName, "strictest"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerExists(resourceName, &pre),
+					testAccCheckLoadBalancerAttribute(resourceName, "routing.http.desync_mitigation_mode", "strictest"),
+					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "strictest"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSLBConfig_desyncMitigationMode(lbName, "monitor"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerExists(resourceName, &mid),
+					testAccCheckLoadBalancerAttribute(resourceName, "routing.http.desync_mitigation_mode", "monitor"),
+					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "monitor"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSLBConfig_desyncMitigationMode(lbName, "defensive"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerExists(resourceName, &post),
+					testAccCheckLoadBalancerAttribute(resourceName, "routing.http.desync_mitigation_mode", "defensive"),
+					resource.TestCheckResourceAttr(resourceName, "desync_mitigation_mode", "defensive"),
 				),
 			},
 		},
@@ -2852,4 +2902,82 @@ resource "aws_security_group" "alb_test" {
   }
 }
 `, lbName))
+}
+
+func testAccAWSLBConfig_desyncMitigationMode(lbName string, mode string) string {
+	return fmt.Sprintf(`
+ resource "aws_lb" "lb_test" {
+   name            = "%s"
+   internal        = true
+   security_groups = ["${aws_security_group.alb_test.id}"]
+   subnets         = "${aws_subnet.alb_test.*.id}"
+
+   idle_timeout               = 30
+   enable_deletion_protection = false
+
+   desync_mitigation_mode = %q
+
+   tags = {
+     Name = "TestAccAWSALB_desync"
+   }
+ }
+
+ variable "subnets" {
+   default = ["10.0.1.0/24", "10.0.2.0/24"]
+   type    = list
+ }
+
+ data "aws_availability_zones" "available" {
+   state = "available"
+
+   filter {
+     name   = "opt-in-status"
+     values = ["opt-in-not-required"]
+   }
+ }
+
+ resource "aws_vpc" "alb_test" {
+   cidr_block = "10.0.0.0/16"
+
+   tags = {
+     Name = "terraform-testacc-lb-desync"
+   }
+ }
+
+ resource "aws_subnet" "alb_test" {
+   count                   = 2
+   vpc_id                  = "${aws_vpc.alb_test.id}"
+   cidr_block              = "${element(var.subnets, count.index)}"
+   map_public_ip_on_launch = true
+   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+   tags = {
+     Name = "tf-acc-lb-desync-${count.index}"
+   }
+ }
+
+ resource "aws_security_group" "alb_test" {
+   name        = "allow_all_alb_test_desync"
+   description = "Used for ALB Testing"
+   vpc_id      = "${aws_vpc.alb_test.id}"
+
+   ingress {
+     from_port   = 0
+     to_port     = 0
+     protocol    = "-1"
+     cidr_blocks = ["0.0.0.0/0"]
+   }
+
+   egress {
+     from_port   = 0
+     to_port     = 0
+     protocol    = "-1"
+     cidr_blocks = ["0.0.0.0/0"]
+   }
+
+   tags = {
+     Name = "TestAccAWSALB_desync"
+   }
+ }
+ `, lbName, mode)
 }

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -1109,7 +1109,7 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change(t *testing.T) {
 	})
 }
 
-func TestAccAWSLB_applicationLoadBalancer_updateDesyncMitigationMode(t *testing.T) {
+func TestAccELBV2LoadBalancer_updateDesyncMitigationMode(t *testing.T) {
 	var pre, mid, post elbv2.LoadBalancer
 	lbName := fmt.Sprintf("testaccawsalb-desync-%s", sdkacctest.RandString(4))
 	resourceName := "aws_lb.lb_test"

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -2947,9 +2947,9 @@ resource "aws_vpc" "alb_test" {
 resource "aws_subnet" "alb_test" {
   count                   = 2
   vpc_id                  = aws_vpc.alb_test.id
-  cidr_block              = "${element(var.subnets, count.index)}"
+  cidr_block              = element(var.subnets, count.index)}
   map_public_ip_on_launch = true
-  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
     Name = "tf-acc-lb-desync-${count.index}"

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -2909,7 +2909,7 @@ func testAccAWSLBConfig_desyncMitigationMode(lbName string, mode string) string 
 resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
-  security_groups = ["${aws_security_group.alb_test.id}"]
+  security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test.*.id
 
   idle_timeout               = 30
@@ -2947,7 +2947,7 @@ resource "aws_vpc" "alb_test" {
 resource "aws_subnet" "alb_test" {
   count                   = 2
   vpc_id                  = aws_vpc.alb_test.id
-  cidr_block              = element(var.subnets, count.index)}
+  cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 

--- a/website/docs/r/elb.html.markdown
+++ b/website/docs/r/elb.html.markdown
@@ -88,6 +88,7 @@ The following arguments are supported:
 * `idle_timeout` - (Optional) The time in seconds that the connection is allowed to be idle. Default: `60`
 * `connection_draining` - (Optional) Boolean to enable connection draining. Default: `false`
 * `connection_draining_timeout` - (Optional) The time in seconds to allow for connections to drain. Default: `300`
+* `desync_mitigation_mode` - (Optional) Determines how the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 Exactly one of `availability_zones` or `subnets` must be specified: this

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -122,6 +122,7 @@ for load balancers of type `network` will force a recreation of the resource.
 * `enable_http2` - (Optional) Indicates whether HTTP/2 is enabled in `application` load balancers. Defaults to `true`.
 * `customer_owned_ipv4_pool` - (Optional) The ID of the customer owned ipv4 pool to use for this load balancer.
 * `ip_address_type` - (Optional) The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`
+* `desync_mitigation_mode` - (Optional) Determines how the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 Access Logs (`access_logs`) support the following:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14696

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

data-source/aws_elb: Add `desync_mitigation_mode` attribute
data-source/aws_lb: Add `desync_mitigation_mode` attribute
resource/aws_elb: Add `desync_mitigation_mode` attribute
resource/aws_lb: Add `desync_mitigation_mode` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
f-lb_desync_mitigation_mode-2 $ make testacc PKG=elbv2 TESTS=TestAccELBV2LoadBalancer_ ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 2 -run='TestAccELBV2LoadBalancer_' -timeout 180m
=== RUN   TestAccELBV2LoadBalancer_ALB_basic
=== PAUSE TestAccELBV2LoadBalancer_ALB_basic
=== RUN   TestAccELBV2LoadBalancer_NLB_basic
=== PAUSE TestAccELBV2LoadBalancer_NLB_basic
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== RUN   TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== RUN   TestAccELBV2LoadBalancer_ALB_outpost
=== PAUSE TestAccELBV2LoadBalancer_ALB_outpost
=== RUN   TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== PAUSE TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== RUN   TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== PAUSE TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== RUN   TestAccELBV2LoadBalancer_backwardsCompatibility
=== PAUSE TestAccELBV2LoadBalancer_backwardsCompatibility
=== RUN   TestAccELBV2LoadBalancer_generatedName
=== PAUSE TestAccELBV2LoadBalancer_generatedName
=== RUN   TestAccELBV2LoadBalancer_generatesNameForZeroValue
=== PAUSE TestAccELBV2LoadBalancer_generatesNameForZeroValue
=== RUN   TestAccELBV2LoadBalancer_namePrefix
=== PAUSE TestAccELBV2LoadBalancer_namePrefix
=== RUN   TestAccELBV2LoadBalancer_tags
=== PAUSE TestAccELBV2LoadBalancer_tags
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== RUN   TestAccELBV2LoadBalancer_updatedSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_updatedSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_updatedSubnets
=== PAUSE TestAccELBV2LoadBalancer_updatedSubnets
=== RUN   TestAccELBV2LoadBalancer_updatedIPAddressType
=== PAUSE TestAccELBV2LoadBalancer_updatedIPAddressType
=== RUN   TestAccELBV2LoadBalancer_noSecurityGroup
=== PAUSE TestAccELBV2LoadBalancer_noSecurityGroup
=== RUN   TestAccELBV2LoadBalancer_ALB_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_ALB_accessLogs
=== RUN   TestAccELBV2LoadBalancer_ALBAccessLogs_prefix
=== PAUSE TestAccELBV2LoadBalancer_ALBAccessLogs_prefix
=== RUN   TestAccELBV2LoadBalancer_NLB_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_NLB_accessLogs
=== RUN   TestAccELBV2LoadBalancer_NLBAccessLogs_prefix
=== PAUSE TestAccELBV2LoadBalancer_NLBAccessLogs_prefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change
=== RUN   TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== PAUSE TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== CONT  TestAccELBV2LoadBalancer_ALB_basic
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (182.23s)
=== CONT  TestAccELBV2LoadBalancer_updateDesyncMitigationMode
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (307.58s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change
--- PASS: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (309.43s)
=== CONT  TestAccELBV2LoadBalancer_NLBAccessLogs_prefix
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change (485.83s)
=== CONT  TestAccELBV2LoadBalancer_NLB_accessLogs
--- PASS: TestAccELBV2LoadBalancer_NLBAccessLogs_prefix (362.80s)
=== CONT  TestAccELBV2LoadBalancer_ALBAccessLogs_prefix
--- PASS: TestAccELBV2LoadBalancer_ALBAccessLogs_prefix (340.48s)
=== CONT  TestAccELBV2LoadBalancer_NLB_privateIPv4Address
--- PASS: TestAccELBV2LoadBalancer_NLB_accessLogs (418.68s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (241.60s)
=== CONT  TestAccELBV2LoadBalancer_tags
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (323.24s)
=== CONT  TestAccELBV2LoadBalancer_namePrefix
--- PASS: TestAccELBV2LoadBalancer_namePrefix (180.03s)
=== CONT  TestAccELBV2LoadBalancer_ALB_accessLogs
--- PASS: TestAccELBV2LoadBalancer_tags (324.26s)
=== CONT  TestAccELBV2LoadBalancer_noSecurityGroup
--- PASS: TestAccELBV2LoadBalancer_noSecurityGroup (236.71s)
=== CONT  TestAccELBV2LoadBalancer_updatedIPAddressType
--- PASS: TestAccELBV2LoadBalancer_ALB_accessLogs (398.41s)
=== CONT  TestAccELBV2LoadBalancer_updatedSubnets
--- PASS: TestAccELBV2LoadBalancer_updatedIPAddressType (301.62s)
=== CONT  TestAccELBV2LoadBalancer_updatedSecurityGroups
--- PASS: TestAccELBV2LoadBalancer_updatedSubnets (278.37s)
=== CONT  TestAccELBV2LoadBalancer_generatesNameForZeroValue
--- PASS: TestAccELBV2LoadBalancer_updatedSecurityGroups (237.65s)
=== CONT  TestAccELBV2LoadBalancer_generatedName
--- PASS: TestAccELBV2LoadBalancer_generatesNameForZeroValue (237.93s)
=== CONT  TestAccELBV2LoadBalancer_backwardsCompatibility
--- PASS: TestAccELBV2LoadBalancer_generatedName (177.05s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (186.58s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (355.87s)
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (296.55s)
=== CONT  TestAccELBV2LoadBalancer_networkLoadBalancerEIP
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (168.24s)
=== CONT  TestAccELBV2LoadBalancer_ALB_outpost
    acctest.go:1241: skipping acceptance testing: AccessDeniedException: User: arn:aws:iam::868807437771:user/cloud_user is not authorized to perform: outposts:ListOutposts on resource: arn:aws:outposts:us-east-1:868807437771:* with an explicit deny
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (0.40s)
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerType_gateway
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (223.42s)
=== CONT  TestAccELBV2LoadBalancer_ipv6SubnetMapping
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (113.67s)
=== CONT  TestAccELBV2LoadBalancer_NLB_basic
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (207.86s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (234.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      3588.660s

f-lb_desync_mitigation_mode-2 $ make testacc PKG=elbv2 TESTS=TestAccELBV2LoadBalancerDataSource_ ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 2 -run='TestAccELBV2LoadBalancerDataSource_' -timeout 180m
=== RUN   TestAccELBV2LoadBalancerDataSource_basic
=== PAUSE TestAccELBV2LoadBalancerDataSource_basic
=== RUN   TestAccELBV2LoadBalancerDataSource_outpost
=== PAUSE TestAccELBV2LoadBalancerDataSource_outpost
=== RUN   TestAccELBV2LoadBalancerDataSource_backwardsCompatibility
=== PAUSE TestAccELBV2LoadBalancerDataSource_backwardsCompatibility
=== CONT  TestAccELBV2LoadBalancerDataSource_basic
=== CONT  TestAccELBV2LoadBalancerDataSource_backwardsCompatibility
--- PASS: TestAccELBV2LoadBalancerDataSource_basic (240.44s)
=== CONT  TestAccELBV2LoadBalancerDataSource_outpost
--- PASS: TestAccELBV2LoadBalancerDataSource_backwardsCompatibility (240.44s)
=== CONT  TestAccELBV2LoadBalancerDataSource_outpost
    acctest.go:1250: skipping since no Outposts found
--- SKIP: TestAccELBV2LoadBalancerDataSource_outpost (0.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      242.559s

f-lb_desync_mitigation_mode-2 $ make testacc PKG=elb TESTS=TestAccELBLoadBalancer_ ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elb/... -v -count 1 -parallel 2 -run='TestAccELBLoadBalancer_' -timeout 180m
=== RUN   TestAccELBLoadBalancer_basic
=== PAUSE TestAccELBLoadBalancer_basic
=== RUN   TestAccELBLoadBalancer_disappears
=== PAUSE TestAccELBLoadBalancer_disappears
=== RUN   TestAccELBLoadBalancer_fullCharacterRange
=== PAUSE TestAccELBLoadBalancer_fullCharacterRange
=== RUN   TestAccELBLoadBalancer_AccessLogs_enabled
=== PAUSE TestAccELBLoadBalancer_AccessLogs_enabled
=== RUN   TestAccELBLoadBalancer_AccessLogs_disabled
=== PAUSE TestAccELBLoadBalancer_AccessLogs_disabled
=== RUN   TestAccELBLoadBalancer_namePrefix
=== PAUSE TestAccELBLoadBalancer_namePrefix
=== RUN   TestAccELBLoadBalancer_generatedName
=== PAUSE TestAccELBLoadBalancer_generatedName
=== RUN   TestAccELBLoadBalancer_generatesNameForZeroValue
=== PAUSE TestAccELBLoadBalancer_generatesNameForZeroValue
=== RUN   TestAccELBLoadBalancer_availabilityZones
=== PAUSE TestAccELBLoadBalancer_availabilityZones
=== RUN   TestAccELBLoadBalancer_tags
=== PAUSE TestAccELBLoadBalancer_tags
=== RUN   TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate
=== PAUSE TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate
=== RUN   TestAccELBLoadBalancer_Swap_subnets
=== PAUSE TestAccELBLoadBalancer_Swap_subnets
=== RUN   TestAccELBLoadBalancer_instanceAttaching
=== PAUSE TestAccELBLoadBalancer_instanceAttaching
=== RUN   TestAccELBLoadBalancer_listener
=== PAUSE TestAccELBLoadBalancer_listener
=== RUN   TestAccELBLoadBalancer_healthCheck
=== PAUSE TestAccELBLoadBalancer_healthCheck
=== RUN   TestAccELBLoadBalancer_timeout
=== PAUSE TestAccELBLoadBalancer_timeout
=== RUN   TestAccELBLoadBalancer_connectionDraining
=== PAUSE TestAccELBLoadBalancer_connectionDraining
=== RUN   TestAccELBLoadBalancer_securityGroups
=== PAUSE TestAccELBLoadBalancer_securityGroups
=== RUN   TestAccELBLoadBalancer_desyncMitigationMode
=== PAUSE TestAccELBLoadBalancer_desyncMitigationMode
=== RUN   TestAccELBLoadBalancer_desyncMitigationMode_update
=== PAUSE TestAccELBLoadBalancer_desyncMitigationMode_update
=== CONT  TestAccELBLoadBalancer_basic
=== CONT  TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate
--- PASS: TestAccELBLoadBalancer_basic (29.02s)
=== CONT  TestAccELBLoadBalancer_healthCheck
--- PASS: TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate (39.55s)
=== CONT  TestAccELBLoadBalancer_listener
--- PASS: TestAccELBLoadBalancer_healthCheck (42.91s)
=== CONT  TestAccELBLoadBalancer_instanceAttaching
--- PASS: TestAccELBLoadBalancer_listener (113.33s)
=== CONT  TestAccELBLoadBalancer_Swap_subnets
--- PASS: TestAccELBLoadBalancer_instanceAttaching (119.17s)
=== CONT  TestAccELBLoadBalancer_desyncMitigationMode
--- PASS: TestAccELBLoadBalancer_desyncMitigationMode (25.65s)
=== CONT  TestAccELBLoadBalancer_desyncMitigationMode_update
--- PASS: TestAccELBLoadBalancer_Swap_subnets (88.10s)
=== CONT  TestAccELBLoadBalancer_timeout
--- PASS: TestAccELBLoadBalancer_timeout (38.79s)
=== CONT  TestAccELBLoadBalancer_securityGroups
--- PASS: TestAccELBLoadBalancer_desyncMitigationMode_update (64.03s)
=== CONT  TestAccELBLoadBalancer_connectionDraining
--- PASS: TestAccELBLoadBalancer_securityGroups (46.21s)
=== CONT  TestAccELBLoadBalancer_namePrefix
--- PASS: TestAccELBLoadBalancer_connectionDraining (56.91s)
=== CONT  TestAccELBLoadBalancer_generatesNameForZeroValue
--- PASS: TestAccELBLoadBalancer_namePrefix (23.08s)
=== CONT  TestAccELBLoadBalancer_generatedName
--- PASS: TestAccELBLoadBalancer_generatesNameForZeroValue (24.05s)
=== CONT  TestAccELBLoadBalancer_tags
--- PASS: TestAccELBLoadBalancer_generatedName (22.82s)
=== CONT  TestAccELBLoadBalancer_AccessLogs_enabled
--- PASS: TestAccELBLoadBalancer_tags (61.75s)
=== CONT  TestAccELBLoadBalancer_availabilityZones
--- PASS: TestAccELBLoadBalancer_AccessLogs_enabled (74.87s)
=== CONT  TestAccELBLoadBalancer_fullCharacterRange
--- PASS: TestAccELBLoadBalancer_availabilityZones (41.03s)
=== CONT  TestAccELBLoadBalancer_disappears
--- PASS: TestAccELBLoadBalancer_fullCharacterRange (23.95s)
=== CONT  TestAccELBLoadBalancer_AccessLogs_disabled
--- PASS: TestAccELBLoadBalancer_disappears (19.89s)
--- PASS: TestAccELBLoadBalancer_AccessLogs_disabled (75.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elb        548.016s

f-lb_desync_mitigation_mode-2 $ make testacc PKG=elb TESTS=TestAccELBLoadBalancerDataSource_ ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elb/... -v -count 1 -parallel 2 -run='TestAccELBLoadBalancerDataSource_' -timeout 180m
=== RUN   TestAccELBLoadBalancerDataSource_basic
=== PAUSE TestAccELBLoadBalancerDataSource_basic
=== CONT  TestAccELBLoadBalancerDataSource_basic
--- PASS: TestAccELBLoadBalancerDataSource_basic (55.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elb        57.333s
```
