### PR TITLE
r/transfer_server - add `security_policy_name` and refactor tests

### DIFF
--- a/.changelog/15375.txt
+++ b/.changelog/15375.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_transfer_server: Add `security_policy_name` argument
+```

--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -66,8 +66,8 @@ func testSweepTransferServers(region string) error {
 
 func TestAccAWSTransferServer_basic(t *testing.T) {
 	var conf transfer.DescribedServer
-	resourceName := "aws_transfer_server.foo"
-	rName := acctest.RandString(5)
+	resourceName := "aws_transfer_server.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
@@ -76,7 +76,7 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSTransferServerConfig_basic,
+				Config: testAccAWSTransferServerBasicConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "transfer", regexp.MustCompile(`server/.+`)),
@@ -85,6 +85,8 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "identity_provider_type", "SERVICE_MANAGED"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "PUBLIC"),
+					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-2018-11"),
 				),
 			},
 			{
@@ -94,17 +96,45 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
-				Config: testAccAWSTransferServerConfig_basicUpdate(rName),
+				Config: testAccAWSTransferServerUpdatedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.NAME", "tf-acc-test-transfer-server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.ENV", "test"),
-					resource.TestCheckResourceAttrPair(
-						resourceName, "logging_role", "aws_iam_role.foo", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "logging_role", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider_type", "SERVICE_MANAGED"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSTransferServer_securityPolicy(t *testing.T) {
+	var conf transfer.DescribedServer
+	resourceName := "aws_transfer_server.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTransferServerSecurityPolicyConfig("TransferSecurityPolicy-2020-06"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-2020-06"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccAWSTransferServerSecurityPolicyConfig("TransferSecurityPolicy-2018-11"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-2018-11"),
 				),
 			},
 		},
@@ -114,6 +144,7 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 func TestAccAWSTransferServer_Vpc(t *testing.T) {
 	var conf transfer.DescribedServer
 	resourceName := "aws_transfer_server.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
@@ -122,7 +153,7 @@ func TestAccAWSTransferServer_Vpc(t *testing.T) {
 		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSTransferServerConfig_Vpc,
+				Config: testAccAWSTransferServerConfig_Vpc(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
@@ -140,7 +171,7 @@ func TestAccAWSTransferServer_Vpc(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
-				Config: testAccAWSTransferServerConfig_VpcUpdate,
+				Config: testAccAWSTransferServerConfig_VpcUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
@@ -155,8 +186,8 @@ func TestAccAWSTransferServer_Vpc(t *testing.T) {
 
 func TestAccAWSTransferServer_apigateway(t *testing.T) {
 	var conf transfer.DescribedServer
-	resourceName := "aws_transfer_server.foo"
-	rName := acctest.RandString(5)
+	resourceName := "aws_transfer_server.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t); testAccPreCheckAWSTransfer(t) },
@@ -168,16 +199,8 @@ func TestAccAWSTransferServer_apigateway(t *testing.T) {
 				Config: testAccAWSTransferServerConfig_apigateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(
-						resourceName, "identity_provider_type", "API_GATEWAY"),
-					resource.TestCheckResourceAttrSet(
-						resourceName, "invocation_role"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.NAME", "tf-acc-test-transfer-server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.TYPE", "apigateway"),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider_type", "API_GATEWAY"),
+					resource.TestCheckResourceAttrPair(resourceName, "invocation_role", "aws_iam_role.test", "arn"),
 				),
 			},
 		},
@@ -186,6 +209,7 @@ func TestAccAWSTransferServer_apigateway(t *testing.T) {
 
 func TestAccAWSTransferServer_disappears(t *testing.T) {
 	var conf transfer.DescribedServer
+	resourceName := "aws_transfer_server.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
@@ -194,10 +218,10 @@ func TestAccAWSTransferServer_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSTransferServerConfig_basic,
+				Config: testAccAWSTransferServerBasicConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &conf),
-					testAccCheckAWSTransferServerDisappears(&conf),
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsTransferServer(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -208,8 +232,8 @@ func TestAccAWSTransferServer_disappears(t *testing.T) {
 func TestAccAWSTransferServer_forcedestroy(t *testing.T) {
 	var conf transfer.DescribedServer
 	var roleConf iam.GetRoleOutput
-	resourceName := "aws_transfer_server.foo"
-	rName := acctest.RandString(5)
+	resourceName := "aws_transfer_server.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
@@ -221,11 +245,9 @@ func TestAccAWSTransferServer_forcedestroy(t *testing.T) {
 				Config: testAccAWSTransferServerConfig_forcedestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
-					testAccCheckAWSRoleExists("aws_iam_role.foo", &roleConf),
-					resource.TestCheckResourceAttr(
-						resourceName, "identity_provider_type", "SERVICE_MANAGED"),
-					resource.TestCheckResourceAttr(
-						resourceName, "force_destroy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider_type", "SERVICE_MANAGED"),
+					resource.TestCheckResourceAttr(resourceName, "force_destroy", "true"),
+					testAccCheckAWSRoleExists("aws_iam_role.test", &roleConf),
 					testAccCheckAWSTransferCreateUser(&conf, &roleConf, rName),
 					testAccCheckAWSTransferCreateSshKey(&conf, rName),
 				),
@@ -242,7 +264,8 @@ func TestAccAWSTransferServer_forcedestroy(t *testing.T) {
 
 func TestAccAWSTransferServer_vpcEndpointId(t *testing.T) {
 	var conf transfer.DescribedServer
-	resourceName := "aws_transfer_server.default"
+	resourceName := "aws_transfer_server.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
@@ -251,11 +274,10 @@ func TestAccAWSTransferServer_vpcEndpointId(t *testing.T) {
 		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSTransferServerConfig_VpcEndPoint,
+				Config: testAccAWSTransferServerConfig_VpcEndPoint(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(
-						resourceName, "endpoint_type", "VPC_ENDPOINT"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "VPC_ENDPOINT"),
 				),
 			},
 			{
@@ -270,7 +292,7 @@ func TestAccAWSTransferServer_vpcEndpointId(t *testing.T) {
 
 func TestAccAWSTransferServer_hostKey(t *testing.T) {
 	var conf transfer.DescribedServer
-	resourceName := "aws_transfer_server.default"
+	resourceName := "aws_transfer_server.test"
 	hostKey := "test-fixtures/transfer-ssh-rsa-key"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -320,23 +342,6 @@ func testAccCheckAWSTransferServerExists(n string, res *transfer.DescribedServer
 		*res = *describe.Server
 
 		return nil
-	}
-}
-
-func testAccCheckAWSTransferServerDisappears(conf *transfer.DescribedServer) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).transferconn
-
-		params := &transfer.DeleteServerInput{
-			ServerId: conf.ServerId,
-		}
-
-		_, err := conn.DeleteServer(params)
-		if err != nil {
-			return err
-		}
-
-		return waitForTransferServerDeletion(conn, *conf.ServerId)
 	}
 }
 
@@ -416,14 +421,24 @@ func testAccPreCheckAWSTransfer(t *testing.T) {
 	}
 }
 
-const testAccAWSTransferServerConfig_basic = `
-resource "aws_transfer_server" "foo" {}
+func testAccAWSTransferServerBasicConfig() string {
+	return `
+resource "aws_transfer_server" "test" {}
 `
+}
 
