### PR TITLE
r/cloudtrail_trail - refactor tests + validations + disappears test

### DIFF
--- a/.changelog/15016.txt
+++ b/.changelog/15016.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_cloudtrail_trail: Add plan time validations for `name`, `cloud_watch_logs_role_arn`, `cloud_watch_logs_group_arn`
+```
+
+```release-note:enhancement
+resource/aws_cloudtrail_trail: Add `sns_topic_arn` attribute
+```

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -52,6 +52,7 @@ func resourceAwsCloudTrail() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateArn,
+				RequiredWith: []string{"cloud_watch_logs_role_arn"},
 			},
 			"include_global_service_events": {
 				Type:     schema.TypeBool,

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -268,7 +268,7 @@ func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if trail == nil {
-		log.Printf("[WARN] CloudTrail (%s) not found", d.Id())
+		log.Printf("[WARN] CloudTrail (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -209,7 +209,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 	var trail cloudtrail.Trail
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -258,7 +258,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 	var trail cloudtrail.Trail
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -305,7 +305,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 func testAccAWSCloudTrail_is_organization(t *testing.T) {
 	var trail cloudtrail.Trail
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
@@ -343,7 +343,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 func testAccAWSCloudTrail_logValidation(t *testing.T) {
 	var trail cloudtrail.Trail
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1076,6 +1076,8 @@ resource "aws_cloudtrail" "foobar" {
   is_multi_region_trail         = true
   include_global_service_events = true
   enable_log_file_validation    = true
+
+  depends_on = [aws_s3_bucket_policy.test]
 }
 
 data "aws_partition" "current" {}
@@ -1120,6 +1122,8 @@ resource "aws_cloudtrail" "foobar" {
   name                          = "tf-acc-trail-log-validation-test-%[1]d"
   s3_bucket_name                = aws_s3_bucket.foo.id
   include_global_service_events = true
+
+  depends_on = [aws_s3_bucket_policy.test]
 }
 
 data "aws_partition" "current" {}

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -198,11 +198,10 @@ For **insight_selector** the following attributes are supported.
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The Amazon Resource Name of the trail.
 * `id` - The name of the trail.
 * `home_region` - The region in which the trail was created.
-* `arn` - The Amazon Resource Name of the trail.
-
-
+* `sns_topic_arn` - The ARN of the Amazon SNS topic that CloudTrail uses to send notifications when log files are delivered. 
 ## Import
 
 Cloudtrails can be imported using the `name`, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cloudtrail: added plan time validations to `cloud_watch_logs_role_arn`, `cloud_watch_logs_group_arn`, `sns_topic_name`, `event_selector.data_resource.values`.

resource_aws_cloudtrail: added `sns_topic_arn` attribute.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudTrail/Trail'
--- PASS: TestAccAWSCloudTrail_serial/Trail/basic (195.49s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/isMultiRegion (298.09s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/logValidation (194.58s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/insightSelector (119.23s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/disappears (91.56s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/cloudwatch (217.20s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/enableLogging (281.62s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/kmsKey (110.75s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/tags (277.05s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/includeGlobalServiceEvents (117.14s)
--- PASS: TestAccAWSCloudTrail_serial/Trail/eventSelector (396.01s)
```
