### PR TITLE
tests/data-source/aws_region: Remove hardcoded us-east-1 handling

### DIFF
--- a/aws/data_source_aws_region_test.go
+++ b/aws/data_source_aws_region_test.go
@@ -2,12 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestFindRegionByEc2Endpoint(t *testing.T) {
@@ -75,12 +74,7 @@ func TestFindRegionByName(t *testing.T) {
 }
 
 func TestAccDataSourceAwsRegion_basic(t *testing.T) {
-	// Ensure we always get a consistent result
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
-	resourceName := "data.aws_region.test"
+	dataSourceName := "data.aws_region.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -89,10 +83,9 @@ func TestAccDataSourceAwsRegion_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsRegionConfig_empty,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", "ec2.us-east-1.amazonaws.com"),
-					resource.TestCheckResourceAttr(resourceName, "name", "us-east-1"),
-					resource.TestCheckResourceAttr(resourceName, "description", "US East (N. Virginia)"),
+					resource.TestMatchResourceAttr(dataSourceName, "description", regexp.MustCompile(`^.+$`)),
+					testAccCheckResourceAttrRegionalHostnameService(dataSourceName, "endpoint", ec2.EndpointsID),
+					resource.TestCheckResourceAttr(dataSourceName, "name", testAccGetRegion()),
 				),
 			},
 		},
