### PR TITLE
New data to fetch EKS OIDC CA thumbprint

### DIFF
--- a/aws/data_source_aws_eks_oidc_thumbprint.go
+++ b/aws/data_source_aws_eks_oidc_thumbprint.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"crypto/sha1"
+	"crypto/tls"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsEksOIDCThumbprint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEksOIDCThumbprintRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"sha1_hash": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsEksOIDCThumbprintRead(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(resource.UniqueId())
+	s, err := oidcEksSha1FingerprintFor(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("could not get thumbprint: %v", err)
+	}
+	if err := d.Set("sha1_hash", s); err != nil {
+		return fmt.Errorf("error setting certificate sha1_hash: %v", err)
+	}
+	return nil
+}
+
+func oidcEksSha1FingerprintFor(region string) (string, error) {
+	endpoint := fmt.Sprintf("oidc.eks.%s.amazonaws.com:443", region)
+	conn, err := tls.Dial("tcp", endpoint, &tls.Config{})
+	if err != nil {
+		return "", fmt.Errorf("connection error trying to reach %s: %v", endpoint, err)
+	}
+	defer conn.Close()
+	certChain := conn.ConnectionState().PeerCertificates
+	// Read the x509.Certificate raw content (DER encoded) and hash it with SHA1,
+	// we're only interested in the CA certificate, the last one
+	fingerprint := sha1.Sum(certChain[len(certChain)-1].Raw)
+	return fmt.Sprintf("%x", fingerprint), nil
+}

--- a/aws/data_source_aws_eks_oidc_thumbprint_test.go
+++ b/aws/data_source_aws_eks_oidc_thumbprint_test.go
@@ -1,0 +1,55 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var (
+	eksThumbprintDataSourceTestRegion = "eu-central-1"
+	// CA Thumbprint for oidc.eks.eu-central-1.amazonaws.com
+	// in the format expected by the IAM OIDC provider resource configuration
+	expectedSHA1Thumbprint = "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
+	//expectedSHA1Thumbprints = []string{"9e99a48a9960b14926bb7f3b02e22da2b0ab7280","02f8cdf9a7cc82efafcf86b5a626a3242bfe978d"}
+)
+
+func TestAccEksOIDCThumbprint_readCertificateForRegion(t *testing.T) {
+	var providers []*schema.Provider
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(&providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsEksThumbprintDataSourceConfig(eksThumbprintDataSourceTestRegion),
+				Check:  resource.TestCheckResourceAttr("data.aws_eks_oidc_thumbprint.frankfurt", "sha1_hash", expectedSHA1Thumbprint),
+			},
+		},
+	})
+}
+
+func TestAccEksOIDCThumbprint_failsToReadCertificateForNonExistingRegion(t *testing.T) {
+	wrongRegion := "bogusregion"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckAwsEksThumbprintDataSourceConfig(wrongRegion),
+				Check:       resource.TestCheckNoResourceAttr("data.aws_eks_oidc_thumbprint.frankfurt", "sha1_hash"),
+				ExpectError: regexp.MustCompile(`.*could not get thumbprint: connection error trying to reach.*`),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsEksThumbprintDataSourceConfig(region string) string {
+	return fmt.Sprintf(`
+data "aws_eks_oidc_thumbprint" "frankfurt" {
+  region = "%s"
+}
+`, region)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -244,6 +244,7 @@ func Provider() *schema.Provider {
 			"aws_eip":                                        dataSourceAwsEip(),
 			"aws_eks_cluster":                                dataSourceAwsEksCluster(),
 			"aws_eks_cluster_auth":                           dataSourceAwsEksClusterAuth(),
+			"aws_eks_oidc_thumbprint":                        dataSourceAwsEksOIDCThumbprint(),
 			"aws_elastic_beanstalk_application":              dataSourceAwsElasticBeanstalkApplication(),
 			"aws_elastic_beanstalk_hosted_zone":              dataSourceAwsElasticBeanstalkHostedZone(),
 			"aws_elastic_beanstalk_solution_stack":           dataSourceAwsElasticBeanstalkSolutionStack(),

--- a/website/docs/d/eks_oidc_thumbprint.html.markdown
+++ b/website/docs/d/eks_oidc_thumbprint.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "EKS"
+layout: "aws"
+page_title: "AWS: aws_eks_oidc_thumbprint"
+description: |-
+  Retrieve CA fingerprint for an EKS OIDC endpoint in a given region 
+---
+
+# Data Source: aws_eks_oidc_thumbprint
+
+Retrieve TLS certificate fingerprint for an EKS OIDC endpoint in a given region
+
+## Example Usage
+
+```hcl
+data "aws_eks_cluster" "example" {
+  name = "example"
+}
+
+data "aws_eks_oidc_thumbprint" "example" {
+  region = "eu-west-1"
+}
+
+resource "aws_iam_openid_connect_provider" "oidc" {
+  # Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019.
+  url = data.aws_eks_cluster.example.identity[0].oidc[0].issuer
+  client_id_list = [ "sts.amazonaws.com" ]
+  thumbprint_list = [ data.aws_eks_oidc_thumbprint.example.sha1_hash ]
+}
+```
+
+## Argument Reference
+
+* `region` - (Required) The name of the region in which provisioning an EKS cluster
+
+## Attributes Reference
+
+* `sha1_hash` - The SHA1 fingerprint to be used in an IAM OpenID Connect provider configuration 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates to #10104.
Currently the only way to have an OIDC provider managed as part of an EKS cluster bootstrapping is by using external scripts or local_exec resources that brings depedencies with them (openssl, sed, sometimes jq...).
This PR creates a data source that allows to fill this gap by providing the CA fingeprints in the format expected by the OIDC providers for EKS endpoints.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* New Data Source: `aws_eks_oidc_thumbprint` allows OIDC providers automated creation for EKS clusters
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccEksOIDCThumbprint_*'                       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccEksOIDCThumbprint_* -timeout 120m
=== RUN   TestAccEksOIDCThumbprint_readCertificateForRegion
--- PASS: TestAccEksOIDCThumbprint_readCertificateForRegion (13.52s)
=== RUN   TestAccEksOIDCThumbprint_failsToReadCertificateForNonExistingRegion
--- PASS: TestAccEksOIDCThumbprint_failsToReadCertificateForNonExistingRegion (2.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       16.358s
```
