### PR TITLE
enhancement/added new options to cloudfront distribution resource

### DIFF
--- a/.changelog/16049.txt
+++ b/.changelog/16049.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_distribution: Add `connection_attempts`, `connection_timeout`, and `origin_shield`.
+```

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -136,6 +136,13 @@ func customOriginSslProtocolsConf() *schema.Set {
 	return schema.NewSet(schema.HashString, []interface{}{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"})
 }
 
+func originShield() map[string]interface{} {
+	return map[string]interface{}{
+		"enabled":              true,
+		"origin_shield_region": "us-east-1",
+	}
+}
+
 func s3OriginConf() map[string]interface{} {
 	return map[string]interface{}{
 		"origin_access_identity": "origin-access-identity/cloudfront/E127EXAMPLE51Z",
@@ -151,6 +158,7 @@ func originWithCustomConf() map[string]interface{} {
 		"custom_header":        originCustomHeadersConf(),
 	}
 }
+
 func originWithS3Conf() map[string]interface{} {
 	return map[string]interface{}{
 		"origin_id":        "S3Origin",
@@ -812,6 +820,27 @@ func TestCloudFrontStructure_flattenCustomOriginConfigSSL(t *testing.T) {
 	out := flattenCustomOriginConfigSSL(ocs)
 
 	if !in.Equal(out) {
+		t.Fatalf("Expected out to be %v, got %v", in, out)
+	}
+}
+
+func TestCloudFrontStructure_expandOriginShield(t *testing.T) {
+	data := originShield()
+	o := expandOriginShield(data)
+	if *o.Enabled != true {
+		t.Fatalf("Expected Enabled to be true, got %v", *o.Enabled)
+	}
+	if *o.OriginShieldRegion != "us-east-1" {
+		t.Fatalf("Expected OriginShieldRegion to be us-east-1, got %v", *o.OriginShieldRegion)
+	}
+}
+
+func TestCloudFrontStructure_flattenOriginShield(t *testing.T) {
+	in := originShield()
+	o := expandOriginShield(in)
+	out := flattenOriginShield(o)
+
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -139,7 +139,7 @@ func customOriginSslProtocolsConf() *schema.Set {
 func originShield() map[string]interface{} {
 	return map[string]interface{}{
 		"enabled":              true,
-		"origin_shield_region": "us-east-1",
+		"origin_shield_region": "testRegion",
 	}
 }
 
@@ -830,8 +830,8 @@ func TestCloudFrontStructure_expandOriginShield(t *testing.T) {
 	if *o.Enabled != true {
 		t.Fatalf("Expected Enabled to be true, got %v", *o.Enabled)
 	}
-	if *o.OriginShieldRegion != "us-east-1" {
-		t.Fatalf("Expected OriginShieldRegion to be us-east-1, got %v", *o.OriginShieldRegion)
+	if *o.OriginShieldRegion != "testRegion" {
+		t.Fatalf("Expected OriginShieldRegion to be testRegion, got %v", *o.OriginShieldRegion)
 	}
 }
 

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -495,6 +495,18 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Set:      originHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"connection_attempts": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      3,
+							ValidateFunc: validation.IntBetween(1, 3),
+						},
+						"connection_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      10,
+							ValidateFunc: validation.IntBetween(1, 10),
+						},
 						"custom_origin_config": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -561,6 +573,24 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"origin_path": {
 							Type:     schema.TypeString,
 							Optional: true,
+						},
+						"origin_shield": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									"origin_shield_region": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringMatch(awsRegionRegexp, "must be a valid AWS Region Code (eg. us-east-1)"),
+									},
+								},
+							},
 						},
 						"s3_origin_config": {
 							Type:     schema.TypeList,

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -587,7 +587,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"origin_shield_region": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validation.StringMatch(awsRegionRegexp, "must be a valid AWS Region Code (eg. us-east-1)"),
+										ValidateFunc: validation.StringMatch(awsRegionRegexp, "must be a valid AWS Region Code"),
 									},
 								},
 							},

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -435,7 +435,110 @@ func TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSCloudFrontDistributionConfig_Origin_EmptyOriginID(),
-				ExpectError: regexp.MustCompile(`origin_id must not be empty`),
+				ExpectError: regexp.MustCompile(`origin.0.origin_id must not be empty`),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontDistribution_Origin_ConnectionAttempts(t *testing.T) {
+	var distribution cloudfront.Distribution
+	resourceName := "aws_cloudfront_distribution.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rInt := acctest.RandInt()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("cloudfront", t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCloudFrontDistributionOriginItem(rName, rInt, `connection_attempts = 0`),
+				ExpectError: regexp.MustCompile(`expected origin.0.connection_attempts to be in the range`),
+			},
+			{
+				Config:      testAccAWSCloudFrontDistributionOriginItem(rName, rInt, `connection_attempts = 4`),
+				ExpectError: regexp.MustCompile(`expected origin.0.connection_attempts to be in the range`),
+			},
+			{
+				Config: testAccAWSCloudFrontDistributionOriginItem(rName, rInt, `connection_attempts = 2`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.connection_attempts", `2`),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontDistribution_Origin_ConnectionTimeout(t *testing.T) {
+	var distribution cloudfront.Distribution
+	resourceName := "aws_cloudfront_distribution.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rInt := acctest.RandInt()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("cloudfront", t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCloudFrontDistributionOriginItem(rName, rInt, `connection_timeout = 0`),
+				ExpectError: regexp.MustCompile(`expected origin.0.connection_timeout to be in the range`),
+			},
+			{
+				Config:      testAccAWSCloudFrontDistributionOriginItem(rName, rInt, `connection_timeout = 11`),
+				ExpectError: regexp.MustCompile(`expected origin.0.connection_timeout to be in the range`),
+			},
+			{
+				Config: testAccAWSCloudFrontDistributionOriginItem(rName, rInt, `connection_timeout = 6`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.connection_timeout", `6`),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontDistribution_Origin_OriginShield(t *testing.T) {
+	var distribution cloudfront.Distribution
+	resourceName := "aws_cloudfront_distribution.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rInt := acctest.RandInt()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("cloudfront", t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCloudFrontDistributionOriginItem(rName, rInt, originShieldItem(`null`, `"us-east-1"`)),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      testAccAWSCloudFrontDistributionOriginItem(rName, rInt, originShieldItem(`false`, `null`)),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      testAccAWSCloudFrontDistributionOriginItem(rName, rInt, originShieldItem(`true`, `null`)),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      testAccAWSCloudFrontDistributionOriginItem(rName, rInt, originShieldItem(`false`, `""`)),
+				ExpectError: regexp.MustCompile(`.*must be a valid AWS Region Code \(eg\. us\-east\-1\).*`),
+			},
+			{
+				Config:      testAccAWSCloudFrontDistributionOriginItem(rName, rInt, originShieldItem(`true`, `"US East (Ohio)"`)),
+				ExpectError: regexp.MustCompile(`.*must be a valid AWS Region Code \(eg\. us\-east\-1\).*`),
+			},
+			{
+				Config: testAccAWSCloudFrontDistributionOriginItem(rName, rInt, originShieldItem(`true`, `"us-east-1"`)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.origin_shield.0.enabled", `true`),
+					resource.TestCheckResourceAttr(resourceName, "origin.0.origin_shield.0.origin_shield_region", "us-east-1"),
+				),
 			},
 		},
 	})
@@ -3520,4 +3623,58 @@ resource "aws_cloudfront_distribution" "test" {
   }
 }
 `, retainOnDelete))
