### PR TITLE
use patch updates for aws_api_gateway_base_path_mapping where possibl…

### DIFF
--- a/aws/resource_aws_api_gateway_base_path_mapping.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping.go
@@ -18,6 +18,7 @@ func resourceAwsApiGatewayBasePathMapping() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsApiGatewayBasePathMappingCreate,
 		Read:   resourceAwsApiGatewayBasePathMappingRead,
+		Update: resourceAwsApiGatewayBasePathMappingUpdate,
 		Delete: resourceAwsApiGatewayBasePathMappingDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -27,17 +28,17 @@ func resourceAwsApiGatewayBasePathMapping() *schema.Resource {
 			"api_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
+				ForceNew: false,
 			},
 			"base_path": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 			},
 			"stage_name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 			},
 			"domain_name": {
 				Type:     schema.TypeString,
@@ -83,6 +84,69 @@ func resourceAwsApiGatewayBasePathMappingCreate(d *schema.ResourceData, meta int
 
 	id := fmt.Sprintf("%s/%s", d.Get("domain_name").(string), d.Get("base_path").(string))
 	d.SetId(id)
+
+	return resourceAwsApiGatewayBasePathMappingRead(d, meta)
+}
+
+func resourceAwsApiGatewayBasePathMappingUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayconn
+
+	operations := make([]*apigateway.PatchOperation, 0)
+
+	if d.HasChange("stage_name") {
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/stage"),
+			Value: aws.String(d.Get("stage_name").(string)),
+		})
+	}
+
+	if d.HasChange("api_id") {
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/restapiId"),
+			Value: aws.String(d.Get("api_id").(string)),
+		})
+	}
+
+	if d.HasChange("base_path") {
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/basePath"),
+			Value: aws.String(d.Get("base_path").(string)),
+		})
+	}
+
+	domainName, basePath, decodeErr := decodeApiGatewayBasePathMappingId(d.Id())
+	if decodeErr != nil {
+		return decodeErr
+	}
+
+	input := apigateway.UpdateBasePathMappingInput{
+		BasePath:        aws.String(basePath),
+		DomainName:      aws.String(domainName),
+		PatchOperations: operations,
+	}
+
+	log.Printf("[INFO] Updating API Gateway base path mapping: %s", input)
+
+	_, err := conn.UpdateBasePathMapping(&input)
+
+	if err != nil {
+		if isResourceTimeoutError(err) {
+			_, err = conn.UpdateBasePathMapping(&input)
+		}
+		if err != nil {
+			return fmt.Errorf("Updating API Gateway base path mapping failed: %s", err)
+		}
+	}
+
+	if d.HasChange("base_path") {
+		id := fmt.Sprintf("%s/%s", d.Get("domain_name").(string), d.Get("base_path").(string))
+		d.SetId(id)
+	}
+
+	log.Printf("[DEBUG] API Gateway base path mapping updated: %s", d.Id())
 
 	return resourceAwsApiGatewayBasePathMappingRead(d, meta)
 }

