### PR TITLE
tests/resource/fms_admin_account: Remove hardcoded environment variable handing

### DIFF
--- a/aws/fms_admin_account_configuration_test.go
+++ b/aws/fms_admin_account_configuration_test.go
@@ -1,0 +1,84 @@
+package aws
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/fms"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// FMS Admin Account Configurations can only be enabled with destinations in specific regions,
+
+// testAccFmsAdminAccountConfigurationRegion is the chosen FMS Admin Account Configurations testing region
+//
+// Cached to prevent issues should multiple regions become available.
+var testAccFmsAdminAccountConfigurationRegion string
+
+// testAccProviderFmsAdminAccountConfiguration is the FMS Admin Account Configurations provider instance
+//
+// This Provider can be used in testing code for API calls without requiring
+// the use of saving and referencing specific ProviderFactories instances.
+//
+// testAccPreCheckFmsAdminAccountConfiguration(t) must be called before using this provider instance.
+var testAccProviderFmsAdminAccountConfiguration *schema.Provider
+
+// testAccProviderFmsAdminAccountConfigurationConfigure ensures the provider is only configured once
+var testAccProviderFmsAdminAccountConfigurationConfigure sync.Once
+
+// testAccPreCheckFmsAdminAccountConfiguration verifies AWS credentials and that FMS Admin Account Configurations is supported
+func testAccPreCheckFmsAdminAccountConfiguration(t *testing.T) {
+	testAccPartitionHasServicePreCheck(fms.EndpointsID, t)
+
+	// Since we are outside the scope of the Terraform configuration we must
+	// call Configure() to properly initialize the provider configuration.
+	testAccProviderFmsAdminAccountConfigurationConfigure.Do(func() {
+		testAccProviderFmsAdminAccountConfiguration = Provider()
+
+		region := testAccGetFmsAdminAccountConfigurationRegion()
+
+		if region == "" {
+			t.Skip("FMS Admin Account Configuration not available in this AWS Partition")
+		}
+
+		config := map[string]interface{}{
+			"region": region,
+		}
+
+		diags := testAccProviderFmsAdminAccountConfiguration.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+
+		if diags != nil && diags.HasError() {
+			for _, d := range diags {
+				if d.Severity == diag.Error {
+					t.Fatalf("error configuring FMS Admin Account Configurations provider: %s", d.Summary)
+				}
+			}
+		}
+	})
+}
+
+// testAccFmsAdminAccountConfigurationRegionProviderConfig is the Terraform provider configuration for FMS Admin Account Configurations region testing
+//
+// Testing FMS Admin Account Configurations assumes no other provider configurations
+// are necessary and overwrites the "aws" provider configuration.
+func testAccFmsAdminAccountConfigurationRegionProviderConfig() string {
+	return testAccRegionalProviderConfig(testAccGetFmsAdminAccountConfigurationRegion())
+}
+
+// testAccGetFmsAdminAccountConfigurationRegion returns the FMS Admin Account Configurations region for testing
+func testAccGetFmsAdminAccountConfigurationRegion() string {
+	if testAccFmsAdminAccountConfigurationRegion != "" {
+		return testAccFmsAdminAccountConfigurationRegion
+	}
+
+	switch testAccGetPartition() {
+	case endpoints.AwsPartitionID:
+		testAccFmsAdminAccountConfigurationRegion = endpoints.UsEast1RegionID
+	}
+
+	return testAccFmsAdminAccountConfigurationRegion
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16106 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
    provider_test.go:685: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- SKIP: TestAccAwsFmsAdminAccount_basic (2.18s)
```

Output from acceptance testing (commercial):

```
    provider_test.go:685: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- SKIP: TestAccAwsFmsAdminAccount_basic (1.17s)
```

Output from acceptance testing (commercial payer):

```
--- PASS: TestAccAwsFmsAdminAccount_basic (108.64s)
```