### PR TITLE
Gateway Load Balancer Support

### DIFF
--- a/aws/data_source_aws_route_table.go
+++ b/aws/data_source_aws_route_table.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -78,6 +79,11 @@ func dataSourceAwsRouteTable() *schema.Resource {
 						},
 
 						"transit_gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"vpc_endpoint_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -228,7 +234,11 @@ func dataSourceRoutesRead(ec2Routes []*ec2.Route) []map[string]interface{} {
 			m["egress_only_gateway_id"] = *r.EgressOnlyInternetGatewayId
 		}
 		if r.GatewayId != nil {
-			m["gateway_id"] = *r.GatewayId
+			if strings.HasPrefix(*r.GatewayId, "vpce-") {
+				m["vpc_endpoint_id"] = *r.GatewayId
+			} else {
+				m["gateway_id"] = *r.GatewayId
+			}
 		}
 		if r.NatGatewayId != nil {
 			m["nat_gateway_id"] = *r.NatGatewayId

--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -93,6 +93,11 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 							Optional: true,
 						},
 
+						"vpc_endpoint_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"vpc_peering_connection_id": {
 							Type:     schema.TypeString,
 							Optional: true,

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -187,6 +187,41 @@ func TestAccAWSDefaultRouteTable_Route_TransitGatewayID(t *testing.T) {
 	})
 }
 
+func TestAccAWSDefaultRouteTable_Route_VpcEndpointId(t *testing.T) {
+	var routeTable1 ec2.RouteTable
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_default_route_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDefaultRouteTableConfigRouteVpcEndpointId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists(resourceName, &routeTable1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSDefaultRouteTableImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			// Default route tables do not currently have a method to remove routes during deletion.
+			// VPC Endpoints will not delete unless the route is removed prior, otherwise will error:
+			// InvalidParameter: Endpoint must be removed from route table before deletion
+			{
+				Config: testAccAWSDefaultRouteTableConfigRouteVpcEndpointIdNoRoute(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists(resourceName, &routeTable1),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDefaultRouteTable_vpc_endpoint(t *testing.T) {
 	var v ec2.RouteTable
 	resourceName := "aws_default_route_table.foo"
@@ -568,6 +603,130 @@ resource "aws_default_route_table" "test" {
   }
 }
 `
+}
+
+func testAccAWSDefaultRouteTableConfigRouteVpcEndpointId(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+# Another route destination for update
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id                  = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  load_balancer_type = "gateway"
+  name               = %[1]q
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  allowed_principals         = [data.aws_caller_identity.current.arn]
+  gateway_load_balancer_arns = [aws_lb.test.arn]
+}
+
+resource "aws_vpc_endpoint" "test" {
+  service_name       = aws_vpc_endpoint_service.test.service_name
+  subnet_ids         = [aws_subnet.test.id]
+  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
+  vpc_id             = aws_vpc.test.id
+}
+
+resource "aws_default_route_table" "test" {
+  default_route_table_id = aws_vpc.test.default_route_table_id
+
+  route {
+    cidr_block      = "0.0.0.0/0"
+    vpc_endpoint_id = aws_vpc_endpoint.test.id
+  }
+}
+`, rName))
+}
+
+func testAccAWSDefaultRouteTableConfigRouteVpcEndpointIdNoRoute(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+# Another route destination for update
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id                  = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  load_balancer_type = "gateway"
+  name               = %[1]q
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  allowed_principals         = [data.aws_caller_identity.current.arn]
+  gateway_load_balancer_arns = [aws_lb.test.arn]
+}
+
+resource "aws_vpc_endpoint" "test" {
+  service_name       = aws_vpc_endpoint_service.test.service_name
+  subnet_ids         = [aws_subnet.test.id]
+  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
+  vpc_id             = aws_vpc.test.id
+}
+
+resource "aws_default_route_table" "test" {
+  default_route_table_id = aws_vpc.test.default_route_table_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+}
+`, rName))
 }
 
 const testAccDefaultRouteTable_vpc_endpoint = `

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -650,10 +650,10 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 resource "aws_vpc_endpoint" "test" {
-  service_name       = aws_vpc_endpoint_service.test.service_name
-  subnet_ids         = [aws_subnet.test.id]
-  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
-  vpc_id             = aws_vpc.test.id
+  service_name      = aws_vpc_endpoint_service.test.service_name
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
+  vpc_id            = aws_vpc.test.id
 }
 
 resource "aws_default_route_table" "test" {
@@ -712,10 +712,10 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 resource "aws_vpc_endpoint" "test" {
-  service_name       = aws_vpc_endpoint_service.test.service_name
-  subnet_ids         = [aws_subnet.test.id]
-  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
-  vpc_id             = aws_vpc.test.id
+  service_name      = aws_vpc_endpoint_service.test.service_name
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
+  vpc_id            = aws_vpc.test.id
 }
 
 resource "aws_default_route_table" "test" {

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -625,9 +625,9 @@ resource "aws_internet_gateway" "test" {
 }
 
 resource "aws_subnet" "test" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id                  = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test-load-balancer"
@@ -687,9 +687,9 @@ resource "aws_internet_gateway" "test" {
 }
 
 resource "aws_subnet" "test" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id                  = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test-load-balancer"

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -74,14 +74,11 @@ func resourceAwsLb() *schema.Resource {
 			},
 
 			"load_balancer_type": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-				Default:  elbv2.LoadBalancerTypeEnumApplication,
-				ValidateFunc: validation.StringInSlice([]string{
-					elbv2.LoadBalancerTypeEnumApplication,
-					elbv2.LoadBalancerTypeEnumNetwork,
-				}, false),
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Default:      elbv2.LoadBalancerTypeEnumApplication,
+				ValidateFunc: validation.StringInSlice(elbv2.LoadBalancerTypeEnum_Values(), false),
 			},
 
 			"security_groups": {

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -66,17 +66,10 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 			},
 
 			"protocol": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					elbv2.ProtocolEnumHttp,
-					elbv2.ProtocolEnumHttps,
-					elbv2.ProtocolEnumTcp,
-					elbv2.ProtocolEnumTls,
-					elbv2.ProtocolEnumUdp,
-					elbv2.ProtocolEnumTcpUdp,
-				}, true),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(elbv2.ProtocolEnum_Values(), true),
 			},
 
 			"vpc_id": {

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -271,6 +271,38 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 	})
 }
 
