### PR TITLE
r/aws_guardduty_organization_configuration: Adds datasource/s3_logs a…

### DIFF
--- a/.changelog/15241.txt
+++ b/.changelog/15241.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_guardduty_organization_configuration: Add `datasources` argument
+```

--- a/aws/resource_aws_guardduty_organization_configuration_test.go
+++ b/aws/resource_aws_guardduty_organization_configuration_test.go
@@ -46,6 +46,43 @@ func testAccAwsGuardDutyOrganizationConfiguration_basic(t *testing.T) {
 	})
 }
 
+func testAccAwsGuardDutyOrganizationConfiguration_s3logs(t *testing.T) {
+	detectorResourceName := "aws_guardduty_detector.test"
+	resourceName := "aws_guardduty_organization_configuration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOrganizationsAccountPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsGuardDutyDetectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGuardDutyOrganizationConfigurationConfigS3Logs(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.0.auto_enable", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGuardDutyOrganizationConfigurationConfigS3Logs(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.0.auto_enable", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccGuardDutyOrganizationConfigurationConfigAutoEnable(autoEnable bool) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
@@ -70,6 +107,40 @@ resource "aws_guardduty_organization_configuration" "test" {
 
   auto_enable = %[1]t
   detector_id = aws_guardduty_detector.test.id
+}
+`, autoEnable)
+}
+
+func testAccGuardDutyOrganizationConfigurationConfigS3Logs(autoEnable bool) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}"]
+  feature_set                   = "ALL"
+}
+
+resource "aws_guardduty_detector" "test" {}
+
+resource "aws_guardduty_organization_admin_account" "test" {
+  depends_on = [aws_organizations_organization.test]
+
+  admin_account_id = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_guardduty_organization_configuration" "test" {
+  depends_on = [aws_guardduty_organization_admin_account.test]
+
+  auto_enable = true
+  detector_id = aws_guardduty_detector.test.id
+
+  datasources {
+	s3_logs {
+	  auto_enable = %[1]t
+	}
+  }
 }
 `, autoEnable)
 }

--- a/aws/resource_aws_guardduty_organization_configuration_test.go
+++ b/aws/resource_aws_guardduty_organization_configuration_test.go
@@ -137,9 +137,9 @@ resource "aws_guardduty_organization_configuration" "test" {
   detector_id = aws_guardduty_detector.test.id
 
   datasources {
-	s3_logs {
-	  auto_enable = %[1]t
-	}
+    s3_logs {
+      auto_enable = %[1]t
+    }
   }
 }
 `, autoEnable)

--- a/aws/resource_aws_guardduty_organization_configuration_test.go
+++ b/aws/resource_aws_guardduty_organization_configuration_test.go
@@ -55,6 +55,7 @@ func testAccAwsGuardDutyOrganizationConfiguration_s3logs(t *testing.T) {
 			testAccPreCheck(t)
 			testAccOrganizationsAccountPreCheck(t)
 		},
+		ErrorCheck:   testAccErrorCheck(t, guardduty.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsGuardDutyDetectorDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_guardduty_test.go
+++ b/aws/resource_aws_guardduty_test.go
@@ -30,7 +30,8 @@ func TestAccAWSGuardDuty_serial(t *testing.T) {
 			"basic": testAccAwsGuardDutyOrganizationAdminAccount_basic,
 		},
 		"OrganizationConfiguration": {
-			"basic": testAccAwsGuardDutyOrganizationConfiguration_basic,
+			"basic":  testAccAwsGuardDutyOrganizationConfiguration_basic,
+			"s3Logs": testAccAwsGuardDutyOrganizationConfiguration_s3logs,
 		},
 		"ThreatIntelSet": {
 			"basic": testAccAwsGuardDutyThreatintelset_basic,

--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -22,6 +22,12 @@ resource "aws_guardduty_detector" "example" {
 resource "aws_guardduty_organization_configuration" "example" {
   auto_enable = true
   detector_id = aws_guardduty_detector.example.id
+
+  datasources {
+    s3_logs {
+      auto_enable = true
+    }
+  }
 }
 ```
 
@@ -31,6 +37,16 @@ The following arguments are supported:
 
 * `auto_enable` - (Required) When this setting is enabled, all new accounts that are created in, or added to, the organization are added as a member accounts of the organization’s GuardDuty delegated administrator and GuardDuty is enabled in that AWS Region.
 * `detector_id` - (Required) The detector ID of the GuardDuty account.
+* `datasources` - (Optional) Configuration for the collected datasources.
+
+`datasources` supports the following:
+
+* `s3_logs` - (Optional) Configuration for the builds to store logs to S3.
+
+`s3_logs` supports the following:
+
+* `auto_enable` - (Optional) Set to `true` if you want S3 data event logs to be automatically enabled for new members of the organization. Default: `false`
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #15106

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
resource/aws_guardduty_organization_configuration: Adds s3_logs auto_enable attribute.
```

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccAWSGuardDuty_serial/OrganizationConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGuardDuty_serial/OrganizationConfiguration -timeout 120m
=== RUN   TestAccAWSGuardDuty_serial
=== RUN   TestAccAWSGuardDuty_serial/OrganizationConfiguration
=== RUN   TestAccAWSGuardDuty_serial/OrganizationConfiguration/basic
=== RUN   TestAccAWSGuardDuty_serial/OrganizationConfiguration/s3Logs
--- PASS: TestAccAWSGuardDuty_serial (103.00s)
    --- PASS: TestAccAWSGuardDuty_serial/OrganizationConfiguration (103.00s)
        --- PASS: TestAccAWSGuardDuty_serial/OrganizationConfiguration/basic (47.72s)
        --- PASS: TestAccAWSGuardDuty_serial/OrganizationConfiguration/s3Logs (55.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	105.249s
```
