### PR TITLE
r/aws_customer_gateway: Add device_name attribute

### DIFF
--- a/aws/data_source_aws_customer_gateway.go
+++ b/aws/data_source_aws_customer_gateway.go
@@ -22,9 +22,12 @@ func dataSourceAwsCustomerGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"bgp_asn": {
 				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"device_name": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"ip_address": {
@@ -80,6 +83,7 @@ func dataSourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("ip_address", cg.IpAddress)
 	d.Set("type", cg.Type)
+	d.Set("device_name", cg.DeviceName)
 	d.SetId(aws.StringValue(cg.CustomerGatewayId))
 
 	if v := aws.StringValue(cg.BgpAsn); v != "" {

--- a/aws/data_source_aws_customer_gateway_test.go
+++ b/aws/data_source_aws_customer_gateway_test.go
@@ -57,6 +57,7 @@ func TestAccAWSCustomerGatewayDataSource_ID(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "ip_address", dataSourceName, "ip_address"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
 					resource.TestCheckResourceAttrPair(resourceName, "type", dataSourceName, "type"),
+					resource.TestCheckResourceAttrPair(resourceName, "device_name", dataSourceName, "device_name"),
 				),
 			},
 		},
@@ -88,9 +89,10 @@ data "aws_customer_gateway" "test" {
 func testAccAWSCustomerGatewayDataSourceConfigID(asn, hostOctet int) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
-  bgp_asn    = %d
-  ip_address = "50.0.0.%d"
-  type       = "ipsec.1"
+  bgp_asn     = %d
+  ip_address  = "50.0.0.%d"
+  device_name = "test"
+  type        = "ipsec.1"
 }
 
 data "aws_customer_gateway" "test" {

--- a/aws/resource_aws_customer_gateway.go
+++ b/aws/resource_aws_customer_gateway.go
@@ -33,6 +33,13 @@ func resourceAwsCustomerGateway() *schema.Resource {
 				ValidateFunc: validate4ByteAsn,
 			},
 
+			"device_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
+			},
+
 			"ip_address": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -53,6 +60,7 @@ func resourceAwsCustomerGateway() *schema.Resource {
 			},
 
 			"tags": tagsSchema(),
+
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -67,8 +75,9 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	ipAddress := d.Get("ip_address").(string)
 	vpnType := d.Get("type").(string)
 	bgpAsn := d.Get("bgp_asn").(string)
+	deviceName := d.Get("device_name").(string)
 
-	alreadyExists, err := resourceAwsCustomerGatewayExists(vpnType, ipAddress, bgpAsn, conn)
+	alreadyExists, err := resourceAwsCustomerGatewayExists(vpnType, ipAddress, bgpAsn, deviceName, conn)
 	if err != nil {
 		return err
 	}
@@ -87,6 +96,10 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 		PublicIp:          aws.String(ipAddress),
 		Type:              aws.String(vpnType),
 		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeCustomerGateway),
+	}
+
+	if len(deviceName) != 0 {
+		createOpts.DeviceName = aws.String(deviceName)
 	}
 
 	// Create the Customer Gateway.
@@ -113,6 +126,7 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	_, stateErr := stateConf.WaitForState()
+
 	if stateErr != nil {
 		return fmt.Errorf(
 			"Error waiting for customer gateway (%s) to become ready: %s", cgId, err)
@@ -150,24 +164,31 @@ func customerGatewayRefreshFunc(conn *ec2.EC2, gatewayId string) resource.StateR
 	}
 }
 
