### PR TITLE
tech-debt/TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow

### DIFF
--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -3568,6 +3568,8 @@ resource "aws_rds_cluster" "test" {
 `, rName, masterUsername)
 }
 
+// We provide preferred_maintenance_window to prevent the following error from a randomly selected window:
+// InvalidParameterValue: The backup window and maintenance window must not overlap.
 func testAccAWSRDSClusterConfig_SnapshotIdentifier_PreferredBackupWindow(rName, preferredBackupWindow string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "source" {
@@ -3585,6 +3587,7 @@ resource "aws_db_cluster_snapshot" "test" {
 resource "aws_rds_cluster" "test" {
   cluster_identifier      = %q
   preferred_backup_window = %q
+  preferred_maintenance_window = "sun:23:00-sun:23:30"
   skip_final_snapshot     = true
   snapshot_identifier     = aws_db_cluster_snapshot.test.id
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #14981

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow'
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (440.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       441.324s
...
```
