### PR TITLE
r/sagemaker_endpoint_configuration - support `data_capture_config` + validations and test refactor

### DIFF
--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -242,7 +242,7 @@ func resourceAwsSagemakerEndpointConfigurationRead(d *schema.ResourceData, meta 
 
 	endpointConfig, err := conn.DescribeEndpointConfig(request)
 	if err != nil {
-		if isAWSErr(err, "ValidationException", "") {
+		if isAWSErr(err, "ValidationException", "Could not find endpoint configuration") {
 			log.Printf("[INFO] unable to find the SageMaker Endpoint Configuration resource and therefore it is removed from the state: %s", d.Id())
 			d.SetId("")
 			return nil
@@ -396,12 +396,9 @@ func flattenSagemakerDataCaptureConfig(dataCaptureConfig *sagemaker.DataCaptureC
 	}
 
 	cfg := map[string]interface{}{
-		//"enable_capture":              aws.BoolValue(dataCaptureConfig.EnableCapture),
 		"initial_sampling_percentage": aws.Int64Value(dataCaptureConfig.InitialSamplingPercentage),
 		"destination_s3_uri":          aws.StringValue(dataCaptureConfig.DestinationS3Uri),
-		//"kms_key_id":                  aws.StringValue(dataCaptureConfig.KmsKeyId),
-		"capture_options": flattenSagemakerCaptureOptions(dataCaptureConfig.CaptureOptions),
-		//"capture_content_type_header": flattenSagemakerCaptureContentTypeHeader(dataCaptureConfig.CaptureContentTypeHeader),
+		"capture_options":             flattenSagemakerCaptureOptions(dataCaptureConfig.CaptureOptions),
 	}
 
 	if dataCaptureConfig.EnableCapture != nil {

--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -92,6 +92,107 @@ func resourceAwsSagemakerEndpointConfiguration() *schema.Resource {
 			},
 
 			"tags": tagsSchema(),
+
+			"data_capture_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_capture": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"initial_sampling_percentage": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IntBetween(0, 100),
+						},
+
+						"destination_url": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validateSagemakerDataCaptureDestinationUrl,
+						},
+
+						"kms_key_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validateArn,
+						},
+
+						"capture_options": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 2,
+							MinItems: 1,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"capture_mode": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice([]string{"Input", "Output"}, false),
+									},
+								},
+							},
+						},
+
+						"capture_content_type_header": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"csv_content_types": {
+										Type:     schema.TypeList,
+										MinItems: 1,
+										MaxItems: 10,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"content_type": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ForceNew:     true,
+													ValidateFunc: validateSagemakerCsvContentType,
+												},
+											},
+										},
+										Optional: true,
+										ForceNew: true,
+									},
+
+									"json_content_types": {
+										Type:     schema.TypeList,
+										MinItems: 1,
+										MaxItems: 10,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"content_type": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ForceNew:     true,
+													ValidateFunc: validateSagemakerJsonContentType,
+												},
+											},
+										},
+										Optional: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -117,6 +218,10 @@ func resourceAwsSagemakerEndpointConfigurationCreate(d *schema.ResourceData, met
 
 	if v, ok := d.GetOk("tags"); ok {
 		createOpts.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SagemakerTags()
+	}
+
+	if v, ok := d.GetOk("data_capture_config"); ok {
+		createOpts.DataCaptureConfig = expandSagemakerDataCaptureConfig(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] SageMaker Endpoint Configuration create config: %#v", *createOpts)
@@ -157,6 +262,9 @@ func resourceAwsSagemakerEndpointConfigurationRead(d *schema.ResourceData, meta 
 		return err
 	}
 	if err := d.Set("kms_key_arn", endpointConfig.KmsKeyId); err != nil {
+		return err
+	}
+	if err := d.Set("data_capture_config", flattenSagemakerDataCaptureConfig(endpointConfig.DataCaptureConfig)); err != nil {
 		return err
 	}
 
@@ -254,4 +362,152 @@ func flattenProductionVariants(list []*sagemaker.ProductionVariant) []map[string
 		result = append(result, l)
 	}
 	return result
+}
+
+func expandSagemakerDataCaptureConfig(configured []interface{}) *sagemaker.DataCaptureConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]interface{})
+
+	c := &sagemaker.DataCaptureConfig{
+		InitialSamplingPercentage: aws.Int64(int64(m["initial_sampling_percentage"].(int))),
+		DestinationS3Uri:          aws.String(m["destination_url"].(string)),
+		CaptureOptions:            expandSagemakerCaptureOptions(m["capture_options"].([]interface{})),
+	}
+
+	if v, ok := m["enable_capture"]; ok {
+		c.EnableCapture = aws.Bool(v.(bool))
+	}
+
+	if v, ok := m["kms_key_id"]; ok && v.(string) != "" {
+		c.KmsKeyId = aws.String(v.(string))
+	}
+
+	if v, ok := m["capture_content_type_header"]; ok && (len(v.([]interface{})) > 0) {
+		c.CaptureContentTypeHeader = expandSagemakerCaptureContentTypeHeader(v.([]interface{})[0].(map[string]interface{}))
+	}
+
+	return c
+}
+
+func flattenSagemakerDataCaptureConfig(dataCaptureConfig *sagemaker.DataCaptureConfig) []map[string]interface{} {
+	if dataCaptureConfig == nil {
+		return []map[string]interface{}{}
+	}
+
+	cfg := map[string]interface{}{
+		//"enable_capture":              aws.BoolValue(dataCaptureConfig.EnableCapture),
+		"initial_sampling_percentage": aws.Int64Value(dataCaptureConfig.InitialSamplingPercentage),
+		"destination_url":             aws.StringValue(dataCaptureConfig.DestinationS3Uri),
+		//"kms_key_id":                  aws.StringValue(dataCaptureConfig.KmsKeyId),
+		"capture_options": flattenSagemakerCaptureOptions(dataCaptureConfig.CaptureOptions),
+		//"capture_content_type_header": flattenSagemakerCaptureContentTypeHeader(dataCaptureConfig.CaptureContentTypeHeader),
+	}
+
+	if dataCaptureConfig.EnableCapture != nil {
+		cfg["enable_capture"] = aws.BoolValue(dataCaptureConfig.EnableCapture)
+	}
+
+	if dataCaptureConfig.KmsKeyId != nil {
+		cfg["kms_key_id"] = aws.StringValue(dataCaptureConfig.KmsKeyId)
+	}
+
+	if dataCaptureConfig.CaptureContentTypeHeader != nil {
+		cfg["capture_content_type_header"] = flattenSagemakerCaptureContentTypeHeader(dataCaptureConfig.CaptureContentTypeHeader)
+	}
+
+	return []map[string]interface{}{cfg}
+}
+
+func expandSagemakerCaptureOptions(configured []interface{}) []*sagemaker.CaptureOption {
+	containers := make([]*sagemaker.CaptureOption, 0, len(configured))
+
+	for _, lRaw := range configured {
+		data := lRaw.(map[string]interface{})
+
+		l := &sagemaker.CaptureOption{
+			CaptureMode: aws.String(data["capture_mode"].(string)),
+		}
+		containers = append(containers, l)
+	}
+
+	return containers
+}
+
+func flattenSagemakerCaptureOptions(list []*sagemaker.CaptureOption) []map[string]interface{} {
+	containers := make([]map[string]interface{}, 0, len(list))
+
+	for _, lRaw := range list {
+		captureOption := make(map[string]interface{})
+		captureOption["capture_mode"] = aws.StringValue(lRaw.CaptureMode)
+		containers = append(containers, captureOption)
+	}
+
+	return containers
+}
+
+func expandSagemakerCaptureContentTypeHeader(m map[string]interface{}) *sagemaker.CaptureContentTypeHeader {
+	c := &sagemaker.CaptureContentTypeHeader{}
+
+	if v, ok := m["csv_content_types"]; ok && len(v.([]interface{})) > 0 {
+		contentTypes := make([]*string, 0, len(v.([]interface{})))
+
+		for _, raw := range v.([]interface{}) {
+			sRaw := raw.(map[string]interface{})["content_type"]
+			contentTypes = append(contentTypes, aws.String(sRaw.(string)))
+		}
+
+		c.CsvContentTypes = contentTypes
+	}
+
+	if v, ok := m["json_content_types"]; ok && len(v.([]interface{})) > 0 {
+		contentTypes := make([]*string, 0, len(v.([]interface{})))
+
+		for _, raw := range v.([]interface{}) {
+			sRaw := raw.(map[string]interface{})["content_type"]
+			contentTypes = append(contentTypes, aws.String(sRaw.(string)))
+		}
+
+		c.JsonContentTypes = contentTypes
+	}
+
+	return c
+}
+
+func flattenSagemakerCaptureContentTypeHeader(contentTypeHeader *sagemaker.CaptureContentTypeHeader) []map[string]interface{} {
+	if contentTypeHeader == nil {
+		return []map[string]interface{}{}
+	}
+
+	l := make(map[string]interface{})
+
+	if contentTypeHeader.CsvContentTypes != nil {
+		csvTypes := make([]map[string]interface{}, 0, len(contentTypeHeader.CsvContentTypes))
+
+		for _, csvType := range contentTypeHeader.CsvContentTypes {
+			m := map[string]interface{}{
+				"content_type": aws.StringValue(csvType),
+			}
+			csvTypes = append(csvTypes, m)
+		}
+
+		l["csv_content_types"] = csvTypes
+	}
+
+	if contentTypeHeader.JsonContentTypes != nil {
+		jsonTypes := make([]map[string]interface{}, 0, len(contentTypeHeader.JsonContentTypes))
+
+		for _, jsonType := range contentTypeHeader.JsonContentTypes {
+			m := map[string]interface{}{
+				"content_type": aws.StringValue(jsonType),
+			}
+			jsonTypes = append(jsonTypes, m)
+		}
+
+		l["json_content_types"] = jsonTypes
+	}
+
+	return []map[string]interface{}{l}
 }

