### PR TITLE
add acl validator to aws s3 bucket resource

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -76,6 +76,14 @@ func resourceAwsS3Bucket() *schema.Resource {
 				Default:       "private",
 				Optional:      true,
 				ConflictsWith: []string{"grant"},
+				ValidateFunc: validation.StringInSlice([]string{
+					s3.BucketCannedACLPrivate,
+					s3.BucketCannedACLPublicRead,
+					s3.BucketCannedACLPublicReadWrite,
+					s3.BucketCannedACLAWSExecRead,
+					s3.BucketCannedACLAuthenticatedRead,
+					s3.BucketCannedACLLogDeliveryWrite,
+				}, false),
 			},
 
 			"grant": {

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -31314,8 +31314,14 @@ const (
 	// BucketCannedACLPublicReadWrite is a BucketCannedACL enum value
 	BucketCannedACLPublicReadWrite = "public-read-write"
 
+	// BucketCannedACLAWSExecRead is a BucketCannedACL enum value
+	BucketCannedACLAWSExecRead = "aws-exec-read"
+
 	// BucketCannedACLAuthenticatedRead is a BucketCannedACL enum value
 	BucketCannedACLAuthenticatedRead = "authenticated-read"
+
+	// BucketCannedACLLogDeliveryWrite is a BucketCannedACL enum value
+	BucketCannedACLLogDeliveryWrite = "log-delivery-write"
 )
 
 // BucketCannedACL_Values returns all elements of the BucketCannedACL enum
@@ -31324,7 +31330,9 @@ func BucketCannedACL_Values() []string {
 		BucketCannedACLPrivate,
 		BucketCannedACLPublicRead,
 		BucketCannedACLPublicReadWrite,
+		BucketCannedACLAWSExecRead,
 		BucketCannedACLAuthenticatedRead,
+		BucketCannedACLLogDeliveryWrite,
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15304

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

- Adds in canned acls that apply to buckets documented in https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl specifically "aws-exec-read" and "log-delivery-write" as valid acls


```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
