### PR TITLE
resource/aws_elastic_beanstalk_environment: Prevent spurious settings updates for custom load balancer listener rules

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -670,6 +670,8 @@ func fetchAwsElasticBeanstalkEnvironmentSettings(d *schema.ResourceData, meta in
 				m["value"] = dropGeneratedSecurityGroup(*optionSetting.Value, meta)
 			case "Subnets", "ELBSubnets":
 				m["value"] = sortValues(*optionSetting.Value)
+			case "HostHeaders":
+				m["value"] = dropGeneratedHostname(*optionSetting.Value)
 			default:
 				m["value"] = *optionSetting.Value
 			}
@@ -945,6 +947,17 @@ func extractOptionSettings(s *schema.Set) []*elasticbeanstalk.ConfigurationOptio
 	}
 
 	return settings
+}
+
+func dropGeneratedHostname(settingValue string) string {
+	var realNames []string
+	names := strings.Split(settingValue, ",")
+	for _, name := range names {
+		if !strings.HasSuffix(name, ".elasticbeanstalk.com") {
+			realNames = append(realNames, name)
+		}
+	}
+	return strings.Join(realNames, ",")
 }
 
 func dropGeneratedSecurityGroup(settingValue string, meta interface{}) string {

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -66,6 +66,39 @@ func testSweepElasticBeanstalkEnvironments(region string) error {
 	return errors
 }
 
+func Test_dropGeneratedHostname(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Input    string
+		Expected string
+	}{
+		{
+			Name:     "simple",
+			Input:    "www.example.com",
+			Expected: "www.example.com",
+		},
+		{
+			Name:     "simple_2",
+			Input:    "www.example.com,abcdef123.us-east-1.elasticbeanstalk.com",
+			Expected: "www.example.com",
+		},
+		{
+			Name:     "simple_3",
+			Input:    "abcdef123.us-east-1.elasticbeanstalk.com",
+			Expected: "",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := dropGeneratedHostname(testCase.Input)
+
+			if got != testCase.Expected {
+				t.Errorf("got %v, expected %v", got, testCase.Expected)
+			}
+		})
+	}
+}
+
 func TestAccAWSBeanstalkEnv_basic(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 


### PR DESCRIPTION
If you specified a load balancer rule like this in your Elastic
Beanstalk environment settings:

```hcl
setting {
  namespace = "aws:elbv2:listenerrule:SharedAlbRedirect"
  name      = "HostHeaders"
  value     = "www.myapp.com"
}
setting {
  namespace = "aws:elbv2:listener:443"
  name      = "Rules"
  value     = "SharedAlbRedirect"
}
```

Terraform would continuously detect environment changes on apply,
showing plan diff like:

```diff
+ setting {
    + name      = "HostHeaders"
    + namespace = "aws:elbv2:listenerrule:SharedAlbRedirect"
    + value     = "www.myapp.com"
  }
- setting {
    - name      = "HostHeaders" -> null
    - namespace = "aws:elbv2:listenerrule:SharedAlbRedirect" -> null
    - value     = "www.myapp.com,abcdef123.us-east-1.elasticbeanstalk.com" -> null
  }
```

Because Elastic Beanstalk automatically adds the environment's CNAME to
your load balancer rules.

It's not possible for users to add this record to their rules, as it's
not predictable before the environment is created.[1] So, we hide it
from the user, similar to how we hide EB's generated security group in
the "SecurityGroups" setting's value.

[1] Well, it is mostly predictable if you specify a cname_prefix. But
that's (IMO) an uncommon option.


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_elastic_beanstalk_environment: Prevent spurious updates due to custom load balancer rules not including the environment's CNAME.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=Test_dropGeneratedHostname'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=Test_dropGeneratedHostname -timeout 120m
=== RUN   Test_dropGeneratedHostname
=== RUN   Test_dropGeneratedHostname/simple
=== RUN   Test_dropGeneratedHostname/simple_2
=== RUN   Test_dropGeneratedHostname/simple_3
--- PASS: Test_dropGeneratedHostname (0.00s)
    --- PASS: Test_dropGeneratedHostname/simple (0.00s)
    --- PASS: Test_dropGeneratedHostname/simple_2 (0.00s)
    --- PASS: Test_dropGeneratedHostname/simple_3 (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.003s
```