+func TestAccAWSLBTargetGroup_Protocol_Geneve(t *testing.T) {
+	var conf elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lb_target_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBTargetGroupConfigProtocolGeneve(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "port", "6081"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", elbv2.ProtocolEnumGeneve),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"lambda_multi_value_headers_enabled",
+					"proxy_protocol_v2",
+					"slow_start",
+				},
+			},
+		},
+	})
+}
+
 func TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol(t *testing.T) {
 	var targetGroup1, targetGroup2 elbv2.TargetGroup
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -1428,6 +1460,30 @@ resource "aws_vpc" "test" {
   }
 }
 `, targetGroupName)
+}
+
+func testAccAWSLBTargetGroupConfigProtocolGeneve(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-lb-target-group"
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 6081
+  protocol = "GENEVE"
+  vpc_id   = aws_vpc.test.id
+
+  health_check {
+    port     = 80
+    protocol = "HTTP"
+  }
+}
+`, rName)
 }
 
 func testAccAWSLBTargetGroupConfigTags1(targetGroupName, tagKey1, tagValue1 string) string {

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1862,9 +1862,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id                  = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test-load-balancer"

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -162,6 +162,38 @@ func TestAccAWSLB_NLB_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSLB_LoadBalancerType_Gateway(t *testing.T) {
+	var conf elbv2.LoadBalancer
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lb.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSLBDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBConfig_LoadBalancerType_Gateway(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBExists(resourceName, &conf),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf("loadbalancer/gwy/%s/.+", rName))),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_type", elbv2.LoadBalancerTypeEnumGateway),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"drop_invalid_header_fields",
+					"enable_http2",
+					"idle_timeout",
+				},
+			},
+		},
+	})
+}
+
 func TestAccAWSLB_ALB_outpost(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	lbName := fmt.Sprintf("testaccawslb-outpost-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -1815,6 +1847,39 @@ resource "aws_subnet" "alb_test" {
   }
 }
 `, lbName, cz))
+}
+
+func testAccAWSLBConfig_LoadBalancerType_Gateway(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id                  = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  load_balancer_type = "gateway"
+  name               = %[1]q
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+`, rName))
 }
 
 func testAccAWSLBConfig_networkLoadBalancerEIP(lbName string) string {

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -1085,10 +1085,10 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 resource "aws_vpc_endpoint" "test" {
-  service_name       = aws_vpc_endpoint_service.test.service_name
-  subnet_ids         = [aws_subnet.test.id]
-  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
-  vpc_id             = aws_vpc.test.id
+  service_name      = aws_vpc_endpoint_service.test.service_name
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
+  vpc_id            = aws_vpc.test.id
 }
 
 resource "aws_route_table" "test" {

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -393,6 +393,31 @@ func TestAccAWSRouteTable_Route_TransitGatewayID(t *testing.T) {
 	})
 }
 
