### PR TITLE
aws_vpn_connection resource's customer_gateway_configuration should be sensitive

### DIFF
--- a/.changelog/15806.txt
+++ b/.changelog/15806.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpn_connection: Mark `customer_gateway_configuration` as [`Sensitive`](https://www.terraform.io/plugin/sdkv2/best-practices/sensitive-state#using-the-sensitive-flag)
+```

--- a/internal/service/ec2/vpn_connection.go
+++ b/internal/service/ec2/vpn_connection.go
@@ -37,8 +37,9 @@ func ResourceVPNConnection() *schema.Resource {
 				Computed: true,
 			},
 			"customer_gateway_configuration": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
 			},
 			"customer_gateway_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### The Problem
The computed `customer_gateway_configuration` on `aws_vpn_connection` contains the raw XML of the VPN connection. This includes all the pre-shared keys which are already sensitive on the resource. Seems like the xml should be too so you don't see it in the stdout when the resource is destroyed:

```
# aws_vpn_connection.example will be destroyed
   - resource "aws_vpn_connection" "example" {
       - arn                            = "arn:aws:ec2:us-east-1:11111111:vpn-connection/vpn-11111111" -> null
       - customer_gateway_configuration = <<~EOT
             <?xml version="1.0" encoding="UTF-8"?>
             <vpn_connection id="vpn-11111111">
               <customer_gateway_id>cgw-11111111</customer_gateway_id>
               <vpn_gateway_id>vgw-11111111</vpn_gateway_id>
               <vpn_connection_type>ipsec.1</vpn_connection_type>
               <vpn_connection_attributes>NoBGPVPNConnection</vpn_connection_attributes>
               <ipsec_tunnel>
                 <customer_gateway>
                   <tunnel_outside_address>
                     <ip_address>1.2.3.4</ip_address>
                   </tunnel_outside_address>
                   <tunnel_inside_address>
                     <ip_address>4.3.2.1</ip_address>
                     <network_mask>255.255.255.252</network_mask>
                     <network_cidr>30</network_cidr>
                   </tunnel_inside_address>
                 </customer_gateway>
                 <vpn_gateway>
                   <tunnel_outside_address>
                     <ip_address>9.8.7.6</ip_address>
                   </tunnel_outside_address>
                   <tunnel_inside_address>
                     <ip_address>6.7.8.9</ip_address>
                     <network_mask>255.255.255.252</network_mask>
                     <network_cidr>30</network_cidr>
                   </tunnel_inside_address>
                 </vpn_gateway>
                 <ike>
                   <authentication_protocol>sha1</authentication_protocol>
                   <encryption_protocol>aes-128-cbc</encryption_protocol>
                   <lifetime>28800</lifetime>
                   <perfect_forward_secrecy>group2</perfect_forward_secrecy>
                   <mode>main</mode>
                   <pre_shared_key>xxxxxxxYYYYYYYzzzzzz</pre_shared_key>
                 </ike>
                 <ipsec>
                   <protocol>esp</protocol>
                   <authentication_protocol>hmac-sha1-96</authentication_protocol>
                   <encryption_protocol>aes-128-cbc</encryption_protocol>
                   <lifetime>3600</lifetime>
                   <perfect_forward_secrecy>group2</perfect_forward_secrecy>
                   <mode>tunnel</mode>
                   <clear_df_bit>true</clear_df_bit>
                   <fragmentation_before_encryption>true</fragmentation_before_encryption>
                   <tcp_mss_adjustment>1379</tcp_mss_adjustment>
                   <dead_peer_detection>
                     <interval>10</interval>
                     <retries>3</retries>
                   </dead_peer_detection>
                 </ipsec>
               </ipsec_tunnel>
               <ipsec_tunnel>
                 <customer_gateway>
                   <tunnel_outside_address>
                     <ip_address>2.3.4.5</ip_address>
                   </tunnel_outside_address>
                   <tunnel_inside_address>
                     <ip_address>5.4.3.2</ip_address>
                     <network_mask>255.255.255.252</network_mask>
                     <network_cidr>30</network_cidr>
                   </tunnel_inside_address>
                 </customer_gateway>
                 <vpn_gateway>
                   <tunnel_outside_address>
                     <ip_address>4.5.6.7</ip_address>
                   </tunnel_outside_address>
                   <tunnel_inside_address>
                     <ip_address>7.6.5.4</ip_address>
                     <network_mask>255.255.255.252</network_mask>
                     <network_cidr>30</network_cidr>
                   </tunnel_inside_address>
                 </vpn_gateway>
                 <ike>
                   <authentication_protocol>sha1</authentication_protocol>
                   <encryption_protocol>aes-128-cbc</encryption_protocol>
                   <lifetime>28800</lifetime>
                   <perfect_forward_secrecy>group2</perfect_forward_secrecy>
                   <mode>main</mode>
                   <pre_shared_key>zzzzzzzzYYYYYYYYxxxxxx</pre_shared_key>
                 </ike>
                 <ipsec>
                   <protocol>esp</protocol>
                   <authentication_protocol>hmac-sha1-96</authentication_protocol>
                   <encryption_protocol>aes-128-cbc</encryption_protocol>
                   <lifetime>3600</lifetime>
                   <perfect_forward_secrecy>group2</perfect_forward_secrecy>
                   <mode>tunnel</mode>
                   <clear_df_bit>true</clear_df_bit>
                   <fragmentation_before_encryption>true</fragmentation_before_encryption>
                   <tcp_mss_adjustment>1379</tcp_mss_adjustment>
                   <dead_peer_detection>
                     <interval>10</interval>
                     <retries>3</retries>
                   </dead_peer_detection>
                 </ipsec>
               </ipsec_tunnel>
             </vpn_connection>
         EOT -> null
       - customer_gateway_id            = "cgw-1111111111111" -> null
       - id                             = "vpn-1111111111111" -> null
       - routes                         = [
           - {
               - destination_cidr_block = "1.1.1.0/24"
               - source                 = ""
               - state                  = "available"
             },
         ] -> null
       - static_routes_only             = true -> null
       - tags                           = {
           - "Name"        = "example"
         } -> null
       - tunnel1_address                = "1.2.3.4" -> null
       - tunnel1_bgp_holdtime           = 0 -> null
       - tunnel1_cgw_inside_address     = "4.3.2.1" -> null
       - tunnel1_preshared_key          = (sensitive value)
       - tunnel1_vgw_inside_address     = "9.8.7.6" -> null
       - tunnel2_address                = "6.7.8.9" -> null
       - tunnel2_bgp_holdtime           = 0 -> null
       - tunnel2_cgw_inside_address     = "4.5.6.7" -> null
       - tunnel2_preshared_key          = (sensitive value)
       - tunnel2_vgw_inside_address     = "7.6.5.4" -> null
       - type                           = "ipsec.1" -> null
       - vgw_telemetry                  = [
           - {
               - accepted_route_count = 1
               - last_status_change   = "2020-01-24T11:56:58Z"
               - outside_ip_address   = "1.2.3.4"
               - status               = "DOWN"
               - status_message       = ""
             },
           - {
               - accepted_route_count = 1
               - last_status_change   = "2020-10-09T20:17:13Z"
               - outside_ip_address   = "2.3.4.5"
               - status               = "DOWN"
               - status_message       = ""
             },
         ] -> null
       - vpn_gateway_id                 = "vgw-111111111111" -> null
     }
```
(note that the IPs and resources have been changed in that destroy plan example, but you get the idea).

Notice how `tunnel1_preshared_key` and `tunnel2_preshared_key` are `(sensitive)` but the raw XML which also contains those keys is not.

### Release note, etc
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
`aws_vpn_connection` resource attribute `customer_gateway_configuration` is sensitive
```

Output from acceptance testing:

This doesn't really affect any acceptance tests as far as I can tell. I could not find any tests in this provider that were checking that   sensitive attributes were not displayed. [hashicorp/terraform](https://github.com/hashicorp/terraform) has tests for that.