### PR TITLE
Adding minimum to support host_resource_group_arn

### DIFF
--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -314,6 +314,10 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"host_resource_group_arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"spread_domain": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -316,7 +316,7 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 						},
 						"host_resource_group_arn": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Computed: true,
 						},
 						"spread_domain": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -510,6 +510,12 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"host_resource_group_arn": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"placement.0.host_id"},
+							ValidateFunc:  validateArn,
+						},
 						"spread_domain": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -1183,13 +1189,14 @@ func getPlacement(p *ec2.LaunchTemplatePlacement) []interface{} {
 	var s []interface{}
 	if p != nil {
 		s = append(s, map[string]interface{}{
-			"affinity":          aws.StringValue(p.Affinity),
-			"availability_zone": aws.StringValue(p.AvailabilityZone),
-			"group_name":        aws.StringValue(p.GroupName),
-			"host_id":           aws.StringValue(p.HostId),
-			"spread_domain":     aws.StringValue(p.SpreadDomain),
-			"tenancy":           aws.StringValue(p.Tenancy),
-			"partition_number":  aws.Int64Value(p.PartitionNumber),
+			"affinity":                aws.StringValue(p.Affinity),
+			"availability_zone":       aws.StringValue(p.AvailabilityZone),
+			"group_name":              aws.StringValue(p.GroupName),
+			"host_id":                 aws.StringValue(p.HostId),
+			"host_resource_group_arn": aws.StringValue(p.HostResourceGroupArn),
+			"spread_domain":           aws.StringValue(p.SpreadDomain),
+			"tenancy":                 aws.StringValue(p.Tenancy),
+			"partition_number":        aws.Int64Value(p.PartitionNumber),
 		})
 	}
 	return s
@@ -1757,6 +1764,10 @@ func readPlacementFromConfig(p map[string]interface{}) *ec2.LaunchTemplatePlacem
 
 	if v, ok := p["host_id"].(string); ok && v != "" {
 		placement.HostId = aws.String(v)
+	}
+
+	if v, ok := p["host_resource_group_arn"].(string); ok && v != "" {
+		placement.HostResourceGroupArn = aws.String(v)
 	}
 
 	if v, ok := p["spread_domain"].(string); ok && v != "" {

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -312,6 +312,7 @@ The `placement` block supports the following:
 * `availability_zone` - The Availability Zone for the instance.
 * `group_name` - The name of the placement group for the instance.
 * `host_id` - The ID of the Dedicated Host for the instance.
+* `host_resource_group_arn` - The ARN of the Host Resource Group in which to launch instances.
 * `spread_domain` - Reserved for future use.
 * `tenancy` - The tenancy of the instance (if the instance is running in a VPC). Can be `default`, `dedicated`, or `host`.
 * `partition_number` - The number of the partition the instance should launch in. Valid only if the placement group strategy is set to partition.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15784

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds support for host_resource_group_arn in launch_template placement.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I haven't written any acceptance tests specifically for this change; I can't see any similar tests for other placement values. Some guidance would be useful here.

I have tested it locally against existing Launch Templates.
```
➜  terraform apply
data.terraform_remote_state.vpc: Refreshing state...
data.aws_launch_template.lt: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

output = {
  "arn" = "arn:aws:ec2:us-west-2:xxxxxxxxxx:launch-template/lt-xxxxxxxxxx"
... snip ...
"placement" = [
    {
      "affinity" = ""
      "availability_zone" = "us-west-2a"
      "group_name" = ""
      "host_id" = ""
      "host_resource_group_arn" = "arn:aws:resource-groups:us-west-2:xxxxxxxxxx:group/groupName"
      "partition_number" = 0
      "spread_domain" = ""
      "tenancy" = "host"
    },
  ]

...
```

creating a template:
```
Terraform will perform the following actions:

  # aws_launch_template. the_launch_template will be created
  + resource "aws_launch_template" "the_launch_template" {
      ...
      + placement {
          + availability_zone       = "us-west-2a"
          + host_resource_group_arn = "arn:aws:resource-groups:us-west-2:xxxxxxxxxx:group/groupName"
          + tenancy                 = "host"
        }
...
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
