### PR TITLE
Add `waiter` functions for CloudFormation Stack and CloudFormation Stack Set operations

### DIFF
--- a/aws/internal/service/cloudformation/lister/list.go
+++ b/aws/internal/service/cloudformation/lister/list.go
@@ -1,0 +1,31 @@
+package lister
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+func ListStackEventsForOperation(conn *cloudformation.CloudFormation, stackID, requestToken string, fn func(*cloudformation.StackEvent)) error {
+	tokenSeen := false
+	err := conn.DescribeStackEventsPages(&cloudformation.DescribeStackEventsInput{
+		StackName: aws.String(stackID),
+	}, func(page *cloudformation.DescribeStackEventsOutput, lastPage bool) bool {
+		for _, e := range page.StackEvents {
+			currentToken := aws.StringValue(e.ClientRequestToken)
+			if !tokenSeen {
+				if currentToken != requestToken {
+					continue
+				}
+				tokenSeen = true
+			} else {
+				if currentToken != requestToken {
+					return false
+				}
+			}
+
+			fn(e)
+		}
+		return !lastPage
+	})
+	return err
+}

--- a/aws/internal/service/cloudformation/waiter/status.go
+++ b/aws/internal/service/cloudformation/waiter/status.go
@@ -67,3 +67,24 @@ func StackSetOperationStatus(conn *cloudformation.CloudFormation, stackSetName, 
 		return output.StackSetOperation, aws.StringValue(output.StackSetOperation.Status), nil
 	}
 }
+
+const (
+	stackStatusError    = "Error"
+	stackStatusNotFound = "NotFound"
+)
+
+// stackStatus is not exported because we need a wrapper to return the last status value
+func stackStatus(conn *cloudformation.CloudFormation, stackName string) (interface{}, string, error) {
+	resp, err := conn.DescribeStacks(&cloudformation.DescribeStacksInput{
+		StackName: aws.String(stackName),
+	})
+	if err != nil {
+		return nil, stackStatusError, err
+	}
+
+	if resp.Stacks == nil || len(resp.Stacks) == 0 {
+		return nil, stackStatusNotFound, nil
+	}
+
+	return resp.Stacks[0], aws.StringValue(resp.Stacks[0].StackStatus), err
+}

--- a/aws/internal/service/cloudformation/waiter/status.go
+++ b/aws/internal/service/cloudformation/waiter/status.go
@@ -1,0 +1,69 @@
+package waiter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func StackSetOperationStatus(conn *cloudformation.CloudFormation, stackSetName, operationID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &cloudformation.DescribeStackSetOperationInput{
+			OperationId:  aws.String(operationID),
+			StackSetName: aws.String(stackSetName),
+		}
+
+		output, err := conn.DescribeStackSetOperation(input)
+
+		if tfawserr.ErrCodeEquals(err, cloudformation.ErrCodeOperationNotFoundException) {
+			return nil, cloudformation.StackSetOperationStatusRunning, nil
+		}
+
+		if err != nil {
+			return nil, cloudformation.StackSetOperationStatusFailed, err
+		}
+
+		if output == nil || output.StackSetOperation == nil {
+			return nil, cloudformation.StackSetOperationStatusRunning, nil
+		}
+
+		if aws.StringValue(output.StackSetOperation.Status) == cloudformation.StackSetOperationStatusFailed {
+			allResults := make([]string, 0)
+			listOperationResultsInput := &cloudformation.ListStackSetOperationResultsInput{
+				OperationId:  aws.String(operationID),
+				StackSetName: aws.String(stackSetName),
+			}
+
+			// TODO: PAGES
+			for {
+				listOperationResultsOutput, err := conn.ListStackSetOperationResults(listOperationResultsInput)
+
+				if err != nil {
+					return output.StackSetOperation, cloudformation.StackSetOperationStatusFailed, fmt.Errorf("error listing Operation (%s) errors: %s", operationID, err)
+				}
+
+				if listOperationResultsOutput == nil {
+					continue
+				}
+
+				for _, summary := range listOperationResultsOutput.Summaries {
+					allResults = append(allResults, fmt.Sprintf("Account (%s) Region (%s) Status (%s) Status Reason: %s", aws.StringValue(summary.Account), aws.StringValue(summary.Region), aws.StringValue(summary.Status), aws.StringValue(summary.StatusReason)))
+				}
+
+				if aws.StringValue(listOperationResultsOutput.NextToken) == "" {
+					break
+				}
+
+				listOperationResultsInput.NextToken = listOperationResultsOutput.NextToken
+			}
+
+			return output.StackSetOperation, cloudformation.StackSetOperationStatusFailed, fmt.Errorf("Operation (%s) Results:\n%s", operationID, strings.Join(allResults, "\n"))
+		}
+
+		return output.StackSetOperation, aws.StringValue(output.StackSetOperation.Status), nil
+	}
+}

