### PR TITLE
tests/resource/aws_route53_query_log: Remove hardcoded environment variable handling

### DIFF
--- a/aws/resource_aws_route53_query_log_test.go
+++ b/aws/resource_aws_route53_query_log_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 	"testing"
 
@@ -69,12 +68,6 @@ func testSweepRoute53QueryLogs(region string) error {
 }
 
 func TestAccAWSRoute53QueryLog_basic(t *testing.T) {
-	// The underlying resources are sensitive to where they are located
-	// Use us-east-1 for testing
-	oldRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldRegion)
-
 	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
 	resourceName := "aws_route53_query_log.test"
 	route53ZoneResourceName := "aws_route53_zone.test"
@@ -82,9 +75,9 @@ func TestAccAWSRoute53QueryLog_basic(t *testing.T) {
 
 	var queryLoggingConfig route53.QueryLoggingConfig
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRoute53QueryLogDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckRoute53QueryLog(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckRoute53QueryLogDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAWSRoute53QueryLogResourceConfigBasic1(rName),
@@ -105,7 +98,7 @@ func TestAccAWSRoute53QueryLog_basic(t *testing.T) {
 
 func testAccCheckRoute53QueryLogExists(pr string, queryLoggingConfig *route53.QueryLoggingConfig) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).r53conn
+		conn := testAccProviderRoute53QueryLog.Meta().(*AWSClient).r53conn
 		rs, ok := s.RootModule().Resources[pr]
 		if !ok {
 			return fmt.Errorf("Not found: %s", pr)
@@ -132,7 +125,7 @@ func testAccCheckRoute53QueryLogExists(pr string, queryLoggingConfig *route53.Qu
 }
 
 func testAccCheckRoute53QueryLogDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).r53conn
+	conn := testAccProviderRoute53QueryLog.Meta().(*AWSClient).r53conn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route53_query_log" {
@@ -155,7 +148,9 @@ func testAccCheckRoute53QueryLogDestroy(s *terraform.State) error {
 }
 
 func testAccCheckAWSRoute53QueryLogResourceConfigBasic1(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccRoute53QueryLogRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
   name              = "/aws/route53/${aws_route53_zone.test.name}"
   retention_in_days = 1
@@ -194,5 +189,5 @@ resource "aws_route53_query_log" "test" {
   cloudwatch_log_group_arn = aws_cloudwatch_log_group.test.arn
   zone_id                  = aws_route53_zone.test.zone_id
 }
-`, rName)
+`, rName))
 }

--- a/aws/route53_query_log_test.go
+++ b/aws/route53_query_log_test.go
@@ -1,0 +1,87 @@
+package aws
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Route 53 Query Logging can only be enabled with CloudWatch Log Groups in specific regions,
+
+// testAccRoute53QueryLogRegion is the chosen Route 53 Query Logging testing region
+//
+// Cached to prevent issues should multiple regions become available.
+var testAccRoute53QueryLogRegion string
+
+// testAccProviderRoute53QueryLog is the Route 53 Query Logging provider instance
+//
+// This Provider can be used in testing code for API calls without requiring
+// the use of saving and referencing specific ProviderFactories instances.
+//
+// testAccPreCheckRoute53QueryLog(t) must be called before using this provider instance.
+var testAccProviderRoute53QueryLog *schema.Provider
+
+// testAccProviderRoute53QueryLogConfigure ensures the provider is only configured once
+var testAccProviderRoute53QueryLogConfigure sync.Once
+
+// testAccPreCheckRoute53QueryLog verifies AWS credentials and that Route 53 Query Logging is supported
+func testAccPreCheckRoute53QueryLog(t *testing.T) {
+	testAccPartitionHasServicePreCheck(route53.EndpointsID, t)
+
+	// Since we are outside the scope of the Terraform configuration we must
+	// call Configure() to properly initialize the provider configuration.
+	testAccProviderRoute53QueryLogConfigure.Do(func() {
+		testAccProviderRoute53QueryLog = Provider()
+
+		region := testAccGetRoute53QueryLogRegion()
+
+		if region == "" {
+			t.Skip("Route 53 Query Log not available in this AWS Partition")
+		}
+
+		config := map[string]interface{}{
+			"region": region,
+		}
+
+		diags := testAccProviderRoute53QueryLog.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+
+		if diags != nil && diags.HasError() {
+			for _, d := range diags {
+				if d.Severity == diag.Error {
+					t.Fatalf("error configuring Route 53 Query Logging provider: %s", d.Summary)
+				}
+			}
+		}
+	})
+}
+
+// testAccRoute53QueryLogRegionProviderConfig is the Terraform provider configuration for Route 53 Query Logging region testing
+//
+// Testing Route 53 Query Logging assumes no other provider configurations
+// are necessary and overwrites the "aws" provider configuration.
+func testAccRoute53QueryLogRegionProviderConfig() string {
+	return testAccRegionalProviderConfig(testAccGetRoute53QueryLogRegion())
+}
+
+// testAccGetRoute53QueryLogRegion returns the Route 53 Query Logging region for testing
+func testAccGetRoute53QueryLogRegion() string {
+	if testAccRoute53QueryLogRegion != "" {
+		return testAccRoute53QueryLogRegion
+	}
+
+	// AWS Commercial: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html
+	// AWS GovCloud (US) - only private DNS: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-r53.html
+	// AWS China - not available yet: https://docs.amazonaws.cn/en_us/aws/latest/userguide/route53.html
+	switch testAccGetPartition() {
+	case endpoints.AwsPartitionID:
+		testAccRoute53QueryLogRegion = endpoints.UsEast1RegionID
+	}
+
+	return testAccRoute53QueryLogRegion
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8316
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15737

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS GovCloud (US):

```
=== CONT  TestAccAWSRoute53QueryLog_basic
TestAccAWSRoute53QueryLog_basic: provider_test.go:184: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: cb8c48d8-2335-4b2f-b5f0-97cd5a4ec4d7  []}]
--- FAIL: TestAccAWSRoute53QueryLog_basic (0.40s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSRoute53QueryLog_basic (46.16s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSRoute53QueryLog_basic (1.56s)
```
