### PR TITLE
d/added default route table conflict warning

### DIFF
--- a/website/docs/r/main_route_table_association.html.markdown
+++ b/website/docs/r/main_route_table_association.html.markdown
@@ -10,6 +10,16 @@ description: |-
 
 Provides a resource for managing the main routing table of a VPC.
 
+It is recommended you **do not** use both `aws_main_route_table_association` to
+manage the default route table **and** use the `aws_default_route_table`,
+due to possible conflict in routes.
+
+For more information about Route Tables, see the AWS Documentation on
+[Route Tables][aws-route-tables].
+
+For more information about managing normal Route Tables in Terraform, see our
+documentation on [aws_route_table][tf-route-tables].
+
 ## Example Usage
 
 ```hcl
@@ -42,3 +52,6 @@ The "Delete" action for a `main_route_table_association` consists of resetting
 this original table as the Main Route Table for the VPC. You'll see this
 additional Route Table in the AWS console; it must remain intact in order for
 the `main_route_table_association` delete to work properly.
+
+[aws-route-tables]: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Route_Tables.html#Route_Replacing_Main_Table
+[tf-route-tables]: /docs/providers/aws/r/route_table.html


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1699

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Updated documentation to include a conflict warning when using this resource with default_route_table
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```

Reasoning for Change: As pointed out in #1699 there is no warning in the docs about the issues of using this with default_route_table.  

This is my first PR to an open-source project, so apologies in advance for any issues or poor PR etiquette!