--- a/aws/internal/service/cloudformation/waiter/status.go
+++ b/aws/internal/service/cloudformation/waiter/status.go
@@ -73,18 +73,19 @@ const (
 	stackStatusNotFound = "NotFound"
 )
 
-// stackStatus is not exported because we need a wrapper to return the last status value
-func stackStatus(conn *cloudformation.CloudFormation, stackName string) (interface{}, string, error) {
-	resp, err := conn.DescribeStacks(&cloudformation.DescribeStacksInput{
-		StackName: aws.String(stackName),
-	})
-	if err != nil {
-		return nil, stackStatusError, err
-	}
+func StackStatus(conn *cloudformation.CloudFormation, stackName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeStacks(&cloudformation.DescribeStacksInput{
+			StackName: aws.String(stackName),
+		})
+		if err != nil {
+			return nil, stackStatusError, err
+		}
 
-	if resp.Stacks == nil || len(resp.Stacks) == 0 {
-		return nil, stackStatusNotFound, nil
-	}
+		if resp.Stacks == nil || len(resp.Stacks) == 0 {
+			return nil, stackStatusNotFound, nil
+		}
 
-	return resp.Stacks[0], aws.StringValue(resp.Stacks[0].StackStatus), err
+		return resp.Stacks[0], aws.StringValue(resp.Stacks[0].StackStatus), err
+	}
 }

--- a/aws/internal/service/cloudformation/waiter/waiter.go
+++ b/aws/internal/service/cloudformation/waiter/waiter.go
@@ -196,10 +196,10 @@ func StackDeleted(conn *cloudformation.CloudFormation, stackName string, timeout
 	if lastStatus == cloudformation.StackStatusDeleteFailed {
 		reasons, err := GetCloudFormationFailures(stackName, conn)
 		if err != nil {
-			return stack, fmt.Errorf("Failed getting reasons for deletion failure: %w", err)
+			return stack, fmt.Errorf("failed to delete CloudFormation stack (%s). Got an error reading failure information: %w", lastStatus, err)
 		}
 
-		return stack, fmt.Errorf("%s: %q", lastStatus, reasons)
+		return stack, fmt.Errorf("failed to delete CloudFormation stack (%s): %q", lastStatus, reasons)
 	}
 
 	return stack, nil

--- a/aws/internal/service/cloudformation/waiter/waiter.go
+++ b/aws/internal/service/cloudformation/waiter/waiter.go
@@ -1,0 +1,42 @@
+package waiter
+
+import (
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	// Default maximum amount of time to wait for a StackSetInstance to be Created
+	StackSetInstanceCreatedDefaultTimeout = 30 * time.Minute
+
+	// Default maximum amount of time to wait for a StackSetInstance to be Updated
+	StackSetInstanceUpdatedDefaultTimeout = 30 * time.Minute
+
+	// Default maximum amount of time to wait for a StackSetInstance to be Deleted
+	StackSetInstanceDeletedDefaultTimeout = 30 * time.Minute
+
+	stackSetOperationDelay = 5 * time.Second
+)
+
+const (
+	// Default maximum amount of time to wait for a StackSet to be Updated
+	StackSetUpdatedDefaultTimeout = 30 * time.Minute
+)
+
+func StackSetOperationSucceeded(conn *cloudformation.CloudFormation, stackSetName, operationID string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{cloudformation.StackSetOperationStatusRunning},
+		Target:  []string{cloudformation.StackSetOperationStatusSucceeded},
+		Refresh: StackSetOperationStatus(conn, stackSetName, operationID),
+		Timeout: timeout,
+		Delay:   stackSetOperationDelay,
+	}
+
+	log.Printf("[DEBUG] Waiting for CloudFormation StackSet (%s) operation: %s", stackSetName, operationID)
+	_, err := stateConf.WaitForState()
+
+	return err
+}

