### PR TITLE
tests/service/elasticache: Remove hardcoded us-east-1 handling

### DIFF
--- a/aws/resource_aws_elasticache_security_group_test.go
+++ b/aws/resource_aws_elasticache_security_group_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -67,24 +66,19 @@ func testSweepElasticacheCacheSecurityGroups(region string) error {
 }
 
 func TestAccAWSElasticacheSecurityGroup_basic(t *testing.T) {
-	// Use EC2-Classic enabled us-east-1 for testing
-	oldRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldRegion)
-
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSElasticacheSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSElasticacheSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheSecurityGroupConfig,
+				Config: testAccAWSElasticacheSecurityGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheSecurityGroupExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
 				),
 			},
 			{
@@ -97,7 +91,7 @@ func TestAccAWSElasticacheSecurityGroup_basic(t *testing.T) {
 }
 
 func testAccCheckAWSElasticacheSecurityGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+	conn := testAccProviderEc2Classic.Meta().(*AWSClient).elasticacheconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_elasticache_security_group" {
@@ -129,7 +123,7 @@ func testAccCheckAWSElasticacheSecurityGroupExists(n string) resource.TestCheckF
 			return fmt.Errorf("No cache security group ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+		conn := testAccProviderEc2Classic.Meta().(*AWSClient).elasticacheconn
 		_, err := conn.DescribeCacheSecurityGroups(&elasticache.DescribeCacheSecurityGroupsInput{
 			CacheSecurityGroupName: aws.String(rs.Primary.ID),
 		})
@@ -140,13 +134,12 @@ func testAccCheckAWSElasticacheSecurityGroupExists(n string) resource.TestCheckF
 	}
 }
 
-var testAccAWSElasticacheSecurityGroupConfig = fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
+func testAccAWSElasticacheSecurityGroupConfig(rName string) string {
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name = "tf-test-security-group-%03d"
+  name = %[1]q
 
   ingress {
     from_port   = -1
@@ -157,7 +150,8 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_elasticache_security_group" "test" {
-  name                 = "tf-test-security-group-%03d"
+  name                 = %[1]q
   security_group_names = [aws_security_group.test.name]
 }
-`, acctest.RandInt(), acctest.RandInt())
+`, rName))
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8316
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15737
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15791

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS GovCloud (US):

```
=== RUN   TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic
TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic: provider_test.go:184: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: 9df5bb8f-fad4-4e95-9262-c306e610a3cf  []}]
--- FAIL: TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic (0.32s)

=== CONT  TestAccAWSElasticacheSecurityGroup_basic
TestAccAWSElasticacheSecurityGroup_basic: provider_test.go:184: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: 925ee8e0-4c50-4e40-a1aa-115a09a1603c  []}]
--- FAIL: TestAccAWSElasticacheSecurityGroup_basic (0.43s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic (533.02s)

--- PASS: TestAccAWSElasticacheSecurityGroup_basic (13.61s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic (3.28s)

--- SKIP: TestAccAWSElasticacheSecurityGroup_basic (2.85s)
```
