### PR TITLE
f/aws_config_remediation_configuration: Support for automatic remedia…

### DIFF
--- a/aws/resource_aws_config_remediation_configuration.go
+++ b/aws/resource_aws_config_remediation_configuration.go
@@ -29,6 +29,10 @@ func resourceAwsConfigRemediationConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"automatic": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"config_rule_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -141,6 +145,9 @@ func resourceAwsConfigRemediationConfigurationPut(d *schema.ResourceData, meta i
 		}
 		remediationConfigurationInput.Parameters = params
 	}
+	if v, ok := d.GetOk("automatic"); ok {
+		remediationConfigurationInput.Automatic = aws.Bool(v.(bool))
+	}
 	if v, ok := d.GetOk("resource_type"); ok {
 		remediationConfigurationInput.ResourceType = aws.String(v.(string))
 	}
@@ -195,6 +202,7 @@ func resourceAwsConfigRemediationConfigurationRead(d *schema.ResourceData, meta 
 
 	remediationConfiguration := out.RemediationConfigurations[0]
 	d.Set("arn", remediationConfiguration.Arn)
+	d.Set("automatic", remediationConfiguration.Automatic)
 	d.Set("config_rule_name", remediationConfiguration.ConfigRuleName)
 	d.Set("resource_type", remediationConfiguration.ResourceType)
 	d.Set("target_id", remediationConfiguration.TargetId)

--- a/aws/resource_aws_config_remediation_configuration.go
+++ b/aws/resource_aws_config_remediation_configuration.go
@@ -33,6 +33,20 @@ func resourceAwsConfigRemediationConfiguration() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"maximum_automatic_attempts": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      5,
+				ValidateFunc: validation.IntBetween(1, 25),
+			},
+			"retry_attempt_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      60,
+				ValidateFunc: validation.IntBetween(1, 2678000),
+			},
 			"config_rule_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -148,6 +162,12 @@ func resourceAwsConfigRemediationConfigurationPut(d *schema.ResourceData, meta i
 	if v, ok := d.GetOk("automatic"); ok {
 		remediationConfigurationInput.Automatic = aws.Bool(v.(bool))
 	}
+	if v, ok := d.GetOk("maximum_automatic_attempts"); ok {
+		remediationConfigurationInput.MaximumAutomaticAttempts = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := d.GetOk("retry_attempt_seconds"); ok {
+		remediationConfigurationInput.RetryAttemptSeconds = aws.Int64(int64(v.(int)))
+	}
 	if v, ok := d.GetOk("resource_type"); ok {
 		remediationConfigurationInput.ResourceType = aws.String(v.(string))
 	}
@@ -203,6 +223,8 @@ func resourceAwsConfigRemediationConfigurationRead(d *schema.ResourceData, meta 
 	remediationConfiguration := out.RemediationConfigurations[0]
 	d.Set("arn", remediationConfiguration.Arn)
 	d.Set("automatic", remediationConfiguration.Automatic)
+	d.Set("maximum_automatic_attempts", remediationConfiguration.MaximumAutomaticAttempts)
+	d.Set("retry_attempt_seconds", remediationConfiguration.RetryAttemptSeconds)
 	d.Set("config_rule_name", remediationConfiguration.ConfigRuleName)
 	d.Set("resource_type", remediationConfiguration.ResourceType)
 	d.Set("target_id", remediationConfiguration.TargetId)

--- a/website/docs/r/config_remediation_configuration.html.markdown
+++ b/website/docs/r/config_remediation_configuration.html.markdown
@@ -53,6 +53,8 @@ resource "aws_config_remediation_configuration" "this" {
 The following arguments are supported:
 
 * `automatic` - (Optional) The remediation is triggered automatically.
+* `maximum_automatic_attempts` - (Optional) The maximum number of failed attempts for auto-remediation. The default is 5.
+* `retry_attempt_seconds` - (Optional) Maximum time in seconds that AWS Config runs auto-remediation. The default is 60 seconds.
 * `config_rule_name` - (Required) The name of the AWS Config rule
 * `resource_type` - (Optional) The type of a resource
 * `target_id` - (Required) Target ID is the name of the public document

--- a/website/docs/r/config_remediation_configuration.html.markdown
+++ b/website/docs/r/config_remediation_configuration.html.markdown
@@ -52,6 +52,7 @@ resource "aws_config_remediation_configuration" "this" {
 
 The following arguments are supported:
 
+* `automatic` - (Optional) The remediation is triggered automatically.
 * `config_rule_name` - (Required) The name of the AWS Config rule
 * `resource_type` - (Optional) The type of a resource
 * `target_id` - (Required) Target ID is the name of the public document


### PR DESCRIPTION
…tion

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #15491

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