--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -119,7 +119,7 @@ func resourceAwsSagemakerEndpointConfiguration() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 							ValidateFunc: validation.All(
-								validation.StringMatch(regexp.MustCompile(` ^(https|s3)://([^/])/?(.*)$`), ""),
+								validation.StringMatch(regexp.MustCompile(`^(https|s3)://([^/])/?(.*)$`), ""),
 								validation.StringLenBetween(1, 512),
 							)},
 

--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -63,9 +63,10 @@ func resourceAwsSagemakerEndpointConfiguration() *schema.Resource {
 						},
 
 						"instance_type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(sagemaker.ProductionVariantInstanceType_Values(), false),
 						},
 
 						"initial_variant_weight": {
@@ -77,9 +78,10 @@ func resourceAwsSagemakerEndpointConfiguration() *schema.Resource {
 						},
 
 						"accelerator_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(sagemaker.ProductionVariantAcceleratorType_Values(), false),
 						},
 					},
 				},

--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
@@ -114,11 +115,13 @@ func resourceAwsSagemakerEndpointConfiguration() *schema.Resource {
 						},
 
 						"destination_s3_uri": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validateSagemakerDataCaptureDestinationUrl,
-						},
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: validation.All(
+								validation.StringMatch(regexp.MustCompile(` ^(https|s3)://([^/])/?(.*)$`), ""),
+								validation.StringLenBetween(1, 512),
+							)},
 
 						"kms_key_id": {
 							Type:         schema.TypeString,
@@ -157,8 +160,11 @@ func resourceAwsSagemakerEndpointConfiguration() *schema.Resource {
 										MinItems: 1,
 										MaxItems: 10,
 										Elem: &schema.Schema{
-											Type:         schema.TypeString,
-											ValidateFunc: validateSagemakerCsvContentType,
+											Type: schema.TypeString,
+											ValidateFunc: validation.All(
+												validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*\/[a-zA-Z0-9](-*[a-zA-Z0-9.])*`), ""),
+												validation.StringLenBetween(1, 256),
+											),
 										},
 										Optional: true,
 										ForceNew: true,
@@ -168,8 +174,11 @@ func resourceAwsSagemakerEndpointConfiguration() *schema.Resource {
 										MinItems: 1,
 										MaxItems: 10,
 										Elem: &schema.Schema{
-											Type:         schema.TypeString,
-											ValidateFunc: validateSagemakerJsonContentType,
+											Type: schema.TypeString,
+											ValidateFunc: validation.All(
+												validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*\/[a-zA-Z0-9](-*[a-zA-Z0-9.])*`), ""),
+												validation.StringLenBetween(1, 256),
+											),
 										},
 										Optional: true,
 										ForceNew: true,

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -314,25 +314,17 @@ func testAccCheckSagemakerEndpointConfigurationExists(n string) resource.TestChe
 }
 
 func testAccSagemakerEndpointConfigurationConfig_Base(rName string) string {
-	imageID := ""
-	switch testAccGetRegion() {
-	case "us-west-2":
-		imageID = "174872318107"
-	case "us-west-1":
-		imageID = "632365934929"
-	case "us-east-1":
-		imageID = "382416733822"
-	case "us-gov-west-1":
-		imageID = "226302683700"
-	}
-	registryPath := fmt.Sprintf("%s.dkr.ecr.%s.%s/kmeans:1", imageID, testAccGetRegion(), testAccGetPartitionDNSSuffix())
 	return fmt.Sprintf(`
+data "aws_sagemaker_prebuilt_ecr_image" "test" {
+  repository_name = "kmeans"
+}
+
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
 
   primary_container {
-    image = %[2]q
+    image = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
   }
 }
 
@@ -352,7 +344,7 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, rName, registryPath)
+`, rName)
 }
 
 func testAccSagemakerEndpointConfigurationConfig_Basic(rName string) string {

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -451,7 +451,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
   data_capture_config {
     enable_capture              = true
     initial_sampling_percentage = 50
-	destination_s3_uri          = "s3://${aws_s3_bucket.foo.bucket}/"
+	destination_s3_uri          = "s3://${aws_s3_bucket.test.bucket}/"
 	
     capture_options {
       capture_mode = "Input"

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -77,6 +77,7 @@ func TestAccAWSSagemakerEndpointConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.initial_instance_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_type", "ml.t2.medium"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.initial_variant_weight", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data_capture_config.#", "0"),
 				),
 			},
 			{
@@ -220,6 +221,7 @@ func TestAccAWSSagemakerEndpointConfiguration_dataCaptureConfig(t *testing.T) {
 				Config: testAccSagemakerEndpointConfigurationDataCaptureConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "data_capture_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.enable_capture", "true"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.initial_sampling_percentage", "50"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.destination_s3_uri", fmt.Sprintf("s3://%s/", rName)),
@@ -453,8 +455,8 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
   }
 
   tags = {
-	%[2]q = %[3]q
-	%[4]q = %[5]q
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
@@ -482,16 +484,16 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
   data_capture_config {
     enable_capture              = true
     initial_sampling_percentage = 50
-	destination_s3_uri          = "s3://${aws_s3_bucket.test.bucket}/"
-	
+    destination_s3_uri          = "s3://${aws_s3_bucket.test.bucket}/"
+
     capture_options {
       capture_mode = "Input"
-	}
-	
+    }
+
     capture_options {
       capture_mode = "Output"
-	}
-	
+    }
+
     capture_content_type_header {
       json_content_types = ["application/json"]
     }

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -198,6 +198,37 @@ func TestAccAWSSagemakerEndpointConfiguration_Tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSSagemakerEndpointConfiguration_DataCaptureConfig(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataDestinationBucketName := fmt.Sprintf("bucket-%s", rName)
+	resourceName := "aws_sagemaker_endpoint_configuration.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfigurationConfig_DataCaptureConfig(rName, dataDestinationBucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.enable_capture", "true"),
+					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.initial_sampling_percentage", "50"),
+					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.destination_url", fmt.Sprintf("s3://%s/", dataDestinationBucketName)),
+					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_options.0.capture_mode", "Input"),
+					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_options.1.capture_mode", "Output"),
+					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_content_type_header.0.json_content_types.0.content_type", "application/json"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckSagemakerEndpointConfigurationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
 
@@ -396,4 +427,43 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
   }
 }
 `, rName)
+}
+
+func testAccSagemakerEndpointConfigurationConfig_DataCaptureConfig(rName string, bucket string) string {
+	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_s3_bucket" "foo" {
+  bucket        = %q
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = %q
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 2
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+
+    data_capture_config {
+    	enable_capture = true
+		initial_sampling_percentage = 50
+		destination_url = "s3://${aws_s3_bucket.foo.bucket}/"
+		capture_options {
+	  		capture_mode = "Input"
+		}
+		capture_options {
+	  		capture_mode = "Output"
+		}
+		capture_content_type_header {
+	  		json_content_types {
+				content_type = "application/json"
+	  		}
+		}
+    }
+}
+`, bucket, rName)
 }

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -314,13 +314,25 @@ func testAccCheckSagemakerEndpointConfigurationExists(n string) resource.TestChe
 }
 
 func testAccSagemakerEndpointConfigurationConfig_Base(rName string) string {
+	imageID := ""
+	switch testAccGetRegion() {
+	case "us-west-2":
+		imageID = "174872318107"
+	case "us-west-1":
+		imageID = "632365934929"
+	case "us-east-1":
+		imageID = "382416733822"
+	case "us-gov-west-1":
+		imageID = "226302683700"
+	}
+	registryPath = fmt.Sprintf("%s.dkr.ecr.%s.%s/kmeans:1", imageID, testAccGetRegion(), testAccGetPartitionDNSSuffix())
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
 
   primary_container {
-    image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+    image = %[2]q
   }
 }
 