+func TestAccAWSRouteTable_Route_VpcEndpointId(t *testing.T) {
+	var routeTable1 ec2.RouteTable
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteTableConfigRouteVpcEndpointId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists(resourceName, &routeTable1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRouteTable_Route_LocalGatewayID(t *testing.T) {
 	var routeTable1 ec2.RouteTable
 	resourceName := "aws_route_table.test"
@@ -1018,6 +1043,63 @@ resource "aws_route_table" "test" {
   }
 }
 `)
+}
+
+func testAccAWSRouteTableConfigRouteVpcEndpointId(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id                  = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  load_balancer_type = "gateway"
+  name               = %[1]q
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  allowed_principals         = [data.aws_caller_identity.current.arn]
+  gateway_load_balancer_arns = [aws_lb.test.arn]
+}
+
+resource "aws_vpc_endpoint" "test" {
+  service_name       = aws_vpc_endpoint_service.test.service_name
+  subnet_ids         = [aws_subnet.test.id]
+  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
+  vpc_id             = aws_vpc.test.id
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block      = "0.0.0.0/0"
+    vpc_endpoint_id = aws_vpc_endpoint.test.id
+  }
+}
+`, rName))
 }
 
 func testAccAWSRouteTableConfigRouteLocalGatewayID() string {

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -1060,9 +1060,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id                  = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test-load-balancer"

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -501,6 +501,34 @@ func TestAccAWSRoute_ConditionalCidrBlock(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_VpcEndpointId(t *testing.T) {
+	var route ec2.Route
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route.test"
+	vpcEndpointResourceName := "aws_vpc_endpoint.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteResourceConfigVpcEndpointId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_endpoint_id", vpcEndpointResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSRouteExists(n string, res *ec2.Route) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1330,4 +1358,62 @@ resource "aws_route" "test" {
   local_gateway_id       = data.aws_ec2_local_gateway.first.id
 }
 `)
+}
+
+func testAccAWSRouteResourceConfigVpcEndpointId(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id                  = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  load_balancer_type = "gateway"
+  name               = %[1]q
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  allowed_principals         = [data.aws_caller_identity.current.arn]
+  gateway_load_balancer_arns = [aws_lb.test.arn]
+}
+
+resource "aws_vpc_endpoint" "test" {
+  service_name       = aws_vpc_endpoint_service.test.service_name
+  subnet_ids         = [aws_subnet.test.id]
+  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
+  vpc_id             = aws_vpc.test.id
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = "172.16.1.0/24"
+  vpc_endpoint_id        = aws_vpc_endpoint.test.id
+}
+`, rName))
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -1400,10 +1400,10 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 resource "aws_vpc_endpoint" "test" {
-  service_name       = aws_vpc_endpoint_service.test.service_name
-  subnet_ids         = [aws_subnet.test.id]
-  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
-  vpc_id             = aws_vpc.test.id
+  service_name      = aws_vpc_endpoint_service.test.service_name
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
+  vpc_id            = aws_vpc.test.id
 }
 
 resource "aws_route_table" "test" {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -1375,9 +1375,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id                  = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test-load-balancer"

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -127,14 +127,11 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 			},
 			"tags": tagsSchema(),
 			"vpc_endpoint_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  ec2.VpcEndpointTypeGateway,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.VpcEndpointTypeGateway,
-					ec2.VpcEndpointTypeInterface,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      ec2.VpcEndpointTypeGateway,
+				ValidateFunc: validation.StringInSlice(ec2.VpcEndpointType_Values(), false),
 			},
 			"vpc_id": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_vpc_endpoint_service.go
+++ b/aws/resource_aws_vpc_endpoint_service.go
@@ -52,13 +52,23 @@ func resourceAwsVpcEndpointService() *schema.Resource {
 				Computed: true,
 				Set:      schema.HashString,
 			},
+			"gateway_load_balancer_arns": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateArn,
+				},
+				Set: schema.HashString,
+			},
 			"manages_vpc_endpoints": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
 			"network_load_balancer_arns": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				MinItems: 1,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
