### PR TITLE
resource/aws_datasync_task: Allow UNAVAILABLE as pending status during creation

### DIFF
--- a/aws/internal/service/datasync/waiter/status.go
+++ b/aws/internal/service/datasync/waiter/status.go
@@ -1,0 +1,37 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datasync"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	TaskStatusUnknown = "Unknown"
+)
+
+// TaskStatus fetches the Operation and its Status
+func TaskStatus(conn *datasync.DataSync, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &datasync.DescribeTaskInput{
+			TaskArn: aws.String(arn),
+		}
+
+		output, err := conn.DescribeTask(input)
+
+		if tfawserr.ErrMessageContains(err, datasync.ErrCodeInvalidRequestException, "not found") {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return output, TaskStatusUnknown, err
+		}
+
+		if output == nil {
+			return output, TaskStatusUnknown, nil
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/aws/internal/service/datasync/waiter/waiter.go
+++ b/aws/internal/service/datasync/waiter/waiter.go
@@ -1,0 +1,49 @@
+package waiter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datasync"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TaskStatusAvailable waits for a Task to return Available
+func TaskStatusAvailable(conn *datasync.DataSync, arn string, timeout time.Duration) (*datasync.DescribeTaskOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			datasync.TaskStatusCreating,
+			datasync.TaskStatusUnavailable,
+		},
+		Target: []string{
+			datasync.TaskStatusAvailable,
+			datasync.TaskStatusRunning,
+		},
+		Refresh: TaskStatus(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*datasync.DescribeTaskOutput); ok {
+		if err != nil && output != nil && output.ErrorCode != nil && output.ErrorDetail != nil {
+			newErr := fmt.Errorf("%s: %s", aws.StringValue(output.ErrorCode), aws.StringValue(output.ErrorDetail))
+
+			switch e := err.(type) {
+			case *resource.TimeoutError:
+				if e.LastError == nil {
+					e.LastError = newErr
+				}
+			case *resource.UnexpectedStateError:
+				if e.LastError == nil {
+					e.LastError = newErr
+				}
+			}
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/resource_aws_datasync_task.go
+++ b/aws/resource_aws_datasync_task.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/datasync"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/datasync/waiter"
 )
 
 func resourceAwsDataSyncTask() *schema.Resource {
@@ -176,55 +176,15 @@ func resourceAwsDataSyncTaskCreate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Creating DataSync Task: %s", input)
 	output, err := conn.CreateTask(input)
+
 	if err != nil {
-		return fmt.Errorf("error creating DataSync Task: %s", err)
+		return fmt.Errorf("error creating DataSync Task: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.TaskArn))
 
-	// Task creation can take a few minutes\
-	taskInput := &datasync.DescribeTaskInput{
-		TaskArn: aws.String(d.Id()),
-	}
-	var taskOutput *datasync.DescribeTaskOutput
-	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		taskOutput, err := conn.DescribeTask(taskInput)
-
-		if isAWSErr(err, "InvalidRequestException", "not found") {
-			return resource.RetryableError(err)
-		}
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		if aws.StringValue(taskOutput.Status) == datasync.TaskStatusAvailable || aws.StringValue(taskOutput.Status) == datasync.TaskStatusRunning {
-			return nil
-		}
-
-		err = fmt.Errorf("waiting for DataSync Task (%s) creation: last status (%s), error code (%s), error detail: %s",
-			d.Id(), aws.StringValue(taskOutput.Status), aws.StringValue(taskOutput.ErrorCode), aws.StringValue(taskOutput.ErrorDetail))
-
-		if aws.StringValue(taskOutput.Status) == datasync.TaskStatusCreating {
-			return resource.RetryableError(err)
-		}
-
-		return resource.NonRetryableError(err) // should only happen if err != nil
-	})
-	if isResourceTimeoutError(err) {
-		taskOutput, err = conn.DescribeTask(taskInput)
-		if isAWSErr(err, "InvalidRequestException", "not found") {
-			return fmt.Errorf("Task not found after creation: %s", err)
-		}
-		if err != nil {
-			return fmt.Errorf("Error describing task after creation: %s", err)
-		}
-		if aws.StringValue(taskOutput.Status) == datasync.TaskStatusCreating {
-			return fmt.Errorf("Data sync task status has not finished creating")
-		}
-	}
-	if err != nil {
-		return fmt.Errorf("error waiting for DataSync Task (%s) creation: %s", d.Id(), err)
+	if _, err := waiter.TaskStatusAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return fmt.Errorf("error waiting for DataSync Task (%s) creation: %w", d.Id(), err)
 	}
 
 	return resourceAwsDataSyncTaskRead(d, meta)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15947

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_datasync_task: Allow `UNAVAILABLE` as pending status during creation
```

Especially for new EFS Mount Targets, the task can temporarily transition from CREATING to UNAVAILABLE (mount failures) then eventually it can transition to AVAILABLE. This also simplifies and updates the base testing configuration based on the current DataSync user guide.

Previously:

```
=== CONT  TestAccAWSDataSyncTask_basic
TestAccAWSDataSyncTask_basic: resource_aws_datasync_task_test.go:85: Step 1/2 error: Error running apply:
Error: error waiting for DataSync Task (arn:aws:datasync:us-west-2:*******:task/task-0e819038fac1ebf6e) creation: waiting for DataSync Task (arn:aws:datasync:us-west-2:*******:task/task-0e819038fac1ebf6e) creation: last status (UNAVAILABLE), error code (MountFailure), error detail: Failed to connect to an NFS server on host fs-7c85ce79.efs.us-west-2.amazonaws.com. Ensure that your DataSync agent has a route to your NFS server and can make a TCP connection to port 2049. Please also ensure that the NFS service is running and listening on port 2049. After resolving any networking issues, retry your task.
--- FAIL: TestAccAWSDataSyncTask_basic (252.60s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDataSyncTask_basic (229.43s)
--- PASS: TestAccAWSDataSyncTask_CloudWatchLogGroupARN (227.57s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_AtimeMtime (348.45s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_BytesPerSecond (266.03s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_Gid (240.71s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_PosixPermissions (287.10s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDeletedFiles (240.21s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDevices (349.08s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_Uid (365.25s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_VerifyMode (356.74s)
--- PASS: TestAccAWSDataSyncTask_disappears (227.63s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSDataSyncTask_basic (240.55s)
--- PASS: TestAccAWSDataSyncTask_CloudWatchLogGroupARN (272.05s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_AtimeMtime (276.25s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_BytesPerSecond (289.87s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_Gid (301.43s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_PosixPermissions (286.56s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDeletedFiles (299.53s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDevices (300.01s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_Uid (312.04s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_VerifyMode (344.80s)
--- PASS: TestAccAWSDataSyncTask_disappears (246.44s)
```
