### PR TITLE
Docs: aws_ses_domain_dkim

### DIFF
--- a/website/docs/r/ses_domain_dkim.html.markdown
+++ b/website/docs/r/ses_domain_dkim.html.markdown
@@ -43,7 +43,7 @@ resource "aws_ses_domain_dkim" "example" {
 resource "aws_route53_record" "example_amazonses_dkim_record" {
   count   = 3
   zone_id = "ABCDEFGHIJ123"
-  name    = "${element(aws_ses_domain_dkim.example.dkim_tokens, count.index)}._domainkey.example.com"
+  name    = "${element(aws_ses_domain_dkim.example.dkim_tokens, count.index)}._domainkey"
   type    = "CNAME"
   ttl     = "600"
   records = ["${element(aws_ses_domain_dkim.example.dkim_tokens, count.index)}.dkim.amazonses.com"]


### PR DESCRIPTION
Everytime I setup DKIM, I fall for the same trap, copying the route53 dkim verification from the docs page and not updating the example.com. As Route53 will automatically add the TLD, I believe the example would be better without it.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```