### PR TITLE
resource/aws_sns_topic_subscription: Add redrive_policy argument

### DIFF
--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -199,6 +199,60 @@ func TestAccAWSSNSTopicSubscription_deliveryPolicy(t *testing.T) {
 	})
 }
 
+func TestAccAWSSNSTopicSubscription_redrivePolicy(t *testing.T) {
+	attributes := make(map[string]string)
+	resourceName := "aws_sns_topic_subscription.test_subscription"
+	ri := acctest.RandInt()
+	dlqQueueName := fmt.Sprintf("queue-dlq-%d", ri)
+	updatedDlqQueueName := fmt.Sprintf("updated-queue-dlq-%d", ri)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSNSTopicSubscriptionConfig_redrivePolicy(
+					ri,
+					dlqQueueName,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckAWSSNSTopicSubscriptionRedrivePolicyAttribute(attributes, dlqQueueName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"confirmation_timeout_in_minutes",
+					"endpoint_auto_confirms",
+				},
+			},
+			// Test attribute update
+			{
+				Config: testAccAWSSNSTopicSubscriptionConfig_redrivePolicy(
+					ri,
+					updatedDlqQueueName,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckAWSSNSTopicSubscriptionRedrivePolicyAttribute(attributes, updatedDlqQueueName),
+				),
+			},
+			// Test attribute removal
+			{
+				Config: testAccAWSSNSTopicSubscriptionConfig(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicSubscriptionExists(resourceName, attributes),
+					resource.TestCheckResourceAttr(resourceName, "redrive_policy", ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSNSTopicSubscription_rawMessageDelivery(t *testing.T) {
 	attributes := make(map[string]string)
 	resourceName := "aws_sns_topic_subscription.test_subscription"
@@ -379,6 +433,37 @@ func testAccCheckAWSSNSTopicSubscriptionDeliveryPolicyAttribute(attributes map[s
 	}
 }
 
+func testAccCheckAWSSNSTopicSubscriptionRedrivePolicyAttribute(attributes map[string]string, expectedDlqName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		apiRedrivePolicyJSONString, ok := attributes["RedrivePolicy"]
+
+		if !ok {
+			return fmt.Errorf("RedrivePolicy attribute not found in attributes: %s", attributes)
+		}
+
+		var apiRedrivePolicy snsTopicSubscriptionRedrivePolicy
+		if err := json.Unmarshal([]byte(apiRedrivePolicyJSONString), &apiRedrivePolicy); err != nil {
+			return fmt.Errorf("unable to unmarshal SNS Topic Subscription redrive policy JSON (%s): %s", apiRedrivePolicyJSONString, err)
+		}
+
+		accountID := testAccProvider.Meta().(*AWSClient).accountid
+		expectedDlqArn := fmt.Sprintf(
+			"arn:aws:sqs:us-west-2:%s:%s",
+			accountID,
+			expectedDlqName,
+		)
+		expectedRedrivePolicy := &snsTopicSubscriptionRedrivePolicy{
+			DeadLetterTargetArn: expectedDlqArn,
+		}
+
+		if reflect.DeepEqual(apiRedrivePolicy, *expectedRedrivePolicy) {
+			return nil
+		}
+
+		return fmt.Errorf("SNS Topic Subscription redrive policy did not match:\n\nReceived\n\n%s\n\nExpected\n\n%s\n\n", apiRedrivePolicy, *expectedRedrivePolicy)
+	}
+}
+
 func TestObfuscateEndpointPassword(t *testing.T) {
 	checks := map[string]string{
 		"https://example.com/myroute":                   "https://example.com/myroute",
@@ -448,6 +533,29 @@ resource "aws_sns_topic_subscription" "test_subscription" {
   topic_arn       = "${aws_sns_topic.test_topic.arn}"
 }
 `, i, i, policy)
+}
+
+func testAccAWSSNSTopicSubscriptionConfig_redrivePolicy(i int, dlqName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test_topic" {
+  name = "terraform-test-topic-%d"
+}
+
+resource "aws_sqs_queue" "test_queue" {
+  name = "terraform-subscription-test-queue-%d"
+}
+
+resource "aws_sqs_queue" "test_queue_dlq" {
+  name = "%s"
+}
+
+resource "aws_sns_topic_subscription" "test_subscription" {
+  redrive_policy  = %s
+  endpoint        = "${aws_sqs_queue.test_queue.arn}"
+  protocol        = "sqs"
+  topic_arn       = "${aws_sns_topic.test_topic.arn}"
+}
+`, i, i, dlqName, strconv.Quote(`{"deadLetterTargetArn": "${aws_sqs_queue.test_queue_dlq.arn}"}`))
 }
 
 func testAccAWSSNSTopicSubscriptionConfig_rawMessageDelivery(i int, rawMessageDelivery bool) string {

--- a/website/docs/r/sns_topic_subscription.html.markdown
+++ b/website/docs/r/sns_topic_subscription.html.markdown
@@ -244,6 +244,7 @@ The following arguments are supported:
 * `raw_message_delivery` - (Optional) Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property) (default is false).
 * `filter_policy` - (Optional) JSON String with the filter policy that will be used in the subscription to filter messages seen by the target resource. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html) for more details.
 * `delivery_policy` - (Optional) JSON String with the delivery policy (retries, backoff, etc.) that will be used in the subscription - this only applies to HTTP/S subscriptions. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/DeliveryPolicies.html) for more details.
+* `redrive_policy` - (Optional) JSON String with the redrive policy that will be used in the subscription. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html#how-messages-moved-into-dead-letter-queue) for more details.
 
 ### Protocols supported
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10931

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sns_topic_subscription: add `redrive_policy` argument.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopicSubscription_redrivePolicy'

==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSNSTopicSubscription_redrivePolicy -timeout 120m

=== RUN   TestAccAWSSNSTopicSubscription_redrivePolicy

=== PAUSE TestAccAWSSNSTopicSubscription_redrivePolicy

=== CONT  TestAccAWSSNSTopicSubscription_redrivePolicy

--- PASS: TestAccAWSSNSTopicSubscription_redrivePolicy (182.14s)

PASS

ok      github.com/terraform-providers/terraform-provider-aws/aws       185.013s
```
