### PR TITLE
Elasticsearch service ebs volume size is different.

### DIFF
--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -240,7 +240,7 @@ The **advanced_security_options** block supports the following attributes:
 
 * `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain.
 * `volume_type` - (Optional) The type of EBS volumes attached to data nodes.
-* `volume_size` - The size of EBS volumes attached to data nodes (in GB).
+* `volume_size` - The size of EBS volumes attached to data nodes (in GiB).
 **Required** if `ebs_enabled` is set to `true`.
 * `iops` - (Optional) The baseline input/output (I/O) performance of EBS volumes
 	attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.


### PR DESCRIPTION
fix document. 
Although it is GB in the document, it was actually GiB.
The AWS documentation is also GiB.

<img width="323" alt="screen_shot 2020-11-08 8 26 59" src="https://user-images.githubusercontent.com/17211631/98453436-559e8900-219c-11eb-9d3d-b1470b2944c6.png">

https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html#ebsresource

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```