### PR TITLE
[WIP] Removing Restriction on Zone ID XOR Name for Route53 Hosted Zone Data Source

### DIFF
--- a/aws/data_source_aws_route53_zone.go
+++ b/aws/data_source_aws_route53_zone.go
@@ -134,7 +134,7 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 
 				if matchingTags && matchingVPC {
 					if hostedZoneFound != nil {
-						return fmt.Errorf("multiple Route53Zone found please use vpc_id option to filter")
+						return fmt.Errorf("Multiple Route53 Hosted Zones found please use zone_id or vpc_id option to filter")
 					}
 
 					hostedZoneFound = hostedZone

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -65,6 +65,29 @@ func TestAccDataSourceAwsRoute53Zone_tags(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccDataSourceAwsRoute53ZoneConfigTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "name_servers", dataSourceName, "name_servers"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRoute53Zone_tagsPrivate(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_route53_zone.test"
+	dataSourceName := "data.aws_route53_zone.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
 				Config: testAccDataSourceAwsRoute53ZoneConfigTagsPrivate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
@@ -142,6 +165,24 @@ resource "aws_route53_zone" "test" {
 
 data "aws_route53_zone" "test" {
   name = aws_route53_zone.test.name
+}
+`, rInt)
+}
+
+func testAccDataSourceAwsRoute53ZoneConfigTags(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = "terraformtestacchz-%[1]d.com."
+
+  tags = {
+    Environment = "tf-acc-test-%[1]d"
+  }
+}
+
+data "aws_route53_zone" "test" {
+  tags = {
+    Environment = "tf-acc-test-%[1]d"
+  }
 }
 `, rInt)
 }

--- a/website/docs/d/route53_zone.html.markdown
+++ b/website/docs/d/route53_zone.html.markdown
@@ -35,11 +35,10 @@ resource "aws_route53_record" "www" {
 ## Argument Reference
 
 The arguments of this data source act as filters for querying the available
-Hosted Zone. You have to use `zone_id` or `name`, not both of them. The given filter must match exactly one
+Hosted Zone. You cannot use both `zone_id` and `name`. The given filter must match exactly one
 Hosted Zone. If you use `name` field for private Hosted Zone, you need to add `private_zone` field to `true`
 
 * `zone_id` - (Optional) The Hosted Zone id of the desired Hosted Zone.
-
 * `name` - (Optional) The Hosted Zone name of the desired Hosted Zone.
 * `private_zone` - (Optional) Used with `name` field to get a private Hosted Zone.
 * `vpc_id` - (Optional) Used with `name` field to get a private Hosted Zone associated with the vpc_id (in this case, private_zone is not mandatory).


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Not sure about the order of operations for this PR. I believe that the restriction of requiring the Route 53 Hosted Zone data source to provide `name` or `zone_id` is unnecessary, but I don't know the context in which that restriction was placed. 

It doesn't seem to be a restriction stemming from the AWS SDK call, as the data source is calling `ListHostedZones` and filtering in Go.

Please provide insight into the reason this restriction is currently in place and what I can do to make this change safe and effective!