### PR TITLE
F/aws fsx windows file system: Support Support updating throughput_capacity and Storage_Capacity

### DIFF
--- a/aws/fsx.go
+++ b/aws/fsx.go
@@ -112,7 +112,7 @@ func waitForFsxFileSystemUpdate(conn *fsx.FSx, id string, timeout time.Duration)
 
 func waitForFsxFileSystemUpdateOptimizing(conn *fsx.FSx, id string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{fsx.StatusInProgress, fsx.StatusUpdatedOptimizing},
+		Pending: []string{fsx.StatusInProgress},
 		Target:  []string{fsx.StatusCompleted},
 		Refresh: refreshFsxFileSystemLifecycleOptimizing(conn, id),
 		Timeout: timeout,

--- a/aws/fsx.go
+++ b/aws/fsx.go
@@ -113,7 +113,7 @@ func waitForFsxFileSystemUpdate(conn *fsx.FSx, id string, timeout time.Duration)
 func waitForFsxFileSystemUpdateOptimizing(conn *fsx.FSx, id string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{fsx.StatusInProgress},
-		Target:  []string{fsx.StatusCompleted},
+		Target:  []string{fsx.StatusCompleted, fsx.StatusUpdatedOptimizing},
 		Refresh: refreshFsxFileSystemLifecycleOptimizing(conn, id),
 		Timeout: timeout,
 		Delay:   30 * time.Second,

--- a/aws/fsx.go
+++ b/aws/fsx.go
@@ -113,7 +113,10 @@ func waitForFsxFileSystemUpdate(conn *fsx.FSx, id string, timeout time.Duration)
 func waitForFsxFileSystemUpdateOptimizing(conn *fsx.FSx, id string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{fsx.StatusInProgress},
-		Target:  []string{fsx.StatusCompleted, fsx.StatusUpdatedOptimizing},
+		Target: []string{
+			fsx.StatusCompleted,
+			fsx.StatusUpdatedOptimizing,
+		},
 		Refresh: refreshFsxFileSystemLifecycleOptimizing(conn, id),
 		Timeout: timeout,
 		Delay:   30 * time.Second,

--- a/aws/fsx.go
+++ b/aws/fsx.go
@@ -48,6 +48,26 @@ func refreshFsxFileSystemLifecycle(conn *fsx.FSx, id string) resource.StateRefre
 	}
 }
 
+func refreshFsxFileSystemLifecycleOptimizing(conn *fsx.FSx, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		filesystem, err := describeFsxFileSystem(conn, id)
+
+		if isAWSErr(err, fsx.ErrCodeFileSystemNotFound, "") {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if filesystem == nil {
+			return nil, "", nil
+		}
+
+		return filesystem, aws.StringValue(filesystem.AdministrativeActions[0].Status), nil
+	}
+}
+
 func waitForFsxFileSystemCreation(conn *fsx.FSx, id string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{fsx.FileSystemLifecycleCreating},
@@ -81,6 +101,20 @@ func waitForFsxFileSystemUpdate(conn *fsx.FSx, id string, timeout time.Duration)
 		Pending: []string{fsx.FileSystemLifecycleUpdating},
 		Target:  []string{fsx.FileSystemLifecycleAvailable},
 		Refresh: refreshFsxFileSystemLifecycle(conn, id),
+		Timeout: timeout,
+		Delay:   30 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func waitForFsxFileSystemUpdateOptimizing(conn *fsx.FSx, id string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{fsx.StatusInProgress, fsx.StatusUpdatedOptimizing},
+		Target:  []string{fsx.StatusCompleted},
+		Refresh: refreshFsxFileSystemLifecycleOptimizing(conn, id),
 		Timeout: timeout,
 		Delay:   30 * time.Second,
 	}

--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -307,6 +307,16 @@ func resourceAwsFsxWindowsFileSystemUpdate(d *schema.ResourceData, meta interfac
 		requestUpdate = true
 	}
 
+	if d.HasChange("throughput_capacity") {
+		input.WindowsConfiguration.ThroughputCapacity = aws.Int64(int64(d.Get("throughput_capacity").(int)))
+		requestUpdate = true
+	}
+
+	if d.HasChange("storage_capacity") {
+		input.StorageCapacity = aws.Int64(int64(d.Get("storage_capacity").(int)))
+		requestUpdate = true
+	}
+
 	if d.HasChange("daily_automatic_backup_start_time") {
 		input.WindowsConfiguration.DailyAutomaticBackupStartTime = aws.String(d.Get("daily_automatic_backup_start_time").(string))
 		requestUpdate = true
@@ -326,6 +336,10 @@ func resourceAwsFsxWindowsFileSystemUpdate(d *schema.ResourceData, meta interfac
 		_, err := conn.UpdateFileSystem(input)
 		if err != nil {
 			return fmt.Errorf("error updating FSX File System (%s): %s", d.Id(), err)
+		}
+
+		if err := waitForFsxFileSystemUpdate(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+			return fmt.Errorf("Error waiting for filesystem (%s) to become available: %w", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -338,7 +338,7 @@ func resourceAwsFsxWindowsFileSystemUpdate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("error updating FSX File System (%s): %s", d.Id(), err)
 		}
 
-		if err := waitForFsxFileSystemUpdate(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		if err := waitForFsxFileSystemUpdateOptimizing(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 			return fmt.Errorf("Error waiting for filesystem (%s) to become available: %w", d.Id(), err)
 		}
 	}

--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -146,7 +146,6 @@ func resourceAwsFsxWindowsFileSystem() *schema.Resource {
 			"storage_capacity": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(32, 65536),
 			},
 			"subnet_ids": {
@@ -160,7 +159,6 @@ func resourceAwsFsxWindowsFileSystem() *schema.Resource {
 			"throughput_capacity": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(8, 2048),
 			},
 			"vpc_id": {

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -538,10 +538,10 @@ func TestAccAWSFsxWindowsFileSystem_StorageCapacity(t *testing.T) {
 		CheckDestroy: testAccCheckFsxWindowsFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsFsxWindowsFileSystemConfigStorageCapacity(33),
+				Config: testAccAwsFsxWindowsFileSystemConfigStorageCapacity(32),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem1),
-					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "33"),
+					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "32"),
 				),
 			},
 			{
@@ -554,11 +554,11 @@ func TestAccAWSFsxWindowsFileSystem_StorageCapacity(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAwsFsxWindowsFileSystemConfigStorageCapacity(34),
+				Config: testAccAwsFsxWindowsFileSystemConfigStorageCapacity(36),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem2),
 					testAccCheckFsxWindowsFileSystemRecreated(&filesystem1, &filesystem2),
-					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "34"),
+					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "36"),
 				),
 			},
 		},