-func testAccAWSTransferServerConfig_basicUpdate(rName string) string {
+func testAccAWSTransferServerSecurityPolicyConfig(policy string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-server-iam-role-%[1]s"
+resource "aws_transfer_server" "test" {
+  security_policy_name = %[1]q
+}
+`, policy)
+}
+
+func testAccAWSTransferServerUpdatedConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -441,9 +456,9 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-server-iam-policy-%[1]s"
-  role = aws_iam_role.foo.id
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
 
   policy = <<POLICY
 {
@@ -462,14 +477,9 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
-resource "aws_transfer_server" "foo" {
+resource "aws_transfer_server" "test" {
   identity_provider_type = "SERVICE_MANAGED"
-  logging_role           = aws_iam_role.foo.arn
-
-  tags = {
-    NAME = "tf-acc-test-transfer-server"
-    ENV  = "test"
-  }
+  logging_role           = aws_iam_role.test.arn
 }
 `, rName)
 }
@@ -477,7 +487,7 @@ resource "aws_transfer_server" "foo" {
 func testAccAWSTransferServerConfig_apigateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "test"
+  name = %[1]q
 }
 
 resource "aws_api_gateway_resource" "test" {
@@ -522,21 +532,21 @@ resource "aws_api_gateway_deployment" "test" {
 
   rest_api_id       = aws_api_gateway_rest_api.test.id
   stage_name        = "test"
-  description       = "%[1]s"
-  stage_description = "%[1]s"
+  description       = %[1]q
+  stage_description = %[1]q
 
   variables = {
     "a" = "2"
   }
 }
 
+<<<<<<< HEAD
 resource "aws_iam_role" "foo" {
   name = "tf-test-transfer-server-iam-role-for-apigateway-%[1]s"
-
-  assume_role_policy = <<EOF
+=======
+resource "aws_iam_role" "test" {
 {
   "Version": "2012-10-17",
-  "Statement": [
     {
       "Effect": "Allow",
       "Principal": {
@@ -549,9 +559,15 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
+<<<<<<< HEAD
 resource "aws_iam_role_policy" "foo" {
   name = "tf-test-transfer-server-iam-policy-%[1]s"
   role = aws_iam_role.foo.id
+=======
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
+>>>>>>> 3fe05e3e5 (add Security Policy test)
 
   policy = <<POLICY
 {
@@ -570,6 +586,7 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
+<<<<<<< HEAD
 data "aws_region" "current" {}
 
 resource "aws_transfer_server" "foo" {
@@ -582,6 +599,13 @@ resource "aws_transfer_server" "foo" {
     NAME = "tf-acc-test-transfer-server"
     TYPE = "apigateway"
   }
+=======
+resource "aws_transfer_server" "test" {
+  identity_provider_type = "API_GATEWAY"
+  url                    = "${aws_api_gateway_deployment.test.invoke_url}${aws_api_gateway_resource.test.path}"
+  invocation_role        = aws_iam_role.test.arn
+  logging_role           = aws_iam_role.test.arn
+>>>>>>> 3fe05e3e5 (add Security Policy test)
 }
 `, rName)
 
@@ -589,12 +613,17 @@ resource "aws_transfer_server" "foo" {
 
 func testAccAWSTransferServerConfig_forcedestroy(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_transfer_server" "foo" {
+resource "aws_transfer_server" "test" {
   force_destroy = true
 }
 
+<<<<<<< HEAD
 resource "aws_iam_role" "foo" {
   name = "tf-test-transfer-user-iam-role-%[1]s"
+=======
+resource "aws_iam_role" "test" {
+  name = %[1]q
+>>>>>>> 3fe05e3e5 (add Security Policy test)
 
   assume_role_policy = <<EOF
 {
@@ -612,9 +641,15 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
+<<<<<<< HEAD
 resource "aws_iam_role_policy" "foo" {
   name = "tf-test-transfer-user-iam-policy-%[1]s"
   role = aws_iam_role.foo.id
+=======
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
+>>>>>>> 3fe05e3e5 (add Security Policy test)
 
   policy = <<POLICY
 {
@@ -635,15 +670,13 @@ POLICY
 `, rName)
 }
 
-const testAccAWSTransferServerConfig_VpcEndPoint = `
-
-data "aws_region" "current" {}
-
+func testAccAWSTransferServerConfig_VpcEndPoint(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-default-route-table-vpc-endpoint"
+    Name = %[1]q
   }
 }
 
@@ -651,12 +684,12 @@ resource "aws_internet_gateway" "igw" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "test"
+    Name = %[1]q
   }
 }
 
 resource "aws_security_group" "sg" {
-  name        = "allow-transfer-server"
+  name        = %[1]q
   description = "Allow TLS inbound traffic"
   vpc_id      = aws_vpc.test.id
 
@@ -666,23 +699,35 @@ resource "aws_security_group" "sg" {
     protocol  = "-1"
     self      = true
   }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_vpc_endpoint_service" "test" {
+  service = "transfer.server"
 }
 
 resource "aws_vpc_endpoint" "transfer" {
   vpc_id            = aws_vpc.test.id
   vpc_endpoint_type = "Interface"
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.transfer.server"
+  service_name      = data.aws_vpc_endpoint_service.test.service_name
 
   security_group_ids = [
     aws_security_group.sg.id,
   ]
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
-resource "aws_default_route_table" "foo" {
+resource "aws_default_route_table" "test" {
   default_route_table_id = aws_vpc.test.default_route_table_id
 
   tags = {
-    Name = "test"
+    Name = %[1]q
   }
 
   route {
@@ -691,23 +736,23 @@ resource "aws_default_route_table" "foo" {
   }
 }
 
-resource "aws_transfer_server" "default" {
+resource "aws_transfer_server" "test" {
   endpoint_type = "VPC_ENDPOINT"
 
   endpoint_details {
     vpc_endpoint_id = aws_vpc_endpoint.transfer.id
   }
 }
-`
+`, rName)
+}
 
-const testAccAWSTransferServerConfig_VpcDefault = `
-data "aws_region" "current" {}
-
+func testAccAWSTransferServerConfig_VpcDefault(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-vpc"
+    Name = %[1]q
   }
 }
 
@@ -715,7 +760,7 @@ resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-igw"
+    Name = %[1]q
   }
 }
 
@@ -723,6 +768,10 @@ resource "aws_subnet" "test" {
   vpc_id                  = aws_vpc.test.id
   cidr_block              = "10.0.0.0/24"
   map_public_ip_on_launch = true
+
+  tags = {
+    Name = %[1]q
+  }
 
   depends_on = [aws_internet_gateway.test]
 }
@@ -736,29 +785,39 @@ resource "aws_default_route_table" "test" {
   }
 
   tags = {
-    Name = "terraform-testacc-subnet"
+    Name = %[1]q
   }
 }
 
 resource "aws_security_group" "test" {
-  name   = "terraform-testacc-security-group"
+  name   = %[1]q
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-security-group"
+    Name = %[1]q
   }
 }
 
 resource "aws_eip" "testa" {
   vpc = true
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_eip" "testb" {
   vpc = true
-}
-`
 
-const testAccAWSTransferServerConfig_Vpc = testAccAWSTransferServerConfig_VpcDefault + `
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccAWSTransferServerConfig_Vpc(rName string) string {
+	return testAccAWSTransferServerConfig_VpcDefault(rName) + `
 resource "aws_transfer_server" "test" {
   endpoint_type = "VPC"
 
@@ -769,8 +828,10 @@ resource "aws_transfer_server" "test" {
   }
 }
 `
+}
 
-const testAccAWSTransferServerConfig_VpcUpdate = testAccAWSTransferServerConfig_VpcDefault + `
+func testAccAWSTransferServerConfig_VpcUpdate(rName string) string {
+	return testAccAWSTransferServerConfig_VpcDefault(rName) + `
 resource "aws_transfer_server" "test" {
   endpoint_type = "VPC"
 
@@ -781,10 +842,11 @@ resource "aws_transfer_server" "test" {
   }
 }
 `
+}
 
 func testAccAWSTransferServerConfig_hostKey(hostKey string) string {
 	return fmt.Sprintf(`
-resource "aws_transfer_server" "default" {
+resource "aws_transfer_server" "test" {
   host_key = file("%s")
 }
 `, hostKey)

--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -80,10 +80,8 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "transfer", regexp.MustCompile(`server/.+`)),
-					resource.TestMatchResourceAttr(
-						resourceName, "endpoint", regexp.MustCompile(fmt.Sprintf("^s-[a-z0-9]+.server.transfer.%s.amazonaws.com$", testAccGetRegion()))),
-					resource.TestCheckResourceAttr(
-						resourceName, "identity_provider_type", "SERVICE_MANAGED"),
+					testAccMatchResourceAttrRegionalHostname(resourceName, "endpoint", "server.transfer", regexp.MustCompile(`s-[a-z0-9]+`)),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider_type", "SERVICE_MANAGED"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "PUBLIC"),
 					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-2018-11"),
@@ -156,12 +154,9 @@ func TestAccAWSTransferServer_Vpc(t *testing.T) {
 				Config: testAccAWSTransferServerConfig_Vpc(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(
-						resourceName, "endpoint_type", "VPC"),
-					resource.TestCheckResourceAttr(
-						resourceName, "endpoint_details.0.subnet_ids.#", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "endpoint_details.0.address_allocation_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "VPC"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_details.0.subnet_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_details.0.address_allocation_ids.#", "1"),
 				),
 			},
 			{
@@ -174,10 +169,8 @@ func TestAccAWSTransferServer_Vpc(t *testing.T) {
 				Config: testAccAWSTransferServerConfig_VpcUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(
-						resourceName, "endpoint_type", "VPC"),
-					resource.TestCheckResourceAttr(
-						resourceName, "endpoint_details.0.address_allocation_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "VPC"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_details.0.address_allocation_ids.#", "1"),
 				),
 			},
 		},
@@ -443,15 +436,13 @@ resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "transfer.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "transfer.amazonaws.com"
+    },
+    "Action": "sts:AssumeRole"
+  }]
 }
 EOF
 }
@@ -463,16 +454,14 @@ resource "aws_iam_role_policy" "test" {
   policy = <<POLICY
 {
   "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowFullAccesstoCloudWatchLogs",
-      "Effect": "Allow",
-      "Action": [
-        "logs:*"
-      ],
-      "Resource": "*"
-    }
-  ]
+  "Statement": [{
+    "Sid": "AllowFullAccesstoCloudWatchLogs",
+    "Effect": "Allow",
+    "Action": [
+      "logs:*"
+    ],
+    "Resource": "*"
+  }]
 }
 POLICY
 }
@@ -540,75 +529,49 @@ resource "aws_api_gateway_deployment" "test" {
   }
 }
 
-<<<<<<< HEAD
-resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-server-iam-role-for-apigateway-%[1]s"
-=======
 resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "transfer.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "transfer.amazonaws.com"
+    },
+    "Action": "sts:AssumeRole"
+  }]
 }
 EOF
 }
 
-<<<<<<< HEAD
-resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-server-iam-policy-%[1]s"
-  role = aws_iam_role.foo.id
-=======
 resource "aws_iam_role_policy" "test" {
   name = %[1]q
   role = aws_iam_role.test.id
->>>>>>> 3fe05e3e5 (add Security Policy test)
 
   policy = <<POLICY
 {
   "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowFullAccesstoCloudWatchLogs",
-      "Effect": "Allow",
-      "Action": [
-        "logs:*"
-      ],
-      "Resource": "*"
-    }
-  ]
+  "Statement": [{
+    "Sid": "AllowFullAccesstoCloudWatchLogs",
+    "Effect": "Allow",
+    "Action": [
+      "logs:*"
+    ],
+    "Resource": "*"
+  }]
 }
 POLICY
 }
 
-<<<<<<< HEAD
-data "aws_region" "current" {}
-
-resource "aws_transfer_server" "foo" {
-  identity_provider_type = "API_GATEWAY"
-  url                    = "https://${aws_api_gateway_rest_api.test.id}.execute-api.${data.aws_region.current.name}.amazonaws.com${aws_api_gateway_resource.test.path}"
-  invocation_role        = aws_iam_role.foo.arn
-  logging_role           = aws_iam_role.foo.arn
-
-  tags = {
-    NAME = "tf-acc-test-transfer-server"
-    TYPE = "apigateway"
-  }
-=======
 resource "aws_transfer_server" "test" {
   identity_provider_type = "API_GATEWAY"
   url                    = "${aws_api_gateway_deployment.test.invoke_url}${aws_api_gateway_resource.test.path}"
   invocation_role        = aws_iam_role.test.arn
   logging_role           = aws_iam_role.test.arn
->>>>>>> 3fe05e3e5 (add Security Policy test)
 }
 `, rName)
-
 }
 
 func testAccAWSTransferServerConfig_forcedestroy(rName string) string {
@@ -617,53 +580,38 @@ resource "aws_transfer_server" "test" {
   force_destroy = true
 }
 
-<<<<<<< HEAD
-resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-user-iam-role-%[1]s"
-=======
 resource "aws_iam_role" "test" {
   name = %[1]q
->>>>>>> 3fe05e3e5 (add Security Policy test)
 
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "transfer.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "transfer.amazonaws.com"
+    },
+    "Action": "sts:AssumeRole"
+  }]
 }
 EOF
 }
 
