### PR TITLE
Use dot internal instead of dot local

### DIFF
--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -20,7 +20,7 @@ resource "aws_vpc" "example" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "example" {
-  name        = "example.terraform.local"
+  name        = "example.terraform.internal"
   description = "example"
   vpc         = aws_vpc.example.id
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

If you create the resources listed in these docs by copy/pasting, the `.local` domain works when Route53 is queried. But Ubuntu (and probably others) won't be able to resolve the hostname because Ubuntu (and probably others) treats `.local` as a special TLD and [doesn't forward those queries](https://en.wikipedia.org/wiki/.local#Linux) to the VPC's DNS server. Using `.internal` works as expected.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A, documentation only.
```
