### PR TITLE
lb_target_group: Allow invalid stickiness config, avoid breaking change

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -152,6 +152,16 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 								"lb_cookie", // Only for ALBs
 								"source_ip", // Only for NLBs
 							}, false),
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								switch d.Get("protocol").(string) {
+								case elbv2.ProtocolEnumTcp, elbv2.ProtocolEnumUdp, elbv2.ProtocolEnumTcpUdp, elbv2.ProtocolEnumTls:
+									if new == "lb_cookie" && !d.Get("stickiness.0.enabled").(bool) {
+										log.Printf("[WARN] invalid configuration, this will fail in a future version: stickiness enabled %v, protocol %s, type %s", d.Get("stickiness.0.enabled").(bool), d.Get("protocol").(string), new)
+										return true
+									}
+								}
+								return false
+							},
 						},
 						"cookie_duration": {
 							Type:         schema.TypeInt,
@@ -447,23 +457,27 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 			if len(stickinessBlocks) == 1 {
 				stickiness := stickinessBlocks[0].(map[string]interface{})
 
-				attrs = append(attrs,
-					&elbv2.TargetGroupAttribute{
-						Key:   aws.String("stickiness.enabled"),
-						Value: aws.String(strconv.FormatBool(stickiness["enabled"].(bool))),
-					},
-					&elbv2.TargetGroupAttribute{
-						Key:   aws.String("stickiness.type"),
-						Value: aws.String(stickiness["type"].(string)),
-					})
-
-				switch d.Get("protocol").(string) {
-				case elbv2.ProtocolEnumHttp, elbv2.ProtocolEnumHttps:
+				if !stickiness["enabled"].(bool) && stickiness["type"].(string) == "lb_cookie" && d.Get("protocol").(string) != elbv2.ProtocolEnumHttp && d.Get("protocol").(string) != elbv2.ProtocolEnumHttps {
+					log.Printf("[WARN] invalid configuration, this will fail in a future version: stickiness enabled %v, protocol %s, type %s", stickiness["enabled"].(bool), d.Get("protocol").(string), stickiness["type"].(string))
+				} else {
 					attrs = append(attrs,
 						&elbv2.TargetGroupAttribute{
-							Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
-							Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
+							Key:   aws.String("stickiness.enabled"),
+							Value: aws.String(strconv.FormatBool(stickiness["enabled"].(bool))),
+						},
+						&elbv2.TargetGroupAttribute{
+							Key:   aws.String("stickiness.type"),
+							Value: aws.String(stickiness["type"].(string)),
 						})
+
+					switch d.Get("protocol").(string) {
+					case elbv2.ProtocolEnumHttp, elbv2.ProtocolEnumHttps:
+						attrs = append(attrs,
+							&elbv2.TargetGroupAttribute{
+								Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
+								Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
+							})
+					}
 				}
 			} else if len(stickinessBlocks) == 0 {
 				attrs = append(attrs, &elbv2.TargetGroupAttribute{

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -1048,6 +1048,15 @@ func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
 				),
 			},
 			{
+				// this test should be invalid but allowed to avoid breaking changes
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("TCP", "lb_cookie", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "false"),
+				),
+			},
+			{
 				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("TCP", "source_ip", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
@@ -1129,11 +1138,6 @@ func TestAccAWSLBTargetGroup_stickinessInvalidNLB(t *testing.T) {
 			{
 				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("TCP_UDP", "lb_cookie", true),
 				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
-			},
-			{
-				Config:             testAccAWSLBTargetGroupConfig_stickinessValidity("TCP_UDP", "lb_cookie", false),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -85,7 +85,7 @@ Stickiness Blocks (`stickiness`) support the following:
 * `cookie_duration` - (Optional) Only used when the type is `lb_cookie`. The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
 * `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`
 
-~> **NOTE:** To help facilitate the authoring of modules that support target groups of any protocol, you can define `stickiness` regardless of the protocol chosen. However, for `TCP` target groups, `enabled` must be `false`.
+~> **NOTE:** Currently, an NLB (i.e., protocol of `HTTP` or `HTTPS`) can have an invalid `stickiness` block with `type` set to `lb_cookie` as long as `enabled` is set to `false`. However, please update your configurations to avoid errors in a future version of the provider: either remove the invalid `stickiness` block or set the `type` to `source_ip`.
 
 Health Check Blocks (`health_check`):
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15603

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Allow invalid configurations that were allowed prior to 3.10.
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSLBTargetGroup_generatedName (40.86s)
--- PASS: TestAccAWSLBTargetGroup_namePrefix (40.99s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (41.03s)
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (48.48s)
--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (49.34s)
--- PASS: TestAccAWSLBTargetGroup_defaults_network (50.62s)
--- PASS: TestAccAWSLBTargetGroup_defaults_application (59.21s)
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (23.52s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (32.28s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (77.30s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (82.51s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (83.38s)
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (84.64s)
--- PASS: TestAccAWSLBTargetGroupAttachment_lambda (44.47s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (87.52s)
--- PASS: TestAccAWSLBTargetGroup_basicUdp (38.22s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (88.25s)
--- PASS: TestAccAWSLBTargetGroup_basic (39.35s)
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (92.62s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (96.76s)
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (98.01s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (74.99s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (118.41s)
--- PASS: TestAccAWSLBTargetGroup_tags (121.59s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (40.67s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (133.30s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (59.85s)
--- PASS: TestAccAWSLBTargetGroupAttachment_Port (93.30s)
--- PASS: TestAccAWSLBTargetGroupAttachment_ipAddress (94.36s)
--- PASS: TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility (93.26s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (168.99s)
--- PASS: TestAccAWSLBTargetGroupAttachment_disappears (93.33s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (97.18s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSLBTargetGroup_generatedName (36.09s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (36.13s)
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (37.18s)
--- PASS: TestAccAWSLBTargetGroup_defaults_application (37.36s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (41.56s)
--- PASS: TestAccAWSLBTargetGroup_defaults_network (47.30s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (60.50s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (27.15s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (64.99s)
--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (32.51s)
--- PASS: TestAccAWSLBTargetGroup_namePrefix (32.99s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (71.33s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (71.82s)
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (73.20s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (74.78s)
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (19.19s)
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (81.91s)
--- PASS: TestAccAWSLBTargetGroupAttachment_lambda (36.98s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (86.84s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (93.53s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (95.29s)
--- PASS: TestAccAWSLBTargetGroup_basic (31.70s)
--- PASS: TestAccAWSLBTargetGroup_basicUdp (33.60s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (62.11s)
--- PASS: TestAccAWSLBTargetGroup_tags (99.93s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (66.00s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (126.24s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (145.36s)
--- PASS: TestAccAWSLBTargetGroupAttachment_Port (89.55s)
--- PASS: TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility (89.05s)
--- PASS: TestAccAWSLBTargetGroupAttachment_disappears (98.74s)
--- PASS: TestAccAWSLBTargetGroupAttachment_ipAddress (110.10s)
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (219.84s)
```