-<<<<<<< HEAD
-resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-user-iam-policy-%[1]s"
-  role = aws_iam_role.foo.id
-=======
 resource "aws_iam_role_policy" "test" {
   name = %[1]q
   role = aws_iam_role.test.id
->>>>>>> 3fe05e3e5 (add Security Policy test)
 
   policy = <<POLICY
 {
   "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowFullAccesstoS3",
-      "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
-      "Resource": "*"
-    }
-  ]
+  "Statement": [{
+    "Sid": "AllowFullAccesstoS3",
+    "Effect": "Allow",
+    "Action": [
+      "s3:*"
+    ],
+    "Resource": "*"
+  }]
 }
 POLICY
 }
@@ -680,7 +628,7 @@ resource "aws_vpc" "test" {
   }
 }
 
-resource "aws_internet_gateway" "igw" {
+resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
 
   tags = {
@@ -688,7 +636,7 @@ resource "aws_internet_gateway" "igw" {
   }
 }
 
-resource "aws_security_group" "sg" {
+resource "aws_security_group" "test" {
   name        = %[1]q
   description = "Allow TLS inbound traffic"
   vpc_id      = aws_vpc.test.id
@@ -709,13 +657,13 @@ data "aws_vpc_endpoint_service" "test" {
   service = "transfer.server"
 }
 
-resource "aws_vpc_endpoint" "transfer" {
+resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
   vpc_endpoint_type = "Interface"
   service_name      = data.aws_vpc_endpoint_service.test.service_name
 
   security_group_ids = [
-    aws_security_group.sg.id,
+    aws_security_group.test.id,
   ]
 
   tags = {
@@ -732,7 +680,7 @@ resource "aws_default_route_table" "test" {
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.igw.id
+    gateway_id = aws_internet_gateway.test.id
   }
 }
 
@@ -740,7 +688,7 @@ resource "aws_transfer_server" "test" {
   endpoint_type = "VPC_ENDPOINT"
 
   endpoint_details {
-    vpc_endpoint_id = aws_vpc_endpoint.transfer.id
+    vpc_endpoint_id = aws_vpc_endpoint.test.id
   }
 }
 `, rName)
@@ -798,15 +746,9 @@ resource "aws_security_group" "test" {
   }
 }
 
-resource "aws_eip" "testa" {
-  vpc = true
+resource "aws_eip" "test" {
+  count = 2
 
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_eip" "testb" {
   vpc = true
 
   tags = {
@@ -817,37 +759,37 @@ resource "aws_eip" "testb" {
 }
 
 func testAccAWSTransferServerConfig_Vpc(rName string) string {
-	return testAccAWSTransferServerConfig_VpcDefault(rName) + `
+	return composeConfig(testAccAWSTransferServerConfig_VpcDefault(rName), `
 resource "aws_transfer_server" "test" {
   endpoint_type = "VPC"
 
   endpoint_details {
-    address_allocation_ids = [aws_eip.testa.id]
+    address_allocation_ids = [aws_eip.test[0].id]
     subnet_ids             = [aws_subnet.test.id]
     vpc_id                 = aws_vpc.test.id
   }
 }
-`
+`)
 }
 
 func testAccAWSTransferServerConfig_VpcUpdate(rName string) string {
-	return testAccAWSTransferServerConfig_VpcDefault(rName) + `
+	return composeConfig(testAccAWSTransferServerConfig_VpcDefault(rName), `
 resource "aws_transfer_server" "test" {
   endpoint_type = "VPC"
 
   endpoint_details {
-    address_allocation_ids = [aws_eip.testb.id]
+    address_allocation_ids = [aws_eip.test[1].id]
     subnet_ids             = [aws_subnet.test.id]
     vpc_id                 = aws_vpc.test.id
   }
 }
-`
+`)
 }
 
 func testAccAWSTransferServerConfig_hostKey(hostKey string) string {
 	return fmt.Sprintf(`
 resource "aws_transfer_server" "test" {
-  host_key = file("%s")
+  host_key = file(%[1]q)
 }
 `, hostKey)
 }

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -76,6 +76,7 @@ The following arguments are supported:
 * `identity_provider_type` - (Optional) The mode of authentication enabled for this service. The default value is `SERVICE_MANAGED`, which allows you to store and access SFTP user credentials within the service. `API_GATEWAY` indicates that user authentication requires a call to an API Gateway endpoint URL provided by you to integrate an identity provider of your choice.
 * `logging_role` - (Optional) Amazon Resource Name (ARN) of an IAM role that allows the service to write your SFTP users’ activity to your Amazon CloudWatch logs for monitoring and auditing purposes.
 * `force_destroy` - (Optional) A boolean that indicates all users associated with the server should be deleted so that the Server can be destroyed without error. The default value is `false`.
+* `security_policy_name` - (Optional) Specifies the name of the security policy that is attached to the server. Possible values are `TransferSecurityPolicy-2018-11`, `TransferSecurityPolicy-2020-06`, and  `TransferSecurityPolicy-FIPS-2020-06`. Default value is: `TransferSecurityPolicy-2018-11`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 **endpoint_details** requires the following:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes: #14694.
Closes: #15761.
Relates: #13527.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_transfer_server -  add `security_policy_name` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSTransferServer_'
--- PASS: TestAccAWSTransferServer_vpcEndpointId (196.21s)
--- PASS: TestAccAWSTransferServer_apigateway (235.13s)
--- PASS: TestAccAWSTransferServer_disappears (202.54s)
--- PASS: TestAccAWSTransferServer_Vpc (357.24s)
--- PASS: TestAccAWSTransferServer_securityPolicy (247.52s)
--- PASS: TestAccAWSTransferServer_forcedestroy (199.85s)
--- PASS: TestAccAWSTransferServer_hostKey (182.57s)
```
