### PR TITLE
tests/resource/aws_lb: Fix TestAccAWSLB_networkLoadbalancerEIP configuration

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1828,7 +1828,7 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "public" {
-  count             = length(data.aws_availability_zones.available.names)
+  count             = 2
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = "10.10.${count.index}.0/24"
   vpc_id            = aws_vpc.main.id
@@ -1852,8 +1852,8 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route_table_association" "a" {
-  count          = length(data.aws_availability_zones.available.names)
-  subnet_id      = aws_subnet.public[*].id[count.index]
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
   route_table_id = aws_route_table.public.id
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
=== CONT  TestAccAWSLB_networkLoadbalancerEIP
TestAccAWSLB_networkLoadbalancerEIP: resource_aws_lb_test.go:241: Step 1/1 error: Error running pre-apply plan: 2020/11/10 23:20:59 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0
Error: Incorrect attribute value type
on config604754392/terraform_plugin_test.tf line 45, in resource "aws_route_table_association" "a":
45:   subnet_id      = aws_subnet.public[*].id[count.index]
|----------------
| aws_subnet.public is tuple with 4 elements
| count.index is 2
Inappropriate value for attribute "subnet_id": string required.
Error: Incorrect attribute value type
on config604754392/terraform_plugin_test.tf line 45, in resource "aws_route_table_association" "a":
45:   subnet_id      = aws_subnet.public[*].id[count.index]
|----------------
| aws_subnet.public is tuple with 4 elements
| count.index is 3
Inappropriate value for attribute "subnet_id": string required.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (248.09s)
```
