### PR TITLE
docs/contributing: fixing typos in aws_sagemaker docs and tests

### DIFF
--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -256,7 +256,7 @@ resource "aws_secretsmanager_secret" "test" {
 
 resource "aws_secretsmanager_secret_version" "test" {
   secret_id     = aws_secretsmanager_secret.test.id
-  secret_string = jsonencode({ username = "example", passowrd = "example" })
+  secret_string = jsonencode({ username = "example", password = "example" })
 }
 
 resource "aws_sagemaker_code_repository" "test" {
@@ -280,7 +280,7 @@ resource "aws_secretsmanager_secret" "test2" {
 
 resource "aws_secretsmanager_secret_version" "test2" {
   secret_id     = aws_secretsmanager_secret.test2.id
-  secret_string = jsonencode({ username = "example", passowrd = "example" })
+  secret_string = jsonencode({ username = "example", password = "example" })
 }
 
 resource "aws_sagemaker_code_repository" "test" {

--- a/website/docs/r/sagemaker_code_repository.htm.markdown
+++ b/website/docs/r/sagemaker_code_repository.htm.markdown
@@ -33,7 +33,7 @@ resource "aws_secretsmanager_secret" "example" {
 
 resource "aws_secretsmanager_secret_version" "example" {
   secret_id     = aws_secretsmanager_secret.example.id
-  secret_string = jsonencode({ username = "example", passowrd = "example" })
+  secret_string = jsonencode({ username = "example", password = "example" })
 }
 
 resource "aws_sagemaker_code_repository" "example" {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Just a simple fix to a couple of typos

Closes #16016 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing:

```
N\A 
```
