### PR TITLE
Add support for protocol version to aws_lb_target_group

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -79,6 +79,21 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				}, true),
 			},
 
+			"protocol_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "HTTP1",
+				StateFunc: func(v interface{}) string {
+					return strings.ToUpper(v.(string))
+				},
+				ValidateFunc: validation.StringInSlice([]string{
+					"HTTP1",
+					"HTTP2",
+					"GRPC",
+				}, true),
+				DiffSuppressFunc: suppressIfTargetType(elbv2.TargetTypeEnumLambda),
+			},
+
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -292,6 +307,7 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 		params.Port = aws.Int64(int64(d.Get("port").(int)))
 		params.Protocol = aws.String(d.Get("protocol").(string))
 		params.VpcId = aws.String(d.Get("vpc_id").(string))
+		params.ProtocolVersion = aws.String(d.Get("protocol_version").(string))
 	}
 
 	if healthChecks := d.Get("health_check").([]interface{}); len(healthChecks) == 1 {

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -1241,7 +1241,7 @@ func testAccCheckAWSLBTargetGroupProtocolVersion(n string, expectedProtocol stri
 
 		actual := *describe.TargetGroups[0].ProtocolVersion
 		if actual != expectedProtocol {
-			return errors.New(fmt.Sprintf("Target Group Protocol Version %s is not %s", actual, expectedProtocol))
+			return fmt.Errorf("Target Group Protocol Version %s is not %s", actual, expectedProtocol)
 		}
 
 		return nil

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -2216,7 +2216,7 @@ func testAccALB_protocol_version(name string, protocolVersion string) string {
 resource "aws_lb_target_group" "test" {
   name             = "%s"
   port             = 443
-  protocol 		   = "HTTP"
+  protocol         = "HTTP"
   protocol_version = "%s"
   vpc_id           = aws_vpc.test.id
 

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -2214,11 +2214,11 @@ resource "aws_vpc" "test" {
 func testAccALB_protocol_version(name string, protocolVersion string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
-  port     = 443
-  protocol = "HTTP"
+  name             = "%s"
+  port             = 443
+  protocol 		   = "HTTP"
   protocol_version = "%s"
-  vpc_id   = aws_vpc.test.id
+  vpc_id           = aws_vpc.test.id
 
   deregistration_delay = 200
   slow_start           = 0


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

AWS released support for gRPC and HTTP/2 for ALBs by adding a
ProtocolVersion property to ALB target groups. This property
specifies what traffic protocol the backends in the target group
receive. The property defaults to HTTP1 (legacy behavior).

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
Closes #15929 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lb_target_group: Add protocol_version
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLBTargetGroup_protocol_version'                                                                                                                       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBTargetGroup_protocol_version -timeout 120m
=== RUN   TestAccAWSLBTargetGroup_protocol_version
=== PAUSE TestAccAWSLBTargetGroup_protocol_version
=== CONT  TestAccAWSLBTargetGroup_protocol_version
--- PASS: TestAccAWSLBTargetGroup_protocol_version (75.23s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       78.749s

$ make testacc TESTARGS='-run=TestAccAWSLBTargetGroup_defaults_application'                                                                                                                   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBTargetGroup_defaults_application -timeout 120m
=== RUN   TestAccAWSLBTargetGroup_defaults_application
=== PAUSE TestAccAWSLBTargetGroup_defaults_application
=== CONT  TestAccAWSLBTargetGroup_defaults_application
--- PASS: TestAccAWSLBTargetGroup_defaults_application (41.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       45.358s
...
```