@@ -91,9 +101,20 @@ func resourceAwsVpcEndpointServiceCreate(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).ec2conn
 
 	req := &ec2.CreateVpcEndpointServiceConfigurationInput{
-		AcceptanceRequired:      aws.Bool(d.Get("acceptance_required").(bool)),
-		NetworkLoadBalancerArns: expandStringSet(d.Get("network_load_balancer_arns").(*schema.Set)),
-		TagSpecifications:       ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), "vpc-endpoint-service"),
+		AcceptanceRequired: aws.Bool(d.Get("acceptance_required").(bool)),
+		TagSpecifications:  ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), "vpc-endpoint-service"),
+	}
+
+	if v, ok := d.GetOk("gateway_load_balancer_arns"); ok {
+		if v, ok := v.(*schema.Set); ok && v.Len() > 0 {
+			req.GatewayLoadBalancerArns = expandStringSet(v)
+		}
+	}
+
+	if v, ok := d.GetOk("network_load_balancer_arns"); ok {
+		if v, ok := v.(*schema.Set); ok && v.Len() > 0 {
+			req.NetworkLoadBalancerArns = expandStringSet(v)
+		}
 	}
 
 	log.Printf("[DEBUG] Creating VPC Endpoint Service configuration: %#v", req)
@@ -161,11 +182,17 @@ func resourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return fmt.Errorf("error setting base_endpoint_dns_names: %s", err)
 	}
