### PR TITLE
r/aws_macie2_custom_data_identifier: New resource

### DIFF
--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -124,6 +124,7 @@ var mapServiceNames = []string{
 	"kinesisvideo",
 	"imagebuilder",
 	"lambda",
+	"macie2",
 	"mediaconnect",
 	"mediaconvert",
 	"medialive",

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -329,6 +329,16 @@ func LambdaKeyValueTags(tags map[string]*string) KeyValueTags {
 	return New(tags)
 }
 
+// Macie2Tags returns macie2 service tags.
+func (tags KeyValueTags) Macie2Tags() map[string]*string {
+	return aws.StringMap(tags.Map())
+}
+
+// Macie2KeyValueTags creates KeyValueTags from macie2 service tags.
+func Macie2KeyValueTags(tags map[string]*string) KeyValueTags {
+	return New(tags)
+}
+
 // MediaconnectTags returns mediaconnect service tags.
 func (tags KeyValueTags) MediaconnectTags() map[string]*string {
 	return aws.StringMap(tags.Map())

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -725,6 +725,7 @@ func Provider() *schema.Provider {
 			"aws_lb_ssl_negotiation_policy":                           resourceAwsLBSSLNegotiationPolicy(),
 			"aws_macie_member_account_association":                    resourceAwsMacieMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":                         resourceAwsMacieS3BucketAssociation(),
+			"aws_macie2_custom_data_identifier":                       resourceAwsMacie2CustomDataIdentifier(),
 			"aws_main_route_table_association":                        resourceAwsMainRouteTableAssociation(),
 			"aws_mq_broker":                                           resourceAwsMqBroker(),
 			"aws_mq_configuration":                                    resourceAwsMqConfiguration(),

--- a/aws/resource_aws_macie2_custom_data_identifier.go
+++ b/aws/resource_aws_macie2_custom_data_identifier.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsMacie2CustomDataIdentifier() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMacie2CustomDataIdentifierCreate,
+		Read:   resourceAwsMacie2CustomDataIdentifierRead,
+		Delete: resourceAwsMacie2CustomDataIdentifierDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 512),
+			},
+			"ignore_words": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(4, 90),
+				},
+			},
+			"keywords": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(4, 90),
+				},
+			},
+			"maximum_match_distance": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      50,
+				ValidateFunc: validation.IntBetween(1, 300),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 128),
+			},
+			"regex": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 500),
+			},
+			"tags": tagsSchemaForceNew(),
+		},
+	}
+}
+
+func resourceAwsMacie2CustomDataIdentifierCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).macie2conn
+
+	input := &macie2.CreateCustomDataIdentifierInput{
+		ClientToken: aws.String(resource.UniqueId()),
+		Name:        aws.String(d.Get("name").(string)),
+		Regex:       aws.String(d.Get("regex").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("ignore_words"); ok {
+		input.IgnoreWords = expandStringSet(v.(*schema.Set))
+	}
+	if v, ok := d.GetOk("keywords"); ok {
+		input.Keywords = expandStringSet(v.(*schema.Set))
+	}
+	if v, ok := d.GetOk("maximum_match_distance"); ok {
+		input.MaximumMatchDistance = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().Macie2Tags()
+	}
+
+	log.Printf("[DEBUG] Creating Macie2 Custom Data Identifier: %s", input)
+	out, err := conn.CreateCustomDataIdentifier(input)
+	if err != nil {
+		return fmt.Errorf("Failed to create custom data identifier: %s", err)
+	}
+
+	d.SetId(*out.CustomDataIdentifierId)
+
+	return resourceAwsMacie2CustomDataIdentifierRead(d, meta)
+}
+
+func resourceAwsMacie2CustomDataIdentifierRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).macie2conn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	input := &macie2.GetCustomDataIdentifierInput{
+		Id: aws.String(d.Id()),
+	}
+
+	output, err := conn.GetCustomDataIdentifier(input)
+
+	if err != nil {
+		return fmt.Errorf("error getting Custom Data Identifier (%s): %s", d.Id(), err)
+	}
+
+	d.Set("arn", output.Arn)
+	d.Set("description", output.Description)
+	d.Set("ignore_words", output.IgnoreWords)
+	d.Set("keywords", output.Keywords)
+	d.Set("maximum_match_distance", output.MaximumMatchDistance)
+	d.Set("name", output.Name)
+	d.Set("regex", output.Regex)
+
+	if err := d.Set("tags", keyvaluetags.Macie2KeyValueTags(output.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsMacie2CustomDataIdentifierDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).macie2conn
+
+	input := &macie2.DeleteCustomDataIdentifierInput{
+		Id: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteCustomDataIdentifier(input)
+	if err != nil {
+		return fmt.Errorf("Error deleting Custom Data Identifier: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_macie2_custom_data_identifier_test.go
+++ b/aws/resource_aws_macie2_custom_data_identifier_test.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSMacie2CustomDataIdentifier_basic(t *testing.T) {
+	resourceName := "aws_macie2_custom_data_identifier.test"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMacie2(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSMacie2CustomDataIdentifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSMacie2CustomDataIdentifierConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "regex", "\\d"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSMacie2CustomDataIdentifier_full(t *testing.T) {
+	resourceName := "aws_macie2_custom_data_identifier.test"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMacie2(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSMacie2CustomDataIdentifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSMacie2CustomDataIdentifierConfig_full(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "regex", "\\d"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Terraform test"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_words.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "keywords.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "maximum_match_distance", "20"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.baz", "qux"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSMacie2CustomDataIdentifierDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).macie2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_macie2_custom_data_identifier" {
+			continue
+		}
+
+		req := &macie2.GetCustomDataIdentifierInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		out, err := conn.GetCustomDataIdentifier(req)
+		if err != nil {
+			return err
+		}
+		if !*out.Deleted {
+			return fmt.Errorf("Custom Data Identifier %s is not deleted", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccPreCheckAWSMacie2(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).macie2conn
+
+	input := &macie2.GetMacieSessionInput{}
+
+	_, err := conn.GetMacieSession(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAWSMacie2CustomDataIdentifierConfig_basic(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_macie2_custom_data_identifier" "test" {
+  name  = "tf-%d"
+  regex = "\\d"
+}
+`, randInt)
+}
+
+func testAccAWSMacie2CustomDataIdentifierConfig_full(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_macie2_custom_data_identifier" "test" {
+  name                   = "tf-%d"
+  regex                  = "\\d"
+  description            = "Terraform test"
+  ignore_words           = ["test", "ignore", "words"]
+  keywords               = ["important", "things"]
+  maximum_match_distance = 20
+  tags = {
+    foo = "bar"
+    baz = "qux"
+  }
+}
+`, randInt)
+}

--- a/website/docs/r/macie2_custom_data_identifier.html.markdown
+++ b/website/docs/r/macie2_custom_data_identifier.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Macie"
+layout: "aws"
+page_title: "AWS: aws_macie2_custom_data_identifier"
+description: |-
+  Provides a Macie Custom Data Identifier resource.
+---
+
+# Resource: aws_macie2_custom_data_identifier
+
+Provides a Macie Custom Data Identifier resource.
+
+~> **NOTE:** Before using Amazon Macie for the first time it must be enabled manually. Instructions are [here](https://docs.aws.amazon.com/macie/latest/user/getting-started.html#enable-macie).
+
+~> **NOTE:** It is highly recommended that you test and refine the custom data identifier in the AWS Console before managing it in Terraform. Because custom data identifiers are used by sensitive data discovery jobs, you can't edit a custom data identifier after you save it. This helps ensure that you have an immutable history of sensitive data findings and discovery results for data privacy and protection audits or investigations that you perform. As such, if you change any of the attributes of an `aws_macie2_custom_data_identifier` resource, Terraform will create a new resource.
+
+## Example Usage
+
+```hcl
+resource "aws_macie2_custom_data_identifier" "example" {
+  name                   = "tf-macie-example"
+  regex                  = "\\d"
+  description            = "An example Macie custom data identifier"
+  ignore_words           = ["ignorethis", "andthis"]
+  keywords               = ["keyword1", "keyword2"]
+  maximum_match_distance = 100
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the custom data identifier.
+* `regex` - (Required) The regular expression that defines a text pattern to match in data. See [the Macie documentation](https://docs.aws.amazon.com/macie/latest/user/custom-data-identifiers.html#custom-data-identifiers-regex-support) for specific details on the supported pattern syntax.
+* `description` - (Optional) A description of the custom data identifier, up to 512 characters in length.
+* `ignore_words` - (Optional) Up to 10 expressions that define specific text to exclude from the results. Each ignore word can contain 4–90 characters. Ignore words are case sensitive.
+* `keywords` - (Optional) Up to 50 keywords that define specific text to match. Each keyword can contain 4–90 characters. Keywords aren't case sensitive.
+* `maximum_match_distance` - (Optional) The maximum allowable distance between text that matches the regex pattern and any of the keywords. Must be between 1 and 300. The default distance is 50 characters.
+* `tags` - (Optional) Key-value mapping of resource tags.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the custom data identifier
+* `id` - The ID of the custom data identifier.
+
+## Import
+
+Custom Data Identifiers can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_macie2_custom_data_identifier 9afbae86-c154-4ae9-ac5f-667a0a83891e
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13432 
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: `aws_macie2_custom_data_identifier` (#13432)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSMacie2CustomDataIdentifier'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMacie2CustomDataIdentifier -timeout 120m
=== RUN   TestAccAWSMacie2CustomDataIdentifier_basic
=== PAUSE TestAccAWSMacie2CustomDataIdentifier_basic
=== RUN   TestAccAWSMacie2CustomDataIdentifier_full
=== PAUSE TestAccAWSMacie2CustomDataIdentifier_full
=== CONT  TestAccAWSMacie2CustomDataIdentifier_basic
=== CONT  TestAccAWSMacie2CustomDataIdentifier_full
--- PASS: TestAccAWSMacie2CustomDataIdentifier_full (33.95s)
--- PASS: TestAccAWSMacie2CustomDataIdentifier_basic (34.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.306s
```
