### PR TITLE
r/sagemaker_model - add support for `image_config` + refactor tests

### DIFF
--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -80,6 +80,20 @@ func resourceAwsSagemakerModel() *schema.Resource {
 							ValidateFunc: validateSagemakerEnvironment,
 							Elem:         &schema.Schema{Type: schema.TypeString},
 						},
+						"image_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"repository_access_mode": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(sagemaker.RepositoryAccessMode_Values(), false),
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -95,22 +109,21 @@ func resourceAwsSagemakerModel() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
 						},
 						"security_group_ids": {
 							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
 						},
 					},
 				},
 			},
 
 			"execution_role_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"enable_network_isolation": {
@@ -159,6 +172,20 @@ func resourceAwsSagemakerModel() *schema.Resource {
 							ForceNew:     true,
 							ValidateFunc: validateSagemakerEnvironment,
 							Elem:         &schema.Schema{Type: schema.TypeString},
+						},
+						"image_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"repository_access_mode": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(sagemaker.RepositoryAccessMode_Values(), false),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -213,7 +240,7 @@ func resourceAwsSagemakerModelCreate(d *schema.ResourceData, meta interface{}) e
 	})
 
 	if err != nil {
-		return fmt.Errorf("error creating Sagemaker model: %s", err)
+		return fmt.Errorf("error creating Sagemaker model: %w", err)
 	}
 	d.SetId(name)
 
