### PR TITLE
r/aws_iot_topic_rule: add http action type

### DIFF
--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -495,6 +495,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -547,6 +548,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -619,6 +621,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -663,6 +666,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -711,6 +715,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -751,6 +756,60 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"http": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"url": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.IsURLWithHTTPS,
+									},
+									"confirmation_url": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.IsURLWithHTTPS,
+									},
+									"http_header": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"key": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -786,6 +845,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -825,6 +885,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -864,6 +925,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -895,6 +957,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -936,6 +999,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -975,6 +1039,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -1014,6 +1079,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -1055,6 +1121,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -1094,6 +1161,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.dynamodbv2",
 								"error_action.0.elasticsearch",
 								"error_action.0.firehose",
+								"error_action.0.http",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
 								"error_action.0.kinesis",
@@ -1982,6 +2050,16 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{Firehose: action}
 				}
+			case "http":
+				for _, tfMapRaw := range v.([]interface{}) {
+					action := expandIotHttpAction([]interface{}{tfMapRaw})
+
+					if action == nil {
+						continue
+					}
+
+					iotErrorAction = &iot.Action{Http: action}
+				}
 			case "iot_analytics":
 				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotIotAnalyticsAction([]interface{}{tfMapRaw})
@@ -2728,6 +2806,10 @@ func flattenIotErrorAction(errorAction *iot.Action) []map[string]interface{} {
 	}
 	if errorAction.Firehose != nil {
 		results = append(results, map[string]interface{}{"firehose": flattenIotFirehoseActions(input)})
+		return results
+	}
+	if errorAction.Http != nil {
+		results = append(results, map[string]interface{}{"http": flattenIotHttpActions(input)})
 		return results
 	}
 	if errorAction.IotAnalytics != nil {

--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -241,7 +241,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.IsURLWithHTTPS,
 						},
-						"headers": {
+						"http_header": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
@@ -1517,7 +1517,7 @@ func expandIotHttpAction(tfList []interface{}) *iot.HttpAction {
 		apiObject.ConfirmationUrl = aws.String(v)
 	}
 
-	if v, ok := tfMap["headers"].([]interface{}); ok {
+	if v, ok := tfMap["http_header"].([]interface{}); ok {
 		headerObjs := []*iot.HttpActionHeader{}
 		for _, val := range v {
 			if m, ok := val.(map[string]interface{}); ok {
@@ -2834,7 +2834,7 @@ func flattenIotHttpAction(apiObject *iot.HttpAction) []interface{} {
 			}
 			headers = append(headers, m)
 		}
-		tfMap["headers"] = headers
+		tfMap["http_header"] = headers
 	}
 
 	return []interface{}{tfMap}

--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -226,6 +226,40 @@ func resourceAwsIotTopicRule() *schema.Resource {
 					},
 				},
 			},
+			"http": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsURLWithHTTPS,
+						},
+						"confirmation_url": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsURLWithHTTPS,
+						},
+						"headers": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"iot_analytics": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -1155,6 +1189,10 @@ func resourceAwsIotTopicRuleRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error setting firehose: %w", err)
 	}
 
+	if err := d.Set("http", flattenIotHttpActions(out.Rule.Actions)); err != nil {
+		return fmt.Errorf("error setting http: %w", err)
+	}
+
 	if err := d.Set("iot_analytics", flattenIotIotAnalyticsActions(out.Rule.Actions)); err != nil {
 		return fmt.Errorf("error setting iot_analytics: %w", err)
 	}
@@ -1210,6 +1248,7 @@ func resourceAwsIotTopicRuleUpdate(d *schema.ResourceData, meta interface{}) err
 		"elasticsearch",
 		"enabled",
 		"firehose",
+		"http",
 		"iot_analytics",
 		"iot_events",
 		"kinesis",
