### PR TITLE
r/sagemaker_domain - new resource

### DIFF
--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -42,3 +42,22 @@ func ImageByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeIma
 
 	return output, nil
 }
+
+// DomainByName returns the domain corresponding to the specified domain id.
+// Returns nil if no domain is found.
+func DomainByName(conn *sagemaker.SageMaker, domainID string) (*sagemaker.DescribeDomainOutput, error) {
+	input := &sagemaker.DescribeDomainInput{
+		DomainId: aws.String(domainID),
+	}
+
+	output, err := conn.DescribeDomain(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output, nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -870,6 +870,7 @@ func Provider() *schema.Provider {
 			"aws_default_route_table":                                 resourceAwsDefaultRouteTable(),
 			"aws_route_table_association":                             resourceAwsRouteTableAssociation(),
 			"aws_sagemaker_code_repository":                           resourceAwsSagemakerCodeRepository(),
+			"aws_sagemaker_domain":                                    resourceAwsSagemakerDomain(),
 			"aws_sagemaker_endpoint_configuration":                    resourceAwsSagemakerEndpointConfiguration(),
 			"aws_sagemaker_image":                                     resourceAwsSagemakerImage(),
 			"aws_sagemaker_endpoint":                                  resourceAwsSagemakerEndpoint(),

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -65,12 +65,6 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 				Default:      sagemaker.AppNetworkAccessTypePublicInternetOnly,
 				ValidateFunc: validation.StringInSlice(sagemaker.AppNetworkAccessType_Values(), false),
 			},
-			"home_efs_file_system_kms_key_id": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				ValidateFunc: validateArn,
-			},
 			"default_user_settings": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -228,10 +222,6 @@ func resourceAwsSagemakerDomainCreate(d *schema.ResourceData, meta interface{}) 
 		DefaultUserSettings:  expandSagemakerDomainDefaultUserSettings(d.Get("default_user_settings").([]interface{})),
 	}
 
-	if v, ok := d.GetOk("home_efs_file_system_kms_key_id"); ok {
-		input.HomeEfsFileSystemKmsKeyId = aws.String(v.(string))
-	}
-
 	if v, ok := d.GetOk("tags"); ok {
 		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SagemakerTags()
 	}
@@ -277,7 +267,6 @@ func resourceAwsSagemakerDomainRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("app_network_access_type", domain.AppNetworkAccessType)
 	d.Set("arn", arn)
 	d.Set("home_efs_file_system_id", domain.HomeEfsFileSystemId)
-	d.Set("home_efs_file_system_kms_key_id", domain.HomeEfsFileSystemKmsKeyId)
 	d.Set("single_sign_on_managed_application_instance_id", domain.SingleSignOnManagedApplicationInstanceId)
 	d.Set("url", domain.Url)
 	d.Set("vpc_id", domain.VpcId)

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -387,7 +387,7 @@ func expandSagemakerDomainJupyterServerAppSettings(l []interface{}) *sagemaker.J
 
 	config := &sagemaker.JupyterServerAppSettings{}
 