--- a/aws/resource_aws_api_gateway_base_path_mapping.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping.go
@@ -28,17 +28,14 @@ func resourceAwsApiGatewayBasePathMapping() *schema.Resource {
 			"api_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: false,
 			},
 			"base_path": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: false,
 			},
 			"stage_name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: false,
 			},
 			"domain_name": {
 				Type:     schema.TypeString,
@@ -133,9 +130,6 @@ func resourceAwsApiGatewayBasePathMappingUpdate(d *schema.ResourceData, meta int
 	_, err := conn.UpdateBasePathMapping(&input)
 
 	if err != nil {
-		if isResourceTimeoutError(err) {
-			_, err = conn.UpdateBasePathMapping(&input)
-		}
 		if err != nil {
 			return fmt.Errorf("Updating API Gateway base path mapping failed: %s", err)
 		}

--- a/aws/resource_aws_api_gateway_base_path_mapping_test.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping_test.go
@@ -121,7 +121,7 @@ func TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty(t *testing.T) {
 }
 
 func TestAccAWSAPIGatewayBasePathMapping_updates(t *testing.T) {
-	var conf apigateway.BasePathMapping
+	var confFirst, conf apigateway.BasePathMapping
 	resourceName := "aws_api_gateway_base_path_mapping.test"
 	name := fmt.Sprintf("tf-acc-%s.terraformtest.com", acctest.RandString(8))
 
@@ -136,20 +136,26 @@ func TestAccAWSAPIGatewayBasePathMapping_updates(t *testing.T) {
 			{
 				Config: testAccAWSAPIGatewayBasePathConfigBasePath(name, key, certificate, ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayBasePathExists(resourceName, &conf),
+					testAccCheckAWSAPIGatewayBasePathExists(resourceName, &confFirst),
+					testAccCheckAWSAPIGatewayBasePathStageAttribute(&confFirst, "test"),
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayBasePathConfigBasePathAltStage(name, key, certificate, ""),
+				Config: testAccAWSAPIGatewayBasePathConfigBasePathAltStageAndAPI(name, key, certificate, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayBasePathExists(resourceName, &conf),
+					testAccCheckAWSAPIGatewayBasePathBasePathAttribute(&conf, "(none)"),
+					testAccCheckAWSAPIGatewayBasePathStageAttribute(&conf, "test2"),
+					testAccCheckAWSAPIGatewayRestApiIdAttributeHasChanged(&conf, &confFirst),
 					resource.TestCheckResourceAttr(resourceName, "stage_name", "test2"),
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayBasePathConfigBasePathAltStage(name, key, certificate, "thing"),
+				Config: testAccAWSAPIGatewayBasePathConfigBasePathAltStageAndAPI(name, key, certificate, "thing"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayBasePathExists(resourceName, &conf),
+					testAccCheckAWSAPIGatewayBasePathBasePathAttribute(&conf, "thing"),
+					testAccCheckAWSAPIGatewayBasePathStageAttribute(&conf, "test2"),
 					resource.TestCheckResourceAttr(resourceName, "stage_name", "test2"),
 					resource.TestCheckResourceAttr(resourceName, "base_path", "thing"),
 				),
@@ -256,6 +262,45 @@ func testAccCheckAWSAPIGatewayBasePathDestroy(name string) resource.TestCheckFun
 	}
 }
 
+func testAccCheckAWSAPIGatewayBasePathStageAttribute(conf *apigateway.BasePathMapping, basePath string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if conf.Stage == nil {
+			return fmt.Errorf("attribute Stage should not be nil")
+		}
+		if *conf.Stage != basePath {
+			return fmt.Errorf("unexpected value Stage: %s", *conf.Stage)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayRestApiIdAttributeHasChanged(conf *apigateway.BasePathMapping, previousConf *apigateway.BasePathMapping) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if conf.RestApiId == nil {
+			return fmt.Errorf("attribute RestApiId should not be nil")
+		}
+		if *conf.RestApiId == *previousConf.RestApiId {
+			return fmt.Errorf("expected RestApiId to have changed")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayBasePathBasePathAttribute(conf *apigateway.BasePathMapping, basePath string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if conf.Stage == nil {
+			return fmt.Errorf("attribute Stage should not be nil")
+		}
+		if *conf.BasePath != basePath {
+			return fmt.Errorf("unexpected value Stage: %s", *conf.BasePath)
+		}
+
+		return nil
+	}
+}
+
 func testAccAWSAPIGatewayBasePathConfigBase(domainName, key, certificate string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
@@ -321,8 +366,18 @@ resource "aws_api_gateway_base_path_mapping" "test" {
 `, basePath)
 }
 
-func testAccAWSAPIGatewayBasePathConfigBasePathAltStage(domainName, key, certificate, basePath string) string {
+func testAccAWSAPIGatewayBasePathConfigBasePathAltStageAndAPI(domainName, key, certificate, basePath string) string {
 	return testAccAWSAPIGatewayBasePathConfigBase(domainName, key, certificate) + fmt.Sprintf(`
+
+resource "aws_api_gateway_rest_api" "test2" {
+  name        = "tf-acc-apigateway-base-path-mapping-alt"
+  description = "Terraform Acceptance Tests"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
 
 resource "aws_api_gateway_stage" "test2" {
 
@@ -331,13 +386,39 @@ resource "aws_api_gateway_stage" "test2" {
   ]
 
   stage_name    = "test2"
-  rest_api_id   = aws_api_gateway_rest_api.test.id
-  deployment_id = aws_api_gateway_deployment.test.id
+  rest_api_id   = aws_api_gateway_rest_api.test2.id
+  deployment_id = aws_api_gateway_deployment.test2.id
+}
+
+resource "aws_api_gateway_resource" "test2" {
+  rest_api_id = aws_api_gateway_rest_api.test2.id
+  parent_id   = aws_api_gateway_rest_api.test2.root_resource_id
+  path_part   = "tf-acc"
+}
+
+resource "aws_api_gateway_method" "test2" {
+  rest_api_id   = aws_api_gateway_rest_api.test2.id
+  resource_id   = aws_api_gateway_resource.test2.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "test2" {
+  rest_api_id = aws_api_gateway_rest_api.test2.id
+  resource_id = aws_api_gateway_resource.test2.id
+  http_method = aws_api_gateway_method.test2.http_method
+  type        = "MOCK"
 }
 
 
+resource "aws_api_gateway_deployment" "test2" {
+  rest_api_id = aws_api_gateway_rest_api.test2.id
+  stage_name  = "test"
+  depends_on  = [aws_api_gateway_integration.test2]
+}
+
 resource "aws_api_gateway_base_path_mapping" "test" {
-  api_id      = aws_api_gateway_rest_api.test.id
+  api_id      = aws_api_gateway_rest_api.test2.id
   base_path   = %[1]q
   stage_name  = aws_api_gateway_stage.test2.stage_name
   domain_name = aws_api_gateway_domain_name.test.domain_name


### PR DESCRIPTION
use patch updates for aws_api_gateway_base_path_mapping where possible, this allows switching the mapped api / stage without destroying and creating the mapping

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_api_gateway_base_path_mapping: Support in-place updates for `stage_name`, `api_id` and `base_path`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayBasePathMapping' ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayBasePathMapping -timeout 120m
=== RUN   TestAccAWSAPIGatewayBasePathMapping_basic
=== PAUSE TestAccAWSAPIGatewayBasePathMapping_basic
=== RUN   TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty
=== PAUSE TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty
=== RUN   TestAccAWSAPIGatewayBasePathMapping_updates
=== PAUSE TestAccAWSAPIGatewayBasePathMapping_updates
=== RUN   TestAccAWSAPIGatewayBasePathMapping_disappears
=== PAUSE TestAccAWSAPIGatewayBasePathMapping_disappears
=== CONT  TestAccAWSAPIGatewayBasePathMapping_basic
=== CONT  TestAccAWSAPIGatewayBasePathMapping_disappears
=== CONT  TestAccAWSAPIGatewayBasePathMapping_updates
=== CONT  TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty
--- PASS: TestAccAWSAPIGatewayBasePathMapping_disappears (58.39s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty (115.67s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_basic (192.74s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_updates (268.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	269.489s

...
```
