### PR TITLE
Updating regex and test to comply with AWS Documentation

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1517,8 +1517,8 @@ func validateAwsKmsGrantName(v interface{}, k string) (ws []string, es []error) 
 
 func validateCognitoIdentityPoolName(v interface{}, k string) (ws []string, errors []error) {
 	val := v.(string)
-	if !regexp.MustCompile(`^[\w _]+$`).MatchString(val) {
-		errors = append(errors, fmt.Errorf("%q must contain only alphanumeric characters and spaces", k))
+	if !regexp.MustCompile(`^[\w\s+=,.@-]+$`).MatchString(val) {
+		errors = append(errors, fmt.Errorf("%q must contain only alphanumeric characters, dots, underscores and hyphens", k))
 	}
 
 	return

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2003,6 +2003,8 @@ func TestValidateCognitoIdentityPoolName(t *testing.T) {
 		"foo bar",
 		"foo_bar",
 		"1foo 2bar 3",
+		"foo-bar_123",
+		"foo-bar",
 	}
 
 	for _, s := range validValues {
@@ -2013,11 +2015,10 @@ func TestValidateCognitoIdentityPoolName(t *testing.T) {
 	}
 
 	invalidValues := []string{
-		"1-2-3",
-		"foo!",
-		"foo-bar",
-		"foo-bar",
-		"foo1-bar2",
+		"foo*",
+		"foo:bar",
+		"foo&bar",
+		"foo1^bar2",
 	}
 
 	for _, s := range invalidValues {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11558

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:


```
% make testacc TESTARGS='-run=TestAccAWSCognitoIdentityPool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCognitoIdentityPool -timeout 120m
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_disappears
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_disappears
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== RUN   TestAccAWSCognitoIdentityPool_basic
=== PAUSE TestAccAWSCognitoIdentityPool_basic
=== RUN   TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== PAUSE TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== RUN   TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_samlProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_samlProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== PAUSE TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== RUN   TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310651870694000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: 1826b2ac-59c8-4975-9c91-b5ad4ec8c954
--- SKIP: TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider (2.42s)
=== RUN   TestAccAWSCognitoIdentityPool_tags
=== PAUSE TestAccAWSCognitoIdentityPool_tags
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== CONT  TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== CONT  TestAccAWSCognitoIdentityPool_basic
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== CONT  TestAccAWSCognitoIdentityPool_tags
=== CONT  TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== CONT  TestAccAWSCognitoIdentityPool_samlProviderArns
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_disappears
=== CONT  TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== CONT  TestAccAWSCognitoIdentityPool_openidConnectProviderArns
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654302499000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: db2ef2c2-241e-46d2-ac52-aa7362c6b9c1
--- SKIP: TestAccAWSCognitoIdentityPool_openidConnectProviderArns (1.65s)
=== CONT  TestAccAWSCognitoIdentityPool_supportedLoginProviders
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654312964000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: 0d40168c-1189-4e57-8bbe-06d4cd58a9a1
--- SKIP: TestAccAWSCognitoIdentityPool_supportedLoginProviders (1.66s)
=== CONT  TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654295763000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: 0421be13-1fc9-439f-bad9-4fa0737d8e89
--- SKIP: TestAccAWSCognitoIdentityPool_cognitoIdentityProviders (1.66s)
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654304804000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: d5c5009f-0f48-4dde-8344-715e0794ba50
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (1.66s)
=== CONT  TestAccAWSCognitoIdentityPool_basic
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654294718000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: 9589ba9d-bae7-4727-9baf-1d77f541e4b6
--- SKIP: TestAccAWSCognitoIdentityPool_basic (1.66s)
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654317487000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: 9aed141f-798a-4787-83da-19be4b4f434b
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (1.65s)
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654321165000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: f5af7c9c-85ac-4277-8f53-78dbd2f234ec
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (1.67s)
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_disappears
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654320846000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: 5554a63b-34d3-4bb5-ad4f-372c079cfae1
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_disappears (1.67s)
=== CONT  TestAccAWSCognitoIdentityPool_tags
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654308298000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: fde5887c-3ebd-43ae-8174-46be3624898c
--- SKIP: TestAccAWSCognitoIdentityPool_tags (1.67s)
=== CONT  TestAccAWSCognitoIdentityPool_samlProviderArns
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654315665000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: 0e64b30d-f97e-4e5f-a093-a2dd01bdb79b
--- SKIP: TestAccAWSCognitoIdentityPool_samlProviderArns (1.67s)
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654310953000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: e6df5cc6-2ebd-404a-a967-286b64fc9796
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (1.67s)
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_basic
    resource_aws_cognito_identity_pool_test.go:373: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::463038042756:assumed-role/Developer/1603310654294624000 is not authorized to perform: cognito-identity:ListIdentityPools on resource: arn:aws:cognito-identity:eu-west-1:463038042756:identitypool/ with an explicit deny
                status code: 400, request id: 9c0e86cc-779a-4ba7-ad4b-94153529a5a4
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (1.81s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       7.413s
```
