### PR TITLE
Add aws_codestarconnections_connection resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -512,6 +512,7 @@ func Provider() *schema.Provider {
 			"aws_codebuild_webhook":                                   resourceAwsCodeBuildWebhook(),
 			"aws_codepipeline":                                        resourceAwsCodePipeline(),
 			"aws_codepipeline_webhook":                                resourceAwsCodePipelineWebhook(),
+			"aws_codestarconnections_connection":                      resourceAwsCodeStarConnectionsConnection(),
 			"aws_codestarnotifications_notification_rule":             resourceAwsCodeStarNotificationsNotificationRule(),
 			"aws_cur_report_definition":                               resourceAwsCurReportDefinition(),
 			"aws_customer_gateway":                                    resourceAwsCustomerGateway(),

--- a/aws/resource_aws_codestarconnections_connection.go
+++ b/aws/resource_aws_codestarconnections_connection.go
@@ -30,7 +30,7 @@ func resourceAwsCodeStarConnectionsConnection() *schema.Resource {
 				Computed: true,
 			},
 
-			"connection_name": {
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -50,7 +50,7 @@ func resourceAwsCodeStarConnectionsConnectionCreate(d *schema.ResourceData, meta
 	conn := meta.(*AWSClient).codestarconnectionsconn
 
 	params := &codestarconnections.CreateConnectionInput{
-		ConnectionName: aws.String(d.Get("connection_name").(string)),
+		ConnectionName: aws.String(d.Get("name").(string)),
 		ProviderType:   aws.String(d.Get("provider_type").(string)),
 	}
 
@@ -82,7 +82,7 @@ func resourceAwsCodeStarConnectionsConnectionRead(d *schema.ResourceData, meta i
 
 	d.SetId(aws.StringValue(rule.Connection.ConnectionArn))
 	d.Set("arn", rule.Connection.ConnectionArn)
-	d.Set("connection_name", rule.Connection.ConnectionName)
+	d.Set("name", rule.Connection.ConnectionName)
 	d.Set("connection_status", rule.Connection.ConnectionStatus)
 	d.Set("provider_type", rule.Connection.ProviderType)
 

--- a/aws/resource_aws_codestarconnections_connection.go
+++ b/aws/resource_aws_codestarconnections_connection.go
@@ -1,0 +1,112 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codestarconnections"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsCodeStarConnectionsConnection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCodeStarConnectionsConnectionCreate,
+		Read:   resourceAwsCodeStarConnectionsConnectionRead,
+		Delete: resourceAwsCodeStarConnectionsConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"connection_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"connection_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"connection_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"provider_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					codestarconnections.ProviderTypeBitbucket,
+				}, false),
+			},
+		},
+	}
+}
+
+func resourceAwsCodeStarConnectionsConnectionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codestarconnectionsconn
+
+	params := &codestarconnections.CreateConnectionInput{
+		ConnectionName: aws.String(d.Get("connection_name").(string)),
+		ProviderType:   aws.String(d.Get("provider_type").(string)),
+	}
+
+	res, err := conn.CreateConnection(params)
+	if err != nil {
+		return fmt.Errorf("error creating codestar connection: %s", err)
+	}
+
+	d.SetId(aws.StringValue(res.ConnectionArn))
+
+	return resourceAwsCodeStarConnectionsConnectionRead(d, meta)
+}
+
+func resourceAwsCodeStarConnectionsConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codestarconnectionsconn
+
+	rule, err := conn.GetConnection(&codestarconnections.GetConnectionInput{
+		ConnectionArn: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		if isAWSErr(err, codestarconnections.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] codestar connection (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading codestar connection: %s", err)
+	}
+
+	d.SetId(aws.StringValue(rule.Connection.ConnectionArn))
+	d.Set("arn", rule.Connection.ConnectionArn)
+	d.Set("connection_arn", rule.Connection.ConnectionArn)
+	d.Set("connection_name", rule.Connection.ConnectionName)
+	d.Set("connection_status", rule.Connection.ConnectionStatus)
+	d.Set("provider_type", rule.Connection.ProviderType)
+
+	return nil
+}
+
+func resourceAwsCodeStarConnectionsConnectionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codestarconnectionsconn
+
+	_, err := conn.DeleteConnection(&codestarconnections.DeleteConnectionInput{
+		ConnectionArn: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return fmt.Errorf("error deleting codestar connection: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_codestarconnections_connection.go
+++ b/aws/resource_aws_codestarconnections_connection.go
@@ -25,11 +25,6 @@ func resourceAwsCodeStarConnectionsConnection() *schema.Resource {
 				Computed: true,
 			},
 
-			"connection_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"connection_status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -87,7 +82,6 @@ func resourceAwsCodeStarConnectionsConnectionRead(d *schema.ResourceData, meta i
 
 	d.SetId(aws.StringValue(rule.Connection.ConnectionArn))
 	d.Set("arn", rule.Connection.ConnectionArn)
-	d.Set("connection_arn", rule.Connection.ConnectionArn)
 	d.Set("connection_name", rule.Connection.ConnectionName)
 	d.Set("connection_status", rule.Connection.ConnectionStatus)
 	d.Set("provider_type", rule.Connection.ProviderType)

--- a/aws/resource_aws_codestarconnections_connection.go
+++ b/aws/resource_aws_codestarconnections_connection.go
@@ -45,9 +45,7 @@ func resourceAwsCodeStarConnectionsConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					codestarconnections.ProviderTypeBitbucket,
-				}, false),
+				ValidateFunc: validation.StringInSlice(codestarconnections.ProviderType_Values(), false),
 			},
 		},
 	}

