### PR TITLE
[WIP] Allow aws_organizations_organization data source from delegated admin accounts

### DIFF
--- a/website/docs/d/organizations_organization.html.markdown
+++ b/website/docs/d/organizations_organization.html.markdown
@@ -82,9 +82,9 @@ In addition to all arguments above, the following attributes are exported:
 * `master_account_email` - The email address that is associated with the AWS account that is designated as the master account for the organization.
 * `master_account_id` - The unique identifier (ID) of the master account of an organization.
 
-### Master Account Attributes Reference
+### Master and Delegated Administrator Account Attributes Reference
 
-If the account is the master account for the organization, the following attributes are also exported:
+If the account is the master account for the organization or a member account that is a delegated administrator for an AWS service, the following attributes are also exported:
 
 * `accounts` - List of organization accounts including the master account. For a list excluding the master account, see the `non_master_accounts` attribute. All elements have these attributes:
     * `arn` - ARN of the account


### PR DESCRIPTION
AWS has added a feature to AWS Organizations to delegated administration
of some services across the organization to other accounts than the
master account.  To make it possible to do so they've allowed accounts
that have any such delegation to use read APIs against the organization.
For example you can call ListAccounts to retrieve the list of member
accounts in such a delgated admin account.

Prior to this commit, Terraform checked that the account was the master
account and skipped setting a number of attributes for the
aws_organizations_organization data source.  This makes it hard to do
things like automatically write a policy for an S3 bucket that these
services will write to that includes an account number in the path.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_organizations_organization: Can be used against delegated admin accounts
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=testAccDataSourceAwsOrganizationsOrganization_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=testAccDataSourceAwsOrganizationsOrganization_basic -timeout 120m
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.458s [no tests to run]```
