### PR TITLE
tests/resource/aws_fms_admin_account: Remove hardcoded environment variable handling

### DIFF
--- a/aws/fms_admin_test.go
+++ b/aws/fms_admin_test.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/fms"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Firewall Management Service admin APIs are only enabled in specific regions, otherwise:
+// InvalidOperationException: This operation is not supported in the 'us-west-2' region.
+
+// testAccFmsAdminRegion is the chosen Firewall Management Service testing region
+//
+// Cached to prevent issues should multiple regions become available.
+var testAccFmsAdminRegion string
+
+// testAccProviderFmsAdmin is the Firewall Management Service provider instance
+//
+// This Provider can be used in testing code for API calls without requiring
+// the use of saving and referencing specific ProviderFactories instances.
+//
+// testAccPreCheckFmsAdmin(t) must be called before using this provider instance.
+var testAccProviderFmsAdmin *schema.Provider
+
+// testAccProviderFmsAdminConfigure ensures the provider is only configured once
+var testAccProviderFmsAdminConfigure sync.Once
+
+// testAccPreCheckFmsAdmin verifies AWS credentials and that Firewall Management Service is supported
+func testAccPreCheckFmsAdmin(t *testing.T) {
+	testAccPartitionHasServicePreCheck(fms.EndpointsID, t)
+
+	// Since we are outside the scope of the Terraform configuration we must
+	// call Configure() to properly initialize the provider configuration.
+	testAccProviderFmsAdminConfigure.Do(func() {
+		testAccProviderFmsAdmin = Provider()
+
+		config := map[string]interface{}{
+			"region": testAccGetFmsAdminRegion(),
+		}
+
+		diags := testAccProviderFmsAdmin.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+
+		if diags != nil && diags.HasError() {
+			for _, d := range diags {
+				if d.Severity == diag.Error {
+					t.Fatalf("error configuring Firewall Management Service provider: %s", d.Summary)
+				}
+			}
+		}
+	})
+}
+
+// testAccFmsAdminRegionProviderConfig is the Terraform provider configuration for Firewall Management Service region testing
+//
+// Testing Firewall Management Service assumes no other provider configurations
+// are necessary and overwrites the "aws" provider configuration.
+func testAccFmsAdminRegionProviderConfig() string {
+	return testAccRegionalProviderConfig(testAccGetFmsAdminRegion())
+}
+
+// testAccGetFmsAdminRegion returns the Firewall Management Service region for testing
+func testAccGetFmsAdminRegion() string {
+	if testAccFmsAdminRegion != "" {
+		return testAccFmsAdminRegion
+	}
+
+	testAccFmsAdminRegion = endpoints.UsEast1RegionID
+
+	return testAccFmsAdminRegion
+}

--- a/aws/resource_aws_fms_admin_account_test.go
+++ b/aws/resource_aws_fms_admin_account_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,19 +11,19 @@ import (
 )
 
 func TestAccAwsFmsAdminAccount_basic(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	resourceName := "aws_fms_admin_account.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckFmsAdminAccountDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckFmsAdmin(t)
+			testAccOrganizationsAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckFmsAdminAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFmsAdminAccountConfig_basic,
+				Config: testAccFmsAdminAccountConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceAttrAccountID(resourceName, "account_id"),
 				),
@@ -34,7 +33,7 @@ func TestAccAwsFmsAdminAccount_basic(t *testing.T) {
 }
 
 func testAccCheckFmsAdminAccountDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).fmsconn
+	conn := testAccProviderFmsAdmin.Meta().(*AWSClient).fmsconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_fms_admin_account" {
@@ -61,13 +60,19 @@ func testAccCheckFmsAdminAccountDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccFmsAdminAccountConfig_basic = `
+func testAccFmsAdminAccountConfig_basic() string {
+	return composeConfig(
+		testAccFmsAdminRegionProviderConfig(),
+		`
+data "aws_partition" "current" {}
+
 resource "aws_organizations_organization" "test" {
-  aws_service_access_principals = ["fms.amazonaws.com"]
+  aws_service_access_principals = ["fms.${data.aws_partition.current.dns_suffix}"]
   feature_set                   = "ALL"
 }
 
 resource "aws_fms_admin_account" "test" {
   account_id = aws_organizations_organization.test.master_account_id
 }
-`
+`)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8316
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15737
Closes #16105, closes #16106

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS GovCloud (US):

```
=== CONT  TestAccAwsFmsAdminAccount_basic
TestAccAwsFmsAdminAccount_basic: provider_test.go:184: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: b96069f2-b851-4a14-814c-e04ebd3a1e7e  []}]
--- FAIL: TestAccAwsFmsAdminAccount_basic (0.33s)
```

Output from acceptance testing in AWS Commercial (standalone account):

```
--- PASS: TestAccAwsFmsAdminAccount_basic (97.32s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAwsFmsAdminAccount_basic (1.51s)
```