-	d.Set("manages_vpc_endpoints", svcCfg.ManagesVpcEndpoints)
-	err = d.Set("network_load_balancer_arns", flattenStringSet(svcCfg.NetworkLoadBalancerArns))
-	if err != nil {
-		return fmt.Errorf("error setting network_load_balancer_arns: %s", err)
+
+	if err := d.Set("gateway_load_balancer_arns", flattenStringSet(svcCfg.GatewayLoadBalancerArns)); err != nil {
+		return fmt.Errorf("error setting gateway_load_balancer_arns: %w", err)
 	}
+
+	d.Set("manages_vpc_endpoints", svcCfg.ManagesVpcEndpoints)
+
+	if err := d.Set("network_load_balancer_arns", flattenStringSet(svcCfg.NetworkLoadBalancerArns)); err != nil {
+		return fmt.Errorf("error setting network_load_balancer_arns: %w", err)
+	}
+
 	d.Set("private_dns_name", svcCfg.PrivateDnsName)
 	d.Set("service_name", svcCfg.ServiceName)
 	d.Set("service_type", svcCfg.ServiceType[0].ServiceType)
@@ -193,7 +220,7 @@ func resourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{})
 func resourceAwsVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	if d.HasChanges("acceptance_required", "network_load_balancer_arns") {
+	if d.HasChanges("acceptance_required", "gateway_load_balancer_arns", "network_load_balancer_arns") {
 		modifyCfgReq := &ec2.ModifyVpcEndpointServiceConfigurationInput{
 			ServiceId: aws.String(d.Id()),
 		}
@@ -201,6 +228,9 @@ func resourceAwsVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{
 		if d.HasChange("acceptance_required") {
 			modifyCfgReq.AcceptanceRequired = aws.Bool(d.Get("acceptance_required").(bool))
 		}
+
+		setVpcEndpointServiceUpdateLists(d, "gateway_load_balancer_arns",
+			&modifyCfgReq.AddGatewayLoadBalancerArns, &modifyCfgReq.RemoveGatewayLoadBalancerArns)
 
 		setVpcEndpointServiceUpdateLists(d, "network_load_balancer_arns",
 			&modifyCfgReq.AddNetworkLoadBalancerArns, &modifyCfgReq.RemoveNetworkLoadBalancerArns)

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -91,7 +91,7 @@ func TestAccAWSVpcEndpointService_basic(t *testing.T) {
 		CheckDestroy: testAccCheckVpcEndpointServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcEndpointServiceConfig_basic(rName1, rName2),
+				Config: testAccVpcEndpointServiceConfig_NetworkLoadBalancerArns(rName1, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
 					resource.TestCheckResourceAttr(resourceName, "acceptance_required", "false"),
@@ -167,12 +167,45 @@ func TestAccAWSVpcEndpointService_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckVpcEndpointServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcEndpointServiceConfig_basic(rName1, rName2),
+				Config: testAccVpcEndpointServiceConfig_NetworkLoadBalancerArns(rName1, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsVpcEndpointService(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSVpcEndpointService_GatewayLoadBalancerArns(t *testing.T) {
+	var svcCfg ec2.ServiceConfiguration
+	resourceName := "aws_vpc_endpoint_service.test"
+	rName := acctest.RandomWithPrefix("tfacctest") // 32 character limit
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcEndpointServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcEndpointServiceConfig_GatewayLoadBalancerArns(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
+					resource.TestCheckResourceAttr(resourceName, "gateway_load_balancer_arns.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccVpcEndpointServiceConfig_GatewayLoadBalancerArns(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
+					resource.TestCheckResourceAttr(resourceName, "gateway_load_balancer_arns.#", "2"),
+				),
 			},
 		},
 	})
@@ -359,7 +392,47 @@ data "aws_caller_identity" "current" {}
 `, rName1, rName2)
 }
 
-func testAccVpcEndpointServiceConfig_basic(rName1, rName2 string) string {
+func testAccVpcEndpointServiceConfig_GatewayLoadBalancerArns(rName string, count int) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id                  = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  count = %[2]d
+
+  load_balancer_type = "gateway"
+  name               = "%[1]s-${count.index}"
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  gateway_load_balancer_arns = aws_lb.test[*].arn
+}
+`, rName, count))
+}
+
+func testAccVpcEndpointServiceConfig_NetworkLoadBalancerArns(rName1, rName2 string) string {
 	return composeConfig(
 		testAccVpcEndpointServiceConfig_base(rName1, rName2),
 		`

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -405,9 +405,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id                  = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test-load-balancer"

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -1163,9 +1163,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id                  = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test-load-balancer"

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -1188,10 +1188,10 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 resource "aws_vpc_endpoint" "test" {
-  service_name       = aws_vpc_endpoint_service.test.service_name
-  subnet_ids         = [aws_subnet.test.id]
-  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
-  vpc_id             = aws_vpc.test.id
+  service_name      = aws_vpc_endpoint_service.test.service_name
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
+  vpc_id            = aws_vpc.test.id
 }
 `, rName))
 }

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -504,6 +504,33 @@ func TestAccAWSVpcEndpoint_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer(t *testing.T) {
+	var endpoint ec2.VpcEndpoint
+	vpcEndpointServiceResourceName := "aws_vpc_endpoint_service.test"
+	resourceName := "aws_vpc_endpoint.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcEndpointConfigVpcEndpointTypeGatewayLoadBalancer(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointExists(resourceName, &endpoint),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_endpoint_type", vpcEndpointServiceResourceName, "service_type"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckVpcEndpointDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -1119,4 +1146,52 @@ resource "aws_vpc_endpoint" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccVpcEndpointConfigVpcEndpointTypeGatewayLoadBalancer(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  vpc_id                  = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  load_balancer_type = "gateway"
+  name               = %[1]q
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  allowed_principals         = [data.aws_caller_identity.current.arn]
+  gateway_load_balancer_arns = [aws_lb.test.arn]
+}
+
+resource "aws_vpc_endpoint" "test" {
+  service_name       = aws_vpc_endpoint_service.test.service_name
+  subnet_ids         = [aws_subnet.test.id]
+  vpc_endpoint_type  = aws_vpc_endpoint_service.test.service_type
+  vpc_id             = aws_vpc.test.id
+}
+`, rName))
 }

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -81,6 +81,7 @@ Each route supports the following:
 * `local_gateway_id` - The Local Gateway ID.
 * `instance_id` - The EC2 instance ID.
 * `transit_gateway_id` - The EC2 Transit Gateway ID.
+* `vpc_endpoint_id` - The VPC Endpoint ID.
 * `vpc_peering_connection_id` - The VPC Peering ID.
 * `network_interface_id` - The ID of the elastic network interface (eni) to use.
 

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -81,6 +81,7 @@ One of the following target arguments must be supplied:
 * `nat_gateway_id` - (Optional) Identifier of a VPC NAT gateway.
 * `network_interface_id` - (Optional) Identifier of an EC2 network interface.
 * `transit_gateway_id` - (Optional) Identifier of an EC2 Transit Gateway.
+* `vpc_endpoint_id` - (Optional) Identifier of a VPC Endpoint. This route must be removed prior to VPC Endpoint deletion.
 * `vpc_peering_connection_id` - (Optional) Identifier of a VPC peering connection.
 
 Note that the default route, mapping the VPC's CIDR block to "local", is created implicitly and cannot be specified.

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -106,7 +106,7 @@ must contain only alphanumeric characters or hyphens, and must not begin or end 
 Terraform will autogenerate a name beginning with `tf-lb`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `internal` - (Optional) If true, the LB will be internal.
-* `load_balancer_type` - (Optional) The type of load balancer to create. Possible values are `application` or `network`. The default value is `application`.
+* `load_balancer_type` - (Optional) The type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
 * `security_groups` - (Optional) A list of security group IDs to assign to the LB. Only valid for Load Balancers of type `application`.
 * `drop_invalid_header_fields` - (Optional) Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is false. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type `application`.
 * `access_logs` - (Optional) An Access Logs block. Access Logs documented below.

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.
 
 * `port` - (Optional, Forces new resource) The port on which targets receive traffic, unless overridden when registering a specific target. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
-* `protocol` - (Optional, Forces new resource) The protocol to use for routing traffic to the targets. Should be one of "TCP", "TLS", "UDP", "TCP_UDP", "HTTP" or "HTTPS". Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
+* `protocol` - (Optional, Forces new resource) The protocol to use for routing traffic to the targets. Should be one of `GENEVE`, `HTTP`, `HTTPS`, `TCP`, `TCP_UDP`, `TLS`, or `UDP`. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 * `vpc_id` - (Optional, Forces new resource) The identifier of the VPC in which to create the target group. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -66,6 +66,7 @@ One of the following target arguments must be supplied:
 * `local_gateway_id` - (Optional) Identifier of a Outpost local gateway.
 * `network_interface_id` - (Optional) Identifier of an EC2 network interface.
 * `transit_gateway_id` - (Optional) Identifier of an EC2 Transit Gateway.
+* `vpc_endpoint_id` - (Optional) Identifier of a VPC Endpoint.
 * `vpc_peering_connection_id` - (Optional) Identifier of a VPC peering connection.
 
 Note that the default route, mapping the VPC's CIDR block to "local", is

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -76,6 +76,7 @@ One of the following target arguments must be supplied:
 * `local_gateway_id` - (Optional) Identifier of a Outpost local gateway.
 * `network_interface_id` - (Optional) Identifier of an EC2 network interface.
 * `transit_gateway_id` - (Optional) Identifier of an EC2 Transit Gateway.
+* `vpc_endpoint_id` - (Optional) Identifier of a VPC Endpoint.
 * `vpc_peering_connection_id` - (Optional) Identifier of a VPC peering connection.
 
 Note that the default route, mapping the VPC's CIDR block to "local", is created implicitly and cannot be specified.

--- a/website/docs/r/vpc_endpoint.html.markdown
+++ b/website/docs/r/vpc_endpoint.html.markdown
@@ -69,10 +69,10 @@ resource "aws_vpc_endpoint_service" "example" {
 }
 
 resource "aws_vpc_endpoint" "example" {
-  service_name       = aws_vpc_endpoint_service.example.service_name
-  subnet_ids         = [aws_subnet.example.id]
-  vpc_endpoint_type  = aws_vpc_endpoint_service.example.service_type
-  vpc_id             = aws_vpc.example.id
+  service_name      = aws_vpc_endpoint_service.example.service_name
+  subnet_ids        = [aws_subnet.example.id]
+  vpc_endpoint_type = aws_vpc_endpoint_service.example.service_type
+  vpc_id            = aws_vpc.example.id
 }
 ```
 

--- a/website/docs/r/vpc_endpoint.html.markdown
+++ b/website/docs/r/vpc_endpoint.html.markdown
@@ -57,6 +57,25 @@ resource "aws_vpc_endpoint" "ec2" {
 }
 ```
 
+### Gateway Load Balancer Endpoint Type
+
+```hcl
+data "aws_caller_identity" "current" {}
+
+resource "aws_vpc_endpoint_service" "example" {
+  acceptance_required        = false
+  allowed_principals         = [data.aws_caller_identity.current.arn]
+  gateway_load_balancer_arns = [aws_lb.example.arn]
+}
+
+resource "aws_vpc_endpoint" "example" {
+  service_name       = aws_vpc_endpoint_service.example.service_name
+  subnet_ids         = [aws_subnet.example.id]
+  vpc_endpoint_type  = aws_vpc_endpoint_service.example.service_type
+  vpc_id             = aws_vpc.example.id
+}
+```
+
 ### Non-AWS Service
 
 ```hcl
@@ -101,10 +120,10 @@ The following arguments are supported:
 * `private_dns_enabled` - (Optional; AWS services and AWS Marketplace partner services only) Whether or not to associate a private hosted zone with the specified VPC. Applicable for endpoints of type `Interface`.
 Defaults to `false`.
 * `route_table_ids` - (Optional) One or more route table IDs. Applicable for endpoints of type `Gateway`.
-* `subnet_ids` - (Optional) The ID of one or more subnets in which to create a network interface for the endpoint. Applicable for endpoints of type `Interface`.
+* `subnet_ids` - (Optional) The ID of one or more subnets in which to create a network interface for the endpoint. Applicable for endpoints of type `GatewayLoadBalancer` and `Interface`.
 * `security_group_ids` - (Optional) The ID of one or more security groups to associate with the network interface. Required for endpoints of type `Interface`.
 * `tags` - (Optional) A map of tags to assign to the resource.
-* `vpc_endpoint_type` - (Optional) The VPC endpoint type, `Gateway` or `Interface`. Defaults to `Gateway`.
+* `vpc_endpoint_type` - (Optional) The VPC endpoint type, `Gateway`, `GatewayLoadBalancer`, or `Interface`. Defaults to `Gateway`.
 
 ### Timeouts
 

--- a/website/docs/r/vpc_endpoint_service.html.markdown
+++ b/website/docs/r/vpc_endpoint_service.html.markdown
@@ -19,7 +19,7 @@ and will overwrite the association.
 
 ## Example Usage
 
-### Basic
+### Network Load Balancers
 
 ```hcl
 resource "aws_vpc_endpoint_service" "example" {
@@ -28,16 +28,12 @@ resource "aws_vpc_endpoint_service" "example" {
 }
 ```
 
-### Basic w/ Tags
+### Gateway Load Balancers
 
 ```hcl
 resource "aws_vpc_endpoint_service" "example" {
   acceptance_required        = false
-  network_load_balancer_arns = [aws_lb.example.arn]
-
-  tags = {
-    Environment = "test"
-  }
+  gateway_load_balancer_arns = [aws_lb.example.arn]
 }
 ```
 
@@ -46,8 +42,9 @@ resource "aws_vpc_endpoint_service" "example" {
 The following arguments are supported:
 
 * `acceptance_required` - (Required) Whether or not VPC endpoint connection requests to the service must be accepted by the service owner - `true` or `false`.
-* `network_load_balancer_arns` - (Required) The ARNs of one or more Network Load Balancers for the endpoint service.
 * `allowed_principals` - (Optional) The ARNs of one or more principals allowed to discover the endpoint service.
+* `gateway_load_balancer_arns` - (Optional) Amazon Resource Names (ARNs) of one or more Gateway Load Balancers for the endpoint service.
+* `network_load_balancer_arns` - (Optional) Amazon Resource Names (ARNs) of one or more Network Load Balancers for the endpoint service.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/14601
Closes #16129

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_route_table: Add `route` `vpc_endpoint_id` attribute
* resource/aws_default_route_table: Add `route` configuration block `vpc_endpoint_id` argument
* resource/aws_lb: Support `load_balancer_type` argument value of `gateway`
* resource/aws_lb_target_group: Support `protocol` argument value of `GENEVE`
* resource/aws_route: Add `vpc_endpoint_id` argument
* resource/aws_route_table: Add `route` configuration block `vpc_endpoint_id` argument
* resource/aws_vpc_endpoint: Support `vpc_endpoint_type` argument value `GatewayLoadBalancer`
* resource/aws_vpc_endpoint_service: Add `gateway_load_balancer_arns` argument
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDefaultRouteTable_ConditionalCidrBlock (79.58s)
--- PASS: TestAccAWSDefaultRouteTable_Route (98.46s)
--- PASS: TestAccAWSDefaultRouteTable_Route_TransitGatewayID (392.89s)
--- PASS: TestAccAWSDefaultRouteTable_Route_VpcEndpointId (311.16s)
--- PASS: TestAccAWSDefaultRouteTable_basic (55.44s)
--- PASS: TestAccAWSDefaultRouteTable_disappears_Vpc (27.64s)
--- PASS: TestAccAWSDefaultRouteTable_swap (81.87s)
--- PASS: TestAccAWSDefaultRouteTable_tags (78.09s)
--- PASS: TestAccAWSDefaultRouteTable_vpc_endpoint (70.70s)

--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (35.91s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Geneve (13.38s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (38.43s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (17.19s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (61.45s)
--- PASS: TestAccAWSLBTargetGroup_basic (14.05s)
--- PASS: TestAccAWSLBTargetGroup_basicUdp (13.38s)
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (81.69s)
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (81.96s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (86.51s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (81.25s)
--- PASS: TestAccAWSLBTargetGroup_defaults_application (43.62s)
--- PASS: TestAccAWSLBTargetGroup_defaults_network (69.36s)
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (80.28s)
--- PASS: TestAccAWSLBTargetGroup_generatedName (37.88s)
--- PASS: TestAccAWSLBTargetGroup_namePrefix (34.40s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (74.50s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (56.08s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (48.09s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (101.07s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (59.08s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (51.65s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (78.75s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (123.29s)
--- PASS: TestAccAWSLBTargetGroup_tags (107.63s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (87.24s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (105.44s)
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (11.08s)

--- PASS: TestAccAWSLB_ALB_AccessLogs (328.05s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (292.59s)
--- PASS: TestAccAWSLB_ALB_basic (221.14s)
--- PASS: TestAccAWSLB_BackwardsCompatibility (157.55s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway (112.95s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (389.86s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (312.70s)
--- PASS: TestAccAWSLB_NLB_basic (215.95s)
--- PASS: TestAccAWSLB_NLB_privateipv4address (206.78s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (287.46s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields (336.41s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (327.80s)
--- PASS: TestAccAWSLB_generatedName (233.50s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (223.68s)
--- PASS: TestAccAWSLB_namePrefix (222.50s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (223.68s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (338.95s)
--- PASS: TestAccAWSLB_noSecurityGroup (155.95s)
--- PASS: TestAccAWSLB_tags (293.86s)
--- PASS: TestAccAWSLB_updatedIpAddressType (217.83s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (282.45s)
--- PASS: TestAccAWSLB_updatedSubnets (220.56s)
--- SKIP: TestAccAWSLB_ALB_outpost (1.95s)

--- PASS: TestAccAWSRouteDataSource_TransitGatewayID (339.24s)
--- PASS: TestAccAWSRouteDataSource_basic (98.80s)
--- SKIP: TestAccAWSRouteDataSource_LocalGatewayID (5.08s)

--- PASS: TestAccAWSRouteTable_ConditionalCidrBlock (63.69s)
--- PASS: TestAccAWSRouteTable_RequireRouteDestination (71.60s)
--- PASS: TestAccAWSRouteTable_RequireRouteTarget (14.34s)
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (85.64s)
--- PASS: TestAccAWSRouteTable_Route_TransitGatewayID (344.45s)
--- PASS: TestAccAWSRouteTable_Route_VpcEndpointId (254.26s)
--- PASS: TestAccAWSRouteTable_basic (52.42s)
--- PASS: TestAccAWSRouteTable_instance (111.34s)
--- PASS: TestAccAWSRouteTable_ipv6 (27.17s)
--- PASS: TestAccAWSRouteTable_tags (81.13s)
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (54.28s)
--- PASS: TestAccAWSRouteTable_vpcPeering (46.40s)
--- SKIP: TestAccAWSRouteTable_Route_LocalGatewayID (1.74s)

--- PASS: TestAccAWSRoute_ConditionalCidrBlock (43.72s)
--- PASS: TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock (343.04s)
--- PASS: TestAccAWSRoute_VpcEndpointId (301.53s)
--- PASS: TestAccAWSRoute_basic (45.59s)
--- PASS: TestAccAWSRoute_changeCidr (48.46s)
--- PASS: TestAccAWSRoute_changeRouteTable (45.74s)
--- PASS: TestAccAWSRoute_disappears (42.60s)
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (38.97s)
--- PASS: TestAccAWSRoute_ipv6Support (39.79s)
--- PASS: TestAccAWSRoute_ipv6ToInstance (110.26s)
--- PASS: TestAccAWSRoute_ipv6ToInternetGateway (37.12s)
--- PASS: TestAccAWSRoute_ipv6ToNetworkInterface (134.33s)
--- PASS: TestAccAWSRoute_ipv6ToPeeringConnection (20.75s)
--- PASS: TestAccAWSRoute_noopdiff (94.82s)
--- SKIP: TestAccAWSRoute_LocalGatewayID (1.49s)

--- PASS: TestAccAWSVpcEndpointConnectionNotification_basic (230.14s)
--- PASS: TestAccAWSVpcEndpointRouteTableAssociation_basic (32.57s)
--- PASS: TestAccAWSVpcEndpointServiceAllowedPrincipal_basic (224.14s)
--- PASS: TestAccAWSVpcEndpointService_AllowedPrincipals (256.49s)
--- PASS: TestAccAWSVpcEndpointService_GatewayLoadBalancerArns (302.99s)
--- PASS: TestAccAWSVpcEndpointService_basic (232.57s)
--- PASS: TestAccAWSVpcEndpointService_disappears (249.77s)
--- PASS: TestAccAWSVpcEndpointService_tags (381.45s)

--- PASS: TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer (235.67s)
--- PASS: TestAccAWSVpcEndpoint_disappears (22.83s)
--- PASS: TestAccAWSVpcEndpoint_gatewayBasic (24.77s)
--- PASS: TestAccAWSVpcEndpoint_gatewayPolicy (41.01s)
--- PASS: TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy (47.12s)
--- PASS: TestAccAWSVpcEndpoint_interfaceBasic (77.87s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate (238.12s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate (294.45s)
--- PASS: TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup (400.21s)
--- PASS: TestAccAWSVpcEndpoint_tags (49.18s)

--- PASS: TestAccDataSourceAwsRouteTable_basic (55.10s)
--- PASS: TestAccDataSourceAwsRouteTable_main (45.70s)

--- PASS: TestAccDataSourceAwsRouteTables_basic (61.82s)
```
