### PR TITLE
Fixed Sid not validating against sid AWS IAM JSON policy

### DIFF
--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -139,6 +140,9 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 				}
 				stmt.Sid = sid.(string)
 				if len(stmt.Sid) > 0 {
+					if ok, _ := regexp.MatchString(`[0-9A-Za-z]*`, stmt.Sid); !ok {
+						return fmt.Errorf("Error in sid (%s), sid must match regex [0-9A-Za-z]*.", sid.(string))
+					}
 					sidMap[stmt.Sid] = struct{}{}
 				}
 			}

--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -127,6 +127,7 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 		var cfgStmtIntf = cfgStmts.([]interface{})
 		stmts := make([]*IAMPolicyStatement, len(cfgStmtIntf))
 		sidMap := make(map[string]struct{})
+		sidTestRegex := regexp.MustCompile(`[0-9A-Za-z]*`)
 
 		for i, stmtI := range cfgStmtIntf {
 			cfgStmt := stmtI.(map[string]interface{})
@@ -140,7 +141,7 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 				}
 				stmt.Sid = sid.(string)
 				if len(stmt.Sid) > 0 {
-					if ok, _ := regexp.MatchString(`[0-9A-Za-z]*`, stmt.Sid); !ok {
+					if !sidTestRegex.MatchString(stmt.Sid) {
 						return fmt.Errorf("Error in sid (%s), sid must match regex [0-9A-Za-z]*.", sid.(string))
 					}
 					sidMap[stmt.Sid] = struct{}{}

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -123,6 +123,19 @@ func TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataSourceIAMPolicyDocument_invalidSid(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSIAMPolicyDocumentInvalidSidConfig,
+				ExpectError: regexp.MustCompile(`sid must match regex`),
+			},
+		},
+	})
+}
+
 func TestAccAWSDataSourceIAMPolicyDocument_duplicateSid(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -717,6 +730,17 @@ var testAccAWSIAMPolicyDocumentNoStatementOverrideExpectedJSON = `{
     }
   ]
 }`
+
+var testAccAWSIAMPolicyDocumentInvalidSidConfig = `
+data "aws_iam_policy_document" "test" {
+  statement {
+    sid       = "Hi-I-Am-Not-Valid"
+    effect    = "Allow"
+    actions   = ["ec2:DescribeAccountAttributes"]
+    resources = ["*"]
+  }
+}
+`
 
 var testAccAWSIAMPolicyDocumentDuplicateSidConfig = `
 data "aws_iam_policy_document" "test" {


### PR DESCRIPTION
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Validate aws_iam_policy_document, statement.sid to meet requirement by AWS https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