-func resourceAwsCustomerGatewayExists(vpnType, ipAddress, bgpAsn string, conn *ec2.EC2) (bool, error) {
-	ipAddressFilter := &ec2.Filter{
-		Name:   aws.String("ip-address"),
-		Values: []*string{aws.String(ipAddress)},
+func resourceAwsCustomerGatewayExists(vpnType, ipAddress, bgpAsn, deviceName string, conn *ec2.EC2) (bool, error) {
+	filters := []*ec2.Filter{
+		{
+			Name:   aws.String("ip-address"),
+			Values: []*string{aws.String(ipAddress)},
+		},
+		{
+			Name:   aws.String("type"),
+			Values: []*string{aws.String(vpnType)},
+		},
+		{
+			Name:   aws.String("bgp-asn"),
+			Values: []*string{aws.String(bgpAsn)},
+		},
 	}
 
-	typeFilter := &ec2.Filter{
-		Name:   aws.String("type"),
-		Values: []*string{aws.String(vpnType)},
-	}
-
-	bgpAsnFilter := &ec2.Filter{
-		Name:   aws.String("bgp-asn"),
-		Values: []*string{aws.String(bgpAsn)},
+	if len(deviceName) != 0 {
+		filters = append(filters, &ec2.Filter{
+			Name:   aws.String("device-name"),
+			Values: []*string{aws.String(deviceName)},
+		})
 	}
 
 	resp, err := conn.DescribeCustomerGateways(&ec2.DescribeCustomerGatewaysInput{
-		Filters: []*ec2.Filter{ipAddressFilter, typeFilter, bgpAsnFilter},
+		Filters: filters,
 	})
 	if err != nil {
 		return false, err
@@ -217,6 +238,7 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("bgp_asn", customerGateway.BgpAsn)
 	d.Set("ip_address", customerGateway.IpAddress)
 	d.Set("type", customerGateway.Type)
+	d.Set("device_name", customerGateway.DeviceName)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(customerGateway.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/website/docs/d/customer_gateway.html.markdown
+++ b/website/docs/d/customer_gateway.html.markdown
@@ -48,6 +48,7 @@ In addition to the arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the customer gateway.
 * `bgp_asn` - (Optional) The gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).
+* `device_name` - (Optional) A name for the customer gateway device.
 * `ip_address` - (Optional) The IP address of the gateway's Internet-routable external interface.
 * `tags` - Map of key-value pairs assigned to the gateway.
 * `type` - (Optional) The type of customer gateway. The only type AWS supports at this time is "ipsec.1".

--- a/website/docs/r/customer_gateway.html.markdown
+++ b/website/docs/r/customer_gateway.html.markdown
@@ -31,6 +31,7 @@ resource "aws_customer_gateway" "main" {
 The following arguments are supported:
 
 * `bgp_asn` - (Required) The gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).
+* `device_name` - (Optional) A name for the customer gateway device.
 * `ip_address` - (Required) The IP address of the gateway's Internet-routable external interface.
 * `type` - (Required) The type of customer gateway. The only type AWS
   supports at this time is "ipsec.1".
@@ -43,6 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The amazon-assigned ID of the gateway.
 * `arn` - The ARN of the customer gateway.
 * `bgp_asn` - The gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).
+* `device_name` - A name for the customer gateway device.
 * `ip_address` - The IP address of the gateway's Internet-routable external interface.
 * `type` - The type of customer gateway.
 * `tags` - Tags applied to the gateway.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14346

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/aws_customer_gateway: Add device_name attribute
d/aws_customer_gateway: Add device_name attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
# For r/aws_customer_gateway
$ make testacc TESTARGS='-run=TestAccAWSCustomerGateway_deviceName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCustomerGateway_deviceName -timeout 120m
=== RUN   TestAccAWSCustomerGateway_deviceName
=== PAUSE TestAccAWSCustomerGateway_deviceName
=== CONT  TestAccAWSCustomerGateway_deviceName
--- PASS: TestAccAWSCustomerGateway_deviceName (48.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.207s

# For d/aws_customer_gateway
$  make testacc TESTARGS='-run=TestAccAWSCustomerGatewayDataSource_ID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCustomerGatewayDataSource_ID -timeout 120m
=== RUN   TestAccAWSCustomerGatewayDataSource_ID
=== PAUSE TestAccAWSCustomerGatewayDataSource_ID
=== CONT  TestAccAWSCustomerGatewayDataSource_ID
--- PASS: TestAccAWSCustomerGatewayDataSource_ID (44.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.584s
...
```

Thank you for your review!