### PR TITLE
E ec2 transit gateway update params

### DIFF
--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -223,7 +223,7 @@ func TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments(t *testing.T) {
 				Config: testAccAWSEc2TransitGatewayConfigAutoAcceptSharedAttachments(ec2.AutoAcceptSharedAttachmentsValueDisable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TransitGatewayExists(resourceName, &transitGateway2),
-					testAccCheckAWSEc2TransitGatewayRecreated(&transitGateway1, &transitGateway2),
+					testAccCheckAWSEc2TransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
 					resource.TestCheckResourceAttr(resourceName, "auto_accept_shared_attachments", ec2.AutoAcceptSharedAttachmentsValueDisable),
 				),
 			},
@@ -348,7 +348,7 @@ func TestAccAWSEc2TransitGateway_DnsSupport(t *testing.T) {
 				Config: testAccAWSEc2TransitGatewayConfigDnsSupport(ec2.DnsSupportValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TransitGatewayExists(resourceName, &transitGateway2),
-					testAccCheckAWSEc2TransitGatewayRecreated(&transitGateway1, &transitGateway2),
+					testAccCheckAWSEc2TransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
 					resource.TestCheckResourceAttr(resourceName, "dns_support", ec2.DnsSupportValueEnable),
 				),
 			},
@@ -381,7 +381,7 @@ func TestAccAWSEc2TransitGateway_VpnEcmpSupport(t *testing.T) {
 				Config: testAccAWSEc2TransitGatewayConfigVpnEcmpSupport(ec2.VpnEcmpSupportValueEnable),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TransitGatewayExists(resourceName, &transitGateway2),
-					testAccCheckAWSEc2TransitGatewayRecreated(&transitGateway1, &transitGateway2),
+					testAccCheckAWSEc2TransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
 					resource.TestCheckResourceAttr(resourceName, "vpn_ecmp_support", ec2.VpnEcmpSupportValueEnable),
 				),
 			},
@@ -414,7 +414,7 @@ func TestAccAWSEc2TransitGateway_Description(t *testing.T) {
 				Config: testAccAWSEc2TransitGatewayConfigDescription("description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TransitGatewayExists(resourceName, &transitGateway2),
-					testAccCheckAWSEc2TransitGatewayRecreated(&transitGateway1, &transitGateway2),
+					testAccCheckAWSEc2TransitGatewayNotRecreated(&transitGateway1, &transitGateway2),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
 				),
 			},

--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -258,7 +258,7 @@ func TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisab
 }
 
 func TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation(t *testing.T) {
-	var transitGateway1, transitGateway2 ec2.TransitGateway
+	var transitGateway1, transitGateway2, transitGateway3 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -286,12 +286,20 @@ func TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_route_table_association", ec2.DefaultRouteTableAssociationValueEnable),
 				),
 			},
+			{
+				Config: testAccAWSEc2TransitGatewayConfigDefaultRouteTableAssociation(ec2.DefaultRouteTableAssociationValueDisable),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayExists(resourceName, &transitGateway3),
+					testAccCheckAWSEc2TransitGatewayNotRecreated(&transitGateway2, &transitGateway3),
+					resource.TestCheckResourceAttr(resourceName, "default_route_table_association", ec2.DefaultRouteTableAssociationValueDisable),
+				),
+			},
 		},
 	})
 }
 
 func TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation(t *testing.T) {
-	var transitGateway1, transitGateway2 ec2.TransitGateway
+	var transitGateway1, transitGateway2, transitGateway3 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -317,6 +325,14 @@ func TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation(t *testing.T) {
 					testAccCheckAWSEc2TransitGatewayExists(resourceName, &transitGateway2),
 					testAccCheckAWSEc2TransitGatewayRecreated(&transitGateway1, &transitGateway2),
 					resource.TestCheckResourceAttr(resourceName, "default_route_table_propagation", ec2.DefaultRouteTablePropagationValueEnable),
+				),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayConfigDefaultRouteTablePropagation(ec2.DefaultRouteTablePropagationValueDisable),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayExists(resourceName, &transitGateway3),
+					testAccCheckAWSEc2TransitGatewayNotRecreated(&transitGateway2, &transitGateway3),
+					resource.TestCheckResourceAttr(resourceName, "default_route_table_propagation", ec2.DefaultRouteTablePropagationValueDisable),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15380

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ec2_transit_gateway options no longer ForceNew unless required to
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -run=TestAccAWSEc2TransitGateway_ -timeout 60m
=== RUN   TestAccAWSEc2TransitGateway_basic
=== PAUSE TestAccAWSEc2TransitGateway_basic
=== RUN   TestAccAWSEc2TransitGateway_disappears
=== PAUSE TestAccAWSEc2TransitGateway_disappears
=== RUN   TestAccAWSEc2TransitGateway_AmazonSideASN
=== PAUSE TestAccAWSEc2TransitGateway_AmazonSideASN
=== RUN   TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments
=== PAUSE TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments
=== RUN   TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled
=== PAUSE TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled
=== RUN   TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation
=== PAUSE TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation
=== RUN   TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation
=== PAUSE TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation
=== RUN   TestAccAWSEc2TransitGateway_DnsSupport
=== PAUSE TestAccAWSEc2TransitGateway_DnsSupport
=== RUN   TestAccAWSEc2TransitGateway_VpnEcmpSupport
=== PAUSE TestAccAWSEc2TransitGateway_VpnEcmpSupport
=== RUN   TestAccAWSEc2TransitGateway_Description
=== PAUSE TestAccAWSEc2TransitGateway_Description
=== RUN   TestAccAWSEc2TransitGateway_Tags
=== PAUSE TestAccAWSEc2TransitGateway_Tags
=== CONT  TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation
=== CONT  TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments
=== CONT  TestAccAWSEc2TransitGateway_Tags
=== CONT  TestAccAWSEc2TransitGateway_Description
--- PASS: TestAccAWSEc2TransitGateway_Description (250.44s)
=== CONT  TestAccAWSEc2TransitGateway_VpnEcmpSupport
--- PASS: TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments (250.46s)
=== CONT  TestAccAWSEc2TransitGateway_DnsSupport
--- PASS: TestAccAWSEc2TransitGateway_Tags (250.75s)
=== CONT  TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation (458.23s)
=== CONT  TestAccAWSEc2TransitGateway_AmazonSideASN
--- PASS: TestAccAWSEc2TransitGateway_DnsSupport (244.72s)
=== CONT  TestAccAWSEc2TransitGateway_disappears
--- PASS: TestAccAWSEc2TransitGateway_VpnEcmpSupport (245.00s)
=== CONT  TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled (154.88s)
=== CONT  TestAccAWSEc2TransitGateway_basic
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation (443.14s)
=== CONT  TestAccAWSEc2TransitGateway_disappears
    resource_aws_ec2_transit_gateway_test.go:151: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSEc2TransitGateway_disappears (200.45s)
--- PASS: TestAccAWSEc2TransitGateway_basic (204.20s)
--- PASS: TestAccAWSEc2TransitGateway_AmazonSideASN (453.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	913.648s
...
```
To set either (default_route_table_association|default_route_table_propagation) you must pass in a route table ID.
On creation, if either of (default_route_table_association|default_route_table_propagation) are set to enable, a default route table is created, and the ID of that route table is used.
On modification, a route table is not created, so an ID must be passed in manually.

Hoping for some guidance, so far I left enabling either of those 2 out of this PR (although now disabling them won't ForceNew), but if the consensus is that they should be fully included, I suppose we could create a routeTable as part of the Update function if any of these change to "enable". Note that making this same change via console would require you to first create a TGW route table.