### PR TITLE
r/aws_lambda_function: Update 'version' and 'qualified_arn' on publish

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -271,7 +271,7 @@ func resourceAwsLambdaFunction() *schema.Resource {
 }
 
 func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	if needsFunctionCodeUpdate(d) {
+	if needsFunctionCodeUpdate(d) || d.HasChange("publish") {
 		d.SetNewComputed("last_modified")
 		publish := d.Get("publish").(bool)
 		if publish {
@@ -924,7 +924,7 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	publish := d.Get("publish").(bool)
-	if publish && (codeUpdate || configUpdate) {
+	if publish && (codeUpdate || configUpdate || d.HasChange("publish")) {
 		versionReq := &lambda.PublishVersionInput{
 			FunctionName: aws.String(d.Id()),
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8081

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lambda_function: Update 'version' and 'qualified_arn' on publish of existing function
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction_enablePublish'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunction_enablePublish -timeout 120m
=== RUN   TestAccAWSLambdaFunction_enablePublish
=== PAUSE TestAccAWSLambdaFunction_enablePublish
=== CONT  TestAccAWSLambdaFunction_enablePublish
--- PASS: TestAccAWSLambdaFunction_enablePublish (75.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       75.229s
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction_disablePublish'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunction_disablePublish -timeout 120m
=== RUN   TestAccAWSLambdaFunction_disablePublish
=== PAUSE TestAccAWSLambdaFunction_disablePublish
=== CONT  TestAccAWSLambdaFunction_disablePublish
--- PASS: TestAccAWSLambdaFunction_disablePublish (74.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       74.195s
```
