### PR TITLE
Add pagination support (introduced in aws-sdk-go v1.33.21) and multiple baselines per patch group.

### DIFF
--- a/.changelog/15213.txt
+++ b/.changelog/15213.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ssm_patch_group: Allow for a single patch group to be registered with multiple patch baselines
+```
+
+```release-note:bug
+resource/aws_ssm_patch_group: Replace `Provider produced inconsistent result after apply` with actual error message
+```

--- a/aws/internal/service/ssm/finder/finder.go
+++ b/aws/internal/service/ssm/finder/finder.go
@@ -30,3 +30,32 @@ func DocumentByName(conn *ssm.SSM, name string) (*ssm.DocumentDescription, error
 
 	return output.Document, nil
 }
+
+// PatchGroup returns matching SSM Patch Group by Patch Group and BaselineId.
+func PatchGroup(conn *ssm.SSM, patchGroup, baselineId string) (*ssm.PatchGroupPatchBaselineMapping, error) {
+	input := &ssm.DescribePatchGroupsInput{}
+	var result *ssm.PatchGroupPatchBaselineMapping
+
+	err := conn.DescribePatchGroupsPages(input, func(page *ssm.DescribePatchGroupsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, mapping := range page.Mappings {
+			if mapping == nil {
+				continue
+			}
+
+			if aws.StringValue(mapping.PatchGroup) == patchGroup {
+				if mapping.BaselineIdentity != nil && aws.StringValue(mapping.BaselineIdentity.BaselineId) == baselineId {
+					result = mapping
+					return false
+				}
+			}
+		}
+
+		return !lastPage
+	})
+
+	return result, err
+}

--- a/aws/resource_aws_ssm_patch_group_migrate.go
+++ b/aws/resource_aws_ssm_patch_group_migrate.go
@@ -29,9 +29,7 @@ func resourceAwsSsmPatchGroupStateUpgradeV0(_ context.Context, rawState map[stri
 		rawState = map[string]interface{}{}
 	}
 
-	if _, ok := rawState["id"]; ok {
-		rawState["id"] = fmt.Sprintf("%s,%s", rawState["patch_group"], rawState["baseline_id"])
-	}
+	rawState["id"] = fmt.Sprintf("%s,%s", rawState["patch_group"], rawState["baseline_id"])
 
 	return rawState, nil
 }

--- a/aws/resource_aws_ssm_patch_group_migrate.go
+++ b/aws/resource_aws_ssm_patch_group_migrate.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsSsmPatchGroupV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"baseline_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"patch_group": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSsmPatchGroupStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState == nil {
+		rawState = map[string]interface{}{}
+	}
+
+	if _, ok := rawState["id"]; ok {
+		rawState["id"] = fmt.Sprintf("%s,%s", rawState["patch_group"], rawState["baseline_id"])
+	}
+
+	return rawState, nil
+}

--- a/aws/resource_aws_ssm_patch_group_migrate_test.go
+++ b/aws/resource_aws_ssm_patch_group_migrate_test.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func testResourceAwsSsmPatchGroupStateDataV0() map[string]interface{} {
+	return map[string]interface{}{
+		"id":          "testgroup",
+		"baseline_id": "pb-0c4e592064EXAMPLE",
+		"patch_group": "testgroup",
+	}
+}
+
+func testResourceAwsSsmPatchGroupStateDataV1() map[string]interface{} {
+	v0 := testResourceAwsSsmPatchGroupStateDataV0()
+	return map[string]interface{}{
+		"id":          fmt.Sprintf("%s,%s", v0["patch_group"], v0["baseline_id"]),
+		"baseline_id": v0["baseline_id"],
+		"patch_group": v0["patch_group"],
+	}
+}
+
+func TestResourceAWSSSMPatchGroupStateUpgradeV0(t *testing.T) {
+	expected := testResourceAwsSsmPatchGroupStateDataV1()
+	actual, err := resourceAwsSsmPatchGroupStateUpgradeV0(context.Background(), testResourceAwsSsmPatchGroupStateDataV0(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
+}

--- a/website/docs/r/ssm_patch_group.html.markdown
+++ b/website/docs/r/ssm_patch_group.html.markdown
@@ -35,4 +35,4 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the patch baseline.
+* `id` - The name of the patch group and ID of the patch baseline separated by a comma (`,`).


### PR DESCRIPTION
This PR modifies the Id for an SSM Patch Group to be the Patch Group Name joined to the BaselineId by a ":". This allows an SSM Patch Group to support multiple baselines.

Please note that pre-existing patch groups will be recreated due to the change in Id (this happens without issue in my testing as the AWS API call succeeds even if the patch group already has that baseline applied).

Secondly, this PR adds pagination support (added in aws-sdk-go v1.33.21) to the aws_ssm_patch_group resource.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #9603 
Closes #13580

As it involved modifying the same code, I have merged the work from my previous PR ( #13752 ) into this one. Please let me know if that's a problem..

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ssm_patch_group: Support multiple baselines (one per OS) on an SSM patch group (#9603)
resource/aws_ssm_patch_group: Support pagination for patch groups (#13580)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMPatchGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSSMPatchGroup -timeout 120m
=== RUN   TestAccAWSSSMPatchGroup_basic
=== PAUSE TestAccAWSSSMPatchGroup_basic
=== CONT  TestAccAWSSSMPatchGroup_basic
--- PASS: TestAccAWSSSMPatchGroup_basic (28.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       29.634s
```
