### PR TITLE
Use the current credentials when trying to get the bucket region

### DIFF
--- a/aws/data_source_aws_s3_bucket.go
+++ b/aws/data_source_aws_s3_bucket.go
@@ -100,6 +100,12 @@ func bucketLocation(client *AWSClient, d *schema.ResourceData, bucket string) er
 		// the provider s3_force_path_style configuration, which defaults to
 		// false, but allows override.
 		r.Config.S3ForcePathStyle = client.s3conn.Config.S3ForcePathStyle
+
+		// By default, GetBucketRegion uses anonymous credentials when doing
+		// a HEAD request to get the bucket region. This breaks in aws-cn regions
+		// when the account doesn't have an ICP license to host public content.
+		// Use the current credentials when getting the bucket region.
+		r.Config.Credentials = client.s3conn.Config.Credentials
 	})
 	if err != nil {
 		return err

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1281,6 +1281,12 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			// the provider s3_force_path_style configuration, which defaults to
 			// false, but allows override.
 			r.Config.S3ForcePathStyle = s3conn.Config.S3ForcePathStyle
+
+			// By default, GetBucketRegion uses anonymous credentials when doing
+			// a HEAD request to get the bucket region. This breaks in aws-cn regions
+			// when the account doesn't have an ICP license to host public content.
+			// Use the current credentials when getting the bucket region.
+			r.Config.Credentials = s3conn.Config.Credentials
 		})
 	})
 	if err != nil {


### PR DESCRIPTION
This fixes https://github.com/terraform-providers/terraform-provider-aws/issues/15420 where in aws-cn using anonymous credentials will cause the Head request to return Unauthorized. That error in turn fill cause terraform bucket operations to fail.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15420

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_s3_bucket: Use current provider credentials when fetching the bucket region
```

Output from acceptance testing in AWS Commercial:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run= TestAccAWSS3Bucket_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket_basic -timeout 120m
=== RUN   TestAccAWSS3Bucket_basic
=== PAUSE TestAccAWSS3Bucket_basic
=== CONT  TestAccAWSS3Bucket_basic
--- PASS: TestAccAWSS3Bucket_basic (63.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	65.843s
...
```

Acceptance tests fail in aws-cn due to a separate issue (`resource_aws_s3_bucket_test.go:170: Check 2/8 error: aws_s3_bucket.bucket: Attribute 'hosted_zone_id' not found`) but have verified the fix manually. 
