### PR TITLE
Enhancement/eks adding service ipv4 range

### DIFF
--- a/aws/data_source_aws_eks_cluster.go
+++ b/aws/data_source_aws_eks_cluster.go
@@ -66,6 +66,18 @@ func dataSourceAwsEksCluster() *schema.Resource {
 					},
 				},
 			},
+			"kubernetes_network_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"service_ipv4_cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -182,6 +194,10 @@ func dataSourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error
 
 	if err := d.Set("vpc_config", flattenEksVpcConfigResponse(cluster.ResourcesVpcConfig)); err != nil {
 		return fmt.Errorf("error setting vpc_config: %s", err)
+	}
+
+	if err := d.Set("kubernetes_network_config", flattenEksNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {
+		return fmt.Errorf("error setting kubernetes_network_config: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_eks_cluster_test.go
+++ b/aws/data_source_aws_eks_cluster_test.go
@@ -34,6 +34,8 @@ func TestAccAWSEksClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "identity.#", dataSourceResourceName, "identity.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "identity.0.oidc.#", dataSourceResourceName, "identity.0.oidc.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "identity.0.oidc.0.issuer", dataSourceResourceName, "identity.0.oidc.0.issuer"),
+					resource.TestCheckResourceAttrPair(resourceName, "kubernetes_network_config.#", dataSourceResourceName, "kubernetes_network_config.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "kubernetes_network_config.0.service_ipv4_cidr", dataSourceResourceName, "kubernetes_network_config.0.service_ipv4_cidr"),
 					resource.TestMatchResourceAttr(dataSourceResourceName, "platform_version", regexp.MustCompile(`^eks\.\d+$`)),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", dataSourceResourceName, "role_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceResourceName, "status"),

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -358,8 +358,10 @@ func resourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting vpc_config: %s", err)
 	}
 
-	if err := d.Set("kubernetes_network_config", flattenEksNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {
-		return fmt.Errorf("error setting network config: %s", err)
+	if _, ok := d.GetOk("kubernetes_network_config"); ok {
+		if err := d.Set("kubernetes_network_config", flattenEksNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {
+			return fmt.Errorf("error setting network config: %s", err)
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -118,6 +118,7 @@ func resourceAwsEksCluster() *schema.Resource {
 			"kubernetes_network_config": {
 				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"service_ipv4_cidr": {

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -113,6 +114,25 @@ func resourceAwsEksCluster() *schema.Resource {
 					},
 				},
 			},
+
+			"kubernetes_network_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"service_ipv4_cidr": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							ValidateFunc: validation.All(
+								validation.IsCIDRNetwork(12, 24),
+								validation.StringMatch(regexp.MustCompile(`^(10|172\.(1[6-9]|2[0-9]|3[0-1])|192\.168)\..*`), "must be within 10.0.0.0/8, 172.16.0.0.0/12, or 192.168.0.0/16"),
+							),
+						},
+					},
+				},
+			},
+
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -216,6 +236,10 @@ func resourceAwsEksClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
 		input.Tags = keyvaluetags.New(v).IgnoreAws().EksTags()
+	}
+
+	if _, ok := d.GetOk("kubernetes_network_config"); ok {
+		input.KubernetesNetworkConfig = expandEksNetworkConfigRequest(d.Get("kubernetes_network_config").([]interface{}))
 	}
 
 	if v, ok := d.GetOk("version"); ok {
@@ -332,6 +356,10 @@ func resourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("vpc_config", flattenEksVpcConfigResponse(cluster.ResourcesVpcConfig)); err != nil {
 		return fmt.Errorf("error setting vpc_config: %s", err)
+	}
+
+	if err := d.Set("kubernetes_network_config", flattenEksNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {
+		return fmt.Errorf("error setting network config: %s", err)
 	}
 
 	return nil
@@ -548,6 +576,22 @@ func expandEksVpcConfigUpdateRequest(l []interface{}) *eks.VpcConfigRequest {
 	return vpcConfigRequest
 }
 
+func expandEksNetworkConfigRequest(tfList []interface{}) *eks.KubernetesNetworkConfigRequest {
+	tfMap, ok := tfList[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	apiObject := &eks.KubernetesNetworkConfigRequest{}
+
+	if v, ok := tfMap["service_ipv4_cidr"].(string); ok && v != "" {
+		apiObject.ServiceIpv4Cidr = aws.String(v)
+	}
+
+	return apiObject
+}
+
 func expandEksLoggingTypes(vEnabledLogTypes *schema.Set) *eks.Logging {
 	vEksLogTypes := []interface{}{}
 	for _, eksLogType := range eks.LogType_Values() {
@@ -669,6 +713,18 @@ func flattenEksEnabledLogTypes(logging *eks.Logging) *schema.Set {
 	}
 
 	return flattenStringSet(enabledLogTypes)
+}
+
+func flattenEksNetworkConfig(apiObject *eks.KubernetesNetworkConfigResponse) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"service_ipv4_cidr": aws.StringValue(apiObject.ServiceIpv4Cidr),
+	}
+
+	return []interface{}{tfMap}
 }
 
 func refreshEksClusterStatus(conn *eks.EKS, clusterName string) resource.StateRefreshFunc {

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -118,12 +118,14 @@ func resourceAwsEksCluster() *schema.Resource {
 			"kubernetes_network_config": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"service_ipv4_cidr": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 							ValidateFunc: validation.All(
 								validation.IsCIDRNetwork(12, 24),

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -359,10 +359,8 @@ func resourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting vpc_config: %s", err)
 	}
 
-	if _, ok := d.GetOk("kubernetes_network_config"); ok {
-		if err := d.Set("kubernetes_network_config", flattenEksNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {
-			return fmt.Errorf("error setting network config: %s", err)
-		}
+	if err := d.Set("kubernetes_network_config", flattenEksNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {
+		return fmt.Errorf("error setting kubernetes_network_config: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -814,11 +814,9 @@ resource "aws_eks_cluster" "test" {
 }
 
 func testAccAWSEksClusterConfig_NetworkConfig_ServiceIpv4Cidr(rName string, serviceIpv4Cidr string) string {
-	return fmt.Sprintf(`
-%[1]s
-
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %[2]q
+  name     = %q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
@@ -831,5 +829,5 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, testAccAWSEksClusterConfig_Base(rName), rName, serviceIpv4Cidr)
+`, rName, serviceIpv4Cidr)
 }

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -449,13 +449,9 @@ func TestAccAWSEksCluster_NetworkConfig_ServiceIpv4Cidr(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSEksClusterConfig_NetworkConfig_ServiceIpv4Cidr(rName, `"10.10.0.0/16"`),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEksClusterExists(resourceName, &cluster2),
-					testAccCheckAWSEksClusterNotRecreated(&cluster1, &cluster2),
-					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.0.service_ipv4_cidr", "10.10.0.0/16"),
-				),
+				Config:   testAccAWSEksClusterConfig_NetworkConfig_ServiceIpv4Cidr(rName, `"10.10.0.0/16"`),
+				PlanOnly: true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -558,7 +558,7 @@ func testAccCheckAWSEksClusterDestroy(s *terraform.State) error {
 func testAccCheckAWSEksClusterRecreated(i, j *eks.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.TimeValue(i.CreatedAt) == aws.TimeValue(j.CreatedAt) {
-			return errors.New("EKS Cluster was recreated")
+			return errors.New("EKS Cluster was not recreated")
 		}
 
 		return nil

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -47,6 +47,8 @@ output "identity-oidc-issuer" {
 * `identity` - Nested attribute containing identity provider information for your cluster. Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019. For an example using this information to enable IAM Roles for Service Accounts, see the [`aws_eks_cluster` resource documentation](/docs/providers/aws/r/eks_cluster.html).
     * `oidc` - Nested attribute containing [OpenID Connect](https://openid.net/connect/) identity provider information for the cluster.
         * `issuer` - Issuer URL for the OpenID Connect identity provider.
+* `kubernetes_network_config` - Nested list containing Kubernetes Network Configuration.
+    * `service_ipv4_cidr` - The CIDR block to assign Kubernetes service IP addresses from.
 * `platform_version` - The platform version for the cluster.
 * `role_arn` - The Amazon Resource Name (ARN) of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
 * `status` - The status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED`.

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -156,6 +156,7 @@ The following arguments are supported:
 * `vpc_config` - (Required) Nested argument for the VPC associated with your cluster. Amazon EKS VPC resources have specific requirements to work properly with Kubernetes. For more information, see [Cluster VPC Considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) and [Cluster Security Group Considerations](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) in the Amazon EKS User Guide. Configuration detailed below.
 * `enabled_cluster_log_types` - (Optional) A list of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
 * `encryption_config` - (Optional) Configuration block with encryption configuration for the cluster. Only available on Kubernetes 1.13 and above clusters created after March 6, 2020. Detailed below.
+* `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster.
 * `tags` - (Optional) Key-value map of resource tags.
 * `version` – (Optional) Desired Kubernetes master version. If you do not specify a value, the latest available version at resource creation is used and no upgrades will occur except those automatically triggered by EKS. The value must be configured and increased to upgrade the version when desired. Downgrades are not supported by EKS.
 
@@ -179,6 +180,18 @@ The following arguments are supported in the `provider` configuration block:
 * `public_access_cidrs` - (Optional) List of CIDR blocks. Indicates which CIDR blocks can access the Amazon EKS public API server endpoint when enabled. EKS defaults this to a list with `0.0.0.0/0`. Terraform will only perform drift detection of its value when present in a configuration.
 * `security_group_ids` – (Optional) List of security group IDs for the cross-account elastic network interfaces that Amazon EKS creates to use to allow communication between your worker nodes and the Kubernetes control plane.
 * `subnet_ids` – (Required) List of subnet IDs. Must be in at least two different availability zones. Amazon EKS creates cross-account elastic network interfaces in these subnets to allow communication between your worker nodes and the Kubernetes control plane.
+
+### kubernetes_network_config
+
+The following arguments are supported in the `kubernetes_network_config` configuration block:
+
+* `service_ipv4_cidr` - (Optional) The CIDR block to assign Kubernetes service IP addresses from. If you don't specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or 172.20.0.0/16 CIDR blocks. We recommend that you specify a block that does not overlap with resources in other networks that are peered or connected to your VPC. The block must meet the following requirements:
+
+  - Within one of the following private IP address blocks: 10.0.0.0/8, 172.16.0.0.0/12, or 192.168.0.0/16.
+
+  - Doesn't overlap with any CIDR block assigned to the VPC that you selected for VPC.
+
+  - Between /24 and /12.
 
 ## Attributes Reference
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -187,11 +187,11 @@ The following arguments are supported in the `kubernetes_network_config` configu
 
 * `service_ipv4_cidr` - (Optional) The CIDR block to assign Kubernetes service IP addresses from. If you don't specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or 172.20.0.0/16 CIDR blocks. We recommend that you specify a block that does not overlap with resources in other networks that are peered or connected to your VPC. The block must meet the following requirements:
 
-  - Within one of the following private IP address blocks: 10.0.0.0/8, 172.16.0.0.0/12, or 192.168.0.0/16.
+    * Within one of the following private IP address blocks: 10.0.0.0/8, 172.16.0.0.0/12, or 192.168.0.0/16.
 
-  - Doesn't overlap with any CIDR block assigned to the VPC that you selected for VPC.
+    * Doesn't overlap with any CIDR block assigned to the VPC that you selected for VPC.
 
-  - Between /24 and /12.
+    * Between /24 and /12.
 
 ## Attributes Reference
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -185,7 +185,7 @@ The following arguments are supported in the `provider` configuration block:
 
 The following arguments are supported in the `kubernetes_network_config` configuration block:
 
-* `service_ipv4_cidr` - (Optional) The CIDR block to assign Kubernetes service IP addresses from. If you don't specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or 172.20.0.0/16 CIDR blocks. We recommend that you specify a block that does not overlap with resources in other networks that are peered or connected to your VPC. The block must meet the following requirements:
+* `service_ipv4_cidr` - (Optional) The CIDR block to assign Kubernetes service IP addresses from. If you don't specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or 172.20.0.0/16 CIDR blocks. We recommend that you specify a block that does not overlap with resources in other networks that are peered or connected to your VPC. You can only specify a custom CIDR block when you create a cluster, changing this value will force a new cluster to be created. The block must meet the following requirements:
 
     * Within one of the following private IP address blocks: 10.0.0.0/8, 172.16.0.0.0/12, or 192.168.0.0/16.
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -156,7 +156,7 @@ The following arguments are supported:
 * `vpc_config` - (Required) Nested argument for the VPC associated with your cluster. Amazon EKS VPC resources have specific requirements to work properly with Kubernetes. For more information, see [Cluster VPC Considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) and [Cluster Security Group Considerations](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) in the Amazon EKS User Guide. Configuration detailed below.
 * `enabled_cluster_log_types` - (Optional) A list of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
 * `encryption_config` - (Optional) Configuration block with encryption configuration for the cluster. Only available on Kubernetes 1.13 and above clusters created after March 6, 2020. Detailed below.
-* `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster. Detailed below.
+* `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster. Detailed below. If removed, Terraform will only perform drift detection if a configuration value is provided.
 * `tags` - (Optional) Key-value map of resource tags.
 * `version` – (Optional) Desired Kubernetes master version. If you do not specify a value, the latest available version at resource creation is used and no upgrades will occur except those automatically triggered by EKS. The value must be configured and increased to upgrade the version when desired. Downgrades are not supported by EKS.
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -156,7 +156,7 @@ The following arguments are supported:
 * `vpc_config` - (Required) Nested argument for the VPC associated with your cluster. Amazon EKS VPC resources have specific requirements to work properly with Kubernetes. For more information, see [Cluster VPC Considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) and [Cluster Security Group Considerations](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) in the Amazon EKS User Guide. Configuration detailed below.
 * `enabled_cluster_log_types` - (Optional) A list of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
 * `encryption_config` - (Optional) Configuration block with encryption configuration for the cluster. Only available on Kubernetes 1.13 and above clusters created after March 6, 2020. Detailed below.
-* `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster.
+* `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags.
 * `version` – (Optional) Desired Kubernetes master version. If you do not specify a value, the latest available version at resource creation is used and no upgrades will occur except those automatically triggered by EKS. The value must be configured and increased to upgrade the version when desired. Downgrades are not supported by EKS.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15505

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added service_ipv4_cidr input to aws_eks_cluster.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -run=TestAccAWSEksCluster_ -timeout 120m
=== RUN   TestAccAWSEksCluster_basic
=== PAUSE TestAccAWSEksCluster_basic
=== RUN   TestAccAWSEksCluster_EncryptionConfig
=== PAUSE TestAccAWSEksCluster_EncryptionConfig
=== RUN   TestAccAWSEksCluster_Version
=== PAUSE TestAccAWSEksCluster_Version
=== RUN   TestAccAWSEksCluster_Logging
=== PAUSE TestAccAWSEksCluster_Logging
=== RUN   TestAccAWSEksCluster_Tags
=== PAUSE TestAccAWSEksCluster_Tags
=== RUN   TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== PAUSE TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== RUN   TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
=== PAUSE TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
=== RUN   TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== PAUSE TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== RUN   TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs
=== PAUSE TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs
=== CONT  TestAccAWSEksCluster_basic
=== CONT  TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== CONT  TestAccAWSEksCluster_Logging
=== CONT  TestAccAWSEksCluster_Version
--- PASS: TestAccAWSEksCluster_Logging (944.83s)
=== CONT  TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (957.92s)
=== CONT  TestAccAWSEksCluster_EncryptionConfig
--- PASS: TestAccAWSEksCluster_basic (992.14s)
=== CONT  TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
--- PASS: TestAccAWSEksCluster_EncryptionConfig (907.86s)
=== CONT  TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
--- PASS: TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs (1211.42s)
=== CONT  TestAccAWSEksCluster_Tags
--- PASS: TestAccAWSEksCluster_Version (2577.52s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1640.84s)
--- PASS: TestAccAWSEksCluster_Tags (840.69s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (2191.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4058.874s
```
Adds a kubernetes_network_configuration block, currently the only field in the block is service_ipv4_cidr, which sets the IP range allocated to k8s services within a cluster