@@ -340,7 +352,7 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, rName)
+`, rName, registryPath)
 }
 
 func testAccSagemakerEndpointConfigurationConfig_Basic(rName string) string {

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -213,7 +213,7 @@ func TestAccAWSSagemakerEndpointConfiguration_DataCaptureConfig(t *testing.T) {
 					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.enable_capture", "true"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.initial_sampling_percentage", "50"),
-					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.destination_s3_uri", fmt.Sprintf("s3://%s/", dataDestinationBucketName)),
+					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.destination_s3_uri", fmt.Sprintf("s3://%s/", rName)),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_options.0.capture_mode", "Input"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_options.1.capture_mode", "Output"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_content_type_header.0.json_content_types.#", "1"),

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -325,7 +325,7 @@ func testAccSagemakerEndpointConfigurationConfig_Base(rName string) string {
 	case "us-gov-west-1":
 		imageID = "226302683700"
 	}
-	registryPath = fmt.Sprintf("%s.dkr.ecr.%s.%s/kmeans:1", imageID, testAccGetRegion(), testAccGetPartitionDNSSuffix())
+	registryPath := fmt.Sprintf("%s.dkr.ecr.%s.%s/kmeans:1", imageID, testAccGetRegion(), testAccGetPartitionDNSSuffix())
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -174,25 +174,34 @@ func TestAccAWSSagemakerEndpointConfiguration_tags(t *testing.T) {
 		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerEndpointConfigurationConfig_Tags(rName),
+				Config: testAccSagemakerEndpointConfigurationConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
-				),
-			},
-			{
-				Config: testAccSagemakerEndpointConfigurationConfig_Tags_Update(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.bar", "baz"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSagemakerEndpointConfigurationConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccSagemakerEndpointConfigurationConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -410,10 +419,10 @@ resource "aws_kms_key" "foo" {
 `, rName, rName)
 }
 
