### PR TITLE
r/aws_kinesis_analytics_application: Correct resource update

### DIFF
--- a/aws/internal/service/kinesisanalytics/finder/finder.go
+++ b/aws/internal/service/kinesisanalytics/finder/finder.go
@@ -1,0 +1,20 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+)
+
+// ApplicationByName returns the application corresponding to the specified name.
+func ApplicationByName(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
+	input := &kinesisanalytics.DescribeApplicationInput{
+		ApplicationName: aws.String(name),
+	}
+
+	output, err := conn.DescribeApplication(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output.ApplicationDetail, nil
+}

--- a/aws/internal/service/kinesisanalytics/waiter/status.go
+++ b/aws/internal/service/kinesisanalytics/waiter/status.go
@@ -3,34 +3,27 @@ package waiter
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/finder"
 )
 
 const (
-	// ApplicationStatus NotFound
-	ApplicationStatusNotFound = "NotFound"
-
-	// ApplicationStatus Unknown
-	ApplicationStatusUnknown = "Unknown"
+	applicationStatusNotFound = "NotFound"
+	applicationStatusUnknown  = "Unknown"
 )
 
 // ApplicationStatus fetches the Application and its Status
-func ApplicationStatus(conn *kinesisanalytics.KinesisAnalytics, applicationName string) resource.StateRefreshFunc {
+func ApplicationStatus(conn *kinesisanalytics.KinesisAnalytics, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &kinesisanalytics.DescribeApplicationInput{
-			ApplicationName: aws.String(applicationName),
-		}
+		application, err := finder.ApplicationByName(conn, name)
 
-		output, err := conn.DescribeApplication(input)
+		if tfawserr.ErrCodeEquals(err, kinesisanalytics.ErrCodeResourceNotFoundException) {
+			return nil, applicationStatusNotFound, nil
+		}
 
 		if err != nil {
-			return nil, ApplicationStatusUnknown, err
-		}
-
-		application := output.ApplicationDetail
-
-		if application == nil {
-			return application, ApplicationStatusNotFound, nil
+			return nil, applicationStatusUnknown, err
 		}
 
 		return application, aws.StringValue(application.ApplicationStatus), nil

--- a/aws/internal/service/kinesisanalytics/waiter/waiter.go
+++ b/aws/internal/service/kinesisanalytics/waiter/waiter.go
@@ -4,21 +4,19 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-const (
-	// Maximum amount of time to wait for an Application to be deleted
-	ApplicationDeletedTimeout = 20 * time.Minute
-)
-
-// ApplicationDeleted waits for an Application to be deleted
-func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, applicationName string) (*kinesisanalytics.ApplicationSummary, error) {
+// ApplicationDeleted waits for an Application to return Deleted
+func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, name string, timeout time.Duration) (*kinesisanalytics.ApplicationSummary, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{kinesisanalytics.ApplicationStatusRunning, kinesisanalytics.ApplicationStatusDeleting},
-		Target:  []string{ApplicationStatusNotFound},
-		Refresh: ApplicationStatus(conn, applicationName),
-		Timeout: ApplicationDeletedTimeout,
+		Target:  []string{},
+		Refresh: ApplicationStatus(conn, name),
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -28,4 +26,47 @@ func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, applicationName
 	}
 
 	return nil, err
+}
+
+// IAMPropagation retries the specified function if the returned error indicates an IAM eventual consistency issue.
+// If the retries time out the specified function is called one last time.
+func IAMPropagation(f func() (interface{}, error)) (interface{}, error) {
+	var output interface{}
+
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = f()
+
+		// Kinesis Stream: https://github.com/terraform-providers/terraform-provider-aws/issues/7032
+		if tfawserr.ErrMessageContains(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics service doesn't have sufficient privileges") {
+			return resource.RetryableError(err)
+		}
+
+		// Kinesis Firehose: https://github.com/terraform-providers/terraform-provider-aws/issues/7394
+		if tfawserr.ErrMessageContains(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics doesn't have sufficient privileges") {
+			return resource.RetryableError(err)
+		}
+
+		// InvalidArgumentException: Given IAM role arn : arn:aws:iam::123456789012:role/xxx does not provide Invoke permissions on the Lambda resource : arn:aws:lambda:us-west-2:123456789012:function:yyy
+		if tfawserr.ErrMessageContains(err, kinesisanalytics.ErrCodeInvalidArgumentException, "does not provide Invoke permissions on the Lambda resource") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = f()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
 }

--- a/aws/internal/service/kinesisanalytics/waiter/waiter.go
+++ b/aws/internal/service/kinesisanalytics/waiter/waiter.go
@@ -38,12 +38,12 @@ func IAMPropagation(f func() (interface{}, error)) (interface{}, error) {
 
 		output, err = f()
 
-		// Kinesis Stream: https://github.com/terraform-providers/terraform-provider-aws/issues/7032
+		// Kinesis Stream: https://github.com/hashicorp/terraform-provider-aws/issues/7032
 		if tfawserr.ErrMessageContains(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics service doesn't have sufficient privileges") {
 			return resource.RetryableError(err)
 		}
 
-		// Kinesis Firehose: https://github.com/terraform-providers/terraform-provider-aws/issues/7394
+		// Kinesis Firehose: https://github.com/hashicorp/terraform-provider-aws/issues/7394
 		if tfawserr.ErrMessageContains(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics doesn't have sufficient privileges") {
 			return resource.RetryableError(err)
 		}

--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -610,9 +608,9 @@ func resourceAwsKinesisAnalyticsApplicationCreate(d *schema.ResourceData, meta i
 		ApplicationCode:          aws.String(d.Get("code").(string)),
 		ApplicationDescription:   aws.String(d.Get("description").(string)),
 		ApplicationName:          aws.String(d.Get("name").(string)),
-		CloudWatchLoggingOptions: expandKinesisAnalyticsV1CloudWatchLoggingOptions(d.Get("cloudwatch_logging_options").([]interface{})),
-		Inputs:                   expandKinesisAnalyticsV1Inputs(d.Get("inputs").([]interface{})),
-		Outputs:                  expandKinesisAnalyticsV1Outputs(d.Get("outputs").(*schema.Set).List()),
+		CloudWatchLoggingOptions: expandKinesisAnalyticsCloudWatchLoggingOptions(d.Get("cloudwatch_logging_options").([]interface{})),
+		Inputs:                   expandKinesisAnalyticsInputs(d.Get("inputs").([]interface{})),
+		Outputs:                  expandKinesisAnalyticsOutputs(d.Get("outputs").(*schema.Set).List()),
 	}
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
@@ -638,7 +636,7 @@ func resourceAwsKinesisAnalyticsApplicationCreate(d *schema.ResourceData, meta i
 		input := &kinesisanalytics.AddApplicationReferenceDataSourceInput{
 			ApplicationName:             applicationSummary.ApplicationName,
 			CurrentApplicationVersionId: aws.Int64(1), // Newly created application version.
-			ReferenceDataSource:         expandKinesisAnalyticsV1ReferenceDataSource(v),
+			ReferenceDataSource:         expandKinesisAnalyticsReferenceDataSource(v),
 		}
 
 		log.Printf("[DEBUG] Adding Kinesis Analytics Application (%s) reference data source: %s", d.Id(), input)
@@ -802,7 +800,7 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 				input := &kinesisanalytics.AddApplicationInputInput{
 					ApplicationName:             aws.String(applicationName),
 					CurrentApplicationVersionId: aws.Int64(currentApplicationVersionId),
-					Input:                       expandKinesisAnalyticsV1Input(n.([]interface{})),
+					Input:                       expandKinesisAnalyticsInput(n.([]interface{})),
 				}
 
 				log.Printf("[DEBUG] Adding Kinesis Analytics Application (%s) input: %s", d.Id(), input)
@@ -822,7 +820,7 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 				return fmt.Errorf("error deleting Kinesis Analytics Application (%s) input", d.Id())
 			} else {
 				// Update existing input.
-				inputUpdate := expandKinesisAnalyticsV1InputUpdate(n.([]interface{}))
+				inputUpdate := expandKinesisAnalyticsInputUpdate(n.([]interface{}))
 
 				if d.HasChange("inputs.0.processing_configuration") {
 					o, n := d.GetChange("inputs.0.processing_configuration")
@@ -835,7 +833,7 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 							ApplicationName:              aws.String(applicationName),
 							CurrentApplicationVersionId:  aws.Int64(currentApplicationVersionId),
 							InputId:                      inputUpdate.InputId,
-							InputProcessingConfiguration: expandKinesisAnalyticsV1InputProcessingConfiguration(n.([]interface{})),
+							InputProcessingConfiguration: expandKinesisAnalyticsInputProcessingConfiguration(n.([]interface{})),
 						}
 
 						log.Printf("[DEBUG] Adding Kinesis Analytics Application (%s) input processing configuration: %s", d.Id(), input)
@@ -931,7 +929,7 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 				input := &kinesisanalytics.AddApplicationOutputInput{
 					ApplicationName:             aws.String(applicationName),
 					CurrentApplicationVersionId: aws.Int64(currentApplicationVersionId),
-					Output:                      expandKinesisAnalyticsV1Output(vOutput),
+					Output:                      expandKinesisAnalyticsOutput(vOutput),
 				}
 
 				log.Printf("[DEBUG] Adding Kinesis Analytics Application (%s) output: %s", d.Id(), input)
@@ -956,7 +954,7 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 				input := &kinesisanalytics.AddApplicationReferenceDataSourceInput{
 					ApplicationName:             aws.String(applicationName),
 					CurrentApplicationVersionId: aws.Int64(currentApplicationVersionId),
-					ReferenceDataSource:         expandKinesisAnalyticsV1ReferenceDataSource(n.([]interface{})),
+					ReferenceDataSource:         expandKinesisAnalyticsReferenceDataSource(n.([]interface{})),
 				}
 
 				log.Printf("[DEBUG] Adding Kinesis Analytics Application (%s) reference data source: %s", d.Id(), input)
@@ -993,7 +991,7 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 				currentApplicationVersionId += 1
 			} else {
 				// Update existing reference data source.
-				referenceDataSourceUpdate := expandKinesisAnalyticsV1ReferenceDataSourceUpdate(n.([]interface{}))
+				referenceDataSourceUpdate := expandKinesisAnalyticsReferenceDataSourceUpdate(n.([]interface{}))
 
 				input.ApplicationUpdate.ReferenceDataSourceUpdates = []*kinesisanalytics.ReferenceDataSourceUpdate{referenceDataSourceUpdate}
 
@@ -1021,183 +1019,6 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.KinesisanalyticsUpdateTags(conn, arn, o, n); err != nil {
 			return fmt.Errorf("error updating Kinesis Analytics Application (%s) tags: %s", arn, err)
-		}
-	}
-
-	return resourceAwsKinesisAnalyticsApplicationRead(d, meta)
-}
-
-func resourceAwsKinesisAnalyticsApplicationUpdateOld(d *schema.ResourceData, meta interface{}) error {
-	var version int
-	conn := meta.(*AWSClient).kinesisanalyticsconn
-	name := d.Get("name").(string)
-
-	if v, ok := d.GetOk("version"); ok {
-		version = v.(int)
-	} else {
-		version = 1
-	}
-
-	if !d.IsNewResource() {
-		updateApplicationOpts := &kinesisanalytics.UpdateApplicationInput{
-			ApplicationName:             aws.String(name),
-			CurrentApplicationVersionId: aws.Int64(int64(version)),
-		}
-
-		applicationUpdate := createApplicationUpdateOpts(d)
-
-		if !reflect.DeepEqual(applicationUpdate, &kinesisanalytics.ApplicationUpdate{}) {
-			updateApplicationOpts.SetApplicationUpdate(applicationUpdate)
-			_, updateErr := conn.UpdateApplication(updateApplicationOpts)
-			if updateErr != nil {
-				return updateErr
-			}
-			version = version + 1
-		}
-
-		oldLoggingOptions, newLoggingOptions := d.GetChange("cloudwatch_logging_options")
-		if len(oldLoggingOptions.([]interface{})) == 0 && len(newLoggingOptions.([]interface{})) > 0 {
-			if v, ok := d.GetOk("cloudwatch_logging_options"); ok {
-				clo := v.([]interface{})[0].(map[string]interface{})
-				cloudwatchLoggingOption := expandKinesisAnalyticsCloudwatchLoggingOption(clo)
-				addOpts := &kinesisanalytics.AddApplicationCloudWatchLoggingOptionInput{
-					ApplicationName:             aws.String(name),
-					CurrentApplicationVersionId: aws.Int64(int64(version)),
-					CloudWatchLoggingOption:     cloudwatchLoggingOption,
-				}
-				// Retry for IAM eventual consistency
-				err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-					_, err := conn.AddApplicationCloudWatchLoggingOption(addOpts)
-					if err != nil {
-						if isAWSErr(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics service doesn't have sufficient privileges") {
-							return resource.RetryableError(err)
-						}
-						return resource.NonRetryableError(err)
-					}
-					return nil
-				})
-				if isResourceTimeoutError(err) {
-					_, err = conn.AddApplicationCloudWatchLoggingOption(addOpts)
-				}
-
-				if err != nil {
-					return fmt.Errorf("Unable to add CloudWatch logging options: %s", err)
-				}
-				version = version + 1
-			}
-		}
-
-		oldInputs, newInputs := d.GetChange("inputs")
-		if len(oldInputs.([]interface{})) == 0 && len(newInputs.([]interface{})) > 0 {
-			if v, ok := d.GetOk("inputs"); ok {
-				i := v.([]interface{})[0].(map[string]interface{})
-				input := expandKinesisAnalyticsInputs(i)
-				addOpts := &kinesisanalytics.AddApplicationInputInput{
-					ApplicationName:             aws.String(name),
-					CurrentApplicationVersionId: aws.Int64(int64(version)),
-					Input:                       input,
-				}
-				// Retry for IAM eventual consistency
-				err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-					_, err := conn.AddApplicationInput(addOpts)
-					if err != nil {
-						if isAWSErr(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics service doesn't have sufficient privileges") {
-							return resource.RetryableError(err)
-						}
-						// InvalidArgumentException: Given IAM role arn : arn:aws:iam::123456789012:role/xxx does not provide Invoke permissions on the Lambda resource : arn:aws:lambda:us-west-2:123456789012:function:yyy
-						if isAWSErr(err, kinesisanalytics.ErrCodeInvalidArgumentException, "does not provide Invoke permissions on the Lambda resource") {
-							return resource.RetryableError(err)
-						}
-						return resource.NonRetryableError(err)
-					}
-					return nil
-				})
-				if isResourceTimeoutError(err) {
-					_, err = conn.AddApplicationInput(addOpts)
-				}
-
-				if err != nil {
-					return fmt.Errorf("Unable to add application inputs: %s", err)
-				}
-				version = version + 1
-			}
-		}
-
-		oldOutputs, newOutputs := d.GetChange("outputs")
-		if len(oldOutputs.([]interface{})) == 0 && len(newOutputs.([]interface{})) > 0 {
-			if v, ok := d.GetOk("outputs"); ok {
-				o := v.([]interface{})[0].(map[string]interface{})
-				output := expandKinesisAnalyticsOutputs(o)
-				addOpts := &kinesisanalytics.AddApplicationOutputInput{
-					ApplicationName:             aws.String(name),
-					CurrentApplicationVersionId: aws.Int64(int64(version)),
-					Output:                      output,
-				}
-				// Retry for IAM eventual consistency
-				err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-					_, err := conn.AddApplicationOutput(addOpts)
-					if err != nil {
-						if isAWSErr(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics service doesn't have sufficient privileges") {
-							return resource.RetryableError(err)
-						}
-						// InvalidArgumentException: Given IAM role arn : arn:aws:iam::123456789012:role/xxx does not provide Invoke permissions on the Lambda resource : arn:aws:lambda:us-west-2:123456789012:function:yyy
-						if isAWSErr(err, kinesisanalytics.ErrCodeInvalidArgumentException, "does not provide Invoke permissions on the Lambda resource") {
-							return resource.RetryableError(err)
-						}
-						return resource.NonRetryableError(err)
-					}
-					return nil
-				})
-				if isResourceTimeoutError(err) {
-					_, err = conn.AddApplicationOutput(addOpts)
-				}
-				if err != nil {
-					return fmt.Errorf("Unable to add application outputs: %s", err)
-				}
-				version = version + 1
-			}
-		}
-
-		arn := d.Get("arn").(string)
-		if d.HasChange("tags") {
-			o, n := d.GetChange("tags")
-
-			if err := keyvaluetags.KinesisanalyticsUpdateTags(conn, arn, o, n); err != nil {
-				return fmt.Errorf("error updating Kinesis Analytics Application (%s) tags: %s", arn, err)
-			}
-		}
-	}
-
-	oldReferenceData, newReferenceData := d.GetChange("reference_data_sources")
-	if len(oldReferenceData.([]interface{})) == 0 && len(newReferenceData.([]interface{})) > 0 {
-		if v := d.Get("reference_data_sources").([]interface{}); len(v) > 0 {
-			for _, r := range v {
-				rd := r.(map[string]interface{})
-				referenceData := expandKinesisAnalyticsReferenceData(rd)
-				addOpts := &kinesisanalytics.AddApplicationReferenceDataSourceInput{
-					ApplicationName:             aws.String(name),
-					CurrentApplicationVersionId: aws.Int64(int64(version)),
-					ReferenceDataSource:         referenceData,
-				}
-				// Retry for IAM eventual consistency
-				err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-					_, err := conn.AddApplicationReferenceDataSource(addOpts)
-					if err != nil {
-						if isAWSErr(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics service doesn't have sufficient privileges") {
-							return resource.RetryableError(err)
-						}
-						return resource.NonRetryableError(err)
-					}
-					return nil
-				})
-				if isResourceTimeoutError(err) {
-					_, err = conn.AddApplicationReferenceDataSource(addOpts)
-				}
-				if err != nil {
-					return fmt.Errorf("Unable to add application reference data source: %s", err)
-				}
-				version = version + 1
-			}
 		}
 	}
 
