### PR TITLE
r/glue_catalog_table - add `parameters` argument to `columns` + validations

### DIFF
--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -50,7 +50,7 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 				Required: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 255),
-					validation.StringDoesNotMatch(regexp.MustCompile(`[A-Z]`), "uppercase charcters cannot be used"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`[A-Z]`), "uppercase characters cannot be used"),
 				),
 			},
 			"owner": {
@@ -274,7 +274,7 @@ func resourceAwsGlueCatalogTableCreate(d *schema.ResourceData, meta interface{})
 	log.Printf("[DEBUG] Glue catalog table input: %#v", input)
 	_, err := conn.CreateTable(input)
 	if err != nil {
-		return fmt.Errorf("Error creating Catalog Table: %w", err)
+		return fmt.Errorf("Error creating Glue Catalog Table: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s:%s", catalogID, dbName, name))

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -77,11 +77,6 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validation.StringLenBetween(1, 255),
 						},
-						"parameters": {
-							Type:     schema.TypeMap,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
 						"type": {
 							Type:         schema.TypeString,
 							Optional:     true,

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -75,6 +75,35 @@ func TestAccAWSGlueCatalogTable_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueCatalogTable_columnParameters(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_catalog_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccGlueCatalogTableColumnParameters(rName),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.parameters.param2", "param2_val"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	description := "A test table from terraform"
@@ -738,6 +767,87 @@ resource "aws_glue_catalog_table" "test" {
       skewed_column_value_location_maps = {}
       skewed_column_values              = []
     }
+  }
+}
+`, rName)
+}
+
+func testAccGlueCatalogTableColumnParameters(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name               = %[1]q
+  database_name      = aws_glue_catalog_database.test.name
+  owner              = "my_owner"
+  retention          = 1
+  table_type         = "VIRTUAL_VIEW"
+  view_expanded_text = "view_expanded_text_1"
+  view_original_text = "view_original_text_1"
+
+  storage_descriptor {
+    bucket_columns            = ["bucket_column_1"]
+    compressed                = false
+    input_format              = "SequenceFileInputFormat"
+    location                  = "my_location"
+    number_of_buckets         = 1
+    output_format             = "SequenceFileInputFormat"
+    stored_as_sub_directories = false
+
+    parameters = {
+      param1 = "param1_val"
+    }
+
+    columns {
+      name    = "my_column_1"
+      type    = "int"
+	  comment = "my_column1_comment"
+	  
+	  parameters = {
+		param2 = "param2_val"
+	  }
+    }
+
+    ser_de_info {
+      name = "ser_de_name"
+
+      parameters = {
+        param1 = "param_val_1"
+      }
+
+      serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
+    }
+
+    sort_columns {
+      column     = "my_column_1"
+      sort_order = 1
+    }
+
+    skewed_info {
+      skewed_column_names = [
+        "my_column_1",
+      ]
+
+      skewed_column_value_location_maps = {
+        my_column_1 = "my_column_1_val_loc_map"
+      }
+
+      skewed_column_values = [
+        "skewed_val_1",
+      ]
+    }
+  }
+
+  partition_keys {
+    name    = "my_column_1"
+    type    = "int"
+    comment = "my_column_1_comment"
+  }
+
+  parameters = {
+    param1 = "param1_val"
   }
 }
 `, rName)

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -63,6 +63,7 @@ func TestAccAWSGlueCatalogTable_basic(t *testing.T) {
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("table/%s/%s", rName, rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					testAccCheckResourceAttrAccountID(resourceName, "catalog_id"),
 				),
 			},
 			{

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -803,11 +803,11 @@ resource "aws_glue_catalog_table" "test" {
     columns {
       name    = "my_column_1"
       type    = "int"
-	  comment = "my_column1_comment"
-	  
-	  parameters = {
-		param2 = "param2_val"
-	  }
+      comment = "my_column1_comment"
+
+      parameters = {
+        param2 = "param2_val"
+      }
     }
 
     ser_de_info {

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -90,14 +90,20 @@ The following arguments are supported:
 * `description` - (Optional) Description of the table.
 * `owner` - (Optional) Owner of the table.
 * `retention` - (Optional) Retention time for this table.
-* `storage_descriptor` - (Optional) A [storage descriptor](#storage_descriptor) object containing information about the physical storage of this table. You can refer to the [Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor) for a full explanation of this object.
-* `partition_keys` - (Optional) A list of columns by which the table is partitioned. Only primitive types are supported as partition keys.
+* `storage_descriptor` - (Optional) A [storage descriptor](#storage-descriptor) object containing information about the physical storage of this table. You can refer to the [Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor) for a full explanation of this object.
+* `partition_keys` - (Optional) A list of columns by which the table is partitioned. Only primitive types are supported as partition keys. see [Partition Keys](#partition-keys) below.
 * `view_original_text` - (Optional) If the table is a view, the original text of the view; otherwise null.
 * `view_expanded_text` - (Optional) If the table is a view, the expanded text of the view; otherwise null.
 * `table_type` - (Optional) The type of this table (EXTERNAL_TABLE, VIRTUAL_VIEW, etc.). While optional, some Athena DDL queries such as `ALTER TABLE` and `SHOW CREATE TABLE` will fail if this argument is empty.
 * `parameters` - (Optional) Properties associated with this table, as a list of key-value pairs.
 
-##### storage_descriptor
+### Partition Keys
+
+* `name` - (Required) The name of the Partition Key.
+* `type` - (Optional) The datatype of data in the Partition Key.
+* `comment` - (Optional) Free-form text comment.
+
+### Storage Descriptor
 
 * `columns` - (Optional) A list of the [Columns](#column) in the table.
 * `location` - (Optional) The physical location of the table. By default this takes the form of the warehouse location, followed by the database location in the warehouse, followed by the table name.
@@ -105,31 +111,32 @@ The following arguments are supported:
 * `output_format` - (Optional) The output format: SequenceFileOutputFormat (binary), or IgnoreKeyTextOutputFormat, or a custom format.
 * `compressed` - (Optional) True if the data in the table is compressed, or False if not.
 * `number_of_buckets` - (Optional) Must be specified if the table contains any dimension columns.
-* `ser_de_info` - (Optional) [Serialization/deserialization (SerDe)](#ser_de_info) information.
+* `ser_de_info` - (Optional) [Serialization/deserialization (SerDe)](#ser-de-info) information.
 * `bucket_columns` - (Optional) A list of reducer grouping columns, clustering columns, and bucketing columns in the table.
-* `sort_columns` - (Optional) A list of [Order](#sort_column) objects specifying the sort order of each bucket in the table.
+* `sort_columns` - (Optional) A list of [Order](#sort-column) objects specifying the sort order of each bucket in the table.
 * `parameters` - (Optional) User-supplied properties in key-value form.
 * `skewed_info` - (Optional) Information about values that appear very frequently in a column (skewed values).
 * `stored_as_sub_directories` - (Optional) True if the table data is stored in subdirectories, or False if not.
 
-##### column
+##### Column
 
 * `name` - (Required) The name of the Column.
 * `type` - (Optional) The datatype of data in the Column.
 * `comment` - (Optional) Free-form text comment.
+* `parameters` - (Optional) These key-value pairs define properties associated with the column.
 
-##### ser_de_info
+##### Ser De Info
 
 * `name` - (Optional) Name of the SerDe.
 * `parameters` - (Optional) A map of initialization parameters for the SerDe, in key-value form.
 * `serialization_library` - (Optional) Usually the class that implements the SerDe. An example is: org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe.
 
-##### sort_columns
+##### Sort Columns
 
 * `column` - (Required) The name of the column.
 * `sort_order` - (Required) Indicates that the column is sorted in ascending order (== 1), or in descending order (==0).
 
-##### skewed_info
+##### Skewed Info
 
 * `skewed_column_names` - (Optional) A list of names of columns that contain skewed values.
 * `skewed_column_value_location_maps` - (Optional) A list of values that appear so frequently as to be considered skewed.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15778


Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_catalog_table - add support for `parameters` argument to `storage_descriptor.columns` block
resource_aws_glue_catalog_table - add plan time validation for `description`, `name`, `partition_keys.name`, `partition_keys.comment`, `partition_keys.type`, `retention`, `view_original_text`, `view_expanded_text`, `storage_descriptor.name`, `storage_descriptor.comment`, `storage_descriptor.type`, `storage_descriptor.bucket_columns`, `storage_descriptor.ser_de_info.name`, `storage_descriptor.skewed_info.skewed_column_names`, `storage_descriptor.sort_columns.column`, `storage_descriptor.sort_columns.sort_order`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCatalogTable_'
--- PASS: TestAccAWSGlueCatalogTable_disappears (42.12s)--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock (42.25s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock (43.59s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock (45.77s)
--- PASS: TestAccAWSGlueCatalogTable_columnParameters (48.80s)
--- PASS: TestAccAWSGlueCatalogTable_basic (52.32s)
--- PASS: TestAccAWSGlueCatalogTable_full (54.09s)
--- PASS: TestAccAWSGlueCatalogTable_recreates (59.63s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_UpdateValues (78.55s)
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (79.21s)
--- PASS: TestAccAWSGlueCatalogTable_update_replaceValues (79.71s)
```
