### PR TITLE
added appliance_mode_support argument/attribute

### DIFF
--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
@@ -16,6 +16,10 @@ func dataSourceAwsEc2TransitGatewayVpcAttachment() *schema.Resource {
 		Read: dataSourceAwsEc2TransitGatewayVpcAttachmentRead,
 
 		Schema: map[string]*schema.Schema{
+			"appliance_mode_support": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"dns_support": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -90,6 +94,7 @@ func dataSourceAwsEc2TransitGatewayVpcAttachmentRead(d *schema.ResourceData, met
 		return fmt.Errorf("error reading EC2 Transit Gateway VPC Attachment (%s): missing options", d.Id())
 	}
 
+	d.Set("appliance_mode_support", transitGatewayVpcAttachment.Options.ApplianceModeSupport)
 	d.Set("dns_support", transitGatewayVpcAttachment.Options.DnsSupport)
 	d.Set("ipv6_support", transitGatewayVpcAttachment.Options.Ipv6Support)
 

--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -18,6 +18,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter(t *testing.T) {
 			{
 				Config: testAccAWSEc2TransitGatewayVpcAttachmentDataSourceConfigFilter(),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "appliance_mode_support", dataSourceName, "appliance_mode_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "dns_support", dataSourceName, "dns_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "ipv6_support", dataSourceName, "ipv6_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_ids.#", dataSourceName, "subnet_ids.#"),
@@ -43,6 +44,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID(t *testing.T) {
 			{
 				Config: testAccAWSEc2TransitGatewayVpcAttachmentDataSourceConfigID(),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "appliance_mode_support", dataSourceName, "appliance_mode_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "dns_support", dataSourceName, "dns_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "ipv6_support", dataSourceName, "ipv6_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_ids.#", dataSourceName, "subnet_ids.#"),

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment.go
@@ -22,6 +22,15 @@ func resourceAwsEc2TransitGatewayVpcAttachment() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"appliance_mode_support": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  ec2.ApplianceModeSupportValueDisable,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.ApplianceModeSupportValueDisable,
+					ec2.ApplianceModeSupportValueEnable,
+				}, false),
+			},
 			"dns_support": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -84,8 +93,9 @@ func resourceAwsEc2TransitGatewayVpcAttachmentCreate(d *schema.ResourceData, met
 
 	input := &ec2.CreateTransitGatewayVpcAttachmentInput{
 		Options: &ec2.CreateTransitGatewayVpcAttachmentRequestOptions{
-			DnsSupport:  aws.String(d.Get("dns_support").(string)),
-			Ipv6Support: aws.String(d.Get("ipv6_support").(string)),
+			ApplianceModeSupport: aws.String(d.Get("appliance_mode_support").(string)),
+			DnsSupport:           aws.String(d.Get("dns_support").(string)),
+			Ipv6Support:          aws.String(d.Get("ipv6_support").(string)),
 		},
 		SubnetIds:         expandStringSet(d.Get("subnet_ids").(*schema.Set)),
 		TransitGatewayId:  aws.String(transitGatewayID),
@@ -188,6 +198,7 @@ func resourceAwsEc2TransitGatewayVpcAttachmentRead(d *schema.ResourceData, meta 
 		return fmt.Errorf("error reading EC2 Transit Gateway VPC Attachment (%s): missing options", d.Id())
 	}
 
+	d.Set("appliance_mode_support", transitGatewayVpcAttachment.Options.ApplianceModeSupport)
 	d.Set("dns_support", transitGatewayVpcAttachment.Options.DnsSupport)
 	d.Set("ipv6_support", transitGatewayVpcAttachment.Options.Ipv6Support)
 
@@ -211,11 +222,12 @@ func resourceAwsEc2TransitGatewayVpcAttachmentRead(d *schema.ResourceData, meta 
 func resourceAwsEc2TransitGatewayVpcAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	if d.HasChanges("dns_support", "ipv6_support", "subnet_ids") {
+	if d.HasChanges("appliance_mode_support", "dns_support", "ipv6_support", "subnet_ids") {
 		input := &ec2.ModifyTransitGatewayVpcAttachmentInput{
 			Options: &ec2.ModifyTransitGatewayVpcAttachmentRequestOptions{
-				DnsSupport:  aws.String(d.Get("dns_support").(string)),
-				Ipv6Support: aws.String(d.Get("ipv6_support").(string)),
+				ApplianceModeSupport: aws.String(d.Get("appliance_mode_support").(string)),
+				DnsSupport:           aws.String(d.Get("dns_support").(string)),
+				Ipv6Support:          aws.String(d.Get("ipv6_support").(string)),
 			},
 			TransitGatewayAttachmentId: aws.String(d.Id()),
 		}

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter.go
@@ -21,6 +21,10 @@ func resourceAwsEc2TransitGatewayVpcAttachmentAccepter() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"appliance_mode_support": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"dns_support": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -166,6 +170,7 @@ func resourceAwsEc2TransitGatewayVpcAttachmentAccepterRead(d *schema.ResourceDat
 		return fmt.Errorf("error reading EC2 Transit Gateway VPC Attachment (%s): missing options", d.Id())
 	}
 
+	d.Set("appliance_mode_support", transitGatewayVpcAttachment.Options.ApplianceModeSupport)
 	d.Set("dns_support", transitGatewayVpcAttachment.Options.DnsSupport)
 	d.Set("ipv6_support", transitGatewayVpcAttachment.Options.Ipv6Support)
 

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
@@ -33,6 +33,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic(t *testing.T) {
 				Config: testAccAWSEc2TransitGatewayVpcAttachmentAccepterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TransitGatewayVpcAttachmentExists(resourceName, &transitGatewayVpcAttachment),
+					resource.TestCheckResourceAttr(resourceName, "appliance_mode_support", ec2.ApplianceModeSupportValueDisable),
 					resource.TestCheckResourceAttr(resourceName, "dns_support", ec2.DnsSupportValueEnable),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_support", ec2.Ipv6SupportValueDisable),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
@@ -78,6 +79,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags(t *testing.T) {
 				Config: testAccAWSEc2TransitGatewayVpcAttachmentAccepterConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TransitGatewayVpcAttachmentExists(resourceName, &transitGatewayVpcAttachment),
+					resource.TestCheckResourceAttr(resourceName, "appliance_mode_support", ec2.ApplianceModeSupportValueDisable),
 					resource.TestCheckResourceAttr(resourceName, "dns_support", ec2.DnsSupportValueEnable),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_support", ec2.Ipv6SupportValueDisable),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
@@ -98,6 +100,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags(t *testing.T) {
 				Config: testAccAWSEc2TransitGatewayVpcAttachmentAccepterConfig_tagsUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TransitGatewayVpcAttachmentExists(resourceName, &transitGatewayVpcAttachment),
+					resource.TestCheckResourceAttr(resourceName, "appliance_mode_support", ec2.ApplianceModeSupportValueDisable),
 					resource.TestCheckResourceAttr(resourceName, "dns_support", ec2.DnsSupportValueEnable),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_support", ec2.Ipv6SupportValueDisable),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -658,10 +658,10 @@ resource "aws_ec2_transit_gateway" "test" {
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
-  appliance_mode_support        = %q
-  subnet_ids         			= [aws_subnet.test.id]
-  transit_gateway_id 			= aws_ec2_transit_gateway.test.id
-  vpc_id             			= aws_vpc.test.id
+  appliance_mode_support = %q
+  subnet_ids             = [aws_subnet.test.id]
+  transit_gateway_id     = aws_ec2_transit_gateway.test.id
+  vpc_id                 = aws_vpc.test.id
 }
 `, appModeSupport)
 }

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -139,6 +139,47 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport(t *testing.T) {
+	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2 ec2.TransitGatewayVpcAttachment
+	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayVpcAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSEc2TransitGatewayVpcAttachmentConfigApplianceModeSupport("false"),
+				ExpectError: regexp.MustCompile(`expected appliance_mode_support to be one of`),
+			},
+			{
+				Config:      testAccAWSEc2TransitGatewayVpcAttachmentConfigApplianceModeSupport("true"),
+				ExpectError: regexp.MustCompile(`expected appliance_mode_support to be one of`),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayVpcAttachmentConfigApplianceModeSupport(ec2.ApplianceModeSupportValueDisable),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayVpcAttachmentExists(resourceName, &transitGatewayVpcAttachment1),
+					resource.TestCheckResourceAttr(resourceName, "appliance_mode_support", ec2.ApplianceModeSupportValueDisable),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayVpcAttachmentConfigApplianceModeSupport(ec2.ApplianceModeSupportValueEnable),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayVpcAttachmentExists(resourceName, &transitGatewayVpcAttachment2),
+					testAccCheckAWSEc2TransitGatewayVpcAttachmentNotRecreated(&transitGatewayVpcAttachment1, &transitGatewayVpcAttachment2),
+					resource.TestCheckResourceAttr(resourceName, "appliance_mode_support", ec2.ApplianceModeSupportValueEnable),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport(t *testing.T) {
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
@@ -580,6 +621,49 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
   vpc_id             = aws_vpc.test.id
 }
 `
+}
+
+func testAccAWSEc2TransitGatewayVpcAttachmentConfigApplianceModeSupport(appModeSupport string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
+  }
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
+  appliance_mode_support        = %q
+  subnet_ids         			= [aws_subnet.test.id]
+  transit_gateway_id 			= aws_ec2_transit_gateway.test.id
+  vpc_id             			= aws_vpc.test.id
+}
+`, appModeSupport)
 }
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigDnsSupport(dnsSupport string) string {

--- a/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -47,6 +47,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `appliance_mode_support` - Whether Appliance Mode support is enabled.
 * `dns_support` - Whether DNS support is enabled.
 * `id` - EC2 Transit Gateway VPC Attachment identifier
 * `ipv6_support` - Whether IPv6 support is enabled.

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 * `subnet_ids` - (Required) Identifiers of EC2 Subnets.
 * `transit_gateway_id` - (Required) Identifier of EC2 Transit Gateway.
 * `vpc_id` - (Required) Identifier of EC2 VPC.
+* `appliance_mode_support` - (Optional) Whether Appliance Mode support is enabled. If enabled, a traffic flow between a source and destination uses the same Availability Zone for the VPC attachment for the lifetime of that flow. Valid values: `disable`, `enable`. Default value: `disable`.
 * `dns_support` - (Optional) Whether DNS support is enabled. Valid values: `disable`, `enable`. Default value: `enable`.
 * `ipv6_support` - (Optional) Whether IPv6 support is enabled. Valid values: `disable`, `enable`. Default value: `disable`.
 * `tags` - (Optional) Key-value tags for the EC2 Transit Gateway VPC Attachment.

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment_accepter.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment_accepter.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - EC2 Transit Gateway Attachment identifier
+* `appliance_mode_support` - Whether Appliance Mode support is enabled. Valid values: `disable`, `enable`.
 * `dns_support` - Whether DNS support is enabled. Valid values: `disable`, `enable`.
 * `ipv6_support` - Whether IPv6 support is enabled. Valid values: `disable`, `enable`.
 * `subnet_ids` - Identifiers of EC2 Subnets.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15936

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_ec2_transit_gateway_vpc_attachment - added appliance_mode_support argument/attribute to resource and data
```

Output from acceptance testing:
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -run=TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ -timeout 60m
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID (385.44s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (385.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       385.501s
```
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -run=TestAccAWSEc2TransitGatewayVpcAttachment -timeout 60m
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_basic
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_basic
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_disappears
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_disappears
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_Tags
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_Tags
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_Tags
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Tags (343.17s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support (343.19s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (366.36s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds (462.11s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_basic
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled (305.30s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway
    resource_aws_ec2_transit_gateway_vpc_attachment_test.go:256: Step 1/2 error: Error running pre-apply refresh:
        Error: Error describing organization: AWSOrganizationsNotInUseException: Your account is not a member of an organization.


--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway (3.14s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation (360.25s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation (460.74s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_disappears
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_basic (385.47s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags
    resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go:69: Step 1/3 error: Error running apply:
        Error: Error associating principal with RAM resource share: OperationNotPermittedException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.



        Error: error associating RAM Resource Share: OperationNotPermittedException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.


--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport (380.67s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport (361.96s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags (239.27s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation
    resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go:138: Step 1/4 error: Error running apply:
        Error: Error associating principal with RAM resource share: OperationNotPermittedException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.



        Error: error associating RAM Resource Share: OperationNotPermittedException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.


=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic
    resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go:23: Step 1/2 error: Error running apply:
        Error: error associating RAM Resource Share: OperationNotPermittedException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.



        Error: Error associating principal with RAM resource share: OperationNotPermittedException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.


--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_disappears (362.67s)
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation (219.07s)
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic (198.47s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID (343.91s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       1431.197s
FAIL
```


Some of the acceptance tests failed locally since I don't have an AWS organization or multiple accounts to test this on, hoping if this looks good someone who has this available can run them to make sure it's all good?

Thanks in advance for your review!

Requires AWS SDK v1.35.18:

#15930