### PR TITLE
f/Codedeploy_deployment_group support for onPremisesTagSet

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -413,7 +413,7 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 				},
 			},
 
-            "on_premises_tag_set": {
+			"on_premises_tag_set": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -542,8 +542,8 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 	}
 
 	if attr, ok := d.GetOk("on_premises_tag_set"); ok {
-        input.OnPremisesTagSet = buildOnPremisesTagSet(attr.(*schema.Set).List())
-    }
+		input.OnPremisesTagSet = buildOnPremisesTagSet(attr.(*schema.Set).List())
+	}
 
 	if attr, ok := d.GetOk("on_premises_instance_tag_filter"); ok {
 		onPremFilters := buildOnPremTagFilters(attr.(*schema.Set).List())
@@ -667,8 +667,8 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 	}
 
 	if err := d.Set("on_premises_tag_set", onPremisesTagSetToMap(resp.DeploymentGroupInfo.OnPremisesTagSet)); err != nil {
-    	return err
-    }
+		return err
+	}
 
 	if err := d.Set("on_premises_instance_tag_filter", onPremisesTagFiltersToMap(resp.DeploymentGroupInfo.OnPremisesInstanceTagFilters)); err != nil {
 		return err
@@ -734,10 +734,10 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 
 	// TagFilters aren't like tags. They don't append. They simply replace.
 	if d.HasChange("on_premises_tag_set") {
-    	_, n := d.GetChange("on_premises_tag_set")
-    	onPremisesTagSet := buildOnPremisesTagSet(n.(*schema.Set).List())
-        input.OnPremisesTagSet = onPremisesTagSet
-    }
+		_, n := d.GetChange("on_premises_tag_set")
+		onPremisesTagSet := buildOnPremisesTagSet(n.(*schema.Set).List())
+		input.OnPremisesTagSet = onPremisesTagSet
+	}
 
 	if d.HasChange("on_premises_instance_tag_filter") {
 		_, n := d.GetChange("on_premises_instance_tag_filter")
@@ -1235,10 +1235,10 @@ func onPremisesTagSetToMap(tagSet *codedeploy.OnPremisesTagSet) []map[string]int
 			for _, item := range filters {
 				filtersAsIntfSlice = append(filtersAsIntfSlice, item)
 			}
-			//tagFilters := map[string]interface{}{
-			//	"on_premises_instance_tag_filter": schema.NewSet(resourceAwsCodeDeployTagFilterHash, filtersAsIntfSlice),
-			//}
-			//result = append(result, tagFilters)
+			tagFilters := map[string]interface{}{
+				"on_premises_instance_tag_filter": schema.NewSet(resourceAwsCodeDeployOnPremTagFilterHash, filtersAsIntfSlice),
+			}
+			result = append(result, tagFilters)
 		}
 	}
 	return result
@@ -1488,7 +1488,24 @@ func resourceAwsCodeDeployTagFilterHash(v interface{}) int {
 	if v, ok := m["value"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
+	return hashcode.String(buf.String())
+}
 
+func resourceAwsCodeDeployOnPremTagFilterHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]string)
+
+	// Nothing's actually required in tag filters, so we must check the
+	// presence of all values before attempting a hash.
+	if m["Key"] != "" {
+		buf.WriteString(fmt.Sprintf("%s-", m["key"]))
+	}
+	if m["type"] != "" {
+		buf.WriteString(fmt.Sprintf("%s-", m["type"]))
+	}
+	if m["value"] != "" {
+		buf.WriteString(fmt.Sprintf("%s-", m["value"]))
+	}
 	return hashcode.String(buf.String())
 }
 

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -43,7 +43,7 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "on_premises_tag_set.#", "0"),
-                    resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ec2_tag_filter.*", map[string]string{
 						"key":   "filterkey",
 						"type":  "KEY_AND_VALUE",
