### PR TITLE
aws/validators: relax db parameter group input validation to include periods

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -211,9 +211,9 @@ func validateTagFilters(v interface{}, k string) (ws []string, errors []error) {
 
 func validateDbParamGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only lowercase alphanumeric characters and hyphens allowed in parameter group %q", k))
+			"only lowercase alphanumeric characters, hyphens and periods allowed in parameter group %q", k))
 	}
 	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1888,6 +1888,10 @@ func TestValidateDbParamGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
+			Value:    "default.aurora-postgresql9.6",
+			ErrCount: 0,
+		},
+		{
 			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},


### PR DESCRIPTION
Fixes: #16098