@@ -643,7 +643,7 @@ func TestAccAWSFsxWindowsFileSystem_ThroughputCapacity(t *testing.T) {
 				Config: testAccAwsFsxWindowsFileSystemConfigThroughputCapacity(32),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem2),
-					testAccCheckFsxWindowsFileSystemRecreated(&filesystem1, &filesystem2),
+					testAccCheckFsxWindowsFileSystemNotRecreated(&filesystem1, &filesystem2),
 					resource.TestCheckResourceAttr(resourceName, "throughput_capacity", "32"),
 				),
 			},
@@ -1000,7 +1000,7 @@ resource "aws_fsx_windows_file_system" "test" {
   skip_final_backup   = true
   storage_capacity    = %[1]d
   subnet_ids          = [aws_subnet.test1.id]
-  throughput_capacity = 8
+  throughput_capacity = 16
 }
 `, storageCapacity)
 }

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -557,7 +557,7 @@ func TestAccAWSFsxWindowsFileSystem_StorageCapacity(t *testing.T) {
 				Config: testAccAwsFsxWindowsFileSystemConfigStorageCapacity(36),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem2),
-					testAccCheckFsxWindowsFileSystemRecreated(&filesystem1, &filesystem2),
+					testAccCheckFsxWindowsFileSystemNotRecreated(&filesystem1, &filesystem2),
 					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "36"),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #15558

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSFsxWindowsFileSystem_ThroughputCapacity'
--- PASS: TestAccAWSFsxWindowsFileSystem_ThroughputCapacity (3546.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3548.249s
$ make testacc TESTARGS='-run=TestAccAWSFsxWindowsFileSystem_StorageCapacity'
--- PASS: TestAccAWSFsxWindowsFileSystem_StorageCapacity (2681.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2683.927s
...
```