@@ -1252,438 +1073,6 @@ func resourceAwsKinesisAnalyticsApplicationImport(d *schema.ResourceData, meta i
 	d.Set("name", parts[1])
 
 	return []*schema.ResourceData{d}, nil
-}
-
-func expandKinesisAnalyticsCloudwatchLoggingOption(clo map[string]interface{}) *kinesisanalytics.CloudWatchLoggingOption {
-	cloudwatchLoggingOption := &kinesisanalytics.CloudWatchLoggingOption{
-		LogStreamARN: aws.String(clo["log_stream_arn"].(string)),
-		RoleARN:      aws.String(clo["role_arn"].(string)),
-	}
-
-	return cloudwatchLoggingOption
-}
-
-func expandKinesisAnalyticsInputs(i map[string]interface{}) *kinesisanalytics.Input {
-	input := &kinesisanalytics.Input{
-		NamePrefix: aws.String(i["name_prefix"].(string)),
-	}
-
-	if v := i["kinesis_firehose"].([]interface{}); len(v) > 0 {
-		kf := v[0].(map[string]interface{})
-		kfi := &kinesisanalytics.KinesisFirehoseInput{
-			ResourceARN: aws.String(kf["resource_arn"].(string)),
-			RoleARN:     aws.String(kf["role_arn"].(string)),
-		}
-		input.KinesisFirehoseInput = kfi
-	}
-
-	if v := i["kinesis_stream"].([]interface{}); len(v) > 0 {
-		ks := v[0].(map[string]interface{})
-		ksi := &kinesisanalytics.KinesisStreamsInput{
-			ResourceARN: aws.String(ks["resource_arn"].(string)),
-			RoleARN:     aws.String(ks["role_arn"].(string)),
-		}
-		input.KinesisStreamsInput = ksi
-	}
-
-	if v := i["parallelism"].([]interface{}); len(v) > 0 {
-		p := v[0].(map[string]interface{})
-
-		if c, ok := p["count"]; ok {
-			ip := &kinesisanalytics.InputParallelism{
-				Count: aws.Int64(int64(c.(int))),
-			}
-			input.InputParallelism = ip
-		}
-	}
-
-	if v := i["processing_configuration"].([]interface{}); len(v) > 0 {
-		pc := v[0].(map[string]interface{})
-
-		if l := pc["lambda"].([]interface{}); len(l) > 0 {
-			lp := l[0].(map[string]interface{})
-			ipc := &kinesisanalytics.InputProcessingConfiguration{
-				InputLambdaProcessor: &kinesisanalytics.InputLambdaProcessor{
-					ResourceARN: aws.String(lp["resource_arn"].(string)),
-					RoleARN:     aws.String(lp["role_arn"].(string)),
-				},
-			}
-			input.InputProcessingConfiguration = ipc
-		}
-	}
-
-	if v := i["schema"].([]interface{}); len(v) > 0 {
-		vL := v[0].(map[string]interface{})
-		ss := expandKinesisAnalyticsSourceSchema(vL)
-		input.InputSchema = ss
-	}
-
-	return input
-}
-
-func expandKinesisAnalyticsSourceSchema(vL map[string]interface{}) *kinesisanalytics.SourceSchema {
-	ss := &kinesisanalytics.SourceSchema{}
-	if v := vL["record_columns"].([]interface{}); len(v) > 0 {
-		var rcs []*kinesisanalytics.RecordColumn
-
-		for _, rc := range v {
-			rcD := rc.(map[string]interface{})
-			rc := &kinesisanalytics.RecordColumn{
-				Name:    aws.String(rcD["name"].(string)),
-				SqlType: aws.String(rcD["sql_type"].(string)),
-			}
-
-			if v, ok := rcD["mapping"]; ok {
-				rc.Mapping = aws.String(v.(string))
-			}
-
-			rcs = append(rcs, rc)
-		}
-
-		ss.RecordColumns = rcs
-	}
-
-	if v, ok := vL["record_encoding"]; ok && v.(string) != "" {
-		ss.RecordEncoding = aws.String(v.(string))
-	}
-
-	if v := vL["record_format"].([]interface{}); len(v) > 0 {
-		vL := v[0].(map[string]interface{})
-		rf := &kinesisanalytics.RecordFormat{}
-
-		if v := vL["mapping_parameters"].([]interface{}); len(v) > 0 {
-			vL := v[0].(map[string]interface{})
-			mp := &kinesisanalytics.MappingParameters{}
-
-			if v := vL["csv"].([]interface{}); len(v) > 0 {
-				cL := v[0].(map[string]interface{})
-				cmp := &kinesisanalytics.CSVMappingParameters{
-					RecordColumnDelimiter: aws.String(cL["record_column_delimiter"].(string)),
-					RecordRowDelimiter:    aws.String(cL["record_row_delimiter"].(string)),
-				}
-				mp.CSVMappingParameters = cmp
-				rf.RecordFormatType = aws.String("CSV")
-			}
-
-			if v := vL["json"].([]interface{}); len(v) > 0 {
-				jL := v[0].(map[string]interface{})
-				jmp := &kinesisanalytics.JSONMappingParameters{
-					RecordRowPath: aws.String(jL["record_row_path"].(string)),
-				}
-				mp.JSONMappingParameters = jmp
-				rf.RecordFormatType = aws.String("JSON")
-			}
-			rf.MappingParameters = mp
-		}
-
-		ss.RecordFormat = rf
-	}
-	return ss
-}
-
-func expandKinesisAnalyticsOutputs(o map[string]interface{}) *kinesisanalytics.Output {
-	output := &kinesisanalytics.Output{
-		Name: aws.String(o["name"].(string)),
-	}
-
-	if v := o["kinesis_firehose"].([]interface{}); len(v) > 0 {
-		kf := v[0].(map[string]interface{})
-		kfo := &kinesisanalytics.KinesisFirehoseOutput{
-			ResourceARN: aws.String(kf["resource_arn"].(string)),
-			RoleARN:     aws.String(kf["role_arn"].(string)),
-		}
-		output.KinesisFirehoseOutput = kfo
-	}
-
-	if v := o["kinesis_stream"].([]interface{}); len(v) > 0 {
-		ks := v[0].(map[string]interface{})
-		kso := &kinesisanalytics.KinesisStreamsOutput{
-			ResourceARN: aws.String(ks["resource_arn"].(string)),
-			RoleARN:     aws.String(ks["role_arn"].(string)),
-		}
-		output.KinesisStreamsOutput = kso
-	}
-
-	if v := o["lambda"].([]interface{}); len(v) > 0 {
-		l := v[0].(map[string]interface{})
-		lo := &kinesisanalytics.LambdaOutput{
-			ResourceARN: aws.String(l["resource_arn"].(string)),
-			RoleARN:     aws.String(l["role_arn"].(string)),
-		}
-		output.LambdaOutput = lo
-	}
-
-	if v := o["schema"].([]interface{}); len(v) > 0 {
-		ds := v[0].(map[string]interface{})
-		dso := &kinesisanalytics.DestinationSchema{
-			RecordFormatType: aws.String(ds["record_format_type"].(string)),
-		}
-		output.DestinationSchema = dso
-	}
-
-	return output
-}
-
-func expandKinesisAnalyticsReferenceData(rd map[string]interface{}) *kinesisanalytics.ReferenceDataSource {
-	referenceData := &kinesisanalytics.ReferenceDataSource{
-		TableName: aws.String(rd["table_name"].(string)),
-	}
-
-	if v := rd["s3"].([]interface{}); len(v) > 0 {
-		s3 := v[0].(map[string]interface{})
-		s3rds := &kinesisanalytics.S3ReferenceDataSource{
-			BucketARN:        aws.String(s3["bucket_arn"].(string)),
-			FileKey:          aws.String(s3["file_key"].(string)),
-			ReferenceRoleARN: aws.String(s3["role_arn"].(string)),
-		}
-		referenceData.S3ReferenceDataSource = s3rds
-	}
-
-	if v := rd["schema"].([]interface{}); len(v) > 0 {
-		ss := expandKinesisAnalyticsSourceSchema(v[0].(map[string]interface{}))
-		referenceData.ReferenceSchema = ss
-	}
-
-	return referenceData
-}
-
-func createApplicationUpdateOpts(d *schema.ResourceData) *kinesisanalytics.ApplicationUpdate {
-	applicationUpdate := &kinesisanalytics.ApplicationUpdate{}
-
-	if d.HasChange("code") {
-		if v, ok := d.GetOk("code"); ok {
-			applicationUpdate.ApplicationCodeUpdate = aws.String(v.(string))
-		}
-	}
-
-	oldLoggingOptions, newLoggingOptions := d.GetChange("cloudwatch_logging_options")
-	if len(oldLoggingOptions.([]interface{})) > 0 && len(newLoggingOptions.([]interface{})) > 0 {
-		if v, ok := d.GetOk("cloudwatch_logging_options"); ok {
-			clo := v.([]interface{})[0].(map[string]interface{})
-			cloudwatchLoggingOption := expandKinesisAnalyticsCloudwatchLoggingOptionUpdate(clo)
-			applicationUpdate.CloudWatchLoggingOptionUpdates = []*kinesisanalytics.CloudWatchLoggingOptionUpdate{cloudwatchLoggingOption}
-		}
-	}
-
-	oldInputs, newInputs := d.GetChange("inputs")
-	if len(oldInputs.([]interface{})) > 0 && len(newInputs.([]interface{})) > 0 {
-		if v, ok := d.GetOk("inputs"); ok {
-			vL := v.([]interface{})[0].(map[string]interface{})
-			inputUpdate := expandKinesisAnalyticsInputUpdate(vL)
-			applicationUpdate.InputUpdates = []*kinesisanalytics.InputUpdate{inputUpdate}
-		}
-	}
-
-	oldOutputs, newOutputs := d.GetChange("outputs")
-	if len(oldOutputs.([]interface{})) > 0 && len(newOutputs.([]interface{})) > 0 {
-		if v, ok := d.GetOk("outputs"); ok {
-			vL := v.([]interface{})[0].(map[string]interface{})
-			outputUpdate := expandKinesisAnalyticsOutputUpdate(vL)
-			applicationUpdate.OutputUpdates = []*kinesisanalytics.OutputUpdate{outputUpdate}
-		}
-	}
-
-	oldReferenceData, newReferenceData := d.GetChange("reference_data_sources")
-	if len(oldReferenceData.([]interface{})) > 0 && len(newReferenceData.([]interface{})) > 0 {
-		if v := d.Get("reference_data_sources").([]interface{}); len(v) > 0 {
-			var rdsus []*kinesisanalytics.ReferenceDataSourceUpdate
-			for _, rd := range v {
-				rdL := rd.(map[string]interface{})
-				rdsu := &kinesisanalytics.ReferenceDataSourceUpdate{
-					ReferenceId:     aws.String(rdL["id"].(string)),
-					TableNameUpdate: aws.String(rdL["table_name"].(string)),
-				}
-
-				if v := rdL["s3"].([]interface{}); len(v) > 0 {
-					vL := v[0].(map[string]interface{})
-					s3rdsu := &kinesisanalytics.S3ReferenceDataSourceUpdate{
-						BucketARNUpdate:        aws.String(vL["bucket_arn"].(string)),
-						FileKeyUpdate:          aws.String(vL["file_key"].(string)),
-						ReferenceRoleARNUpdate: aws.String(vL["role_arn"].(string)),
-					}
-					rdsu.S3ReferenceDataSourceUpdate = s3rdsu
-				}
-
-				if v := rdL["schema"].([]interface{}); len(v) > 0 {
-					vL := v[0].(map[string]interface{})
-					ss := expandKinesisAnalyticsSourceSchema(vL)
-					rdsu.ReferenceSchemaUpdate = ss
-				}
-
-				rdsus = append(rdsus, rdsu)
-			}
-			applicationUpdate.ReferenceDataSourceUpdates = rdsus
-		}
-	}
-
-	return applicationUpdate
-}
-
-func expandKinesisAnalyticsInputUpdate(vL map[string]interface{}) *kinesisanalytics.InputUpdate {
-	inputUpdate := &kinesisanalytics.InputUpdate{
-		InputId:          aws.String(vL["id"].(string)),
-		NamePrefixUpdate: aws.String(vL["name_prefix"].(string)),
-	}
-
-	if v := vL["kinesis_firehose"].([]interface{}); len(v) > 0 {
-		kf := v[0].(map[string]interface{})
-		kfiu := &kinesisanalytics.KinesisFirehoseInputUpdate{
-			ResourceARNUpdate: aws.String(kf["resource_arn"].(string)),
-			RoleARNUpdate:     aws.String(kf["role_arn"].(string)),
-		}
-		inputUpdate.KinesisFirehoseInputUpdate = kfiu
-	}
-
-	if v := vL["kinesis_stream"].([]interface{}); len(v) > 0 {
-		ks := v[0].(map[string]interface{})
-		ksiu := &kinesisanalytics.KinesisStreamsInputUpdate{
-			ResourceARNUpdate: aws.String(ks["resource_arn"].(string)),
-			RoleARNUpdate:     aws.String(ks["role_arn"].(string)),
-		}
-		inputUpdate.KinesisStreamsInputUpdate = ksiu
-	}
-
-	if v := vL["parallelism"].([]interface{}); len(v) > 0 {
-		p := v[0].(map[string]interface{})
-
-		if c, ok := p["count"]; ok {
-			ipu := &kinesisanalytics.InputParallelismUpdate{
-				CountUpdate: aws.Int64(int64(c.(int))),
-			}
-			inputUpdate.InputParallelismUpdate = ipu
-		}
-	}
-
-	if v := vL["processing_configuration"].([]interface{}); len(v) > 0 {
-		pc := v[0].(map[string]interface{})
-
-		if l := pc["lambda"].([]interface{}); len(l) > 0 {
-			lp := l[0].(map[string]interface{})
-			ipc := &kinesisanalytics.InputProcessingConfigurationUpdate{
-				InputLambdaProcessorUpdate: &kinesisanalytics.InputLambdaProcessorUpdate{
-					ResourceARNUpdate: aws.String(lp["resource_arn"].(string)),
-					RoleARNUpdate:     aws.String(lp["role_arn"].(string)),
-				},
-			}
-			inputUpdate.InputProcessingConfigurationUpdate = ipc
-		}
-	}
-
-	if v := vL["schema"].([]interface{}); len(v) > 0 {
-		ss := &kinesisanalytics.InputSchemaUpdate{}
-		vL := v[0].(map[string]interface{})
-
-		if v := vL["record_columns"].([]interface{}); len(v) > 0 {
-			var rcs []*kinesisanalytics.RecordColumn
-
-			for _, rc := range v {
-				rcD := rc.(map[string]interface{})
-				rc := &kinesisanalytics.RecordColumn{
-					Name:    aws.String(rcD["name"].(string)),
-					SqlType: aws.String(rcD["sql_type"].(string)),
-				}
-
-				if v, ok := rcD["mapping"]; ok {
-					rc.Mapping = aws.String(v.(string))
-				}
-
-				rcs = append(rcs, rc)
-			}
-
-			ss.RecordColumnUpdates = rcs
-		}
-
-		if v, ok := vL["record_encoding"]; ok && v.(string) != "" {
-			ss.RecordEncodingUpdate = aws.String(v.(string))
-		}
-
-		if v := vL["record_format"].([]interface{}); len(v) > 0 {
-			vL := v[0].(map[string]interface{})
-			rf := &kinesisanalytics.RecordFormat{}
-
-			if v := vL["mapping_parameters"].([]interface{}); len(v) > 0 {
-				vL := v[0].(map[string]interface{})
-				mp := &kinesisanalytics.MappingParameters{}
-
-				if v := vL["csv"].([]interface{}); len(v) > 0 {
-					cL := v[0].(map[string]interface{})
-					cmp := &kinesisanalytics.CSVMappingParameters{
-						RecordColumnDelimiter: aws.String(cL["record_column_delimiter"].(string)),
-						RecordRowDelimiter:    aws.String(cL["record_row_delimiter"].(string)),
-					}
-					mp.CSVMappingParameters = cmp
-					rf.RecordFormatType = aws.String("CSV")
-				}
-
-				if v := vL["json"].([]interface{}); len(v) > 0 {
-					jL := v[0].(map[string]interface{})
-					jmp := &kinesisanalytics.JSONMappingParameters{
-						RecordRowPath: aws.String(jL["record_row_path"].(string)),
-					}
-					mp.JSONMappingParameters = jmp
-					rf.RecordFormatType = aws.String("JSON")
-				}
-				rf.MappingParameters = mp
-			}
-			ss.RecordFormatUpdate = rf
-		}
-		inputUpdate.InputSchemaUpdate = ss
-	}
-
-	return inputUpdate
-}
-
-func expandKinesisAnalyticsOutputUpdate(vL map[string]interface{}) *kinesisanalytics.OutputUpdate {
-	outputUpdate := &kinesisanalytics.OutputUpdate{
-		OutputId:   aws.String(vL["id"].(string)),
-		NameUpdate: aws.String(vL["name"].(string)),
-	}
-
-	if v := vL["kinesis_firehose"].([]interface{}); len(v) > 0 {
-		kf := v[0].(map[string]interface{})
-		kfou := &kinesisanalytics.KinesisFirehoseOutputUpdate{
-			ResourceARNUpdate: aws.String(kf["resource_arn"].(string)),
-			RoleARNUpdate:     aws.String(kf["role_arn"].(string)),
-		}
-		outputUpdate.KinesisFirehoseOutputUpdate = kfou
-	}
-
-	if v := vL["kinesis_stream"].([]interface{}); len(v) > 0 {
-		ks := v[0].(map[string]interface{})
-		ksou := &kinesisanalytics.KinesisStreamsOutputUpdate{
-			ResourceARNUpdate: aws.String(ks["resource_arn"].(string)),
-			RoleARNUpdate:     aws.String(ks["role_arn"].(string)),
-		}
-		outputUpdate.KinesisStreamsOutputUpdate = ksou
-	}
-
-	if v := vL["lambda"].([]interface{}); len(v) > 0 {
-		l := v[0].(map[string]interface{})
-		lou := &kinesisanalytics.LambdaOutputUpdate{
-			ResourceARNUpdate: aws.String(l["resource_arn"].(string)),
-			RoleARNUpdate:     aws.String(l["role_arn"].(string)),
-		}
-		outputUpdate.LambdaOutputUpdate = lou
-	}
-
-	if v := vL["schema"].([]interface{}); len(v) > 0 {
-		ds := v[0].(map[string]interface{})
-		dsu := &kinesisanalytics.DestinationSchema{
-			RecordFormatType: aws.String(ds["record_format_type"].(string)),
-		}
-		outputUpdate.DestinationSchemaUpdate = dsu
-	}
-
-	return outputUpdate
-}
-
-func expandKinesisAnalyticsCloudwatchLoggingOptionUpdate(clo map[string]interface{}) *kinesisanalytics.CloudWatchLoggingOptionUpdate {
-	cloudwatchLoggingOption := &kinesisanalytics.CloudWatchLoggingOptionUpdate{
-		CloudWatchLoggingOptionId: aws.String(clo["id"].(string)),
-		LogStreamARNUpdate:        aws.String(clo["log_stream_arn"].(string)),
-		RoleARNUpdate:             aws.String(clo["role_arn"].(string)),
-	}
-	return cloudwatchLoggingOption
 }
 
 func flattenKinesisAnalyticsCloudwatchLoggingOptions(options []*kinesisanalytics.CloudWatchLoggingOptionDescription) []interface{} {
@@ -1963,7 +1352,7 @@ func flattenKinesisAnalyticsReferenceDataSources(dataSources []*kinesisanalytics
 // TODO Remove 'V1'.
 //
 
-func expandKinesisAnalyticsV1CloudWatchLoggingOptions(vCloudWatchLoggingOptions []interface{}) []*kinesisanalytics.CloudWatchLoggingOption {
+func expandKinesisAnalyticsCloudWatchLoggingOptions(vCloudWatchLoggingOptions []interface{}) []*kinesisanalytics.CloudWatchLoggingOption {
 	if len(vCloudWatchLoggingOptions) == 0 || vCloudWatchLoggingOptions[0] == nil {
 		return nil
 	}
@@ -1982,15 +1371,15 @@ func expandKinesisAnalyticsV1CloudWatchLoggingOptions(vCloudWatchLoggingOptions 
 	return []*kinesisanalytics.CloudWatchLoggingOption{cloudWatchLoggingOption}
 }
 
-func expandKinesisAnalyticsV1Inputs(vInputs []interface{}) []*kinesisanalytics.Input {
+func expandKinesisAnalyticsInputs(vInputs []interface{}) []*kinesisanalytics.Input {
 	if len(vInputs) == 0 || vInputs[0] == nil {
 		return nil
 	}
 
-	return []*kinesisanalytics.Input{expandKinesisAnalyticsV1Input(vInputs)}
+	return []*kinesisanalytics.Input{expandKinesisAnalyticsInput(vInputs)}
 }
 
-func expandKinesisAnalyticsV1Input(vInput []interface{}) *kinesisanalytics.Input {
+func expandKinesisAnalyticsInput(vInput []interface{}) *kinesisanalytics.Input {
 	if len(vInput) == 0 || vInput[0] == nil {
 		return nil
 	}
@@ -2012,11 +1401,11 @@ func expandKinesisAnalyticsV1Input(vInput []interface{}) *kinesisanalytics.Input
 	}
 
 	if vInputProcessingConfiguration, ok := mInput["processing_configuration"].([]interface{}); ok {
-		input.InputProcessingConfiguration = expandKinesisAnalyticsV1InputProcessingConfiguration(vInputProcessingConfiguration)
+		input.InputProcessingConfiguration = expandKinesisAnalyticsInputProcessingConfiguration(vInputProcessingConfiguration)
 	}
 
 	if vInputSchema, ok := mInput["schema"].([]interface{}); ok {
-		input.InputSchema = expandKinesisAnalyticsV1SourceSchema(vInputSchema)
+		input.InputSchema = expandKinesisAnalyticsSourceSchema(vInputSchema)
 	}
 
 	if vKinesisFirehoseInput, ok := mInput["kinesis_firehose"].([]interface{}); ok && len(vKinesisFirehoseInput) > 0 && vKinesisFirehoseInput[0] != nil {
@@ -2056,7 +1445,7 @@ func expandKinesisAnalyticsV1Input(vInput []interface{}) *kinesisanalytics.Input
 	return input
 }
 
-func expandKinesisAnalyticsV1InputProcessingConfiguration(vInputProcessingConfiguration []interface{}) *kinesisanalytics.InputProcessingConfiguration {
+func expandKinesisAnalyticsInputProcessingConfiguration(vInputProcessingConfiguration []interface{}) *kinesisanalytics.InputProcessingConfiguration {
 	if len(vInputProcessingConfiguration) == 0 || vInputProcessingConfiguration[0] == nil {
 		return nil
 	}
@@ -2083,7 +1472,7 @@ func expandKinesisAnalyticsV1InputProcessingConfiguration(vInputProcessingConfig
 	return inputProcessingConfiguration
 }
 
-func expandKinesisAnalyticsV1InputUpdate(vInput []interface{}) *kinesisanalytics.InputUpdate {
+func expandKinesisAnalyticsInputUpdate(vInput []interface{}) *kinesisanalytics.InputUpdate {
 	if len(vInput) == 0 || vInput[0] == nil {
 		return nil
 	}
@@ -2137,7 +1526,7 @@ func expandKinesisAnalyticsV1InputUpdate(vInput []interface{}) *kinesisanalytics
 		mInputSchema := vInputSchema[0].(map[string]interface{})
 
 		if vRecordColumns, ok := mInputSchema["record_columns"].(*schema.Set); ok && vRecordColumns.Len() > 0 {
-			inputSchemaUpdate.RecordColumnUpdates = expandKinesisAnalyticsV1RecordColumns(vRecordColumns.List())
+			inputSchemaUpdate.RecordColumnUpdates = expandKinesisAnalyticsRecordColumns(vRecordColumns.List())
 		}
 
 		if vRecordEncoding, ok := mInputSchema["record_encoding"].(string); ok && vRecordEncoding != "" {
@@ -2145,7 +1534,7 @@ func expandKinesisAnalyticsV1InputUpdate(vInput []interface{}) *kinesisanalytics
 		}
 
 		if vRecordFormat, ok := mInputSchema["record_format"].([]interface{}); ok {
-			inputSchemaUpdate.RecordFormatUpdate = expandKinesisAnalyticsV1RecordFormat(vRecordFormat)
+			inputSchemaUpdate.RecordFormatUpdate = expandKinesisAnalyticsRecordFormat(vRecordFormat)
 		}
 
 		inputUpdate.InputSchemaUpdate = inputSchemaUpdate
@@ -2188,7 +1577,7 @@ func expandKinesisAnalyticsV1InputUpdate(vInput []interface{}) *kinesisanalytics
 	return inputUpdate
 }
 
-func expandKinesisAnalyticsV1Output(vOutput interface{}) *kinesisanalytics.Output {
+func expandKinesisAnalyticsOutput(vOutput interface{}) *kinesisanalytics.Output {
 	if vOutput == nil {
 		return nil
 	}
@@ -2261,7 +1650,7 @@ func expandKinesisAnalyticsV1Output(vOutput interface{}) *kinesisanalytics.Outpu
 	return output
 }
 
-func expandKinesisAnalyticsV1Outputs(vOutputs []interface{}) []*kinesisanalytics.Output {
+func expandKinesisAnalyticsOutputs(vOutputs []interface{}) []*kinesisanalytics.Output {
 	if len(vOutputs) == 0 {
 		return nil
 	}
@@ -2269,7 +1658,7 @@ func expandKinesisAnalyticsV1Outputs(vOutputs []interface{}) []*kinesisanalytics
 	outputs := []*kinesisanalytics.Output{}
 
 	for _, vOutput := range vOutputs {
-		output := expandKinesisAnalyticsV1Output(vOutput)
+		output := expandKinesisAnalyticsOutput(vOutput)
 
 		if output != nil {
 			outputs = append(outputs, output)
@@ -2279,7 +1668,7 @@ func expandKinesisAnalyticsV1Outputs(vOutputs []interface{}) []*kinesisanalytics
 	return outputs
 }
 
-func expandKinesisAnalyticsV1RecordColumns(vRecordColumns []interface{}) []*kinesisanalytics.RecordColumn {
+func expandKinesisAnalyticsRecordColumns(vRecordColumns []interface{}) []*kinesisanalytics.RecordColumn {
 	recordColumns := []*kinesisanalytics.RecordColumn{}
 
 	for _, vRecordColumn := range vRecordColumns {
@@ -2303,7 +1692,7 @@ func expandKinesisAnalyticsV1RecordColumns(vRecordColumns []interface{}) []*kine
 	return recordColumns
 }
 
-func expandKinesisAnalyticsV1RecordFormat(vRecordFormat []interface{}) *kinesisanalytics.RecordFormat {
+func expandKinesisAnalyticsRecordFormat(vRecordFormat []interface{}) *kinesisanalytics.RecordFormat {
 	if len(vRecordFormat) == 0 || vRecordFormat[0] == nil {
 		return nil
 	}
@@ -2354,7 +1743,7 @@ func expandKinesisAnalyticsV1RecordFormat(vRecordFormat []interface{}) *kinesisa
 	return recordFormat
 }
 
-func expandKinesisAnalyticsV1ReferenceDataSource(vReferenceDataSource []interface{}) *kinesisanalytics.ReferenceDataSource {
+func expandKinesisAnalyticsReferenceDataSource(vReferenceDataSource []interface{}) *kinesisanalytics.ReferenceDataSource {
 	if len(vReferenceDataSource) == 0 || vReferenceDataSource[0] == nil {
 		return nil
 	}
@@ -2364,7 +1753,7 @@ func expandKinesisAnalyticsV1ReferenceDataSource(vReferenceDataSource []interfac
 	mReferenceDataSource := vReferenceDataSource[0].(map[string]interface{})
 
 	if vReferenceSchema, ok := mReferenceDataSource["schema"].([]interface{}); ok {
-		referenceDataSource.ReferenceSchema = expandKinesisAnalyticsV1SourceSchema(vReferenceSchema)
+		referenceDataSource.ReferenceSchema = expandKinesisAnalyticsSourceSchema(vReferenceSchema)
 	}
 
 	if vS3ReferenceDataSource, ok := mReferenceDataSource["s3"].([]interface{}); ok && len(vS3ReferenceDataSource) > 0 && vS3ReferenceDataSource[0] != nil {
@@ -2392,7 +1781,7 @@ func expandKinesisAnalyticsV1ReferenceDataSource(vReferenceDataSource []interfac
 	return referenceDataSource
 }
 
-func expandKinesisAnalyticsV1ReferenceDataSourceUpdate(vReferenceDataSource []interface{}) *kinesisanalytics.ReferenceDataSourceUpdate {
+func expandKinesisAnalyticsReferenceDataSourceUpdate(vReferenceDataSource []interface{}) *kinesisanalytics.ReferenceDataSourceUpdate {
 	if len(vReferenceDataSource) == 0 || vReferenceDataSource[0] == nil {
 		return nil
 	}
@@ -2406,7 +1795,7 @@ func expandKinesisAnalyticsV1ReferenceDataSourceUpdate(vReferenceDataSource []in
 	}
 
 	if vReferenceSchema, ok := mReferenceDataSource["schema"].([]interface{}); ok {
-		referenceDataSourceUpdate.ReferenceSchemaUpdate = expandKinesisAnalyticsV1SourceSchema(vReferenceSchema)
+		referenceDataSourceUpdate.ReferenceSchemaUpdate = expandKinesisAnalyticsSourceSchema(vReferenceSchema)
 	}
 
 	if vS3ReferenceDataSource, ok := mReferenceDataSource["s3"].([]interface{}); ok && len(vS3ReferenceDataSource) > 0 && vS3ReferenceDataSource[0] != nil {
@@ -2434,7 +1823,7 @@ func expandKinesisAnalyticsV1ReferenceDataSourceUpdate(vReferenceDataSource []in
 	return referenceDataSourceUpdate
 }
 
-func expandKinesisAnalyticsV1SourceSchema(vSourceSchema []interface{}) *kinesisanalytics.SourceSchema {
+func expandKinesisAnalyticsSourceSchema(vSourceSchema []interface{}) *kinesisanalytics.SourceSchema {
 	if len(vSourceSchema) == 0 || vSourceSchema[0] == nil {
 		return nil
 	}
@@ -2444,7 +1833,7 @@ func expandKinesisAnalyticsV1SourceSchema(vSourceSchema []interface{}) *kinesisa
 	mSourceSchema := vSourceSchema[0].(map[string]interface{})
 
 	if vRecordColumns, ok := mSourceSchema["record_columns"].(*schema.Set); ok && vRecordColumns.Len() > 0 {
-		sourceSchema.RecordColumns = expandKinesisAnalyticsV1RecordColumns(vRecordColumns.List())
+		sourceSchema.RecordColumns = expandKinesisAnalyticsRecordColumns(vRecordColumns.List())
 	}
 
 	if vRecordEncoding, ok := mSourceSchema["record_encoding"].(string); ok && vRecordEncoding != "" {
@@ -2452,7 +1841,7 @@ func expandKinesisAnalyticsV1SourceSchema(vSourceSchema []interface{}) *kinesisa
 	}
 
 	if vRecordFormat, ok := mSourceSchema["record_format"].([]interface{}); ok && len(vRecordFormat) > 0 && vRecordFormat[0] != nil {
-		sourceSchema.RecordFormat = expandKinesisAnalyticsV1RecordFormat(vRecordFormat)
+		sourceSchema.RecordFormat = expandKinesisAnalyticsRecordFormat(vRecordFormat)
 	}
 
 	return sourceSchema

--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -825,7 +825,7 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 				inputUpdate := expandKinesisAnalyticsV1InputUpdate(n.([]interface{}))
 
 				if d.HasChange("inputs.0.processing_configuration") {
-					o, n := d.GetChange("inputs.0.processing_configurationn")
+					o, n := d.GetChange("inputs.0.processing_configuration")
 
 					// Update of existing input processing configuration is handled via the updating of the existing input.
 

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -139,6 +139,63 @@ func TestAccAWSKinesisAnalyticsApplication_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSKinesisAnalyticsApplication_Code_Update(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigCode(rName, "SELECT 1;\n"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", "SELECT 1;\n"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigCode(rName, "SELECT 2;\n"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", "SELECT 2;\n"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisAnalyticsApplication_update(t *testing.T) {
 	var application kinesisanalytics.ApplicationDetail
 	resName := "aws_kinesis_analytics_application.test"
@@ -807,6 +864,16 @@ resource "aws_kinesis_analytics_application" "test" {
   name = %[1]q
 }
 `, rName)
+}
+
+func testAccKinesisAnalyticsApplicationConfigCode(rName, code string) string {
+	return fmt.Sprintf(`
+resource "aws_kinesis_analytics_application" "test" {
+  name        = %[1]q
+  description = "test"
+  code        = %[2]q
+}
+`, rName, code)
 }
 
 func testAccKinesisAnalyticsApplication_basic(rInt int) string {

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -1721,8 +1721,8 @@ resource "aws_kinesis_analytics_application" "test" {
   name = %[1]q
 
   cloudwatch_logging_options {
-    log_stream_arn = aws_cloudwatch_log_stream.test[%[2]d].arn
-    role_arn       = aws_iam_role.test[%[2]d].arn
+    log_stream_arn = aws_cloudwatch_log_stream.test.%[2]d.arn
+    role_arn       = aws_iam_role.test.%[2]d.arn
   }
 }
 `, rName, streamIndex))
@@ -1784,7 +1784,7 @@ resource "aws_kinesis_analytics_application" "test" {
         name     = "COLUMN_2"
         sql_type = "VARCHAR(8)"
         mapping  = "MAPPING-2"
-	  }
+      }
 
       record_columns {
         name     = "COLUMN_3"
@@ -1841,8 +1841,8 @@ resource "aws_kinesis_analytics_application" "test" {
 
     processing_configuration {
       lambda {
-        resource_arn = aws_lambda_function.test[%[2]d].arn
-        role_arn     = aws_iam_role.test[%[2]d].arn
+        resource_arn = aws_lambda_function.test.%[2]d.arn
+        role_arn     = aws_iam_role.test.%[2]d.arn
       }
     }
 

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -243,6 +243,193 @@ func TestAccAWSKinesisAnalyticsApplication_Code_Update(t *testing.T) {
 	})
 }
 
+func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRoleResourceName := "aws_iam_role.test.0"
+	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test.0"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigCloudWatchLoggingOptions(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.log_stream_arn", cloudWatchLogStreamResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRoleResourceName := "aws_iam_role.test.0"
+	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test.0"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigCloudWatchLoggingOptions(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.log_stream_arn", cloudWatchLogStreamResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRole1ResourceName := "aws_iam_role.test.0"
+	iamRole2ResourceName := "aws_iam_role.test.1"
+	cloudWatchLogStream1ResourceName := "aws_cloudwatch_log_stream.test.0"
+	cloudWatchLogStream2ResourceName := "aws_cloudwatch_log_stream.test.1"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigCloudWatchLoggingOptions(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.log_stream_arn", cloudWatchLogStream1ResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigCloudWatchLoggingOptions(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.log_stream_arn", cloudWatchLogStream2ResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisAnalyticsApplication_update(t *testing.T) {
 	var application kinesisanalytics.ApplicationDetail
 	resName := "aws_kinesis_analytics_application.test"
@@ -849,6 +1036,81 @@ func testAccPreCheckAWSKinesisAnalytics(t *testing.T) {
 	}
 }
 
+func testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  count = 2
+
+  name               = "%[1]s.${count.index}"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["sts:AssumeRole"],
+      "Principal": {"Service": "firehose.amazonaws.com"}
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["sts:AssumeRole"],
+      "Principal": {"Service": "kinesisanalytics.amazonaws.com"}
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["sts:AssumeRole"],
+      "Principal": {"Service": "lambda.amazonaws.com"}
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "test" {
+  name   = %[1]q
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:*"],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["firehose:*"],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["lambda:*"],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["logs:*"],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:*"],
+      "Resource": ["*"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  count = 2
+
+  role       = aws_iam_role.test[count.index].name
+  policy_arn = aws_iam_policy.test.arn
+}
+`, rName)
+}
+
 func testAccKinesisAnalyticsApplicationConfigBasic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kinesis_analytics_application" "test" {
@@ -890,6 +1152,32 @@ resource "aws_kinesis_analytics_application" "test" {
   code        = %[2]q
 }
 `, rName, code)
+}
+
+func testAccKinesisAnalyticsApplicationConfigCloudWatchLoggingOptions(rName string, streamIndex int) string {
+	return composeConfig(
+		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
+		fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_cloudwatch_log_stream" "test" {
+  count = 2
+
+  name           = "%[1]s.${count.index}"
+  log_group_name = aws_cloudwatch_log_group.test.name
+}
+
+resource "aws_kinesis_analytics_application" "test" {
+  name = %[1]q
+
+  cloudwatch_logging_options {
+    log_stream_arn = aws_cloudwatch_log_stream.test[%[2]d].arn
+    role_arn       = aws_iam_role.test[%[2]d].arn
+  }
+}
+`, rName, streamIndex))
 }
 
 func testAccKinesisAnalyticsApplication_basic(rInt int) string {

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -431,6 +431,203 @@ func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update(t *te
 	})
 }
 
+func TestAccAWSKinesisAnalyticsApplication_Input_Add(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRoleResourceName := "aws_iam_role.test.0"
+	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigInput(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisAnalyticsApplication_Input_Update(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRole1ResourceName := "aws_iam_role.test.0"
+	iamRole2ResourceName := "aws_iam_role.test.1"
+	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	streamsResourceName := "aws_kinesis_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigInput(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigInputUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "42"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "2"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_2",
+						"sql_type": "VARCHAR(8)",
+						"mapping":  "MAPPING-2",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_3",
+						"sql_type": "DOUBLE",
+						"mapping":  "MAPPING-3",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", "UTF-8"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.0.record_row_path", "$path.to.record"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "JSON"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_2"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "42"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.resource_arn", streamsResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisAnalyticsApplication_Output_Update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
 	resourceName := "aws_kinesis_analytics_application.test"
@@ -1586,6 +1783,90 @@ resource "aws_kinesis_analytics_application" "test" {
   }
 }
 `, rName, streamIndex))
+}
+
+func testAccKinesisAnalyticsApplicationConfigInput(rName string) string {
+	return composeConfig(
+		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
+		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
+		fmt.Sprintf(`
+resource "aws_kinesis_analytics_application" "test" {
+  name = %[1]q
+
+  inputs {
+    name_prefix = "NAME_PREFIX_1"
+
+    schema {
+      record_columns {
+        name     = "COLUMN_1"
+        sql_type = "INTEGER"
+      }
+
+      record_format {
+        mapping_parameters {
+          csv {
+            record_column_delimiter = ","
+            record_row_delimiter    = "|"
+          }
+        }
+      }
+    }
+
+    kinesis_firehose {
+      resource_arn = aws_kinesis_firehose_delivery_stream.test.arn
+      role_arn     = aws_iam_role.test[0].arn
+    }
+  }
+}
+`, rName))
+}
+
+func testAccKinesisAnalyticsApplicationConfigInputUpdated(rName string) string {
+	return composeConfig(
+		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
+		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
+		fmt.Sprintf(`
+resource "aws_kinesis_analytics_application" "test" {
+  name = %[1]q
+
+  inputs {
+    name_prefix = "NAME_PREFIX_2"
+
+    parallelism {
+      count = 42
+    }
+
+    schema {
+      record_columns {
+        name     = "COLUMN_2"
+        sql_type = "VARCHAR(8)"
+        mapping  = "MAPPING-2"
+	  }
+
+      record_columns {
+        name     = "COLUMN_3"
+        sql_type = "DOUBLE"
+        mapping  = "MAPPING-3"
+      }
+
+      record_encoding = "UTF-8"
+
+      record_format {
+        mapping_parameters {
+          json {
+            record_row_path = "$path.to.record"
+          }
+        }
+      }
+    }
+
+    kinesis_stream {
+      resource_arn = aws_kinesis_stream.test.arn
+      role_arn     = aws_iam_role.test[1].arn
+    }
+  }
+}
+`, rName))
 }
 
 func testAccKinesisAnalyticsApplicationOutput(rName string) string {

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -966,6 +966,181 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update(t
 	})
 }
 
+func TestAccAWSKinesisAnalyticsApplication_Multiple_Update(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRole1ResourceName := "aws_iam_role.test.0"
+	iamRole2ResourceName := "aws_iam_role.test.1"
+	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test"
+	lambdaResourceName := "aws_lambda_function.test.0"
+	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	streamsResourceName := "aws_kinesis_stream.test"
+	s3BucketResourceName := "aws_s3_bucket.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigMultiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.log_stream_arn", cloudWatchLogStreamResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.0.lambda.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.resource_arn", lambdaResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"name":                        "OUTPUT_1",
+						"schema.#":                    "1",
+						"schema.0.record_format_type": "CSV",
+						"kinesis_firehose.#":          "1",
+						"kinesis_stream.#":            "0",
+						"lambda.#":                    "0",
+					}),
+					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_firehose.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigMultipleUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "42"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "2"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_2",
+						"sql_type": "VARCHAR(8)",
+						"mapping":  "MAPPING-2",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_3",
+						"sql_type": "DOUBLE",
+						"mapping":  "MAPPING-3",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", "UTF-8"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.0.record_row_path", "$path.to.record"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "JSON"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_2"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "42"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.resource_arn", streamsResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "2"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"name":                        "OUTPUT_2",
+						"schema.#":                    "1",
+						"schema.0.record_format_type": "JSON",
+						"kinesis_firehose.#":          "0",
+						"kinesis_stream.#":            "1",
+						"lambda.#":                    "0",
+					}),
+					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_stream.0.resource_arn", streamsResourceName, "arn"),
+					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_stream.0.role_arn", iamRole2ResourceName, "arn"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"name":                        "OUTPUT_3",
+						"schema.#":                    "1",
+						"schema.0.record_format_type": "CSV",
+						"kinesis_firehose.#":          "0",
+						"kinesis_stream.#":            "0",
+						"lambda.#":                    "1",
+					}),
+					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.lambda.0.resource_arn", lambdaResourceName, "arn"),
+					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.lambda.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "reference_data_sources.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.s3.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "reference_data_sources.0.s3.0.bucket_arn", s3BucketResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.s3.0.file_key", "KEY-1"),
+					resource.TestCheckResourceAttrPair(resourceName, "reference_data_sources.0.s3.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.table_name", "TABLE-1"),
+					resource.TestCheckResourceAttrSet(resourceName, "reference_data_sources.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "Value3"),
+					resource.TestCheckResourceAttr(resourceName, "version", "8"), // Delete CloudWatch logging options + add reference data source + delete input processing configuration+ update application + delete output + 2 * add output.
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisAnalyticsApplication_Output_Update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
 	resourceName := "aws_kinesis_analytics_application.test"
@@ -1678,6 +1853,185 @@ resource "aws_kinesis_analytics_application" "test" {
   }
 }
 `, rName, lambdaIndex))
+}
+
+func testAccKinesisAnalyticsApplicationConfigMultiple(rName string) string {
+	return composeConfig(
+		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
+		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
+		fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_cloudwatch_log_stream" "test" {
+  name           = %[1]q
+  log_group_name = aws_cloudwatch_log_group.test.name
+}
+
+resource "aws_kinesis_analytics_application" "test" {
+  name = %[1]q
+
+  cloudwatch_logging_options {
+    log_stream_arn = aws_cloudwatch_log_stream.test.arn
+    role_arn       = aws_iam_role.test[1].arn
+  }
+
+  inputs {
+    name_prefix = "NAME_PREFIX_1"
+
+    schema {
+      record_columns {
+        name     = "COLUMN_1"
+        sql_type = "INTEGER"
+      }
+
+      record_format {
+        mapping_parameters {
+          csv {
+            record_column_delimiter = ","
+            record_row_delimiter    = "|"
+          }
+        }
+      }
+    }
+
+    processing_configuration {
+      lambda {
+        resource_arn = aws_lambda_function.test[0].arn
+        role_arn     = aws_iam_role.test[0].arn
+      }
+    }
+
+    kinesis_firehose {
+      resource_arn = aws_kinesis_firehose_delivery_stream.test.arn
+      role_arn     = aws_iam_role.test[0].arn
+    }
+  }
+
+  outputs {
+    name = "OUTPUT_1"
+
+    schema {
+      record_format_type = "CSV"
+    }
+
+    kinesis_firehose {
+      resource_arn = aws_kinesis_firehose_delivery_stream.test.arn
+      role_arn     = aws_iam_role.test[1].arn
+    }
+  }
+
+  tags = {
+    Key1 = "Value1"
+  }
+}
+`, rName))
+}
+
+func testAccKinesisAnalyticsApplicationConfigMultipleUpdated(rName string) string {
+	return composeConfig(
+		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
+		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
+		fmt.Sprintf(`
+resource "aws_kinesis_analytics_application" "test" {
+  name = %[1]q
+
+  inputs {
+    name_prefix = "NAME_PREFIX_2"
+
+    parallelism {
+      count = 42
+    }
+
+    schema {
+      record_columns {
+        name     = "COLUMN_2"
+        sql_type = "VARCHAR(8)"
+        mapping  = "MAPPING-2"
+      }
+
+      record_columns {
+        name     = "COLUMN_3"
+        sql_type = "DOUBLE"
+        mapping  = "MAPPING-3"
+      }
+
+      record_encoding = "UTF-8"
+
+      record_format {
+        mapping_parameters {
+          json {
+            record_row_path = "$path.to.record"
+          }
+        }
+      }
+    }
+
+    kinesis_stream {
+      resource_arn = aws_kinesis_stream.test.arn
+      role_arn     = aws_iam_role.test[1].arn
+    }
+  }
+
+  outputs {
+    name = "OUTPUT_2"
+
+    schema {
+      record_format_type = "JSON"
+    }
+
+    kinesis_stream {
+      resource_arn = aws_kinesis_stream.test.arn
+      role_arn     = aws_iam_role.test[1].arn
+    }
+  }
+
+  outputs {
+    name = "OUTPUT_3"
+
+    schema {
+      record_format_type = "CSV"
+    }
+
+    lambda {
+      resource_arn = aws_lambda_function.test[0].arn
+      role_arn     = aws_iam_role.test[0].arn
+    }
+  }
+
+  reference_data_sources {
+    table_name = "TABLE-1"
+
+    schema {
+      record_columns {
+        name     = "COLUMN_1"
+        sql_type = "INTEGER"
+      }
+
+      record_format {
+        mapping_parameters {
+          csv {
+            record_column_delimiter = ","
+            record_row_delimiter    = "|"
+          }
+        }
+      }
+    }
+
+    s3 {
+      bucket_arn = aws_s3_bucket.test.arn
+      file_key   = "KEY-1"
+      role_arn   = aws_iam_role.test[1].arn
+    }
+  }
+
+  tags = {
+    Key2 = "Value2"
+    Key3 = "Value3"
+  }
+}
+`, rName))
 }
 
 func testAccKinesisAnalyticsApplicationOutput(rName string) string {

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -628,6 +628,344 @@ func TestAccAWSKinesisAnalyticsApplication_Input_Update(t *testing.T) {
 	})
 }
 
+func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRoleResourceName := "aws_iam_role.test.0"
+	lambdaResourceName := "aws_lambda_function.test.0"
+	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigInput(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigInputProcessingConfiguration(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.0.lambda.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.resource_arn", lambdaResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "3"), // Add input processing configuration + update input.
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRoleResourceName := "aws_iam_role.test.0"
+	lambdaResourceName := "aws_lambda_function.test.0"
+	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigInputProcessingConfiguration(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.0.lambda.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.resource_arn", lambdaResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigInput(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "3"), // Delete input processing configuration + update input.
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRole1ResourceName := "aws_iam_role.test.0"
+	iamRole2ResourceName := "aws_iam_role.test.1"
+	lambda1ResourceName := "aws_lambda_function.test.0"
+	lambda2ResourceName := "aws_lambda_function.test.1"
+	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigInputProcessingConfiguration(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.0.lambda.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.resource_arn", lambda1ResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigInputProcessingConfiguration(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "inputs.0.schema.0.record_columns.*", map[string]string{
+						"name":     "COLUMN_1",
+						"sql_type": "INTEGER",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.0.lambda.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.resource_arn", lambda2ResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisAnalyticsApplication_Output_Update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
 	resourceName := "aws_kinesis_analytics_application.test"
@@ -1002,551 +1340,6 @@ func TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update(t *testing
 	})
 }
 
-func TestAccAWSKinesisAnalyticsApplication_update(t *testing.T) {
-	var application kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKinesisAnalyticsApplication_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-				),
-			},
-			{
-				Config: testAccKinesisAnalyticsApplication_update(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resName, "version", "2"),
-					resource.TestCheckResourceAttr(resName, "code", "testCode2\n"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions(t *testing.T) {
-	var application kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_basic(rInt)
-	thirdStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_cloudwatchLoggingOptions(rInt, "testStream")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: firstStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-					resource.TestCheckResourceAttr(resName, "version", "1"),
-				),
-			},
-			{
-				Config: thirdStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-					resource.TestCheckResourceAttr(resName, "version", "2"),
-					resource.TestCheckResourceAttr(resName, "cloudwatch_logging_options.#", "1"),
-					resource.TestCheckResourceAttrPair(resName, "cloudwatch_logging_options.0.log_stream_arn", "aws_cloudwatch_log_stream.test", "arn"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions(t *testing.T) {
-	var application kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_cloudwatchLoggingOptions(rInt, "testStream")
-	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_cloudwatchLoggingOptions(rInt, "testStream2")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: firstStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-					resource.TestCheckResourceAttr(resName, "version", "1"),
-					resource.TestCheckResourceAttr(resName, "cloudwatch_logging_options.#", "1"),
-					resource.TestCheckResourceAttrPair(resName, "cloudwatch_logging_options.0.log_stream_arn", "aws_cloudwatch_log_stream.test", "arn"),
-				),
-			},
-			{
-				Config: secondStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-					resource.TestCheckResourceAttr(resName, "version", "2"),
-					resource.TestCheckResourceAttr(resName, "cloudwatch_logging_options.#", "1"),
-					resource.TestCheckResourceAttrPair(resName, "cloudwatch_logging_options.0.log_stream_arn", "aws_cloudwatch_log_stream.test", "arn"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose(t *testing.T) {
-	var application kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_inputsKinesisFirehose(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-					resource.TestCheckResourceAttr(resName, "inputs.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.kinesis_firehose.#", "1"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream(t *testing.T) {
-	var application kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_inputsKinesisStream(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-					resource.TestCheckResourceAttr(resName, "version", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.name_prefix", "test_prefix"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.kinesis_stream.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.parallelism.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.0.record_columns.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.0.record_format.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "1"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_inputsAdd(t *testing.T) {
-	var before, after kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_basic(rInt)
-	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_inputsKinesisStream(rInt)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: firstStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &before),
-					resource.TestCheckResourceAttr(resName, "version", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.#", "0"),
-				),
-			},
-			{
-				Config: secondStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &after),
-					resource.TestCheckResourceAttr(resName, "version", "2"),
-					resource.TestCheckResourceAttr(resName, "inputs.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.name_prefix", "test_prefix"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.kinesis_stream.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.parallelism.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.0.record_columns.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.0.record_format.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "1"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream(t *testing.T) {
-	var before, after kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_inputsKinesisStream(rInt)
-	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_inputsUpdateKinesisStream(rInt, "testStream")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: firstStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &before),
-					resource.TestCheckResourceAttr(resName, "version", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.name_prefix", "test_prefix"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.parallelism.0.count", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "1"),
-				),
-			},
-			{
-				Config: secondStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &after),
-					resource.TestCheckResourceAttr(resName, "version", "2"),
-					resource.TestCheckResourceAttr(resName, "inputs.#", "1"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.name_prefix", "test_prefix2"),
-					resource.TestCheckResourceAttrPair(resName, "inputs.0.kinesis_stream.0.resource_arn", "aws_kinesis_stream.test", "arn"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.parallelism.0.count", "2"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.0.record_columns.0.name", "test2"),
-					resource.TestCheckResourceAttr(resName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream(t *testing.T) {
-	var application kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_outputsKinesisStream(rInt)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: firstStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-					resource.TestCheckResourceAttr(resName, "version", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.name", "test_name"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.kinesis_stream.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.schema.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.schema.0.record_format_type", "JSON"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_outputsMultiple(t *testing.T) {
-	var application kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt1 := acctest.RandInt()
-	rInt2 := acctest.RandInt()
-	step := testAccKinesisAnalyticsApplication_prereq(rInt1) + testAccKinesisAnalyticsApplication_outputsMultiple(rInt1, rInt2)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: step,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-					resource.TestCheckResourceAttr(resName, "outputs.#", "2"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_outputsAdd(t *testing.T) {
-	var before, after kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_basic(rInt)
-	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_outputsKinesisStream(rInt)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: firstStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &before),
-					resource.TestCheckResourceAttr(resName, "version", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.#", "0"),
-				),
-			},
-			{
-				Config: secondStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &after),
-					resource.TestCheckResourceAttr(resName, "version", "2"),
-					resource.TestCheckResourceAttr(resName, "outputs.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.name", "test_name"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.kinesis_stream.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.schema.#", "1"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream(t *testing.T) {
-	var before, after kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_outputsKinesisStream(rInt)
-	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_outputsUpdateKinesisStream(rInt, "testStream")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: firstStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &before),
-					resource.TestCheckResourceAttr(resName, "version", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.name", "test_name"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.kinesis_stream.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.schema.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.schema.0.record_format_type", "JSON"),
-				),
-			},
-			{
-				Config: secondStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &after),
-					resource.TestCheckResourceAttr(resName, "version", "2"),
-					resource.TestCheckResourceAttr(resName, "outputs.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.name", "test_name2"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.kinesis_stream.#", "1"),
-					resource.TestCheckResourceAttrPair(resName, "outputs.0.kinesis_stream.0.resource_arn", "aws_kinesis_stream.test", "arn"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.schema.#", "1"),
-					resource.TestCheckResourceAttr(resName, "outputs.0.schema.0.record_format_type", "CSV"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add(t *testing.T) {
-	var application1, application2 kinesisanalytics.ApplicationDetail
-	iamRoleResourceName := "aws_iam_role.kinesis_analytics_application"
-	lambdaFunctionResourceName := "aws_lambda_function.test"
-	resourceName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &application1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1"),
-					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
-				),
-			},
-			{
-				Config: testAccKinesisAnalyticsApplicationConfigOutputsLambda(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &application2),
-					resource.TestCheckResourceAttr(resourceName, "version", "2"),
-					resource.TestCheckResourceAttr(resourceName, "outputs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "outputs.0.lambda.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "outputs.0.lambda.0.resource_arn", lambdaFunctionResourceName, "arn"),
-					resource.TestCheckResourceAttrPair(resourceName, "outputs.0.lambda.0.role_arn", iamRoleResourceName, "arn"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create(t *testing.T) {
-	var application1 kinesisanalytics.ApplicationDetail
-	iamRoleResourceName := "aws_iam_role.kinesis_analytics_application"
-	lambdaFunctionResourceName := "aws_lambda_function.test"
-	resourceName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKinesisAnalyticsApplicationConfigOutputsLambda(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &application1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1"),
-					resource.TestCheckResourceAttr(resourceName, "outputs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "outputs.0.lambda.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "outputs.0.lambda.0.resource_arn", lambdaFunctionResourceName, "arn"),
-					resource.TestCheckResourceAttrPair(resourceName, "outputs.0.lambda.0.role_arn", iamRoleResourceName, "arn"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_referenceDataSource(t *testing.T) {
-	var application kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_referenceDataSource(rInt)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: firstStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
-					resource.TestCheckResourceAttr(resName, "version", "2"),
-					resource.TestCheckResourceAttr(resName, "reference_data_sources.#", "1"),
-					resource.TestCheckResourceAttr(resName, "reference_data_sources.0.schema.#", "1"),
-					resource.TestCheckResourceAttr(resName, "reference_data_sources.0.schema.0.record_columns.#", "1"),
-					resource.TestCheckResourceAttr(resName, "reference_data_sources.0.schema.0.record_format.#", "1"),
-					resource.TestCheckResourceAttr(resName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.0.json.#", "1"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate(t *testing.T) {
-	var before, after kinesisanalytics.ApplicationDetail
-	resName := "aws_kinesis_analytics_application.test"
-	rInt := acctest.RandInt()
-	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_referenceDataSource(rInt)
-	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_referenceDataSourceUpdate(rInt)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: firstStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &before),
-					resource.TestCheckResourceAttr(resName, "version", "2"),
-					resource.TestCheckResourceAttr(resName, "reference_data_sources.#", "1"),
-				),
-			},
-			{
-				Config: secondStep,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisAnalyticsApplicationExists(resName, &after),
-					resource.TestCheckResourceAttr(resName, "version", "3"),
-					resource.TestCheckResourceAttr(resName, "reference_data_sources.#", "1"),
-				),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func testAccCheckKinesisAnalyticsApplicationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).kinesisanalyticsconn
 
@@ -1724,31 +1517,6 @@ resource "aws_kinesis_analytics_application" "test" {
 `, rName)
 }
 
-func testAccKinesisAnalyticsApplicationConfigTags1(rName, tagKey1, tagValue1 string) string {
-	return fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
-  name = %[1]q
-
-  tags = {
-    %[2]q = %[3]q
-  }
-}
-`, rName, tagKey1, tagValue1)
-}
-
-func testAccKinesisAnalyticsApplicationConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
-  name = %[1]q
-
-  tags = {
-    %[2]q = %[3]q
-    %[4]q = %[5]q
-  }
-}
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
-}
-
 func testAccKinesisAnalyticsApplicationConfigCode(rName, code string) string {
 	return fmt.Sprintf(`
 resource "aws_kinesis_analytics_application" "test" {
@@ -1867,6 +1635,49 @@ resource "aws_kinesis_analytics_application" "test" {
   }
 }
 `, rName))
+}
+
+func testAccKinesisAnalyticsApplicationConfigInputProcessingConfiguration(rName string, lambdaIndex int) string {
+	return composeConfig(
+		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
+		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
+		fmt.Sprintf(`
+resource "aws_kinesis_analytics_application" "test" {
+  name = %[1]q
+
+  inputs {
+    name_prefix = "NAME_PREFIX_1"
+
+    schema {
+      record_columns {
+        name     = "COLUMN_1"
+        sql_type = "INTEGER"
+      }
+
+      record_format {
+        mapping_parameters {
+          csv {
+            record_column_delimiter = ","
+            record_row_delimiter    = "|"
+          }
+        }
+      }
+    }
+
+    processing_configuration {
+      lambda {
+        resource_arn = aws_lambda_function.test[%[2]d].arn
+        role_arn     = aws_iam_role.test[%[2]d].arn
+      }
+    }
+
+    kinesis_firehose {
+      resource_arn = aws_kinesis_firehose_delivery_stream.test.arn
+      role_arn     = aws_iam_role.test[0].arn
+    }
+  }
+}
+`, rName, lambdaIndex))
 }
 
 func testAccKinesisAnalyticsApplicationOutput(rName string) string {
@@ -2018,524 +1829,27 @@ resource "aws_kinesis_analytics_application" "test" {
 `, rName))
 }
 
-func testAccKinesisAnalyticsApplication_basic(rInt int) string {
+func testAccKinesisAnalyticsApplicationConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode\n"
+  name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
 }
-`, rInt)
+`, rName, tagKey1, tagValue1)
 }
 
-func testAccKinesisAnalyticsApplication_update(rInt int) string {
+func testAccKinesisAnalyticsApplicationConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode2\n"
-}
-`, rInt)
-}
+  name = %[1]q
 
-func testAccKinesisAnalyticsApplication_cloudwatchLoggingOptions(rInt int, streamName string) string {
-	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
-  name = "testAcc-%d"
-}
-
-resource "aws_cloudwatch_log_stream" "test" {
-  name           = "testAcc-%s-%d"
-  log_group_name = aws_cloudwatch_log_group.test.name
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode\n"
-
-  cloudwatch_logging_options {
-    log_stream_arn = aws_cloudwatch_log_stream.test.arn
-    role_arn       = aws_iam_role.test.arn
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, rInt, streamName, rInt, rInt)
-}
-
-func testAccKinesisAnalyticsApplication_inputsKinesisFirehose(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_iam_policy_document" "trust_firehose" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["firehose.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "firehose" {
-  name               = "testAcc-firehose-%d"
-  assume_role_policy = data.aws_iam_policy_document.trust_firehose.json
-}
-
-data "aws_iam_policy_document" "trust_lambda" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "lambda" {
-  name               = "testAcc-lambda-%d"
-  assume_role_policy = data.aws_iam_policy_document.trust_lambda.json
-}
-
-resource "aws_s3_bucket" "test" {
-  bucket = "testacc-%d"
-  acl    = "private"
-}
-
-resource "aws_lambda_function" "test" {
-  filename      = "test-fixtures/lambdatest.zip"
-  function_name = "testAcc-%d"
-  handler       = "exports.example"
-  role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs12.x"
-}
-
-resource "aws_kinesis_firehose_delivery_stream" "test" {
-  name        = "testAcc-%d"
-  destination = "extended_s3"
-
-  extended_s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.test.arn
-  }
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode\n"
-
-  inputs {
-    name_prefix = "test_prefix"
-
-    kinesis_firehose {
-      resource_arn = aws_kinesis_firehose_delivery_stream.test.arn
-      role_arn     = aws_iam_role.test.arn
-    }
-
-    parallelism {
-      count = 1
-    }
-
-    schema {
-      record_columns {
-        mapping  = "$.test"
-        name     = "test"
-        sql_type = "VARCHAR(8)"
-      }
-
-      record_encoding = "UTF-8"
-
-      record_format {
-        mapping_parameters {
-          csv {
-            record_column_delimiter = ","
-            record_row_delimiter    = "\n"
-          }
-        }
-      }
-    }
-  }
-}
-`, rInt, rInt, rInt, rInt, rInt, rInt)
-}
-
-func testAccKinesisAnalyticsApplication_inputsKinesisStream(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_kinesis_stream" "test" {
-  name        = "testAcc-%d"
-  shard_count = 1
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode\n"
-
-  inputs {
-    name_prefix = "test_prefix"
-
-    kinesis_stream {
-      resource_arn = aws_kinesis_stream.test.arn
-      role_arn     = aws_iam_role.test.arn
-    }
-
-    parallelism {
-      count = 1
-    }
-
-    schema {
-      record_columns {
-        mapping  = "$.test"
-        name     = "test"
-        sql_type = "VARCHAR(8)"
-      }
-
-      record_encoding = "UTF-8"
-
-      record_format {
-        mapping_parameters {
-          json {
-            record_row_path = "$"
-          }
-        }
-      }
-    }
-  }
-}
-`, rInt, rInt)
-}
-
-func testAccKinesisAnalyticsApplication_inputsUpdateKinesisStream(rInt int, streamName string) string {
-	return fmt.Sprintf(`
-resource "aws_kinesis_stream" "test" {
-  name        = "testAcc-%s-%d"
-  shard_count = 1
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode\n"
-
-  inputs {
-    name_prefix = "test_prefix2"
-
-    kinesis_stream {
-      resource_arn = aws_kinesis_stream.test.arn
-      role_arn     = aws_iam_role.test.arn
-    }
-
-    parallelism {
-      count = 2
-    }
-
-    schema {
-      record_columns {
-        mapping  = "$.test2"
-        name     = "test2"
-        sql_type = "VARCHAR(8)"
-      }
-
-      record_encoding = "UTF-8"
-
-      record_format {
-        mapping_parameters {
-          csv {
-            record_column_delimiter = ","
-            record_row_delimiter    = "\n"
-          }
-        }
-      }
-    }
-  }
-}
-`, streamName, rInt, rInt)
-}
-
-func testAccKinesisAnalyticsApplication_outputsKinesisStream(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_kinesis_stream" "test" {
-  name        = "testAcc-%d"
-  shard_count = 1
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode\n"
-
-  outputs {
-    name = "test_name"
-
-    kinesis_stream {
-      resource_arn = aws_kinesis_stream.test.arn
-      role_arn     = aws_iam_role.test.arn
-    }
-
-    schema {
-      record_format_type = "JSON"
-    }
-  }
-}
-`, rInt, rInt)
-}
-
-func testAccKinesisAnalyticsApplication_outputsMultiple(rInt1, rInt2 int) string {
-	return fmt.Sprintf(`
-resource "aws_kinesis_stream" "test1" {
-  name        = "testAcc-%d"
-  shard_count = 1
-}
-
-resource "aws_kinesis_stream" "test2" {
-  name        = "testAcc-%d"
-  shard_count = 1
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode\n"
-
-  outputs {
-    name = "test_name1"
-
-    kinesis_stream {
-      resource_arn = aws_kinesis_stream.test1.arn
-      role_arn     = aws_iam_role.test.arn
-    }
-
-    schema {
-      record_format_type = "JSON"
-    }
-  }
-
-  outputs {
-    name = "test_name2"
-
-    kinesis_stream {
-      resource_arn = aws_kinesis_stream.test2.arn
-      role_arn     = aws_iam_role.test.arn
-    }
-
-    schema {
-      record_format_type = "JSON"
-    }
-  }
-}
-`, rInt1, rInt2, rInt1)
-}
-
-func testAccKinesisAnalyticsApplicationConfigOutputsLambda(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_iam_policy_document" "kinesisanalytics_assume_role_policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["kinesisanalytics.amazonaws.com"]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "lambda_assume_role_policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
-
-data "aws_partition" "current" {}
-
-resource "aws_iam_role" "kinesis_analytics_application" {
-  name               = "tf-acc-test-%d-kinesis"
-  assume_role_policy = data.aws_iam_policy_document.kinesisanalytics_assume_role_policy.json
-}
-
-resource "aws_iam_role_policy_attachment" "kinesis_analytics_application-AWSLambdaRole" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaRole"
-  role       = aws_iam_role.kinesis_analytics_application.name
-}
-
-resource "aws_iam_role" "lambda_function" {
-  name               = "tf-acc-test-%d-lambda"
-  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_function-AWSLambdaBasicExecutionRole" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  role       = aws_iam_role.lambda_function.name
-}
-
-resource "aws_lambda_function" "test" {
-  filename      = "test-fixtures/lambdatest.zip"
-  function_name = "tf-acc-test-%d"
-  handler       = "exports.example"
-  role          = aws_iam_role.lambda_function.arn
-  runtime       = "nodejs12.x"
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode\n"
-
-  outputs {
-    name = "test_name"
-
-    lambda {
-      resource_arn = aws_lambda_function.test.arn
-      role_arn     = aws_iam_role.kinesis_analytics_application.arn
-    }
-
-    schema {
-      record_format_type = "JSON"
-    }
-  }
-}
-`, rInt, rInt, rInt, rInt)
-}
-
-func testAccKinesisAnalyticsApplication_outputsUpdateKinesisStream(rInt int, streamName string) string {
-	return fmt.Sprintf(`
-resource "aws_kinesis_stream" "test" {
-  name        = "testAcc-%s-%d"
-  shard_count = 1
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-  code = "testCode\n"
-
-  outputs {
-    name = "test_name2"
-
-    kinesis_stream {
-      resource_arn = aws_kinesis_stream.test.arn
-      role_arn     = aws_iam_role.test.arn
-    }
-
-    schema {
-      record_format_type = "CSV"
-    }
-  }
-}
-`, streamName, rInt, rInt)
-}
-
-func testAccKinesisAnalyticsApplication_referenceDataSource(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "test" {
-  bucket = "testacc-%d"
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-
-  reference_data_sources {
-    table_name = "test_table"
-
-    s3 {
-      bucket_arn = aws_s3_bucket.test.arn
-      file_key   = "test_file_key"
-      role_arn   = aws_iam_role.test.arn
-    }
-
-    schema {
-      record_columns {
-        mapping  = "$.test"
-        name     = "test"
-        sql_type = "VARCHAR(8)"
-      }
-
-      record_encoding = "UTF-8"
-
-      record_format {
-        mapping_parameters {
-          json {
-            record_row_path = "$"
-          }
-        }
-      }
-    }
-  }
-}
-`, rInt, rInt)
-}
-
-func testAccKinesisAnalyticsApplication_referenceDataSourceUpdate(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "test" {
-  bucket = "testacc2-%d"
-}
-
-resource "aws_kinesis_analytics_application" "test" {
-  name = "testAcc-%d"
-
-  reference_data_sources {
-    table_name = "test_table2"
-
-    s3 {
-      bucket_arn = aws_s3_bucket.test.arn
-      file_key   = "test_file_key"
-      role_arn   = aws_iam_role.test.arn
-    }
-
-    schema {
-      record_columns {
-        mapping  = "$.test2"
-        name     = "test2"
-        sql_type = "VARCHAR(8)"
-      }
-
-      record_encoding = "UTF-8"
-
-      record_format {
-        mapping_parameters {
-          csv {
-            record_column_delimiter = ","
-            record_row_delimiter    = "\n"
-          }
-        }
-      }
-    }
-  }
-}
-`, rInt, rInt)
-}
-
-// this is used to set up the IAM role
-func testAccKinesisAnalyticsApplication_prereq(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_iam_policy_document" "trust" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["kinesisanalytics.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "test" {
-  name               = "testAcc-%d"
-  assume_role_policy = data.aws_iam_policy_document.trust.json
-}
-
-data "aws_iam_policy_document" "test" {
-  statement {
-    actions   = ["firehose:*"]
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_policy" "test" {
-  name   = "testAcc-%d"
-  policy = data.aws_iam_policy_document.test.json
-}
-
-resource "aws_iam_role_policy_attachment" "test" {
-  role       = aws_iam_role.test.name
-  policy_arn = aws_iam_policy.test.arn
-}
-`, rInt, rInt)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/15881.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/14541.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/13280.

Uses the same resource updated logic as in https://github.com/hashicorp/terraform-provider-aws/pull/11652 (with attribute names changed). That, and adding an equivalent set of test cases as for _v2_, flushed out a number of additional fixes that weren't in the linked PRs but have been noted in the release notes.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_kinesis_analytics_application: Wait for resource deletion.
resource/aws_kinesis_analytics_application: `inputs.parallelism` is a computed attribute.
resource/aws_kinesis_analytics_application: Handle `inputs.processing_configuration` addition and deletion.
resource/aws_kinesis_analytics_application: Handle `reference_data_sources` deletion.
resource/aws_kinesis_analytics_application: Handle `cloudwatch_logging_options` deletion.
resource/aws_kinesis_analytics_application: Set the `description` attribute on creation.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSKinesisAnalyticsApplication_' ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSKinesisAnalyticsApplication_ -timeout 120m
=== RUN   TestAccAWSKinesisAnalyticsApplication_basic
=== PAUSE TestAccAWSKinesisAnalyticsApplication_basic
=== RUN   TestAccAWSKinesisAnalyticsApplication_disappears
=== PAUSE TestAccAWSKinesisAnalyticsApplication_disappears
=== RUN   TestAccAWSKinesisAnalyticsApplication_Tags
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Tags
=== RUN   TestAccAWSKinesisAnalyticsApplication_Code_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Code_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete
=== PAUSE TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete
=== RUN   TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_Input_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Input_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_Input_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Input_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete
=== PAUSE TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete
=== RUN   TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_Multiple_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Multiple_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_Output_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Output_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete
=== PAUSE TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete
=== RUN   TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update
=== CONT  TestAccAWSKinesisAnalyticsApplication_basic
=== CONT  TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add
=== CONT  TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (20.86s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete
--- PASS: TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update (59.88s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add
--- PASS: TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete (52.99s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Output_Update
=== CONT  TestAccAWSKinesisAnalyticsApplication_Multiple_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add (47.23s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add (133.02s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update
=== CONT  TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete
--- PASS: TestAccAWSKinesisAnalyticsApplication_Output_Update (139.46s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Multiple_Update (129.83s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete
--- PASS: TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update (126.58s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Input_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete (47.23s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Input_Add
--- PASS: TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete (128.84s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_Input_Update (105.67s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Code_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update (50.43s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add
--- PASS: TestAccAWSKinesisAnalyticsApplication_Code_Update (33.61s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Tags
--- PASS: TestAccAWSKinesisAnalyticsApplication_Input_Add (116.26s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_disappears
--- PASS: TestAccAWSKinesisAnalyticsApplication_disappears (21.58s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add (47.36s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Tags (48.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	447.894s```
