### PR TITLE
aws_lambda_permission: Add example with cloudwatch logs

### DIFF
--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -128,6 +128,57 @@ resource "aws_lambda_permission" "lambda_permission" {
 }
 ```
 
+## Usage with CloudWatch log group
+
+```hcl
+resource "aws_lambda_permission" "logging" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.logging.function_name
+  principal     = "logs.eu-west-1.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_log_group.default.arn}:*"
+}
+
+resource "aws_cloudwatch_log_group" "default" {
+  name = "/default"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "logging" {
+  depends_on      = [aws_lambda_permission.logging]
+  destination_arn = aws_lambda_function.logging.arn
+  filter_pattern  = ""
+  log_group_name  = aws_cloudwatch_log_group.default.name
+  name            = "logging_default"
+}
+
+resource "aws_lambda_function" "logging" {
+  filename      = "lamba_logging.zip"
+  function_name = "lambda_called_from_cloudwatch_logs"
+  handler       = "exports.handler"
+  role          = aws_iam_role.default.arn
+  runtime       = "python2.7"
+}
+
+resource "aws_iam_role" "default" {
+  name = "iam_for_lambda_called_from_cloudwatch_logs"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+```
+
 ## Argument Reference
 
 * `action` - (Required) The AWS Lambda action you want to allow in this statement. (e.g. `lambda:InvokeFunction`)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Reasoning

The Lambda permission setup for cloudwatch groups is tricky. The source ARN requires a wildcard at the end, otherwise it fails with error:
`Error creating Cloudwatch log subscription filter: InvalidParameterException: Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function.`

This isn't really clear and so I think people will find this example useful. Over the past year I've got stuck on this quite a few times. 