### PR TITLE
service/s3: Prefix internal error constants with ErrCode and remove multiple service imports from aws_s3_bucket_public_access_block

### DIFF
--- a/aws/internal/keyvaluetags/s3_tags.go
+++ b/aws/internal/keyvaluetags/s3_tags.go
@@ -25,7 +25,7 @@ func S3BucketListTags(conn *s3.S3, identifier string) (KeyValueTags, error) {
 	// S3 API Reference (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
 	// lists the special error as NoSuchTagSetError, however the existing logic used NoSuchTagSet
 	// and the AWS Go SDK has neither as a constant.
-	if tfawserr.ErrCodeEquals(err, tfs3.NoSuchTagSet) {
+	if tfawserr.ErrCodeEquals(err, tfs3.ErrCodeNoSuchTagSet) {
 		return New(nil), nil
 	}
 
@@ -88,7 +88,7 @@ func S3ObjectListTags(conn *s3.S3, bucket, key string) (KeyValueTags, error) {
 
 	output, err := conn.GetObjectTagging(input)
 
-	if tfawserr.ErrCodeEquals(err, tfs3.NoSuchTagSet) {
+	if tfawserr.ErrCodeEquals(err, tfs3.ErrCodeNoSuchTagSet) {
 		return New(nil), nil
 	}
 

--- a/aws/internal/service/s3/errors.go
+++ b/aws/internal/service/s3/errors.go
@@ -1,5 +1,9 @@
 package s3
 
+// Error code constants missing from AWS Go SDK:
+// https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#pkg-constants
+
 const (
-	NoSuchTagSet = "NoSuchTagSet"
+	ErrCodeNoSuchPublicAccessBlockConfiguration = "NoSuchPublicAccessBlockConfiguration"
+	ErrCodeNoSuchTagSet                         = "NoSuchTagSet"
 )

--- a/aws/resource_aws_s3_bucket_public_access_block_test.go
+++ b/aws/resource_aws_s3_bucket_public_access_block_test.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3control"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfs3 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/s3"
 )
 
 func TestAccAWSS3BucketPublicAccessBlock_basic(t *testing.T) {
@@ -271,7 +272,7 @@ func testAccCheckAWSS3BucketPublicAccessBlockExists(n string, config *s3.PublicA
 			var err error
 			output, err = conn.GetPublicAccessBlock(input)
 
-			if isAWSErr(err, s3control.ErrCodeNoSuchPublicAccessBlockConfiguration, "") {
+			if tfawserr.ErrCodeEquals(err, tfs3.ErrCodeNoSuchPublicAccessBlockConfiguration) {
 				return resource.RetryableError(err)
 			}
 
@@ -324,7 +325,7 @@ func testAccCheckAWSS3BucketPublicAccessBlockDisappears(n string) resource.TestC
 		return resource.Retry(1*time.Minute, func() *resource.RetryError {
 			_, err := conn.GetPublicAccessBlock(getInput)
 
-			if isAWSErr(err, s3control.ErrCodeNoSuchPublicAccessBlockConfiguration, "") {
+			if tfawserr.ErrCodeEquals(err, tfs3.ErrCodeNoSuchPublicAccessBlockConfiguration) {
 				return nil
 			}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/contributing/pullrequest-submission-and-lifecycle.md (Adds Error Codes Missing from the AWS Go SDK to Internal Service Package)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from `semgrep`:

```
     > aws/resource_aws_s3_bucket_public_access_block.go:3
     ╷
    3│   import (
    4│   	"fmt"
    5│   	"log"
    6│   	"time"
    7│
    8│   	"github.com/aws/aws-sdk-go/aws"
    9│   	"github.com/aws/aws-sdk-go/service/s3"
   10│   	"github.com/aws/aws-sdk-go/service/s3control"
     ╵
     = Resources should not implement multiple AWS service functionality
```

Output from acceptance testing:

```
--- PASS: TestAccAWSS3BucketPublicAccessBlock_basic (33.01s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls (73.17s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy (71.77s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_bucketDisappears (19.24s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_disappears (29.51s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls (72.38s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets (74.05s)
```