@@ -248,7 +275,7 @@ func resourceAwsSagemakerModelRead(d *schema.ResourceData, meta interface{}) err
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading Sagemaker model %s: %s", d.Id(), err)
+		return fmt.Errorf("error reading Sagemaker model %s: %w", d.Id(), err)
 	}
 
 	if err := d.Set("arn", model.ModelArn); err != nil {
@@ -270,16 +297,16 @@ func resourceAwsSagemakerModelRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	if err := d.Set("vpc_config", flattenSageMakerVpcConfigResponse(model.VpcConfig)); err != nil {
-		return fmt.Errorf("error setting vpc_config: %s", err)
+		return fmt.Errorf("error setting vpc_config: %w", err)
 	}
 
 	tags, err := keyvaluetags.SagemakerListTags(conn, aws.StringValue(model.ModelArn))
 	if err != nil {
-		return fmt.Errorf("error listing tags for Sagemaker Model (%s): %s", d.Id(), err)
+		return fmt.Errorf("error listing tags for Sagemaker Model (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil
@@ -291,8 +318,8 @@ func flattenSageMakerVpcConfigResponse(vpcConfig *sagemaker.VpcConfig) []map[str
 	}
 
 	m := map[string]interface{}{
-		"security_group_ids": schema.NewSet(schema.HashString, flattenStringList(vpcConfig.SecurityGroupIds)),
-		"subnets":            schema.NewSet(schema.HashString, flattenStringList(vpcConfig.Subnets)),
+		"security_group_ids": flattenStringSet(vpcConfig.SecurityGroupIds),
+		"subnets":            flattenStringSet(vpcConfig.Subnets),
 	}
 
 	return []map[string]interface{}{m}
@@ -305,7 +332,7 @@ func resourceAwsSagemakerModelUpdate(d *schema.ResourceData, meta interface{}) e
 		o, n := d.GetChange("tags")
 
 		if err := keyvaluetags.SagemakerUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Sagemaker Model (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("error updating Sagemaker Model (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -335,7 +362,7 @@ func resourceAwsSagemakerModelDelete(d *schema.ResourceData, meta interface{}) e
 		_, err = conn.DeleteModel(deleteOpts)
 	}
 	if err != nil {
-		return fmt.Errorf("Error deleting sagemaker model: %s", err)
+		return fmt.Errorf("Error deleting sagemaker model: %w", err)
 	}
 	return nil
 }
@@ -359,7 +386,25 @@ func expandContainer(m map[string]interface{}) *sagemaker.ContainerDefinition {
 		container.Environment = stringMapToPointers(v.(map[string]interface{}))
 	}
 
+	if v, ok := m["image_config"]; ok {
+		container.ImageConfig = expandSagemakerModelImageConfig(v.([]interface{}))
+	}
+
 	return &container
+}
+
+func expandSagemakerModelImageConfig(l []interface{}) *sagemaker.ImageConfig {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	imageConfig := &sagemaker.ImageConfig{
+		RepositoryAccessMode: aws.String(m["repository_access_mode"].(string)),
+	}
+
+	return imageConfig
 }
 
 func expandContainers(a []interface{}) []*sagemaker.ContainerDefinition {
@@ -379,21 +424,37 @@ func flattenContainer(container *sagemaker.ContainerDefinition) []interface{} {
 
 	cfg := make(map[string]interface{})
 
-	cfg["image"] = *container.Image
+	cfg["image"] = aws.StringValue(container.Image)
 
 	if container.Mode != nil {
-		cfg["mode"] = *container.Mode
+		cfg["mode"] = aws.StringValue(container.Mode)
 	}
 
 	if container.ContainerHostname != nil {
-		cfg["container_hostname"] = *container.ContainerHostname
+		cfg["container_hostname"] = aws.StringValue(container.ContainerHostname)
 	}
 	if container.ModelDataUrl != nil {
-		cfg["model_data_url"] = *container.ModelDataUrl
+		cfg["model_data_url"] = aws.StringValue(container.ModelDataUrl)
 	}
 	if container.Environment != nil {
-		cfg["environment"] = flattenEnvironment(container.Environment)
+		cfg["environment"] = aws.StringValueMap(container.Environment)
 	}
+
+	if container.ImageConfig != nil {
+		cfg["image_config"] = flattenSagemakerImageConfig(container.ImageConfig)
+	}
+
+	return []interface{}{cfg}
+}
+
+func flattenSagemakerImageConfig(imageConfig *sagemaker.ImageConfig) []interface{} {
+	if imageConfig == nil {
+		return []interface{}{}
+	}
+
+	cfg := make(map[string]interface{})
+
+	cfg["repository_access_mode"] = aws.StringValue(imageConfig.RepositoryAccessMode)
 
 	return []interface{}{cfg}
 }
@@ -404,12 +465,4 @@ func flattenContainers(containers []*sagemaker.ContainerDefinition) []interface{
 		fContainers = append(fContainers, flattenContainer(container)[0].(map[string]interface{}))
 	}
 	return fContainers
-}
-
-func flattenEnvironment(env map[string]*string) map[string]string {
-	m := map[string]string{}
-	for k, v := range env {
-		m[k] = *v
-	}
-	return m
 }

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -82,6 +82,7 @@ func resourceAwsSagemakerModel() *schema.Resource {
 						"image_config": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"repository_access_mode": {
@@ -175,6 +176,7 @@ func resourceAwsSagemakerModel() *schema.Resource {
 						"image_config": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"repository_access_mode": {

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -270,7 +269,7 @@ func resourceAwsSagemakerModelRead(d *schema.ResourceData, meta interface{}) err
 
 	model, err := conn.DescribeModel(request)
 	if err != nil {
-		if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ValidationException" {
+		if isAWSErr(err, "ValidationException", "") {
 			log.Printf("[INFO] unable to find the sagemaker model resource and therefore it is removed from the state: %s", d.Id())
 			d.SetId("")
 			return nil

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -268,8 +268,8 @@ func TestAccAWSSagemakerModel_containers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerModelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "container.#", "2"),
-					resource.TestCheckResourceAttrPair(resourceName, "primary_container.0.image", "data.aws_sagemaker_prebuilt_ecr_image.test", "registry_path"),
-					resource.TestCheckResourceAttrPair(resourceName, "primary_container.0.image", "data.aws_sagemaker_prebuilt_ecr_image.test", "registry_path"),
+					resource.TestCheckResourceAttrPair(resourceName, "container.0.image", "data.aws_sagemaker_prebuilt_ecr_image.test", "registry_path"),
+					resource.TestCheckResourceAttrPair(resourceName, "container.1.image", "data.aws_sagemaker_prebuilt_ecr_image.test", "registry_path"),
 				),
 			},
 			{
@@ -328,6 +328,27 @@ func TestAccAWSSagemakerModel_networkIsolation(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerModel_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_model.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerModelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerModelConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerModelExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerModel(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -570,12 +570,12 @@ resource "aws_sagemaker_model" "test" {
 func testAccSagemakerPrimaryContainerImageConfigConfig(rName string) string {
 	return testAccSagemakerModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
-  name               = %[1]q
+  name               = "%[1]q"
   execution_role_arn = aws_iam_role.test.arn
 
   primary_container {
     image = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
-	
+
     image_config {
       repository_access_mode = "Platform"
     }

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -574,11 +574,11 @@ resource "aws_sagemaker_model" "test" {
   execution_role_arn = aws_iam_role.test.arn
 
   primary_container {
-	image = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
+    image = data.aws_sagemaker_prebuilt_ecr_image.test.registry_path
 	
-	image_config {
-	  repository_access_mode = "Platform"
-	}
+    image_config {
+      repository_access_mode = "Platform"
+    }
   }
 }
 `, rName)

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -476,7 +476,7 @@ resource "aws_sagemaker_model" "test" {
 
   tags = {
     %[2]q = %[3]q
-    %[4]q = %[5]q	
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -570,7 +570,7 @@ resource "aws_sagemaker_model" "test" {
 func testAccSagemakerPrimaryContainerImageConfigConfig(rName string) string {
 	return testAccSagemakerModelConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_model" "test" {
-  name               = "%[1]q"
+  name               = %[1]q
   execution_role_arn = aws_iam_role.test.arn
 
   primary_container {

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -15,16 +15,16 @@ Provides a SageMaker model resource.
 Basic usage:
 
 ```hcl
-resource "aws_sagemaker_model" "m" {
+resource "aws_sagemaker_model" "example" {
   name               = "my-model"
-  execution_role_arn = aws_iam_role.foo.arn
+  execution_role_arn = aws_iam_role.example.arn
 
   primary_container {
     image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
   }
 }
 
-resource "aws_iam_role" "r" {
+resource "aws_iam_role" "example" {
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -60,6 +60,11 @@ The `primary_container` and `container` block both support:
 * `container_hostname` - (Optional) The DNS host name for the container.
 * `environment` - (Optional) Environment variables for the Docker container.
    A list of key value pairs.
+* `image_config` - (Optional) Specifies whether the model container is in Amazon ECR or a private Docker registry accessible from your Amazon Virtual Private Cloud (VPC). For more information see [Using a Private Docker Registry for Real-Time Inference Containers](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-containers-inference-private.html). see [Image Config](#image-config).
+
+### Image Config
+
+* `repository_access_mode` - (Required) Specifies whether the model container is in Amazon ECR or a private Docker registry accessible from your Amazon Virtual Private Cloud (VPC). Allowed values are: `Platform` and `Vpc`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sagemaker_model - add support for `primary_container. image_config` and `containers.image_config`
resource_aws_sagemaker_model - add plan time validation for `execution_role_arn`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerModel_'
--- PASS: TestAccAWSSagemakerModel_disappears (56.13s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerModeSingle (56.14s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerEnvironment (56.48s)
--- PASS: TestAccAWSSagemakerModel_basic (60.75s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerImageConfig (61.04s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerHostname (62.97s)
--- PASS: TestAccAWSSagemakerModel_networkIsolation (64.59s)
--- PASS: TestAccAWSSagemakerModel_containers (64.71s)
--- PASS: TestAccAWSSagemakerModel_vpcConfig (82.24s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerModelDataUrl (91.82s)
--- PASS: TestAccAWSSagemakerModel_tags (125.73s)
```
