### PR TITLE
r/glue_catalog_database - plan time validations + read after create

### DIFF
--- a/aws/resource_aws_glue_catalog_database.go
+++ b/aws/resource_aws_glue_catalog_database.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/glue"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsGlueCatalogDatabase() *schema.Resource {
@@ -37,10 +39,15 @@ func resourceAwsGlueCatalogDatabase() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringDoesNotMatch(regexp.MustCompile(`[A-Z]`), "uppercase charcters cannot be used"),
+				),
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 2048),
 			},
 			"location_uri": {
 				Type:     schema.TypeString,
@@ -60,21 +67,35 @@ func resourceAwsGlueCatalogDatabaseCreate(d *schema.ResourceData, meta interface
 	catalogID := createAwsGlueCatalogID(d, meta.(*AWSClient).accountid)
 	name := d.Get("name").(string)
 
+	dbInput := &glue.DatabaseInput{
+		Name: aws.String(name),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		dbInput.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("location_uri"); ok {
+		dbInput.LocationUri = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		dbInput.Parameters = stringMapToPointers(v.(map[string]interface{}))
+	}
+
 	input := &glue.CreateDatabaseInput{
-		CatalogId: aws.String(catalogID),
-		DatabaseInput: &glue.DatabaseInput{
-			Name: aws.String(name),
-		},
+		CatalogId:     aws.String(catalogID),
+		DatabaseInput: dbInput,
 	}
 
 	_, err := conn.CreateDatabase(input)
 	if err != nil {
-		return fmt.Errorf("Error creating Catalog Database: %s", err)
+		return fmt.Errorf("Error creating Catalog Database: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", catalogID, name))
 
-	return resourceAwsGlueCatalogDatabaseUpdate(d, meta)
+	return resourceAwsGlueCatalogDatabaseRead(d, meta)
 }
 
 func resourceAwsGlueCatalogDatabaseUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -94,20 +115,16 @@ func resourceAwsGlueCatalogDatabaseUpdate(d *schema.ResourceData, meta interface
 		Name: aws.String(name),
 	}
 
-	if desc, ok := d.GetOk("description"); ok {
-		dbInput.Description = aws.String(desc.(string))
+	if v, ok := d.GetOk("description"); ok {
+		dbInput.Description = aws.String(v.(string))
 	}
 
-	if loc, ok := d.GetOk("location_uri"); ok {
-		dbInput.LocationUri = aws.String(loc.(string))
+	if v, ok := d.GetOk("location_uri"); ok {
+		dbInput.LocationUri = aws.String(v.(string))
 	}
 
-	if params, ok := d.GetOk("parameters"); ok {
-		parametersInput := make(map[string]*string)
-		for key, value := range params.(map[string]interface{}) {
-			parametersInput[key] = aws.String(value.(string))
-		}
-		dbInput.Parameters = parametersInput
+	if v, ok := d.GetOk("parameters"); ok {
+		dbInput.Parameters = stringMapToPointers(v.(map[string]interface{}))
 	}
 
 	dbUpdateInput.DatabaseInput = dbInput
@@ -159,14 +176,7 @@ func resourceAwsGlueCatalogDatabaseRead(d *schema.ResourceData, meta interface{}
 	d.Set("catalog_id", catalogID)
 	d.Set("description", out.Database.Description)
 	d.Set("location_uri", out.Database.LocationUri)
-
-	dParams := make(map[string]string)
-	if len(out.Database.Parameters) > 0 {
-		for key, value := range out.Database.Parameters {
-			dParams[key] = *value
-		}
-	}
-	d.Set("parameters", dParams)
+	d.Set("parameters", aws.StringValueMap(out.Database.Parameters))
 
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7958

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_catalog_database - add plan time validations for `description` and `name`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCatalogDatabase_'
--- PASS: TestAccAWSGlueCatalogDatabase_disappears (36.09s)
--- PASS: TestAccAWSGlueCatalogDatabase_full (100.61s)
...
```
