### PR TITLE
Add TLS Config to api gateway integration

### DIFF
--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -150,6 +150,21 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 				ValidateFunc: validation.IntBetween(50, 29000),
 				Default:      29000,
 			},
+
+			"tls_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 0,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"insecure_skip_verification": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -224,6 +239,11 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 		timeoutInMillis = aws.Int64(int64(v.(int)))
 	}
 
+	var tlsConfig *apigateway.TlsConfig
+	if v, ok := d.GetOk("tls_config"); ok {
+		tlsConfig = expandApiGatewayTlsConfig(v.([]interface{}))
+	}
+
 	_, err := conn.PutIntegration(&apigateway.PutIntegrationInput{
 		HttpMethod:            aws.String(d.Get("http_method").(string)),
 		ResourceId:            aws.String(d.Get("resource_id").(string)),
@@ -241,6 +261,7 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 		ConnectionType:        connectionType,
 		ConnectionId:          connectionId,
 		TimeoutInMillis:       timeoutInMillis,
+		TlsConfig:             tlsConfig,
 	})
 	if err != nil {
 		return fmt.Errorf("Error creating API Gateway Integration: %s", err)
@@ -300,6 +321,10 @@ func resourceAwsApiGatewayIntegrationRead(d *schema.ResourceData, meta interface
 	d.Set("timeout_milliseconds", integration.TimeoutInMillis)
 	d.Set("type", integration.Type)
 	d.Set("uri", integration.Uri)
+
+	if err := d.Set("tls_config", flattenApiGatewayTlsConfig(integration.TlsConfig)); err != nil {
+		return fmt.Errorf("error setting tls_config: %s", err)
+	}
 
 	return nil
 }
@@ -464,6 +489,20 @@ func resourceAwsApiGatewayIntegrationUpdate(d *schema.ResourceData, meta interfa
 		})
 	}
 
+	if d.HasChange("tls_config.0.insecure_skip_verification") {
+		// The domain name must have an endpoint type.
+		// If attempting to remove the configuration, do nothing.
+		if v, ok := d.GetOk("tls_config"); ok && len(v.([]interface{})) > 0 {
+			m := v.([]interface{})[0].(map[string]interface{})
+
+			operations = append(operations, &apigateway.PatchOperation{
+				Op:    aws.String(apigateway.OpReplace),
+				Path:  aws.String("/tlsConfig/insecureSkipVerification"),
+				Value: aws.String(strconv.FormatBool(m["insecure_skip_verification"].(bool))),
+			})
+		}
+	}
+
 	params := &apigateway.UpdateIntegrationInput{
 		HttpMethod:      aws.String(d.Get("http_method").(string)),
 		ResourceId:      aws.String(d.Get("resource_id").(string)),
@@ -500,4 +539,28 @@ func resourceAwsApiGatewayIntegrationDelete(d *schema.ResourceData, meta interfa
 	}
 
 	return nil
+}
+
+func expandApiGatewayTlsConfig(vConfig []interface{}) *apigateway.TlsConfig {
+	config := &apigateway.TlsConfig{}
+
+	if len(vConfig) == 0 || vConfig[0] == nil {
+		return config
+	}
+	mConfig := vConfig[0].(map[string]interface{})
+
+	if insecureSkipVerification, ok := mConfig["insecure_skip_verification"].(bool); ok {
+		config.InsecureSkipVerification = aws.Bool(insecureSkipVerification)
+	}
+	return config
+}
+
+func flattenApiGatewayTlsConfig(config *apigateway.TlsConfig) []interface{} {
+	if config == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{map[string]interface{}{
+		"insecure_skip_verification": aws.BoolValue(config.InsecureSkipVerification),
+	}}
 }

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -272,11 +272,10 @@ func TestAccAWSAPIGatewayIntegration_integrationType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayIntegrationConfig_IntegrationTypeInternet(rName),
+				Config: testAccAWSAPIGatewayIntegrationConfig_IntegrationTLSConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayIntegrationExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
-					resource.TestCheckResourceAttr(resourceName, "connection_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.0.insecure_skip_verification", "true"),
 				),
 			},
 			{
@@ -811,6 +810,24 @@ resource "aws_api_gateway_integration" "test" {
   integration_http_method = "GET"
   passthrough_behavior    = "WHEN_NO_MATCH"
   content_handling        = "CONVERT_TO_TEXT"
+}
+`
+}
+
+func testAccAWSAPIGatewayIntegrationConfig_IntegrationTLSConfig(rName string) string {
+	return testAccAWSAPIGatewayIntegrationConfig_IntegrationTypeBase(rName) + `
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+  type                    = "HTTP"
+  uri                     = "https://www.google.de"
+  integration_http_method = "GET"
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  content_handling        = "CONVERT_TO_TEXT"
+  tls_config {
+    insecure_skip_verification = true
+  }
 }
 `
 }

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -820,11 +820,13 @@ resource "aws_api_gateway_integration" "test" {
   rest_api_id = aws_api_gateway_rest_api.test.id
   resource_id = aws_api_gateway_resource.test.id
   http_method = aws_api_gateway_method.test.http_method
+
   type                    = "HTTP"
   uri                     = "https://www.google.de"
   integration_http_method = "GET"
   passthrough_behavior    = "WHEN_NO_MATCH"
   content_handling        = "CONVERT_TO_TEXT"
+
   tls_config {
     insecure_skip_verification = true
   }

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -40,6 +40,10 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
   cache_namespace      = "foobar"
   timeout_milliseconds = 29000
 
+  tls_config {
+    insecure_skip_verification = true
+  }
+
   request_parameters = {
     "integration.request.header.X-Authorization" = "'static'"
   }
@@ -229,6 +233,7 @@ The following arguments are supported:
 * `cache_namespace` - (Optional) The integration's cache namespace.
 * `content_handling` - (Optional) Specifies how to handle request payload content type conversions. Supported values are `CONVERT_TO_BINARY` and `CONVERT_TO_TEXT`. If this property is not defined, the request payload will be passed through from the method request to integration request without modification, provided that the passthroughBehaviors is configured to support payload pass-through.
 * `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.