@@ -51,10 +51,10 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 					}),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_instance_tag_filter.*", map[string]string{
-                    	"key":   "filterkey",
-                    	"type":  "KEY_AND_VALUE",
-                    	"value": "filtervalue",
-                    }),
+						"key":   "filterkeyonprem",
+						"type":  "KEY_AND_VALUE",
+						"value": "filtervalueonprem",
+					}),
 
 					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
@@ -73,17 +73,17 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "on_premises_tag_set.#", "0"),
-                    resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ec2_tag_filter.*", map[string]string{
 						"key":   "filterkey",
 						"type":  "KEY_AND_VALUE",
 						"value": "anotherfiltervalue",
 					}),
 
-                    tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_instance_tag_filter.*", map[string]string{
-						"key":   "filterkey",
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_instance_tag_filter.*", map[string]string{
+						"key":   "filterkeyonprem",
 						"type":  "KEY_AND_VALUE",
-						"value": "anotherfiltervalue",
+						"value": "anotherfiltervalueonprem",
 					}),
 
 					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
@@ -197,9 +197,9 @@ func TestAccAWSCodeDeployDeploymentGroup_onPremisestagSet(t *testing.T) {
 						"on_premises_instance_tag_filter.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_tag_set.*.on_premises_instance_tag_filter.*", map[string]string{
-						"key":   "filterkey",
+						"key":   "filterkeyonprem",
 						"type":  "KEY_AND_VALUE",
-						"value": "filtervalue",
+						"value": "filtervalueonprem",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "0"),
 
@@ -222,9 +222,9 @@ func TestAccAWSCodeDeployDeploymentGroup_onPremisestagSet(t *testing.T) {
 						"on_premises_instance_tag_filter.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_tag_set.*.on_premises_instance_tag_filter.*", map[string]string{
-						"key":   "filterkey",
+						"key":   "filterkeyonprem",
 						"type":  "KEY_AND_VALUE",
-						"value": "anotherfiltervalue",
+						"value": "anotherfiltervalueonprem",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "0"),
 
@@ -267,9 +267,9 @@ func TestAccAWSCodeDeployDeploymentGroup_onPremiseTag(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.test", "on_premises_instance_tag_filter.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "on_premises_instance_tag_filter.*", map[string]string{
-						"key":   "filterkey",
+						"key":   "filterkeyonprem",
 						"type":  "KEY_AND_VALUE",
-						"value": "filtervalue",
+						"value": "filtervalueonprem",
 					}),
 				),
 			},
