### PR TITLE
tests/service/rds: Remove hardcoded us-east-1 environment variable handling

### DIFF
--- a/aws/data_source_aws_db_instance_test.go
+++ b/aws/data_source_aws_db_instance_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -42,15 +41,11 @@ func TestAccAWSDbInstanceDataSource_basic(t *testing.T) {
 }
 
 func TestAccAWSDbInstanceDataSource_ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDBInstanceDataSourceConfig_ec2Classic(rInt),
@@ -99,7 +94,9 @@ data "aws_db_instance" "bar" {
 }
 
 func testAccAWSDBInstanceDataSourceConfig_ec2Classic(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "test" {
   engine                     = "mysql"
   engine_version             = "5.6.41"
@@ -124,5 +121,5 @@ resource "aws_db_instance" "bar" {
 data "aws_db_instance" "bar" {
   db_instance_identifier = aws_db_instance.bar.identifier
 }
-`, rInt)
+`, rInt))
 }

--- a/aws/ec2_classic_test.go
+++ b/aws/ec2_classic_test.go
@@ -6,7 +6,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -74,4 +76,18 @@ func testAccGetEc2ClassicRegion() string {
 	}
 
 	return testAccGetRegion()
+}
+
+// testAccCheckResourceAttrRegionalARNEc2Classic ensures the Terraform state exactly matches a formatted ARN with EC2-Classic region
+func testAccCheckResourceAttrRegionalARNEc2Classic(resourceName, attributeName, arnService, arnResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attributeValue := arn.ARN{
+			AccountID: testAccGetAccountID(),
+			Partition: testAccGetPartition(),
+			Region:    testAccGetEc2ClassicRegion(),
+			Resource:  arnResource,
+			Service:   arnService,
+		}.String()
+		return resource.TestCheckResourceAttr(resourceName, attributeName, attributeValue)(s)
+	}
 }

--- a/aws/resource_aws_db_security_group_test.go
+++ b/aws/resource_aws_db_security_group_test.go
@@ -2,8 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -17,25 +15,20 @@ import (
 
 func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 	var v rds.DBSecurityGroup
-
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	resourceName := "aws_db_security_group.test"
 	rName := fmt.Sprintf("tf-acc-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDBSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSDBSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDBSecurityGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBSecurityGroupExists(resourceName, &v),
 					testAccCheckAWSDBSecurityGroupAttributes(&v),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("secgrp:%s$", rName))),
+					testAccCheckResourceAttrRegionalARNEc2Classic(resourceName, "arn", "rds", fmt.Sprintf("secgrp:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
@@ -146,7 +139,9 @@ func testAccCheckAWSDBSecurityGroupExists(n string, v *rds.DBSecurityGroup) reso
 }
 
 func testAccAWSDBSecurityGroupConfig(name string) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_db_security_group" "test" {
   name = "%s"
 
@@ -158,5 +153,5 @@ resource "aws_db_security_group" "test" {
     foo = "test"
   }
 }
-`, name)
+`, name))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8316
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15791

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS Commercial:

```
=== CONT  TestAccAWSDBInstance_ec2Classic
TestAccAWSDBInstance_ec2Classic: resource_aws_db_instance_test.go:2242: Step 1/1 error: Error running apply: 2020/11/02 10:23:21 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0
Error: Error creating DB Instance: InsufficientDBInstanceCapacity: Cannot create a db.t3.micro database instance because there are no availability zones with sufficient capacity for non-VPC and storage type : standard for db.t3.micro. Please try the request again at a later time.
  status code: 400, request id: cb437def-f533-4894-874a-235bef9fe874
--- FAIL: TestAccAWSDBInstance_ec2Classic (11.36s)
```

Previously in AWS GovCloud (US):

```
=== CONT  TestAccAWSDbInstanceDataSource_ec2Classic
TestAccAWSDbInstanceDataSource_ec2Classic: provider_test.go:196: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: 4f3cfbfa-bc43-46bd-8834-5eeb10cc4fc9  []}]
--- FAIL: TestAccAWSDbInstanceDataSource_ec2Classic (0.49s)

=== CONT  TestAccAWSDBInstance_ec2Classic
TestAccAWSDBInstance_ec2Classic: provider_test.go:196: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: 2af3b934-784b-43e5-8e67-38b7b7333b94  []}]
--- FAIL: TestAccAWSDBInstance_ec2Classic (0.38s)

=== CONT  TestAccAWSDBSecurityGroup_basic
TestAccAWSDBSecurityGroup_basic: provider_test.go:196: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: 2ac5b1af-30f7-4c64-81d8-0cf983ce035b  []}]
--- FAIL: TestAccAWSDBSecurityGroup_basic (0.33s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDbInstanceDataSource_ec2Classic (452.57s)

--- PASS: TestAccAWSDBInstance_ec2Classic (496.81s)

--- PASS: TestAccAWSDBSecurityGroup_basic (35.95s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSDbInstanceDataSource_ec2Classic (2.84s)

--- SKIP: TestAccAWSDBInstance_ec2Classic (2.81s)

--- SKIP: TestAccAWSDBSecurityGroup_basic (2.72s)
```