### PR TITLE
[WIP] Check for ClusterNotFoundException when reading ECS service

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -584,6 +584,13 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	if isResourceTimeoutError(err) {
 		out, err = conn.DescribeServices(&input)
 	}
+
+	if isAWSErr(err, ecs.ErrCodeClusterNotFoundException, "") {
+		log.Printf("[WARN] ECS Service %s parent cluster %s not found, removing from state.", d.Id(), d.Get("cluster").(string))
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error reading ECS service: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15917

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ecs_service: Handle ClusterNotFoundException when reading service (#15917)
```

<!--
Output from acceptance testing:


Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
-->

### WIP

I think this will fix the issue but I'm not sure how to write acceptance tests for it. Deleting the cluster doesn't make it immediately disappear from the account. The only way I know of to simulate the error without waiting for days is to update the state after manually deleting the service to point to an invalid cluster ARN. Then when terraform tries to read the service it will get the exception. I can't figure out how to do that in the tests. I tried messing with `terraform.State` but it seems like that's only there for reading