-func testAccSagemakerEndpointConfigurationConfig_Tags(rName string) string {
+func testAccSagemakerEndpointConfigurationConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
-resource "aws_sagemaker_endpoint_configuration" "foo" {
-  name = %q
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
 
   production_variants {
     variant_name           = "variant-1"
@@ -424,16 +433,16 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
   }
 
   tags = {
-    foo = "bar"
+    %[2]q = %[3]q
   }
 }
-`, rName)
+`, rName, tagKey1, tagValue1)
 }
 
-func testAccSagemakerEndpointConfigurationConfig_Tags_Update(rName string) string {
+func testAccSagemakerEndpointConfigurationConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
-resource "aws_sagemaker_endpoint_configuration" "foo" {
-  name = %q
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
 
   production_variants {
     variant_name           = "variant-1"
@@ -444,10 +453,11 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
   }
 
   tags = {
-    bar = "baz"
+	%[2]q = %[3]q
+	%[4]q = %[5]q
   }
 }
-`, rName)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
 func testAccSagemakerEndpointConfigurationDataCaptureConfig(rName string) string {

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -198,9 +198,9 @@ func TestAccAWSSagemakerEndpointConfiguration_Tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfiguration_DataCaptureConfig(t *testing.T) {
+func TestAccAWSSagemakerEndpointConfiguration_dataCaptureConfig(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_endpoint_configuration.foo"
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -88,7 +88,7 @@ func TestAccAWSSagemakerEndpointConfiguration_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfiguration_ProductionVariants_InitialVariantWeight(t *testing.T) {
+func TestAccAWSSagemakerEndpointConfiguration_productionVariants_InitialVariantWeight(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 
@@ -114,7 +114,7 @@ func TestAccAWSSagemakerEndpointConfiguration_ProductionVariants_InitialVariantW
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfiguration_ProductionVariants_AcceleratorType(t *testing.T) {
+func TestAccAWSSagemakerEndpointConfiguration_productionVariants_AcceleratorType(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 
@@ -139,7 +139,7 @@ func TestAccAWSSagemakerEndpointConfiguration_ProductionVariants_AcceleratorType
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfiguration_KmsKeyId(t *testing.T) {
+func TestAccAWSSagemakerEndpointConfiguration_kmsKeyId(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 
@@ -152,7 +152,7 @@ func TestAccAWSSagemakerEndpointConfiguration_KmsKeyId(t *testing.T) {
 				Config: testAccSagemakerEndpointConfiguration_Config_KmsKeyId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", "aws_kms_key.foo", "arn"),
 				),
 			},
 			{
@@ -164,7 +164,7 @@ func TestAccAWSSagemakerEndpointConfiguration_KmsKeyId(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfiguration_Tags(t *testing.T) {
+func TestAccAWSSagemakerEndpointConfiguration_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 
@@ -224,6 +224,27 @@ func TestAccAWSSagemakerEndpointConfiguration_dataCaptureConfig(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerEndpointConfiguration_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_endpoint_configuration.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfigurationConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerEndpointConfiguration(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -59,7 +59,7 @@ func testSweepSagemakerEndpointConfigurations(region string) error {
 
 func TestAccAWSSagemakerEndpointConfiguration_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_endpoint_configuration.foo"
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -90,7 +90,7 @@ func TestAccAWSSagemakerEndpointConfiguration_basic(t *testing.T) {
 
 func TestAccAWSSagemakerEndpointConfiguration_productionVariants_InitialVariantWeight(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_endpoint_configuration.foo"
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -116,7 +116,7 @@ func TestAccAWSSagemakerEndpointConfiguration_productionVariants_InitialVariantW
 
 func TestAccAWSSagemakerEndpointConfiguration_productionVariants_AcceleratorType(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_endpoint_configuration.foo"
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -141,7 +141,7 @@ func TestAccAWSSagemakerEndpointConfiguration_productionVariants_AcceleratorType
 
 func TestAccAWSSagemakerEndpointConfiguration_kmsKeyId(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_endpoint_configuration.foo"
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -152,7 +152,7 @@ func TestAccAWSSagemakerEndpointConfiguration_kmsKeyId(t *testing.T) {
 				Config: testAccSagemakerEndpointConfiguration_Config_KmsKeyId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", "aws_kms_key.foo", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", "aws_kms_key.test", "arn"),
 				),
 			},
 			{
@@ -166,7 +166,7 @@ func TestAccAWSSagemakerEndpointConfiguration_kmsKeyId(t *testing.T) {
 
 func TestAccAWSSagemakerEndpointConfiguration_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_endpoint_configuration.foo"
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -240,7 +240,7 @@ func TestAccAWSSagemakerEndpointConfiguration_dataCaptureConfig(t *testing.T) {
 
 func TestAccAWSSagemakerEndpointConfiguration_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_endpoint_configuration.foo"
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -313,17 +313,17 @@ func testAccCheckSagemakerEndpointConfigurationExists(n string) resource.TestChe
 
 func testAccSagemakerEndpointConfigurationConfig_Base(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sagemaker_model" "foo" {
-  name               = %q
-  execution_role_arn = aws_iam_role.foo.arn
+resource "aws_sagemaker_model" "test" {
+  name               = %[1]q
+  execution_role_arn = aws_iam_role.test.arn
 
   primary_container {
     image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
   }
 }
 
-resource "aws_iam_role" "foo" {
-  name               = %q
+resource "aws_iam_role" "test" {
+  name               = %[1]q
   path               = "/"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
@@ -338,17 +338,17 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccSagemakerEndpointConfigurationConfig_Basic(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
-resource "aws_sagemaker_endpoint_configuration" "foo" {
+resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %q
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = aws_sagemaker_model.foo.name
+    model_name             = aws_sagemaker_model.test.name
     initial_instance_count = 2
     instance_type          = "ml.t2.medium"
     initial_variant_weight = 1
@@ -359,19 +359,19 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 
 func testAccSagemakerEndpointConfigurationConfig_ProductionVariants_InitialVariantWeight(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
-resource "aws_sagemaker_endpoint_configuration" "foo" {
+resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %q
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = aws_sagemaker_model.foo.name
+    model_name             = aws_sagemaker_model.test.name
     initial_instance_count = 1
     instance_type          = "ml.t2.medium"
   }
 
   production_variants {
     variant_name           = "variant-2"
-    model_name             = aws_sagemaker_model.foo.name
+    model_name             = aws_sagemaker_model.test.name
     initial_instance_count = 1
     instance_type          = "ml.t2.medium"
     initial_variant_weight = 0.5
@@ -382,12 +382,12 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 
 func testAccSagemakerEndpointConfigurationConfig_ProductionVariant_AcceleratorType(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
-resource "aws_sagemaker_endpoint_configuration" "foo" {
+resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %q
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = aws_sagemaker_model.foo.name
+    model_name             = aws_sagemaker_model.test.name
     initial_instance_count = 2
     instance_type          = "ml.t2.medium"
     accelerator_type       = "ml.eia1.medium"
@@ -399,20 +399,20 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 
 func testAccSagemakerEndpointConfiguration_Config_KmsKeyId(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
-resource "aws_sagemaker_endpoint_configuration" "foo" {
+resource "aws_sagemaker_endpoint_configuration" "test" {
   name        = %q
-  kms_key_arn = aws_kms_key.foo.arn
+  kms_key_arn = aws_kms_key.test.arn
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = aws_sagemaker_model.foo.name
+    model_name             = aws_sagemaker_model.test.name
     initial_instance_count = 1
     instance_type          = "ml.t2.medium"
     initial_variant_weight = 1
   }
 }
 
-resource "aws_kms_key" "foo" {
+resource "aws_kms_key" "test" {
   description             = %q
   deletion_window_in_days = 10
 }
@@ -426,7 +426,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = aws_sagemaker_model.foo.name
+    model_name             = aws_sagemaker_model.test.name
     initial_instance_count = 1
     instance_type          = "ml.t2.medium"
     initial_variant_weight = 1
@@ -446,7 +446,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = aws_sagemaker_model.foo.name
+    model_name             = aws_sagemaker_model.test.name
     initial_instance_count = 1
     instance_type          = "ml.t2.medium"
     initial_variant_weight = 1
@@ -473,7 +473,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = aws_sagemaker_model.foo.name
+    model_name             = aws_sagemaker_model.test.name
     initial_instance_count = 2
     instance_type          = "ml.t2.medium"
     initial_variant_weight = 1

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -508,48 +508,6 @@ func validateSagemakerModelDataUrl(v interface{}, k string) (ws []string, errors
 	return
 }
 
-func validateSagemakerDataCaptureDestinationUrl(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^(https|s3)://([^/]+)/?(.*)$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q must be a valid path: %q",
-			k, value))
-	}
-	if len(value) > 512 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 512 characters: %q", k, value))
-	}
-	return
-}
-
-func validateSagemakerCsvContentType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*\/[a-zA-Z0-9](-*[a-zA-Z0-9.])*`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q must be a valid content type: %q",
-			k, value))
-	}
-	if len(value) < 1 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be shorter than 1 character: %q", k, value))
-	}
-	return
-}
-
-func validateSagemakerJsonContentType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*\/[a-zA-Z0-9](-*[a-zA-Z0-9.])*`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q must be a valid content type: %q",
-			k, value))
-	}
-	if len(value) < 1 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be shorter than 1 character: %q", k, value))
-	}
-	return
-}
-
 func validateCloudWatchDashboardName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 255 {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -508,6 +508,48 @@ func validateSagemakerModelDataUrl(v interface{}, k string) (ws []string, errors
 	return
 }
 
+func validateSagemakerDataCaptureDestinationUrl(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^(https|s3)://([^/]+)/?(.*)$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid path: %q",
+			k, value))
+	}
+	if len(value) > 512 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 512 characters: %q", k, value))
+	}
+	return
+}
+
+func validateSagemakerCsvContentType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*\/[a-zA-Z0-9](-*[a-zA-Z0-9.])*`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid content type: %q",
+			k, value))
+	}
+	if len(value) < 1 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be shorter than 1 character: %q", k, value))
+	}
+	return
+}
+
+func validateSagemakerJsonContentType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*\/[a-zA-Z0-9](-*[a-zA-Z0-9.])*`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid content type: %q",
+			k, value))
+	}
+	if len(value) < 1 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be shorter than 1 character: %q", k, value))
+	}
+	return
+}
+
 func validateCloudWatchDashboardName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 255 {

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -39,7 +39,8 @@ The following arguments are supported:
 * `production_variants` - (Required) Fields are documented below.
 * `kms_key_arn` - (Optional) Amazon Resource Name (ARN) of a AWS Key Management Service key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance that hosts the endpoint.
 * `name` - (Optional) The name of the endpoint configuration. If omitted, Terraform will assign a random, unique name.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+* `data_capture_config` - (Optional) Specifies the parameters to capture input/output of Sagemaker models endpoints. Fields are documented below.
 
 The `production_variants` block supports:
 
@@ -49,6 +50,28 @@ The `production_variants` block supports:
 * `initial_variant_weight` (Optional) - Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to 1.0.
 * `model_name` - (Required) The name of the model to use.
 * `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