--- a/aws/internal/service/cloudformation/waiter/waiter.go
+++ b/aws/internal/service/cloudformation/waiter/waiter.go
@@ -40,3 +40,124 @@ func StackSetOperationSucceeded(conn *cloudformation.CloudFormation, stackSetNam
 
 	return err
 }
+
+const (
+	// Default maximum amount of time to wait for a Stack to be Created
+	StackCreatedDefaultTimeout = 30 * time.Minute
+
+	stackCreatedMinTimeout = 1 * time.Second
+
+	// Default maximum amount of time to wait for a Stack to be Updated
+	StackUpdatedDefaultTimeout = 30 * time.Minute
+
+	stackUpdatedMinTimeout = 5 * time.Second
+
+	// Default maximum amount of time to wait for a Stack to be Deleted
+	StackDeletedDefaultTimeout = 30 * time.Minute
+
+	stackDeletedMinTimeout = 5 * time.Second
+)
+
+// StackCreated extends the waiter pattern to also return the last status
+func StackCreated(conn *cloudformation.CloudFormation, stackName string, timeout time.Duration) (*cloudformation.Stack, string, error) {
+	var lastStatus string
+
+	stateConf := resource.StateChangeConf{
+		Pending: []string{
+			cloudformation.StackStatusCreateInProgress,
+			cloudformation.StackStatusDeleteInProgress,
+			cloudformation.StackStatusRollbackInProgress,
+		},
+		Target: []string{
+			cloudformation.StackStatusCreateComplete,
+			cloudformation.StackStatusCreateFailed,
+			cloudformation.StackStatusDeleteComplete,
+			cloudformation.StackStatusDeleteFailed,
+			cloudformation.StackStatusRollbackComplete,
+			cloudformation.StackStatusRollbackFailed,
+		},
+		Timeout:    timeout,
+		MinTimeout: stackCreatedMinTimeout,
+		Refresh: func() (interface{}, string, error) {
+			var (
+				raw interface{}
+				err error
+			)
+			raw, lastStatus, err = stackStatus(conn, stackName)
+			return raw, lastStatus, err
+		},
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*cloudformation.Stack); ok {
+		return v, lastStatus, err
+	}
+	return nil, lastStatus, err
+}
+
+// StackUpdated extends the waiter pattern to also return the last status
+func StackUpdated(conn *cloudformation.CloudFormation, stackName string, timeout time.Duration) (*cloudformation.Stack, string, error) {
+	var lastStatus string
+
+	stateConf := resource.StateChangeConf{
+		Pending: []string{
+			cloudformation.StackStatusUpdateCompleteCleanupInProgress,
+			cloudformation.StackStatusUpdateInProgress,
+			cloudformation.StackStatusUpdateRollbackInProgress,
+			cloudformation.StackStatusUpdateRollbackCompleteCleanupInProgress,
+		},
+		Target: []string{
+			cloudformation.StackStatusCreateComplete,
+			cloudformation.StackStatusUpdateComplete,
+			cloudformation.StackStatusUpdateRollbackComplete,
+			cloudformation.StackStatusUpdateRollbackFailed,
+		},
+		Timeout:    timeout,
+		MinTimeout: stackUpdatedMinTimeout,
+		Refresh: func() (interface{}, string, error) {
+			var raw interface{}
+			var err error
+			raw, lastStatus, err = stackStatus(conn, stackName)
+			return raw, lastStatus, err
+		},
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*cloudformation.Stack); ok {
+		return v, lastStatus, err
+	}
+	return nil, lastStatus, err
+}
+
+// StackDeleted extends the waiter pattern to also return the last status
+func StackDeleted(conn *cloudformation.CloudFormation, stackName string, timeout time.Duration) (*cloudformation.Stack, string, error) {
+	var lastStatus string
+
+	stateConf := resource.StateChangeConf{
+		Pending: []string{
+			cloudformation.StackStatusDeleteInProgress,
+			cloudformation.StackStatusRollbackInProgress,
+		},
+		Target: []string{
+			cloudformation.StackStatusDeleteComplete,
+			cloudformation.StackStatusDeleteFailed,
+		},
+		Timeout:    timeout,
+		MinTimeout: stackDeletedMinTimeout,
+		Refresh: func() (interface{}, string, error) {
+			var raw interface{}
+			var err error
+			raw, lastStatus, err = stackStatus(conn, stackName)
+			return raw, lastStatus, err
+		},
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*cloudformation.Stack); ok {
+		return v, lastStatus, err
+	}
+	return nil, lastStatus, err
+}

