### PR TITLE
adding fix for aws org feature_set update issue from #15462

### DIFF
--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -402,7 +402,7 @@ func resourceAwsOrganizationsOrganizationUpdate(d *schema.ResourceData, meta int
 
 	if d.HasChange("feature_set") {
 		if _, err := conn.EnableAllFeatures(&organizations.EnableAllFeaturesInput{}); err != nil {
-			return fmt.Errorf("error changing feature_set to ALL")
+			return fmt.Errorf("error enabling all features in Organization (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -151,23 +151,15 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						organizations.PolicyTypeAiservicesOptOutPolicy,
-						organizations.PolicyTypeBackupPolicy,
-						organizations.PolicyTypeServiceControlPolicy,
-						organizations.PolicyTypeTagPolicy,
-					}, false),
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(organizations.PolicyType_Values(), false),
 				},
 			},
 			"feature_set": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  organizations.OrganizationFeatureSetAll,
-				ValidateFunc: validation.StringInSlice([]string{
-					organizations.OrganizationFeatureSetAll,
-					organizations.OrganizationFeatureSetConsolidatedBilling,
-				}, true),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      organizations.OrganizationFeatureSetAll,
+				ValidateFunc: validation.StringInSlice(organizations.OrganizationFeatureSet_Values(), true),
 			},
 		},
 	}
@@ -405,6 +397,12 @@ func resourceAwsOrganizationsOrganizationUpdate(d *schema.ResourceData, meta int
 			if err := waitForOrganizationDefaultRootPolicyTypeEnable(conn, policyType); err != nil {
 				return fmt.Errorf("error waiting for policy type (%s) enabling in Organization (%s) Root (%s): %s", policyType, d.Id(), defaultRootID, err)
 			}
+		}
+	}
+
+	if d.HasChange("feature_set") {
+		if _, err := conn.EnableAllFeatures(&organizations.EnableAllFeaturesInput{}); err != nil {
+			return fmt.Errorf("error changing feature_set to ALL")
 		}
 	}
 

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -230,7 +230,7 @@ func testAccAwsOrganizationsOrganization_FeatureSetForcesNew(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &afterValue),
 					resource.TestCheckResourceAttr(resourceName, "feature_set", organizations.OrganizationFeatureSetConsolidatedBilling),
-					testAccAwsOrganizationsOrganizationRecreated(t, &beforeValue, &afterValue),
+					testAccAwsOrganizationsOrganizationRecreated(&beforeValue, &afterValue),
 				),
 			},
 		},
@@ -267,7 +267,7 @@ func testAccAwsOrganizationsOrganization_FeatureSetUpdate(t *testing.T) {
 					// via Console. Until then, the FeatureSet will not actually be toggled to ALL
 					// and will continue to show as CONSOLIDATED_BILLING when calling DescribeOrganization
 					// resource.TestCheckResourceAttr(resourceName, "feature_set", organizations.OrganizationFeatureSetAll),
-					testAccAwsOrganizationsOrganizationNotRecreated(t, &beforeValue, &afterValue),
+					testAccAwsOrganizationsOrganizationNotRecreated(&beforeValue, &afterValue),
 				),
 			},
 		},
@@ -425,7 +425,7 @@ func testFlattenOrganizationsRootPolicyTypes(t *testing.T, index int, result []m
 	}
 }
 
-func testAccAwsOrganizationsOrganizationRecreated(t *testing.T, before, after *organizations.Organization) resource.TestCheckFunc {
+func testAccAwsOrganizationsOrganizationRecreated(before, after *organizations.Organization) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.StringValue(before.Id) == aws.StringValue(after.Id) {
 			return fmt.Errorf("Organization (%s) not recreated", aws.StringValue(before.Id))
@@ -434,7 +434,7 @@ func testAccAwsOrganizationsOrganizationRecreated(t *testing.T, before, after *o
 	}
 }
 
-func testAccAwsOrganizationsOrganizationNotRecreated(t *testing.T, before, after *organizations.Organization) resource.TestCheckFunc {
+func testAccAwsOrganizationsOrganizationNotRecreated(before, after *organizations.Organization) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.StringValue(before.Id) != aws.StringValue(after.Id) {
 			return fmt.Errorf("Organization (%s) recreated", aws.StringValue(before.Id))

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -10,7 +10,9 @@ func TestAccAWSOrganizations_serial(t *testing.T) {
 			"basic":                      testAccAwsOrganizationsOrganization_basic,
 			"AwsServiceAccessPrincipals": testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals,
 			"EnabledPolicyTypes":         testAccAwsOrganizationsOrganization_EnabledPolicyTypes,
-			"FeatureSet":                 testAccAwsOrganizationsOrganization_FeatureSet,
+			"FeatureSet_Basic":           testAccAwsOrganizationsOrganization_FeatureSet,
+			"FeatureSet_Update":          testAccAwsOrganizationsOrganization_FeatureSetUpdate,
+			"FeatureSet_ForcesNew":       testAccAwsOrganizationsOrganization_FeatureSetForcesNew,
 			"DataSource":                 testAccDataSourceAwsOrganizationsOrganization_basic,
 		},
 		"Account": {

--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a resource to create an organization.
 
+!> **WARNING:** When migrating from a `feature_set` of `CONSOLIDATED_BILLING` to `ALL`, the Organization account owner will received an email stating the following: "You started the process to enable all features for your AWS organization. As part of that process, all member accounts that joined your organization by invitation must approve the change. You don’t need approval from member accounts that you directly created from within your AWS organization." After all member accounts have accepted the invitation, the Organization account owner must then finalize the changes via the [AWS Console](https://console.aws.amazon.com/organizations/home#/organization/settings/migration-progress). Until these steps are performed, Terraform will perpetually show a difference, and the `DescribeOrganization` API will continue to show the `FeatureSet` as `CONSOLIDATED_BILLING`. See the [AWS Organizations documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_org_support-all-features.html) for more information.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15462

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSOrganizations_serial/Organization/FeatureSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSOrganizations_serial/Organization/FeatureSet -timeout 120m
=== RUN   TestAccAWSOrganizations_serial
=== RUN   TestAccAWSOrganizations_serial/OrganizationalUnits
=== RUN   TestAccAWSOrganizations_serial/Organization
=== RUN   TestAccAWSOrganizations_serial/Organization/FeatureSet_Basic
=== RUN   TestAccAWSOrganizations_serial/Organization/FeatureSet_Update
    resource_aws_organizations_organization_test.go:413: [INFO] Got non-empty plan, as expected
    resource_aws_organizations_organization_test.go:413: [INFO] Got non-empty plan, as expected
=== RUN   TestAccAWSOrganizations_serial/Organization/FeatureSet_ForcesNew
=== RUN   TestAccAWSOrganizations_serial/OrganizationalUnit
--- PASS: TestAccAWSOrganizations_serial (141.11s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnits (0.00s)
    --- PASS: TestAccAWSOrganizations_serial/Organization (141.11s)
        --- PASS: TestAccAWSOrganizations_serial/Organization/FeatureSet_Basic (27.37s)
        --- PASS: TestAccAWSOrganizations_serial/Organization/FeatureSet_Update (52.12s)
        --- PASS: TestAccAWSOrganizations_serial/Organization/FeatureSet_ForcesNew (61.62s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	142.790s
```
