### PR TITLE
8349 - Adding timeouts for aws_ebs_volume

### DIFF
--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -25,6 +25,12 @@ func resourceAwsEbsVolume() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -149,7 +155,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 		Pending:    []string{ec2.VolumeStateCreating},
 		Target:     []string{ec2.VolumeStateAvailable},
 		Refresh:    volumeStateRefreshFunc(conn, *result.VolumeId),
-		Timeout:    5 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
@@ -199,7 +205,7 @@ func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 			Pending:    []string{ec2.VolumeStateCreating, ec2.VolumeModificationStateModifying},
 			Target:     []string{ec2.VolumeStateAvailable, ec2.VolumeStateInUse},
 			Refresh:    volumeStateRefreshFunc(conn, *result.VolumeModification.VolumeId),
-			Timeout:    5 * time.Minute,
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,
 		}
@@ -304,7 +310,7 @@ func resourceAwsEbsVolumeDelete(d *schema.ResourceData, meta interface{}) error 
 		VolumeId: aws.String(d.Id()),
 	}
 
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.DeleteVolume(input)
 
 		if isAWSErr(err, "InvalidVolume.NotFound", "") {
@@ -335,7 +341,7 @@ func resourceAwsEbsVolumeDelete(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	var output *ec2.DescribeVolumesOutput
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		var err error
 		output, err = conn.DescribeVolumes(describeInput)
 

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -513,8 +513,8 @@ resource "aws_ebs_volume" "test" {
   size              = 1
 
   timeouts {
-	create = "10m"
-	update = "10m"
+    create = "10m"
+    update = "10m"
     delete = "10m"
   }
 }

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -511,6 +511,12 @@ resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "gp2"
   size              = 1
+
+  timeouts {
+	create = "10m"
+	update = "10m"
+    delete = "10m"
+  }
 }
 `
 

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -42,6 +42,15 @@ The following arguments are supported:
 
 ~> **NOTE**: When changing the `size`, `iops` or `type` of an instance, there are [considerations](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/considerations.html) to be aware of that Amazon have written about this.
 
+### Timeouts
+
+`aws_ebs_volume` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `5 minutes`) Used for creating volumes. This includes the time required for the volume to become available.
+- `update` - (Default `5 minutes`) Used for size, type, or iops volume changes.
+- `delete` - (Default `5 minutes`) Used for destroying volumes.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relevant to #8349

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
Adding timeouts for aws_ebs_volume
```

Output from acceptance testing:
```
make testacc TESTARGS='-run=TestAccAWSEBSVolume_updateSize'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEBSVolume_updateSize -timeout 120m
=== RUN   TestAccAWSEBSVolume_updateSize
=== PAUSE TestAccAWSEBSVolume_updateSize
=== CONT  TestAccAWSEBSVolume_updateSize
--- PASS: TestAccAWSEBSVolume_updateSize (52.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws   54.693s
```