@@ -100,186 +93,100 @@ func TestAccDataSourceAwsRegion_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAwsRegion_endpoint(t *testing.T) {
-	// Ensure we always get a consistent result
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
-	endpoint1 := "ec2.us-east-1.amazonaws.com"
-	endpoint2 := "ec2.us-east-2.amazonaws.com"
-	name1 := "us-east-1"
-	name2 := "us-east-2"
-	description1 := "US East (N. Virginia)"
-	description2 := "US East (Ohio)"
-	resourceName := "data.aws_region.test"
+	dataSourceName := "data.aws_region.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRegionConfig_endpoint(endpoint1),
+				Config: testAccDataSourceAwsRegionConfig_endpoint(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
-					resource.TestCheckResourceAttr(resourceName, "name", name1),
-					resource.TestCheckResourceAttr(resourceName, "description", description1),
+					resource.TestMatchResourceAttr(dataSourceName, "description", regexp.MustCompile(`^.+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "endpoint", regexp.MustCompile(fmt.Sprintf("^ec2\\.[^.]+\\.%s$", testAccGetPartitionDNSSuffix()))),
+					resource.TestMatchResourceAttr(dataSourceName, "name", regexp.MustCompile(`^.+$`)),
 				),
-			},
-			{
-				Config: testAccDataSourceAwsRegionConfig_endpoint(endpoint2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
-					resource.TestCheckResourceAttr(resourceName, "name", name2),
-					resource.TestCheckResourceAttr(resourceName, "description", description2),
-				),
-			},
-			{
-				Config:      testAccDataSourceAwsRegionConfig_endpoint("does-not-exist"),
-				ExpectError: regexp.MustCompile(`region not found for endpoint: does-not-exist`),
 			},
 		},
 	})
 }
 
 func TestAccDataSourceAwsRegion_endpointAndName(t *testing.T) {
-	// Ensure we always get a consistent result
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
-	endpoint1 := "ec2.us-east-1.amazonaws.com"
-	endpoint2 := "ec2.us-east-2.amazonaws.com"
-	name1 := "us-east-1"
-	name2 := "us-east-2"
-	description1 := "US East (N. Virginia)"
-	description2 := "US East (Ohio)"
-	resourceName := "data.aws_region.test"
+	dataSourceName := "data.aws_region.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRegionConfig_endpointAndName(endpoint1, name1),
+				Config: testAccDataSourceAwsRegionConfig_endpointAndName(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
-					resource.TestCheckResourceAttr(resourceName, "name", name1),
-					resource.TestCheckResourceAttr(resourceName, "description", description1),
+					resource.TestMatchResourceAttr(dataSourceName, "description", regexp.MustCompile(`^.+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "endpoint", regexp.MustCompile(fmt.Sprintf("^ec2\\.[^.]+\\.%s$", testAccGetPartitionDNSSuffix()))),
+					resource.TestMatchResourceAttr(dataSourceName, "name", regexp.MustCompile(`^.+$`)),
 				),
-			},
-			{
-				Config: testAccDataSourceAwsRegionConfig_endpointAndName(endpoint2, name2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
-					resource.TestCheckResourceAttr(resourceName, "name", name2),
-					resource.TestCheckResourceAttr(resourceName, "description", description2),
-				),
-			},
-			{
-				Config: testAccDataSourceAwsRegionConfig_endpointAndName(endpoint1, name1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
-					resource.TestCheckResourceAttr(resourceName, "name", name1),
-					resource.TestCheckResourceAttr(resourceName, "description", description1),
-				),
-			},
-			{
-				Config:      testAccDataSourceAwsRegionConfig_endpointAndName(endpoint1, name2),
-				ExpectError: regexp.MustCompile(`multiple regions matched`),
-			},
-			{
-				Config:      testAccDataSourceAwsRegionConfig_endpointAndName(endpoint2, name1),
-				ExpectError: regexp.MustCompile(`multiple regions matched`),
 			},
 		},
 	})
 }
 
 func TestAccDataSourceAwsRegion_name(t *testing.T) {
-	// Ensure we always get a consistent result
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
-	endpoint1 := "ec2.us-east-1.amazonaws.com"
-	endpoint2 := "ec2.us-east-2.amazonaws.com"
-	name1 := "us-east-1"
-	name2 := "us-east-2"
-	description1 := "US East (N. Virginia)"
-	description2 := "US East (Ohio)"
-	resourceName := "data.aws_region.test"
+	dataSourceName := "data.aws_region.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRegionConfig_name(name1),
+				Config: testAccDataSourceAwsRegionConfig_name(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
-					resource.TestCheckResourceAttr(resourceName, "name", name1),
-					resource.TestCheckResourceAttr(resourceName, "description", description1),
+					resource.TestMatchResourceAttr(dataSourceName, "description", regexp.MustCompile(`^.+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "endpoint", regexp.MustCompile(fmt.Sprintf("^ec2\\.[^.]+\\.%s$", testAccGetPartitionDNSSuffix()))),
+					resource.TestMatchResourceAttr(dataSourceName, "name", regexp.MustCompile(`^.+$`)),
 				),
-			},
-			{
-				Config: testAccDataSourceAwsRegionConfig_name(name2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
-					resource.TestCheckResourceAttr(resourceName, "name", name2),
-					resource.TestCheckResourceAttr(resourceName, "description", description2),
-				),
-			},
-			{
-				Config:      testAccDataSourceAwsRegionConfig_name("does-not-exist"),
-				ExpectError: regexp.MustCompile(`region not found for name: does-not-exist`),
 			},
 		},
 	})
-}
-
-func testAccDataSourceAwsRegionCheck(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		return nil
-	}
 }
 
 const testAccDataSourceAwsRegionConfig_empty = `
 data "aws_region" "test" {}
 `
 
-func testAccDataSourceAwsRegionConfig_endpoint(endpoint string) string {
-	return fmt.Sprintf(`
-data "aws_region" "test" {
-  endpoint = "%s"
-}
-`, endpoint)
+func testAccDataSourceAwsRegionConfig_endpoint() string {
+	return `
+data "aws_partition" "test" {}
+
+data "aws_regions" "test" {
 }
 
-func testAccDataSourceAwsRegionConfig_endpointAndName(endpoint, name string) string {
-	return fmt.Sprintf(`
 data "aws_region" "test" {
-  endpoint = "%s"
-  name     = "%s"
+  endpoint = "ec2.${tolist(data.aws_regions.test.names)[0]}.${data.aws_partition.test.dns_suffix}"
 }
-`, endpoint, name)
+`
 }
 
-func testAccDataSourceAwsRegionConfig_name(name string) string {
-	return fmt.Sprintf(`
-data "aws_region" "test" {
-  name = "%s"
+func testAccDataSourceAwsRegionConfig_endpointAndName() string {
+	return `
+data "aws_partition" "test" {}
+
+data "aws_regions" "test" {
 }
-`, name)
+
+data "aws_region" "test" {
+  endpoint = "ec2.${tolist(data.aws_regions.test.names)[0]}.${data.aws_partition.test.dns_suffix}"
+  name     = tolist(data.aws_regions.test.names)[0]
+}
+`
+}
+
+func testAccDataSourceAwsRegionConfig_name() string {
+	return `
+data "aws_regions" "test" {
+}
+
+data "aws_region" "test" {
+  name = tolist(data.aws_regions.test.names)[0]
+}
+`
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8316
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15737

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Much of the functionality is unit tested.

Previously in AWS GovCloud (US):

```
=== CONT  TestAccDataSourceAwsRegion_basic
TestAccDataSourceAwsRegion_basic: provider_test.go:196: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: f02b1c17-7e7d-4e95-ae14-2e02a2f785f4  []}]
--- FAIL: TestAccDataSourceAwsRegion_basic (0.54s)

=== CONT  TestAccDataSourceAwsRegion_endpoint
TestAccDataSourceAwsRegion_endpoint: provider_test.go:196: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: 74c054be-32b1-432f-b338-3211315ed76c  []}]
--- FAIL: TestAccDataSourceAwsRegion_endpoint (0.50s)

=== CONT  TestAccDataSourceAwsRegion_endpointAndName
TestAccDataSourceAwsRegion_endpointAndName: provider_test.go:196: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: 1527b1e9-a329-43f7-b37e-f3a8da479861  []}]
--- FAIL: TestAccDataSourceAwsRegion_endpointAndName (0.51s)

=== CONT  TestAccDataSourceAwsRegion_name
TestAccDataSourceAwsRegion_name: provider_test.go:196: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: eef98021-bbe9-46f0-bb2a-4649a0b808dd  []}]
--- FAIL: TestAccDataSourceAwsRegion_name (0.43s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccDataSourceAwsRegion_basic (13.01s)
--- PASS: TestAccDataSourceAwsRegion_name (14.91s)
--- PASS: TestAccDataSourceAwsRegion_endpoint (14.92s)
--- PASS: TestAccDataSourceAwsRegion_endpointAndName (14.94s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccDataSourceAwsRegion_basic (17.09s)
--- PASS: TestAccDataSourceAwsRegion_name (19.02s)
--- PASS: TestAccDataSourceAwsRegion_endpoint (19.04s)
--- PASS: TestAccDataSourceAwsRegion_endpointAndName (19.05s)
```