### PR TITLE
New resource: aws_cloudwatch_composite_alarm

### DIFF
--- a/aws/internal/service/cloudwatch/finder/finder.go
+++ b/aws/internal/service/cloudwatch/finder/finder.go
@@ -1,17 +1,19 @@
 package finder
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 )
 
-func CompositeAlarmByName(conn *cloudwatch.CloudWatch, name string) (*cloudwatch.CompositeAlarm, error) {
+func CompositeAlarmByName(ctx context.Context, conn *cloudwatch.CloudWatch, name string) (*cloudwatch.CompositeAlarm, error) {
 	input := cloudwatch.DescribeAlarmsInput{
 		AlarmNames: aws.StringSlice([]string{name}),
 		AlarmTypes: aws.StringSlice([]string{cloudwatch.AlarmTypeCompositeAlarm}),
 	}
 
-	output, err := conn.DescribeAlarms(&input)
+	output, err := conn.DescribeAlarmsWithContext(ctx, &input)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/internal/service/cloudwatch/finder/finder.go
+++ b/aws/internal/service/cloudwatch/finder/finder.go
@@ -1,0 +1,24 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+)
+
+func CompositeAlarmByName(conn *cloudwatch.CloudWatch, name string) (*cloudwatch.CompositeAlarm, error) {
+	input := cloudwatch.DescribeAlarmsInput{
+		AlarmNames: aws.StringSlice([]string{name}),
+		AlarmTypes: aws.StringSlice([]string{cloudwatch.AlarmTypeCompositeAlarm}),
+	}
+
+	output, err := conn.DescribeAlarms(&input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.CompositeAlarms) != 1 {
+		return nil, nil
+	}
+
+	return output.CompositeAlarms[0], nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -513,6 +513,7 @@ func Provider() *schema.Provider {
 			"aws_cloudhsm_v2_cluster":                                 resourceAwsCloudHsmV2Cluster(),
 			"aws_cloudhsm_v2_hsm":                                     resourceAwsCloudHsmV2Hsm(),
 			"aws_cognito_resource_server":                             resourceAwsCognitoResourceServer(),
+			"aws_cloudwatch_composite_alarm":                          resourceAwsCloudWatchCompositeAlarm(),
 			"aws_cloudwatch_metric_alarm":                             resourceAwsCloudWatchMetricAlarm(),
 			"aws_cloudwatch_dashboard":                                resourceAwsCloudWatchDashboard(),
 			"aws_codedeploy_app":                                      resourceAwsCodeDeployApp(),

--- a/aws/resource_aws_cloudwatch_composite_alarm.go
+++ b/aws/resource_aws_cloudwatch_composite_alarm.go
@@ -1,0 +1,269 @@
+package aws
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsCloudWatchCompositeAlarm() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAwsCloudWatchCompositeAlarmCreate,
+		ReadContext:   resourceAwsCloudWatchCompositeAlarmRead,
+		UpdateContext: resourceAwsCloudWatchCompositeAlarmUpdate,
+		DeleteContext: resourceAwsCloudWatchCompositeAlarmDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"actions_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"alarm_actions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      schema.HashString,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateArn,
+				},
+			},
+			"alarm_description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
+			"alarm_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(0, 255),
+			},
+			"alarm_rule": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 10240),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"insufficient_data_actions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      schema.HashString,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateArn,
+				},
+			},
+			"ok_actions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      schema.HashString,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateArn,
+				},
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsCloudWatchCompositeAlarmCreate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	conn := meta.(*AWSClient).cloudwatchconn
+	name := d.Get("alarm_name").(string)
+
+	input := expandAwsCloudWatchPutCompositeAlarmInput(d)
+	_, err := conn.PutCompositeAlarmWithContext(ctx, &input)
+	if err != nil {
+		return diag.Errorf("create composite alarm: %s", err)
+	}
+
+	log.Printf("[INFO] Created Composite Alarm %s.", name)
+	d.SetId(name)
+
+	return resourceAwsCloudWatchCompositeAlarmRead(ctx, d, meta)
+}
+
+func resourceAwsCloudWatchCompositeAlarmRead(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	conn := meta.(*AWSClient).cloudwatchconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+	name := d.Id()
+
+	alarm, ok, err := getAwsCloudWatchCompositeAlarm(ctx, conn, name)
+	switch {
+	case err != nil:
+		return diag.FromErr(err)
+	case !ok:
+		log.Printf("[WARN] Composite alarm %s has disappeared!", name)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("actions_enabled", alarm.ActionsEnabled)
+
+	if err := d.Set("alarm_actions", flattenStringSet(alarm.AlarmActions)); err != nil {
+		return diag.Errorf("set alarm_actions: %s", err)
+	}
+
+	d.Set("alarm_description", alarm.AlarmDescription)
+	d.Set("alarm_name", alarm.AlarmName)
+	d.Set("alarm_rule", alarm.AlarmRule)
+	d.Set("arn", alarm.AlarmArn)
+
+	if err := d.Set("insufficient_data_actions", flattenStringSet(alarm.InsufficientDataActions)); err != nil {
+		return diag.Errorf("set insufficient_data_actions: %s", err)
+	}
+
+	if err := d.Set("ok_actions", flattenStringSet(alarm.OKActions)); err != nil {
+		return diag.Errorf("set ok_actions: %s", err)
+	}
+
+	tags, err := keyvaluetags.CloudwatchListTags(conn, aws.StringValue(alarm.AlarmArn))
+	if err != nil {
+		return diag.Errorf("list tags of alarm: %s", err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.Errorf("set tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsCloudWatchCompositeAlarmUpdate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	conn := meta.(*AWSClient).cloudwatchconn
+	name := d.Id()
+
+	log.Printf("[INFO] Updating Composite Alarm %s...", name)
+
+	input := expandAwsCloudWatchPutCompositeAlarmInput(d)
+	_, err := conn.PutCompositeAlarmWithContext(ctx, &input)
+	if err != nil {
+		return diag.Errorf("create composite alarm: %s", err)
+	}
+
+	arn := d.Get("arn").(string)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.CloudwatchUpdateTags(conn, arn, o, n); err != nil {
+			return diag.Errorf("update tags: %s", err)
+		}
+	}
+
+	return resourceAwsCloudWatchCompositeAlarmRead(ctx, d, meta)
+}
+
+func resourceAwsCloudWatchCompositeAlarmDelete(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	conn := meta.(*AWSClient).cloudwatchconn
+	name := d.Id()
+
+	log.Printf("[INFO] Deleting Composite Alarm %s...", name)
+
+	input := cloudwatch.DeleteAlarmsInput{
+		AlarmNames: aws.StringSlice([]string{name}),
+	}
+
+	_, err := conn.DeleteAlarmsWithContext(ctx, &input)
+	switch {
+	case isAWSErr(err, "ResourceNotFound", ""):
+		log.Printf("[WARN] Composite Alarm %s has disappeared!", name)
+		return nil
+	case err != nil:
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func expandAwsCloudWatchPutCompositeAlarmInput(d *schema.ResourceData) cloudwatch.PutCompositeAlarmInput {
+	out := cloudwatch.PutCompositeAlarmInput{}
+
+	if v, ok := d.GetOk("actions_enabled"); ok {
+		out.ActionsEnabled = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("alarm_actions"); ok {
+		out.AlarmActions = expandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("alarm_description"); ok {
+		out.AlarmDescription = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("alarm_name"); ok {
+		out.AlarmName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("alarm_rule"); ok {
+		out.AlarmRule = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("insufficient_data_actions"); ok {
+		out.InsufficientDataActions = expandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("ok_actions"); ok {
+		out.OKActions = expandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		out.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().CloudwatchTags()
+	}
+
+	return out
+}
+
+func getAwsCloudWatchCompositeAlarm(
+	ctx context.Context,
+	conn *cloudwatch.CloudWatch,
+	name string,
+) (*cloudwatch.CompositeAlarm, bool, error) {
+	input := cloudwatch.DescribeAlarmsInput{
+		AlarmNames: aws.StringSlice([]string{name}),
+		AlarmTypes: aws.StringSlice([]string{cloudwatch.AlarmTypeCompositeAlarm}),
+	}
+
+	output, err := conn.DescribeAlarmsWithContext(ctx, &input)
+	switch {
+	case err != nil:
+		return nil, false, err
+	case len(output.CompositeAlarms) != 1:
+		return nil, false, nil
+	}
+
+	return output.CompositeAlarms[0], true, nil
+}

--- a/aws/resource_aws_cloudwatch_composite_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_composite_alarm_test.go
@@ -1,0 +1,256 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func testAccCheckAwsCloudWatchCompositeAlarmExists(n string, alarm *cloudwatch.CompositeAlarm) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
+		params := cloudwatch.DescribeAlarmsInput{
+			AlarmNames: []*string{aws.String(rs.Primary.ID)},
+			AlarmTypes: []*string{aws.String(cloudwatch.AlarmTypeCompositeAlarm)},
+		}
+		resp, err := conn.DescribeAlarms(&params)
+		if err != nil {
+			return err
+		}
+		if len(resp.CompositeAlarms) == 0 {
+			return fmt.Errorf("Alarm not found")
+		}
+		*alarm = *resp.CompositeAlarms[0]
+
+		return nil
+	}
+}
+
+func testAccCheckAwsCloudWatchCompositeAlarmDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudwatch_composite_alarm" {
+			continue
+		}
+
+		params := cloudwatch.DescribeAlarmsInput{
+			AlarmNames: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		resp, err := conn.DescribeAlarms(&params)
+
+		if err == nil {
+			if len(resp.MetricAlarms) != 0 &&
+				*resp.MetricAlarms[0].AlarmName == rs.Primary.ID {
+				return fmt.Errorf("Alarm Still Exists: %s", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccAwsCloudWatchCompositeAlarm_basic(t *testing.T) {
+	alarm := cloudwatch.CompositeAlarm{}
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_create(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 1"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_name", "tf-test-composite-"+suffix),
+					resource.TestCheckResourceAttr(resourceName, "alarm_rule", fmt.Sprintf("ALARM(tf-test-metric-0-%[1]s) OR ALARM(tf-test-metric-1-%[1]s)", suffix)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudwatch", regexp.MustCompile(`alarm:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_update(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 2"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_name", "tf-test-composite-"+suffix),
+					resource.TestCheckResourceAttr(resourceName, "alarm_rule", fmt.Sprintf("ALARM(tf-test-metric-0-%[1]s)", suffix)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudwatch", regexp.MustCompile(`alarm:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_create(suffix string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "test" {
+  count = 2
+
+  alarm_name          = "tf-test-metric-${count.index}-%[1]s"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 120
+  statistic           = "Average"
+  threshold           = 80
+
+  dimensions = {
+    InstanceId = "i-abc123"
+  }
+}
+
+resource "aws_sns_topic" "test" {
+  count = 1
+  name  = "tf-test-alarms-${count.index}-%[1]s"
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_actions             = aws_sns_topic.test.*.arn
+  alarm_description         = "Test 1"
+  alarm_name                = "tf-test-composite-%[1]s"
+  alarm_rule                = join(" OR ", formatlist("ALARM(%%s)", aws_cloudwatch_metric_alarm.test.*.alarm_name))
+  insufficient_data_actions = aws_sns_topic.test.*.arn
+  ok_actions                = aws_sns_topic.test.*.arn
+
+  tags = {
+    Foo = "Bar"
+  }
+}
+`, suffix)
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_update(suffix string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "test" {
+  count = 2
+
+  alarm_name          = "tf-test-metric-${count.index}-%[1]s"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 120
+  statistic           = "Average"
+  threshold           = 80
+
+  dimensions = {
+    InstanceId = "i-abc123"
+  }
+}
+
+resource "aws_sns_topic" "test" {
+  count = 2
+  name  = "tf-test-alarms-${count.index}-%[1]s"
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_actions             = aws_sns_topic.test.*.arn
+  alarm_description         = "Test 2"
+  alarm_name                = "tf-test-composite-%[1]s"
+  alarm_rule                = "ALARM(${aws_cloudwatch_metric_alarm.test[0].alarm_name})"
+  insufficient_data_actions = aws_sns_topic.test.*.arn
+  ok_actions                = aws_sns_topic.test.*.arn
+
+  tags = {
+    Foo = "Bar"
+	Bax = "Baf"
+  }
+}
+`, suffix)
+}
+
+func TestAccAwsCloudWatchCompositeAlarm_disappears(t *testing.T) {
+	alarm := cloudwatch.CompositeAlarm{}
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	checkDisappears := func(*terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
+		alarmNames := []string{
+			"tf-test-composite-" + suffix,
+			"tf-test-metric-" + suffix,
+		}
+
+		for _, name := range alarmNames {
+			input := cloudwatch.DeleteAlarmsInput{
+				AlarmNames: []*string{&name},
+			}
+
+			_, err := conn.DeleteAlarms(&input)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_disappears(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName, &alarm),
+					checkDisappears,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_disappears(suffix string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "test" {
+  alarm_name          = "tf-test-metric-%[1]s"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 120
+  statistic           = "Average"
+  threshold           = 80
+
+  dimensions = {
+    InstanceId = "i-abc123"
+  }
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_name = "tf-test-composite-%[1]s"
+  alarm_rule = "ALARM(${aws_cloudwatch_metric_alarm.test.alarm_name})"
+}
+`, suffix)
+}

--- a/aws/resource_aws_cloudwatch_composite_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_composite_alarm_test.go
@@ -1,40 +1,86 @@
 package aws
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudwatch/finder"
 )
 
-func testAccCheckAwsCloudWatchCompositeAlarmDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
+func init() {
+	resource.AddTestSweepers("aws_cloudwatch_composite_alarm", &resource.Sweeper{
+		Name: "aws_cloudwatch_composite_alarm",
+		F:    testSweepCloudWatchCompositeAlarms,
+	})
+}
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudwatch_composite_alarm" {
-			continue
-		}
-
-		params := cloudwatch.DescribeAlarmsInput{
-			AlarmNames: []*string{aws.String(rs.Primary.ID)},
-		}
-
-		resp, err := conn.DescribeAlarms(&params)
-
-		if err == nil {
-			if len(resp.MetricAlarms) != 0 &&
-				aws.StringValue(resp.MetricAlarms[0].AlarmName) == rs.Primary.ID {
-				return fmt.Errorf("Alarm Still Exists: %s", rs.Primary.ID)
-			}
-		}
+func testSweepCloudWatchCompositeAlarms(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
 	}
 
-	return nil
+	conn := client.(*AWSClient).cloudwatchconn
+	ctx := context.Background()
+
+	input := &cloudwatch.DescribeAlarmsInput{
+		AlarmTypes: aws.StringSlice([]string{cloudwatch.AlarmTypeCompositeAlarm}),
+	}
+
+	var sweeperErrs *multierror.Error
+
+	err = conn.DescribeAlarmsPagesWithContext(ctx, input, func(page *cloudwatch.DescribeAlarmsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, compositeAlarm := range page.CompositeAlarms {
+			if compositeAlarm == nil {
+				continue
+			}
+
+			name := aws.StringValue(compositeAlarm.AlarmName)
+
+			log.Printf("[INFO] Deleting CloudWatch Composite Alarm: %s", name)
+
+			r := resourceAwsCloudWatchCompositeAlarm()
+			d := r.Data(nil)
+			d.SetId(name)
+
+			diags := r.DeleteContext(ctx, d, client)
+
+			for i := range diags {
+				if diags[i].Severity == diag.Error {
+					log.Printf("[ERROR] %s", diags[i].Summary)
+					sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf(diags[i].Summary))
+					continue
+				}
+			}
+		}
+
+		return !isLast
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping CloudWatch Composite Alarms sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving CloudWatch Composite Alarms: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
 }
 
 func TestAccAwsCloudWatchCompositeAlarm_basic(t *testing.T) {
@@ -50,14 +96,15 @@ func TestAccAwsCloudWatchCompositeAlarm_basic(t *testing.T) {
 				Config: testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 1"),
+					resource.TestCheckResourceAttr(resourceName, "actions_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_description", ""),
 					resource.TestCheckResourceAttr(resourceName, "alarm_name", "tf-test-composite-"+suffix),
 					resource.TestCheckResourceAttr(resourceName, "alarm_rule", fmt.Sprintf("ALARM(tf-test-metric-0-%[1]s) OR ALARM(tf-test-metric-1-%[1]s)", suffix)),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudwatch", regexp.MustCompile(`alarm:.+`)),
-					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -67,45 +114,6 @@ func TestAccAwsCloudWatchCompositeAlarm_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix string) string {
-	return fmt.Sprintf(`
-resource "aws_cloudwatch_metric_alarm" "test" {
-  count = 2
-
-  alarm_name          = "tf-test-metric-${count.index}-%[1]s"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = 2
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/EC2"
-  period              = 120
-  statistic           = "Average"
-  threshold           = 80
-
-  dimensions = {
-    InstanceId = "i-abc123"
-  }
-}
-
-resource "aws_sns_topic" "test" {
-  count = 1
-  name  = "tf-test-alarms-${count.index}-%[1]s"
-}
-
-resource "aws_cloudwatch_composite_alarm" "test" {
-  alarm_actions             = aws_sns_topic.test.*.arn
-  alarm_description         = "Test 1"
-  alarm_name                = "tf-test-composite-%[1]s"
-  alarm_rule                = join(" OR ", formatlist("ALARM(%%s)", aws_cloudwatch_metric_alarm.test.*.alarm_name))
-  insufficient_data_actions = aws_sns_topic.test.*.arn
-  ok_actions                = aws_sns_topic.test.*.arn
-
-  tags = {
-    Foo = "Bar"
-  }
-}
-`, suffix)
 }
 
 func TestAccAwsCloudWatchCompositeAlarm_disappears(t *testing.T) {
@@ -118,7 +126,7 @@ func TestAccAwsCloudWatchCompositeAlarm_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsCloudWatchCompositeAlarmConfig_disappears(suffix),
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchCompositeAlarm(), resourceName),
@@ -129,31 +137,7 @@ func TestAccAwsCloudWatchCompositeAlarm_disappears(t *testing.T) {
 	})
 }
 
-func testAccAwsCloudWatchCompositeAlarmConfig_disappears(suffix string) string {
-	return fmt.Sprintf(`
-resource "aws_cloudwatch_metric_alarm" "test" {
-  alarm_name          = "tf-test-metric-%[1]s"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = 2
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/EC2"
-  period              = 120
-  statistic           = "Average"
-  threshold           = 80
-
-  dimensions = {
-    InstanceId = "i-abc123"
-  }
-}
-
-resource "aws_cloudwatch_composite_alarm" "test" {
-  alarm_name = "tf-test-composite-%[1]s"
-  alarm_rule = "ALARM(${aws_cloudwatch_metric_alarm.test.alarm_name})"
-}
-`, suffix)
-}
-
-func TestAccAwsCloudWatchCompositeAlarm_update(t *testing.T) {
+func TestAccAwsCloudWatchCompositeAlarm_actionsEnabled(t *testing.T) {
 	suffix := acctest.RandString(8)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
 
@@ -163,17 +147,10 @@ func TestAccAwsCloudWatchCompositeAlarm_update(t *testing.T) {
 		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsCloudWatchCompositeAlarmConfig_update_before(suffix),
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_actionsEnabled(false, suffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 1"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_name", "tf-test-composite-"+suffix),
-					resource.TestCheckResourceAttr(resourceName, "alarm_rule", fmt.Sprintf("ALARM(tf-test-metric-0-%[1]s) OR ALARM(tf-test-metric-1-%[1]s)", suffix)),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudwatch", regexp.MustCompile(`alarm:.+`)),
-					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions_enabled", "false"),
 				),
 			},
 			{
@@ -182,29 +159,340 @@ func TestAccAwsCloudWatchCompositeAlarm_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAwsCloudWatchCompositeAlarmConfig_update_after(suffix),
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_actionsEnabled(true, suffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 2"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_name", "tf-test-composite-"+suffix),
-					resource.TestCheckResourceAttr(resourceName, "alarm_rule", fmt.Sprintf("ALARM(tf-test-metric-0-%[1]s)", suffix)),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudwatch", regexp.MustCompile(`alarm:.+`)),
-					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions_enabled", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func testAccAwsCloudWatchCompositeAlarmConfig_update_before(suffix string) string {
+func TestAccAwsCloudWatchCompositeAlarm_alarmActions(t *testing.T) {
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_alarmActions(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_updateAlarmActions(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsCloudWatchCompositeAlarm_description(t *testing.T) {
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_description("Test 1", suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_description("Test Updated", suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test Updated"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsCloudWatchCompositeAlarm_insufficientDataActions(t *testing.T) {
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_insufficientDataActions(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_updateInsufficientDataActions(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsCloudWatchCompositeAlarm_okActions(t *testing.T) {
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_okActions(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_updateOkActions(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsCloudWatchCompositeAlarm_allActions(t *testing.T) {
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_allActions(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsCloudWatchCompositeAlarm_updateAlarmRule(t *testing.T) {
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_updateAlarmRule(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_rule", fmt.Sprintf("ALARM(tf-test-metric-0-%[1]s)", suffix)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsCloudWatchCompositeAlarmDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudwatch_composite_alarm" {
+			continue
+		}
+
+		alarm, err := finder.CompositeAlarmByName(context.Background(), conn, rs.Primary.ID)
+
+		if tfawserr.ErrCodeEquals(err, cloudwatch.ErrCodeResourceNotFound) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error reading CloudWatch composite alarm (%s): %w", rs.Primary.ID, err)
+		}
+
+		if alarm != nil {
+			return fmt.Errorf("CloudWatch composite alarm (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource %s has not set its id", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
+
+		alarm, err := finder.CompositeAlarmByName(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("error reading CloudWatch composite alarm (%s): %w", rs.Primary.ID, err)
+		}
+
+		if alarm == nil {
+			return fmt.Errorf("CloudWatch composite alarm (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_metric_alarm" "test" {
   count = 2
 
-  alarm_name          = "tf-test-metric-${count.index}-%[1]s"
+  alarm_name          = "tf-test-metric-${count.index}-%s"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
   metric_name         = "CPUUtilization"
@@ -215,87 +503,174 @@ resource "aws_cloudwatch_metric_alarm" "test" {
 
   dimensions = {
     InstanceId = "i-abc123"
-  }
-}
-
-resource "aws_sns_topic" "test" {
-  count = 1
-  name  = "tf-test-alarms-${count.index}-%[1]s"
-}
-
-resource "aws_cloudwatch_composite_alarm" "test" {
-  alarm_actions             = aws_sns_topic.test.*.arn
-  alarm_description         = "Test 1"
-  alarm_name                = "tf-test-composite-%[1]s"
-  alarm_rule                = join(" OR ", formatlist("ALARM(%%s)", aws_cloudwatch_metric_alarm.test.*.alarm_name))
-  insufficient_data_actions = aws_sns_topic.test.*.arn
-  ok_actions                = aws_sns_topic.test.*.arn
-
-  tags = {
-    Foo = "Bar"
   }
 }
 `, suffix)
 }
 
-func testAccAwsCloudWatchCompositeAlarmConfig_update_after(suffix string) string {
-	return fmt.Sprintf(`
-resource "aws_cloudwatch_metric_alarm" "test" {
-  count = 2
-
-  alarm_name          = "tf-test-metric-${count.index}-%[1]s"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = 2
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/EC2"
-  period              = 120
-  statistic           = "Average"
-  threshold           = 80
-
-  dimensions = {
-    InstanceId = "i-abc123"
-  }
+func testAccAwsCloudWatchCompositeAlarmConfig_actionsEnabled(enabled bool, suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_cloudwatch_composite_alarm" "test" {
+  actions_enabled = %t
+  alarm_name      = "tf-test-composite-%s"
+  alarm_rule      = join(" OR ", formatlist("ALARM(%%s)", aws_cloudwatch_metric_alarm.test.*.alarm_name))
+}
+`, enabled, suffix))
 }
 
+func testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_name = "tf-test-composite-%[1]s"
+  alarm_rule = join(" OR ", formatlist("ALARM(%%s)", aws_cloudwatch_metric_alarm.test.*.alarm_name))
+}
+`, suffix))
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_description(description, suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_description = %q
+  alarm_name        = "tf-test-composite-%s"
+  alarm_rule        = join(" OR ", formatlist("ALARM(%%s)", aws_cloudwatch_metric_alarm.test.*.alarm_name))
+}
+`, description, suffix))
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_alarmActions(suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   count = 2
   name  = "tf-test-alarms-${count.index}-%[1]s"
 }
 
 resource "aws_cloudwatch_composite_alarm" "test" {
-  alarm_actions             = aws_sns_topic.test.*.arn
-  alarm_description         = "Test 2"
+  alarm_actions = aws_sns_topic.test.*.arn
+  alarm_name    = "tf-test-composite-%[1]s"
+  alarm_rule    = "ALARM(${aws_cloudwatch_metric_alarm.test[0].alarm_name})"
+}
+`, suffix))
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_updateAlarmActions(suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  count = 2
+  name  = "tf-test-alarms-${count.index}-%[1]s"
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_actions = [aws_sns_topic.test[0].arn]
+  alarm_name    = "tf-test-composite-%[1]s"
+  alarm_rule    = "ALARM(${aws_cloudwatch_metric_alarm.test[0].alarm_name})"
+}
+`, suffix))
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_updateAlarmRule(suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_name = "tf-test-composite-%[1]s"
+  alarm_rule = "ALARM(${aws_cloudwatch_metric_alarm.test[0].alarm_name})"
+}
+`, suffix))
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_insufficientDataActions(suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  count = 2
+  name  = "tf-test-alarms-${count.index}-%[1]s"
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
   alarm_name                = "tf-test-composite-%[1]s"
   alarm_rule                = "ALARM(${aws_cloudwatch_metric_alarm.test[0].alarm_name})"
   insufficient_data_actions = aws_sns_topic.test.*.arn
-  ok_actions                = aws_sns_topic.test.*.arn
-
-  tags = {
-    Foo = "Bar"
-    Bax = "Baf"
-  }
 }
-`, suffix)
+`, suffix))
 }
 
-func testAccCheckAwsCloudWatchCompositeAlarmExists(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-		conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
-		params := cloudwatch.DescribeAlarmsInput{
-			AlarmNames: []*string{aws.String(rs.Primary.ID)},
-			AlarmTypes: []*string{aws.String(cloudwatch.AlarmTypeCompositeAlarm)},
-		}
-		resp, err := conn.DescribeAlarms(&params)
-		if err != nil {
-			return err
-		}
-		if len(resp.CompositeAlarms) == 0 {
-			return fmt.Errorf("Alarm not found")
-		}
-		return nil
-	}
+func testAccAwsCloudWatchCompositeAlarmConfig_updateInsufficientDataActions(suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  count = 2
+  name  = "tf-test-alarms-${count.index}-%[1]s"
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_name                = "tf-test-composite-%[1]s"
+  alarm_rule                = "ALARM(${aws_cloudwatch_metric_alarm.test[0].alarm_name})"
+  insufficient_data_actions = [aws_sns_topic.test[0].arn]
+}
+`, suffix))
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_okActions(suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  count = 2
+  name  = "tf-test-alarms-${count.index}-%[1]s"
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_name = "tf-test-composite-%[1]s"
+  alarm_rule = "ALARM(${aws_cloudwatch_metric_alarm.test[0].alarm_name})"
+  ok_actions = aws_sns_topic.test.*.arn
+}
+`, suffix))
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_updateOkActions(suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  count = 2
+  name  = "tf-test-alarms-${count.index}-%[1]s"
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_name = "tf-test-composite-%[1]s"
+  alarm_rule = "ALARM(${aws_cloudwatch_metric_alarm.test[0].alarm_name})"
+  ok_actions = [aws_sns_topic.test[0].arn]
+}
+`, suffix))
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_allActions(suffix string) string {
+	return composeConfig(
+		testAccAwsCloudWatchCompositeAlarmBaseConfig(suffix),
+		fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  count = 3
+  name  = "tf-test-alarms-${count.index}-%[1]s"
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_actions             = [aws_sns_topic.test[0].arn]
+  alarm_name                = "tf-test-composite-%[1]s"
+  alarm_rule                = "ALARM(${aws_cloudwatch_metric_alarm.test[0].alarm_name})"
+  insufficient_data_actions = [aws_sns_topic.test[1].arn]
+  ok_actions                = [aws_sns_topic.test[2].arn]
+}
+`, suffix))
 }

--- a/aws/resource_aws_cloudwatch_composite_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_composite_alarm_test.go
@@ -12,31 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func testAccCheckAwsCloudWatchCompositeAlarmExists(n string, alarm *cloudwatch.CompositeAlarm) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
-		params := cloudwatch.DescribeAlarmsInput{
-			AlarmNames: []*string{aws.String(rs.Primary.ID)},
-			AlarmTypes: []*string{aws.String(cloudwatch.AlarmTypeCompositeAlarm)},
-		}
-		resp, err := conn.DescribeAlarms(&params)
-		if err != nil {
-			return err
-		}
-		if len(resp.CompositeAlarms) == 0 {
-			return fmt.Errorf("Alarm not found")
-		}
-		*alarm = *resp.CompositeAlarms[0]
-
-		return nil
-	}
-}
-
 func testAccCheckAwsCloudWatchCompositeAlarmDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
 
@@ -53,7 +28,7 @@ func testAccCheckAwsCloudWatchCompositeAlarmDestroy(s *terraform.State) error {
 
 		if err == nil {
 			if len(resp.MetricAlarms) != 0 &&
-				*resp.MetricAlarms[0].AlarmName == rs.Primary.ID {
+				aws.StringValue(resp.MetricAlarms[0].AlarmName) == rs.Primary.ID {
 				return fmt.Errorf("Alarm Still Exists: %s", rs.Primary.ID)
 			}
 		}
@@ -63,7 +38,6 @@ func testAccCheckAwsCloudWatchCompositeAlarmDestroy(s *terraform.State) error {
 }
 
 func TestAccAwsCloudWatchCompositeAlarm_basic(t *testing.T) {
-	alarm := cloudwatch.CompositeAlarm{}
 	suffix := acctest.RandString(8)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
 
@@ -73,9 +47,9 @@ func TestAccAwsCloudWatchCompositeAlarm_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsCloudWatchCompositeAlarmConfig_create(suffix),
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName, &alarm),
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 1"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_name", "tf-test-composite-"+suffix),
@@ -91,25 +65,11 @@ func TestAccAwsCloudWatchCompositeAlarm_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config: testAccAwsCloudWatchCompositeAlarmConfig_update(suffix),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName, &alarm),
-					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 2"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_name", "tf-test-composite-"+suffix),
-					resource.TestCheckResourceAttr(resourceName, "alarm_rule", fmt.Sprintf("ALARM(tf-test-metric-0-%[1]s)", suffix)),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudwatch", regexp.MustCompile(`alarm:.+`)),
-					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-				),
-			},
 		},
 	})
 }
 
-func testAccAwsCloudWatchCompositeAlarmConfig_create(suffix string) string {
+func testAccAwsCloudWatchCompositeAlarmConfig_basic(suffix string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_metric_alarm" "test" {
   count = 2
@@ -148,7 +108,137 @@ resource "aws_cloudwatch_composite_alarm" "test" {
 `, suffix)
 }
 
-func testAccAwsCloudWatchCompositeAlarmConfig_update(suffix string) string {
+func TestAccAwsCloudWatchCompositeAlarm_disappears(t *testing.T) {
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_disappears(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchCompositeAlarm(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_disappears(suffix string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "test" {
+  alarm_name          = "tf-test-metric-%[1]s"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 120
+  statistic           = "Average"
+  threshold           = 80
+
+  dimensions = {
+    InstanceId = "i-abc123"
+  }
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_name = "tf-test-composite-%[1]s"
+  alarm_rule = "ALARM(${aws_cloudwatch_metric_alarm.test.alarm_name})"
+}
+`, suffix)
+}
+
+func TestAccAwsCloudWatchCompositeAlarm_update(t *testing.T) {
+	suffix := acctest.RandString(8)
+	resourceName := "aws_cloudwatch_composite_alarm.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_update_before(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 1"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_name", "tf-test-composite-"+suffix),
+					resource.TestCheckResourceAttr(resourceName, "alarm_rule", fmt.Sprintf("ALARM(tf-test-metric-0-%[1]s) OR ALARM(tf-test-metric-1-%[1]s)", suffix)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudwatch", regexp.MustCompile(`alarm:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsCloudWatchCompositeAlarmConfig_update_after(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_description", "Test 2"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_name", "tf-test-composite-"+suffix),
+					resource.TestCheckResourceAttr(resourceName, "alarm_rule", fmt.Sprintf("ALARM(tf-test-metric-0-%[1]s)", suffix)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudwatch", regexp.MustCompile(`alarm:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "insufficient_data_actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ok_actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_update_before(suffix string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "test" {
+  count = 2
+
+  alarm_name          = "tf-test-metric-${count.index}-%[1]s"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 120
+  statistic           = "Average"
+  threshold           = 80
+
+  dimensions = {
+    InstanceId = "i-abc123"
+  }
+}
+
+resource "aws_sns_topic" "test" {
+  count = 1
+  name  = "tf-test-alarms-${count.index}-%[1]s"
+}
+
+resource "aws_cloudwatch_composite_alarm" "test" {
+  alarm_actions             = aws_sns_topic.test.*.arn
+  alarm_description         = "Test 1"
+  alarm_name                = "tf-test-composite-%[1]s"
+  alarm_rule                = join(" OR ", formatlist("ALARM(%%s)", aws_cloudwatch_metric_alarm.test.*.alarm_name))
+  insufficient_data_actions = aws_sns_topic.test.*.arn
+  ok_actions                = aws_sns_topic.test.*.arn
+
+  tags = {
+    Foo = "Bar"
+  }
+}
+`, suffix)
+}
+
+func testAccAwsCloudWatchCompositeAlarmConfig_update_after(suffix string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_metric_alarm" "test" {
   count = 2
@@ -182,75 +272,30 @@ resource "aws_cloudwatch_composite_alarm" "test" {
 
   tags = {
     Foo = "Bar"
-	Bax = "Baf"
+    Bax = "Baf"
   }
 }
 `, suffix)
 }
 
-func TestAccAwsCloudWatchCompositeAlarm_disappears(t *testing.T) {
-	alarm := cloudwatch.CompositeAlarm{}
-	suffix := acctest.RandString(8)
-	resourceName := "aws_cloudwatch_composite_alarm.test"
-
-	checkDisappears := func(*terraform.State) error {
+func testAccCheckAwsCloudWatchCompositeAlarmExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
 		conn := testAccProvider.Meta().(*AWSClient).cloudwatchconn
-		alarmNames := []string{
-			"tf-test-composite-" + suffix,
-			"tf-test-metric-" + suffix,
+		params := cloudwatch.DescribeAlarmsInput{
+			AlarmNames: []*string{aws.String(rs.Primary.ID)},
+			AlarmTypes: []*string{aws.String(cloudwatch.AlarmTypeCompositeAlarm)},
 		}
-
-		for _, name := range alarmNames {
-			input := cloudwatch.DeleteAlarmsInput{
-				AlarmNames: []*string{&name},
-			}
-
-			_, err := conn.DeleteAlarms(&input)
-			if err != nil {
-				return err
-			}
+		resp, err := conn.DescribeAlarms(&params)
+		if err != nil {
+			return err
 		}
-
+		if len(resp.CompositeAlarms) == 0 {
+			return fmt.Errorf("Alarm not found")
+		}
 		return nil
 	}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsCloudWatchCompositeAlarmDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAwsCloudWatchCompositeAlarmConfig_disappears(suffix),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsCloudWatchCompositeAlarmExists(resourceName, &alarm),
-					checkDisappears,
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func testAccAwsCloudWatchCompositeAlarmConfig_disappears(suffix string) string {
-	return fmt.Sprintf(`
-resource "aws_cloudwatch_metric_alarm" "test" {
-  alarm_name          = "tf-test-metric-%[1]s"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = 2
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/EC2"
-  period              = 120
-  statistic           = "Average"
-  threshold           = 80
-
-  dimensions = {
-    InstanceId = "i-abc123"
-  }
-}
-
-resource "aws_cloudwatch_composite_alarm" "test" {
-  alarm_name = "tf-test-composite-%[1]s"
-  alarm_rule = "ALARM(${aws_cloudwatch_metric_alarm.test.alarm_name})"
-}
-`, suffix)
 }

--- a/website/docs/r/cloudwatch_composite_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_composite_alarm.html.markdown
@@ -32,12 +32,12 @@ EOF
 ## Argument Reference
 
 * `actions_enabled` - (Optional) Indicates whether actions should be executed during any changes to the alarm state of the composite alarm. Defaults to `true`.
-* `alarm_actions` - (Optional) The set of actions to execute when this alarm transitions to the ALARM state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
+* `alarm_actions` - (Optional) The set of actions to execute when this alarm transitions to the `ALARM` state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
 * `alarm_description` - (Optional) The description for the composite alarm.
 * `alarm_name` - (Required) The name for the composite alarm. This name must be unique within the region.
 * `alarm_rule` - (Required) An expression that specifies which other alarms are to be evaluated to determine this composite alarm's state. For syntax, see [Creating a Composite Alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html). The maximum length is 10240 characters.
-* `insufficient_data_actions` - (Optional) The set of actions to execute when this alarm transitions to the INSUFFICIENT_DATA state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
-* `ok_actions` - (Optional) The set of actions to execute when this alarm transitions to an OK state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
+* `insufficient_data_actions` - (Optional) The set of actions to execute when this alarm transitions to the `INSUFFICIENT_DATA` state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
+* `ok_actions` - (Optional) The set of actions to execute when this alarm transitions to an `OK` state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
 * `tags` - (Optional) A map of tags to associate with the alarm. Up to 50 tags are allowed.
 
 ## Attributes Reference

--- a/website/docs/r/cloudwatch_composite_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_composite_alarm.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "CloudWatch"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_composite_alarm"
+description: |-
+  Provides a CloudWatch Composite Alarm resource.
+---
+
+# Resource: aws_cloudwatch_composite_alarm
+
+Provides a CloudWatch Composite Alarm resource.
+
+~> **NOTE:** An alarm (composite or metric) cannot be destroyed when there are other composite alarms depending on it. This can lead to a cyclical dependency on update, as Terraform will unsuccessfully attempt to destroy alarms before updating the rule. Consider using `depends_on`, references to alarm names, and two-stage updates.
+
+## Example Usage
+
+```hcl
+resource "aws_cloudwatch_composite_alarm" "example" {
+  alarm_description = "This is a composite alarm!"
+  alarm_name        = "example-composite-alarm"
+
+  alarm_actions = aws_sns_topic.example.arn
+  ok_actions    = aws_sns_topic.example.arn
+
+  alarm_rule = <<EOF
+ALARM(${aws_cloudwatch_metric_alarm.alpha.alarm_name}) OR
+ALARM(${aws_cloudwatch_metric_alarm.bravo.alarm_name})
+EOF
+}
+```
+
+## Argument Reference
+
+* `actions_enabled` - (Optional) Indicates whether actions should be executed during any changes to the alarm state of the composite alarm. Defaults to `true`.
+* `alarm_actions` - (Optional) The set of actions to execute when this alarm transitions to the ALARM state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
+* `alarm_description` - (Optional) The description for the composite alarm.
+* `alarm_name` - (Required) The name for the composite alarm. This name must be unique within the region.
+* `alarm_rule` - (Required) An expression that specifies which other alarms are to be evaluated to determine this composite alarm's state. For syntax, see [Creating a Composite Alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html). The maximum length is 10240 characters.
+* `insufficient_data_actions` - (Optional) The set of actions to execute when this alarm transitions to the INSUFFICIENT_DATA state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
+* `ok_actions` - (Optional) The set of actions to execute when this alarm transitions to an OK state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
+* `tags` - (Optional) A map of tags to associate with the alarm. Up to 50 tags are allowed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the composite alarm.
+* `id` - The ID of the composite alarm resource, which is equivalent to its `alarm_name`.
+
+## Import
+
+Use the `alarm_name` to import a CloudWatch Composite Alarm. For example:
+
+```
+$ terraform import aws_cloudwatch_composite_alarm.test my-alarm
+```

--- a/website/docs/r/cloudwatch_composite_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_composite_alarm.html.markdown
@@ -31,7 +31,7 @@ EOF
 
 ## Argument Reference
 
-* `actions_enabled` - (Optional) Indicates whether actions should be executed during any changes to the alarm state of the composite alarm. Defaults to `true`.
+* `actions_enabled` - (Optional, Forces new resource) Indicates whether actions should be executed during any changes to the alarm state of the composite alarm. Defaults to `true`.
 * `alarm_actions` - (Optional) The set of actions to execute when this alarm transitions to the `ALARM` state from any other state. Each action is specified as an ARN. Up to 5 actions are allowed.
 * `alarm_description` - (Optional) The description for the composite alarm.
 * `alarm_name` - (Required) The name for the composite alarm. This name must be unique within the region.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12272

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:
- **New Resource:** `aws_cloudwatch_composite_alarm`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsCloudWatchCompositeAlarm_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsCloudWatchCompositeAlarm_ -timeout 120m
--- PASS: TestAccAwsCloudWatchCompositeAlarm_disappears (19.78s)
--- PASS: TestAccAwsCloudWatchCompositeAlarm_basic (22.99s)
--- PASS: TestAccAwsCloudWatchCompositeAlarm_update (36.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       38.508s

```