--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -403,81 +402,4 @@ func resourceAwsCloudFormationStackDelete(d *schema.ResourceData, meta interface
 	log.Printf("[INFO] CloudFormation stack (%s) deleted", d.Id())
 
 	return nil
-}
-
-// TODO: remove
-func cfStackStateRefresh(conn *cloudformation.CloudFormation, stackId string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeStacks(&cloudformation.DescribeStacksInput{
-			StackName: aws.String(stackId),
-		})
-		if err != nil {
-			return nil, "", fmt.Errorf("error describing CloudFormation stacks: %s", err)
-		}
-
-		n := len(resp.Stacks)
-		switch n {
-		case 0:
-			return "", cloudformation.StackStatusDeleteComplete, nil
-
-		case 1:
-			stack := resp.Stacks[0]
-			return stack, aws.StringValue(stack.StackStatus), nil
-
-		default:
-			return nil, "", fmt.Errorf("found %d CloudFormation stacks for %s, expected 1", n, stackId)
-		}
-	}
-}
-
-// TODO: remove
-func waitForCloudFormationStackCreation(conn *cloudformation.CloudFormation, stackId string, timeout time.Duration) (string, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			cloudformation.StackStatusCreateInProgress,
-			cloudformation.StackStatusDeleteInProgress,
-			cloudformation.StackStatusRollbackInProgress,
-		},
-		Target: []string{
-			cloudformation.StackStatusCreateComplete,
-			cloudformation.StackStatusCreateFailed,
-			cloudformation.StackStatusDeleteComplete,
-			cloudformation.StackStatusDeleteFailed,
-			cloudformation.StackStatusRollbackComplete,
-			cloudformation.StackStatusRollbackFailed,
-		},
-		Refresh:    cfStackStateRefresh(conn, stackId),
-		Timeout:    timeout,
-		Delay:      10 * time.Second,
-		MinTimeout: 5 * time.Second,
-	}
-
-	v, err := stateConf.WaitForState()
-	if err != nil {
-		return "", err
-	}
-
-	return aws.StringValue(v.(*cloudformation.Stack).StackStatus), nil
-}
-
-// TODO: remove
-func waitForCloudFormationStackDeletion(conn *cloudformation.CloudFormation, stackId string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			cloudformation.StackStatusDeleteInProgress,
-			cloudformation.StackStatusRollbackInProgress,
-		},
-		Target: []string{
-			cloudformation.StackStatusDeleteComplete,
-			cloudformation.StackStatusDeleteFailed,
-		},
-		Refresh:    cfStackStateRefresh(conn, stackId),
-		Timeout:    timeout,
-		Delay:      10 * time.Second,
-		MinTimeout: 5 * time.Second,
-	}
-
-	_, err := stateConf.WaitForState()
-
-	return err
 }

