### PR TITLE
r/aws_elasticache_replication_group: Add a DiffSuppressFunc to the en…

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -102,6 +102,20 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					versions := strings.Split(new, ".")
+
+					// For example 6.x
+					if len(versions) == 2 {
+						major, minor := versions[0], versions[1]
+
+						if minor == "x" && strings.HasPrefix(old, major) {
+							return true
+						}
+					}
+
+					return false
+				},
 			},
 			"maintenance_window": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -105,11 +106,16 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					versions := strings.Split(new, ".")
 
-					// For example 6.x
-					if len(versions) == 2 {
-						major, minor := versions[0], versions[1]
+					majorInt, err := strconv.Atoi(versions[0])
+					if err != nil {
+						return false
+					}
 
-						if minor == "x" && strings.HasPrefix(old, major) {
+					// For example 6.x
+					if majorInt >= 6 && len(versions) == 2 {
+						majorStr, minorStr := versions[0], versions[1]
+
+						if minorStr == "x" && strings.HasPrefix(old, majorStr) {
 							return true
 						}
 					}

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -750,6 +750,33 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFail
 	})
 }
 
+func TestAccAWSElasticacheReplicationGroup_redisEngineVersion6x(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfigEngineVersion(rName, "6.x"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestMatchResourceAttr(resourceName, "engine_version", regexp.MustCompile(`^6\.`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
 func TestAccAWSElasticacheReplicationGroup_tags(t *testing.T) {
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1652,6 +1679,23 @@ resource "aws_elasticache_replication_group" "test" {
   subnet_group_name             = aws_elasticache_subnet_group.test.name
 }
 `, rName, autoFailover, numberCacheClusters)
+}
+
+func testAccAWSElasticacheReplicationGroupConfigEngineVersion(rName string, version string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[1]q
+  replication_group_description = "test description"
+  node_type                     = "cache.t3.small"
+  number_cache_clusters         = 2
+  port                          = 6379
+  apply_immediately             = true
+  auto_minor_version_upgrade    = false
+  maintenance_window            = "tue:06:30-tue:07:30"
+  snapshot_window               = "01:00-02:00"
+  engine_version                = %[2]q
+}
+`, rName, version)
 }
 
 func testAccAWSElasticacheReplicationGroupConfigTags1(rName, tagKey1, tagValue1 string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/15625

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_elasticache_replication_group: Add a DiffSuppressFunc to the engine_version field
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_redisEngineVersion6x''
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_redisEngineVersion6x -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_redisEngineVersion6x
=== PAUSE TestAccAWSElasticacheReplicationGroup_redisEngineVersion6x
=== CONT  TestAccAWSElasticacheReplicationGroup_redisEngineVersion6x
--- PASS: TestAccAWSElasticacheReplicationGroup_redisEngineVersion6x (643.37s)
PASS
```

Added a diff suppression function for the engine_version field. Thank you for your review! 