### PR TITLE
add the ability to specify/change managed AD settings for RDS cluster

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -975,9 +975,9 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("domain", "")
 	d.Set("domain_iam_role_name", "")
-	if len(v.DomainMemberships) > 0 && v.DomainMemberships[0] != nil {
-		d.Set("domain", v.DomainMemberships[0].Domain)
-		d.Set("domain_iam_role_name", v.DomainMemberships[0].IAMRoleName)
+	if len(dbc.DomainMemberships) > 0 && dbc.DomainMemberships[0] != nil {
+		d.Set("domain", dbc.DomainMemberships[0].Domain)
+		d.Set("domain_iam_role_name", dbc.DomainMemberships[0].IAMRoleName)
 	}
 
 	var vpcg []string

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -973,8 +973,12 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("storage_encrypted", dbc.StorageEncrypted)
 	d.Set("enable_http_endpoint", dbc.HttpEndpointEnabled)
 
-	d.Set("domain", dbc.Domain)
-	d.Set("domain_iam_role_name", dbc.DomainIAMRoleName)
+	d.Set("domain", "")
+	d.Set("domain_iam_role_name", "")
+	if len(v.DomainMemberships) > 0 && v.DomainMemberships[0] != nil {
+		d.Set("domain", v.DomainMemberships[0].Domain)
+		d.Set("domain_iam_role_name", v.DomainMemberships[0].IAMRoleName)
+	}
 
 	var vpcg []string
 	for _, g := range dbc.VpcSecurityGroups {

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -540,11 +540,11 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr, ok := d.GetOkExists("domain"); ok {
-			createOpts.Domain = aws.String(attr.(string))
+			opts.Domain = aws.String(attr.(string))
 		}
 
 		if attr, ok := d.GetOkExists("domain_iam_role_name"); ok {
-			createOpts.DomainIAMRoleName = aws.String(attr.(string))
+			opts.DomainIAMRoleName = aws.String(attr.(string))
 		}
 
 		log.Printf("[DEBUG] RDS Cluster restore from snapshot configuration: %s", opts)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12230, adds the ability to specify/change managed AD settings for aws_rds_cluster resource

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Closes #12230, adds the ability to specify/change managed AD settings for aws_rds_cluster resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