@@ -1457,6 +1496,42 @@ func expandIotFirehoseAction(tfList []interface{}) *iot.FirehoseAction {
 
 	if v, ok := tfMap["separator"].(string); ok && v != "" {
 		apiObject.Separator = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandIotHttpAction(tfList []interface{}) *iot.HttpAction {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	apiObject := &iot.HttpAction{}
+	tfMap := tfList[0].(map[string]interface{})
+
+	if v, ok := tfMap["url"].(string); ok && v != "" {
+		apiObject.Url = aws.String(v)
+	}
+
+	if v, ok := tfMap["confirmation_url"].(string); ok && v != "" {
+		apiObject.ConfirmationUrl = aws.String(v)
+	}
+
+	if v, ok := tfMap["headers"].([]interface{}); ok {
+		headerObjs := []*iot.HttpActionHeader{}
+		for _, val := range v {
+			if m, ok := val.(map[string]interface{}); ok {
+				headerObj := &iot.HttpActionHeader{}
+				if v, ok := m["key"].(string); ok && v != "" {
+					headerObj.Key = aws.String(v)
+				}
+				if v, ok := m["value"].(string); ok && v != "" {
+					headerObj.Value = aws.String(v)
+				}
+				headerObjs = append(headerObjs, headerObj)
+			}
+		}
+		apiObject.Headers = headerObjs
 	}
 
 	return apiObject
@@ -1724,6 +1799,17 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 		}
 
 		actions = append(actions, &iot.Action{Firehose: action})
+	}
+
+	// Legacy root attribute handling
+	for _, tfMapRaw := range d.Get("http").(*schema.Set).List() {
+		action := expandIotHttpAction([]interface{}{tfMapRaw})
+
+		if action == nil {
+			continue
+		}
+
+		actions = append(actions, &iot.Action{Http: action})
 	}
 
 	// Legacy root attribute handling
@@ -2701,6 +2787,54 @@ func flattenIotStepFunctionsAction(apiObject *iot.StepFunctionsAction) []interfa
 
 	if v := apiObject.RoleArn; v != nil {
 		tfMap["role_arn"] = aws.StringValue(v)
+	}
+
+	return []interface{}{tfMap}
+}
+
+// Legacy root attribute handling
+func flattenIotHttpActions(actions []*iot.Action) []interface{} {
+	results := make([]interface{}, 0)
+
+	for _, action := range actions {
+		if action == nil {
+			continue
+		}
+
+		if v := action.Http; v != nil {
+			results = append(results, flattenIotHttpAction(v)...)
+		}
+	}
+
+	return results
+}
+
+func flattenIotHttpAction(apiObject *iot.HttpAction) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := make(map[string]interface{})
+
+	if v := apiObject.Url; v != nil {
+		tfMap["url"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.ConfirmationUrl; v != nil {
+		tfMap["confirmation_url"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Headers; v != nil {
+		headers := []map[string]string{}
+
+		for _, h := range v {
+			m := map[string]string{
+				"key":   aws.StringValue(h.Key),
+				"value": aws.StringValue(h.Value),
+			}
+			headers = append(headers, m)
+		}
+		tfMap["headers"] = headers
 	}
 
 	return []interface{}{tfMap}

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -271,6 +271,42 @@ func TestAccAWSIoTTopicRule_firehose_separator(t *testing.T) {
 	})
 }
 
+func TestAccAWSIoTTopicRule_http(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTTopicRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTTopicRule_http(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTTopicRuleExists("aws_iot_topic_rule.rule"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSIoTTopicRule_http_confirmation_url(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTTopicRuleExists("aws_iot_topic_rule.rule"),
+				),
+			},
+			{
+				Config: testAccAWSIoTTopicRule_http_headers(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTTopicRuleExists("aws_iot_topic_rule.rule"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSIoTTopicRule_kinesis(t *testing.T) {
 	rName := acctest.RandString(5)
 	resourceName := "aws_iot_topic_rule.rule"
@@ -839,6 +875,63 @@ resource "aws_iot_topic_rule" "rule" {
   }
 }
 `, rName, separator)
+}
+
+func testAccAWSIoTTopicRule_http(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_topic_rule" "rule" {
+  name        = "test_rule_%[1]s"
+  description = "Example rule"
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+
+  http {
+	url = "https://foo.bar/ingress"
+  }
+}
+`, rName)
+}
+
+func testAccAWSIoTTopicRule_http_confirmation_url(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_topic_rule" "rule" {
+  name        = "test_rule_%[1]s"
+  description = "Example rule"
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+
+  http {
+	url = "https://foo.bar/ingress"
+	confirmation_url = "https://foo.bar/"
+  }
+}
+`, rName)
+}
+
+func testAccAWSIoTTopicRule_http_headers(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_topic_rule" "rule" {
+  name        = "test_rule_%[1]s"
+  description = "Example rule"
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+
+  http {
+	url = "https://foo.bar/ingress"
+	headers {
+		key = "foo"
+		value = "bar"
+	}
+	headers {
+		key = "oof"
+		value = "rab"
+	}
+  }
+}
+`, rName)
 }
 
 func testAccAWSIoTTopicRule_kinesis(rName string) string {

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -921,11 +921,11 @@ resource "aws_iot_topic_rule" "rule" {
 
   http {
 	url = "https://foo.bar/ingress"
-	headers {
+	http_header {
 		key = "foo"
 		value = "bar"
 	}
-	headers {
+	http_header {
 		key = "oof"
 		value = "rab"
 	}

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -303,6 +303,12 @@ func TestAccAWSIoTTopicRule_http(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				Config: testAccAWSIoTTopicRule_http_errorAction(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTTopicRuleExists("aws_iot_topic_rule.rule"),
+				),
+			},
 		},
 	})
 }
@@ -930,6 +936,28 @@ resource "aws_iot_topic_rule" "rule" {
 		value = "rab"
 	}
   }
+}
+`, rName)
+}
+
+func testAccAWSIoTTopicRule_http_errorAction(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_topic_rule" "rule" {
+	name        = "test_rule_%[1]s"
+	description = "Example rule"
+	enabled     = true
+	sql         = "SELECT * FROM 'topic/test'"
+	sql_version = "2015-10-08"
+
+	http {
+		url = "https://foo.bar/ingress"
+    }
+
+	error_action {
+		http {
+			url = "https://bar.foo/error-ingress"
+		}
+  	}
 }
 `, rName)
 }

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -88,7 +88,7 @@ EOF
 * `enabled` - (Required) Specifies whether the rule is enabled.
 * `sql` - (Required) The SQL statement used to query the topic. For more information, see AWS IoT SQL Reference (http://docs.aws.amazon.com/iot/latest/developerguide/iot-rules.html#aws-iot-sql-reference) in the AWS IoT Developer Guide.
 * `sql_version` - (Required) The version of the SQL rules engine to use when evaluating the rule.
-* `error_action` - (Optional) Configuration block with error action to be associated with the rule. See the documentation for `cloudwatch_alarm`, `cloudwatch_metric`, `dynamodb`, `dynamodbv2`, `elasticsearch`, `firehose`, `iot_analytics`, `iot_events`, `kinesis`, `lambda`, `republish`, `s3`, `step_functions`, `sns`, `sqs` configuration blocks for further configuration details.
+* `error_action` - (Optional) Configuration block with error action to be associated with the rule. See the documentation for `cloudwatch_alarm`, `cloudwatch_metric`, `dynamodb`, `dynamodbv2`, `elasticsearch`, `firehose`, `http`, `iot_analytics`, `iot_events`, `kinesis`, `lambda`, `republish`, `s3`, `step_functions`, `sns`, `sqs` configuration blocks for further configuration details.
 * `tags` - (Optional) Key-value map of resource tags
 
 The `cloudwatch_alarm` object takes the following arguments:
@@ -139,6 +139,17 @@ The `firehose` object takes the following arguments:
 * `delivery_stream_name` - (Required) The delivery stream name.
 * `role_arn` - (Required) The IAM role ARN that grants access to the Amazon Kinesis Firehose stream.
 * `separator` - (Optional) A character separator that is used to separate records written to the Firehose stream. Valid values are: '\n' (newline), '\t' (tab), '\r\n' (Windows newline), ',' (comma).
+
+The `http` object takes the following arguments:
+
+* `url` - (Required) The HTTPS URL.
+* `confirmation_url` - (Optional) The HTTPS URL used to verify ownership of `url`.
+* `http_header` - (Optional) Custom HTTP header IoT Core should send. It is possible to define more than one custom header.
+
+The `http_header` object takes the following arguments:
+
+* `key` - (Required) The name of the HTTP header.
+* `value` - (Required) The value of the HTTP header.
 
 The `kinesis` object takes the following arguments:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11940

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_iot_topic_rule: Add http action type
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSIoTTopicRule_http'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIoTTopicRule_http -timeout 120m
=== RUN   TestAccAWSIoTTopicRule_http
=== PAUSE TestAccAWSIoTTopicRule_http
=== CONT  TestAccAWSIoTTopicRule_http
--- PASS: TestAccAWSIoTTopicRule_http (70.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       70.033s
```
