### PR TITLE
Add configurable timeouts to workspaces

### DIFF
--- a/aws/internal/service/workspaces/waiter/waiter.go
+++ b/aws/internal/service/workspaces/waiter/waiter.go
@@ -69,7 +69,7 @@ func DirectoryDeregistered(conn *workspaces.WorkSpaces, directoryID string) (*wo
 	return nil, err
 }
 
-func WorkspaceAvailable(conn *workspaces.WorkSpaces, workspaceID string) (*workspaces.Workspace, error) {
+func WorkspaceAvailable(conn *workspaces.WorkSpaces, workspaceID string, timeout time.Duration) (*workspaces.Workspace, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			workspaces.WorkspaceStatePending,
@@ -77,7 +77,7 @@ func WorkspaceAvailable(conn *workspaces.WorkSpaces, workspaceID string) (*works
 		},
 		Target:  []string{workspaces.WorkspaceStateAvailable},
 		Refresh: WorkspaceState(conn, workspaceID),
-		Timeout: WorkspaceAvailableTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -89,7 +89,7 @@ func WorkspaceAvailable(conn *workspaces.WorkSpaces, workspaceID string) (*works
 	return nil, err
 }
 
-func WorkspaceTerminated(conn *workspaces.WorkSpaces, workspaceID string) (*workspaces.Workspace, error) {
+func WorkspaceTerminated(conn *workspaces.WorkSpaces, workspaceID string, timeout time.Duration) (*workspaces.Workspace, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			workspaces.WorkspaceStatePending,
@@ -111,7 +111,7 @@ func WorkspaceTerminated(conn *workspaces.WorkSpaces, workspaceID string) (*work
 		},
 		Target:  []string{},
 		Refresh: WorkspaceState(conn, workspaceID),
-		Timeout: WorkspaceTerminatedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -123,7 +123,7 @@ func WorkspaceTerminated(conn *workspaces.WorkSpaces, workspaceID string) (*work
 	return nil, err
 }
 
-func WorkspaceUpdated(conn *workspaces.WorkSpaces, workspaceID string) (*workspaces.Workspace, error) {
+func WorkspaceUpdated(conn *workspaces.WorkSpaces, workspaceID string, timeout time.Duration) (*workspaces.Workspace, error) {
 	// OperationInProgressException: The properties of this WorkSpace are currently under modification. Please try again in a moment.
 	// AWS Workspaces service doesn't change instance status to "Updating" during property modification. Respective AWS Support feature request has been created. Meanwhile, artificial delay is placed here as a workaround.
 	stateConf := &resource.StateChangeConf{
@@ -136,7 +136,7 @@ func WorkspaceUpdated(conn *workspaces.WorkSpaces, workspaceID string) (*workspa
 		},
 		Refresh: WorkspaceState(conn, workspaceID),
 		Delay:   WorkspaceUpdatingDelay,
-		Timeout: WorkspaceUpdatingTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/workspaces/waiter"
 )
 

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/workspaces/waiter"
 )
 
 func init() {
@@ -33,7 +35,7 @@ func testSweepWorkspacesWorkspace(region string) error {
 	input := &workspaces.DescribeWorkspacesInput{}
 	err = conn.DescribeWorkspacesPages(input, func(resp *workspaces.DescribeWorkspacesOutput, _ bool) bool {
 		for _, workspace := range resp.Workspaces {
-			err := workspaceDelete(aws.StringValue(workspace.WorkspaceId), conn)
+			err := workspaceDelete(conn, aws.StringValue(workspace.WorkspaceId), waiter.WorkspaceTerminatedTimeout)
 			if err != nil {
 				errors = multierror.Append(errors, err)
 			}
@@ -317,6 +319,33 @@ func TestAccAwsWorkspacesWorkspace_recreate(t *testing.T) {
 	})
 }
 
+func TestAccAwsWorkspacesWorkspace_timeout(t *testing.T) {
+	var v workspaces.Workspace
+	rName := acctest.RandString(8)
+
+	resourceName := "aws_workspaces_workspace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Destroy: false,
+				Config:  testAccWorkspacesWorkspaceConfig_timeout(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsWorkspacesWorkspaceDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).workspacesconn
 
@@ -550,6 +579,25 @@ resource "aws_workspaces_workspace" "test" {
 
   tags = {
     TerraformProviderAwsTest = true
+  }
+}
+`
+}
+
+func testAccWorkspacesWorkspaceConfig_timeout(rName string) string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+resource "aws_workspaces_workspace" "test" {
+  bundle_id    = data.aws_workspaces_bundle.test.id
+  directory_id = aws_workspaces_directory.test.id
+
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator"
+
+  timeouts {
+    create = "60m"
+    update = "30m"
+    delete = "30m"
   }
 }
 `

--- a/website/docs/r/workspaces_workspace.html.markdown
+++ b/website/docs/r/workspaces_workspace.html.markdown
@@ -64,6 +64,15 @@ The following arguments are supported:
 * `running_mode_auto_stop_timeout_in_minutes` – (Optional) The time after a user logs off when WorkSpaces are automatically stopped. Configured in 60-minute intervals.
 * `user_volume_size_gib` – (Optional) The size of the user storage.
 
+### Timeouts
+
+`aws_workspaces_workspace` provides the following
+[Timeouts](/docs/configuration/resources.html#operation-timeouts) configuration options:
+
+- `create` - (Default `30 minutes`) Used for WorkSpace creation.
+- `update` - (Default `10 minutes`) Used for WorkSpace updating.
+- `delete` - (Default `10 minutes`) Used for WorkSpace termination.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates to #13598

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Configurable workspaces timeouts
```

### Acceptance Tests

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsWorkspacesWorkspace_timeout'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWorkspacesWorkspace_timeout -timeout 120m
=== RUN   TestAccAwsWorkspacesWorkspace_timeout
=== PAUSE TestAccAwsWorkspacesWorkspace_timeout
=== CONT  TestAccAwsWorkspacesWorkspace_timeout
--- PASS: TestAccAwsWorkspacesWorkspace_timeout (1019.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1023.255s
```
