### PR TITLE
r/aws_apigatewayv2_integration: Different range of valid values and defaults for 'timeout_milliseconds' between HTTP and WebSocket APIs

### DIFF
--- a/aws/resource_aws_apigatewayv2_integration.go
+++ b/aws/resource_aws_apigatewayv2_integration.go
@@ -124,10 +124,9 @@ func resourceAwsApiGatewayV2Integration() *schema.Resource {
 				Optional: true,
 			},
 			"timeout_milliseconds": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      29000,
-				ValidateFunc: validation.IntBetween(50, 29000),
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
 			},
 			"tls_config": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -84,7 +84,7 @@ func TestAccAWSAPIGatewayV2Integration_basicHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
 				),
 			},
 			{
@@ -267,7 +267,7 @@ func TestAccAWSAPIGatewayV2Integration_LambdaHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
 				),
 			},
@@ -357,7 +357,7 @@ func TestAccAWSAPIGatewayV2Integration_VpcLinkHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "5001"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29001"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.0.server_name_to_verify", "www.example.com"),
 				),
@@ -386,7 +386,7 @@ func TestAccAWSAPIGatewayV2Integration_VpcLinkHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "4999"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29001"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.0.server_name_to_verify", "www.example.org"),
 				),
@@ -436,7 +436,7 @@ func TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "request_parameters.QueueUrl", sqsQueue1ResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
 				),
 			},
@@ -461,7 +461,7 @@ func TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "request_parameters.QueueUrl", sqsQueue2ResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
 				),
 			},
@@ -800,7 +800,7 @@ resource "aws_apigatewayv2_integration" "test" {
   description          = "Test private integration"
   integration_method   = "GET"
   integration_uri      = aws_lb_listener.test.arn
-  timeout_milliseconds = 5001
+  timeout_milliseconds = 29001
 
   tls_config {
     server_name_to_verify = "www.example.com"
@@ -817,12 +817,11 @@ resource "aws_apigatewayv2_integration" "test" {
   api_id           = aws_apigatewayv2_api.test.id
   integration_type = "HTTP_PROXY"
 
-  connection_type      = "VPC_LINK"
-  connection_id        = aws_apigatewayv2_vpc_link.test.id
-  description          = "Test private integration updated"
-  integration_method   = "POST"
-  integration_uri      = aws_lb_listener.test.arn
-  timeout_milliseconds = 4999
+  connection_type    = "VPC_LINK"
+  connection_id      = aws_apigatewayv2_vpc_link.test.id
+  description        = "Test private integration updated"
+  integration_method = "POST"
+  integration_uri    = aws_lb_listener.test.arn
 
   tls_config {
     server_name_to_verify = "www.example.org"

--- a/website/docs/r/apigatewayv2_integration.html.markdown
+++ b/website/docs/r/apigatewayv2_integration.html.markdown
@@ -86,7 +86,9 @@ Valid values: `WHEN_NO_MATCH`, `WHEN_NO_TEMPLATES`, `NEVER`. Default is `WHEN_NO
 Supported only for WebSocket APIs.
 * `request_templates` - (Optional) A map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. Supported only for WebSocket APIs.
 * `template_selection_expression` - (Optional) The [template selection expression](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-template-selection-expressions) for the integration.
-* `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds or 29 seconds.
+* `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs.
+The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.
+Terraform will only perform drift detection of its value when present in a configuration.
 * `tls_config` - (Optional) The TLS configuration for a private integration. Supported only for HTTP APIs.
 
 The `tls_config` object supports the following:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16002.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_integration: `timeout_milliseconds` has different valid ranges and default values between HTTP and WebSocket APIs. `timeout_milliseconds` is now `Computed`, meaning Terraform will only perform drift detection of its value when present in a configuration.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Integration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 1 -run=TestAccAWSAPIGatewayV2Integration_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Integration_basicWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_basicWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_basicHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_basicHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_disappears
=== PAUSE TestAccAWSAPIGatewayV2Integration_disappears
=== RUN   TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_LambdaWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_LambdaWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_LambdaHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_LambdaHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration
=== PAUSE TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration
=== CONT  TestAccAWSAPIGatewayV2Integration_basicWebSocket
--- PASS: TestAccAWSAPIGatewayV2Integration_basicWebSocket (29.37s)
=== CONT  TestAccAWSAPIGatewayV2Integration_LambdaHttp
--- PASS: TestAccAWSAPIGatewayV2Integration_LambdaHttp (46.22s)
=== CONT  TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration
--- PASS: TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration (35.78s)
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLinkHttp (373.24s)
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket (683.60s)
=== CONT  TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
--- PASS: TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp (33.91s)
=== CONT  TestAccAWSAPIGatewayV2Integration_LambdaWebSocket
--- PASS: TestAccAWSAPIGatewayV2Integration_LambdaWebSocket (38.50s)
=== CONT  TestAccAWSAPIGatewayV2Integration_disappears
--- PASS: TestAccAWSAPIGatewayV2Integration_disappears (16.60s)
=== CONT  TestAccAWSAPIGatewayV2Integration_basicHttp
--- PASS: TestAccAWSAPIGatewayV2Integration_basicHttp (20.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1277.308s
```
