### PR TITLE
tests/resource/aws_default_security_group: Remove hardcoded us-east-1 handling

### DIFF
--- a/aws/ec2_classic_test.go
+++ b/aws/ec2_classic_test.go
@@ -6,7 +6,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -74,4 +76,18 @@ func testAccGetEc2ClassicRegion() string {
 	}
 
 	return testAccGetRegion()
+}
+
+// testAccCheckResourceAttrRegionalARNEc2Classic ensures the Terraform state exactly matches a formatted ARN with EC2-Classic region
+func testAccCheckResourceAttrRegionalARNEc2Classic(resourceName, attributeName, arnService, arnResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attributeValue := arn.ARN{
+			AccountID: testAccGetAccountID(),
+			Partition: testAccGetPartition(),
+			Region:    testAccGetEc2ClassicRegion(),
+			Resource:  arnResource,
+			Service:   arnService,
+		}.String()
+		return resource.TestCheckResourceAttr(resourceName, attributeName, attributeValue)(s)
+	}
 }

--- a/aws/resource_aws_default_security_group_test.go
+++ b/aws/resource_aws_default_security_group_test.go
@@ -118,7 +118,7 @@ func TestAccAWSDefaultSecurityGroup_Classic_basic(t *testing.T) {
 						"cidr_blocks.0": "10.0.0.0/8",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
-					testAccCheckAWSDefaultSecurityGroupARN(resourceName, &group),
+					testAccCheckAWSDefaultSecurityGroupARNEc2Classic(resourceName, &group),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-acc-test"),
@@ -233,6 +233,12 @@ func testAccCheckAWSDefaultSecurityGroupEc2ClassicExists(n string, group *ec2.Se
 }
 
 func testAccCheckAWSDefaultSecurityGroupARN(resourceName string, group *ec2.SecurityGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ec2", fmt.Sprintf("security-group/%s", aws.StringValue(group.GroupId)))(s)
+	}
+}
+
+func testAccCheckAWSDefaultSecurityGroupARNEc2Classic(resourceName string, group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return testAccCheckResourceAttrRegionalARNEc2Classic(resourceName, "arn", "ec2", fmt.Sprintf("security-group/%s", aws.StringValue(group.GroupId)))(s)
 	}

--- a/aws/resource_aws_default_security_group_test.go
+++ b/aws/resource_aws_default_security_group_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -95,23 +94,18 @@ func TestAccAWSDefaultSecurityGroup_Vpc_empty(t *testing.T) {
 }
 
 func TestAccAWSDefaultSecurityGroup_Classic_basic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var group ec2.SecurityGroup
 	resourceName := "aws_default_security_group.test"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSDefaultSecurityGroupDestroy,
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSDefaultSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDefaultSecurityGroupConfig_Classic,
+				Config: testAccAWSDefaultSecurityGroupConfig_Classic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDefaultSecurityGroupExists(resourceName, &group),
+					testAccCheckAWSDefaultSecurityGroupEc2ClassicExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "name", "default"),
 					resource.TestCheckResourceAttr(resourceName, "description", "default group"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_id", ""),
@@ -131,10 +125,11 @@ func TestAccAWSDefaultSecurityGroup_Classic_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:   testAccAWSDefaultSecurityGroupConfig_Classic,
+				Config:   testAccAWSDefaultSecurityGroupConfig_Classic(),
 				PlanOnly: true,
 			},
 			{
+				Config:                  testAccAWSDefaultSecurityGroupConfig_Classic(),
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -150,23 +145,18 @@ func TestAccAWSDefaultSecurityGroup_Classic_empty(t *testing.T) {
 	// Additional references:
 	//  * https://github.com/hashicorp/terraform-provider-aws/issues/14631
 
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var group ec2.SecurityGroup
 	resourceName := "aws_default_security_group.test"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSDefaultSecurityGroupDestroy,
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSDefaultSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDefaultSecurityGroupConfig_Classic_empty,
+				Config: testAccAWSDefaultSecurityGroupConfig_Classic_empty(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDefaultSecurityGroupExists(resourceName, &group),
+					testAccCheckAWSDefaultSecurityGroupEc2ClassicExists(resourceName, &group),
 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
 				),
@@ -209,9 +199,42 @@ func testAccCheckAWSDefaultSecurityGroupExists(n string, group *ec2.SecurityGrou
 	}
 }
 
+func testAccCheckAWSDefaultSecurityGroupEc2ClassicExists(n string, group *ec2.SecurityGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No EC2 Default Security Group ID is set")
+		}
+
+		conn := testAccProviderEc2Classic.Meta().(*AWSClient).ec2conn
+
+		input := &ec2.DescribeSecurityGroupsInput{
+			GroupIds: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		resp, err := conn.DescribeSecurityGroups(input)
+
+		if err != nil {
+			return fmt.Errorf("error describing EC2 Default Security Group (%s): %w", rs.Primary.ID, err)
+		}
+
+		if len(resp.SecurityGroups) == 0 || aws.StringValue(resp.SecurityGroups[0].GroupId) != rs.Primary.ID {
+			return fmt.Errorf("EC2 Default Security Group (%s) not found", rs.Primary.ID)
+		}
+
+		*group = *resp.SecurityGroups[0]
+
+		return nil
+	}
+}
+
 func testAccCheckAWSDefaultSecurityGroupARN(resourceName string, group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		return testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ec2", fmt.Sprintf("security-group/%s", aws.StringValue(group.GroupId)))(s)
+		return testAccCheckResourceAttrRegionalARNEc2Classic(resourceName, "arn", "ec2", fmt.Sprintf("security-group/%s", aws.StringValue(group.GroupId)))(s)
 	}
 }
 
@@ -261,7 +284,10 @@ resource "aws_default_security_group" "test" {
 }
 `
 
-const testAccAWSDefaultSecurityGroupConfig_Classic = `
+func testAccAWSDefaultSecurityGroupConfig_Classic() string {
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		`
 resource "aws_default_security_group" "test" {
   ingress {
     protocol    = "6"
@@ -274,13 +300,18 @@ resource "aws_default_security_group" "test" {
     Name = "tf-acc-test"
   }
 }
-`
+`)
+}
 
-const testAccAWSDefaultSecurityGroupConfig_Classic_empty = `
+func testAccAWSDefaultSecurityGroupConfig_Classic_empty() string {
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		`
 resource "aws_default_security_group" "test" {
   # No attributes set.
 }
-`
+`)
+}
 
 func TestAWSDefaultSecurityGroupMigrateState(t *testing.T) {
 	cases := map[string]struct {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8316
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15737
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15791

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS GovCloud (US):

```
=== RUN   TestAccAWSDefaultSecurityGroup_Classic_basic
TestAccAWSDefaultSecurityGroup_Classic_basic: provider_test.go:196: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: fc6cf64f-8c40-4e8b-a37c-a82d8c6a69c9  []}]
--- FAIL: TestAccAWSDefaultSecurityGroup_Classic_basic (0.40s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDefaultSecurityGroup_Classic_basic (16.47s)
--- SKIP: TestAccAWSDefaultSecurityGroup_Classic_empty (0.00s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSDefaultSecurityGroup_Classic_basic (2.90s)
--- SKIP: TestAccAWSDefaultSecurityGroup_Classic_empty (0.00s)
```
