### PR TITLE
r/aws_storagegateway_smb_file_share: Add `file_share_name` argument

### DIFF
--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -63,6 +63,11 @@ func resourceAwsStorageGatewaySmbFileShare() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"file_share_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"gateway_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -191,6 +196,10 @@ func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta in
 		input.AuditDestinationARN = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("file_share_name"); ok {
+		input.FileShareName = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("smb_acl_enabled"); ok {
 		input.SMBACLEnabled = aws.Bool(v.(bool))
 	}
@@ -255,6 +264,7 @@ func resourceAwsStorageGatewaySmbFileShareRead(d *schema.ResourceData, meta inte
 	d.Set("authentication", fileshare.Authentication)
 	d.Set("default_storage_class", fileshare.DefaultStorageClass)
 	d.Set("fileshare_id", fileshare.FileShareId)
+	d.Set("file_share_name", fileshare.FileShareName)
 	d.Set("gateway_arn", fileshare.GatewayARN)
 	d.Set("guess_mime_type_enabled", fileshare.GuessMIMETypeEnabled)
 	d.Set("case_sensitivity", fileshare.CaseSensitivity)
@@ -306,7 +316,7 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 	if d.HasChanges("admin_user_list", "default_storage_class", "guess_mime_type_enabled", "invalid_user_list",
 		"kms_encrypted", "object_acl", "read_only", "requester_pays", "requester_pays",
 		"valid_user_list", "kms_key_arn", "audit_destination_arn", "smb_acl_enabled", "cache_attributes",
-		"case_sensitivity") {
+		"case_sensitivity", "file_share_name") {
 		input := &storagegateway.UpdateSMBFileShareInput{
 			DefaultStorageClass:  aws.String(d.Get("default_storage_class").(string)),
 			FileShareARN:         aws.String(d.Id()),
@@ -328,6 +338,10 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 
 		if v, ok := d.GetOk("audit_destination_arn"); ok {
 			input.AuditDestinationARN = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("file_share_name"); ok {
+			input.FileShareName = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("cache_attributes"); ok {

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -49,6 +49,7 @@ The following arguments are supported:
 * `authentication` - (Optional) The authentication method that users use to access the file share. Defaults to `ActiveDirectory`. Valid values: `ActiveDirectory`, `GuestAccess`.
 * `audit_destination_arn` - (Optional) The Amazon Resource Name (ARN) of the CloudWatch Log Group used for the audit logs.
 * `default_storage_class` - (Optional) The default storage class for objects put into an Amazon S3 bucket by the file gateway. Defaults to `S3_STANDARD`. Valid values: `S3_STANDARD`, `S3_STANDARD_IA`, `S3_ONEZONE_IA`.
+* `file_share_name` - (Optional) The name of the file share. Must be set if an S3 prefix name is set in `location_arn`.
 * `guess_mime_type_enabled` - (Optional) Boolean value that enables guessing of the MIME type for uploaded objects based on file extensions. Defaults to `true`.
 * `invalid_user_list` - (Optional) A list of users in the Active Directory that are not allowed to access the file share. Only valid if `authentication` is set to `ActiveDirectory`.
 * `kms_encrypted` - (Optional) Boolean value if `true` to use Amazon S3 server side encryption with your own AWS KMS key, or `false` to use a key managed by Amazon S3. Defaults to `false`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15937

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_storagegateway_smb_file_share: Add `file_share_name` argument ([#16008](https://github.com/hashicorp/terraform-provider-aws/issues/16008))
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSStorageGatewaySmbFileShare_FileShareName'  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSStorageGatewaySmbFileShare_FileShareName -timeout 120m
=== RUN   TestAccAWSStorageGatewaySmbFileShare_FileShareName
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_FileShareName
=== CONT  TestAccAWSStorageGatewaySmbFileShare_FileShareName
--- PASS: TestAccAWSStorageGatewaySmbFileShare_FileShareName (349.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	351.306s

$ make testacc TESTARGS='-run=TestAccAWSStorageGatewaySmbFileShare_Authentication_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSStorageGatewaySmbFileShare_Authentication_ -timeout 120m
=== RUN   TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory
=== RUN   TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess
=== CONT  TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory
=== CONT  TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess (308.84s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory (797.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	799.389s
```
