### PR TITLE
resource/db_instance: add restore to point in time support

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -308,7 +308,6 @@ func resourceAwsDbInstance() *schema.Resource {
 						"use_latest_restorable_time": {
 							Type:          schema.TypeBool,
 							Optional:      true,
-							Default:       false,
 							ConflictsWith: []string{"restore_to_point_in_time.0.restore_time"},
 						},
 					},
@@ -1956,7 +1955,7 @@ func expandRestoreToPointInTime(l []interface{}) *rds.RestoreDBInstanceToPointIn
 	if v, ok := tfMap["source_dbi_resource_id"].(string); ok && v != "" {
 		input.SourceDbiResourceId = aws.String(v)
 	}
-	if v, ok := tfMap["use_latest_restorable_time"].(bool); ok {
+	if v, ok := tfMap["use_latest_restorable_time"].(bool); ok && v {
 		input.UseLatestRestorableTime = aws.Bool(v)
 	}
 

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1398,7 +1398,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("availability_zone", v.AvailabilityZone)
 	d.Set("backup_retention_period", v.BackupRetentionPeriod)
 	d.Set("backup_window", v.PreferredBackupWindow)
-	d.Set("latest_restorable_time", v.LatestRestorableTime.Format(time.RFC3339))
+	d.Set("latest_restorable_time", aws.TimeValue(v.LatestRestorableTime).Format(time.RFC3339))
 	d.Set("license_model", v.LicenseModel)
 	d.Set("maintenance_window", v.PreferredMaintenanceWindow)
 	d.Set("max_allocated_storage", v.MaxAllocatedStorage)

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -191,6 +191,11 @@ func resourceAwsDbInstance() *schema.Resource {
 				Optional: true,
 			},
 
+			"latest_restorable_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"license_model": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -271,6 +276,42 @@ func resourceAwsDbInstance() *schema.Resource {
 						es = append(es, fmt.Errorf("%q cannot end in a hyphen", k))
 					}
 					return
+				},
+			},
+
+			"restore_to_point_in_time": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"s3_import",
+					"snapshot_identifier",
+					"replicate_source_db",
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"restore_time": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ValidateFunc:  validateUTCTimestamp,
+							ConflictsWith: []string{"restore_to_point_in_time.0.use_latest_restorable_time"},
+						},
+						"source_db_instance_identifier": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"source_dbi_resource_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"use_latest_restorable_time": {
+							Type:          schema.TypeBool,
+							Optional:      true,
+							Default:       false,
+							ConflictsWith: []string{"restore_to_point_in_time.0.restore_time"},
+						},
+					},
 				},
 			},
 
@@ -1036,6 +1077,77 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf("Error creating DB Instance: %s", err)
 		}
