### PR TITLE
adding 'url' attribute to resource_aws_sqs_queue

### DIFF
--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -107,6 +107,10 @@ func resourceAwsSqsQueue() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"fifo_queue": {
 				Type:     schema.TypeBool,
 				Default:  false,
@@ -314,6 +318,7 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("policy", "")
 	d.Set("receive_wait_time_seconds", 0)
 	d.Set("redrive_policy", "")
+	d.Set("url", d.Id())
 	d.Set("visibility_timeout_seconds", 30)
 
 	if attributeOutput != nil {

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -87,6 +87,7 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
 					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					resource.TestCheckResourceAttrPair(resourceName, "id", resourceName, "url"),
 				),
 			},
 			{

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -73,6 +73,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The URL for the created Amazon SQS queue.
 * `arn` - The ARN of the SQS queue
+* `url` - Same as `id`: The URL for the created Amazon SQS queue.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #11848 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added `url` attribute to `resource_aws_sqs_queue`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSQSQueue_'     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSQSQueue_ -timeout 120m
=== RUN   TestAccAWSSQSQueue_basic
=== PAUSE TestAccAWSSQSQueue_basic
=== RUN   TestAccAWSSQSQueue_tags
=== PAUSE TestAccAWSSQSQueue_tags
=== RUN   TestAccAWSSQSQueue_namePrefix
=== PAUSE TestAccAWSSQSQueue_namePrefix
=== RUN   TestAccAWSSQSQueue_namePrefix_fifo
=== PAUSE TestAccAWSSQSQueue_namePrefix_fifo
=== RUN   TestAccAWSSQSQueue_policy
=== PAUSE TestAccAWSSQSQueue_policy
=== RUN   TestAccAWSSQSQueue_queueDeletedRecently
=== PAUSE TestAccAWSSQSQueue_queueDeletedRecently
=== RUN   TestAccAWSSQSQueue_redrivePolicy
=== PAUSE TestAccAWSSQSQueue_redrivePolicy
=== RUN   TestAccAWSSQSQueue_Policybasic
=== PAUSE TestAccAWSSQSQueue_Policybasic
=== RUN   TestAccAWSSQSQueue_FIFO
=== PAUSE TestAccAWSSQSQueue_FIFO
=== RUN   TestAccAWSSQSQueue_FIFOExpectNameError
=== PAUSE TestAccAWSSQSQueue_FIFOExpectNameError
=== RUN   TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== PAUSE TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== RUN   TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== PAUSE TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== RUN   TestAccAWSSQSQueue_Encryption
=== PAUSE TestAccAWSSQSQueue_Encryption
=== CONT  TestAccAWSSQSQueue_basic
=== CONT  TestAccAWSSQSQueue_Encryption
=== CONT  TestAccAWSSQSQueue_redrivePolicy
=== CONT  TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== CONT  TestAccAWSSQSQueue_namePrefix_fifo
=== CONT  TestAccAWSSQSQueue_Policybasic
=== CONT  TestAccAWSSQSQueue_namePrefix
=== CONT  TestAccAWSSQSQueue_tags
=== CONT  TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== CONT  TestAccAWSSQSQueue_FIFOExpectNameError
=== CONT  TestAccAWSSQSQueue_FIFO
=== CONT  TestAccAWSSQSQueue_queueDeletedRecently
=== CONT  TestAccAWSSQSQueue_policy
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (12.23s)
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (12.33s)
2020/10/03 20:40:04 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSSQSQueue_namePrefix (37.91s)
--- PASS: TestAccAWSSQSQueue_Encryption (38.07s)
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (38.07s)
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (38.08s)
--- PASS: TestAccAWSSQSQueue_FIFO (38.11s)
--- PASS: TestAccAWSSQSQueue_redrivePolicy (38.29s)
--- PASS: TestAccAWSSQSQueue_Policybasic (42.53s)
--- PASS: TestAccAWSSQSQueue_policy (42.57s)
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (53.96s)
--- PASS: TestAccAWSSQSQueue_tags (83.07s)
--- PASS: TestAccAWSSQSQueue_basic (83.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       83.110s
```
