### PR TITLE
S3 object version id is not correctly updated during diff

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -412,26 +412,8 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceAwsS3BucketObjectUpdate(d *schema.ResourceData, meta interface{}) error {
-	// Changes to any of these attributes requires creation of a new object version (if bucket is versioned):
-	for _, key := range []string{
-		"cache_control",
-		"content_base64",
-		"content_disposition",
-		"content_encoding",
-		"content_language",
-		"content_type",
-		"content",
-		"etag",
-		"kms_key_id",
-		"metadata",
-		"server_side_encryption",
-		"source",
-		"storage_class",
-		"website_redirect",
-	} {
-		if d.HasChange(key) {
-			return resourceAwsS3BucketObjectPut(d, meta)
-		}
+	if d.HasChanges("cache_control", "content_base64", "content_disposition", "content_encoding", "content_language", "content_type", "content", "etag", "kms_key_id", "metadata", "server_side_encryption", "source", "storage_class", "website_redirect") {
+		return resourceAwsS3BucketObjectPut(d, meta)
 	}
 
 	conn := meta.(*AWSClient).s3conn

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -535,8 +535,27 @@ func validateMetadataIsLowerCase(v interface{}, k string) (ws []string, errors [
 }
 
 func resourceAwsS3BucketObjectCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	if d.HasChange("etag") {
-		d.SetNewComputed("version_id")
+
+	for _, key := range []string{
+		"cache_control",
+		"content_base64",
+		"content_disposition",
+		"content_encoding",
+		"content_language",
+		"content_type",
+		"content",
+		"etag",
+		"kms_key_id",
+		"metadata",
+		"server_side_encryption",
+		"source",
+		"storage_class",
+		"website_redirect",
+	} {
+		if d.HasChange(key) {
+			return d.SetNewComputed("version_id")
+		}
+
 	}
 
 	return nil

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -196,6 +196,7 @@ func TestAccAWSS3BucketObject_etagEncryption(t *testing.T) {
 	resourceName := "aws_s3_bucket_object.object"
 	rInt := acctest.RandInt()
 	source := testAccAWSS3BucketObjectCreateTempFile(t, "{anything will do }")
+	defer os.Remove(source)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1258,8 +1259,8 @@ func testAccCheckAWSS3BucketObjectCheckTags(n string, expectedTags map[string]st
 func testAccAWSS3BucketObjectConfigBasic(bucket, key string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket_object" "object" {
-  bucket = %q
-  key    = %q
+  bucket = %[1]q
+  key    = %[2]q
 }
 `, bucket, key)
 }
@@ -1280,13 +1281,13 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfigSource(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
   bucket       = aws_s3_bucket.object_bucket.bucket
   key          = "test-key"
-  source       = %q
+  source       = %[2]q
   content_type = "binary/octet-stream"
 }
 `, randInt, source)
@@ -1295,13 +1296,13 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_withContentCharacteristics(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
   bucket           = aws_s3_bucket.object_bucket.bucket
   key              = "test-key"
-  source           = %q
+  source           = %[2]q
   content_language = "en"
   content_type     = "binary/octet-stream"
   website_redirect = "http://google.com"
@@ -1312,13 +1313,13 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfigContent(randInt int, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
   bucket  = aws_s3_bucket.object_bucket.bucket
   key     = "test-key"
-  content = %q
+  content = %[2]q
 }
 `, randInt, content)
 }
@@ -1342,13 +1343,13 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfigContentBase64(randInt int, contentBase64 string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
   bucket         = aws_s3_bucket.object_bucket.bucket
   key            = "test-key"
-  content_base64 = %q
+  content_base64 = %[2]q
 }
 `, randInt, contentBase64)
 }
@@ -1356,10 +1357,10 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_updateable(randInt int, bucketVersioning bool, source string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket_3" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
-    enabled = %t
+    enabled = %[2]t
   }
 }
 
@@ -1401,13 +1402,13 @@ func testAccAWSS3BucketObjectConfig_withKMSId(randInt int, source string) string
 resource "aws_kms_key" "kms_key_1" {}
 
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
   bucket     = aws_s3_bucket.object_bucket.bucket
   key        = "test-key"
-  source     = %q
+  source     = %[2]q
   kms_key_id = aws_kms_key.kms_key_1.arn
 }
 `, randInt, source)
@@ -1416,13 +1417,13 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_withSSE(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
   bucket                 = aws_s3_bucket.object_bucket.bucket
   key                    = "test-key"
-  source                 = %q
+  source                 = %[2]q
   server_side_encryption = "AES256"
 }
 `, randInt, source)
@@ -1431,7 +1432,7 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_acl(randInt int, content, acl string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -1441,8 +1442,8 @@ resource "aws_s3_bucket" "object_bucket" {
 resource "aws_s3_bucket_object" "object" {
   bucket  = aws_s3_bucket.object_bucket.bucket
   key     = "test-key"
-  content = %q
-  acl     = %q
+  content = %[2]q
+  acl     = %[3]q
 }
 `, randInt, content, acl)
 }
@@ -1450,14 +1451,14 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_storageClass(randInt int, storage_class string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
   bucket        = aws_s3_bucket.object_bucket.bucket
   key           = "test-key"
   content       = "some_bucket_content"
-  storage_class = %q
+  storage_class = %[2]q
 }
 `, randInt, storage_class)
 }
@@ -1465,7 +1466,7 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_withTags(randInt int, key, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -1474,8 +1475,8 @@ resource "aws_s3_bucket" "object_bucket" {
 
 resource "aws_s3_bucket_object" "object" {
   bucket  = aws_s3_bucket.object_bucket.bucket
-  key     = %q
-  content = %q
+  key     = %[2]q
+  content = %[3]q
 
   tags = {
     Key1 = "AAA"
@@ -1489,7 +1490,7 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_withUpdatedTags(randInt int, key, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -1498,8 +1499,8 @@ resource "aws_s3_bucket" "object_bucket" {
 
 resource "aws_s3_bucket_object" "object" {
   bucket  = aws_s3_bucket.object_bucket.bucket
-  key     = %q
-  content = %q
+  key     = %[2]q
+  content = %[3]q
 
   tags = {
     Key2 = "BBB"
@@ -1514,7 +1515,7 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_withNoTags(randInt int, key, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -1523,8 +1524,8 @@ resource "aws_s3_bucket" "object_bucket" {
 
 resource "aws_s3_bucket_object" "object" {
   bucket  = aws_s3_bucket.object_bucket.bucket
-  key     = %q
-  content = %q
+  key     = %[2]q
+  content = %[3]q
 }
 `, randInt, key, content)
 }
@@ -1532,7 +1533,7 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_withMetadata(randInt int, metadataKey1, metadataValue1, metadataKey2, metadataValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
@@ -1550,7 +1551,7 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_noObjectLockLegalHold(randInt int, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -1564,7 +1565,7 @@ resource "aws_s3_bucket" "object_bucket" {
 resource "aws_s3_bucket_object" "object" {
   bucket        = aws_s3_bucket.object_bucket.bucket
   key           = "test-key"
-  content       = %q
+  content       = %[2]q
   force_destroy = true
 }
 `, randInt, content)
@@ -1573,7 +1574,7 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_withObjectLockLegalHold(randInt int, content, legalHoldStatus string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -1587,8 +1588,8 @@ resource "aws_s3_bucket" "object_bucket" {
 resource "aws_s3_bucket_object" "object" {
   bucket                        = aws_s3_bucket.object_bucket.bucket
   key                           = "test-key"
-  content                       = %q
-  object_lock_legal_hold_status = %q
+  content                       = %[2]q
+  object_lock_legal_hold_status = %[3]q
   force_destroy                 = true
 }
 `, randInt, content, legalHoldStatus)
@@ -1597,7 +1598,7 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_noObjectLockRetention(randInt int, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -1611,7 +1612,7 @@ resource "aws_s3_bucket" "object_bucket" {
 resource "aws_s3_bucket_object" "object" {
   bucket        = aws_s3_bucket.object_bucket.bucket
   key           = "test-key"
-  content       = %q
+  content       = %[2]q
   force_destroy = true
 }
 `, randInt, content)
@@ -1620,7 +1621,7 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_withObjectLockRetention(randInt int, content, retainUntilDate string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -1634,10 +1635,10 @@ resource "aws_s3_bucket" "object_bucket" {
 resource "aws_s3_bucket_object" "object" {
   bucket                        = aws_s3_bucket.object_bucket.bucket
   key                           = "test-key"
-  content                       = %q
+  content                       = %[2]q
   force_destroy                 = true
   object_lock_mode              = "GOVERNANCE"
-  object_lock_retain_until_date = %q
+  object_lock_retain_until_date = %[3]q
 }
 `, randInt, content, retainUntilDate)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The configuration keys listed always result in changes to `version_id`. We make terraform aware of this. Currently terraform bails out during apply and refers to the AWS provider to fix this.
This also fixes unrelated bugs in the tests

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14899

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_s3_bucket_object: version_id is correctly updated when certain configuration keys are changed
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSS3BucketObject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketObject -timeout 120m
=== RUN   TestAccAWSS3BucketObject_noNameNoKey
=== PAUSE TestAccAWSS3BucketObject_noNameNoKey
=== RUN   TestAccAWSS3BucketObject_empty
=== PAUSE TestAccAWSS3BucketObject_empty
=== RUN   TestAccAWSS3BucketObject_source
=== PAUSE TestAccAWSS3BucketObject_source
=== RUN   TestAccAWSS3BucketObject_content
=== PAUSE TestAccAWSS3BucketObject_content
=== RUN   TestAccAWSS3BucketObject_etagEncryption
=== PAUSE TestAccAWSS3BucketObject_etagEncryption
=== RUN   TestAccAWSS3BucketObject_contentBase64
=== PAUSE TestAccAWSS3BucketObject_contentBase64
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
=== PAUSE TestAccAWSS3BucketObject_withContentCharacteristics
=== RUN   TestAccAWSS3BucketObject_NonVersioned
=== PAUSE TestAccAWSS3BucketObject_NonVersioned
=== RUN   TestAccAWSS3BucketObject_updates
=== PAUSE TestAccAWSS3BucketObject_updates
=== RUN   TestAccAWSS3BucketObject_updateSameFile
=== PAUSE TestAccAWSS3BucketObject_updateSameFile
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioning
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== RUN   TestAccAWSS3BucketObject_kms
=== PAUSE TestAccAWSS3BucketObject_kms
=== RUN   TestAccAWSS3BucketObject_sse
=== PAUSE TestAccAWSS3BucketObject_sse
=== RUN   TestAccAWSS3BucketObject_acl
=== PAUSE TestAccAWSS3BucketObject_acl
=== RUN   TestAccAWSS3BucketObject_metadata
=== PAUSE TestAccAWSS3BucketObject_metadata
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== RUN   TestAccAWSS3BucketObject_tags
=== PAUSE TestAccAWSS3BucketObject_tags
=== RUN   TestAccAWSS3BucketObject_tagsLeadingSlash
=== PAUSE TestAccAWSS3BucketObject_tagsLeadingSlash
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== CONT  TestAccAWSS3BucketObject_noNameNoKey
=== CONT  TestAccAWSS3BucketObject_kms
=== CONT  TestAccAWSS3BucketObject_storageClass
=== CONT  TestAccAWSS3BucketObject_withContentCharacteristics
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioning
=== CONT  TestAccAWSS3BucketObject_updateSameFile
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== CONT  TestAccAWSS3BucketObject_updates
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== CONT  TestAccAWSS3BucketObject_NonVersioned
=== CONT  TestAccAWSS3BucketObject_acl
=== CONT  TestAccAWSS3BucketObject_metadata
=== CONT  TestAccAWSS3BucketObject_content
=== CONT  TestAccAWSS3BucketObject_tags
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== CONT  TestAccAWSS3BucketObject_contentBase64
=== CONT  TestAccAWSS3BucketObject_etagEncryption
=== CONT  TestAccAWSS3BucketObject_tagsLeadingSlash
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (5.69s)
=== CONT  TestAccAWSS3BucketObject_sse
=== CONT  TestAccAWSS3BucketObject_updateSameFile
    resource_aws_s3_bucket_object_test.go:350: [INFO] Got non-empty plan, as expected
    resource_aws_s3_bucket_object_test.go:350: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSS3BucketObject_NonVersioned (48.64s)
=== CONT  TestAccAWSS3BucketObject_empty
--- PASS: TestAccAWSS3BucketObject_content (50.02s)
=== CONT  TestAccAWSS3BucketObject_source
--- PASS: TestAccAWSS3BucketObject_contentBase64 (50.38s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (50.43s)
--- PASS: TestAccAWSS3BucketObject_etagEncryption (50.82s)
--- PASS: TestAccAWSS3BucketObject_kms (53.53s)
--- PASS: TestAccAWSS3BucketObject_sse (49.89s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (96.28s)
--- PASS: TestAccAWSS3BucketObject_empty (48.69s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (97.77s)
--- PASS: TestAccAWSS3BucketObject_updates (98.41s)
--- PASS: TestAccAWSS3BucketObject_source (49.26s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (99.45s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (107.91s)
--- PASS: TestAccAWSS3BucketObject_metadata (138.22s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (142.66s)
--- PASS: TestAccAWSS3BucketObject_acl (143.81s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (144.76s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (185.26s)
--- PASS: TestAccAWSS3BucketObject_tags (186.29s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (186.29s)
--- PASS: TestAccAWSS3BucketObject_storageClass (229.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	229.446
```