### PR TITLE
r/glue_crawler - support mongodb target

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -537,7 +537,7 @@ func resourceAwsGlueCrawlerUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	if d.HasChanges(
 		"catalog_target", "classifiers", "configuration", "description", "dynamodb_target", "jdbc_target", "role",
-		"s3_target", "schedule", "schema_change_policy", "security_configuration", "table_prefix") {
+		"s3_target", "schedule", "schema_change_policy", "security_configuration", "table_prefix", "mongodb_target") {
 		updateCrawlerInput, err := updateCrawlerInput(name, d)
 		if err != nil {
 			return err

--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -267,16 +267,12 @@ func resourceAwsGlueCrawlerCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func createCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.CreateCrawlerInput, error) {
-	crawlerTargets, err := expandGlueCrawlerTargets(d)
-	if err != nil {
-		return nil, err
-	}
 	crawlerInput := &glue.CreateCrawlerInput{
 		Name:         aws.String(crawlerName),
 		DatabaseName: aws.String(d.Get("database_name").(string)),
 		Role:         aws.String(d.Get("role").(string)),
 		Tags:         keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().GlueTags(),
-		Targets:      crawlerTargets,
+		Targets:      expandGlueCrawlerTargets(d),
 	}
 	if description, ok := d.GetOk("description"); ok {
 		crawlerInput.Description = aws.String(description.(string))
@@ -313,15 +309,11 @@ func createCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.Creat
 }
 
 func updateCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.UpdateCrawlerInput, error) {
-	crawlerTargets, err := expandGlueCrawlerTargets(d)
-	if err != nil {
-		return nil, err
-	}
 	crawlerInput := &glue.UpdateCrawlerInput{
 		Name:         aws.String(crawlerName),
 		DatabaseName: aws.String(d.Get("database_name").(string)),
 		Role:         aws.String(d.Get("role").(string)),
-		Targets:      crawlerTargets,
+		Targets:      expandGlueCrawlerTargets(d),
 	}
 	if description, ok := d.GetOk("description"); ok {
 		crawlerInput.Description = aws.String(description.(string))
@@ -379,7 +371,7 @@ func expandGlueSchemaChangePolicy(v []interface{}) *glue.SchemaChangePolicy {
 	return schemaPolicy
 }
 
-func expandGlueCrawlerTargets(d *schema.ResourceData) (*glue.CrawlerTargets, error) {
+func expandGlueCrawlerTargets(d *schema.ResourceData) *glue.CrawlerTargets {
 	crawlerTargets := &glue.CrawlerTargets{}
 
 	log.Print("[DEBUG] Creating crawler target")
@@ -404,7 +396,7 @@ func expandGlueCrawlerTargets(d *schema.ResourceData) (*glue.CrawlerTargets, err
 		crawlerTargets.MongoDBTargets = expandGlueMongoDBTargets(v.([]interface{}))
 	}
 
-	return crawlerTargets, nil
+	return crawlerTargets
 }
 
 func expandGlueDynamoDBTargets(targets []interface{}) []*glue.DynamoDBTarget {

--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -101,9 +101,10 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				Optional: true,
 			},
 			"s3_target": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MinItems: 1,
+				Type:         schema.TypeList,
+				Optional:     true,
+				MinItems:     1,
+				AtLeastOneOf: []string{"s3_target", "dynamodb_target", "mongodb_target", "jdbc_target", "catalog_target"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"connection_name": {
@@ -123,9 +124,10 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				},
 			},
 			"dynamodb_target": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MinItems: 1,
+				Type:         schema.TypeList,
+				Optional:     true,
+				MinItems:     1,
+				AtLeastOneOf: []string{"s3_target", "dynamodb_target", "mongodb_target", "jdbc_target", "catalog_target"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"path": {
@@ -145,10 +147,34 @@ func resourceAwsGlueCrawler() *schema.Resource {
 					},
 				},
 			},
+			"mongodb_target": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				MinItems:     1,
+				AtLeastOneOf: []string{"s3_target", "dynamodb_target", "mongodb_target", "jdbc_target", "catalog_target"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"connection_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"scan_all": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+					},
+				},
+			},
 			"jdbc_target": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MinItems: 1,
+				Type:         schema.TypeList,
+				Optional:     true,
+				MinItems:     1,
+				AtLeastOneOf: []string{"s3_target", "dynamodb_target", "mongodb_target", "jdbc_target", "catalog_target"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"connection_name": {
@@ -168,9 +194,10 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				},
 			},
 			"catalog_target": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MinItems: 1,
+				Type:         schema.TypeList,
+				Optional:     true,
+				MinItems:     1,
+				AtLeastOneOf: []string{"s3_target", "dynamodb_target", "mongodb_target", "jdbc_target", "catalog_target"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"database_name": {
@@ -355,19 +382,27 @@ func expandGlueSchemaChangePolicy(v []interface{}) *glue.SchemaChangePolicy {
 func expandGlueCrawlerTargets(d *schema.ResourceData) (*glue.CrawlerTargets, error) {
 	crawlerTargets := &glue.CrawlerTargets{}
 
-	dynamodbTargets, dynamodbTargetsOk := d.GetOk("dynamodb_target")
-	jdbcTargets, jdbcTargetsOk := d.GetOk("jdbc_target")
-	s3Targets, s3TargetsOk := d.GetOk("s3_target")
-	catalogTargets, catalogTargetsOk := d.GetOk("catalog_target")
-	if !dynamodbTargetsOk && !jdbcTargetsOk && !s3TargetsOk && !catalogTargetsOk {
-		return nil, fmt.Errorf("One of the following configurations is required: dynamodb_target, jdbc_target, s3_target, catalog_target")
+	log.Print("[DEBUG] Creating crawler target")
+
+	if v, ok := d.GetOk("dynamodb_target"); ok {
+		crawlerTargets.DynamoDBTargets = expandGlueDynamoDBTargets(v.([]interface{}))
 	}
 
-	log.Print("[DEBUG] Creating crawler target")
-	crawlerTargets.DynamoDBTargets = expandGlueDynamoDBTargets(dynamodbTargets.([]interface{}))
-	crawlerTargets.JdbcTargets = expandGlueJdbcTargets(jdbcTargets.([]interface{}))
-	crawlerTargets.S3Targets = expandGlueS3Targets(s3Targets.([]interface{}))
-	crawlerTargets.CatalogTargets = expandGlueCatalogTargets(catalogTargets.([]interface{}))
+	if v, ok := d.GetOk("jdbc_target"); ok {
+		crawlerTargets.JdbcTargets = expandGlueJdbcTargets(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("s3_target"); ok {
+		crawlerTargets.S3Targets = expandGlueS3Targets(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("catalog_target"); ok {
+		crawlerTargets.CatalogTargets = expandGlueCatalogTargets(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("mongodb_target"); ok {
+		crawlerTargets.MongoDBTargets = expandGlueMongoDBTargets(v.([]interface{}))
+	}
 
 	return crawlerTargets, nil
 }
@@ -468,6 +503,29 @@ func expandGlueCatalogTarget(cfg map[string]interface{}) *glue.CatalogTarget {
 	target := &glue.CatalogTarget{
 		DatabaseName: aws.String(cfg["database_name"].(string)),
 		Tables:       expandStringList(cfg["tables"].([]interface{})),
+	}
+
+	return target
+}
+
+func expandGlueMongoDBTargets(targets []interface{}) []*glue.MongoDBTarget {
+	if len(targets) < 1 {
+		return []*glue.MongoDBTarget{}
+	}
+
+	perms := make([]*glue.MongoDBTarget, len(targets))
+	for i, rawCfg := range targets {
+		cfg := rawCfg.(map[string]interface{})
+		perms[i] = expandGlueMongoDBTarget(cfg)
+	}
+	return perms
+}
+
+func expandGlueMongoDBTarget(cfg map[string]interface{}) *glue.MongoDBTarget {
+	target := &glue.MongoDBTarget{
+		ConnectionName: aws.String(cfg["connection_name"].(string)),
+		Path:           aws.String(cfg["path"].(string)),
+		ScanAll:        aws.Bool(cfg["scan_all"].(bool)),
 	}
 
 	return target
@@ -595,6 +653,10 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 		if err := d.Set("catalog_target", flattenGlueCatalogTargets(crawlerOutput.Crawler.Targets.CatalogTargets)); err != nil {
 			return fmt.Errorf("error setting catalog_target: %s", err)
 		}
+
+		if err := d.Set("mongodb_target", flattenGlueMongoDBTargets(crawlerOutput.Crawler.Targets.MongoDBTargets)); err != nil {
+			return fmt.Errorf("error setting mongodb_target: %w", err)
+		}
 	}
 
 	tags, err := keyvaluetags.GlueListTags(glueConn, crawlerARN)
@@ -659,6 +721,20 @@ func flattenGlueJdbcTargets(jdbcTargets []*glue.JdbcTarget) []map[string]interfa
 		attrs["connection_name"] = aws.StringValue(jdbcTarget.ConnectionName)
 		attrs["exclusions"] = flattenStringList(jdbcTarget.Exclusions)
 		attrs["path"] = aws.StringValue(jdbcTarget.Path)
+
+		result = append(result, attrs)
+	}
+	return result
+}
+
+func flattenGlueMongoDBTargets(mongoDBTargets []*glue.MongoDBTarget) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+
+	for _, mongoDBTarget := range mongoDBTargets {
+		attrs := make(map[string]interface{})
+		attrs["connection_name"] = aws.StringValue(mongoDBTarget.ConnectionName)
+		attrs["path"] = aws.StringValue(mongoDBTarget.Path)
+		attrs["scan_all"] = aws.BoolValue(mongoDBTarget.ScanAll)
 
 		result = append(result, attrs)
 	}

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -2296,7 +2296,7 @@ resource "aws_glue_crawler" "test" {
 
   mongodb_target {
     connection_name = aws_glue_connection.test.name
-	path            = "database-name/table-name"
+    path            = "database-name/table-name"
 	scan_all        = %[2]t
   }
 }
@@ -2310,15 +2310,15 @@ resource "aws_glue_catalog_database" "test" {
 }
 
 resource "aws_glue_connection" "test" {
-	name            = %[1]q
-	connection_type = "MONGODB"
+  name            = %[1]q
+  connection_type = "MONGODB"
   
-	connection_properties = {
-	  CONNECTION_URL = "mongodb://testdb.com:27017/databasename"
-	  PASSWORD       = "testpassword"
-	  USERNAME       = "testusername"
-	}
+  connection_properties = {
+    CONNECTION_URL = "mongodb://testdb.com:27017/databasename"
+    PASSWORD       = "testpassword"
+    USERNAME       = "testusername"
   }
+}
 
 resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -379,6 +379,149 @@ func TestAccAWSGlueCrawler_JdbcTarget_Multiple(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueCrawler_mongoDBTarget(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerConfigMongoDBTarget(rName, "database-name/%"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.scan_all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.path", "database-name/%"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGlueCrawlerConfigMongoDBTarget(rName, "database-name/table-name"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.scan_all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.path", "database-name/table-name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueCrawler_mongoDBTarget_scan_all(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerConfigMongoDBTargetScanAll(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.scan_all", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.path", "database-name/table-name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGlueCrawlerConfigMongoDBTargetScanAll(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.scan_all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.path", "database-name/table-name"),
+				),
+			},
+			{
+				Config: testAccGlueCrawlerConfigMongoDBTargetScanAll(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.scan_all", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.path", "database-name/table-name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueCrawler_mongoDBTarget_multiple(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerConfigMongoDBMultiple(rName, "database-name/table1", "database-name/table2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.scan_all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.path", "database-name/table1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.1.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.1.scan_all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.1.path", "database-name/table2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGlueCrawlerConfigMongoDBTarget(rName, "database-name/%"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.scan_all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.path", "database-name/%"),
+				),
+			},
+			{
+				Config: testAccGlueCrawlerConfigMongoDBMultiple(rName, "database-name/table1", "database-name/table2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.scan_all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.0.path", "database-name/table1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.1.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.1.scan_all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_target.1.path", "database-name/table2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueCrawler_S3Target(t *testing.T) {
 	var crawler glue.Crawler
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -2093,4 +2236,106 @@ resource "aws_glue_crawler" "test" {
   }
 }
 `, rName, securityConfiguration, rName)
+}
+
+func testAccGlueCrawlerConfigMongoDBTarget(rName, path string) string {
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_connection" "test" {
+  name            = %[1]q
+  connection_type = "MONGODB"
+
+  connection_properties = {
+    CONNECTION_URL = "mongodb://testdb.com:27017/databasename"
+    PASSWORD       = "testpassword"
+    USERNAME       = "testusername"
+  }
+}
+
+resource "aws_glue_crawler" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
+
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+  role          = aws_iam_role.test.name
+
+  mongodb_target {
+    connection_name = aws_glue_connection.test.name
+    path            = %[2]q
+  }
+}
+`, rName, path)
+}
+
+func testAccGlueCrawlerConfigMongoDBTargetScanAll(rName string, scan bool) string {
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_connection" "test" {
+  name            = %[1]q
+  connection_type = "MONGODB"
+
+  connection_properties = {
+    CONNECTION_URL = "mongodb://testdb.com:27017/databasename"
+    PASSWORD       = "testpassword"
+    USERNAME       = "testusername"
+  }
+}
+
+resource "aws_glue_crawler" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
+
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+  role          = aws_iam_role.test.name
+
+  mongodb_target {
+    connection_name = aws_glue_connection.test.name
+	path            = "database-name/table-name"
+	scan_all        = %[2]t
+  }
+}
+`, rName, scan)
+}
+
+func testAccGlueCrawlerConfigMongoDBMultiple(rName, path1, path2 string) string {
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_connection" "test" {
+	name            = %[1]q
+	connection_type = "MONGODB"
+  
+	connection_properties = {
+	  CONNECTION_URL = "mongodb://testdb.com:27017/databasename"
+	  PASSWORD       = "testpassword"
+	  USERNAME       = "testusername"
+	}
+  }
+
+resource "aws_glue_crawler" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
+
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+  role          = aws_iam_role.test.name
+
+  mongodb_target {
+    connection_name = aws_glue_connection.test.name
+    path            = %[2]q
+  }
+
+  mongodb_target {
+    connection_name = aws_glue_connection.test.name
+    path            = %[3]q
+  }
+}
+`, rName, path1, path2)
 }

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -2279,7 +2279,7 @@ resource "aws_glue_catalog_database" "test" {
 resource "aws_glue_connection" "test" {
   name            = %[1]q
   connection_type = "MONGODB"
-
+  
   connection_properties = {
     CONNECTION_URL = "mongodb://testdb.com:27017/databasename"
     PASSWORD       = "testpassword"
@@ -2312,7 +2312,7 @@ resource "aws_glue_catalog_database" "test" {
 resource "aws_glue_connection" "test" {
   name            = %[1]q
   connection_type = "MONGODB"
-  
+
   connection_properties = {
     CONNECTION_URL = "mongodb://testdb.com:27017/databasename"
     PASSWORD       = "testpassword"

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -2279,7 +2279,7 @@ resource "aws_glue_catalog_database" "test" {
 resource "aws_glue_connection" "test" {
   name            = %[1]q
   connection_type = "MONGODB"
-  
+
   connection_properties = {
     CONNECTION_URL = "mongodb://testdb.com:27017/databasename"
     PASSWORD       = "testpassword"
@@ -2297,7 +2297,7 @@ resource "aws_glue_crawler" "test" {
   mongodb_target {
     connection_name = aws_glue_connection.test.name
     path            = "database-name/table-name"
-	scan_all        = %[2]t
+    scan_all        = %[2]t
   }
 }
 `, rName, scan)

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -84,6 +84,21 @@ EOF
 }
 ```
 
+### MongoDB Target
+
+```hcl
+resource "aws_glue_crawler" "example" {
+  database_name = aws_glue_catalog_database.example.name
+  name          = "example"
+  role          = aws_iam_role.example.arn
+
+  mongodb_target {
+    connection_name = aws_glue_connection.example.name
+    path            = "database-name/%"
+  }
+}
+```
+
 ## Argument Reference
 
 ~> **NOTE:** Must specify at least one of `dynamodb_target`, `jdbc_target`, `s3_target` or `catalog_target`.
@@ -99,6 +114,7 @@ The following arguments are supported:
 * `dynamodb_target` (Optional) List of nested DynamoDB target arguments. See below.
 * `jdbc_target` (Optional) List of nested JBDC target arguments. See below.
 * `s3_target` (Optional) List nested Amazon S3 target arguments. See below.
+* `mongodb_target` (Optional) List nested MongoDB target arguments. See below.
 * `schedule` (Optional) A cron expression used to specify the schedule. For more information, see [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html). For example, to run something every day at 12:15 UTC, you would specify: `cron(15 12 * * ? *)`.
 * `schema_change_policy` (Optional) Policy for the crawler's update and deletion behavior.
 * `security_configuration` (Optional) The name of Security Configuration to be used by the crawler
@@ -127,6 +143,12 @@ The following arguments are supported:
 
 * `database_name` - (Required) The name of the Glue database to be synchronized.
 * `tables` - (Required) A list of catalog tables to be synchronized.
+
+### mongodb_target Argument Reference
+
+* `connection_name` - (Required) The name of the connection to use to connect to the Amazon DocumentDB or MongoDB target.
+* `path` - (Required) The path of the Amazon DocumentDB or MongoDB target (database/collection).
+* `scan_all` - (Optional) Indicates whether to scan all the records, or to sample rows from the table. Scanning all the records can take a long time when the table is not a high throughput table. Default value is `true`.
 
 ~> **Note:** `deletion_behavior` of catalog target doesn't support `DEPRECATE_IN_DATABASE`.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ glue_crawler - support mongodb target
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run= TestAccAWSGlueCrawler_'
--- PASS: TestAccAWSGlueCrawler_disappears (63.98s)
--- PASS: TestAccAWSGlueCrawler_Role_Name_Path (68.00s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_NoPath (72.37s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_Path (72.38s)
--- PASS: TestAccAWSGlueCrawler_S3Target_ConnectionName (98.68s)
--- PASS: TestAccAWSGlueCrawler_RemoveTablePrefix (103.74s)
--- PASS: TestAccAWSGlueCrawler_S3Target (108.69s)
--- PASS: TestAccAWSGlueCrawler_Configuration (109.71s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (109.81s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Exclusions (110.36s)
--- PASS: TestAccAWSGlueCrawler_TablePrefix (110.43s)
--- PASS: TestAccAWSGlueCrawler_SchemaChangePolicy (110.90s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (113.60s)
--- PASS: TestAccAWSGlueCrawler_SecurityConfiguration (116.05s)
--- PASS: TestAccAWSGlueCrawler_Tags (139.93s)
--- PASS: TestAccAWSGlueCrawler_Schedule (141.61s)
--- PASS: TestAccAWSGlueCrawler_mongoDBTarget_multiple (141.61s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Multiple (141.84s)
--- PASS: TestAccAWSGlueCrawler_Description (101.13s)
--- PASS: TestAccAWSGlueCrawler_CatalogTarget (176.19s)
--- PASS: TestAccAWSGlueCrawler_mongoDBTarget (103.81s)
--- PASS: TestAccAWSGlueCrawler_Classifiers (139.34s)
--- PASS: TestAccAWSGlueCrawler_mongoDBTarget_scan_all (140.11s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget (108.07s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget_scanRate (138.67s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Multiple (146.42s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget_scanAll (141.91s)
--- PASS: TestAccAWSGlueCrawler_CatalogTarget_Multiple (261.86s)
```