-	if v, ok := m["default_resurce_spec"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["default_resource_spec"].([]interface{}); ok && len(v) > 0 {
 		config.DefaultResourceSpec = expandSagemakerDomainDefaultResourceSpec(v)
 	}
 
@@ -403,7 +403,7 @@ func expandSagemakerDomainKernelGatewayAppSettings(l []interface{}) *sagemaker.K
 
 	config := &sagemaker.KernelGatewayAppSettings{}
 
-	if v, ok := m["default_resurce_spec"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["default_resource_spec"].([]interface{}); ok && len(v) > 0 {
 		config.DefaultResourceSpec = expandSagemakerDomainDefaultResourceSpec(v)
 	}
 
@@ -419,7 +419,7 @@ func expandSagemakerDomainTensorBoardAppSettings(l []interface{}) *sagemaker.Ten
 
 	config := &sagemaker.TensorBoardAppSettings{}
 
-	if v, ok := m["default_resurce_spec"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["default_resource_spec"].([]interface{}); ok && len(v) > 0 {
 		config.DefaultResourceSpec = expandSagemakerDomainDefaultResourceSpec(v)
 	}
 
@@ -528,7 +528,7 @@ func flattenSagemakerDomainTensorBoardAppSettings(config *sagemaker.TensorBoardA
 	m := map[string]interface{}{}
 
 	if config.DefaultResourceSpec != nil {
-		m["default_resurce_spec"] = flattenSagemakerDomainDefaultResourceSpec(config.DefaultResourceSpec)
+		m["default_resource_spec"] = flattenSagemakerDomainDefaultResourceSpec(config.DefaultResourceSpec)
 	}
 
 	return []map[string]interface{}{m}
@@ -542,7 +542,7 @@ func flattenSagemakerDomainJupyterServerAppSettings(config *sagemaker.JupyterSer
 	m := map[string]interface{}{}
 
 	if config.DefaultResourceSpec != nil {
-		m["default_resurce_spec"] = flattenSagemakerDomainDefaultResourceSpec(config.DefaultResourceSpec)
+		m["default_resource_spec"] = flattenSagemakerDomainDefaultResourceSpec(config.DefaultResourceSpec)
 	}
 
 	return []map[string]interface{}{m}
@@ -556,7 +556,7 @@ func flattenSagemakerDomainKernelGatewayAppSettings(config *sagemaker.KernelGate
 	m := map[string]interface{}{}
 
 	if config.DefaultResourceSpec != nil {
-		m["default_resurce_spec"] = flattenSagemakerDomainDefaultResourceSpec(config.DefaultResourceSpec)
+		m["default_resource_spec"] = flattenSagemakerDomainDefaultResourceSpec(config.DefaultResourceSpec)
 	}
 
 	return []map[string]interface{}{m}

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -58,6 +58,13 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 				MaxItems: 16,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"kms_key_id": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateArn,
+			},
 			"app_network_access_type": {
 				Type:         schema.TypeString,
 				ForceNew:     true,
@@ -251,6 +258,10 @@ func resourceAwsSagemakerDomainCreate(d *schema.ResourceData, meta interface{}) 
 		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SagemakerTags()
 	}
 
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		input.KmsKeyId = aws.String(v.(string))
+	}
+
 	log.Printf("[DEBUG] sagemaker domain create config: %#v", *input)
 	output, err := conn.CreateDomain(input)
 	if err != nil {
@@ -294,7 +305,7 @@ func resourceAwsSagemakerDomainRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("home_efs_file_system_id", domain.HomeEfsFileSystemId)
 	d.Set("single_sign_on_managed_application_instance_id", domain.SingleSignOnManagedApplicationInstanceId)
 	d.Set("url", domain.Url)
-	d.Set("vpc_id", domain.VpcId)
+	d.Set("kms_key_id", domain.KmsKeyId)
 
 	if err := d.Set("subnet_ids", flattenStringSet(domain.SubnetIds)); err != nil {
 		return fmt.Errorf("error setting subnet_ids for SageMaker domain (%s): %w", d.Id(), err)

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -30,7 +30,6 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"domain_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -71,7 +70,6 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validateArn,
 			},
-
 			"default_user_settings": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -86,7 +84,7 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 						},
 						"execution_role": {
 							Type:         schema.TypeString,
-							Optional:     true,
+							Required:     true,
 							ValidateFunc: validateArn,
 						},
 						"sharing_settings": {

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -245,7 +245,7 @@ func resourceAwsSagemakerDomainCreate(d *schema.ResourceData, meta interface{}) 
 	d.SetId(domainID)
 
 	if _, err := waiter.DomainInService(conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for sagemaker domain (%s) to create: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for SageMaker domain (%s) to create: %w", d.Id(), err)
 	}
 
 	return resourceAwsSagemakerDomainRead(d, meta)
@@ -276,17 +276,17 @@ func resourceAwsSagemakerDomainRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("vpc_id", domain.VpcId)
 
 	if err := d.Set("subnet_ids", flattenStringSet(domain.SubnetIds)); err != nil {
-		return fmt.Errorf("error setting subnet_ids for sagemaker domain (%s): %w", d.Id(), err)
+		return fmt.Errorf("error setting subnet_ids for SageMaker domain (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("default_user_settings", flattenSagemakerDomainDefaultUserSettings(domain.DefaultUserSettings)); err != nil {
-		return fmt.Errorf("error setting default_user_settings for sagemaker domain (%s): %w", d.Id(), err)
+		return fmt.Errorf("error setting default_user_settings for SageMaker domain (%s): %w", d.Id(), err)
 	}
 
 	tags, err := keyvaluetags.SagemakerListTags(conn, arn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Sagemaker Domain (%s): %w", d.Id(), err)
+		return fmt.Errorf("error listing tags for SageMaker Domain (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
@@ -316,7 +316,7 @@ func resourceAwsSagemakerDomainUpdate(d *schema.ResourceData, meta interface{}) 
 		o, n := d.GetChange("tags")
 
 		if err := keyvaluetags.SagemakerUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Sagemaker Notebook Instance (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("error updating SageMaker domain (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -338,7 +338,7 @@ func resourceAwsSagemakerDomainDelete(d *schema.ResourceData, meta interface{}) 
 
 	if _, err := waiter.DomainDeleted(conn, d.Id()); err != nil {
 		if !isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
-			return fmt.Errorf("error waiting for sagemaker domain (%s) to delete: %w", d.Id(), err)
+			return fmt.Errorf("error waiting for SageMaker domain (%s) to delete: %w", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -305,6 +305,7 @@ func resourceAwsSagemakerDomainRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("home_efs_file_system_id", domain.HomeEfsFileSystemId)
 	d.Set("single_sign_on_managed_application_instance_id", domain.SingleSignOnManagedApplicationInstanceId)
 	d.Set("url", domain.Url)
+	d.Set("vpc_id", domain.VpcId)
 	d.Set("kms_key_id", domain.KmsKeyId)
 
 	if err := d.Set("subnet_ids", flattenStringSet(domain.SubnetIds)); err != nil {

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -85,6 +85,7 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 						"sharing_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
+							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -370,7 +371,7 @@ func expandSagemakerDomainDefaultUserSettings(l []interface{}) *sagemaker.UserSe
 		config.JupyterServerAppSettings = expandSagemakerDomainJupyterServerAppSettings(v)
 	}
 
-	if v, ok := m["share_settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["sharing_settings"].([]interface{}); ok && len(v) > 0 {
 		config.SharingSettings = expandSagemakerDomainShareSettings(v)
 	}
 
@@ -495,7 +496,7 @@ func flattenSagemakerDomainDefaultUserSettings(config *sagemaker.UserSettings) [
 	}
 
 	if config.SharingSettings != nil {
-		m["share_settings"] = flattenSagemakerDomainShareSettings(config.SharingSettings)
+		m["sharing_settings"] = flattenSagemakerDomainShareSettings(config.SharingSettings)
 	}
 
 	return []map[string]interface{}{m}

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -101,7 +101,7 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 										Default:      sagemaker.NotebookOutputOptionDisabled,
 										ValidateFunc: validation.StringInSlice(sagemaker.NotebookOutputOption_Values(), false),
 									},
-									"s3_kms_Key_id": {
+									"s3_kms_key_id": {
 										Type:         schema.TypeString,
 										Optional:     true,
 										ValidateFunc: validateArn,

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -1,0 +1,568 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+)
+
+func resourceAwsSagemakerDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerDomainCreate,
+		Read:   resourceAwsSagemakerDomainRead,
+		Update: resourceAwsSagemakerDomainUpdate,
+		Delete: resourceAwsSagemakerDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 63),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*$`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
+				),
+			},
+			"auth_mode": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(sagemaker.AuthMode_Values(), false),
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 16,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"app_network_access_type": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Default:      sagemaker.AppNetworkAccessTypePublicInternetOnly,
+				ValidateFunc: validation.StringInSlice(sagemaker.AppNetworkAccessType_Values(), false),
+			},
+			"home_efs_file_system_kms_key_id": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
+
+			"default_user_settings": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"security_groups": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 5,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"execution_role": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
+						},
+						"sharing_settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"notebook_output_option": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      sagemaker.NotebookOutputOptionDisabled,
+										ValidateFunc: validation.StringInSlice(sagemaker.NotebookOutputOption_Values(), false),
+									},
+									"s3_kms_Key_id": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateArn,
+									},
+									"s3_output_path": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"tensor_board_app_settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"jupyter_server_app_settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"kernel_gateway_app_settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"tags": tagsSchema(),
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"single_sign_on_managed_application_instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"home_efs_file_system_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSagemakerDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	input := &sagemaker.CreateDomainInput{
+		DomainName:           aws.String(d.Get("domain_name").(string)),
+		AuthMode:             aws.String(d.Get("auth_mode").(string)),
+		VpcId:                aws.String(d.Get("vpc_id").(string)),
+		AppNetworkAccessType: aws.String(d.Get("app_network_access_type").(string)),
+		SubnetIds:            expandStringSet(d.Get("subnet_ids").(*schema.Set)),
+		DefaultUserSettings:  expandSagemakerDomainDefaultUserSettings(d.Get("default_user_settings").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("home_efs_file_system_kms_key_id"); ok {
+		input.HomeEfsFileSystemKmsKeyId = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] sagemaker domain create config: %#v", *input)
+	output, err := conn.CreateDomain(input)
+	if err != nil {
+		return fmt.Errorf("error creating SageMaker domain: %w", err)
+	}
+
+	domainArn := aws.StringValue(output.DomainArn)
+	domainID, err := decodeSagemakerDomainID(domainArn)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(domainID)
+
+	return resourceAwsSagemakerDomainRead(d, meta)
+}
+
+func resourceAwsSagemakerDomainRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	domain, err := finder.DomainByName(conn, d.Id())
+	if err != nil {
+		if isAWSErr(err, "ValidationException", "Cannot find Domain") {
+			d.SetId("")
+			log.Printf("[WARN] Unable to find SageMaker domain (%s), removing from state", d.Id())
+			return nil
+		}
+		return fmt.Errorf("error reading SageMaker domain (%s): %w", d.Id(), err)
+	}
+
+	d.Set("domain_name", domain.DomainName)
+	d.Set("auth_mode", domain.AuthMode)
+	d.Set("app_network_access_type", domain.AppNetworkAccessType)
+	d.Set("arn", domain.DomainArn)
+	d.Set("home_efs_file_system_id", domain.HomeEfsFileSystemId)
+	d.Set("home_efs_file_system_kms_key_id", domain.HomeEfsFileSystemKmsKeyId)
+	d.Set("single_sign_on_managed_application_instance_id", domain.SingleSignOnManagedApplicationInstanceId)
+	d.Set("url", domain.Url)
+	d.Set("vpc_id", domain.VpcId)
+
+	if err := d.Set("subnet_ids", flattenStringSet(domain.SubnetIds)); err != nil {
+		return fmt.Errorf("error setting subnet_ids for sagemaker domain (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("default_user_settings", flattenSagemakerDomainDefaultUserSettings(domain.DefaultUserSettings)); err != nil {
+		return fmt.Errorf("error setting default_user_settings for sagemaker domain (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsSagemakerDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	input := &sagemaker.UpdateDomainInput{
+		DomainId:            aws.String(d.Id()),
+		DefaultUserSettings: expandSagemakerDomainDefaultUserSettings(d.Get("default_user_settings").([]interface{})),
+	}
+
+	log.Printf("[DEBUG] sagemaker domain update config: %#v", *input)
+	_, err := conn.UpdateDomain(input)
+	if err != nil {
+		return fmt.Errorf("error updating SageMaker domain: %w", err)
+	}
+
+	return resourceAwsSagemakerDomainRead(d, meta)
+}
+
+func resourceAwsSagemakerDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	input := &sagemaker.DeleteDomainInput{
+		DomainId: aws.String(d.Id()),
+	}
+
+	if _, err := conn.DeleteDomain(input); err != nil {
+		if isAWSErr(err, "ValidationException", "Cannot find Domain") {
+			return nil
+		}
+		return fmt.Errorf("error deleting SageMaker domain (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandSagemakerDomainDefaultUserSettings(l []interface{}) *sagemaker.UserSettings {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.UserSettings{}
+
+	if v, ok := m["execution_role"].(string); ok && v != "" {
+		config.ExecutionRole = aws.String(v)
+	}
+
+	if v, ok := m["security_groups"].(*schema.Set); ok && v.Len() > 0 {
+		config.SecurityGroups = expandStringSet(v)
+	}
+
+	if v, ok := m["tensor_board_app_settings"].([]interface{}); ok && len(v) > 0 {
+		config.TensorBoardAppSettings = expandSagemakerDomainTensorBoardAppSettings(v)
+	}
+
+	if v, ok := m["kernel_gateway_app_settings"].([]interface{}); ok && len(v) > 0 {
+		config.KernelGatewayAppSettings = expandSagemakerDomainKernelGatewayAppSettings(v)
+	}
+
+	if v, ok := m["jupyter_server_app_settings"].([]interface{}); ok && len(v) > 0 {
+		config.JupyterServerAppSettings = expandSagemakerDomainJupyterServerAppSettings(v)
+	}
+
+	if v, ok := m["share_settings"].([]interface{}); ok && len(v) > 0 {
+		config.SharingSettings = expandSagemakerDomainShareSettings(v)
+	}
+
+	return config
+}
+
+func expandSagemakerDomainJupyterServerAppSettings(l []interface{}) *sagemaker.JupyterServerAppSettings {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.JupyterServerAppSettings{}
+
+	if v, ok := m["default_resurce_spec"].([]interface{}); ok && len(v) > 0 {
+		config.DefaultResourceSpec = expandSagemakerDomainDefaultResourceSpec(v)
+	}
+
+	return config
+}
+
+func expandSagemakerDomainKernelGatewayAppSettings(l []interface{}) *sagemaker.KernelGatewayAppSettings {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.KernelGatewayAppSettings{}
+
+	if v, ok := m["default_resurce_spec"].([]interface{}); ok && len(v) > 0 {
+		config.DefaultResourceSpec = expandSagemakerDomainDefaultResourceSpec(v)
+	}
+
+	return config
+}
+
+func expandSagemakerDomainTensorBoardAppSettings(l []interface{}) *sagemaker.TensorBoardAppSettings {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.TensorBoardAppSettings{}
+
+	if v, ok := m["default_resurce_spec"].([]interface{}); ok && len(v) > 0 {
+		config.DefaultResourceSpec = expandSagemakerDomainDefaultResourceSpec(v)
+	}
+
+	return config
+}
+
+func expandSagemakerDomainDefaultResourceSpec(l []interface{}) *sagemaker.ResourceSpec {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.ResourceSpec{}
+
+	if v, ok := m["instance_type"].(string); ok && v != "" {
+		config.InstanceType = aws.String(v)
+	}
+
+	if v, ok := m["sagemaker_image_arn"].(string); ok && v != "" {
+		config.SageMakerImageArn = aws.String(v)
+	}
+
+	return config
+}
+
+func expandSagemakerDomainShareSettings(l []interface{}) *sagemaker.SharingSettings {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.SharingSettings{
+		NotebookOutputOption: aws.String(m["notebook_output_option"].(string)),
+	}
+
+	if v, ok := m["s3_kms_key_id"].(string); ok && v != "" {
+		config.S3KmsKeyId = aws.String(v)
+	}
+
+	if v, ok := m["s3_output_path"].(string); ok && v != "" {
+		config.S3OutputPath = aws.String(v)
+	}
+
+	return config
+}
+
+func flattenSagemakerDomainDefaultUserSettings(config *sagemaker.UserSettings) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if config.ExecutionRole != nil {
+		m["execution_role"] = aws.StringValue(config.ExecutionRole)
+	}
+
+	if config.SecurityGroups != nil {
+		m["security_groups"] = flattenStringSet(config.SecurityGroups)
+	}
+
+	if config.JupyterServerAppSettings != nil {
+		m["jupyter_server_app_settings"] = flattenSagemakerDomainJupyterServerAppSettings(config.JupyterServerAppSettings)
+	}
+
+	if config.KernelGatewayAppSettings != nil {
+		m["kernel_gateway_app_settings"] = flattenSagemakerDomainKernelGatewayAppSettings(config.KernelGatewayAppSettings)
+	}
+
+	if config.TensorBoardAppSettings != nil {
+		m["tensor_board_app_settings"] = flattenSagemakerDomainTensorBoardAppSettings(config.TensorBoardAppSettings)
+	}
+
+	if config.SharingSettings != nil {
+		m["share_settings"] = flattenSagemakerDomainShareSettings(config.SharingSettings)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenSagemakerDomainDefaultResourceSpec(config *sagemaker.ResourceSpec) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if config.InstanceType != nil {
+		m["instance_type"] = aws.StringValue(config.InstanceType)
+	}
+
+	if config.SageMakerImageArn != nil {
+		m["sagemaker_image_arn"] = aws.StringValue(config.SageMakerImageArn)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenSagemakerDomainTensorBoardAppSettings(config *sagemaker.TensorBoardAppSettings) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if config.DefaultResourceSpec != nil {
+		m["default_resurce_spec"] = flattenSagemakerDomainDefaultResourceSpec(config.DefaultResourceSpec)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenSagemakerDomainJupyterServerAppSettings(config *sagemaker.JupyterServerAppSettings) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if config.DefaultResourceSpec != nil {
+		m["default_resurce_spec"] = flattenSagemakerDomainDefaultResourceSpec(config.DefaultResourceSpec)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenSagemakerDomainKernelGatewayAppSettings(config *sagemaker.KernelGatewayAppSettings) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if config.DefaultResourceSpec != nil {
+		m["default_resurce_spec"] = flattenSagemakerDomainDefaultResourceSpec(config.DefaultResourceSpec)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenSagemakerDomainShareSettings(config *sagemaker.SharingSettings) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"notebook_output_option": aws.StringValue(config.NotebookOutputOption),
+	}
+
+	if config.S3KmsKeyId != nil {
+		m["s3_kms_key_id"] = aws.StringValue(config.S3KmsKeyId)
+	}
+
+	if config.S3OutputPath != nil {
+		m["s3_output_path"] = aws.StringValue(config.S3OutputPath)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func decodeSagemakerDomainID(id string) (string, error) {
+	domainArn, err := arn.Parse(id)
+	if err != nil {
+		return "", err
+	}
+
+	domainName := strings.TrimPrefix(domainArn.Resource, "domain/")
+	return domainName, nil
+}

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -110,6 +110,7 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 						"tensor_board_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
+							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -138,6 +139,7 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 						"jupyter_server_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
+							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -166,6 +168,7 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 						"kernel_gateway_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
+							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -321,19 +320,6 @@ func resourceAwsSagemakerDomainDelete(d *schema.ResourceData, meta interface{}) 
 		if !isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
 			return fmt.Errorf("error waiting for sagemaker domain (%s) to delete: %w", d.Id(), err)
 		}
-	}
-
-	efsConn := meta.(*AWSClient).efsconn
-	efsFsID := d.Get("home_efs_file_system_id").(string)
-
-	_, err := efsConn.DeleteFileSystem(&efs.DeleteFileSystemInput{
-		FileSystemId: aws.String(efsFsID),
-	})
-	if err != nil {
-		if isAWSErr(err, efs.ErrCodeFileSystemNotFound, "") {
-			return nil
-		}
-		return fmt.Errorf("Error delete EFS file system (%s): %w", efsFsID, err)
 	}
 
 	return nil

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -62,7 +62,6 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 				Type:         schema.TypeString,
 				ForceNew:     true,
 				Optional:     true,
-				Computed:     true,
 				ValidateFunc: validateArn,
 			},
 			"app_network_access_type": {

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -235,7 +235,67 @@ func TestAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.0.default_resource_spec.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
-					// testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
+					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerDomain_kernelGatewayAppSettings(t *testing.T) {
+	var notebook sagemaker.DescribeDomainOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerDomainConfigKernelGatewayAppSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
+	var notebook sagemaker.DescribeDomainOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerDomainConfigJupyterServerAppSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
 				),
 			},
 			{
@@ -608,6 +668,48 @@ resource "aws_sagemaker_domain" "test" {
 	execution_role = aws_iam_role.test.arn
 	
     tensor_board_app_settings {
+	  default_resource_spec {
+        instance_type = "ml.t3.micro"
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSSagemakerDomainConfigJupyterServerAppSettings(rName string) string {
+	return testAccAWSSagemakerDomainConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = [aws_subnet.test.id]
+
+  default_user_settings {
+	execution_role = aws_iam_role.test.arn
+	
+    jupyter_server_app_settings {
+	  default_resource_spec {
+        instance_type = "ml.t3.micro"
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSSagemakerDomainConfigKernelGatewayAppSettings(rName string) string {
+	return testAccAWSSagemakerDomainConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = [aws_subnet.test.id]
+
+  default_user_settings {
+	execution_role = aws_iam_role.test.arn
+	
+    kernel_gateway_app_settings {
 	  default_resource_spec {
         instance_type = "ml.t3.micro"
       }

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -105,33 +105,6 @@ func TestAccAWSSagemakerDomain_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_efsKms(t *testing.T) {
-	var notebook sagemaker.DescribeDomainOutput
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_domain.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSagemakerDomainConfigEFSKMS(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
-					resource.TestCheckResourceAttrPair(resourceName, "home_efs_file_system_kms_key_id", "aws_kms_key.test", "arn"),
-					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSSagemakerDomain_tags(t *testing.T) {
 	var notebook sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -486,45 +459,6 @@ resource "aws_sagemaker_domain" "test" {
   default_user_settings {
     execution_role  = aws_iam_role.test.arn
     security_groups = [aws_security_group.test.id, aws_security_group.test2.id]
-  }
-}
-`, rName)
-}
-
-func testAccAWSSagemakerDomainConfigEFSKMS(rName string) string {
-	return testAccAWSSagemakerDomainConfigBase(rName) + fmt.Sprintf(`
-resource "aws_kms_key" "test" {
-  description             = "Terraform acc test %s"
-  deletion_window_in_days = 7
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "kms-tf-1",
-  "Statement": [
-    {
-      "Sid": "Enable IAM User Permissions",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": "kms:*",
-      "Resource": "*"
-    }
-  ]
-}
-POLICY
-}
-
-resource "aws_sagemaker_domain" "test" {
-  domain_name                     = %[1]q
-  auth_mode                       = "IAM"
-  vpc_id                          = aws_vpc.test.id
-  subnet_ids                      = [aws_subnet.test.id]
-  home_efs_file_system_kms_key_id = aws_kms_key.test.arn
-
-  default_user_settings {
-    execution_role = aws_iam_role.test.arn
   }
 }
 `, rName)

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -679,8 +679,8 @@ resource "aws_sagemaker_domain" "test" {
 
     sharing_settings {
       domain_output_option = "Allowed"
-      s3_kms_key_id          = aws_kms_key.test.arn
-      s3_output_path         = "s3://${aws_s3_bucket.test.bucket}/sharing"
+      s3_kms_key_id        = aws_kms_key.test.arn
+      s3_output_path       = "s3://${aws_s3_bucket.test.bucket}/sharing"
     }
   }
 }
@@ -726,7 +726,7 @@ resource "aws_sagemaker_domain" "test" {
 
     tensor_board_app_settings {
       default_resource_spec {
-		instance_type       = "ml.t3.micro"
+        instance_type       = "ml.t3.micro"
         sagemaker_image_arn = aws_sagemaker_image.test.arn
       }
     }

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -398,7 +398,7 @@ resource "aws_sagemaker_domain" "test" {
 
   default_user_settings {
     execution_role  = aws_iam_role.test.arn
-    security_groups = [aws_security_group.test.id] 
+    security_groups = [aws_security_group.test.id]
   }
 }
 `, rName)
@@ -422,7 +422,7 @@ resource "aws_sagemaker_domain" "test" {
 
   default_user_settings {
     execution_role  = aws_iam_role.test.arn
-    security_groups = [aws_security_group.test.id, aws_security_group.test2.id] 
+    security_groups = [aws_security_group.test.id, aws_security_group.test2.id]
   }
 }
 `, rName)

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -1,0 +1,345 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_sagemaker_domain", &resource.Sweeper{
+		Name: "aws_sagemaker_domain",
+		F:    testSweepSagemakerDomains,
+	})
+}
+
+func testSweepSagemakerDomains(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sagemakerconn
+
+	err = conn.ListDomainsPages(&sagemaker.ListDomainsInput{}, func(page *sagemaker.ListDomainsOutput, lastPage bool) bool {
+		for _, instance := range page.Domains {
+			domainArn := aws.StringValue(instance.DomainArn)
+			domainID, err := decodeSagemakerDomainID(domainArn)
+			if err != nil {
+				log.Printf("[ERROR] Error parsing sagemaker domain arn (%s): %s", domainArn, err)
+			}
+			input := &sagemaker.DeleteDomainInput{
+				DomainId: aws.String(domainID),
+			}
+
+			log.Printf("[INFO] Deleting SageMaker domain: %s", domainArn)
+			if _, err := conn.DeleteDomain(input); err != nil {
+				log.Printf("[ERROR] Error deleting SageMaker domain (%s): %s", domainArn, err)
+				continue
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping SageMaker domain sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving SageMaker domains: %w", err)
+	}
+
+	return nil
+}
+
+func TestAccAWSSagemakerDomain_basic(t *testing.T) {
+	var notebook sagemaker.DescribeDomainOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerDomainBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("domain/%s", rName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// func TestAccAWSSagemakerDomain_gitConfig_branch(t *testing.T) {
+// 	var notebook sagemaker.DescribeDomainOutput
+// 	rName := acctest.RandomWithPrefix("tf-acc-test")
+// 	resourceName := "aws_sagemaker_domain.test"
+
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccAWSSagemakerDomainGitConfigBranchConfig(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+// 					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
+// 					testAccCheckResourceAttrRegionalARN(resourceName0......, "arn", "sagemaker", fmt.Sprintf("code-repository/%s", rName)),
+// 					resource.TestCheckResourceAttr(resourceName, "git_config.#", "1"),
+// 					resource.TestCheckResourceAttr(resourceName, "git_config.0.repository_url", "https://github.com/terraform-providers/terraform-provider-aws.git"),
+// 					resource.TestCheckResourceAttr(resourceName, "git_config.0.branch", "master"),
+// 				),
+// 			},
+// 			{
+// 				ResourceName:      resourceName,
+// 				ImportState:       true,
+// 				ImportStateVerify: true,
+// 			},
+// 		},
+// 	})
+// }
+
+// func TestAccAWSSagemakerDomain_gitConfig_secret(t *testing.T) {
+// 	var notebook sagemaker.DescribeDomainOutput
+// 	rName := acctest.RandomWithPrefix("tf-acc-test")
+// 	resourceName := "aws_sagemaker_domain.test"
+
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccAWSSagemakerDomainGitConfigSecretConfig(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+// 					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
+// 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("code-repository/%s", rName)),
+// 					resource.TestCheckResourceAttr(resourceName, "git_config.#", "1"),
+// 					resource.TestCheckResourceAttr(resourceName, "git_config.0.repository_url", "https://github.com/terraform-providers/terraform-provider-aws.git"),
+// 					resource.TestCheckResourceAttrPair(resourceName, "git_config.0.secret_arn", "aws_secretsmanager_secret.test", "arn"),
+// 				),
+// 			},
+// 			{
+// 				ResourceName:      resourceName,
+// 				ImportState:       true,
+// 				ImportStateVerify: true,
+// 			},
+// 			{
+// 				Config: testAccAWSSagemakerDomainGitConfigSecretUpdatedConfig(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+// 					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
+// 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("code-repository/%s", rName)),
+// 					resource.TestCheckResourceAttr(resourceName, "git_config.#", "1"),
+// 					resource.TestCheckResourceAttr(resourceName, "git_config.0.repository_url", "https://github.com/terraform-providers/terraform-provider-aws.git"),
+// 					resource.TestCheckResourceAttrPair(resourceName, "git_config.0.secret_arn", "aws_secretsmanager_secret.test2", "arn"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+func TestAccAWSSagemakerDomain_disappears(t *testing.T) {
+	var notebook sagemaker.DescribeDomainOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerDomainBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerDomain(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSagemakerDomainDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_domain" {
+			continue
+		}
+
+		domain, err := finder.DomainByName(conn, rs.Primary.ID)
+		if err != nil {
+			return nil
+		}
+
+		domainArn := aws.StringValue(domain.DomainArn)
+		domainID, err := decodeSagemakerDomainID(domainArn)
+		if err != nil {
+			return err
+		}
+
+		if domainID == rs.Primary.ID {
+			return fmt.Errorf("sagemaker domain %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSSagemakerDomainExists(n string, codeRepo *sagemaker.DescribeDomainOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No sagmaker domain ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+		resp, err := finder.DomainByName(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*codeRepo = *resp
+
+		return nil
+	}
+}
+
+func testAccAWSSagemakerDomainConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.1.0/24"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.amazonaws.com"]
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSSagemakerDomainBasicConfig(rName string) string {
+	return testAccAWSSagemakerDomainConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = [aws_subnet.test.id]
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+  }
+}
+`, rName)
+}
+
+// func testAccAWSSagemakerDomainGitConfigBranchConfig(rName string) string {
+// 	return fmt.Sprintf(`
+// resource "aws_sagemaker_domain" "test" {
+//   domain_name = %[1]q
+
+//   git_config {
+//     repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+//     branch         = "master"
+//   }
+// }
+// `, rName)
+// }
+
+// func testAccAWSSagemakerDomainGitConfigSecretConfig(rName string) string {
+// 	return fmt.Sprintf(`
+// resource "aws_secretsmanager_secret" "test" {
+//   name = %[1]q
+// }
+
+// resource "aws_secretsmanager_secret_version" "test" {
+//   secret_id     = aws_secretsmanager_secret.test.id
+//   secret_string = jsonencode({ username = "example", passowrd = "example" })
+// }
+
+// resource "aws_sagemaker_domain" "test" {
+//   domain_name = %[1]q
+
+//   git_config {
+//     repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+//     secret_arn     = aws_secretsmanager_secret.test.arn
+//   }
+
+//   depends_on = [aws_secretsmanager_secret_version.test]
+// }
+// `, rName)
+// }
+
+// func testAccAWSSagemakerDomainGitConfigSecretUpdatedConfig(rName string) string {
+// 	return fmt.Sprintf(`
+// resource "aws_secretsmanager_secret" "test2" {
+//   name = "%[1]s-2"
+// }
+
+// resource "aws_secretsmanager_secret_version" "test2" {
+//   secret_id     = aws_secretsmanager_secret.test2.id
+//   secret_string = jsonencode({ username = "example", passowrd = "example" })
+// }
+
+// resource "aws_sagemaker_domain" "test" {
+//   domain_name = %[1]q
+
+//   git_config {
+//     repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+//     secret_arn     = aws_secretsmanager_secret.test2.arn
+//   }
+
+//   depends_on = [aws_secretsmanager_secret_version.test2]
+// }
+// `, rName)
+// }

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -93,7 +93,6 @@ func TestAccAWSSagemakerDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "aws_vpc.test", "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "url"),
 					resource.TestCheckResourceAttrSet(resourceName, "home_efs_file_system_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
 					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
 				),
 			},

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -379,7 +379,7 @@ func testAccCheckAWSSagemakerDomainDeleteImplicitResources(n string) resource.Te
 		for _, sg := range sgResp.SecurityGroups {
 			sgID := aws.StringValue(sg.GroupId)
 			sgName := aws.StringValue(sg.GroupName)
-			if sgName != "default" && strings.HasPrefix(sgName, "tf-acc-test") {
+			if sgName != "default" && !strings.HasPrefix(sgName, "tf-acc-test") {
 				r := resourceAwsSecurityGroup()
 				d := r.Data(nil)
 				d.SetId(sgID)

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -334,7 +334,6 @@ func testAccCheckAWSSagemakerDomainDeleteImplicitResources(n string) resource.Te
 func testAccAWSSagemakerDomainConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
-	
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -398,8 +397,8 @@ resource "aws_sagemaker_domain" "test" {
   subnet_ids  = [aws_subnet.test.id]
 
   default_user_settings {
-	execution_role  = aws_iam_role.test.arn
-	security_groups = [aws_security_group.test.id] 
+    execution_role  = aws_iam_role.test.arn
+    security_groups = [aws_security_group.test.id] 
   }
 }
 `, rName)
@@ -422,8 +421,8 @@ resource "aws_sagemaker_domain" "test" {
   subnet_ids  = [aws_subnet.test.id]
 
   default_user_settings {
-	execution_role  = aws_iam_role.test.arn
-	security_groups = [aws_security_group.test.id, aws_security_group.test2.id] 
+    execution_role  = aws_iam_role.test.arn
+    security_groups = [aws_security_group.test.id, aws_security_group.test2.id] 
   }
 }
 `, rName)
@@ -500,8 +499,8 @@ resource "aws_sagemaker_domain" "test" {
   }
 
   tags = {
-	%[2]q = %[3]q
-	%[4]q = %[5]q
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -305,7 +306,7 @@ func testAccCheckAWSSagemakerDomainDeleteImplicitResources(n string) resource.Te
 		})
 
 		if err != nil {
-			return fmt.Errorf("Sagemaker domain EFS mount targets not found: %w", err)
+			return fmt.Errorf("Sagemaker domain EFS mount targets for EFS FS (%s) not found: %w", efsFsID, err)
 		}
 
 		//reusing EFS mount target delete for wait logic
@@ -377,7 +378,8 @@ func testAccCheckAWSSagemakerDomainDeleteImplicitResources(n string) resource.Te
 
 		for _, sg := range sgResp.SecurityGroups {
 			sgID := aws.StringValue(sg.GroupId)
-			if aws.StringValue(sg.GroupName) != "default" {
+			sgName := aws.StringValue(sg.GroupName)
+			if sgName != "default" && strings.HasPrefix(sgName, "tf-acc-test") {
 				r := resourceAwsSecurityGroup()
 				d := r.Data(nil)
 				d.SetId(sgID)
@@ -459,7 +461,7 @@ resource "aws_sagemaker_domain" "test" {
 
   default_user_settings {
     execution_role  = aws_iam_role.test.arn
-    security_groups = [aws_security_sg.test.id]
+    security_groups = [aws_security_group.test.id]
   }
 }
 `, rName)
@@ -483,7 +485,7 @@ resource "aws_sagemaker_domain" "test" {
 
   default_user_settings {
     execution_role  = aws_iam_role.test.arn
-    security_groups = [aws_security_sg.test.id, aws_security_sg.test2.id]
+    security_groups = [aws_security_group.test.id, aws_security_group.test2.id]
   }
 }
 `, rName)

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -233,9 +233,9 @@ func TestAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
 					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.default_resource_spec.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.default_resource_spec.instance_type", "ml.t3.micro"),
-					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					// testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
 				),
 			},
 			{
@@ -609,7 +609,7 @@ resource "aws_sagemaker_domain" "test" {
 	
     tensor_board_app_settings {
 	  default_resource_spec {
-        instance_type = "ml.t3.micro"  
+        instance_type = "ml.t3.micro"
       }
     }
   }

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -644,13 +644,13 @@ resource "aws_sagemaker_domain" "test" {
   subnet_ids  = [aws_subnet.test.id]
 
   default_user_settings {
-	execution_role = aws_iam_role.test.arn
-	
+    execution_role = aws_iam_role.test.arn
+
     sharing_settings {
       notebook_output_option = "Allowed"
       s3_kms_key_id          = aws_kms_key.test.arn
       s3_output_path         = "s3://${aws_s3_bucket.test.bucket}/sharing"
-	}
+    }
   }
 }
 `, rName)
@@ -665,10 +665,10 @@ resource "aws_sagemaker_domain" "test" {
   subnet_ids  = [aws_subnet.test.id]
 
   default_user_settings {
-	execution_role = aws_iam_role.test.arn
-	
+    execution_role = aws_iam_role.test.arn
+
     tensor_board_app_settings {
-	  default_resource_spec {
+      default_resource_spec {
         instance_type = "ml.t3.micro"
       }
     }
@@ -686,10 +686,10 @@ resource "aws_sagemaker_domain" "test" {
   subnet_ids  = [aws_subnet.test.id]
 
   default_user_settings {
-	execution_role = aws_iam_role.test.arn
-	
+    execution_role = aws_iam_role.test.arn
+
     jupyter_server_app_settings {
-	  default_resource_spec {
+      default_resource_spec {
         instance_type = "ml.t3.micro"
       }
     }
@@ -707,10 +707,10 @@ resource "aws_sagemaker_domain" "test" {
   subnet_ids  = [aws_subnet.test.id]
 
   default_user_settings {
-	execution_role = aws_iam_role.test.arn
-	
+    execution_role = aws_iam_role.test.arn
+
     kernel_gateway_app_settings {
-	  default_resource_spec {
+      default_resource_spec {
         instance_type = "ml.t3.micro"
       }
     }

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -230,7 +230,7 @@ func TestAccAWSSagemakerDomain_sharingSettings(t *testing.T) {
 					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.0.domain_output_option", "Allowed"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.0.notebook_output_option", "Allowed"),
 					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.sharing_settings.0.s3_kms_key_id", "aws_kms_key.test", "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "default_user_settings.0.sharing_settings.0.s3_output_path"),
 					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -88,8 +88,6 @@ func TestAccAWSSagemakerDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.execution_role", "aws_iam_role.test", "arn"),
-					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.0.notebook_output_option", "Disabled"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "sagemaker", regexp.MustCompile(`domain/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "aws_vpc.test", "id"),

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -69,7 +69,7 @@ func testSweepSagemakerDomains(region string) error {
 }
 
 func TestAccAWSSagemakerDomain_basic(t *testing.T) {
-	var notebook sagemaker.DescribeDomainOutput
+	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
@@ -81,7 +81,7 @@ func TestAccAWSSagemakerDomain_basic(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "auth_mode", "IAM"),
 					resource.TestCheckResourceAttr(resourceName, "app_network_access_type", "PublicInternetOnly"),
@@ -106,7 +106,7 @@ func TestAccAWSSagemakerDomain_basic(t *testing.T) {
 }
 
 func TestAccAWSSagemakerDomain_tags(t *testing.T) {
-	var notebook sagemaker.DescribeDomainOutput
+	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
@@ -118,7 +118,7 @@ func TestAccAWSSagemakerDomain_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -131,7 +131,7 @@ func TestAccAWSSagemakerDomain_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -140,7 +140,7 @@ func TestAccAWSSagemakerDomain_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
@@ -151,7 +151,7 @@ func TestAccAWSSagemakerDomain_tags(t *testing.T) {
 }
 
 func TestAccAWSSagemakerDomain_securityGroup(t *testing.T) {
-	var notebook sagemaker.DescribeDomainOutput
+	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
@@ -163,7 +163,7 @@ func TestAccAWSSagemakerDomain_securityGroup(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainConfigSecurityGroup1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.security_groups.#", "1"),
 				),
@@ -176,7 +176,7 @@ func TestAccAWSSagemakerDomain_securityGroup(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainConfigSecurityGroup2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.security_groups.#", "2"),
 					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
@@ -187,7 +187,7 @@ func TestAccAWSSagemakerDomain_securityGroup(t *testing.T) {
 }
 
 func TestAccAWSSagemakerDomain_sharingSettings(t *testing.T) {
-	var notebook sagemaker.DescribeDomainOutput
+	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
@@ -199,10 +199,10 @@ func TestAccAWSSagemakerDomain_sharingSettings(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainConfigSharingSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.0.notebook_output_option", "Allowed"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.sharing_settings.0.domain_output_option", "Allowed"),
 					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.sharing_settings.0.s3_kms_key_id", "aws_kms_key.test", "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "default_user_settings.0.sharing_settings.0.s3_output_path"),
 					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
@@ -218,7 +218,7 @@ func TestAccAWSSagemakerDomain_sharingSettings(t *testing.T) {
 }
 
 func TestAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
-	var notebook sagemaker.DescribeDomainOutput
+	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
@@ -230,7 +230,7 @@ func TestAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainConfigTensorBoardAppSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.0.default_resource_spec.#", "1"),
@@ -247,8 +247,39 @@ func TestAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
 	})
 }
 
+func TestAccAWSSagemakerDomain_tensorboardAppSettingsWithImage(t *testing.T) {
+	var domain sagemaker.DescribeDomainOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerDomainConfigTensorBoardAppSettingsWithImage(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.tensor_board_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.tensor_board_app_settings.0.default_resource_spec.0.sagemaker_image_arn", "aws_sagemaker_image.test", "arn"),
+					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSSagemakerDomain_kernelGatewayAppSettings(t *testing.T) {
-	var notebook sagemaker.DescribeDomainOutput
+	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
@@ -260,7 +291,7 @@ func TestAccAWSSagemakerDomain_kernelGatewayAppSettings(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainConfigKernelGatewayAppSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
@@ -278,7 +309,7 @@ func TestAccAWSSagemakerDomain_kernelGatewayAppSettings(t *testing.T) {
 }
 
 func TestAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
-	var notebook sagemaker.DescribeDomainOutput
+	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
@@ -290,7 +321,7 @@ func TestAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainConfigJupyterServerAppSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.#", "1"),
@@ -308,7 +339,7 @@ func TestAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
 }
 
 func TestAccAWSSagemakerDomain_disappears(t *testing.T) {
-	var notebook sagemaker.DescribeDomainOutput
+	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
@@ -320,7 +351,7 @@ func TestAccAWSSagemakerDomain_disappears(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDomainBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDomainExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerDomainExists(resourceName, &domain),
 					testAccCheckAWSSagemakerDomainDeleteImplicitResources(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerDomain(), resourceName),
 				),
@@ -647,7 +678,7 @@ resource "aws_sagemaker_domain" "test" {
     execution_role = aws_iam_role.test.arn
 
     sharing_settings {
-      notebook_output_option = "Allowed"
+      domain_output_option = "Allowed"
       s3_kms_key_id          = aws_kms_key.test.arn
       s3_output_path         = "s3://${aws_s3_bucket.test.bucket}/sharing"
     }
@@ -670,6 +701,33 @@ resource "aws_sagemaker_domain" "test" {
     tensor_board_app_settings {
       default_resource_spec {
         instance_type = "ml.t3.micro"
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSSagemakerDomainConfigTensorBoardAppSettingsWithImage(rName string) string {
+	return testAccAWSSagemakerDomainConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_image" "test" {
+  image_name = %[1]q
+  role_arn   = aws_iam_role.test.arn
+}
+
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = [aws_subnet.test.id]
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+
+    tensor_board_app_settings {
+      default_resource_spec {
+		instance_type       = "ml.t3.micro"
+        sagemaker_image_arn = aws_sagemaker_image.test.arn
       }
     }
   }

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -412,7 +412,7 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_security_group" "test2" {
-  name = "%[2]s-2"
+  name = "%[1]s-2"
 }
 
 resource "aws_sagemaker_domain" "test" {

--- a/aws/resource_aws_sagemaker_image.go
+++ b/aws/resource_aws_sagemaker_image.go
@@ -201,11 +201,10 @@ func resourceAwsSagemakerImageDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if _, err := waiter.ImageDeleted(conn, d.Id()); err != nil {
-		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "No Image with the name") {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "does not exist") {
 			return nil
 		}
 		return fmt.Errorf("error waiting for SageMaker Image (%s) to delete: %w", d.Id(), err)
-
 	}
 
 	return nil

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -1,0 +1,109 @@
+---
+subcategory: "Sagemaker"
+layout: "aws"
+page_title: "AWS: aws_sagemaker_domain"
+description: |-
+  Provides a Sagemaker Domain resource.
+---
+
+# Resource: aws_sagemaker_domain
+
+Provides a Sagemaker Domain resource.
+
+## Example Usage
+
+### Basic usage
+
+```hcl
+resource "aws_sagemaker_domain" "example" {
+  domain_name = "example"
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = [aws_subnet.test.id]
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+  }
+}
+
+resource "aws_iam_role" "example" {
+  name               = "example"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.example.json
+}
+
+data "aws_iam_policy_document" "example" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.amazonaws.com"]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required) The domain name.
+* `auth_mode` - (Required) The mode of authentication that members use to access the domain. Valid values are `IAM` and `SSO`.
+* `vpc_id` - (Required) The ID of the Amazon Virtual Private Cloud (VPC) that Studio uses for communication.
+* `subnet_ids` - (Required) The VPC subnets that Studio uses for communication.
+* `default_user_settings` - (Required) The default user settings. see [Default User Settings](#default-user-settings) below.
+* `app_network_access_type` - (Optional) Specifies the VPC used for non-EFS traffic. The default value is `PublicInternetOnly`. Valid values are `PublicInternetOnly` and `VpcOnly`.
+* `home_efs_file_system_kms_key_id` - (Optional) The AWS Key Management Service (KMS) encryption key ARN.
+* `tags` - (Optional) A map of tags to assign to the resource.
+
+### Default User Settings
+
+* `execution_role` - (Required) The execution role ARN for the user.
+* `security_groups` - (Optional) The security groups.
+* `sharing_settings` - (Optional) The sharing settings. see [Sharing Settings](#sharing-settings) below.
+* `tensor_board_app_settings` - (Optional) The TensorBoard app settings. see [TensorBoard App Settings](#tensorboard-app-settings) below.
+* `jupyter_server_app_settings` - (Optional) The kernel gateway app settings. see [Jupyter Server App Settings](#jupyter-server-app-settings) below.
+* `kernel_gateway_app_settings` - (Optional) The Jupyter server's app settings. see [Kernel Gateway App Settings](#kernal-gateway-app-settings) below.
+
+#### Sharing Settings
+
+* `notebook_output_option` - (Optional) Whether to include the notebook cell output when sharing the notebook. The default is `Disabled`. Valid values are `Allowed` and `Disabled`.
+* `s3_kms_key_id` - (Optional) When `notebook_output_option` is Allowed, the AWS Key Management Service (KMS) encryption key ID used to encrypt the notebook cell output in the Amazon S3 bucket.
+* `s3_output_path` - (Optional) When `notebook_output_option` is Allowed, the Amazon S3 bucket used to save the notebook cell output.
+
+#### TensorBoard App Settings
+
+* `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
+
+#### Kernel Gateway App Settings
+
+* `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
+
+#### Jupyter Server App Settings
+
+* `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
+
+##### Default Resource Spec
+
+* `instance_type` - (Optional) The instance type.
+* `sagemaker_image_arn` - (Optional) The Amazon Resource Name (ARN) of the SageMaker image created on the instance.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Domain.
+* `arn` - The Amazon Resource Name (ARN) assigned by AWS to this Domain.
+* `url` - The domain's URL.
+* `single_sign_on_managed_application_instance_id` - The SSO managed application instance ID.
+* `home_efs_file_system_id` - The ID of the Amazon Elastic File System (EFS) managed by this Domain.
+
+
+## Import
+
+Sagemaker Code Domains can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_sagemaker_domain.test_domain d-8jgsjtilstu8
+```

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -54,7 +54,6 @@ The following arguments are supported:
 * `subnet_ids` - (Required) The VPC subnets that Studio uses for communication.
 * `default_user_settings` - (Required) The default user settings. see [Default User Settings](#default-user-settings) below.
 * `app_network_access_type` - (Optional) Specifies the VPC used for non-EFS traffic. The default value is `PublicInternetOnly`. Valid values are `PublicInternetOnly` and `VpcOnly`.
-* `home_efs_file_system_kms_key_id` - (Optional) The AWS Key Management Service (KMS) encryption key ARN.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ### Default User Settings

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -53,6 +53,7 @@ The following arguments are supported:
 * `vpc_id` - (Required) The ID of the Amazon Virtual Private Cloud (VPC) that Studio uses for communication.
 * `subnet_ids` - (Required) The VPC subnets that Studio uses for communication.
 * `default_user_settings` - (Required) The default user settings. See [Default User Settings](#default-user-settings) below.
+* `kms_key_id` - (Optional) The AWS KMS customer managed CMK used to encrypt the EFS volume attached to the domain.
 * `app_network_access_type` - (Optional) Specifies the VPC used for non-EFS traffic. The default value is `PublicInternetOnly`. Valid values are `PublicInternetOnly` and `VpcOnly`.
 * `tags` - (Optional) A map of tags to assign to the resource.
 

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -78,6 +78,7 @@ The following arguments are supported:
 #### Kernel Gateway App Settings
 
 * `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
+* `custom_image` - (Optional) A list of custom SageMaker images that are configured to run as a KernelGateway app. see [Custom Image](#custom-image) below.
 
 #### Jupyter Server App Settings
 
@@ -87,6 +88,12 @@ The following arguments are supported:
 
 * `instance_type` - (Optional) The instance type.
 * `sagemaker_image_arn` - (Optional) The Amazon Resource Name (ARN) of the SageMaker image created on the instance.
+
+##### Custom Image
+
+* `app_image_config_name` - (Required) The name of the App Image Config.
+* `image_name` - (Required) The name of the Custom Image.
+* `image_version_number` - (Optional) The version number of the Custom Image.
 
 ## Attributes Reference
 

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 * `auth_mode` - (Required) The mode of authentication that members use to access the domain. Valid values are `IAM` and `SSO`.
 * `vpc_id` - (Required) The ID of the Amazon Virtual Private Cloud (VPC) that Studio uses for communication.
 * `subnet_ids` - (Required) The VPC subnets that Studio uses for communication.
-* `default_user_settings` - (Required) The default user settings. see [Default User Settings](#default-user-settings) below.
+* `default_user_settings` - (Required) The default user settings. See [Default User Settings](#default-user-settings) below.
 * `app_network_access_type` - (Optional) Specifies the VPC used for non-EFS traffic. The default value is `PublicInternetOnly`. Valid values are `PublicInternetOnly` and `VpcOnly`.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
@@ -60,10 +60,10 @@ The following arguments are supported:
 
 * `execution_role` - (Required) The execution role ARN for the user.
 * `security_groups` - (Optional) The security groups.
-* `sharing_settings` - (Optional) The sharing settings. see [Sharing Settings](#sharing-settings) below.
-* `tensor_board_app_settings` - (Optional) The TensorBoard app settings. see [TensorBoard App Settings](#tensorboard-app-settings) below.
-* `jupyter_server_app_settings` - (Optional) The kernel gateway app settings. see [Jupyter Server App Settings](#jupyter-server-app-settings) below.
-* `kernel_gateway_app_settings` - (Optional) The Jupyter server's app settings. see [Kernel Gateway App Settings](#kernal-gateway-app-settings) below.
+* `sharing_settings` - (Optional) The sharing settings. See [Sharing Settings](#sharing-settings) below.
+* `tensor_board_app_settings` - (Optional) The TensorBoard app settings. See [TensorBoard App Settings](#tensorboard-app-settings) below.
+* `jupyter_server_app_settings` - (Optional) The Jupyter server's app settings. See [Jupyter Server App Settings](#jupyter-server-app-settings) below.
+* `kernel_gateway_app_settings` - (Optional) The kernel gateway app settings. See [Kernel Gateway App Settings](#kernal-gateway-app-settings) below.
 
 #### Sharing Settings
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14453

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sagemaker_domain - add new resource
resource_aws_sagemaker_image - fix error on wait for delete when image does not exist
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerDomain_'
--- PASS: TestAccAWSSagemakerDomain_basic (228.59s)--- PASS: TestAccAWSSagemakerDomain_kernelGatewayAppSettings (233.93s)
--- PASS: TestAccAWSSagemakerDomain_disappears (222.39s)
--- PASS: TestAccAWSSagemakerDomain_jupyterServerAppSettings (223.22s)
--- PASS: TestAccAWSSagemakerDomain_sharingSettings (233.47s)
--- PASS: TestAccAWSSagemakerDomain_tensorboardAppSettings (237.31s)
--- PASS: TestAccAWSSagemakerDomain_securityGroup (288.18s)
--- PASS: TestAccAWSSagemakerDomain_tags (346.14s)
--- PASS: TestAccAWSSagemakerDomain_kms (242.96s)
```
