### PR TITLE
Added lifecycle ignore_changes stanza to example usage

### DIFF
--- a/website/docs/r/route53_vpc_association_authorization.html.markdown
+++ b/website/docs/r/route53_vpc_association_authorization.html.markdown
@@ -32,6 +32,13 @@ resource "aws_route53_zone" "example" {
   vpc {
     vpc_id = aws_vpc.example.id
   }
+  
+  # Prevent the deletion of associated VPCs after
+  # the initial creation. See documentation on 
+  # aws_route53_zone_association for details
+  lifecycle {
+    ignore_changes = [vpc]
+  }
 }
 
 resource "aws_vpc" "alternate" {


### PR DESCRIPTION
Related to https://github.com/terraform-providers/terraform-provider-aws/issues/14872

Docs for [route53_zone_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone_association) explain the required usage of `lifecycle{ ignore_changes = [vpc] }`.

The `lifecycle` example has been added here as well, along with a note to see the docs on `route53_zone_association` for additional information (so the exact same info isn't in the docs twice, which over time I'm sure would cause more confusion as things change)

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
None
```