--- a/aws/resource_aws_cloudformation_stack_set.go
+++ b/aws/resource_aws_cloudformation_stack_set.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -12,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudformation/waiter"
 )
 
 func resourceAwsCloudFormationStackSet() *schema.Resource {
@@ -26,7 +26,7 @@ func resourceAwsCloudFormationStackSet() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Update: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(waiter.StackSetUpdatedDefaultTimeout),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -240,7 +240,7 @@ func resourceAwsCloudFormationStackSetUpdate(d *schema.ResourceData, meta interf
 		return fmt.Errorf("error updating CloudFormation StackSet (%s): %s", d.Id(), err)
 	}
 
-	if err := waitForCloudFormationStackSetOperation(conn, d.Id(), aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
+	if err := waiter.StackSetOperationSucceeded(conn, d.Id(), aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return fmt.Errorf("error waiting for CloudFormation StackSet (%s) update: %s", d.Id(), err)
 	}
 

--- a/aws/resource_aws_cloudformation_stack_set_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_test.go
@@ -123,7 +123,7 @@ func TestAccAWSCloudFormationStackSet_disappears(t *testing.T) {
 				Config: testAccAWSCloudFormationStackSetConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
-					testAccCheckCloudFormationStackSetDisappears(&stackSet1),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudFormationStackSet(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -636,20 +636,6 @@ func testAccCheckAWSCloudFormationStackSetDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckCloudFormationStackSetDisappears(stackSet *cloudformation.StackSet) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).cfconn
-
-		input := &cloudformation.DeleteStackSetInput{
-			StackSetName: stackSet.StackSetName,
-		}
-
-		_, err := conn.DeleteStackSet(input)
-
-		return err
-	}
 }
 
 func testAccCheckCloudFormationStackSetNotRecreated(i, j *cloudformation.StackSet) resource.TestCheckFunc {

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -77,7 +78,7 @@ func testSweepCloudformationStacks(region string) error {
 
 func TestAccAWSCloudFormationStack_basic(t *testing.T) {
 	var stack cloudformation.Stack
-	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))
+	stackName := acctest.RandomWithPrefix("tf-acc-test-basic")
 	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -89,12 +90,89 @@ func TestAccAWSCloudFormationStack_basic(t *testing.T) {
 				Config: testAccAWSCloudFormationStackConfig(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckNoResourceAttr(resourceName, "on_failure"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStack_CreationFailure_DoNothing(t *testing.T) {
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCloudFormationStackConfigCreationFailure(stackName, cloudformation.OnFailureDoNothing),
+				ExpectError: regexp.MustCompile(`failed to create CloudFormation stack \(CREATE_FAILED\).*The following resource\(s\) failed to create.*This is not a valid CIDR block`),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStack_CreationFailure_Delete(t *testing.T) {
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCloudFormationStackConfigCreationFailure(stackName, cloudformation.OnFailureDelete),
+				ExpectError: regexp.MustCompile(`failed to create CloudFormation stack, delete requested \(DELETE_COMPLETE\).*The following resource\(s\) failed to create.*This is not a valid CIDR block`),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStack_CreationFailure_Rollback(t *testing.T) {
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCloudFormationStackConfigCreationFailure(stackName, cloudformation.OnFailureRollback),
+				ExpectError: regexp.MustCompile(`failed to create CloudFormation stack, rollback requested \(ROLLBACK_COMPLETE\).*The following resource\(s\) failed to create.*This is not a valid CIDR block`),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStack_UpdateFailure(t *testing.T) {
+	var stack cloudformation.Stack
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack.test"
+
+	vpcCidrInitial := "10.0.0.0/16"
+	vpcCidrInvalid := "1000.0.0.0/16"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackConfig_withParams(stackName, vpcCidrInitial),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
+				),
+			},
+			{
+				Config:      testAccAWSCloudFormationStackConfig_withParams(stackName, vpcCidrInvalid),
+				ExpectError: regexp.MustCompile(`failed to update CloudFormation stack \(UPDATE_ROLLBACK_COMPLETE\).*This is not a valid CIDR block`),
 			},
 		},
 	})
@@ -236,15 +314,20 @@ func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 	stackName := fmt.Sprintf("tf-acc-test-with-params-%s", acctest.RandString(10))
 	resourceName := "aws_cloudformation_stack.test"
 
+	vpcCidrInitial := "10.0.0.0/16"
+	vpcCidrUpdated := "12.0.0.0/16"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationStackConfig_withParams(stackName),
+				Config: testAccAWSCloudFormationStackConfig_withParams(stackName, vpcCidrInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.VpcCIDR", vpcCidrInitial),
 				),
 			},
 			{
@@ -254,9 +337,11 @@ func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"on_failure", "parameters"},
 			},
 			{
-				Config: testAccAWSCloudFormationStackConfig_withParams_modified(stackName),
+				Config: testAccAWSCloudFormationStackConfig_withParams(stackName, vpcCidrUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.VpcCIDR", vpcCidrUpdated),
 				),
 			},
 		},
@@ -491,6 +576,41 @@ STACK
 `, stackName)
 }
 
+func testAccAWSCloudFormationStackConfigCreationFailure(stackName, onFailure string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack" "test" {
+  name       = %[1]q
+  on_failure = %[2]q
+
+  template_body = <<STACK
+{
+  "Resources" : {
+    "MyVPC": {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : "1000.0.0.0/16",
+        "Tags" : [
+          {"Key": "Name", "Value": "Primary_CF_VPC"}
+        ]
+      }
+    }
+  },
+  "Outputs" : {
+    "DefaultSgId" : {
+      "Description": "The ID of default security group",
+      "Value" : { "Fn::GetAtt" : [ "MyVPC", "DefaultSecurityGroup" ]}
+    },
+    "VpcID" : {
+      "Description": "The VPC ID",
+      "Value" : { "Ref" : "MyVPC" }
+    }
+  }
+}
+STACK
+}
+`, stackName, onFailure)
+}
+
 func testAccAWSCloudFormationStackConfig_yaml(stackName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
@@ -692,7 +812,8 @@ func testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(stackN
 		policyBody)
 }
 
