### PR TITLE
r/fsx_lustre_filesystem - remove required with for `auto_policy_import`

### DIFF
--- a/aws/resource_aws_fsx_lustre_file_system.go
+++ b/aws/resource_aws_fsx_lustre_file_system.go
@@ -56,7 +56,6 @@ func resourceAwsFsxLustreFileSystem() *schema.Resource {
 					validation.StringLenBetween(3, 900),
 					validation.StringMatch(regexp.MustCompile(`^s3://`), "must begin with s3://"),
 				),
-				RequiredWith: []string{"auto_import_policy"},
 			},
 			"imported_file_chunk_size": {
 				Type:         schema.TypeInt,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15498

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run= TestAccAWSFsxLustreFileSystem_'
--- PASS: TestAccAWSFsxLustreFileSystem_basic (538.73s)
--- PASS: TestAccAWSFsxLustreFileSystem_automaticBackupRetentionDays (838.72s)
--- PASS: TestAccAWSFsxLustreFileSystem_WeeklyMaintenanceStartTime (646.51s)
--- PASS: TestAccAWSFsxLustreFileSystem_SecurityGroupIds (1227.99s)
--- PASS: TestAccAWSFsxLustreFileSystem_autoImportPolicy (1455.48s)
--- PASS: TestAccAWSFsxLustreFileSystem_Tags (675.53s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageCapacity (1083.51s)
--- PASS: TestAccAWSFsxLustreFileSystem_DeploymentTypeScratch2 (548.57s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportPath (1866.69s)
--- PASS: TestAccAWSFsxLustreFileSystem_ExportPath (1725.16s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportedFileChunkSize (1841.24s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageTypeHddDriveCacheNone (587.87s)
--- PASS: TestAccAWSFsxLustreFileSystem_DeploymentTypePersistent1 (448.41s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageTypeHddDriveCacheRead (593.33s)
--- PASS: TestAccAWSFsxLustreFileSystem_dailyAutomaticBackupStartTime (671.29s)
--- PASS: TestAccAWSFsxLustreFileSystem_disappears (637.18s)
--- PASS: TestAccAWSFsxLustreFileSystem_KmsKeyId (1328.39s)
...
```


reverting required with until a better solution comes up to allow CI to pass.
