### PR TITLE
Support Backup Region Settings

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -454,6 +454,7 @@ func Provider() *schema.Provider {
 			"aws_autoscaling_schedule":                                resourceAwsAutoscalingSchedule(),
 			"aws_autoscalingplans_scaling_plan":                       resourceAwsAutoScalingPlansScalingPlan(),
 			"aws_backup_plan":                                         resourceAwsBackupPlan(),
+			"aws_backup_region_settings":                              resourceAwsBackupRegionSettings(),
 			"aws_backup_selection":                                    resourceAwsBackupSelection(),
 			"aws_backup_vault":                                        resourceAwsBackupVault(),
 			"aws_backup_vault_notifications":                          resourceAwsBackupVaultNotifications(),

--- a/aws/resource_aws_backup_region_settings.go
+++ b/aws/resource_aws_backup_region_settings.go
@@ -1,0 +1,65 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsBackupRegionSettings() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsBackupRegionSettingsUpdate,
+		Update: resourceAwsBackupRegionSettingsUpdate,
+		Read:   resourceAwsBackupRegionSettingsRead,
+		Delete: schema.Noop,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"resource_type_opt_in_preference": {
+				Type:     schema.TypeMap,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeBool},
+			},
+		},
+	}
+}
+
+func resourceAwsBackupRegionSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	prefrences := d.Get("resource_type_opt_in_preference").(map[string]interface{})
+	list := make(map[string]*bool, len(prefrences))
+	for i, v := range prefrences {
+		list[i] = aws.Bool(v.(bool))
+	}
+
+	input := &backup.UpdateRegionSettingsInput{
+		ResourceTypeOptInPreference: list,
+	}
+
+	_, err := conn.UpdateRegionSettings(input)
+	if err != nil {
+		return fmt.Errorf("error setting Backup Region Settings (%s): %w", d.Id(), err)
+	}
+
+	d.SetId(meta.(*AWSClient).region)
+
+	return resourceAwsBackupRegionSettingsRead(d, meta)
+}
+
+func resourceAwsBackupRegionSettingsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	resp, err := conn.DescribeRegionSettings(&backup.DescribeRegionSettingsInput{})
+	if err != nil {
+		return fmt.Errorf("error reading Backup Region Settings (%s): %w", d.Id(), err)
+	}
+
+	d.Set("resource_type_opt_in_preference", aws.BoolValueMap(resp.ResourceTypeOptInPreference))
+
+	return nil
+}

