### PR TITLE
Workflow/assign merged pr to current milestone

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
     types: [closed]
-name: Add merged PR and linked issues to current milestone
+name: Add merged PR and linked issues to current milestone of target branch
 jobs:
   AddMergedToCurrentMilestone:
     if: github.event.pull_request.merged

--- a/.github/workflows/pull_requests_add_to_milestone.yml
+++ b/.github/workflows/pull_requests_add_to_milestone.yml
@@ -21,3 +21,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pull_number: ${{ github.event.pull_request.number }}
           milestone_number: ${{ steps.get-milestone-id.outputs.milestone_id }}
+          

--- a/.github/workflows/pull_requests_add_to_milestone.yml
+++ b/.github/workflows/pull_requests_add_to_milestone.yml
@@ -21,4 +21,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pull_number: ${{ github.event.pull_request.number }}
           milestone_number: ${{ steps.get-milestone-id.outputs.milestone_id }}
-          

--- a/.github/workflows/pull_requests_add_to_milestone.yml
+++ b/.github/workflows/pull_requests_add_to_milestone.yml
@@ -1,0 +1,23 @@
+on:
+  pull_request:
+    types: [closed]
+name: Add merged PR and linked issues to current milestone
+jobs:
+  AddMergedToCurrentMilestone:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: get-current-milestone
+        run: |
+            echo ::set-output name=current_milestone::v$(head -1 CHANGELOG.md | cut -d " " -f 2)
+      - run: echo ${{ steps.get-current-milestone.outputs.current_milestone }}
+      - id: get-milestone-id 
+        run: |
+          echo ::set-output name=milestone_id::$(curl -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/milestones | jq 'map(select(.title == "${{ steps.get-current-milestone.outputs.current_milestone }}"))[0].number')
+      - run: echo ${{ steps.get-milestone-id.outputs.milestone_id }}
+      - uses: breathingdust/current-milestone-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pull_number: ${{ github.event.pull_request.number }}
+          milestone_number: ${{ steps.get-milestone-id.outputs.milestone_id }}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

This action acts upon newly merged pull requests:

- Looks up the current milestone from `CHANGELOG.md` file
- Looks up any issues linked from the PR that are marked with any '[closing](https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords)' keyword.
- Assigns that milestone to the PR and all Issues.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

