### PR TITLE
tests/resource/aws_spot_datafeed_subscription: Add missing S3 grants to configuration and minor refactoring

### DIFF
--- a/aws/resource_aws_spot_datafeed_subscription_test.go
+++ b/aws/resource_aws_spot_datafeed_subscription_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -16,7 +17,6 @@ func TestAccAWSSpotDatafeedSubscription_serial(t *testing.T) {
 	cases := map[string]func(t *testing.T){
 		"basic":      testAccAWSSpotDatafeedSubscription_basic,
 		"disappears": testAccAWSSpotDatafeedSubscription_disappears,
-		"import":     testAccAWSSpotDatafeedSubscription_importBasic,
 	}
 
 	for name, tc := range cases {
@@ -26,42 +26,26 @@ func TestAccAWSSpotDatafeedSubscription_serial(t *testing.T) {
 	}
 }
 
-func testAccAWSSpotDatafeedSubscription_importBasic(t *testing.T) {
-	resourceName := "aws_spot_datafeed_subscription.default"
-	ri := acctest.RandInt()
+func testAccAWSSpotDatafeedSubscription_basic(t *testing.T) {
+	var subscription ec2.SpotDatafeedSubscription
+	resourceName := "aws_spot_datafeed_subscription.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSpotDatafeedSubscription(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotDatafeedSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotDatafeedSubscription(ri),
+				Config: testAccAWSSpotDatafeedSubscription(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSpotDatafeedSubscriptionExists(resourceName, &subscription),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccAWSSpotDatafeedSubscription_basic(t *testing.T) {
-	var subscription ec2.SpotDatafeedSubscription
-	ri := acctest.RandInt()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotDatafeedSubscriptionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotDatafeedSubscription(ri),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotDatafeedSubscriptionExists("aws_spot_datafeed_subscription.default", &subscription),
-				),
 			},
 		},
 	})
@@ -93,17 +77,18 @@ func testAccCheckAWSSpotDatafeedSubscriptionDisappears(subscription *ec2.SpotDat
 
 func testAccAWSSpotDatafeedSubscription_disappears(t *testing.T) {
 	var subscription ec2.SpotDatafeedSubscription
-	ri := acctest.RandInt()
+	resourceName := "aws_spot_datafeed_subscription.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSpotDatafeedSubscription(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotDatafeedSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotDatafeedSubscription(ri),
+				Config: testAccAWSSpotDatafeedSubscription(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSpotDatafeedSubscriptionExists("aws_spot_datafeed_subscription.default", &subscription),
+					testAccCheckAWSSpotDatafeedSubscriptionExists(resourceName, &subscription),
 					testAccCheckAWSSpotDatafeedSubscriptionDisappears(&subscription),
 				),
 				ExpectNonEmptyPlan: true,
@@ -144,32 +129,62 @@ func testAccCheckAWSSpotDatafeedSubscriptionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		// Try to get subscription
 		_, err := conn.DescribeSpotDatafeedSubscription(&ec2.DescribeSpotDatafeedSubscriptionInput{})
-		if err == nil {
-			return fmt.Errorf("still exist.")
+
+		if tfawserr.ErrCodeEquals(err, "InvalidSpotDatafeed.NotFound") {
+			continue
 		}
 
-		awsErr, ok := err.(awserr.Error)
-		if !ok {
-			return err
-		}
-		if awsErr.Code() != "InvalidSpotDatafeed.NotFound" {
-			return err
+		if err != nil {
+			return fmt.Errorf("error descripting EC2 Spot Datafeed Subscription: %w", err)
 		}
 	}
 
 	return nil
 }
 
-func testAccAWSSpotDatafeedSubscription(randInt int) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "default" {
-  bucket = "tf-spot-datafeed-%d"
+func testAccPreCheckAWSSpotDatafeedSubscription(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	input := &ec2.DescribeSpotDatafeedSubscriptionInput{}
+
+	_, err := conn.DescribeSpotDatafeedSubscription(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if tfawserr.ErrCodeEquals(err, "InvalidSpotDatafeed.NotFound") {
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
-resource "aws_spot_datafeed_subscription" "default" {
-  bucket = aws_s3_bucket.default.bucket
+func testAccAWSSpotDatafeedSubscription(rName string) string {
+	return fmt.Sprintf(`
+data "aws_canonical_user_id" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  grant {
+    id          = data.aws_canonical_user_id.current.id
+    permissions = ["FULL_CONTROL"]
+    type        = "CanonicalUser"
+  }
+
+  grant {
+    id          = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0" # EC2 Account
+    permissions = ["FULL_CONTROL"]
+    type        = "CanonicalUser"
+  }
 }
-`, randInt)
+
+resource "aws_spot_datafeed_subscription" "test" {
+  bucket = aws_s3_bucket.test.bucket
+}
+`, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15953

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS Commercial:

```
TestAccAWSSpotDatafeedSubscription_serial/basic: resource_aws_spot_datafeed_subscription_test.go:55: Step 1/1 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
stdout
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# aws_s3_bucket.default will be updated in-place
~ resource "aws_s3_bucket" "default" {
id                          = "tf-spot-datafeed-6406181564871998861"
tags                        = {}
# (9 unchanged attributes hidden)
- grant {
- id          = "--OMITTED--" -> null
- permissions = [
- "FULL_CONTROL",
] -> null
- type        = "CanonicalUser" -> null
}
- grant {
- id          = "--OMITTED--" -> null
- permissions = [
- "FULL_CONTROL",
] -> null
- type        = "CanonicalUser" -> null
}
# (1 unchanged block hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
```

Previously in AWS GovCloud (US):

```
TestAccAWSSpotDatafeedSubscription_serial/basic: resource_aws_spot_datafeed_subscription_test.go:55: Step 1/1 error: Error running apply: 2020/10/30 16:59:42 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0
Error: Error Creating Spot Datafeed Subscription: UnsupportedOperation: The functionality you requested is not available in this region.
  status code: 400, request id: d8186507-bcbe-4424-b4a9-dd593eab637a
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSSpotDatafeedSubscription_serial (57.83s)
    --- PASS: TestAccAWSSpotDatafeedSubscription_serial/basic (30.21s)
    --- PASS: TestAccAWSSpotDatafeedSubscription_serial/disappears (27.61s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSSpotDatafeedSubscription_serial (3.10s)
    --- SKIP: TestAccAWSSpotDatafeedSubscription_serial/basic (1.64s)
    --- SKIP: TestAccAWSSpotDatafeedSubscription_serial/disappears (1.45s)
```

