### PR TITLE
r/glue_classifier - `quote_symbol` fix optional

### DIFF
--- a/aws/resource_aws_glue_classifier.go
+++ b/aws/resource_aws_glue_classifier.go
@@ -286,14 +286,6 @@ func resourceAwsGlueClassifierDelete(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func validateHeaderOptions() schema.SchemaValidateFunc {
-	return validation.StringInSlice([]string{
-		"UNKNOWN",
-		"PRESENT",
-		"ABSENT",
-	}, true)
-}
-
 func deleteGlueClassifier(conn *glue.Glue, name string) error {
 	input := &glue.DeleteClassifierInput{
 		Name: aws.String(name),

--- a/aws/resource_aws_glue_classifier.go
+++ b/aws/resource_aws_glue_classifier.go
@@ -68,7 +68,7 @@ func resourceAwsGlueClassifier() *schema.Resource {
 						"contains_header": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validateHeaderOptions(),
+							ValidateFunc: validation.StringInSlice(glue.CsvHeaderOption_Values(), false),
 						},
 						"delimiter": {
 							Type:     schema.TypeString,
@@ -77,6 +77,7 @@ func resourceAwsGlueClassifier() *schema.Resource {
 						"disable_value_trimming": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  true,
 						},
 						"header": {
 							Type:     schema.TypeList,
@@ -316,15 +317,14 @@ func expandGlueCsvClassifierCreate(name string, m map[string]interface{}) *glue.
 		Delimiter:            aws.String(m["delimiter"].(string)),
 		DisableValueTrimming: aws.Bool(m["disable_value_trimming"].(bool)),
 		Name:                 aws.String(name),
-		QuoteSymbol:          aws.String(m["quote_symbol"].(string)),
 	}
 
-	if v, ok := m["header"]; ok {
-		header := make([]string, len(v.([]interface{})))
-		for i, item := range v.([]interface{}) {
-			header[i] = fmt.Sprint(item)
-		}
-		csvClassifier.Header = aws.StringSlice(header)
+	if v, ok := m["quote_symbol"].(string); ok && v != "" {
+		csvClassifier.QuoteSymbol = aws.String(v)
+	}
+
+	if v, ok := m["header"].([]interface{}); ok {
+		csvClassifier.Header = expandStringList(v)
 	}
 
 	return csvClassifier
@@ -337,15 +337,14 @@ func expandGlueCsvClassifierUpdate(name string, m map[string]interface{}) *glue.
 		Delimiter:            aws.String(m["delimiter"].(string)),
 		DisableValueTrimming: aws.Bool(m["disable_value_trimming"].(bool)),
 		Name:                 aws.String(name),
-		QuoteSymbol:          aws.String(m["quote_symbol"].(string)),
 	}
 
-	if v, ok := m["header"]; ok {
-		header := make([]string, len(v.([]interface{})))
-		for i, item := range v.([]interface{}) {
-			header[i] = fmt.Sprint(item)
-		}
-		csvClassifier.Header = aws.StringSlice(header)
+	if v, ok := m["quote_symbol"].(string); ok && v != "" {
+		csvClassifier.QuoteSymbol = aws.String(v)
+	}
+
+	if v, ok := m["header"].([]interface{}); ok {
+		csvClassifier.Header = expandStringList(v)
 	}
 
 	return csvClassifier

--- a/aws/resource_aws_glue_classifier_test.go
+++ b/aws/resource_aws_glue_classifier_test.go
@@ -518,7 +518,7 @@ resource "aws_glue_classifier" "test" {
     allow_single_column = false
     contains_header     = "PRESENT"
     delimiter           = ","
-	header              = ["header_column1", "header_column2"]
+    header              = ["header_column1", "header_column2"]
     quote_symbol        = %[2]q
   }
 }

--- a/aws/resource_aws_glue_classifier_test.go
+++ b/aws/resource_aws_glue_classifier_test.go
@@ -519,7 +519,7 @@ resource "aws_glue_classifier" "test" {
     contains_header     = "PRESENT"
     delimiter           = ","
 	header              = ["header_column1", "header_column2"]
-	quote_symbol        = %[2]q
+    quote_symbol        = %[2]q
   }
 }
 `, rName, symbol)

--- a/aws/resource_aws_glue_classifier_test.go
+++ b/aws/resource_aws_glue_classifier_test.go
@@ -89,7 +89,6 @@ func TestAccAWSGlueClassifier_CsvClassifier(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.disable_value_trimming", "false"),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.header.0", "header_column1"),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.header.1", "header_column2"),
-					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.quote_symbol", "\""),
 					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -107,11 +106,46 @@ func TestAccAWSGlueClassifier_CsvClassifier(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.disable_value_trimming", "false"),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.header.0", "header_column1"),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.header.1", "header_column2"),
-					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.quote_symbol", "\""),
 					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueClassifier_CsvClassifier_quoteSymbol(t *testing.T) {
+	var classifier glue.Classifier
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_classifier.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueClassifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueClassifierConfigCsvClassifierQuoteSymbol(rName, "\""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.quote_symbol", "\""),
+				),
+			},
+			{
+				Config: testAccAWSGlueClassifierConfigCsvClassifierQuoteSymbol(rName, "'"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.quote_symbol", "'"),
 				),
 			},
 			{
@@ -377,6 +411,29 @@ func TestAccAWSGlueClassifier_XmlClassifier(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueClassifier_disappears(t *testing.T) {
+	var classifier glue.Classifier
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_classifier.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueClassifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueClassifierConfig_CsvClassifier(rName, false, "PRESENT", "|", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsGlueClassifier(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSGlueClassifierExists(resourceName string, classifier *glue.Classifier) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -447,10 +504,25 @@ resource "aws_glue_classifier" "test" {
     delimiter              = "%s"
     disable_value_trimming = "%t"
     header                 = ["header_column1", "header_column2"]
-    quote_symbol           = "\""
   }
 }
 `, rName, allowSingleColumn, containsHeader, delimiter, disableValueTrimming)
+}
+
+func testAccAWSGlueClassifierConfigCsvClassifierQuoteSymbol(rName, symbol string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_classifier" "test" {
+  name = %[1]q
+
+  csv_classifier {
+    allow_single_column = false
+    contains_header     = "PRESENT"
+    delimiter           = ","
+	header              = ["header_column1", "header_column2"]
+	quote_symbol        = %[2]q
+  }
+}
+`, rName, symbol)
 }
 
 func testAccAWSGlueClassifierConfig_GrokClassifier(rName, classification, grokPattern string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13058
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_classifier - fix `quote_symbol` being optional
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueClassifier_'
--- PASS: TestAccAWSGlueClassifier_disappears (25.94s)
--- PASS: TestAccAWSGlueClassifier_XmlClassifier (58.44s)
--- PASS: TestAccAWSGlueClassifier_GrokClassifier_CustomPatterns (58.67s)
--- PASS: TestAccAWSGlueClassifier_CsvClassifier_quoteSymbol (58.79s)
--- PASS: TestAccAWSGlueClassifier_GrokClassifier (58.83s)
--- PASS: TestAccAWSGlueClassifier_JsonClassifier (59.26s)
--- PASS: TestAccAWSGlueClassifier_CsvClassifier (60.07s)
--- PASS: TestAccAWSGlueClassifier_TypeChange (109.12s)
...
```