-var tpl_testAccAWSCloudFormationStackConfig_withParams = `
+func testAccAWSCloudFormationStackConfig_withParams(stackName, cidr string) string {
+	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
   name = "%[1]s"
   parameters = {
@@ -723,20 +844,7 @@ STACK
   on_failure         = "DELETE"
   timeout_in_minutes = 1
 }
-`
-
-func testAccAWSCloudFormationStackConfig_withParams(stackName string) string {
-	return fmt.Sprintf(
-		tpl_testAccAWSCloudFormationStackConfig_withParams,
-		stackName,
-		"10.0.0.0/16")
-}
-
-func testAccAWSCloudFormationStackConfig_withParams_modified(stackName string) string {
-	return fmt.Sprintf(
-		tpl_testAccAWSCloudFormationStackConfig_withParams,
-		stackName,
-		"12.0.0.0/16")
+`, stackName, cidr)
 }
 
 func testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, bucketKey, vpcCidr string) string {

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -114,7 +114,7 @@ func TestAccAWSCloudFormationStack_disappears(t *testing.T) {
 				Config: testAccAWSCloudFormationStackConfig(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists(resourceName, &stack),
-					testAccCheckCloudFormationStackDisappears(&stack),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudFormationStack(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -425,7 +425,7 @@ func testAccCheckAWSCloudFormationDestroy(s *terraform.State) error {
 		}
 
 		for _, s := range resp.Stacks {
-			if *s.StackId == rs.Primary.ID && *s.StackStatus != "DELETE_COMPLETE" {
+			if aws.StringValue(s.StackId) == rs.Primary.ID && aws.StringValue(s.StackStatus) != cloudformation.StackStatusDeleteComplete {
 				return fmt.Errorf("CloudFormation stack still exists: %q", rs.Primary.ID)
 			}
 		}

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudformation/waiter"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
@@ -285,7 +286,7 @@ func TestAccAWSS3Bucket_tagsWithSystemTags(t *testing.T) {
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 
-	var stackId string
+	var stackID string
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -296,16 +297,18 @@ func TestAccAWSS3Bucket_tagsWithSystemTags(t *testing.T) {
 				// Tear down CF stack.
 				conn := testAccProvider.Meta().(*AWSClient).cfconn
 
+				requestToken := resource.UniqueId()
 				req := &cloudformation.DeleteStackInput{
-					StackName: aws.String(stackId),
+					StackName:          aws.String(stackID),
+					ClientRequestToken: aws.String(requestToken),
 				}
 
-				log.Printf("[DEBUG] Deleting CloudFormation stack: %#v", req)
+				log.Printf("[DEBUG] Deleting CloudFormation stack: %s", req)
 				if _, err := conn.DeleteStack(req); err != nil {
-					return fmt.Errorf("Error deleting CloudFormation stack: %s", err)
+					return fmt.Errorf("error deleting CloudFormation stack: %w", err)
 				}
 
-				if err := waitForCloudFormationStackDeletion(conn, stackId, 10*time.Minute); err != nil {
+				if _, err := waiter.StackDeleted(conn, stackID, requestToken, 10*time.Minute); err != nil {
 					return fmt.Errorf("Error waiting for CloudFormation stack deletion: %s", err)
 				}
 
@@ -319,7 +322,7 @@ func TestAccAWSS3Bucket_tagsWithSystemTags(t *testing.T) {
 					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					testAccCheckAWSS3DestroyBucket(resourceName),
-					testAccCheckAWSS3BucketCreateViaCloudFormation(bucketName, &stackId),
+					testAccCheckAWSS3BucketCreateViaCloudFormation(bucketName, &stackID),
 				),
 			},
 			{
@@ -2554,7 +2557,7 @@ func testAccCheckAWSS3BucketAddObjectsWithLegalHold(n string, keys ...string) re
 }
 
 // Create an S3 bucket via a CF stack so that it has system tags.
-func testAccCheckAWSS3BucketCreateViaCloudFormation(n string, stackId *string) resource.TestCheckFunc {
+func testAccCheckAWSS3BucketCreateViaCloudFormation(n string, stackID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).cfconn
 		stackName := acctest.RandomWithPrefix("tf-acc-test-s3tags")
@@ -2569,26 +2572,29 @@ func testAccCheckAWSS3BucketCreateViaCloudFormation(n string, stackId *string) r
   }
 }`, n)
 
