### PR TITLE
Prevent aws_ec2_client_vpn_authorization_rule exception when aws_ec2_client_vpn_endpoint is not found

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_authorization_rule.go
+++ b/aws/resource_aws_ec2_client_vpn_authorization_rule.go
@@ -111,6 +111,11 @@ func resourceAwsEc2ClientVpnAuthorizationRuleRead(d *schema.ResourceData, meta i
 		d.SetId("")
 		return nil
 	}
+	if isAWSErr(err, tfec2.ErrCodeClientVpnEndpointIdNotFound, "") {
+		log.Printf("[WARN] EC2 Client VPN (%s) not found, removing rule from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("error reading Client VPN authorization rule: %w", err)
 	}
@@ -172,6 +177,9 @@ func deleteClientVpnAuthorizationRule(conn *ec2.EC2, input *ec2.RevokeClientVpnI
 
 	_, err := conn.RevokeClientVpnIngress(input)
 	if isAWSErr(err, tfec2.ErrCodeClientVpnAuthorizationRuleNotFound, "") {
+		return nil
+	}
+	if isAWSErr(err, tfec2.ErrCodeClientVpnEndpointIdNotFound, "") {
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

```release-note
Prevent aws_ec2_client_vpn_authorization_rule from throwing the error InvalidClientVpnEndpointId.NotFound the case that the linked resource aws_ec2_client_vpn_endpoint does not exist.
```