+}
+
+func originShieldItem(enabled, region string) string {
+	return fmt.Sprintf(`
+origin_shield {
+  enabled              = %[1]s
+  origin_shield_region = %[2]s
+}
+`, enabled, region)
+}
+
+func testAccAWSCloudFrontDistributionOriginItem(rName string, rInt int, item string) string {
+	return composeConfig(
+		originBucket,
+		testAccAWSCloudFrontDistributionConfigCacheBehaviorRealtimeLogConfigBase(rName),
+		fmt.Sprintf(`
+variable rand_id {
+  default = %[1]d
+}
+
+resource "aws_cloudfront_distribution" "test" {
+  origin {
+    domain_name = "${aws_s3_bucket.s3_bucket_origin.id}.s3.amazonaws.com"
+    origin_id   = "myOrigin"
+    %[2]s
+  }
+  enabled = true
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "myOrigin"
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+  price_class = "PriceClass_200"
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`, rInt, item))
 }

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -452,6 +452,10 @@ argument should not be specified.
 
 #### Origin Arguments
 
+* `connection_attempts` (Optional) - The number of times that CloudFront attempts to connect to the origin. Must be between 1-3. Defaults to 3.
+
+* `connection_timeout` (Optional) - The number of seconds that CloudFront waits when trying to establish a connection to the origin. Must be between 1-10. Defaults to 10.
+
 * `custom_origin_config` - The [CloudFront custom
     origin](#custom-origin-config-arguments) configuration information. If an S3
     origin is required, use `s3_origin_config` instead.
@@ -468,6 +472,9 @@ argument should not be specified.
 * `origin_path` (Optional) - An optional element that causes CloudFront to
     request your content from a directory in your Amazon S3 bucket or your
     custom origin.
+
+* `origin_shield` - The [CloudFront Origin Shield](#origin-shield-arguments)
+    configuration information. Using Origin Shield can help reduce the load on your origin. For more information, see [Using Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html) in the Amazon CloudFront Developer Guide.
 
 * `s3_origin_config` - The [CloudFront S3 origin](#s3-origin-config-arguments)
     configuration information. If a custom origin is required, use
@@ -489,6 +496,12 @@ argument should not be specified.
 * `origin_keepalive_timeout` - (Optional) The Custom KeepAlive timeout, in seconds. By default, AWS enforces a limit of `60`. But you can request an [increase](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-request-timeout).
 
 * `origin_read_timeout` - (Optional) The Custom Read timeout, in seconds. By default, AWS enforces a limit of `60`. But you can request an [increase](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-request-timeout).
+
+##### Origin Shield Arguments
+
+* `enabled` (Required) - A flag that specifies whether Origin Shield is enabled.
+
+* `origin_shield_region` (Required) - The AWS Region for Origin Shield. To specify a region, use the region code, not the region name. For example, specify the US East (Ohio) region as us-east-2.
 
 ##### S3 Origin Config Arguments
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15752
Closes #16009

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cloudfront_distribution: Add `origin_shield`, `connection_attempts` and `connection_timeout` arguments to `origin` block
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestCloudFrontStructure_ -timeout 60m
=== RUN   TestCloudFrontStructure_expandCloudFrontDefaultCacheBehavior
--- PASS: TestCloudFrontStructure_expandCloudFrontDefaultCacheBehavior (0.00s)
=== RUN   TestCloudFrontStructure_expandTrustedSigners
--- PASS: TestCloudFrontStructure_expandTrustedSigners (0.00s)
=== RUN   TestCloudFrontStructure_flattenTrustedSigners
--- PASS: TestCloudFrontStructure_flattenTrustedSigners (0.00s)
=== RUN   TestCloudFrontStructure_expandTrustedSigners_empty
--- PASS: TestCloudFrontStructure_expandTrustedSigners_empty (0.00s)
=== RUN   TestCloudFrontStructure_expandLambdaFunctionAssociations
--- PASS: TestCloudFrontStructure_expandLambdaFunctionAssociations (0.00s)
=== RUN   TestCloudFrontStructure_flattenlambdaFunctionAssociations
--- PASS: TestCloudFrontStructure_flattenlambdaFunctionAssociations (0.00s)
=== RUN   TestCloudFrontStructure_expandlambdaFunctionAssociations_empty
--- PASS: TestCloudFrontStructure_expandlambdaFunctionAssociations_empty (0.00s)
=== RUN   TestCloudFrontStructure_expandForwardedValues
--- PASS: TestCloudFrontStructure_expandForwardedValues (0.00s)
=== RUN   TestCloudFrontStructure_flattenForwardedValues
--- PASS: TestCloudFrontStructure_flattenForwardedValues (0.00s)
=== RUN   TestCloudFrontStructure_expandHeaders
--- PASS: TestCloudFrontStructure_expandHeaders (0.00s)
=== RUN   TestCloudFrontStructure_flattenHeaders
--- PASS: TestCloudFrontStructure_flattenHeaders (0.00s)
=== RUN   TestCloudFrontStructure_expandQueryStringCacheKeys
--- PASS: TestCloudFrontStructure_expandQueryStringCacheKeys (0.00s)
=== RUN   TestCloudFrontStructure_flattenQueryStringCacheKeys
--- PASS: TestCloudFrontStructure_flattenQueryStringCacheKeys (0.00s)
=== RUN   TestCloudFrontStructure_expandCookiePreference
--- PASS: TestCloudFrontStructure_expandCookiePreference (0.00s)
=== RUN   TestCloudFrontStructure_flattenCookiePreference
--- PASS: TestCloudFrontStructure_flattenCookiePreference (0.00s)
=== RUN   TestCloudFrontStructure_expandCookieNames
--- PASS: TestCloudFrontStructure_expandCookieNames (0.00s)
=== RUN   TestCloudFrontStructure_flattenCookieNames
--- PASS: TestCloudFrontStructure_flattenCookieNames (0.00s)
=== RUN   TestCloudFrontStructure_expandAllowedMethods
--- PASS: TestCloudFrontStructure_expandAllowedMethods (0.00s)
=== RUN   TestCloudFrontStructure_flattenAllowedMethods
--- PASS: TestCloudFrontStructure_flattenAllowedMethods (0.00s)
=== RUN   TestCloudFrontStructure_expandCachedMethods
--- PASS: TestCloudFrontStructure_expandCachedMethods (0.00s)
=== RUN   TestCloudFrontStructure_flattenCachedMethods
--- PASS: TestCloudFrontStructure_flattenCachedMethods (0.00s)
=== RUN   TestCloudFrontStructure_expandOrigins
--- PASS: TestCloudFrontStructure_expandOrigins (0.00s)
=== RUN   TestCloudFrontStructure_flattenOrigins
--- PASS: TestCloudFrontStructure_flattenOrigins (0.00s)
=== RUN   TestCloudFrontStructure_expandOriginGroups
--- PASS: TestCloudFrontStructure_expandOriginGroups (0.00s)
=== RUN   TestCloudFrontStructure_flattenOriginGroups
--- PASS: TestCloudFrontStructure_flattenOriginGroups (0.00s)
=== RUN   TestCloudFrontStructure_expandOrigin
--- PASS: TestCloudFrontStructure_expandOrigin (0.00s)
=== RUN   TestCloudFrontStructure_flattenOrigin
--- PASS: TestCloudFrontStructure_flattenOrigin (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomHeaders
--- PASS: TestCloudFrontStructure_expandCustomHeaders (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomHeaders
--- PASS: TestCloudFrontStructure_flattenCustomHeaders (0.00s)
=== RUN   TestCloudFrontStructure_flattenOriginCustomHeader
--- PASS: TestCloudFrontStructure_flattenOriginCustomHeader (0.00s)
=== RUN   TestCloudFrontStructure_expandOriginCustomHeader
--- PASS: TestCloudFrontStructure_expandOriginCustomHeader (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomOriginConfig
--- PASS: TestCloudFrontStructure_expandCustomOriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomOriginConfig
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomOriginConfigSSL
--- PASS: TestCloudFrontStructure_expandCustomOriginConfigSSL (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomOriginConfigSSL
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfigSSL (0.00s)
=== RUN   TestCloudFrontStructure_expandOriginShield
--- PASS: TestCloudFrontStructure_expandOriginShield (0.00s)
=== RUN   TestCloudFrontStructure_flattenOriginShield
--- PASS: TestCloudFrontStructure_flattenOriginShield (0.00s)
=== RUN   TestCloudFrontStructure_expandS3OriginConfig
--- PASS: TestCloudFrontStructure_expandS3OriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_flattenS3OriginConfig
--- PASS: TestCloudFrontStructure_flattenS3OriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomErrorResponses
--- PASS: TestCloudFrontStructure_expandCustomErrorResponses (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomErrorResponses
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponses (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomErrorResponse
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomErrorResponse
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponse (0.00s)
=== RUN   TestCloudFrontStructure_expandLoggingConfig
--- PASS: TestCloudFrontStructure_expandLoggingConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandLoggingConfig_nilValue
--- PASS: TestCloudFrontStructure_expandLoggingConfig_nilValue (0.00s)
=== RUN   TestCloudFrontStructure_expandAliases
--- PASS: TestCloudFrontStructure_expandAliases (0.00s)
=== RUN   TestCloudFrontStructure_flattenAliases
--- PASS: TestCloudFrontStructure_flattenAliases (0.00s)
=== RUN   TestCloudFrontStructure_expandRestrictions
--- PASS: TestCloudFrontStructure_expandRestrictions (0.00s)
=== RUN   TestCloudFrontStructure_expandGeoRestriction_whitelist
--- PASS: TestCloudFrontStructure_expandGeoRestriction_whitelist (0.00s)
=== RUN   TestCloudFrontStructure_flattenGeoRestriction_whitelist
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_whitelist (0.00s)
=== RUN   TestCloudFrontStructure_expandGeoRestriction_no_items
--- PASS: TestCloudFrontStructure_expandGeoRestriction_no_items (0.00s)
=== RUN   TestCloudFrontStructure_flattenGeoRestriction_no_items
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_no_items (0.00s)
=== RUN   TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate
--- PASS: TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate (0.00s)
=== RUN   TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id
--- PASS: TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id (0.00s)
=== RUN   TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn
--- PASS: TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.041s
```
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontDistribution_ -timeout 60m
=== RUN   TestAccAWSCloudFrontDistribution_disappears
=== PAUSE TestAccAWSCloudFrontDistribution_disappears
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
=== PAUSE TestAccAWSCloudFrontDistribution_S3Origin
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== PAUSE TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_customOrigin
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_multiOrigin
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== RUN   TestAccAWSCloudFrontDistribution_Origin_ConnectionAttempts
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_ConnectionAttempts
=== RUN   TestAccAWSCloudFrontDistribution_Origin_ConnectionTimeout
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_ConnectionTimeout
=== RUN   TestAccAWSCloudFrontDistribution_Origin_OriginShield
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_OriginShield
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
=== PAUSE TestAccAWSCloudFrontDistribution_HTTP11Config
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== PAUSE TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== RUN   TestAccAWSCloudFrontDistribution_Enabled
=== PAUSE TestAccAWSCloudFrontDistribution_Enabled
=== RUN   TestAccAWSCloudFrontDistribution_RetainOnDelete
=== PAUSE TestAccAWSCloudFrontDistribution_RetainOnDelete
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccAWSCloudFrontDistribution_WaitForDeployment
=== PAUSE TestAccAWSCloudFrontDistribution_WaitForDeployment
=== RUN   TestAccAWSCloudFrontDistribution_OriginGroups
=== PAUSE TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_disappears
=== CONT  TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== CONT  TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_Origin_OriginShield
=== CONT  TestAccAWSCloudFrontDistribution_multiOrigin
=== CONT  TestAccAWSCloudFrontDistribution_WaitForDeployment
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== CONT  TestAccAWSCloudFrontDistribution_S3Origin
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_RetainOnDelete
=== CONT  TestAccAWSCloudFrontDistribution_Enabled
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== CONT  TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 1 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:21 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (4.45s)
=== CONT  TestAccAWSCloudFrontDistribution_Origin_ConnectionTimeout
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (4.50s)
=== CONT  TestAccAWSCloudFrontDistribution_Origin_ConnectionAttempts
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:26 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:26 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:26 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:26 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/05 14:50:29 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/11/05 14:50:29 [DEBUG] Waiting for state to become: [success]
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
    resource_aws_cloudfront_distribution_test.go:861: Step 1/2 error: Error running apply:
        Error: error importing ACM Certificate: LimitExceededException: You have imported the maximum number of 20 certificates in the last year.


--- FAIL: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (14.39s)
=== CONT  TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
2020/11/05 14:50:33 [DEBUG] Waiting for state to become: [success]
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
    resource_aws_cloudfront_distribution_test.go:893: Step 1/2 error: Error running apply:
        Error: error importing ACM Certificate: LimitExceededException: You have imported the maximum number of 20 certificates in the last year.


--- FAIL: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (17.06s)
=== CONT  TestAccAWSCloudFrontDistribution_HTTP11Config
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (238.63s)
=== CONT  TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_disappears (250.53s)
=== CONT  TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (262.29s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (264.33s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (265.31s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (342.97s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (416.63s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (452.29s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (443.18s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_OriginShield (459.03s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (459.41s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (512.63s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (513.38s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (513.72s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_ConnectionAttempts (509.81s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (515.00s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (498.88s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_ConnectionTimeout (513.22s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (518.18s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (628.59s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (390.50s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (552.57s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       804.137s
FAIL
```

The single failed acceptance test is due to me hitting the quota for imported certificates while testing this locally. The WARN and DEBUG messages appear to be a known issue in terraform.

I lumped origin_shield with the 2 new connection arguments since they were small changes, but happy to move them into their own PR if you want!
