### PR TITLE
docs/provider: Add protocol to api_endpoint attribute

### DIFF
--- a/website/docs/r/apigatewayv2_api.html.markdown
+++ b/website/docs/r/apigatewayv2_api.html.markdown
@@ -76,7 +76,7 @@ The `cors_configuration` object supports the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The API identifier.
-* `api_endpoint` - The URI of the API, of the form `{api-id}.execute-api.{region}.amazonaws.com`.
+* `api_endpoint` - The URI of the API, of the form `https://{api-id}.execute-api.{region}.amazonaws.com`.
 * `arn` - The ARN of the API.
 * `execution_arn` - The ARN prefix to be used in an [`aws_lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn` attribute
 or in an [`aws_iam_policy`](/docs/providers/aws/r/iam_policy.html) to authorize access to the [`@connections` API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-connections.html).

--- a/website/docs/r/apigatewayv2_api.html.markdown
+++ b/website/docs/r/apigatewayv2_api.html.markdown
@@ -76,7 +76,7 @@ The `cors_configuration` object supports the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The API identifier.
-* `api_endpoint` - The URI of the API, of the form `https://{api-id}.execute-api.{region}.amazonaws.com`.
+* `api_endpoint` - The URI of the API, of the form `https://{api-id}.execute-api.{region}.amazonaws.com` for HTTP APIs and `wss://{api-id}.execute-api.{region}.amazonaws.com` for WebSocket APIs.
 * `arn` - The ARN of the API.
 * `execution_arn` - The ARN prefix to be used in an [`aws_lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn` attribute
 or in an [`aws_iam_policy`](/docs/providers/aws/r/iam_policy.html) to authorize access to the [`@connections` API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-connections.html).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This is just a small change to include `https://` in the `api_endpoint` attribute, so people don't rely on this for DNS records or whatever.