--- a/aws/resource_aws_codestarconnections_connection.go
+++ b/aws/resource_aws_codestarconnections_connection.go
@@ -37,9 +37,9 @@ func resourceAwsCodeStarConnectionsConnection() *schema.Resource {
 			},
 
 			"provider_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(codestarconnections.ProviderType_Values(), false),
 			},
 		},

--- a/aws/resource_aws_codestarconnections_connection.go
+++ b/aws/resource_aws_codestarconnections_connection.go
@@ -101,6 +101,10 @@ func resourceAwsCodeStarConnectionsConnectionDelete(d *schema.ResourceData, meta
 	})
 
 	if err != nil {
+		if isAWSErr(err, codestarconnections.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+
 		return fmt.Errorf("error deleting CodeStar connection: %w", err)
 	}
 

--- a/aws/resource_aws_codestarconnections_connection.go
+++ b/aws/resource_aws_codestarconnections_connection.go
@@ -80,6 +80,10 @@ func resourceAwsCodeStarConnectionsConnectionRead(d *schema.ResourceData, meta i
 		return fmt.Errorf("error reading CodeStar connection: %s", err)
 	}
 
+	if rule == nil || rule.Connection == nil {
+		return fmt.Errorf("error reading CodeStar connection (%s): empty response", d.Id())
+	}
+
 	d.SetId(aws.StringValue(rule.Connection.ConnectionArn))
 	d.Set("arn", rule.Connection.ConnectionArn)
 	d.Set("name", rule.Connection.ConnectionName)

--- a/aws/resource_aws_codestarconnections_connection.go
+++ b/aws/resource_aws_codestarconnections_connection.go
@@ -54,12 +54,12 @@ func resourceAwsCodeStarConnectionsConnectionCreate(d *schema.ResourceData, meta
 		ProviderType:   aws.String(d.Get("provider_type").(string)),
 	}
 
-	res, err := conn.CreateConnection(params)
+	resp, err := conn.CreateConnection(params)
 	if err != nil {
 		return fmt.Errorf("error creating CodeStar connection: %w", err)
 	}
 
-	d.SetId(aws.StringValue(res.ConnectionArn))
+	d.SetId(aws.StringValue(resp.ConnectionArn))
 
 	return resourceAwsCodeStarConnectionsConnectionRead(d, meta)
 }
