### PR TITLE
Introduce aws_elasticache_replication_group.reader_endpoint_address

### DIFF
--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -114,9 +114,7 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 		}
 		d.Set("port", rg.NodeGroups[0].PrimaryEndpoint.Port)
 		d.Set("primary_endpoint_address", rg.NodeGroups[0].PrimaryEndpoint.Address)
-		if rg.NodeGroups[0].ReaderEndpoint != nil {
-			d.Set("reader_endpoint_address", rg.NodeGroups[0].ReaderEndpoint.Address)
-		}
+		d.Set("reader_endpoint_address", rg.NodeGroups[0].ReaderEndpoint.Address)
 	}
 	d.Set("number_cache_clusters", len(rg.MemberClusters))
 	if err := d.Set("member_clusters", flattenStringList(rg.MemberClusters)); err != nil {

--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -115,7 +115,7 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 		d.Set("port", rg.NodeGroups[0].PrimaryEndpoint.Port)
 		d.Set("primary_endpoint_address", rg.NodeGroups[0].PrimaryEndpoint.Address)
 		if rg.NodeGroups[0].ReaderEndpoint != nil {
-			d.Set("reader_primary_endpoint_address", rg.NodeGroups[0].ReaderEndpoint.Address)
+			d.Set("reader_endpoint_address", rg.NodeGroups[0].ReaderEndpoint.Address)
 		}
 	}
 	d.Set("number_cache_clusters", len(rg.MemberClusters))

--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -41,6 +41,10 @@ func dataSourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"reader_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"number_cache_clusters": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -110,6 +114,9 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 		}
 		d.Set("port", rg.NodeGroups[0].PrimaryEndpoint.Port)
 		d.Set("primary_endpoint_address", rg.NodeGroups[0].PrimaryEndpoint.Address)
+		if rg.NodeGroups[0].ReaderEndpoint != nil {
+			d.Set("reader_primary_endpoint_address", rg.NodeGroups[0].ReaderEndpoint.Address)
+		}
 	}
 	d.Set("number_cache_clusters", len(rg.MemberClusters))
 	if err := d.Set("member_clusters", flattenStringList(rg.MemberClusters)); err != nil {

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -28,6 +28,7 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "number_cache_clusters", resourceName, "number_cache_clusters"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "primary_endpoint_address", resourceName, "primary_endpoint_address"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "reader_endpoint_address", resourceName, "reader_endpoint_address"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_description", resourceName, "replication_group_description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_id", resourceName, "replication_group_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "snapshot_window", resourceName, "snapshot_window"),

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -156,6 +156,10 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"reader_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"replication_group_description": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -492,6 +496,7 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		} else {
 			d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
 			d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
+			d.Set("reader_endpoint_address", rgp.NodeGroups[0].ReaderEndpoint.Address)
 		}
 
 		d.Set("auto_minor_version_upgrade", c.AutoMinorVersionUpgrade)

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -328,6 +328,8 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 						resourceName, "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
 						resourceName, "primary_endpoint_address"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "reader_endpoint_address"),
 				),
 			},
 			{
@@ -363,6 +365,8 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 						resourceName, "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
 						resourceName, "primary_endpoint_address"),
+					resource.TestCheckResourceAttrSet(
+						resourceName, "reader_endpoint_address"),
 				),
 			},
 			{

--- a/website/docs/d/elasticache_replication_group.html.markdown
+++ b/website/docs/d/elasticache_replication_group.html.markdown
@@ -40,4 +40,4 @@ In addition to all arguments above, the following attributes are exported:
 * `port` – The port number on which the configuration endpoint will accept connections.
 * `configuration_endpoint_address` - The configuration endpoint address to allow host discovery.
 * `primary_endpoint_address` - The endpoint of the primary node in this node group (shard).
-* `reader_endpoint_address` - The endpoint of the primary node in this node group (shard).
+* `reader_endpoint_address` - The endpoint of the reader node in this node group (shard).

--- a/website/docs/d/elasticache_replication_group.html.markdown
+++ b/website/docs/d/elasticache_replication_group.html.markdown
@@ -40,3 +40,4 @@ In addition to all arguments above, the following attributes are exported:
 * `port` – The port number on which the configuration endpoint will accept connections.
 * `configuration_endpoint_address` - The configuration endpoint address to allow host discovery.
 * `primary_endpoint_address` - The endpoint of the primary node in this node group (shard).
+* `reader_endpoint_address` - The endpoint of the primary node in this node group (shard).

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -149,6 +149,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the ElastiCache Replication Group.
 * `configuration_endpoint_address` - The address of the replication group configuration endpoint when cluster mode is enabled.
 * `primary_endpoint_address` - (Redis only) The address of the endpoint for the primary node in the replication group, if the cluster mode is disabled.
+* `reader_endpoint_address` - (Redis only) The address of the endpoint for the reader node in the replication group, if the cluster mode is disabled.
 * `member_clusters` - The identifiers of all the nodes that are part of this replication group.
 
 ## Timeouts


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15513

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_elasticache_replication_group: Add `reader_endpoint_address` attribute
resource/aws_elasticache_replication_group: Add `reader_endpoint_address` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsElasticacheReplicationGroup -timeout 120m
=== RUN   TestAccDataSourceAwsElasticacheReplicationGroup_basic
=== PAUSE TestAccDataSourceAwsElasticacheReplicationGroup_basic
=== RUN   TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode
=== PAUSE TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode
=== RUN   TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent
=== PAUSE TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent
=== CONT  TestAccDataSourceAwsElasticacheReplicationGroup_basic
=== CONT  TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent
=== CONT  TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent (12.54s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_basic (715.92s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode (856.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	856.714s

...
```