+
+The `data_capture_config` block supports:
+
+* `initial_sampling_percentage` - (Required) Portion of data to capture. Should be between 0 and 100.
+* `destination_url` - (Required) The URL for S3 location where the captured data is stored.
+* `capture_options` - (Required) Specifies what data to capture. Fields are documented below.
+* `kms_key_id` - (Optional) Amazon Resource Name (ARN) of a AWS Key Management Service key that Amazon SageMaker uses to encrypt the captured data on Amazon S3.
+* `enable_capture` - (Optional) Flag to enable data capture. Defaults to `false`.
+* `capture_content_type_header` - (Optional) The content type headers to capture. Fields are documented below.
+
+The `capture_options` block supports:
+
+* `capture_mode` - (Required) Specifies the data to be captured. Should be one of `Input` or `Output`.
+
+The `capture_content_type_header` block supports:
+
+* `csv_content_types` - (Optional) The CSV content type headers to capture. Fields are documented below.
+* `json_content_types` - (Optional) The JSON content type headers to capture. Fields are documented below.
+
+The `csv_content_types` and `json_content_types` block both support:
+
+* `content_type` - (Required) The value of the content type header.
 
 ## Attributes Reference
 

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -54,7 +54,7 @@ The `production_variants` block supports:
 The `data_capture_config` block supports:
 
 * `initial_sampling_percentage` - (Required) Portion of data to capture. Should be between 0 and 100.
