### PR TITLE
r/storagegateway_nfs_file_share - support `file_share_name`

### DIFF
--- a/aws/resource_aws_storagegateway_nfs_file_share.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share.go
@@ -163,6 +163,11 @@ func resourceAwsStorageGatewayNfsFileShare() *schema.Resource {
 					"RootSquash",
 				}, false),
 			},
+			"file_share_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
+			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -190,6 +195,10 @@ func resourceAwsStorageGatewayNfsFileShareCreate(d *schema.ResourceData, meta in
 
 	if v, ok := d.GetOk("kms_key_arn"); ok {
 		input.KMSKey = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("file_share_name"); ok {
+		input.FileShareName = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("cache_attributes"); ok {
@@ -261,6 +270,7 @@ func resourceAwsStorageGatewayNfsFileShareRead(d *schema.ResourceData, meta inte
 	d.Set("kms_encrypted", fileshare.KMSEncrypted)
 	d.Set("kms_key_arn", fileshare.KMSKey)
 	d.Set("location_arn", fileshare.LocationARN)
+	d.Set("file_share_name", fileshare.FileShareName)
 
 	if err := d.Set("nfs_file_share_defaults", flattenStorageGatewayNfsFileShareDefaults(fileshare.NFSFileShareDefaults)); err != nil {
 		return fmt.Errorf("error setting nfs_file_share_defaults: %w", err)
@@ -296,7 +306,7 @@ func resourceAwsStorageGatewayNfsFileShareUpdate(d *schema.ResourceData, meta in
 
 	if d.HasChanges("client_list", "default_storage_class", "guess_mime_type_enabled", "kms_encrypted",
 		"nfs_file_share_defaults", "object_acl", "read_only", "requester_pays", "squash", "kms_key_arn",
-		"cache_attributes") {
+		"cache_attributes", "file_share_name") {
 
 		input := &storagegateway.UpdateNFSFileShareInput{
 			ClientList:           expandStringSet(d.Get("client_list").(*schema.Set)),
@@ -313,6 +323,10 @@ func resourceAwsStorageGatewayNfsFileShareUpdate(d *schema.ResourceData, meta in
 
 		if v, ok := d.GetOk("kms_key_arn"); ok {
 			input.KMSKey = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("file_share_name"); ok {
+			input.FileShareName = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("cache_attributes"); ok {

--- a/aws/resource_aws_storagegateway_nfs_file_share.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share.go
@@ -166,6 +166,7 @@ func resourceAwsStorageGatewayNfsFileShare() *schema.Resource {
 			"file_share_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"tags": tagsSchema(),

--- a/aws/resource_aws_storagegateway_nfs_file_share_test.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share_test.go
@@ -48,6 +48,7 @@ func TestAccAWSStorageGatewayNfsFileShare_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", iamResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "squash", "RootSquash"),
 					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "file_share_name", rName),
 				),
 			},
 			{

--- a/aws/resource_aws_storagegateway_nfs_file_share_test.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share_test.go
@@ -106,6 +106,39 @@ func TestAccAWSStorageGatewayNfsFileShare_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSStorageGatewayNfsFileShare_fileShareName(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfigFileShareName(rName, "test_1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "file_share_name", "test_1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfigFileShareName(rName, "test_2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "file_share_name", "test_2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSStorageGatewayNfsFileShare_ClientList(t *testing.T) {
 	var nfsFileShare storagegateway.NFSFileShareInfo
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -653,6 +686,18 @@ resource "aws_storagegateway_nfs_file_share" "test" {
   role_arn     = aws_iam_role.test.arn
 }
 `
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfigFileShareName(rName, fsName string) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list     = ["0.0.0.0/0"]
+  gateway_arn     = aws_storagegateway_gateway.test.arn
+  location_arn    = aws_s3_bucket.test.arn
+  role_arn        = aws_iam_role.test.arn
+  file_share_name = %[1]q
+}
+`, fsName)
 }
 
 func testAccAWSStorageGatewayNfsFileShareConfigTags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/storagegateway_nfs_file_share.html.markdown
+++ b/website/docs/r/storagegateway_nfs_file_share.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `read_only` - (Optional) Boolean to indicate write status of file share. File share does not accept writes if `true`. Defaults to `false`.
 * `requester_pays` - (Optional) Boolean who pays the cost of the request and the data download from the Amazon S3 bucket. Set this value to `true` if you want the requester to pay instead of the bucket owner. Defaults to `false`.
 * `squash` - (Optional) Maps a user to anonymous user. Defaults to `RootSquash`. Valid values: `RootSquash` (only root is mapped to anonymous user), `NoSquash` (no one is mapped to anonymous user), `AllSquash` (everyone is mapped to anonymous user)
-* `file_share_name` - (Optional) The name of the file share. must be set if an S3 prefix name is set in `location_arn`.
+* `file_share_name` - (Optional) The name of the file share. Must be set if an S3 prefix name is set in `location_arn`.
 * `tags` - (Optional) Key-value map of resource tags
 
 ### nfs_file_share_defaults

--- a/website/docs/r/storagegateway_nfs_file_share.html.markdown
+++ b/website/docs/r/storagegateway_nfs_file_share.html.markdown
@@ -39,6 +39,7 @@ The following arguments are supported:
 * `read_only` - (Optional) Boolean to indicate write status of file share. File share does not accept writes if `true`. Defaults to `false`.
 * `requester_pays` - (Optional) Boolean who pays the cost of the request and the data download from the Amazon S3 bucket. Set this value to `true` if you want the requester to pay instead of the bucket owner. Defaults to `false`.
 * `squash` - (Optional) Maps a user to anonymous user. Defaults to `RootSquash`. Valid values: `RootSquash` (only root is mapped to anonymous user), `NoSquash` (no one is mapped to anonymous user), `AllSquash` (everyone is mapped to anonymous user)
+* `file_share_name` - (Optional) The name of the file share. must be set if an S3 prefix name is set in `location_arn`.
 * `tags` - (Optional) Key-value map of resource tags
 
 ### nfs_file_share_defaults


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_storagegateway_nfs_file_share - support `file_share_name`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSStorageGatewayNfsFileShare_'
--- PASS: TestAccAWSStorageGatewayNfsFileShare_basic (286.69s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_disappears (314.00s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_cacheAttributes (545.97s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSKeyArn (554.94s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ReadOnly (409.35s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_Squash (459.57s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ObjectACL (377.12s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_RequesterPays (393.68s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSEncrypted (341.95s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_DefaultStorageClass (444.18s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_fileShareName (428.53s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_NFSFileShareDefaults (469.43s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_tags (543.66s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ClientList (672.34s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_GuessMIMETypeEnabled (444.01s)
```
