### PR TITLE
bugfix/treat empty secretOptions as null to prevent batch_job_definition recreation every time

### DIFF
--- a/.changelog/16120.txt
+++ b/.changelog/16120.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_job_definition: Treat empty `container_properties.logConfiguration.secretOptions` array as `null` to prevent continual diffs
+```

--- a/aws/internal/service/batch/equivalency/container_properties.go
+++ b/aws/internal/service/batch/equivalency/container_properties.go
@@ -30,6 +30,13 @@ func (cp *containerProperties) Reduce() error {
 	}
 
 	// Prevent difference of API response that adds an empty array when not configured during the request
+	if cp.LogConfiguration != nil {
+		if len(cp.LogConfiguration.SecretOptions) == 0 {
+			cp.LogConfiguration.SecretOptions = nil
+		}
+	}
+
+	// Prevent difference of API response that adds an empty array when not configured during the request
 	if len(cp.MountPoints) == 0 {
 		cp.MountPoints = nil
 	}

--- a/aws/internal/service/batch/equivalency/container_properties_test.go
+++ b/aws/internal/service/batch/equivalency/container_properties_test.go
@@ -209,7 +209,7 @@ func TestEquivalentBatchContainerPropertiesJSON(t *testing.T) {
 			ExpectEquivalent: true,
 		},
 		{
-			Name: "empty command, mountPoints, resourceRequirements, secrets, ulimits, volumes",
+			Name: "empty command, logConfiguration.secretOptions, mountPoints, resourceRequirements, secrets, ulimits, volumes",
 			ApiJson: `
 {
 	"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
@@ -219,6 +219,10 @@ func TestEquivalentBatchContainerPropertiesJSON(t *testing.T) {
 	"jobRoleArn": "arn:aws:iam::123:role/role-test",
 	"volumes": [],
 	"environment": [{"name":"ENVIRONMENT","value":"test"}],
+	"logConfiguration": {
+		"logDriver": "awslogs",
+		"secretOptions": []
+	},
 	"mountPoints": [],
 	"ulimits": [],
 	"resourceRequirements": [],
@@ -236,7 +240,10 @@ func TestEquivalentBatchContainerPropertiesJSON(t *testing.T) {
         "name": "ENVIRONMENT",
         "value": "test"
       }
-   ]
+   ],
+   "logConfiguration": {
+		"logDriver": "awslogs"
+	}
 }
 `,
 			ExpectEquivalent: true,

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -198,7 +198,7 @@ func resourceAwsBatchJobDefinitionCreate(d *schema.ResourceData, meta interface{
 	}
 
 	if v, ok := d.GetOk("retry_strategy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.RetryStrategy = expandRetryStrategy(v.([]interface{})[0].(map[string]interface{}))
+		input.RetryStrategy = expandBatchRetryStrategy(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
@@ -254,7 +254,7 @@ func resourceAwsBatchJobDefinitionRead(d *schema.ResourceData, meta interface{})
 	d.Set("propagate_tags", jobDefinition.PropagateTags)
 
 	if jobDefinition.RetryStrategy != nil {
-		if err := d.Set("retry_strategy", []interface{}{flattenRetryStrategy(jobDefinition.RetryStrategy)}); err != nil {
+		if err := d.Set("retry_strategy", []interface{}{flattenBatchRetryStrategy(jobDefinition.RetryStrategy)}); err != nil {
 			return fmt.Errorf("error setting retry_strategy: %w", err)
 		}
 	} else {
@@ -343,7 +343,7 @@ func expandJobDefinitionParameters(params map[string]interface{}) map[string]*st
 	return jobParams
 }
 
-func expandRetryStrategy(tfMap map[string]interface{}) *batch.RetryStrategy {
+func expandBatchRetryStrategy(tfMap map[string]interface{}) *batch.RetryStrategy {
 	if tfMap == nil {
 		return nil
 	}
@@ -355,13 +355,13 @@ func expandRetryStrategy(tfMap map[string]interface{}) *batch.RetryStrategy {
 	}
 
 	if v, ok := tfMap["evaluate_on_exit"].([]interface{}); ok && len(v) > 0 {
-		apiObject.EvaluateOnExit = expandEvaluateOnExits(v)
+		apiObject.EvaluateOnExit = expandBatchEvaluateOnExits(v)
 	}
 
 	return apiObject
 }
 
-func expandEvaluateOnExit(tfMap map[string]interface{}) *batch.EvaluateOnExit {
+func expandBatchEvaluateOnExit(tfMap map[string]interface{}) *batch.EvaluateOnExit {
 	if tfMap == nil {
 		return nil
 	}
@@ -387,7 +387,7 @@ func expandEvaluateOnExit(tfMap map[string]interface{}) *batch.EvaluateOnExit {
 	return apiObject
 }
 
-func expandEvaluateOnExits(tfList []interface{}) []*batch.EvaluateOnExit {
+func expandBatchEvaluateOnExits(tfList []interface{}) []*batch.EvaluateOnExit {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -401,7 +401,7 @@ func expandEvaluateOnExits(tfList []interface{}) []*batch.EvaluateOnExit {
 			continue
 		}
 
-		apiObject := expandEvaluateOnExit(tfMap)
+		apiObject := expandBatchEvaluateOnExit(tfMap)
 
 		if apiObject == nil {
 			continue
@@ -413,7 +413,7 @@ func expandEvaluateOnExits(tfList []interface{}) []*batch.EvaluateOnExit {
 	return apiObjects
 }
 
-func flattenRetryStrategy(apiObject *batch.RetryStrategy) map[string]interface{} {
+func flattenBatchRetryStrategy(apiObject *batch.RetryStrategy) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -425,13 +425,13 @@ func flattenRetryStrategy(apiObject *batch.RetryStrategy) map[string]interface{}
 	}
 
 	if v := apiObject.EvaluateOnExit; v != nil {
-		tfMap["evaluate_on_exit"] = flattenEvaluateOnExits(v)
+		tfMap["evaluate_on_exit"] = flattenBatchEvaluateOnExits(v)
 	}
 
 	return tfMap
 }
 
-func flattenEvaluateOnExit(apiObject *batch.EvaluateOnExit) map[string]interface{} {
+func flattenBatchEvaluateOnExit(apiObject *batch.EvaluateOnExit) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -457,7 +457,7 @@ func flattenEvaluateOnExit(apiObject *batch.EvaluateOnExit) map[string]interface
 	return tfMap
 }
 
-func flattenEvaluateOnExits(apiObjects []*batch.EvaluateOnExit) []interface{} {
+func flattenBatchEvaluateOnExits(apiObjects []*batch.EvaluateOnExit) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -469,7 +469,7 @@ func flattenEvaluateOnExits(apiObjects []*batch.EvaluateOnExit) []interface{} {
 			continue
 		}
 
-		tfList = append(tfList, flattenEvaluateOnExit(apiObject))
+		tfList = append(tfList, flattenBatchEvaluateOnExit(apiObject))
 	}
 
 	return tfList


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13629
Relates #11998
Closes #16014

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Before updating the acceptance test:
```
$ TF_ACC=1 go test ./aws/internal/service/batch/equivalency -v -count 1 -parallel 4 -run=TestEquivalentBatchContainerPropertiesJSON
=== RUN   TestEquivalentBatchContainerPropertiesJSON
=== RUN   TestEquivalentBatchContainerPropertiesJSON/empty
=== RUN   TestEquivalentBatchContainerPropertiesJSON/empty_ResourceRequirements
=== RUN   TestEquivalentBatchContainerPropertiesJSON/reordered_Environment
=== RUN   TestEquivalentBatchContainerPropertiesJSON/empty_environment,_mountPoints,_ulimits,_and_volumes
=== RUN   TestEquivalentBatchContainerPropertiesJSON/empty_command,_mountPoints,_resourceRequirements,_secrets,_ulimits,_volumes
--- PASS: TestEquivalentBatchContainerPropertiesJSON (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/empty (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/empty_ResourceRequirements (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/reordered_Environment (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/empty_environment,_mountPoints,_ulimits,_and_volumes (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/empty_command,_mountPoints,_resourceRequirements,_secrets,_ulimits,_volumes (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency    0.006s
```

After updating the acceptance test:
```
$ TF_ACC=1 go test ./aws/internal/service/batch/equivalency -v -count 1 -parallel 4 -run=TestEquivalentBatchContainerPropertiesJSON
=== RUN   TestEquivalentBatchContainerPropertiesJSON
=== RUN   TestEquivalentBatchContainerPropertiesJSON/empty
=== RUN   TestEquivalentBatchContainerPropertiesJSON/empty_ResourceRequirements
=== RUN   TestEquivalentBatchContainerPropertiesJSON/reordered_Environment
=== RUN   TestEquivalentBatchContainerPropertiesJSON/empty_environment,_mountPoints,_ulimits,_and_volumes
=== RUN   TestEquivalentBatchContainerPropertiesJSON/empty_command,_logConfiguration.secretOptions,_mountPoints,_resourceRequirements,_secrets,_ulimits,_volumes
--- PASS: TestEquivalentBatchContainerPropertiesJSON (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/empty (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/empty_ResourceRequirements (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/reordered_Environment (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/empty_environment,_mountPoints,_ulimits,_and_volumes (0.00s)
    --- PASS: TestEquivalentBatchContainerPropertiesJSON/empty_command,_logConfiguration.secretOptions,_mountPoints,_resourceRequirements,_secrets,_ulimits,_volumes (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency    0.005s
```

Resource acceptance test:
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 5 -run=TestAccAWSBatchJobDefinition_
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (14.78s)
--- PASS: TestAccAWSBatchJobDefinition_basic (15.13s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (24.80s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (38.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       38.239s
```