### PR TITLE
Skeleton for an elastic_beanstalk_environment data source

### DIFF
--- a/aws/data_source_aws_elastic_beanstalk_environment.go
+++ b/aws/data_source_aws_elastic_beanstalk_environment.go
@@ -1,0 +1,65 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsElasticBeanstalkEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsElasticBeanstalkEnvironmentRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"application": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+// dataSourceAwsElasticBeanstalkEnvironmentRead performs the EB environment lookup.
+func dataSourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticbeanstalkconn
+
+	params := &elasticbeanstalk.DescribeEnvironmentsInput{
+		ApplicationName: aws.String(d.Get("application").(string)),
+	}
+
+	log.Printf("[DEBUG] Reading Elastic Beanstalk Environments: %s", params)
+
+	describeResp, err := conn.DescribeEnvironments(params)
+	if err != nil {
+		return fmt.Errorf("Error retrieving environments: %s", err)
+	}
+
+	// TODO: just return first for now
+	env := describeResp.Environments[0]
+
+	d.SetId(aws.StringValue(describeResp.Environments[0].EnvironmentId))
+
+	arn := aws.StringValue(env.EnvironmentArn)
+	d.Set("arn", arn)
+
+	if err := d.Set("name", env.EnvironmentName); err != nil {
+		return err
+	}
+
+	if err := d.Set("application", env.ApplicationName); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -249,6 +249,7 @@ func Provider() *schema.Provider {
 			"aws_eks_cluster":                                dataSourceAwsEksCluster(),
 			"aws_eks_cluster_auth":                           dataSourceAwsEksClusterAuth(),
 			"aws_elastic_beanstalk_application":              dataSourceAwsElasticBeanstalkApplication(),
+			"aws_elastic_beanstalk_environment":              dataSourceAwsElasticBeanstalkEnvironment(),
 			"aws_elastic_beanstalk_hosted_zone":              dataSourceAwsElasticBeanstalkHostedZone(),
 			"aws_elastic_beanstalk_solution_stack":           dataSourceAwsElasticBeanstalkSolutionStack(),
 			"aws_elasticache_cluster":                        dataSourceAwsElastiCacheCluster(),

--- a/website/docs/d/elastic_beanstalk_environment.html.markdown
+++ b/website/docs/d/elastic_beanstalk_environment.html.markdown
@@ -1,0 +1,31 @@
+---
+subcategory: "Elastic Beanstalk"
+layout: "aws"
+page_title: "AWS: aws_elastic_beanstalk_environment"
+description: |-
+  Retrieve information about an Elastic Beanstalk Environment
+---
+
+# Data Source: aws_elastic_beanstalk_environment
+
+Retrieve information about an Elastic Beanstalk Environment.
+
+## Example Usage
+
+```hcl
+data "aws_elastic_beanstalk_environment" "example" {
+  application = "my-app"
+}
+
+output "name" {
+  value = data.aws_elastic_beanstalk_environment.example.name
+}
+```
+
+## Argument Reference
+
+* `application` - (Required) The name of the application to which the environment belongs.
+
+## Attributes Reference
+
+* `name` - The name of the environment


### PR DESCRIPTION
Related to: https://github.com/terraform-providers/terraform-provider-aws/issues/2051

This would allow for lookup of existing EB environments, which could be useful in case they are configured outside of terraform (which is likely given the EB tooling).

There is still quite a lot to be done to make this a fully fledged PR, but posting it in draft form for early feedback (mainly: is a change such as this likely to be merged once filled out?)

Having said that, in it's current form, it's possible to have lookup an EB env by `application` (it's hardcoded to return just the first match - this would likely change) and get `arn`, `name`, and `application` back as attributes, e.g.:

```
data "aws_elastic_beanstalk_environment" "my-env" {
  application = "my-app"
}

output "env-name" {
  value = data.aws_elastic_beanstalk_environment.my-env.name
}
```

So very much skeleton code, and not that useful yet, but could be made so without too much effort (but I'd like to know the chances of a merge before investing that effort - I see *a lot* of open PRs in this repo 😄)
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