+		requestToken := resource.UniqueId()
 		req := &cloudformation.CreateStackInput{
-			StackName:    aws.String(stackName),
-			TemplateBody: aws.String(templateBody),
+			StackName:          aws.String(stackName),
+			TemplateBody:       aws.String(templateBody),
+			ClientRequestToken: aws.String(requestToken),
 		}
 
-		log.Printf("[DEBUG] Creating CloudFormation stack: %#v", req)
+		log.Printf("[DEBUG] Creating CloudFormation stack: %s", req)
 		resp, err := conn.CreateStack(req)
 		if err != nil {
-			return fmt.Errorf("Error creating CloudFormation stack: %s", err)
+			return fmt.Errorf("error creating CloudFormation stack: %w", err)
 		}
 
-		status, err := waitForCloudFormationStackCreation(conn, aws.StringValue(resp.StackId), 10*time.Minute)
+		stack, err := waiter.StackCreated(conn, aws.StringValue(resp.StackId), requestToken, 10*time.Minute)
 		if err != nil {
-			return fmt.Errorf("Error waiting for CloudFormation stack creation: %s", err)
+			return fmt.Errorf("Error waiting for CloudFormation stack creation: %w", err)
 		}
+		status := aws.StringValue(stack.StackStatus)
 		if status != cloudformation.StackStatusCreateComplete {
 			return fmt.Errorf("Invalid CloudFormation stack creation status: %s", status)
 		}
 
-		*stackId = aws.StringValue(resp.StackId)
+		*stackID = aws.StringValue(resp.StackId)
 		return nil
 	}
 }


### PR DESCRIPTION
Add `waiter` function for CloudFormation Stack and CloudFormation Stack Set operations

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudFormationStackSetInstance_\|TestAccAWSCloudFormationStackSet_\|TestAccAWSS3Bucket_tagsWithSystemTags'

--- PASS: TestAccAWSCloudFormationStack_CreationFailure_Delete (194.51s)
--- PASS: TestAccAWSCloudFormationStack_CreationFailure_Rollback (218.42s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (288.99s)
--- PASS: TestAccAWSCloudFormationStack_disappears (314.48s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (348.60s)
--- PASS: TestAccAWSCloudFormationStack_CreationFailure_DoNothing (174.23s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (387.48s)
--- PASS: TestAccAWSCloudFormationStack_defaultParams (402.39s)
--- PASS: TestAccAWSCloudFormationStack_yaml (422.50s)
--- PASS: TestAccAWSCloudFormationStack_withTransform (424.94s)
--- PASS: TestAccAWSCloudFormationStack_UpdateFailure (437.46s)
--- PASS: TestAccAWSCloudFormationStack_basic (267.91s)
--- PASS: TestAccAWSCloudFormationStack_allAttributes (499.19s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (519.21s)
--- PASS: TestAccAWSCloudFormationStack_withParams (563.59s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (567.65s)

--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears (382.56s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (386.45s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_basic (456.71s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_RetainStack (634.84s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (715.05s)

--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (610.68s)
```
