### PR TITLE
tests/resource/aws_waf_web_acl: Remove hardcoded environment variable handling

### DIFF
--- a/aws/waf_logging_configuration_test.go
+++ b/aws/waf_logging_configuration_test.go
@@ -1,0 +1,87 @@
+package aws
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// WAF Logging Configurations can only be enabled with destinations in specific regions,
+
+// testAccWafLoggingConfigurationRegion is the chosen WAF Logging Configurations testing region
+//
+// Cached to prevent issues should multiple regions become available.
+var testAccWafLoggingConfigurationRegion string
+
+// testAccProviderWafLoggingConfiguration is the WAF Logging Configurations provider instance
+//
+// This Provider can be used in testing code for API calls without requiring
+// the use of saving and referencing specific ProviderFactories instances.
+//
+// testAccPreCheckWafLoggingConfiguration(t) must be called before using this provider instance.
+var testAccProviderWafLoggingConfiguration *schema.Provider
+
+// testAccProviderWafLoggingConfigurationConfigure ensures the provider is only configured once
+var testAccProviderWafLoggingConfigurationConfigure sync.Once
+
+// testAccPreCheckWafLoggingConfiguration verifies AWS credentials and that WAF Logging Configurations is supported
+func testAccPreCheckWafLoggingConfiguration(t *testing.T) {
+	testAccPartitionHasServicePreCheck(waf.EndpointsID, t)
+
+	// Since we are outside the scope of the Terraform configuration we must
+	// call Configure() to properly initialize the provider configuration.
+	testAccProviderWafLoggingConfigurationConfigure.Do(func() {
+		testAccProviderWafLoggingConfiguration = Provider()
+
+		region := testAccGetWafLoggingConfigurationRegion()
+
+		if region == "" {
+			t.Skip("WAF Logging Configuration not available in this AWS Partition")
+		}
+
+		config := map[string]interface{}{
+			"region": region,
+		}
+
+		diags := testAccProviderWafLoggingConfiguration.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+
+		if diags != nil && diags.HasError() {
+			for _, d := range diags {
+				if d.Severity == diag.Error {
+					t.Fatalf("error configuring WAF Logging Configurations provider: %s", d.Summary)
+				}
+			}
+		}
+	})
+}
+
+// testAccWafLoggingConfigurationRegionProviderConfig is the Terraform provider configuration for WAF Logging Configurations region testing
+//
+// Testing WAF Logging Configurations assumes no other provider configurations
+// are necessary and overwrites the "aws" provider configuration.
+func testAccWafLoggingConfigurationRegionProviderConfig() string {
+	return testAccRegionalProviderConfig(testAccGetWafLoggingConfigurationRegion())
+}
+
+// testAccGetWafLoggingConfigurationRegion returns the WAF Logging Configurations region for testing
+func testAccGetWafLoggingConfigurationRegion() string {
+	if testAccWafLoggingConfigurationRegion != "" {
+		return testAccWafLoggingConfigurationRegion
+	}
+
+	// AWS Commercial: https://docs.aws.amazon.com/waf/latest/developerguide/classic-logging.html
+	// AWS GovCloud (US) - not available yet: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-waf.html
+	// AWS China - not available yet
+	switch testAccGetPartition() {
+	case endpoints.AwsPartitionID:
+		testAccWafLoggingConfigurationRegion = endpoints.UsEast1RegionID
+	}
+
+	return testAccWafLoggingConfigurationRegion
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/8316
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15737

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS GovCloud (US):

```
=== CONT  TestAccAWSWafWebAcl_LoggingConfiguration
TestAccAWSWafWebAcl_LoggingConfiguration: provider_test.go:184: [{0 error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
  status code: 403, request id: 525f91fb-c193-46b4-861a-9cabab7f4303  []}]
--- FAIL: TestAccAWSWafWebAcl_LoggingConfiguration (0.38s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSWafWebAcl_LoggingConfiguration (115.97s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSWafWebAcl_LoggingConfiguration (24.06s)
```