@@ -2335,9 +2335,9 @@ ec2_tag_set {
 
 on_premises_tag_set {
   on_premises_instance_tag_filter {
-    key   = "filterkey"
+    key   = "filterkeyonprem"
     type  = "KEY_AND_VALUE"
-    value = "filtervalue"
+    value = "filtervalueonprem"
   }
 }
 `
@@ -2351,9 +2351,9 @@ ec2_tag_filter {
 }
 
 on_premises_instance_tag_filter {
-  key   = "filterkey"
+  key   = "filterkeyonprem"
   type  = "KEY_AND_VALUE"
-  value = "filtervalue"
+  value = "filtervalueonprem"
 }
 `
 
@@ -2438,9 +2438,9 @@ ec2_tag_set {
 
 on_premises_tag_set {
   on_premises_instance_tag_filter {
-    key   = "filterkey"
+    key   = "filterkeyonprem"
     type  = "KEY_AND_VALUE"
-    value = "anotherfiltervalue"
+    value = "anotherfiltervalueonprem"
   }
 }
 `
@@ -2454,9 +2454,9 @@ ec2_tag_filter {
 }
 
 on_premises_instance_tag_filter {
-  key   = "filterkey"
+  key   = "filterkeyonprem"
   type  = "KEY_AND_VALUE"
-  value = "anotherfiltervalue"
+  value = "anotherfiltervalueonprem"
 }
 `
 
@@ -2590,9 +2590,9 @@ resource "aws_codedeploy_deployment_group" "test" {
   service_role_arn      = aws_iam_role.test.arn
 
   on_premises_instance_tag_filter {
-    key   = "filterkey"
+    key   = "filterkeyonprem"
     type  = "KEY_AND_VALUE"
-    value = "filtervalue"
+    value = "filtervalueonprem"
   }
 }
 `, rName)

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -42,11 +42,19 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_premises_tag_set.#", "0"),
+                    resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ec2_tag_filter.*", map[string]string{
 						"key":   "filterkey",
 						"type":  "KEY_AND_VALUE",
 						"value": "filtervalue",
 					}),
+
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_instance_tag_filter.*", map[string]string{
+                    	"key":   "filterkey",
+                    	"type":  "KEY_AND_VALUE",
+                    	"value": "filtervalue",
+                    }),
 
 					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
@@ -64,7 +72,15 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_premises_tag_set.#", "0"),
+                    resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ec2_tag_filter.*", map[string]string{
+						"key":   "filterkey",
+						"type":  "KEY_AND_VALUE",
+						"value": "anotherfiltervalue",
+					}),
+
+                    tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_instance_tag_filter.*", map[string]string{
 						"key":   "filterkey",
 						"type":  "KEY_AND_VALUE",
 						"value": "anotherfiltervalue",
@@ -140,6 +156,77 @@ func TestAccAWSCodeDeployDeploymentGroup_basic_tagSet(t *testing.T) {
 						"value": "anotherfiltervalue",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_configuration.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_onPremisestagSet(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
+
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeDeployDeploymentGroup(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "app_name", "tf-acc-test-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_group_name", "tf-acc-test-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", "aws_iam_role.test", "arn"),
+
+					resource.TestCheckResourceAttr(resourceName, "on_premises_tag_set.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_tag_set.*", map[string]string{
+						"on_premises_instance_tag_filter.#": "1",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_tag_set.*.on_premises_instance_tag_filter.*", map[string]string{
+						"key":   "filterkey",
+						"type":  "KEY_AND_VALUE",
+						"value": "filtervalue",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_configuration.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSCodeDeployDeploymentGroupModified(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "app_name", "tf-acc-test-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_group_name", "tf-acc-test-updated-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", "aws_iam_role.test_updated", "arn"),
+
+					resource.TestCheckResourceAttr(resourceName, "on_premises_tag_set.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_tag_set.*", map[string]string{
+						"on_premises_instance_tag_filter.#": "1",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_tag_set.*.on_premises_instance_tag_filter.*", map[string]string{
+						"key":   "filterkey",
+						"type":  "KEY_AND_VALUE",
+						"value": "anotherfiltervalue",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "on_premises_instance_tag_filter.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
@@ -2245,11 +2332,25 @@ ec2_tag_set {
     value = "filtervalue"
   }
 }
+
+on_premises_tag_set {
+  on_premises_instance_tag_filter {
+    key   = "filterkey"
+    type  = "KEY_AND_VALUE"
+    value = "filtervalue"
+  }
+}
 `
 
 	} else {
 		tagGroupOrFilter = `
 ec2_tag_filter {
+  key   = "filterkey"
+  type  = "KEY_AND_VALUE"
+  value = "filtervalue"
+}
+
+on_premises_instance_tag_filter {
   key   = "filterkey"
   type  = "KEY_AND_VALUE"
   value = "filtervalue"
@@ -2334,11 +2435,25 @@ ec2_tag_set {
     value = "anotherfiltervalue"
   }
 }
+
+on_premises_tag_set {
+  on_premises_instance_tag_filter {
+    key   = "filterkey"
+    type  = "KEY_AND_VALUE"
+    value = "anotherfiltervalue"
+  }
+}
 `
 
 	} else {
 		tagGroupOrFilter = `
 ec2_tag_filter {
+  key   = "filterkey"
+  type  = "KEY_AND_VALUE"
+  value = "anotherfiltervalue"
+}
+
+on_premises_instance_tag_filter {
   key   = "filterkey"
   type  = "KEY_AND_VALUE"
   value = "anotherfiltervalue"

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -67,6 +67,14 @@ resource "aws_codedeploy_deployment_group" "example" {
     }
   }
 
+  on_premises_tag_set {
+    on_premises_instance_tag_filter {
+      key   = "filterkeyonprem"
+      type  = "KEY_AND_VALUE"
+      value = "filtervalueonprem"
+    }
+  }
+
   trigger_configuration {
     trigger_events     = ["DeploymentFailure"]
     trigger_name       = "example-trigger"
@@ -196,11 +204,12 @@ The following arguments are supported:
 * `blue_green_deployment_config` - (Optional) Configuration block of the blue/green deployment options for a deployment group (documented below).
 * `deployment_config_name` - (Optional) The name of the group's deployment config. The default is "CodeDeployDefault.OneAtATime".
 * `deployment_style` - (Optional) Configuration block of the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer (documented below).
-* `ec2_tag_filter` - (Optional) Tag filters associated with the deployment group. See the AWS docs for details.
-* `ec2_tag_set` - (Optional) Configuration block(s) of Tag filters associated with the deployment group, which are also referred to as tag groups (documented below). See the AWS docs for details.
+* `ec2_tag_filter` - (Optional) Tag filters associated with the deployment group. See the AWS docs for details. Cannot be used in the same call as ec2_tag_set.
+* `ec2_tag_set` - (Optional) Configuration block(s) of Tag filters associated with the deployment group, which are also referred to as tag groups (documented below). See the AWS docs for details. Cannot be used in the same call as ec2_tag_filter.
 * `ecs_service` - (Optional) Configuration block(s) of the ECS services for a deployment group (documented below).
 * `load_balancer_info` - (Optional) Single configuration block of the load balancer to use in a blue/green deployment (documented below).
-* `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
+* `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details. Cannot be used in the same call as on_premises_tag_set.
+* `on_premises_tag_set` - (Optional) Configuration block(s) of On premise tag filters associated with the deployment group, which are also referred to as tag groups (documented below). See the AWS docs for details. Cannot be used in the same call as on_premises_instance_tag_filter.
 * `trigger_configuration` - (Optional) Configuration block(s) of the triggers for the deployment group (documented below).
 
 ### alarm_configuration Argument Reference
@@ -337,6 +346,10 @@ The `on_premises_tag_filter` configuration block supports the following:
 * `key` - (Optional) The key of the tag filter.
 * `type` - (Optional) The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.
 * `value` - (Optional) The value of the tag filter.
+
+### on_premises_tag_set Argument Reference
+
+You can form a tag group by putting a set of On premise tag filters into `on_premises_tag_set`. If multiple tag groups are specified, any instance that matches to at least one tag filter of every tag group is selected.
 
 ### trigger_configuration Argument Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14920.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23940.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup_onPremisestagSet'
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremisestagSet (162.21s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       163.204s

$ make testacc TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup'
PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (246.65s)
PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (252.61s)
PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (256.23s)
PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (272.02s)
PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (286.99s)
PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (403.04s)
PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (404.00s)
PASS: TestAccAWSCodeDeployDeploymentGroup_basic (407.94s)
PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (417.22s)
PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (417.47s)
PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (419.61s)
PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (422.25s)
PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (426.21s)
PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (426.24s)
PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (426.57s)
PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (449.64s)
PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (450.97s)
PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (455.18s)
PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (215.95s)
PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (525.33s)
PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (335.54s)
PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (165.39s)
PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (340.84s)
PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (341.06s)
PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (192.00s)
PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (186.83s)
PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (320.69s)
PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (255.40s)
PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (257.03s)
PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (250.59s)
PASS: TestAccAWSCodeDeployDeploymentGroup_onPremisestagSet (252.93s)
PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (249.07s)
PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (736.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       736.779s
...
```
