### PR TITLE
d/aws_security_group: more verbose error on dne

### DIFF
--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -59,10 +59,13 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 		req.GroupIds = []*string{aws.String(id.(string))}
 	}
 
+	group_name := d.Get("name").(string)
+	vpc_id := d.Get("vpc_id").(string)
+
 	req.Filters = buildEC2AttributeFilterList(
 		map[string]string{
-			"group-name": d.Get("name").(string),
-			"vpc-id":     d.Get("vpc_id").(string),
+			"group-name": group_name,
+			"vpc-id":     vpc_id,
 		},
 	)
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
@@ -82,7 +85,14 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 	if resp == nil || len(resp.SecurityGroups) == 0 {
-		return fmt.Errorf("no matching SecurityGroup found")
+
+		err_msg := ""
+		if group_name != "" && vpc_id != "" {
+			err_msg = fmt.Sprintf(": %s/%s", vpc_id, group_name)
+		} else if group_name != "" {
+			err_msg = fmt.Sprintf(": %s", group_name)
+		}
+		return fmt.Errorf("no matching SecurityGroup found%s", err_msg)
 	}
 	if len(resp.SecurityGroups) > 1 {
 		return fmt.Errorf("multiple Security Groups matched; use additional constraints to reduce matches to a single Security Group")

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"strings"
@@ -27,6 +28,23 @@ func TestAccDataSourceAwsSecurityGroup_basic(t *testing.T) {
 					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_name"),
 					testAccDataSourceAwsSecurityGroupCheckDefault("data.aws_security_group.default_by_name"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsSecurityGroup_dne(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsSecurityGroupConfigDne(),
+				ExpectError: regexp.MustCompile(`no matching SecurityGroup found: dne`),
+			},
+			{
+				Config:      testAccDataSourceAwsSecurityGroupConfigDneVpc(),
+				ExpectError: regexp.MustCompile(`no matching SecurityGroup found: vpc-xxxxxxx/dne`),
 			},
 		},
 	})
@@ -150,4 +168,21 @@ data "aws_security_group" "by_filter" {
   }
 }
 `, rInt, rInt)
+}
+
+func testAccDataSourceAwsSecurityGroupConfigDne() string {
+	return `
+data "aws_security_group" "dne" {
+  name = "dne"
+}
+`
+}
+
+func testAccDataSourceAwsSecurityGroupConfigDneVpc() string {
+	return `
+data "aws_security_group" "dne_vpc" {
+  name   = "dne"
+  vpc_id = "vpc-xxxxxxx"
+}
+`
 }


### PR DESCRIPTION
If the security group does not exist output the sg name in the error message.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsSecurityGroup_dne'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSecurityGroup_dne -timeout 120m
=== RUN   TestAccDataSourceAwsSecurityGroup_dne
=== PAUSE TestAccDataSourceAwsSecurityGroup_dne
=== CONT  TestAccDataSourceAwsSecurityGroup_dne
--- PASS: TestAccDataSourceAwsSecurityGroup_dne (7.21s)
PASS
...
```
