### PR TITLE
resource_aws_elasticache_replication_group: Add arn attribute

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -34,6 +34,10 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"at_rest_encryption_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -520,6 +524,16 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 			return fmt.Errorf("error setting tags: %w", err)
 		}
 	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "elasticache",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("replicationgroup:%s", d.Id()),
+	}.String()
+
+	d.Set("arn", arn)
 
 	return nil
 }

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -138,9 +138,9 @@ SNS topic to send ElastiCache notifications to. Example:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the created ElastiCache Cluster.
 * `cache_nodes` - List of node objects including `id`, `address`, `port` and `availability_zone`.
    Referenceable e.g. as `${aws_elasticache_cluster.bar.cache_nodes.0.address}`
-
 * `configuration_endpoint` - (Memcached only) The configuration endpoint to allow host discovery.
 * `cluster_address` - (Memcached only) The DNS name of the cache cluster without the port appended.
 

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -146,6 +146,7 @@ Cluster Mode (`cluster_mode`) supports the following:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the created ElastiCache Replication Group.
 * `id` - The ID of the ElastiCache Replication Group.
 * `configuration_endpoint_address` - The address of the replication group configuration endpoint when cluster mode is enabled.
 * `primary_endpoint_address` - (Redis only) The address of the endpoint for the primary node in the replication group, if the cluster mode is disabled.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15267

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_elasticache_replication_group: Add arn attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_vpc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_vpc -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_vpc
=== PAUSE TestAccAWSElasticacheReplicationGroup_vpc
=== CONT  TestAccAWSElasticacheReplicationGroup_vpc
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (601.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	601.621s
...
```
