### PR TITLE
support for maintenance start time configuration (15331)

### DIFF
--- a/aws/resource_aws_storagegateway_gateway.go
+++ b/aws/resource_aws_storagegateway_gateway.go
@@ -223,28 +223,43 @@ func resourceAwsStorageGatewayGateway() *schema.Resource {
 						"ipv4_address": {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+					},
+				},
+			},
 			"maintenance_start_time": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"hour": {
+						"hour_of_day": {
 							Type:         schema.TypeInt,
 							Required:     true,
 							ValidateFunc: validation.IntBetween(0, 23),
+							Default:      0,
+							Computed: true,
 						},
-						"minute": {
+						"minute_of_hour": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(0, 59),
 							Default:      0,
+							Computed: true,
 						},
 						"day_of_week": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(0, 6),
 							Default:      0,
+							Computed: true,
+						},
+						"day_of_month": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 28),
+							Default:      0,
+							Computed: true,
 						},
 					},
 				},
@@ -405,9 +420,10 @@ func resourceAwsStorageGatewayGatewayCreate(d *schema.ResourceData, meta interfa
 
 		input := &storagegateway.UpdateMaintenanceStartTimeInput{
 			DayOfWeek:    aws.Int64(int64(m["day_of_week"].(int))),
+			DayOfMonth:   aws.Int64(int64(m["day_of_month"].(int))),
 			GatewayARN:   aws.String(d.Id()),
-			HourOfDay:    aws.Int64(int64(m["hour"].(int))),
-			MinuteOfHour: aws.Int64(int64(m["minute"].(int))),
+			HourOfDay:    aws.Int64(int64(m["hour_of_day"].(int))),
+			MinuteOfHour: aws.Int64(int64(m["minute_of_hour"].(int))),
 		}
 
 		log.Printf("[DEBUG] Storage Gateway Gateway %q updating maintenance start time", d.Id())
@@ -582,9 +598,10 @@ func resourceAwsStorageGatewayGatewayRead(d *schema.ResourceData, meta interface
 	}
 	if err == nil {
 		m := map[string]interface{}{
-			"hour":        aws.Int64Value(maintenanceStartTimeOutput.HourOfDay),
-			"minute":      aws.Int64Value(maintenanceStartTimeOutput.MinuteOfHour),
-			"day_of_week": aws.Int64Value(maintenanceStartTimeOutput.DayOfWeek),
+			"hour_of_day":    aws.Int64Value(maintenanceStartTimeOutput.HourOfDay),
+			"minute_of_hour": aws.Int64Value(maintenanceStartTimeOutput.MinuteOfHour),
+			"day_of_week":    aws.Int64Value(maintenanceStartTimeOutput.DayOfWeek),
+			"day_of_month":   aws.Int64Value(maintenanceStartTimeOutput.DayOfMonth),
 		}
 		if err := d.Set("maintenance_start_time", []map[string]interface{}{m}); err != nil {
 			return fmt.Errorf("error setting maintenance_start_time: %w", err)
@@ -727,9 +744,10 @@ func resourceAwsStorageGatewayGatewayUpdate(d *schema.ResourceData, meta interfa
 
 		input := &storagegateway.UpdateMaintenanceStartTimeInput{
 			DayOfWeek:    aws.Int64(int64(m["day_of_week"].(int))),
+			DayOfMonth:   aws.Int64(int64(m["day_of_month"].(int))),
 			GatewayARN:   aws.String(d.Id()),
-			HourOfDay:    aws.Int64(int64(m["hour"].(int))),
-			MinuteOfHour: aws.Int64(int64(m["minute"].(int))),
+			HourOfDay:    aws.Int64(int64(m["hour_of_day"].(int))),
+			MinuteOfHour: aws.Int64(int64(m["minute_of_month"].(int))),
 		}
 
 		log.Printf("[DEBUG] Storage Gateway Gateway %q updating maintenance start time", d.Id())

--- a/aws/resource_aws_storagegateway_gateway.go
+++ b/aws/resource_aws_storagegateway_gateway.go
@@ -223,6 +223,28 @@ func resourceAwsStorageGatewayGateway() *schema.Resource {
 						"ipv4_address": {
 							Type:     schema.TypeString,
 							Computed: true,
+			"maintenance_start_time": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hour": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntBetween(0, 23),
+						},
+						"minute": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 59),
+							Default:      0,
+						},
+						"day_of_week": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 6),
+							Default:      0,
 						},
 					},
 				},
@@ -375,6 +397,23 @@ func resourceAwsStorageGatewayGatewayCreate(d *schema.ResourceData, meta interfa
 		_, err := conn.UpdateGatewayInformation(input)
 		if err != nil {
 			return fmt.Errorf("error setting CloudWatch Log Group: %w", err)
+		}
+	}
+
+	if v, ok := d.GetOk("maintenance_start_time"); ok && len(v.([]interface{})) > 0 {
+		m := v.([]interface{})[0].(map[string]interface{})
+
+		input := &storagegateway.UpdateMaintenanceStartTimeInput{
+			DayOfWeek:    aws.Int64(int64(m["day_of_week"].(int))),
+			GatewayARN:   aws.String(d.Id()),
+			HourOfDay:    aws.Int64(int64(m["hour"].(int))),
+			MinuteOfHour: aws.Int64(int64(m["minute"].(int))),
+		}
+
+		log.Printf("[DEBUG] Storage Gateway Gateway %q updating maintenance start time", d.Id())
+		_, err := conn.UpdateMaintenanceStartTime(input)
+		if err != nil {
+			return fmt.Errorf("error updating maintenance start time: %w", err)
 		}
 	}
 
