### PR TITLE
r/aws_apigatewayv2_stage: Correctly handle deletion of route_settings

### DIFF
--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"strings"
@@ -11,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -170,7 +168,6 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 						},
 					},
 				},
-				Set: apiGatewayV2RouteSettingsHash,
 			},
 			"stage_variables": {
 				Type:     schema.TypeMap,
@@ -536,7 +533,7 @@ func expandApiGatewayV2RouteSettings(vSettings *schema.Set, protocolType string)
 	return settings
 }
 
-func flattenApiGatewayV2RouteSettings(settings map[string]*apigatewayv2.RouteSettings) *schema.Set {
+func flattenApiGatewayV2RouteSettings(settings map[string]*apigatewayv2.RouteSettings) []interface{} {
 	vSettings := []interface{}{}
 
 	for k, routeSetting := range settings {
@@ -550,32 +547,5 @@ func flattenApiGatewayV2RouteSettings(settings map[string]*apigatewayv2.RouteSet
 		})
 	}
 
-	return schema.NewSet(apiGatewayV2RouteSettingsHash, vSettings)
-}
-
-func apiGatewayV2RouteSettingsHash(vSettings interface{}) int {
-	var buf bytes.Buffer
-
-	mSettings := vSettings.(map[string]interface{})
-
-	if v, ok := mSettings["route_key"].(string); ok {
-		buf.WriteString(fmt.Sprintf("%s-", v))
-	}
-	if v, ok := mSettings["data_trace_enabled"].(bool); ok {
-		buf.WriteString(fmt.Sprintf("%t-", v))
-	}
-	if v, ok := mSettings["detailed_metrics_enabled"].(bool); ok {
-		buf.WriteString(fmt.Sprintf("%t-", v))
-	}
-	if v, ok := mSettings["logging_level"].(string); ok {
-		buf.WriteString(fmt.Sprintf("%s-", v))
-	}
-	if v, ok := mSettings["throttling_burst_limit"].(int); ok {
-		buf.WriteString(fmt.Sprintf("%d-", v))
-	}
-	if v, ok := mSettings["throttling_rate_limit"].(float64); ok {
-		buf.WriteString(fmt.Sprintf("%g-", v))
-	}
-
-	return hashcode.String(buf.String())
+	return vSettings
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes: https://github.com/hashicorp/terraform-provider-aws/issues/16094.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_stage: Correctly handle deletion of route_settings
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Stage_' ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSAPIGatewayV2Stage_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== RUN   TestAccAWSAPIGatewayV2Stage_basicHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_basicHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== PAUSE TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== RUN   TestAccAWSAPIGatewayV2Stage_autoDeployHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_autoDeployHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_disappears
=== PAUSE TestAccAWSAPIGatewayV2Stage_disappears
=== RUN   TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== PAUSE TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== RUN   TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== PAUSE TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== RUN   TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket
=== RUN   TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_Deployment
=== PAUSE TestAccAWSAPIGatewayV2Stage_Deployment
=== RUN   TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket
=== RUN   TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp_WithRoute
=== PAUSE TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp_WithRoute
=== RUN   TestAccAWSAPIGatewayV2Stage_StageVariables
=== PAUSE TestAccAWSAPIGatewayV2Stage_StageVariables
=== RUN   TestAccAWSAPIGatewayV2Stage_Tags
=== PAUSE TestAccAWSAPIGatewayV2Stage_Tags
=== CONT  TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== CONT  TestAccAWSAPIGatewayV2Stage_Tags
=== CONT  TestAccAWSAPIGatewayV2Stage_StageVariables
--- PASS: TestAccAWSAPIGatewayV2Stage_basicWebSocket (21.08s)
=== CONT  TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp_WithRoute
--- PASS: TestAccAWSAPIGatewayV2Stage_Tags (33.37s)
=== CONT  TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp
--- PASS: TestAccAWSAPIGatewayV2Stage_StageVariables (33.85s)
=== CONT  TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket
=== CONT  TestAccAWSAPIGatewayV2Stage_Deployment
--- PASS: TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp_WithRoute (37.98s)
--- PASS: TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp (44.02s)
=== CONT  TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp
--- PASS: TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket (45.42s)
=== CONT  TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket
--- PASS: TestAccAWSAPIGatewayV2Stage_Deployment (24.58s)
=== CONT  TestAccAWSAPIGatewayV2Stage_AccessLogSettings
--- PASS: TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp (41.40s)
=== CONT  TestAccAWSAPIGatewayV2Stage_disappears
--- PASS: TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket (41.28s)
=== CONT  TestAccAWSAPIGatewayV2Stage_autoDeployHttp
--- PASS: TestAccAWSAPIGatewayV2Stage_disappears (14.36s)
=== CONT  TestAccAWSAPIGatewayV2Stage_defaultHttpStage
--- PASS: TestAccAWSAPIGatewayV2Stage_AccessLogSettings (58.89s)
=== CONT  TestAccAWSAPIGatewayV2Stage_basicHttp
--- PASS: TestAccAWSAPIGatewayV2Stage_defaultHttpStage (18.91s)
=== CONT  TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
--- PASS: TestAccAWSAPIGatewayV2Stage_autoDeployHttp (32.23s)
--- PASS: TestAccAWSAPIGatewayV2Stage_basicHttp (17.51s)
--- PASS: TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription (30.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	182.621s
```
