### PR TITLE
tests/data-source/aws_pricing_product: Remove hardcoded us-east-1 handling

### DIFF
--- a/aws/pricing_test.go
+++ b/aws/pricing_test.go
@@ -1,0 +1,81 @@
+package aws
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// testAccPricingRegion is the chosen Pricing testing region
+//
+// Cached to prevent issues should multiple regions become available.
+var testAccPricingRegion string
+
+// testAccProviderPricing is the Pricing provider instance
+//
+// This Provider can be used in testing code for API calls without requiring
+// the use of saving and referencing specific ProviderFactories instances.
+//
+// testAccPreCheckPricing(t) must be called before using this provider instance.
+var testAccProviderPricing *schema.Provider
+
+// testAccProviderPricingConfigure ensures the provider is only configured once
+var testAccProviderPricingConfigure sync.Once
+
+// testAccPreCheckPricing verifies AWS credentials and that Pricing is supported
+func testAccPreCheckPricing(t *testing.T) {
+	testAccPartitionHasServicePreCheck(pricing.EndpointsID, t)
+
+	// Since we are outside the scope of the Terraform configuration we must
+	// call Configure() to properly initialize the provider configuration.
+	testAccProviderPricingConfigure.Do(func() {
+		testAccProviderPricing = Provider()
+
+		config := map[string]interface{}{
+			"region": testAccGetPricingRegion(),
+		}
+
+		diags := testAccProviderPricing.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+
+		if diags != nil && diags.HasError() {
+			for _, d := range diags {
+				if d.Severity == diag.Error {
+					t.Fatalf("error configuring Pricing provider: %s", d.Summary)
+				}
+			}
+		}
+	})
+}
+
+// testAccPricingRegionProviderConfig is the Terraform provider configuration for Pricing region testing
+//
+// Testing Pricing assumes no other provider configurations
+// are necessary and overwrites the "aws" provider configuration.
+func testAccPricingRegionProviderConfig() string {
+	return testAccRegionalProviderConfig(testAccGetPricingRegion())
+}
+
+// testAccGetPricingRegion returns the Pricing region for testing
+func testAccGetPricingRegion() string {
+	if testAccPricingRegion != "" {
+		return testAccPricingRegion
+	}
+
+	if rs, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), testAccGetPartition(), pricing.ServiceName); ok {
+		// return available region (random if multiple)
+		for regionID := range rs {
+			testAccPricingRegion = regionID
+			return testAccPricingRegion
+		}
+	}
+
+	testAccPricingRegion = testAccGetRegion()
+
+	return testAccPricingRegion
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8316
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15737

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS GovCloud (US):

```
=== CONT  TestAccDataSourceAwsPricingProduct_ec2
TestAccDataSourceAwsPricingProduct_ec2: provider_test.go:184: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: bc4d07ae-04d0-4fad-b695-5ef067be32ee  []}]
--- FAIL: TestAccDataSourceAwsPricingProduct_ec2 (0.41s)

=== CONT  TestAccDataSourceAwsPricingProduct_redshift
TestAccDataSourceAwsPricingProduct_redshift: provider_test.go:184: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: 0871bc77-35ba-4dbe-aa49-7a54304986ce  []}]
--- FAIL: TestAccDataSourceAwsPricingProduct_redshift (0.38s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccDataSourceAwsPricingProduct_ec2 (18.23s)
--- PASS: TestAccDataSourceAwsPricingProduct_redshift (18.42s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccDataSourceAwsPricingProduct_ec2 (1.54s)
--- SKIP: TestAccDataSourceAwsPricingProduct_redshift (1.54s)
```