### PR TITLE
Documentation: Fix cycle error in documentation example

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -149,7 +149,7 @@ variable "lambda_function_name" {
 }
 
 resource "aws_lambda_function" "test_lambda" {
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
   # ... other configuration ...
   depends_on = [

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -144,6 +144,10 @@ resource "aws_efs_access_point" "access_point_for_lambda" {
 For more information about CloudWatch Logs for Lambda, see the [Lambda User Guide](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-logs.html).
 
 ```hcl
+variable "lambda_function_name" {
+  default = "lambda_function_name"
+}
+
 resource "aws_lambda_function" "test_lambda" {
   function_name = "${var.lambda_function_name}"
 

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -145,7 +145,7 @@ For more information about CloudWatch Logs for Lambda, see the [Lambda User Guid
 
 ```hcl
 resource "aws_lambda_function" "test_lambda" {
-  function_name = "lambda_function_name"
+  function_name = "${var.lambda_function_name}"
 
   # ... other configuration ...
   depends_on = [
@@ -157,7 +157,7 @@ resource "aws_lambda_function" "test_lambda" {
 # This is to optionally manage the CloudWatch Log Group for the Lambda Function.
 # If skipping this resource configuration, also add "logs:CreateLogGroup" to the IAM policy below.
 resource "aws_cloudwatch_log_group" "example" {
-  name              = "/aws/lambda/${aws_lambda_function.test_lambda.function_name}"
+  name              = "/aws/lambda/${var.lambda_function_name}"
   retention_in_days = 14
 }
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The documentation instructions for modifying a lambda function's cloudwatch logs group results in a cycle and failed Terraform. <https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#cloudwatch-logging-and-permissions>

The documentation instructs:

```hcl
resource "aws_lambda_function" "test_lambda" {
  function_name = "lambda_function_name"

  # ... other configuration ...
  depends_on = [
    aws_iam_role_policy_attachment.lambda_logs,
    aws_cloudwatch_log_group.example,
  ]
}

# This is to optionally manage the CloudWatch Log Group for the Lambda Function.
# If skipping this resource configuration, also add "logs:CreateLogGroup" to the IAM policy below.
resource "aws_cloudwatch_log_group" "example" {
  name              = "/aws/lambda/${aws_lambda_function.test_lambda.function_name}"
  retention_in_days = 14
}
```

So `aws_lambda_function.test_lambda` explicitly depends on `aws_cloudwatch_log_group.example`, but `aws_cloudwatch_log_group.example` has an implicit dependency on `aws_lambda_function.test_lambda.function_name`. This isn't valid Terraform. This documentation should be updated to show a valid example for this customization.

Updated the documentation with valid Terraform code. Some sort of similar documentation change should be made, if we don't want to reference variables.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Some kind of release note, probably. What is used for documentation? Enhancement?
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