@@ -67,7 +67,7 @@ func resourceAwsCodeStarConnectionsConnectionCreate(d *schema.ResourceData, meta
 func resourceAwsCodeStarConnectionsConnectionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codestarconnectionsconn
 
-	rule, err := conn.GetConnection(&codestarconnections.GetConnectionInput{
+	resp, err := conn.GetConnection(&codestarconnections.GetConnectionInput{
 		ConnectionArn: aws.String(d.Id()),
 	})
 
@@ -80,15 +80,15 @@ func resourceAwsCodeStarConnectionsConnectionRead(d *schema.ResourceData, meta i
 		return fmt.Errorf("error reading CodeStar connection: %s", err)
 	}
 
-	if rule == nil || rule.Connection == nil {
+	if resp == nil || resp.Connection == nil {
 		return fmt.Errorf("error reading CodeStar connection (%s): empty response", d.Id())
 	}
 
-	d.SetId(aws.StringValue(rule.Connection.ConnectionArn))
-	d.Set("arn", rule.Connection.ConnectionArn)
-	d.Set("name", rule.Connection.ConnectionName)
-	d.Set("connection_status", rule.Connection.ConnectionStatus)
-	d.Set("provider_type", rule.Connection.ProviderType)
+	d.SetId(aws.StringValue(resp.Connection.ConnectionArn))
+	d.Set("arn", resp.Connection.ConnectionArn)
+	d.Set("name", resp.Connection.ConnectionName)
+	d.Set("connection_status", resp.Connection.ConnectionStatus)
+	d.Set("provider_type", resp.Connection.ProviderType)
 
 	return nil
 }

--- a/aws/resource_aws_codestarconnections_connection.go
+++ b/aws/resource_aws_codestarconnections_connection.go
@@ -56,7 +56,7 @@ func resourceAwsCodeStarConnectionsConnectionCreate(d *schema.ResourceData, meta
 
 	res, err := conn.CreateConnection(params)
 	if err != nil {
-		return fmt.Errorf("error creating codestar connection: %s", err)
+		return fmt.Errorf("error creating CodeStar connection: %w", err)
 	}
 
 	d.SetId(aws.StringValue(res.ConnectionArn))
@@ -73,11 +73,11 @@ func resourceAwsCodeStarConnectionsConnectionRead(d *schema.ResourceData, meta i
 
 	if err != nil {
 		if isAWSErr(err, codestarconnections.ErrCodeResourceNotFoundException, "") {
-			log.Printf("[WARN] codestar connection (%s) not found, removing from state", d.Id())
+			log.Printf("[WARN] CodeStar connection (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading codestar connection: %s", err)
+		return fmt.Errorf("error reading CodeStar connection: %s", err)
 	}
 
 	d.SetId(aws.StringValue(rule.Connection.ConnectionArn))
@@ -97,7 +97,7 @@ func resourceAwsCodeStarConnectionsConnectionDelete(d *schema.ResourceData, meta
 	})
 
 	if err != nil {
-		return fmt.Errorf("error deleting codestar connection: %s", err)
+		return fmt.Errorf("error deleting CodeStar connection: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_codestarconnections_connection_test.go
+++ b/aws/resource_aws_codestarconnections_connection_test.go
@@ -106,8 +106,8 @@ func testAccCheckAWSCodeStarConnectionsConnectionDestroy(s *terraform.State) err
 func testAccAWSCodeStarConnectionsConnectionConfigBasic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codestarconnections_connection" "test" {
-  name = %[1]q
-  provider_type   = "Bitbucket"
+  name          = %[1]q
+  provider_type = "Bitbucket"
 }
 `, rName)
 }

--- a/aws/resource_aws_codestarconnections_connection_test.go
+++ b/aws/resource_aws_codestarconnections_connection_test.go
@@ -26,7 +26,6 @@ func TestAccAWSCodeStarConnectionsConnection_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccMatchResourceAttrRegionalARN(resourceName, "id", "codestar-connections", regexp.MustCompile("connection/.+")),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codestar-connections", regexp.MustCompile("connection/.+")),
-					testAccMatchResourceAttrRegionalARN(resourceName, "connection_arn", "codestar-connections", regexp.MustCompile("connection/.+")),
 					resource.TestCheckResourceAttr(resourceName, "provider_type", codestarconnections.ProviderTypeBitbucket),
 					resource.TestCheckResourceAttr(resourceName, "connection_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "connection_status", codestarconnections.ConnectionStatusPending),

--- a/aws/resource_aws_codestarconnections_connection_test.go
+++ b/aws/resource_aws_codestarconnections_connection_test.go
@@ -1,0 +1,70 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codestarconnections"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSCodeStarConnectionsConnection_Basic(t *testing.T) {
+	resourceName := "aws_codestarconnections_connection.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeStarConnectionsConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeStarConnectionsConnectionConfigBasic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccMatchResourceAttrRegionalARN(resourceName, "id", "codestar-connections", regexp.MustCompile("connection/.+")),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codestar-connections", regexp.MustCompile("connection/.+")),
+					testAccMatchResourceAttrRegionalARN(resourceName, "connection_arn", "codestar-connections", regexp.MustCompile("connection/.+")),
+					resource.TestCheckResourceAttr(resourceName, "provider_type", codestarconnections.ProviderTypeBitbucket),
+					resource.TestCheckResourceAttr(resourceName, "connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "connection_status", codestarconnections.ConnectionStatusPending),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCodeStarConnectionsConnectionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).codestarconnectionsconn
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "aws_codestarconnections_connection":
+			_, err := conn.GetConnection(&codestarconnections.GetConnectionInput{
+				ConnectionArn: aws.String(rs.Primary.ID),
+			})
+
+			if err != nil && !isAWSErr(err, codestarconnections.ErrCodeResourceNotFoundException, "") {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSCodeStarConnectionsConnectionConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codestarconnections_connection" "test" {
+  connection_name = %[1]q
+  provider_type   = "Bitbucket"
+}
+`, rName)
+}

--- a/aws/resource_aws_codestarconnections_connection_test.go
+++ b/aws/resource_aws_codestarconnections_connection_test.go
@@ -27,7 +27,7 @@ func TestAccAWSCodeStarConnectionsConnection_Basic(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "id", "codestar-connections", regexp.MustCompile("connection/.+")),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codestar-connections", regexp.MustCompile("connection/.+")),
 					resource.TestCheckResourceAttr(resourceName, "provider_type", codestarconnections.ProviderTypeBitbucket),
-					resource.TestCheckResourceAttr(resourceName, "connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "connection_status", codestarconnections.ConnectionStatusPending),
 				),
 			},
@@ -62,7 +62,7 @@ func testAccCheckAWSCodeStarConnectionsConnectionDestroy(s *terraform.State) err
 func testAccAWSCodeStarConnectionsConnectionConfigBasic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codestarconnections_connection" "test" {
-  connection_name = %[1]q
+  name = %[1]q
   provider_type   = "Bitbucket"
 }
 `, rName)

--- a/website/docs/r/codestarconnections_connection.markdown
+++ b/website/docs/r/codestarconnections_connection.markdown
@@ -1,0 +1,171 @@
+---
+subcategory: "CodeStar Connections"
+layout: "aws"
+page_title: "AWS: aws_codestarconnections_connection"
+description: |-
+  Provides a CodeStar Connection
+---
+
+# Resource: aws_codestarconnections_connection
+
+Provides a CodeStar Connection.
+
+## Example Usage
+
+```hcl
+resource "aws_s3_bucket" "codepipeline_bucket" {
+  bucket = "tf-codestarconnections-codepipeline-bucket"
+  acl    = "private"
+}
+
+resource "aws_codestarconnections_connection" "example" {
+  connection_name = "example-connection"
+  provider_type   = "Bitbucket"
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name               = "test-role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codepipeline.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  name   = "codepipeline_policy"
+  role   = aws_iam_role.codepipeline_role.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "codestar-connections:UseConnection",
+      "Resource": "${aws_codestarconnections_connection.example.arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject*",
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.codepipeline_bucket.arn}",
+        "${aws_s3_bucket.codepipeline_bucket.arn}/*"
+      ]
+    },
+    {
+      "Action": [
+          "codebuild:BatchGetBuilds",
+          "codebuild:StartBuild"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+data "aws_kms_alias" "s3kmskey" {
+  name = "alias/aws/s3"
+}
+
+resource "aws_codepipeline" "codepipeline" {
+  name     = "tf-test-pipeline"
+  role_arn = aws_iam_role.codepipeline_role.arn
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+    type     = "S3"
+    encryption_key {
+      id   = data.aws_kms_alias.s3kmskey.arn
+      type = "KMS"
+    }
+  }
+  stage {
+    name = "Source"
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["source_output"]
+      configuration = {
+        Owner         = "my-organization"
+        ConnectionArn = aws_codestarconnections_connection.example.arn
+        Repo          = "foo/test"
+        Branch        = "master"
+      }
+    }
+  }
+  stage {
+    name = "Build"
+    action {
+      name             = "Build"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["source_output"]
+      output_artifacts = ["build_output"]
+      version          = "1"
+      configuration = {
+        ProjectName = "test"
+      }
+    }
+  }
+  stage {
+    name = "Deploy"
+    action {
+      name            = "Deploy"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "CloudFormation"
+      input_artifacts = ["build_output"]
+      version         = "1"
+      configuration = {
+        ActionMode     = "REPLACE_ON_FAILURE"
+        Capabilities   = "CAPABILITY_AUTO_EXPAND,CAPABILITY_IAM"
+        OutputFileName = "CreateStackOutput.json"
+        StackName      = "MyStack"
+        TemplatePath   = "build_output::sam-templated.yaml"
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `connection_name` - (Required) The name of the connection to be created. The name must be unique in the calling AWS account.
+* `provider_type` - (Required) The name of the external provider where your third-party code repository is configured. Currently, the valid provider type is `Bitbucket`, `GitHub`, or `GitHubEnterpriseServer`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The codestar connection ARN.
+* `arn` - The codestar connection ARN.
+* `connection_arn` - The codestar connection ARN.
+* `connection_status` - The codestar connection status. Possible values are `PENDING`, `AVAILABLE` and `ERROR`.
+
+## Import
+
+CodeStar connections can be imported using the ARN, e.g.
+
+```
+$ terraform import aws_codestarconnections_connection.test-connection arn:aws:codestar-connections:us-west-1:0123456789:connection/79d4d357-a2ee-41e4-b350-2fe39ae59448
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/15453, https://github.com/hashicorp/terraform-provider-aws/pull/15960
Closes #12637
Closes #11389

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_codestarconnections_connection`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeStarConnectionsConnection_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeStarConnectionsConnection_* -timeout 120m
=== RUN   TestAccAWSCodeStarConnectionsConnection_Basic
=== PAUSE TestAccAWSCodeStarConnectionsConnection_Basic
=== RUN   TestAccAWSCodeStarConnectionsConnection_disappears
=== PAUSE TestAccAWSCodeStarConnectionsConnection_disappears
=== CONT  TestAccAWSCodeStarConnectionsConnection_disappears
=== CONT  TestAccAWSCodeStarConnectionsConnection_Basic
--- PASS: TestAccAWSCodeStarConnectionsConnection_disappears (36.78s)
--- PASS: TestAccAWSCodeStarConnectionsConnection_Basic (49.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	51.265s
```

This is the second part of a PR to add `aws_codestarconnections_connection` resource (the first part: https://github.com/hashicorp/terraform-provider-aws/pull/15960). This PR originally came from https://github.com/hashicorp/terraform-provider-aws/pull/12637. Thank you for your review!