+* `tls_config` - (Optional) Specifies the TLS configuration for an integration defined as a block. Supports `insecure_skip_verification` toggle.
 
 ## Import
 


### PR DESCRIPTION
Co-authored-by: jake-mcdermott <mail@jake.ie>

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15492

The change was based on a similar tls_config block in the API gateway V2 integration here:
https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_apigatewayv2_integration.go#L132

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_api_gateway_integration: Add `tls_config` block to support `insecureSkipVerification` 
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAWSAPIGatewayIntegration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayIntegration -timeout 120m
=== RUN   TestAccAWSAPIGatewayIntegrationResponse_basic
=== PAUSE TestAccAWSAPIGatewayIntegrationResponse_basic
=== RUN   TestAccAWSAPIGatewayIntegrationResponse_disappears
=== PAUSE TestAccAWSAPIGatewayIntegrationResponse_disappears
=== RUN   TestAccAWSAPIGatewayIntegration_basic
=== PAUSE TestAccAWSAPIGatewayIntegration_basic
=== RUN   TestAccAWSAPIGatewayIntegration_contentHandling
=== PAUSE TestAccAWSAPIGatewayIntegration_contentHandling
=== RUN   TestAccAWSAPIGatewayIntegration_cache_key_parameters
=== PAUSE TestAccAWSAPIGatewayIntegration_cache_key_parameters
=== RUN   TestAccAWSAPIGatewayIntegration_integrationType
=== PAUSE TestAccAWSAPIGatewayIntegration_integrationType
=== RUN   TestAccAWSAPIGatewayIntegration_disappears
=== PAUSE TestAccAWSAPIGatewayIntegration_disappears
=== CONT  TestAccAWSAPIGatewayIntegrationResponse_basic
=== CONT  TestAccAWSAPIGatewayIntegration_cache_key_parameters
=== CONT  TestAccAWSAPIGatewayIntegration_disappears
=== CONT  TestAccAWSAPIGatewayIntegration_basic
=== CONT  TestAccAWSAPIGatewayIntegration_contentHandling
=== CONT  TestAccAWSAPIGatewayIntegration_integrationType
=== CONT  TestAccAWSAPIGatewayIntegrationResponse_disappears
=== CONT  TestAccAWSAPIGatewayIntegration_disappears
    resource_aws_api_gateway_integration_test.go:296: [INFO] Got non-empty plan, as expected
=== CONT  TestAccAWSAPIGatewayIntegrationResponse_disappears
    resource_aws_api_gateway_integration_response_test.go:67: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSAPIGatewayIntegration_disappears (128.41s)
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_disappears (132.04s)
--- PASS: TestAccAWSAPIGatewayIntegration_cache_key_parameters (143.51s)
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_basic (220.33s)
2020/10/05 20:01:55 [INFO] Successfully derived credentials from session
2020/10/05 20:01:55 [INFO] AWS Auth provider used: "AssumeRoleProvider"
--- PASS: TestAccAWSAPIGatewayIntegration_contentHandling (282.20s)
--- PASS: TestAccAWSAPIGatewayIntegration_basic (374.41s)
--- PASS: TestAccAWSAPIGatewayIntegration_integrationType (917.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       920.219s```