-* `destination_url` - (Required) The URL for S3 location where the captured data is stored.
+* `destination_s3_uri` - (Required) The URL for S3 location where the captured data is stored.
 * `capture_options` - (Required) Specifies what data to capture. Fields are documented below.
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of a AWS Key Management Service key that Amazon SageMaker uses to encrypt the captured data on Amazon S3.
 * `enable_capture` - (Optional) Flag to enable data capture. Defaults to `false`.
@@ -66,12 +66,8 @@ The `capture_options` block supports:
 
 The `capture_content_type_header` block supports:
 
-* `csv_content_types` - (Optional) The CSV content type headers to capture. Fields are documented below.
-* `json_content_types` - (Optional) The JSON content type headers to capture. Fields are documented below.
-
-The `csv_content_types` and `json_content_types` block both support:
-
-* `content_type` - (Required) The value of the content type header.
+* `csv_content_types` - (Optional) The CSV content type headers to capture.
+* `json_content_types` - (Optional) The JSON content type headers to capture.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Supersedes #11484
Closes #14170
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sagemaker_endpoint_configuration -  support `data_capture_config`
resource_aws_sagemaker_endpoint_configuration -  add plan time validation for `production_variants.accelerator_type`, `production_variants.instance_type `
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerEndpointConfiguration_'
--- PASS: TestAccAWSSagemakerEndpointConfiguration_kmsKeyId (65.41s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_disappears (67.85s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_basic (68.95s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_dataCaptureConfig (80.93s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_productionVariants_InitialVariantWeight (84.77s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_productionVariants_AcceleratorType (86.74s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_tags (140.43s)
```
