### PR TITLE
codeartifact resources tagging support

### DIFF
--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -36,6 +36,7 @@ var serviceNames = []string{
 	"cloudwatch",
 	"cloudwatchevents",
 	"cloudwatchlogs",
+	"codeartifact",
 	"codecommit",
 	"codedeploy",
 	"codepipeline",

--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -30,6 +30,7 @@ var sliceServiceNames = []string{
 	"cloudtrail",
 	"cloudwatch",
 	"cloudwatchevents",
+	"codeartifact",
 	"codebuild",
 	"codedeploy",
 	"codepipeline",

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -37,6 +37,7 @@ var serviceNames = []string{
 	"cloudwatch",
 	"cloudwatchevents",
 	"cloudwatchlogs",
+	"codeartifact",
 	"codecommit",
 	"codedeploy",
 	"codepipeline",

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/codeartifact"
 	"github.com/aws/aws-sdk-go/service/codecommit"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
@@ -432,6 +433,23 @@ func CloudwatchlogsListTags(conn *cloudwatchlogs.CloudWatchLogs, identifier stri
 	}
 
 	return CloudwatchlogsKeyValueTags(output.Tags), nil
+}
+
+// CodeartifactListTags lists codeartifact service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func CodeartifactListTags(conn *codeartifact.CodeArtifact, identifier string) (KeyValueTags, error) {
+	input := &codeartifact.ListTagsForResourceInput{
+		ResourceArn: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return CodeartifactKeyValueTags(output.Tags), nil
 }
 
 // CodecommitListTags lists codecommit service tags.

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/codeartifact"
 	"github.com/aws/aws-sdk-go/service/codecommit"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
@@ -164,6 +165,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(cloudwatchevents.New)
 	case "cloudwatchlogs":
 		funcType = reflect.TypeOf(cloudwatchlogs.New)
+	case "codeartifact":
+		funcType = reflect.TypeOf(codeartifact.New)
 	case "codecommit":
 		funcType = reflect.TypeOf(codecommit.New)
 	case "codedeploy":

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	"github.com/aws/aws-sdk-go/service/codeartifact"
 	"github.com/aws/aws-sdk-go/service/codebuild"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
@@ -905,6 +906,33 @@ func (tags KeyValueTags) CloudwatcheventsTags() []*cloudwatchevents.Tag {
 
 // CloudwatcheventsKeyValueTags creates KeyValueTags from cloudwatchevents service tags.
 func CloudwatcheventsKeyValueTags(tags []*cloudwatchevents.Tag) KeyValueTags {
+	m := make(map[string]*string, len(tags))
+
+	for _, tag := range tags {
+		m[aws.StringValue(tag.Key)] = tag.Value
+	}
+
+	return New(m)
+}
+
+// CodeartifactTags returns codeartifact service tags.
+func (tags KeyValueTags) CodeartifactTags() []*codeartifact.Tag {
+	result := make([]*codeartifact.Tag, 0, len(tags))
+
+	for k, v := range tags.Map() {
+		tag := &codeartifact.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		result = append(result, tag)
+	}
+
+	return result
+}
+
+// CodeartifactKeyValueTags creates KeyValueTags from codeartifact service tags.
+func CodeartifactKeyValueTags(tags []*codeartifact.Tag) KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -116,7 +116,7 @@ func resourceAwsCodeArtifactDomainRead(d *schema.ResourceData, meta interface{})
 	tags, err := keyvaluetags.CodeartifactListTags(conn, arn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Codeartifact Domain (%s): %w", arn, err)
+		return fmt.Errorf("error listing tags for CodeArtifact Domain (%s): %w", arn, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
@@ -132,7 +132,7 @@ func resourceAwsCodeArtifactDomainUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.CodeartifactUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Codeartifact Domain (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("error updating CodeArtifact Domain (%s) tags: %w", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/codeartifact"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsCodeArtifactDomain() *schema.Resource {
@@ -17,6 +18,7 @@ func resourceAwsCodeArtifactDomain() *schema.Resource {
 		Create: resourceAwsCodeArtifactDomainCreate,
 		Read:   resourceAwsCodeArtifactDomainRead,
 		Delete: resourceAwsCodeArtifactDomainDelete,
+		Update: resourceAwsCodeArtifactDomainUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -53,6 +55,7 @@ func resourceAwsCodeArtifactDomain() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -64,6 +67,7 @@ func resourceAwsCodeArtifactDomainCreate(d *schema.ResourceData, meta interface{
 	params := &codeartifact.CreateDomainInput{
 		Domain:        aws.String(d.Get("domain").(string)),
 		EncryptionKey: aws.String(d.Get("encryption_key").(string)),
+		Tags:          keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().CodeartifactTags(),
 	}
 
 	domain, err := conn.CreateDomain(params)
@@ -78,6 +82,7 @@ func resourceAwsCodeArtifactDomainCreate(d *schema.ResourceData, meta interface{
 
 func resourceAwsCodeArtifactDomainRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codeartifactconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	log.Printf("[DEBUG] Reading CodeArtifact Domain: %s", d.Id())
 
@@ -99,15 +104,39 @@ func resourceAwsCodeArtifactDomainRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error reading CodeArtifact Domain (%s): %w", d.Id(), err)
 	}
 
+	arn := aws.StringValue(sm.Domain.Arn)
 	d.Set("domain", sm.Domain.Name)
-	d.Set("arn", sm.Domain.Arn)
+	d.Set("arn", arn)
 	d.Set("encryption_key", sm.Domain.EncryptionKey)
 	d.Set("owner", sm.Domain.Owner)
 	d.Set("asset_size_bytes", sm.Domain.AssetSizeBytes)
 	d.Set("repository_count", sm.Domain.RepositoryCount)
 	d.Set("created_time", sm.Domain.CreatedTime.Format(time.RFC3339))
 
+	tags, err := keyvaluetags.CodeartifactListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Codeartifact Domain (%s): %w", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
 	return nil
+}
+
+func resourceAwsCodeArtifactDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codeartifactconn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.CodeartifactUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Codeartifact Domain (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsCodeArtifactDomainRead(d, meta)
 }
 
 func resourceAwsCodeArtifactDomainDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -108,7 +108,7 @@ func TestAccAWSCodeArtifactDomain_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeArtifactDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodeArtifactDomainBasicConfigTags1(rName, "key1", "value1"),
+				Config: testAccAWSCodeArtifactDomainConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeArtifactDomainExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -121,7 +121,7 @@ func TestAccAWSCodeArtifactDomain_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCodeArtifactDomainBasicConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAWSCodeArtifactDomainConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeArtifactDomainExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -130,7 +130,7 @@ func TestAccAWSCodeArtifactDomain_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCodeArtifactDomainBasicConfigTags1(rName, "key2", "value2"),
+				Config: testAccAWSCodeArtifactDomainConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeArtifactDomainExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -236,7 +236,7 @@ resource "aws_codeartifact_domain" "test" {
 `, rName)
 }
 
-func testAccAWSCodeArtifactDomainBasicConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccAWSCodeArtifactDomainConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -254,7 +254,7 @@ resource "aws_codeartifact_domain" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccAWSCodeArtifactDomainBasicConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAWSCodeArtifactDomainConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -86,12 +86,55 @@ func TestAccAWSCodeArtifactDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
 					resource.TestCheckResourceAttrPair(resourceName, "encryption_key", "aws_kms_key.test", "arn"),
 					testAccCheckResourceAttrAccountID(resourceName, "owner"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeArtifactDomain_tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codeartifact_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("codeartifact", t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeArtifactDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeArtifactDomainBasicConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeArtifactDomainExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCodeArtifactDomainBasicConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeArtifactDomainExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSCodeArtifactDomainBasicConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeArtifactDomainExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2")),
 			},
 		},
 	})
@@ -191,4 +234,41 @@ resource "aws_codeartifact_domain" "test" {
   encryption_key = aws_kms_key.test.arn
 }
 `, rName)
+}
+
+func testAccAWSCodeArtifactDomainBasicConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_codeartifact_domain" "test" {
+  domain         = %[1]q
+  encryption_key = aws_kms_key.test.arn
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSCodeArtifactDomainBasicConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_codeartifact_domain" "test" {
+  domain         = %[1]q
+  encryption_key = aws_kms_key.test.arn
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_codeartifact_repository.go
+++ b/aws/resource_aws_codeartifact_repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/codeartifact"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsCodeArtifactRepository() *schema.Resource {
@@ -85,6 +86,7 @@ func resourceAwsCodeArtifactRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -96,6 +98,7 @@ func resourceAwsCodeArtifactRepositoryCreate(d *schema.ResourceData, meta interf
 	params := &codeartifact.CreateRepositoryInput{
 		Repository: aws.String(d.Get("repository").(string)),
 		Domain:     aws.String(d.Get("domain").(string)),
+		Tags:       keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().CodeartifactTags(),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -140,6 +143,7 @@ func resourceAwsCodeArtifactRepositoryUpdate(d *schema.ResourceData, meta interf
 	conn := meta.(*AWSClient).codeartifactconn
 	log.Print("[DEBUG] Updating CodeArtifact Repository")
 
+	needsUpdate := false
 	params := &codeartifact.UpdateRepositoryInput{
 		Repository:  aws.String(d.Get("repository").(string)),
 		Domain:      aws.String(d.Get("domain").(string)),
@@ -149,18 +153,22 @@ func resourceAwsCodeArtifactRepositoryUpdate(d *schema.ResourceData, meta interf
 	if d.HasChange("description") {
 		if v, ok := d.GetOk("description"); ok {
 			params.Description = aws.String(v.(string))
+			needsUpdate = true
 		}
 	}
 
 	if d.HasChange("upstream") {
 		if v, ok := d.GetOk("upstream"); ok {
 			params.Upstreams = expandCodeArtifactUpstreams(v.([]interface{}))
+			needsUpdate = true
 		}
 	}
 
-	_, err := conn.UpdateRepository(params)
-	if err != nil {
-		return fmt.Errorf("error updating CodeArtifact Repository: %w", err)
+	if needsUpdate {
+		_, err := conn.UpdateRepository(params)
+		if err != nil {
+			return fmt.Errorf("error updating CodeArtifact Repository: %w", err)
+		}
 	}
 
 	if d.HasChange("external_connections") {
@@ -194,11 +202,19 @@ func resourceAwsCodeArtifactRepositoryUpdate(d *schema.ResourceData, meta interf
 		}
 	}
 
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.CodeartifactUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Codeartifact Repository (%s) tags: %w", d.Id(), err)
+		}
+	}
+
 	return resourceAwsCodeArtifactRepositoryRead(d, meta)
 }
 
 func resourceAwsCodeArtifactRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codeartifactconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	log.Printf("[DEBUG] Reading CodeArtifact Repository: %s", d.Id())
 
@@ -220,8 +236,9 @@ func resourceAwsCodeArtifactRepositoryRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error reading CodeArtifact Repository (%s): %w", d.Id(), err)
 	}
 
+	arn := aws.StringValue(sm.Repository.Arn)
 	d.Set("repository", sm.Repository.Name)
-	d.Set("arn", sm.Repository.Arn)
+	d.Set("arn", arn)
 	d.Set("domain_owner", sm.Repository.DomainOwner)
 	d.Set("domain", sm.Repository.DomainName)
 	d.Set("administrator_account", sm.Repository.AdministratorAccount)
@@ -237,6 +254,16 @@ func resourceAwsCodeArtifactRepositoryRead(d *schema.ResourceData, meta interfac
 		if err := d.Set("external_connections", flattenCodeArtifactExternalConnections(sm.Repository.ExternalConnections)); err != nil {
 			return fmt.Errorf("[WARN] Error setting external_connections: %w", err)
 		}
+	}
+
+	tags, err := keyvaluetags.CodeartifactListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Codeartifact Repository (%s): %w", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_codeartifact_repository.go
+++ b/aws/resource_aws_codeartifact_repository.go
@@ -205,7 +205,7 @@ func resourceAwsCodeArtifactRepositoryUpdate(d *schema.ResourceData, meta interf
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.CodeartifactUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Codeartifact Repository (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("error updating CodeArtifact Repository (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -259,7 +259,7 @@ func resourceAwsCodeArtifactRepositoryRead(d *schema.ResourceData, meta interfac
 	tags, err := keyvaluetags.CodeartifactListTags(conn, arn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Codeartifact Repository (%s): %w", arn, err)
+		return fmt.Errorf("error listing tags for CodeArtifact Repository (%s): %w", arn, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {

--- a/aws/resource_aws_codeartifact_repository_test.go
+++ b/aws/resource_aws_codeartifact_repository_test.go
@@ -89,12 +89,56 @@ func TestAccAWSCodeArtifactRepository_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "upstream.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "external_connections.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeArtifactRepository_tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codeartifact_repository.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("codeartifact", t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeArtifactRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeArtifactRepositoryConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeArtifactRepositoryExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCodeArtifactRepositoryConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeArtifactRepositoryExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSCodeArtifactRepositoryConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeArtifactRepositoryExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -432,4 +476,31 @@ resource "aws_codeartifact_repository" "test" {
   }
 }
 `, rName)
+}
+
+func testAccAWSCodeArtifactRepositoryConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccAWSCodeArtifactRepositoryBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_codeartifact_repository" "test" {
+  repository = %[1]q
+  domain     = aws_codeartifact_domain.test.domain
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSCodeArtifactRepositoryConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSCodeArtifactRepositoryBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_codeartifact_repository" "test" {
+  repository = %[1]q
+  domain     = aws_codeartifact_domain.test.domain
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 
 * `domain` - (Required) The name of the domain to create. All domain names in an AWS Region that are in the same AWS account must be unique. The domain name is used as the prefix in DNS hostnames. Do not use sensitive information in a domain name because it is publicly discoverable.
 * `encryption_key` - (Required) The encryption key for the domain. This is used to encrypt content stored in a domain. The KMS Key Amazon Resource Name (ARN).
+* `tags` - (Optional) Key-value map of resource tags.
 
 ## Attributes Reference
 

--- a/website/docs/r/codeartifact_repository.html.markdown
+++ b/website/docs/r/codeartifact_repository.html.markdown
@@ -74,6 +74,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the repository.
 * `upstream` - (Optional) A list of upstream repositories to associate with the repository. The order of the upstream repositories in the list determines their priority order when AWS CodeArtifact looks for a requested package version. see [Upstream](#upstream)
 * `external_connections` - An array of external connections associated with the repository. Only one external connection can be set per repository. see [External Connections](#external-connections).
+* `tags` - (Optional) Key-value map of resource tags.
 
 ### Upstream
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15958

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_codeartifact_domain - add `tags` argument.
resource_aws_codeartifact_repository - add `tags` argument.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSCodeArtifactDomain_disappears (46.43s)
--- PASS: TestAccAWSCodeArtifactDomain_basic (56.14s)
--- PASS: TestAccAWSCodeArtifactDomain_tags (142.23s)

--- PASS: TestAccAWSCodeArtifactRepository_disappears (55.96s)
--- PASS: TestAccAWSCodeArtifactRepository_basic (62.72s)
--- PASS: TestAccAWSCodeArtifactRepository_owner (65.24s)
--- PASS: TestAccAWSCodeArtifactRepository_description (111.50s)
--- PASS: TestAccAWSCodeArtifactRepository_tags (153.52s)
--- PASS: TestAccAWSCodeArtifactRepository_externalConnection (158.15s)
--- PASS: TestAccAWSCodeArtifactRepository_upstreams (178.47s)
```