--- a/aws/resource_aws_backup_region_settings_test.go
+++ b/aws/resource_aws_backup_region_settings_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/aws/aws-sdk-go/service/fsx"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/aws/resource_aws_backup_region_settings_test.go
+++ b/aws/resource_aws_backup_region_settings_test.go
@@ -92,14 +92,14 @@ func testAccBackupRegionSettingsConfig1(rName string) string {
 	return `
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
-	"DynamoDB"        = true
-	"Aurora"          = true
-	"EBS"             = true
-	"EC2"             = true
-	"EFS"             = true
-	"FSx"             = true
-	"RDS"             = true
-	"Storage Gateway" = true
+    "DynamoDB"        = true
+    "Aurora"          = true
+    "EBS"             = true
+    "EC2"             = true
+    "EFS"             = true
+    "FSx"             = true
+    "RDS"             = true
+    "Storage Gateway" = true
   }
 }
 `
@@ -109,14 +109,14 @@ func testAccBackupRegionSettingsConfig2(rName string) string {
 	return `
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
-	"DynamoDB"        = true
-	"Aurora"          = false
-	"EBS"             = true
-	"EC2"             = true
-	"EFS"             = true
-	"FSx"             = true
-	"RDS"             = true
-	"Storage Gateway" = true
+    "DynamoDB"        = true
+    "Aurora"          = false
+    "EBS"             = true
+    "EC2"             = true
+    "EFS"             = true
+    "FSx"             = true
+    "RDS"             = true
+    "Storage Gateway" = true
   }
 }
 `

--- a/aws/resource_aws_backup_region_settings_test.go
+++ b/aws/resource_aws_backup_region_settings_test.go
@@ -16,7 +16,7 @@ func TestAccAwsBackupRegionSettings_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_backup_region_settings.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() {
+		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPartitionHasServicePreCheck(fsx.EndpointsID, t)
 			testAccPreCheckAWSBackup(t)

--- a/aws/resource_aws_backup_region_settings_test.go
+++ b/aws/resource_aws_backup_region_settings_test.go
@@ -15,7 +15,11 @@ func TestAccAwsBackupRegionSettings_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_backup_region_settings.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		PreCheck:     func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(fsx.EndpointsID, t)
+			testAccPreCheckAWSBackup(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_backup_region_settings_test.go
+++ b/aws/resource_aws_backup_region_settings_test.go
@@ -1,0 +1,123 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsBackupRegionSettings_basic(t *testing.T) {
+	var settings backup.DescribeRegionSettingsOutput
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_backup_region_settings.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupRegionSettingsConfig1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupRegionSettingsExists(&settings),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "8"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EC2", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EFS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupRegionSettingsConfig2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupRegionSettingsExists(&settings),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "8"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "false"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EC2", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EFS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
+				),
+			},
+			{
+				Config: testAccBackupRegionSettingsConfig1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupRegionSettingsExists(&settings),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "8"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EC2", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EFS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsBackupRegionSettingsExists(settings *backup.DescribeRegionSettingsOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*AWSClient).backupconn
+		resp, err := conn.DescribeRegionSettings(&backup.DescribeRegionSettingsInput{})
+		if err != nil {
+			return err
+		}
+
+		*settings = *resp
+
+		return nil
+	}
+}
+
+func testAccBackupRegionSettingsConfig1(rName string) string {
+	return `
+resource "aws_backup_region_settings" "test" {
+  resource_type_opt_in_preference = {
+	"DynamoDB"        = true
+	"Aurora"          = true
+	"EBS"             = true
+	"EC2"             = true
+	"EFS"             = true
+	"FSx"             = true
+	"RDS"             = true
+	"Storage Gateway" = true
+  }
+}
+`
+}
+
+func testAccBackupRegionSettingsConfig2(rName string) string {
+	return `
+resource "aws_backup_region_settings" "test" {
+  resource_type_opt_in_preference = {
+	"DynamoDB"        = true
+	"Aurora"          = false
+	"EBS"             = true
+	"EC2"             = true
+	"EFS"             = true
+	"FSx"             = true
+	"RDS"             = true
+	"Storage Gateway" = true
+  }
+}
+`
+}

--- a/website/docs/r/backup_region_settings.html.markdown
+++ b/website/docs/r/backup_region_settings.html.markdown
@@ -15,14 +15,14 @@ Provides an AWS Backup Region Settings resource.
 ```hcl
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
-	"DynamoDB"        = true
-	"Aurora"          = true
-	"EBS"             = true
-	"EC2"             = true
-	"EFS"             = true
-	"FSx"             = true
-	"RDS"             = true
-	"Storage Gateway" = true
+    "DynamoDB"        = true
+    "Aurora"          = true
+    "EBS"             = true
+    "EC2"             = true
+    "EFS"             = true
+    "FSx"             = true
+    "RDS"             = true
+    "Storage Gateway" = true
   }
 }
 ```

--- a/website/docs/r/backup_region_settings.html.markdown
+++ b/website/docs/r/backup_region_settings.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Backup"
+layout: "aws"
+page_title: "AWS: aws_backup_region_settings"
+description: |-
+  Provides an AWS Backup Region Settings resource.
+---
+
+# Resource: aws_backup_region_settings
+
+Provides an AWS Backup Region Settings resource.
+
+## Example Usage
+
+```hcl
+resource "aws_backup_region_settings" "test" {
+  resource_type_opt_in_preference = {
+	"DynamoDB"        = true
+	"Aurora"          = true
+	"EBS"             = true
+	"EC2"             = true
+	"EFS"             = true
+	"FSx"             = true
+	"RDS"             = true
+	"Storage Gateway" = true
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_type_opt_in_preference` - (Required) A map of services along with the opt-in preferences for the Region.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The AWS region.
+
+## Import
+
+Backup Region Settings can be imported using the `region`, e.g.
+
+```
+$ terraform import aws_backup_region_settings.test us-west-2
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13449

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_backup_region_settings - new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAwsBackupRegionSettings_basic (79.48s)
...
```
