### PR TITLE
tests/provider: Add concurrency to sweep (WAF Web ACL)

### DIFF
--- a/aws/resource_aws_waf_web_acl_test.go
+++ b/aws/resource_aws_waf_web_acl_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -21,6 +22,74 @@ func init() {
 		Name: "aws_waf_web_acl",
 		F:    testSweepWafWebAcls,
 	})
+}
+
+func testSweepWafWebAclsWorker(workerID int, conn *waf.WAF, jobs <-chan string, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	for webACLID := range jobs {
+		deleteInput := &waf.DeleteWebACLInput{
+			WebACLId: aws.String(webACLID),
+		}
+		wr := newWafRetryer(conn)
+
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			deleteInput.ChangeToken = token
+			log.Printf("[INFO] Deleting WAF Regional Web ACL (worker %v): %s", workerID, webACLID)
+			return conn.DeleteWebACL(deleteInput)
+		})
+
+		if isAWSErr(err, waf.ErrCodeNonEmptyEntityException, "") {
+			getWebACLInput := &waf.GetWebACLInput{
+				WebACLId: aws.String(webACLID),
+			}
+
+			getWebACLOutput, getWebACLErr := conn.GetWebACL(getWebACLInput)
+
+			if getWebACLErr != nil {
+				log.Printf("[ERROR] error getting WAF Regional Web ACL (%s) (worker %v): %s", webACLID, workerID, getWebACLErr)
+				continue
+			}
+
+			var updates []*waf.WebACLUpdate
+			updateWebACLInput := &waf.UpdateWebACLInput{
+				DefaultAction: getWebACLOutput.WebACL.DefaultAction,
+				Updates:       updates,
+				WebACLId:      aws.String(webACLID),
+			}
+
+			for _, rule := range getWebACLOutput.WebACL.Rules {
+				update := &waf.WebACLUpdate{
+					Action:        aws.String(waf.ChangeActionDelete),
+					ActivatedRule: rule,
+				}
+
+				updateWebACLInput.Updates = append(updateWebACLInput.Updates, update)
+			}
+
+			_, updateWebACLErr := wr.RetryWithToken(func(token *string) (interface{}, error) {
+				updateWebACLInput.ChangeToken = token
+				log.Printf("[INFO] Removing Rules from WAF Regional Web ACL (worker %v): %s", workerID, webACLID)
+				return conn.UpdateWebACL(updateWebACLInput)
+			})
+
+			if updateWebACLErr != nil {
+				log.Printf("[ERROR] error removing rules from WAF Regional Web ACL (%s) (worker %v): %s", webACLID, workerID, updateWebACLErr)
+				continue
+			}
+
+			_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+				deleteInput.ChangeToken = token
+				log.Printf("[INFO] Deleting WAF Regional Web ACL (worker %v): %s", workerID, webACLID)
+				return conn.DeleteWebACL(deleteInput)
+			})
+		}
+
+		if err != nil {
+			log.Printf("[ERROR] error deleting WAF Regional Web ACL (%s) (worker %v): %s", webACLID, workerID, err)
+			continue
+		}
+	}
 }
 
 func testSweepWafWebAcls(region string) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15334

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Sweeping test (2 WAF Web ACLs exist):

```
% SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_waf_web_acl make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_waf_web_acl -timeout 60m
2020/09/25 13:16:17 [DEBUG] Running Sweepers for region (us-west-2):
2020/09/25 13:16:17 [DEBUG] Running Sweeper (aws_waf_web_acl) in region (us-west-2)
2020/09/25 13:16:18 [DEBUG] Locking "WafRetryer"
2020/09/25 13:16:18 [DEBUG] Locking "WafRetryer"
2020/09/25 13:16:18 [DEBUG] Locked "WafRetryer"
2020/09/25 13:16:18 [DEBUG] Waiting for state to become: [success]
2020/09/25 13:16:18 [INFO] Deleting WAF Regional Web ACL (worker 3): affa6971-82ef-4327-9f0f-8fb272031649
2020/09/25 13:16:18 [DEBUG] Unlocking "WafRetryer"
2020/09/25 13:16:18 [DEBUG] Unlocked "WafRetryer"
2020/09/25 13:16:18 [DEBUG] Locked "WafRetryer"
2020/09/25 13:16:18 [DEBUG] Waiting for state to become: [success]
2020/09/25 13:16:18 [INFO] Deleting WAF Regional Web ACL (worker 0): e10b1701-615e-4fcb-aae4-4de8cb0df651
2020/09/25 13:16:19 [DEBUG] Unlocking "WafRetryer"
2020/09/25 13:16:19 [DEBUG] Unlocked "WafRetryer"
2020/09/25 13:16:19 Sweeper Tests ran successfully:
	- aws_waf_web_acl
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3.181s
```