### PR TITLE
Improve documentation for EventBridge target input transformer template

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -237,6 +237,53 @@ DOC
 }
 ```
 
+## Example Input Transformer Usage - JSON Object
+
+```terraform
+resource "aws_cloudwatch_event_target" "example" {
+  arn  = aws_lambda_function.example.arn
+  rule = aws_cloudwatch_event_rule.example.id
+
+  input_transformer {
+    input_paths = {
+      instance = "$.detail.instance",
+      status   = "$.detail.status",
+    }
+    input_template = <<EOF
+{
+  "instance_id": <instance>,
+  "instance_status": <status>
+}
+EOF
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "example" {
+  # ...
+}
+```
+
+## Example Input Transformer Usage - Simple String
+
+```terraform
+resource "aws_cloudwatch_event_target" "example" {
+  arn  = aws_lambda_function.example.arn
+  rule = aws_cloudwatch_event_rule.example.id
+
+  input_transformer {
+    input_paths = {
+      instance = "$.detail.instance",
+      status   = "$.detail.status",
+    }
+    input_template = "\"<instance> is in state <status>\""
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "example" {
+  # ...
+}
+```
+
 ## Argument Reference
 
 -> **Note:** `input` and `input_path` are mutually exclusive options.
@@ -307,7 +354,7 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
     * You must use JSON dot notation, not bracket notation.
     * The keys can't start with "AWS".
 
-* `input_template` - (Required) Structure containing the template body.
+* `input_template` - (Required) Template to customize data sent to the target. Must be valid JSON. To send a string value, the string value must include double quotes. Values must be escaped for both JSON and Terraform, e.g. `"\"Your string goes here.\\nA new line.\""`
 
 ## Import
 


### PR DESCRIPTION
Improve documentation for EventBridge target input transformer template. Clarifies that values must be valid JSON and be escaped for both JSON and Terraform. Adds a test for simple JSON string value.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7280

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchEventTarget_'

--- PASS: TestAccAWSCloudWatchEventTarget_inputTransformerJsonString (305.20s)
--- PASS: TestAccAWSCloudWatchEventTarget_sqs (323.24s)
--- PASS: TestAccAWSCloudWatchEventTarget_missingTargetId (324.82s)
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (338.81s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (353.46s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount (358.13s)
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (373.26s)
--- PASS: TestAccAWSCloudWatchEventTarget_kinesis (380.33s)
--- PASS: TestAccAWSCloudWatchEventTarget_full (380.65s)
--- PASS: TestAccAWSCloudWatchEventTarget_basic (403.41s)
--- PASS: TestAccAWSCloudWatchEventTarget_batch (448.04s)
```
