### PR TITLE
New resource: Timestream Write database resource

### DIFF
--- a/.changelog/15463.txt
+++ b/.changelog/15463.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_timestreamwrite_database
+```

--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -116,6 +116,7 @@ var serviceNames = []string{
 	"ssoadmin",
 	"storagegateway",
 	"swf",
+	"timestreamwrite",
 	"transfer",
 	"waf",
 	"wafregional",

--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -97,6 +97,7 @@ var sliceServiceNames = []string{
 	"ssoadmin",
 	"storagegateway",
 	"swf",
+	"timestreamwrite",
 	"transfer",
 	"waf",
 	"wafregional",

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -124,6 +124,7 @@ var serviceNames = []string{
 	"storagegateway",
 	"swf",
 	"synthetics",
+	"timestreamwrite",
 	"transfer",
 	"waf",
 	"wafregional",

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -103,6 +103,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/aws/aws-sdk-go/service/swf"
+	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 	"github.com/aws/aws-sdk-go/service/transfer"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
@@ -1806,6 +1807,23 @@ func SwfListTags(conn *swf.SWF, identifier string) (KeyValueTags, error) {
 	}
 
 	return SwfKeyValueTags(output.Tags), nil
+}
+
+// TimestreamwriteListTags lists timestreamwrite service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func TimestreamwriteListTags(conn *timestreamwrite.TimestreamWrite, identifier string) (KeyValueTags, error) {
+	input := &timestreamwrite.ListTagsForResourceInput{
+		ResourceARN: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return TimestreamwriteKeyValueTags(output.Tags), nil
 }
 
 // TransferListTags lists transfer service tags.

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -115,6 +115,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/aws/aws-sdk-go/service/synthetics"
+	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 	"github.com/aws/aws-sdk-go/service/transfer"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
@@ -349,6 +350,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(swf.New)
 	case "synthetics":
 		funcType = reflect.TypeOf(synthetics.New)
+	case "timestreamwrite":
+		funcType = reflect.TypeOf(timestreamwrite.New)
 	case "transfer":
 		funcType = reflect.TypeOf(transfer.New)
 	case "waf":
@@ -751,6 +754,8 @@ func ServiceTagInputIdentifierField(serviceName string) string {
 	case "ssm":
 		return "ResourceId"
 	case "storagegateway":
+		return "ResourceARN"
+	case "timestreamwrite":
 		return "ResourceARN"
 	case "transfer":
 		return "Arn"

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -85,6 +85,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/aws/aws-sdk-go/service/swf"
+	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 	"github.com/aws/aws-sdk-go/service/transfer"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafv2"
@@ -2781,6 +2782,33 @@ func (tags KeyValueTags) SwfTags() []*swf.ResourceTag {
 
 // SwfKeyValueTags creates KeyValueTags from swf service tags.
 func SwfKeyValueTags(tags []*swf.ResourceTag) KeyValueTags {
+	m := make(map[string]*string, len(tags))
+
+	for _, tag := range tags {
+		m[aws.StringValue(tag.Key)] = tag.Value
+	}
+
+	return New(m)
+}
+
+// TimestreamwriteTags returns timestreamwrite service tags.
+func (tags KeyValueTags) TimestreamwriteTags() []*timestreamwrite.Tag {
+	result := make([]*timestreamwrite.Tag, 0, len(tags))
+
+	for k, v := range tags.Map() {
+		tag := &timestreamwrite.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		result = append(result, tag)
+	}
+
+	return result
+}
+
+// TimestreamwriteKeyValueTags creates KeyValueTags from timestreamwrite service tags.
+func TimestreamwriteKeyValueTags(tags []*timestreamwrite.Tag) KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -113,6 +113,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/aws/aws-sdk-go/service/synthetics"
+	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 	"github.com/aws/aws-sdk-go/service/transfer"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
@@ -3967,6 +3968,42 @@ func SyntheticsUpdateTags(conn *synthetics.Synthetics, identifier string, oldTag
 		input := &synthetics.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        updatedTags.IgnoreAws().SyntheticsTags(),
+		}
+
+		_, err := conn.TagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}
+
+// TimestreamwriteUpdateTags updates timestreamwrite service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func TimestreamwriteUpdateTags(conn *timestreamwrite.TimestreamWrite, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+		input := &timestreamwrite.UntagResourceInput{
+			ResourceARN: aws.String(identifier),
+			TagKeys:     aws.StringSlice(removedTags.IgnoreAws().Keys()),
+		}
+
+		_, err := conn.UntagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+		input := &timestreamwrite.TagResourceInput{
+			ResourceARN: aws.String(identifier),
+			Tags:        updatedTags.IgnoreAws().TimestreamwriteTags(),
 		}
 
 		_, err := conn.TagResource(input)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1055,6 +1055,7 @@ func Provider() *schema.Provider {
 			"aws_subnet":                                              resourceAwsSubnet(),
 			"aws_swf_domain":                                          resourceAwsSwfDomain(),
 			"aws_synthetics_canary":                                   resourceAwsSyntheticsCanary(),
+			"aws_timestreamwrite_database":                            resourceAwsTimestreamWriteDatabase(),
 			"aws_transfer_server":                                     resourceAwsTransferServer(),
 			"aws_transfer_ssh_key":                                    resourceAwsTransferSshKey(),
 			"aws_transfer_user":                                       resourceAwsTransferUser(),

--- a/aws/resource_aws_timestreamwrite_database.go
+++ b/aws/resource_aws_timestreamwrite_database.go
@@ -34,9 +34,10 @@ func resourceAwsTimestreamWriteDatabase() *schema.Resource {
 			},
 
 			"kms_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"tags": tagsSchema(),
@@ -58,12 +59,15 @@ func resourceAwsTimestreamWriteDatabaseCreate(d *schema.ResourceData, meta inter
 		input.Tags = keyvaluetags.New(attr.(map[string]interface{})).IgnoreAws().TimestreamwriteTags()
 	}
 
-	_, err := conn.CreateDatabase(input)
+	resp, err := conn.CreateDatabase(input)
+
 	if err != nil {
 		return err
 	}
 
-	d.SetId(d.Get("database_name").(string))
+	name := aws.StringValue(resp.Database.DatabaseName)
+
+	d.SetId(name)
 
 	return resourceAwsTimestreamWriteDatabaseRead(d, meta)
 }

--- a/aws/resource_aws_timestreamwrite_database.go
+++ b/aws/resource_aws_timestreamwrite_database.go
@@ -1,0 +1,148 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/timestreamwrite"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsTimestreamWriteDatabase() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsTimestreamWriteDatabaseCreate,
+		Read:   resourceAwsTimestreamWriteDatabaseRead,
+		Update: resourceAwsTimestreamWriteDatabaseUpdate,
+		Delete: resourceAwsTimestreamWriteDatabaseDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"database_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsTimestreamWriteDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).timestreamwriteconn
+
+	input := &timestreamwrite.CreateDatabaseInput{
+		DatabaseName: aws.String(d.Get("database_name").(string)),
+	}
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		input.KmsKeyId = aws.String(v.(string))
+	}
+
+	if attr, ok := d.GetOk("tags"); ok {
+		input.Tags = keyvaluetags.New(attr.(map[string]interface{})).IgnoreAws().TimestreamwriteTags()
+	}
+
+	_, err := conn.CreateDatabase(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(d.Get("database_name").(string))
+
+	return resourceAwsTimestreamWriteDatabaseRead(d, meta)
+}
+
+func resourceAwsTimestreamWriteDatabaseRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).timestreamwriteconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	resp, err := conn.DescribeDatabase(&timestreamwrite.DescribeDatabaseInput{
+		DatabaseName: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, timestreamwrite.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] Timestream Database %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("database_name", resp.Database.DatabaseName)
+	d.Set("kms_key_id", resp.Database.KmsKeyId)
+	d.Set("arn", resp.Database.Arn)
+
+	arn := aws.StringValue(resp.Database.Arn)
+
+	tags, err := keyvaluetags.TimestreamwriteListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Timestream Database (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsTimestreamWriteDatabaseUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).timestreamwriteconn
+
+	if d.HasChange("kms_key_id") {
+		input := &timestreamwrite.UpdateDatabaseInput{
+			DatabaseName: aws.String(d.Id()),
+			KmsKeyId:     aws.String(d.Get("kms_key_id").(string)),
+		}
+
+		_, err := conn.UpdateDatabase(input)
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.TimestreamwriteUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Timesteram Database (%s) tags: %s", d.Get("arn").(string), err)
+		}
+	}
+
+	return resourceAwsTimestreamWriteDatabaseRead(d, meta)
+}
+
+func resourceAwsTimestreamWriteDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).timestreamwriteconn
+
+	input := &timestreamwrite.DeleteDatabaseInput{
+		DatabaseName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteDatabase(input)
+	if err != nil {
+		if isAWSErr(err, timestreamwrite.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_timestreamwrite_database.go
+++ b/aws/resource_aws_timestreamwrite_database.go
@@ -43,9 +43,13 @@ func resourceAwsTimestreamWriteDatabase() *schema.Resource {
 			},
 
 			"kms_key_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// The Timestream API accepts the KmsKeyId as an ID, ARN, alias, or alias ARN but always returns the ARN of the key.
+				// The ARN is of the format 'arn:aws:kms:REGION:ACCOUNT_ID:key/KMS_KEY_ID'. Appropriate diff suppression
+				// would require an extra API call to the kms service's DescribeKey method to decipher aliases.
+				// To avoid importing an extra service in this resource, input here is restricted to only ARNs.
 				ValidateFunc: validateArn,
 			},
 

--- a/aws/resource_aws_timestreamwrite_database_test.go
+++ b/aws/resource_aws_timestreamwrite_database_test.go
@@ -18,6 +18,7 @@ func TestAccAWSTimestreamWriteDatabase_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, timestreamwrite.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSTimestreamWriteDatabaseDestroy,
 		Steps: []resource.TestStep{
@@ -47,6 +48,7 @@ func TestAccAWSTimestreamWriteDatabase_kmsKey(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, timestreamwrite.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSTimestreamWriteDatabaseDestroy,
 		Steps: []resource.TestStep{
@@ -73,6 +75,7 @@ func TestAccAWSTimestreamWriteDatabase_Tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, timestreamwrite.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSTimestreamWriteDatabaseDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_timestreamwrite_database_test.go
+++ b/aws/resource_aws_timestreamwrite_database_test.go
@@ -1,0 +1,219 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/timestreamwrite"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSTimestreamWriteDatabase_basic(t *testing.T) {
+	resourceName := "aws_timestreamwrite_database.test_database"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTimestreamWriteDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTimestreamWriteDatabaseConfigNoTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTimestreamWriteDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSTimestreamWriteDatabase_kmsKey(t *testing.T) {
+	resourceName := "aws_timestreamwrite_database.test_database"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	kmsResourceName := "aws_kms_key.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTimestreamWriteDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTimestreamWriteDatabaseConfigKmsKey(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTimestreamWriteDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSTimestreamWriteDatabase_Tags(t *testing.T) {
+	resourceName := "aws_timestreamwrite_database.test_database"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTimestreamWriteDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTimestreamWriteDatabaseConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTimestreamWriteDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSTimestreamWriteDatabaseConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTimestreamWriteDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSTimestreamWriteDatabaseConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTimestreamWriteDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSTimestreamWriteDatabaseDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).timestreamwriteconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_timestreamwrite_database" {
+			continue
+		}
+
+		_, err := conn.DescribeDatabase(&timestreamwrite.DescribeDatabaseInput{
+			DatabaseName: aws.String(rs.Primary.ID),
+		})
+
+		if isAWSErr(err, timestreamwrite.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+
+		if err == nil {
+			return fmt.Errorf("Timestream Database (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSTimestreamWriteDatabaseExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Timestream Database ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).timestreamwriteconn
+
+		_, err := conn.DescribeDatabase(&timestreamwrite.DescribeDatabaseInput{
+			DatabaseName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSTimestreamWriteDatabaseConfigNoTags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_timestreamwrite_database" "test_database" {
+  database_name = %[1]q
+}
+`, rName)
+}
+
+func testAccAWSTimestreamWriteDatabaseConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_timestreamwrite_database" "test_database" {
+  database_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSTimestreamWriteDatabaseConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_timestreamwrite_database" "test_database" {
+  database_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAWSTimestreamWriteDatabaseConfigKmsKey(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "foo" {
+  description = "Terraform acc test"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_timestreamwrite_database" "test_database" {
+  database_name = %[1]q
+  kms_key_id    = aws_kms_key.foo.arn
+}
+`, rName)
+}

--- a/website/docs/r/timestreamwrite_database.html.markdown
+++ b/website/docs/r/timestreamwrite_database.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "TimestreamWrite"
+subcategory: "Timestream Write"
 layout: "aws"
 page_title: "AWS: aws_timestreamwrite_database"
 description: |-
@@ -38,14 +38,8 @@ resource "aws_timestreamwrite_database" "test_database" {
 The following arguments are supported:
 
 * `database_name` – (Required) The name of the Timestream database. Minimum length of 3. Maximum length of 64.
-
-* `kms_key_id` - (Optional) The KMS key for the database. You can specify a key ID using any of the following:
-    * Key ID: `1234abcd-12ab-34cd-56ef-1234567890ab`
-    * Key ARN: `arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`
-    * Alias name: `alias/ExampleAlias`
-    * Alias ARN: `arn:aws:kms:us-east-1:111122223333:alias/ExampleAlias`
+* `kms_key_id` - (Optional) The KMS key for the database. You can specify a key ARN.
     If the KMS key is not specified, the database will be encrypted with a Timestream managed KMS key located in your account. Refer to [AWS managed KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk) for more info.
-
 * `tags` - (Optional) A map of tags to assign to the resource
 
 
@@ -54,7 +48,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name that uniquely identifies this database.
-
 * `kms_key_id` - The identifier of the KMS key used to encrypt the data stored in the database.
 
 ## Import

--- a/website/docs/r/timestreamwrite_database.html.markdown
+++ b/website/docs/r/timestreamwrite_database.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "TimestreamWrite"
+layout: "aws"
+page_title: "AWS: aws_timestreamwrite_database"
+description: |-
+  Provides a Timestream database resource.
+---
+
+# Resource: aws_timestreamwrite_database
+
+Provides a Timestream database resource.
+
+## Example Usage
+
+### Basic usage
+
+```hcl
+resource "aws_timestreamwrite_database" "test_database" {
+  database_name = "database-example"
+}
+```
+
+### Full usage
+
+```hcl
+resource "aws_timestreamwrite_database" "test_database" {
+  database_name = "database-example"
+  kms_key_id    = aws_kms_key.foo.arn
+
+  tags = {
+    Name = "value"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `database_name` – (Required) The name of the Timestream database. Minimum length of 3. Maximum length of 64.
+
+* `kms_key_id` - (Optional) The KMS key for the database. You can specify a key ID using any of the following:
+    * Key ID: `1234abcd-12ab-34cd-56ef-1234567890ab`
+    * Key ARN: `arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`
+    * Alias name: `alias/ExampleAlias`
+    * Alias ARN: `arn:aws:kms:us-east-1:111122223333:alias/ExampleAlias`
+    If the KMS key is not specified, the database will be encrypted with a Timestream managed KMS key located in your account. Refer to [AWS managed KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk) for more info.
+
+* `tags` - (Optional) A map of tags to assign to the resource
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name that uniquely identifies this database.
+
+* `kms_key_id` - The identifier of the KMS key used to encrypt the data stored in the database.
+
+## Import
+
+Timestream databases can be imported using the `database_name`, e.g.
+
+```
+$ terraform import aws_timestreamwrite_database.my_database my_database
+```
+

--- a/website/docs/r/timestreamwrite_database.html.markdown
+++ b/website/docs/r/timestreamwrite_database.html.markdown
@@ -15,7 +15,7 @@ Provides a Timestream database resource.
 ### Basic usage
 
 ```hcl
-resource "aws_timestreamwrite_database" "test_database" {
+resource "aws_timestreamwrite_database" "example" {
   database_name = "database-example"
 }
 ```
@@ -23,9 +23,9 @@ resource "aws_timestreamwrite_database" "test_database" {
 ### Full usage
 
 ```hcl
-resource "aws_timestreamwrite_database" "test_database" {
+resource "aws_timestreamwrite_database" "example" {
   database_name = "database-example"
-  kms_key_id    = aws_kms_key.foo.arn
+  kms_key_id    = aws_kms_key.example.arn
 
   tags = {
     Name = "value"
@@ -38,23 +38,23 @@ resource "aws_timestreamwrite_database" "test_database" {
 The following arguments are supported:
 
 * `database_name` – (Required) The name of the Timestream database. Minimum length of 3. Maximum length of 64.
-* `kms_key_id` - (Optional) The KMS key for the database. You can specify a key ARN.
-    If the KMS key is not specified, the database will be encrypted with a Timestream managed KMS key located in your account. Refer to [AWS managed KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk) for more info.
-* `tags` - (Optional) A map of tags to assign to the resource
-
+* `kms_key_id` - (Optional) The ARN (not Alias ARN) of the KMS key to be used to encrypt the data stored in the database. If the KMS key is not specified, the database will be encrypted with a Timestream managed KMS key located in your account. Refer to [AWS managed KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk) for more info.
+* `tags` - (Optional) Map of tags to assign to this resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The Amazon Resource Name that uniquely identifies this database.
-* `kms_key_id` - The identifier of the KMS key used to encrypt the data stored in the database.
+* `id` - The name of the Timestream database.
+* `arn` - The ARN that uniquely identifies this database.
+* `kms_key_id` - The ARN of the KMS key used to encrypt the data stored in the database.
+* `table_count` - The total number of tables found within the Timestream database.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 
 Timestream databases can be imported using the `database_name`, e.g.
 
 ```
-$ terraform import aws_timestreamwrite_database.my_database my_database
+$ terraform import aws_timestreamwrite_database.example example
 ```
-


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15421

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:
- **New Resource:** `aws_timestreamwrite_database`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAWSTimestreamWriteDatabase_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSTimestreamWriteDatabase_ -timeout 120m
=== RUN   TestAccAWSTimestreamWriteDatabase_basic
=== PAUSE TestAccAWSTimestreamWriteDatabase_basic
=== RUN   TestAccAWSTimestreamWriteDatabase_kmsKey
=== PAUSE TestAccAWSTimestreamWriteDatabase_kmsKey
=== RUN   TestAccAWSTimestreamWriteDatabase_Tags
=== PAUSE TestAccAWSTimestreamWriteDatabase_Tags
=== CONT  TestAccAWSTimestreamWriteDatabase_basic
=== CONT  TestAccAWSTimestreamWriteDatabase_Tags
=== CONT  TestAccAWSTimestreamWriteDatabase_kmsKey
--- PASS: TestAccAWSTimestreamWriteDatabase_basic (17.00s)
--- PASS: TestAccAWSTimestreamWriteDatabase_kmsKey (18.86s)
--- PASS: TestAccAWSTimestreamWriteDatabase_Tags (40.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	43.229s
```