@@ -534,6 +573,24 @@ func resourceAwsStorageGatewayGatewayRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("error setting gateway_network_interface: %w", err)
 	}
 
+	maintenanceStartTimeInput := &storagegateway.DescribeMaintenanceStartTimeInput{
+		GatewayARN: aws.String(d.Id()),
+	}
+	maintenanceStartTimeOutput, err := conn.DescribeMaintenanceStartTime(maintenanceStartTimeInput)
+	if err != nil && !isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified operation is not supported") {
+		return fmt.Errorf("error reading Storage Gateway Maintenance time start: %s", err)
+	}
+	if err == nil {
+		m := map[string]interface{}{
+			"hour":        aws.Int64Value(maintenanceStartTimeOutput.HourOfDay),
+			"minute":      aws.Int64Value(maintenanceStartTimeOutput.MinuteOfHour),
+			"day_of_week": aws.Int64Value(maintenanceStartTimeOutput.DayOfWeek),
+		}
+		if err := d.Set("maintenance_start_time", []map[string]interface{}{m}); err != nil {
+			return fmt.Errorf("error setting maintenance_start_time: %w", err)
+		}
+	}
+
 	bandwidthInput := &storagegateway.DescribeBandwidthRateLimitInput{
 		GatewayARN: aws.String(d.Id()),
 	}
@@ -662,7 +719,24 @@ func resourceAwsStorageGatewayGatewayUpdate(d *schema.ResourceData, meta interfa
 				return fmt.Errorf("error unsetting Bandwidth Rate Limit: %w", err)
 			}
 		}
+	}
 
+	if d.HasChange("maintenance_start_time") {
+		l := d.Get("maintenance_start_time").([]interface{})
+		m := l[0].(map[string]interface{})
+
+		input := &storagegateway.UpdateMaintenanceStartTimeInput{
+			DayOfWeek:    aws.Int64(int64(m["day_of_week"].(int))),
+			GatewayARN:   aws.String(d.Id()),
+			HourOfDay:    aws.Int64(int64(m["hour"].(int))),
+			MinuteOfHour: aws.Int64(int64(m["minute"].(int))),
+		}
+
+		log.Printf("[DEBUG] Storage Gateway Gateway %q updating maintenance start time", d.Id())
+		_, err := conn.UpdateMaintenanceStartTime(input)
+		if err != nil {
+			return fmt.Errorf("error updating maintenance start time: %w", err)
+		}
 	}
 
 	return resourceAwsStorageGatewayGatewayRead(d, meta)

--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -1215,18 +1215,19 @@ resource "aws_storagegateway_gateway" "test" {
 `, rName, rate)
 }
 
-func testAccAWSStorageGatewayGatewayMaintenanceStartTimeConfig(rName string, hour int, minute int, day_of_week int) string {
+func testAccAWSStorageGatewayGatewayMaintenanceStartTimeConfig(rName string, hour_of_day int, minute_of_hour int, day_of_week int, day_of_month int) string {
 	return testAccAWSStorageGateway_TapeAndVolumeGatewayBase(rName) + fmt.Sprintf(`
 resource "aws_storagegateway_gateway" "test" {
-  gateway_ip_address                          = aws_instance.test.public_ip
-  gateway_name                                = %[1]q
-  gateway_timezone                            = "GMT"
-  gateway_type                                = "CACHED"
+  gateway_ip_address = aws_instance.test.public_ip
+  gateway_name       = %[1]q
+  gateway_timezone   = "GMT"
+  gateway_type       = "CACHED"
   maintenance_start_time {
-	hour = %[2]d
-	minute = %[3]d
-	day_of_week = %[4]d  
+    hour_of_day    = %[2]d
+    minute_of_hour = %[3]d
+    day_of_week    = %[4]d  
+    day_of_month   = %[5]d  
   }
 }
-`, rName, hour, minute, day_of_week)
+`, rName, hour_of_day, minute_of_hour, day_of_week, day_of_month)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15331

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_storagegateway_gateway: configurable maintenance start time
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSStorageGatewayGateway_maintenanceStartTime'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSStorageGatewayGateway_maintenanceStartTime -timeout 120m
=== RUN   TestAccAWSStorageGatewayGateway_maintenanceStartTime
=== PAUSE TestAccAWSStorageGatewayGateway_maintenanceStartTime
=== CONT  TestAccAWSStorageGatewayGateway_maintenanceStartTime
--- PASS: TestAccAWSStorageGatewayGateway_maintenanceStartTime (223.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	225.609s
```
