### PR TITLE
Validate that security group names aren't prefixed with sg-

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -47,7 +48,10 @@ func resourceAwsSecurityGroup() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validation.StringLenBetween(0, 255),
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringDoesNotMatch(regexp.MustCompile(`^sg-`), "cannot begin with sg-"),
+				),
 			},
 
 			"name_prefix": {


### PR DESCRIPTION
The [API docs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html) have this to say:

> Constraints: Up to 255 characters in length. Cannot start with sg-.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Didn't see an issue for it but it was mentioned in https://stackoverflow.com/q/63724161/2291321 and thought it could with the extra validation adding.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_security_group: Provide additional plan-time validation for `name`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-parallel=5 -run=TestAccAWSSecurityGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -parallel=5 -run=TestAccAWSSecurityGroup_ -timeout 120m
=== RUN   TestAccAWSSecurityGroup_allowAll
=== PAUSE TestAccAWSSecurityGroup_allowAll
=== RUN   TestAccAWSSecurityGroup_sourceSecurityGroup
=== PAUSE TestAccAWSSecurityGroup_sourceSecurityGroup
=== RUN   TestAccAWSSecurityGroup_IPRangeAndSecurityGroupWithSameRules
=== PAUSE TestAccAWSSecurityGroup_IPRangeAndSecurityGroupWithSameRules
=== RUN   TestAccAWSSecurityGroup_IPRangesWithSameRules
=== PAUSE TestAccAWSSecurityGroup_IPRangesWithSameRules
=== RUN   TestAccAWSSecurityGroup_basic
=== PAUSE TestAccAWSSecurityGroup_basic
=== RUN   TestAccAWSSecurityGroup_egressConfigMode
=== PAUSE TestAccAWSSecurityGroup_egressConfigMode
=== RUN   TestAccAWSSecurityGroup_ingressConfigMode
=== PAUSE TestAccAWSSecurityGroup_ingressConfigMode
=== RUN   TestAccAWSSecurityGroup_ruleGathering
=== PAUSE TestAccAWSSecurityGroup_ruleGathering
=== RUN   TestAccAWSSecurityGroup_forceRevokeRulesTrue
=== PAUSE TestAccAWSSecurityGroup_forceRevokeRulesTrue
=== RUN   TestAccAWSSecurityGroup_forceRevokeRulesFalse
=== PAUSE TestAccAWSSecurityGroup_forceRevokeRulesFalse
=== RUN   TestAccAWSSecurityGroup_ipv6
=== PAUSE TestAccAWSSecurityGroup_ipv6
=== RUN   TestAccAWSSecurityGroup_namePrefix
=== PAUSE TestAccAWSSecurityGroup_namePrefix
=== RUN   TestAccAWSSecurityGroup_self
=== PAUSE TestAccAWSSecurityGroup_self
=== RUN   TestAccAWSSecurityGroup_vpc
=== PAUSE TestAccAWSSecurityGroup_vpc
=== RUN   TestAccAWSSecurityGroup_vpcNegOneIngress
=== PAUSE TestAccAWSSecurityGroup_vpcNegOneIngress
=== RUN   TestAccAWSSecurityGroup_vpcProtoNumIngress
=== PAUSE TestAccAWSSecurityGroup_vpcProtoNumIngress
=== RUN   TestAccAWSSecurityGroup_multiIngress
=== PAUSE TestAccAWSSecurityGroup_multiIngress
=== RUN   TestAccAWSSecurityGroup_change
=== PAUSE TestAccAWSSecurityGroup_change
=== RUN   TestAccAWSSecurityGroup_ruleDescription
=== PAUSE TestAccAWSSecurityGroup_ruleDescription
=== RUN   TestAccAWSSecurityGroup_generatedName
=== PAUSE TestAccAWSSecurityGroup_generatedName
=== RUN   TestAccAWSSecurityGroup_defaultEgressVPC
=== PAUSE TestAccAWSSecurityGroup_defaultEgressVPC
=== RUN   TestAccAWSSecurityGroup_defaultEgressClassic
=== PAUSE TestAccAWSSecurityGroup_defaultEgressClassic
=== RUN   TestAccAWSSecurityGroup_drift
=== PAUSE TestAccAWSSecurityGroup_drift
=== RUN   TestAccAWSSecurityGroup_driftComplex
=== PAUSE TestAccAWSSecurityGroup_driftComplex
=== RUN   TestAccAWSSecurityGroup_invalidCIDRBlock
=== PAUSE TestAccAWSSecurityGroup_invalidCIDRBlock
=== RUN   TestAccAWSSecurityGroup_tags
=== PAUSE TestAccAWSSecurityGroup_tags
=== RUN   TestAccAWSSecurityGroup_CIDRandGroups
=== PAUSE TestAccAWSSecurityGroup_CIDRandGroups
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGsVPC
=== PAUSE TestAccAWSSecurityGroup_ingressWithCidrAndSGsVPC
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGsClassic
=== PAUSE TestAccAWSSecurityGroup_ingressWithCidrAndSGsClassic
=== RUN   TestAccAWSSecurityGroup_egressWithPrefixList
=== PAUSE TestAccAWSSecurityGroup_egressWithPrefixList
=== RUN   TestAccAWSSecurityGroup_ingressWithPrefixList
=== PAUSE TestAccAWSSecurityGroup_ingressWithPrefixList
=== RUN   TestAccAWSSecurityGroup_ipv4andipv6Egress
=== PAUSE TestAccAWSSecurityGroup_ipv4andipv6Egress
=== RUN   TestAccAWSSecurityGroup_failWithDiffMismatch
=== PAUSE TestAccAWSSecurityGroup_failWithDiffMismatch
=== RUN   TestAccAWSSecurityGroup_ruleLimitExceededAppend
=== PAUSE TestAccAWSSecurityGroup_ruleLimitExceededAppend
=== RUN   TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend
=== PAUSE TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend
=== RUN   TestAccAWSSecurityGroup_ruleLimitExceededPrepend
=== PAUSE TestAccAWSSecurityGroup_ruleLimitExceededPrepend
=== RUN   TestAccAWSSecurityGroup_ruleLimitExceededAllNew
=== PAUSE TestAccAWSSecurityGroup_ruleLimitExceededAllNew
=== RUN   TestAccAWSSecurityGroup_rulesDropOnError
=== PAUSE TestAccAWSSecurityGroup_rulesDropOnError
=== CONT  TestAccAWSSecurityGroup_allowAll
=== CONT  TestAccAWSSecurityGroup_defaultEgressVPC
=== CONT  TestAccAWSSecurityGroup_vpcProtoNumIngress
=== CONT  TestAccAWSSecurityGroup_ipv6
=== CONT  TestAccAWSSecurityGroup_vpcNegOneIngress
2020/09/03 15:33:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/09/03 15:33:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSSecurityGroup_allowAll (53.68s)
=== CONT  TestAccAWSSecurityGroup_vpc
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (55.40s)
=== CONT  TestAccAWSSecurityGroup_self
--- PASS: TestAccAWSSecurityGroup_defaultEgressVPC (56.06s)
=== CONT  TestAccAWSSecurityGroup_namePrefix
--- PASS: TestAccAWSSecurityGroup_vpcProtoNumIngress (56.40s)
=== CONT  TestAccAWSSecurityGroup_ruleDescription
--- PASS: TestAccAWSSecurityGroup_ipv6 (56.73s)
=== CONT  TestAccAWSSecurityGroup_ingressWithPrefixList
--- PASS: TestAccAWSSecurityGroup_namePrefix (46.04s)
=== CONT  TestAccAWSSecurityGroup_generatedName
--- PASS: TestAccAWSSecurityGroup_vpc (55.92s)
=== CONT  TestAccAWSSecurityGroup_egressWithPrefixList
2020/09/03 15:34:34 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSSecurityGroup_self (57.06s)
=== CONT  TestAccAWSSecurityGroup_tags
--- PASS: TestAccAWSSecurityGroup_ingressWithPrefixList (71.28s)
=== CONT  TestAccAWSSecurityGroup_ingressWithCidrAndSGsClassic
    provider_test.go:492: This test can only run in EC2 Classic, platforms available in us-west-2: ["VPC"]
--- SKIP: TestAccAWSSecurityGroup_ingressWithCidrAndSGsClassic (1.62s)
=== CONT  TestAccAWSSecurityGroup_ingressWithCidrAndSGsVPC
--- PASS: TestAccAWSSecurityGroup_generatedName (44.86s)
=== CONT  TestAccAWSSecurityGroup_CIDRandGroups
--- PASS: TestAccAWSSecurityGroup_egressWithPrefixList (69.48s)
=== CONT  TestAccAWSSecurityGroup_invalidCIDRBlock
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (3.38s)
=== CONT  TestAccAWSSecurityGroup_egressConfigMode
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGsVPC (54.38s)
=== CONT  TestAccAWSSecurityGroup_forceRevokeRulesFalse
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (53.60s)
=== CONT  TestAccAWSSecurityGroup_forceRevokeRulesTrue
--- PASS: TestAccAWSSecurityGroup_ruleDescription (156.30s)
=== CONT  TestAccAWSSecurityGroup_ruleGathering
--- PASS: TestAccAWSSecurityGroup_tags (110.07s)
=== CONT  TestAccAWSSecurityGroup_driftComplex
--- PASS: TestAccAWSSecurityGroup_driftComplex (54.98s)
=== CONT  TestAccAWSSecurityGroup_drift
--- PASS: TestAccAWSSecurityGroup_ruleGathering (72.14s)
=== CONT  TestAccAWSSecurityGroup_defaultEgressClassic
=== CONT  TestAccAWSSecurityGroup_drift
    resource_aws_security_group_test.go:1550: Step 1/2 error: terraform failed: exit status 1
        
        stderr:
        
        Error: Error creating Security Group: VPCIdNotSpecified: No default VPC for this user
        	status code: 400, request id: 16e4970a-e223-45c3-8df7-26e5c6247c23
        
        
--- FAIL: TestAccAWSSecurityGroup_drift (7.44s)
=== CONT  TestAccAWSSecurityGroup_ingressConfigMode
=== CONT  TestAccAWSSecurityGroup_defaultEgressClassic
    provider_test.go:492: This test can only run in EC2 Classic, platforms available in us-west-2: ["VPC"]
--- SKIP: TestAccAWSSecurityGroup_defaultEgressClassic (1.60s)
=== CONT  TestAccAWSSecurityGroup_basic
--- PASS: TestAccAWSSecurityGroup_egressConfigMode (110.16s)
=== CONT  TestAccAWSSecurityGroup_IPRangesWithSameRules
--- PASS: TestAccAWSSecurityGroup_basic (54.60s)
=== CONT  TestAccAWSSecurityGroup_IPRangeAndSecurityGroupWithSameRules
--- PASS: TestAccAWSSecurityGroup_IPRangesWithSameRules (53.32s)
=== CONT  TestAccAWSSecurityGroup_sourceSecurityGroup
--- PASS: TestAccAWSSecurityGroup_ingressConfigMode (109.10s)
=== CONT  TestAccAWSSecurityGroup_change
--- PASS: TestAccAWSSecurityGroup_sourceSecurityGroup (49.72s)
=== CONT  TestAccAWSSecurityGroup_multiIngress
--- PASS: TestAccAWSSecurityGroup_IPRangeAndSecurityGroupWithSameRules (58.95s)
=== CONT  TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend
--- PASS: TestAccAWSSecurityGroup_multiIngress (65.56s)
=== CONT  TestAccAWSSecurityGroup_rulesDropOnError
=== CONT  TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend
    resource_aws_security_group_test.go:2484: Step 2/3, expected an error but got none
--- FAIL: TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend (75.62s)
=== CONT  TestAccAWSSecurityGroup_failWithDiffMismatch
--- PASS: TestAccAWSSecurityGroup_change (107.16s)
=== CONT  TestAccAWSSecurityGroup_ruleLimitExceededAppend
--- PASS: TestAccAWSSecurityGroup_failWithDiffMismatch (50.29s)
=== CONT  TestAccAWSSecurityGroup_ruleLimitExceededPrepend
--- PASS: TestAccAWSSecurityGroup_rulesDropOnError (94.51s)
=== CONT  TestAccAWSSecurityGroup_ipv4andipv6Egress
=== CONT  TestAccAWSSecurityGroup_ruleLimitExceededAppend
    resource_aws_security_group_test.go:2443: Step 2/3, expected an error but got none
--- FAIL: TestAccAWSSecurityGroup_ruleLimitExceededAppend (80.60s)
=== CONT  TestAccAWSSecurityGroup_ruleLimitExceededAllNew
=== CONT  TestAccAWSSecurityGroup_ruleLimitExceededPrepend
    resource_aws_security_group_test.go:2549: Step 2/3, expected an error but got none
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (46.29s)
--- FAIL: TestAccAWSSecurityGroup_ruleLimitExceededPrepend (78.31s)
=== CONT  TestAccAWSSecurityGroup_ruleLimitExceededAllNew
    resource_aws_security_group_test.go:2590: Step 2/3, expected an error but got none
--- FAIL: TestAccAWSSecurityGroup_ruleLimitExceededAllNew (78.85s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesFalse (723.13s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesTrue (793.31s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	993.885s
FAIL
GNUmakefile:27: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```
Acceptance test errors look linked to https://github.com/terraform-providers/terraform-provider-aws/pull/14209 (limit is now 60 by default) and not having a default VPC in the account and region it was ran in. Wouldn't except acceptance test errors from a validation change anyway unless this validation change was a new, breaking thing.