+	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok {
+		if input := expandRestoreToPointInTime(v.([]interface{})); input != nil {
+			input.AutoMinorVersionUpgrade = aws.Bool(d.Get("auto_minor_version_upgrade").(bool))
+			input.CopyTagsToSnapshot = aws.Bool(d.Get("copy_tags_to_snapshot").(bool))
+			input.DBInstanceClass = aws.String(d.Get("instance_class").(string))
+			input.DeletionProtection = aws.Bool(d.Get("deletion_protection").(bool))
+			input.PubliclyAccessible = aws.Bool(d.Get("publicly_accessible").(bool))
+			input.Tags = tags
+			input.TargetDBInstanceIdentifier = aws.String(d.Get("identifier").(string))
+
+			if v, ok := d.GetOk("availability_zone"); ok {
+				input.AvailabilityZone = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("domain"); ok {
+				input.Domain = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("domain_iam_role_name"); ok {
+				input.DomainIAMRoleName = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && v.(*schema.Set).Len() > 0 {
+				input.EnableCloudwatchLogsExports = expandStringSet(v.(*schema.Set))
+			}
+			if v, ok := d.GetOk("engine"); ok {
+				input.Engine = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("iam_database_authentication_enabled"); ok {
+				input.EnableIAMDatabaseAuthentication = aws.Bool(v.(bool))
+			}
+			if v, ok := d.GetOk("iops"); ok {
+				input.Iops = aws.Int64(int64(v.(int)))
+			}
+			if v, ok := d.GetOk("license_model"); ok {
+				input.LicenseModel = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("max_allocated_storage"); ok {
+				input.MaxAllocatedStorage = aws.Int64(int64(v.(int)))
+			}
+			if v, ok := d.GetOk("multi_az"); ok {
+				input.MultiAZ = aws.Bool(v.(bool))
+			}
+			if v, ok := d.GetOk("name"); ok {
+				input.DBName = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("option_group_name"); ok {
+				input.OptionGroupName = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("parameter_group_name"); ok {
+				input.DBParameterGroupName = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("port"); ok {
+				input.Port = aws.Int64(int64(v.(int)))
+			}
+			if v, ok := d.GetOk("storage_type"); ok {
+				input.StorageType = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("subnet_group_name"); ok {
+				input.DBSubnetGroupName = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("tde_credential_arn"); ok {
+				input.TdeCredentialArn = aws.String(v.(string))
+			}
+			if v, ok := d.GetOk("vpc_security_group_ids"); ok && v.(*schema.Set).Len() > 0 {
+				input.VpcSecurityGroupIds = expandStringSet(v.(*schema.Set))
+			}
+
+			log.Printf("[DEBUG] DB Instance restore to point in time configuration: %s", input)
+			_, err := conn.RestoreDBInstanceToPointInTime(input)
+			if err != nil {
+				return fmt.Errorf("error creating DB Instance: %w", err)
+			}
+		}
 	} else {
 		if _, ok := d.GetOk("allocated_storage"); !ok {
 			return fmt.Errorf(`provider.aws: aws_db_instance: %s: "allocated_storage": required field is not set`, d.Get("name").(string))
@@ -1287,6 +1399,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("availability_zone", v.AvailabilityZone)
 	d.Set("backup_retention_period", v.BackupRetentionPeriod)
 	d.Set("backup_window", v.PreferredBackupWindow)
+	d.Set("latest_restorable_time", v.LatestRestorableTime.Format(time.RFC3339))
 	d.Set("license_model", v.LicenseModel)
 	d.Set("maintenance_window", v.PreferredMaintenanceWindow)
 	d.Set("max_allocated_storage", v.MaxAllocatedStorage)
@@ -1820,4 +1933,32 @@ var resourceAwsDbInstanceUpdatePendingStates = []string{
 	"stopping",
 	"storage-full",
 	"upgrading",
+}
+
+func expandRestoreToPointInTime(l []interface{}) *rds.RestoreDBInstanceToPointInTimeInput {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	input := &rds.RestoreDBInstanceToPointInTimeInput{}
+	if v, ok := tfMap["restore_time"].(string); ok && v != "" {
+		parsedTime, err := time.Parse(time.RFC3339, v)
+		if err == nil {
+			input.RestoreTime = aws.Time(parsedTime)
+		}
+	}
+	if v, ok := tfMap["source_db_instance_identifier"].(string); ok && v != "" {
+		input.SourceDBInstanceIdentifier = aws.String(v)
+	}
+	if v, ok := tfMap["source_dbi_resource_id"].(string); ok && v != "" {
+		input.SourceDbiResourceId = aws.String(v)
+	}
+	if v, ok := tfMap["use_latest_restorable_time"].(bool); ok {
+		input.UseLatestRestorableTime = aws.Bool(v)
+	}
+
+	return input
 }

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -297,14 +297,17 @@ func resourceAwsDbInstance() *schema.Resource {
 							ValidateFunc:  validateUTCTimestamp,
 							ConflictsWith: []string{"restore_to_point_in_time.0.use_latest_restorable_time"},
 						},
+
 						"source_db_instance_identifier": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+
 						"source_dbi_resource_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+
 						"use_latest_restorable_time": {
 							Type:          schema.TypeBool,
 							Optional:      true,
@@ -1089,59 +1092,77 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			if v, ok := d.GetOk("availability_zone"); ok {
 				input.AvailabilityZone = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("domain"); ok {
 				input.Domain = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("domain_iam_role_name"); ok {
 				input.DomainIAMRoleName = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && v.(*schema.Set).Len() > 0 {
 				input.EnableCloudwatchLogsExports = expandStringSet(v.(*schema.Set))
 			}
+
 			if v, ok := d.GetOk("engine"); ok {
 				input.Engine = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("iam_database_authentication_enabled"); ok {
 				input.EnableIAMDatabaseAuthentication = aws.Bool(v.(bool))
 			}
+
 			if v, ok := d.GetOk("iops"); ok {
 				input.Iops = aws.Int64(int64(v.(int)))
 			}
+
 			if v, ok := d.GetOk("license_model"); ok {
 				input.LicenseModel = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("max_allocated_storage"); ok {
 				input.MaxAllocatedStorage = aws.Int64(int64(v.(int)))
 			}
+
 			if v, ok := d.GetOk("multi_az"); ok {
 				input.MultiAZ = aws.Bool(v.(bool))
 			}
+
 			if v, ok := d.GetOk("name"); ok {
 				input.DBName = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("option_group_name"); ok {
 				input.OptionGroupName = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("parameter_group_name"); ok {
 				input.DBParameterGroupName = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("port"); ok {
 				input.Port = aws.Int64(int64(v.(int)))
 			}
+
 			if v, ok := d.GetOk("storage_type"); ok {
 				input.StorageType = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("subnet_group_name"); ok {
 				input.DBSubnetGroupName = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("tde_credential_arn"); ok {
 				input.TdeCredentialArn = aws.String(v.(string))
 			}
+
 			if v, ok := d.GetOk("vpc_security_group_ids"); ok && v.(*schema.Set).Len() > 0 {
 				input.VpcSecurityGroupIds = expandStringSet(v.(*schema.Set))
 			}
 
 			log.Printf("[DEBUG] DB Instance restore to point in time configuration: %s", input)
+
 			_, err := conn.RestoreDBInstanceToPointInTime(input)
 			if err != nil {
 				return fmt.Errorf("error creating DB Instance: %w", err)
@@ -1938,23 +1959,29 @@ func expandRestoreToPointInTime(l []interface{}) *rds.RestoreDBInstanceToPointIn
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
+
 	tfMap, ok := l[0].(map[string]interface{})
 	if !ok {
 		return nil
 	}
+
 	input := &rds.RestoreDBInstanceToPointInTimeInput{}
+
 	if v, ok := tfMap["restore_time"].(string); ok && v != "" {
 		parsedTime, err := time.Parse(time.RFC3339, v)
 		if err == nil {
 			input.RestoreTime = aws.Time(parsedTime)
 		}
 	}
+
 	if v, ok := tfMap["source_db_instance_identifier"].(string); ok && v != "" {
 		input.SourceDBInstanceIdentifier = aws.String(v)
 	}
+
 	if v, ok := tfMap["source_dbi_resource_id"].(string); ok && v != "" {
 		input.SourceDbiResourceId = aws.String(v)
 	}
+
 	if v, ok := tfMap["use_latest_restorable_time"].(bool); ok && v {
 		input.UseLatestRestorableTime = aws.Bool(v)
 	}

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -2984,6 +2984,76 @@ func TestAccAWSDBInstance_CACertificateIdentifier(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBInstance_RestoreToPointInTime_SourceIdentifier(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	sourceName := "aws_db_instance.test"
+	resourceName := "aws_db_instance.restore"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_RestoreToPointInTime_SourceIdentifier(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceName, &sourceDbInstance),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"delete_automated_backups",
+					"final_snapshot_identifier",
+					"latest_restorable_time", // dynamic value of a DBInstance
+					"password",
+					"restore_to_point_in_time",
+					"skip_final_snapshot",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_RestoreToPointInTime_SourceResourceID(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	sourceName := "aws_db_instance.test"
+	resourceName := "aws_db_instance.restore"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_RestoreToPointInTime_SourceResourceID(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceName, &sourceDbInstance),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"delete_automated_backups",
+					"final_snapshot_identifier",
+					"latest_restorable_time", // dynamic value of a DBInstance
+					"password",
+					"restore_to_point_in_time",
+					"skip_final_snapshot",
+				},
+			},
+		},
+	})
+}
+
 func testAccAWSDBInstanceConfig_orderableClass(engine, version, license string) string {
 	return fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "test" {
@@ -3544,6 +3614,55 @@ resource "aws_db_instance" "test" {
   username            = "foo"
 }
 `, rName)
+}
+
+const testAccAWSDBInstanceBaseConfig = `
+resource "aws_db_instance" "test" {
+  allocated_storage       = 10
+  backup_retention_period = 1
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  name                    = "baz"
+  parameter_group_name    = "default.mysql5.6"
+  password                = "barbarbarbar"
+  skip_final_snapshot     = true
+  username                = "foo"
+}
+`
+
+func testAccAWSDBInstanceConfig_RestoreToPointInTime_SourceIdentifier() string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAWSDBInstanceBaseConfig,
+		fmt.Sprintf(`
+resource "aws_db_instance" "restore" {
+  identifier     = "tf-acc-test-point-in-time-restore-%d"
+  instance_class = aws_db_instance.test.instance_class
+  restore_to_point_in_time {
+    source_db_instance_identifier = aws_db_instance.test.identifier
+    use_latest_restorable_time    = true
+  }
+  skip_final_snapshot = true
+}
+`, acctest.RandInt()))
+}
+
+func testAccAWSDBInstanceConfig_RestoreToPointInTime_SourceResourceID() string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAWSDBInstanceBaseConfig,
+		fmt.Sprintf(`
+resource "aws_db_instance" "restore" {
+  identifier     = "tf-acc-test-point-in-time-restore-%d"
+  instance_class = aws_db_instance.test.instance_class
+  restore_to_point_in_time {
+    source_dbi_resource_id     = aws_db_instance.test.resource_id
+    use_latest_restorable_time = true
+  }
+  skip_final_snapshot = true
+}
+`, acctest.RandInt()))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotInstanceConfig_iopsUpdate(rName string, iops int) string {

--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -68,7 +68,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 						"metric_timestamp": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validateIoTTopicRuleCloudWatchMetricTimestamp,
+							ValidateFunc: validateUTCTimestamp,
 						},
 						"metric_unit": {
 							Type:     schema.TypeString,
@@ -489,7 +489,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 									"metric_timestamp": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validateIoTTopicRuleCloudWatchMetricTimestamp,
+										ValidateFunc: validateUTCTimestamp,
 									},
 									"metric_unit": {
 										Type:     schema.TypeString,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1965,14 +1965,16 @@ func validateIoTTopicRuleCloudWatchAlarmStateValue(v interface{}, s string) ([]s
 	return nil, []error{fmt.Errorf("State must be one of OK, ALARM, or INSUFFICIENT_DATA")}
 }
 
-func validateIoTTopicRuleCloudWatchMetricTimestamp(v interface{}, s string) ([]string, []error) {
+// validateUTCTimestamp validates a string in UTC Format required by APIs including:
+// https://docs.aws.amazon.com/iot/latest/apireference/API_CloudwatchMetricAction.html
+// https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceToPointInTime.html
+func validateUTCTimestamp(v interface{}, k string) (ws []string, errors []error) {
 	dateString := v.(string)
-
-	// https://docs.aws.amazon.com/iot/latest/apireference/API_CloudwatchMetricAction.html
-	if _, err := time.Parse(time.RFC3339, dateString); err != nil {
-		return nil, []error{err}
+	_, err := time.Parse(time.RFC3339, dateString)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q cannot be parsed in UTC format e.g. %q", k, time.RFC3339))
 	}
-	return nil, nil
+	return
 }
 
 func validateIoTTopicRuleElasticSearchEndpoint(v interface{}, k string) (ws []string, errors []error) {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1081,6 +1081,9 @@ func validateOnceADayWindowFormat(v interface{}, k string) (ws []string, errors 
 	return
 }
 
+// validateUTCTimestamp validates a string in UTC Format required by APIs including:
+// https://docs.aws.amazon.com/iot/latest/apireference/API_CloudwatchMetricAction.html
+// https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceToPointInTime.html
 func validateUTCTimestamp(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, err := time.Parse(time.RFC3339, value)
@@ -1963,18 +1966,6 @@ func validateIoTTopicRuleCloudWatchAlarmStateValue(v interface{}, s string) ([]s
 	}
 
 	return nil, []error{fmt.Errorf("State must be one of OK, ALARM, or INSUFFICIENT_DATA")}
-}
-
-// validateUTCTimestamp validates a string in UTC Format required by APIs including:
-// https://docs.aws.amazon.com/iot/latest/apireference/API_CloudwatchMetricAction.html
-// https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceToPointInTime.html
-func validateUTCTimestamp(v interface{}, k string) (ws []string, errors []error) {
-	dateString := v.(string)
-	_, err := time.Parse(time.RFC3339, dateString)
-	if err != nil {
-		errors = append(errors, fmt.Errorf("%q cannot be parsed in UTC format e.g. %q", k, time.RFC3339))
-	}
-	return
 }
 
 func validateIoTTopicRuleElasticSearchEndpoint(v interface{}, k string) (ws []string, errors []error) {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3262,7 +3262,7 @@ func TestValidateUTCTimestamp(t *testing.T) {
 	for _, f := range validT {
 		_, errors := validateUTCTimestamp(f, "UTC timestamp")
 		if len(errors) > 0 {
-			t.Fatalf("Expected the time %q to be in valid format, got error %q", f, errors)
+			t.Fatalf("expected the time %q to be in valid format, got error %q", f, errors)
 		}
 	}
 

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3234,40 +3234,14 @@ func TestValidateUTCTimestamp(t *testing.T) {
 	}
 
 	for _, f := range validT {
-		_, errors := validateUTCTimestamp(f, "valid_restorable_time_format")
-		if len(errors) > 0 {
-			t.Fatalf("Expected the time %q to be in valid format, got error %q", f, errors)
-		}
-	}
-
-	for _, f := range invalidT {
-		_, errors := validateUTCTimestamp(f, "invalid_restorable_time_format")
-		if len(errors) == 0 {
-			t.Fatalf("Expected the time %q to fail validation", f)
-		}
-	}
-}
-
-func TestValidateUTCTimestamp(t *testing.T) {
-	validT := []string{
-		"2006-01-02T15:04:05Z",
-	}
-
-	invalidT := []string{
-		"2015-03-07 23:45:00",
-		"27-03-2019 23:45:00",
-		"Mon, 02 Jan 2006 15:04:05 -0700",
-	}
-
-	for _, f := range validT {
-		_, errors := validateUTCTimestamp(f, "UTC timestamp")
+		_, errors := validateUTCTimestamp(f, "utc_timestamp")
 		if len(errors) > 0 {
 			t.Fatalf("expected the time %q to be in valid format, got error %q", f, errors)
 		}
 	}
 
 	for _, f := range invalidT {
-		_, errors := validateUTCTimestamp(f, "invalid UTC timestamp")
+		_, errors := validateUTCTimestamp(f, "utc_timestamp")
 		if len(errors) == 0 {
 			t.Fatalf("expected the time %q to fail validation", f)
 		}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3247,3 +3247,29 @@ func TestValidateUTCTimestamp(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateUTCTimestamp(t *testing.T) {
+	validT := []string{
+		"2006-01-02T15:04:05Z",
+	}
+
+	invalidT := []string{
+		"2015-03-07 23:45:00",
+		"27-03-2019 23:45:00",
+		"Mon, 02 Jan 2006 15:04:05 -0700",
+	}
+
+	for _, f := range validT {
+		_, errors := validateUTCTimestamp(f, "UTC timestamp")
+		if len(errors) > 0 {
+			t.Fatalf("Expected the time %q to be in valid format, got error %q", f, errors)
+		}
+	}
+
+	for _, f := range invalidT {
+		_, errors := validateUTCTimestamp(f, "invalid UTC timestamp")
+		if len(errors) == 0 {
+			t.Fatalf("Expected the time %q to fail validation", f)
+		}
+	}
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3269,7 +3269,7 @@ func TestValidateUTCTimestamp(t *testing.T) {
 	for _, f := range invalidT {
 		_, errors := validateUTCTimestamp(f, "invalid UTC timestamp")
 		if len(errors) == 0 {
-			t.Fatalf("Expected the time %q to fail validation", f)
+			t.Fatalf("expected the time %q to fail validation", f)
 		}
 	}
 }

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -218,9 +218,9 @@ The `restore_to_point_in_time` block supports the following arguments:
 
 * `restore_time` - (Optional) The date and time to restore from. Value must be a time in Universal Coordinated Time (UTC) format and must be before the latest restorable time for the DB instance. Cannot be specified with `use_latest_restorable_time`.
 
-* `source_db_instance_identifier` - (Optional) The identifier of the source DB instance from which to restore. Must match the identifier of an existing DB instance.
+* `source_db_instance_identifier` - (Optional) The identifier of the source DB instance from which to restore. Must match the identifier of an existing DB instance. Required if `source_dbi_resource_id` is not specified.
 
-* `source_dbi_resource_id` - (Optional) The resource ID of the source DB instance from which to restore.
+* `source_dbi_resource_id` - (Optional) The resource ID of the source DB instance from which to restore. Required if `source_db_instance_identifier` is not specified.
 
 * `use_latest_restorable_time` - (Optional) A boolean value that indicates whether the DB instance is restored from the latest backup time. Defaults to `false`. Cannot be specified with `restore_time`.
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -217,11 +217,8 @@ This setting does not apply to `aurora-mysql` or `aurora-postgresql` DB engines.
 The `restore_to_point_in_time` block supports the following arguments:
 
 * `restore_time` - (Optional) The date and time to restore from. Value must be a time in Universal Coordinated Time (UTC) format and must be before the latest restorable time for the DB instance. Cannot be specified with `use_latest_restorable_time`.
-
 * `source_db_instance_identifier` - (Optional) The identifier of the source DB instance from which to restore. Must match the identifier of an existing DB instance. Required if `source_dbi_resource_id` is not specified.
-
 * `source_dbi_resource_id` - (Optional) The resource ID of the source DB instance from which to restore. Required if `source_db_instance_identifier` is not specified.
-
 * `use_latest_restorable_time` - (Optional) A boolean value that indicates whether the DB instance is restored from the latest backup time. Defaults to `false`. Cannot be specified with `restore_time`.
 
 ### S3 Import Options


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #5286
Preceded by #7031 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/db_instance: add `restore_to_point_in_time` argument
resource/db_instance: add `latest_restorable_time` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSDBInstance_RestoreToPointInTime_SourceIdentifier (1469.96s)
--- PASS: TestAccAWSDBInstance_RestoreToPointInTime_SourceResourceID (1275.53s)

--- PASS: TestAccAWSDBInstance_kmsKey (430.59s) (previously panicking but fixed w/ commit 81ca42c14)

other test results in progress...
```
