### PR TITLE
tests/resource/aws_eks_node_group: Fix test failures

### DIFF
--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -386,7 +386,7 @@ func TestAccAWSEksNodeGroup_LaunchTemplate_Name(t *testing.T) {
 }
 
 func TestAccAWSEksNodeGroup_LaunchTemplate_Version(t *testing.T) {
-	var nodeGroup1 eks.Nodegroup
+	var nodeGroup1, nodeGroup2 eks.Nodegroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	launchTemplateResourceName := "aws_launch_template.test"
 	resourceName := "aws_eks_node_group.test"
@@ -411,14 +411,12 @@ func TestAccAWSEksNodeGroup_LaunchTemplate_Version(t *testing.T) {
 			},
 			{
 				Config: testAccAWSEksNodeGroupConfigLaunchTemplateVersion2(rName),
-				// This API error is incorrect and will need to be rectified by the service team.
-				ExpectError: regexp.MustCompile(`User data was not in the MIME multipart format`),
-				// Check: resource.ComposeTestCheckFunc(
-				// 	testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
-				// 	testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
-				// 	resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
-				// 	resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.version", launchTemplateResourceName, "default_version"),
-				// ),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.version", launchTemplateResourceName, "default_version"),
+				),
 			},
 		},
 	})
@@ -436,7 +434,7 @@ func TestAccAWSEksNodeGroup_ReleaseVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName, "1.15"),
+				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName, "1.17"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
 					resource.TestCheckResourceAttrPair(resourceName, "release_version", ssmParameterDataSourceName, "value"),
@@ -448,7 +446,7 @@ func TestAccAWSEksNodeGroup_ReleaseVersion(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName, "1.16"),
+				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName, "1.18"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
 					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16146
Reference: https://github.com/aws/containers-roadmap/issues/771
Reference: https://github.com/awslabs/amazon-eks-ami/issues/559

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
=== CONT  TestAccAWSEksNodeGroup_LaunchTemplate_Version
TestAccAWSEksNodeGroup_LaunchTemplate_Version: resource_aws_eks_node_group_test.go:394: Step 3/3, expected an error but got none
--- FAIL: TestAccAWSEksNodeGroup_LaunchTemplate_Version (2495.73s)

=== CONT  TestAccAWSEksNodeGroup_ReleaseVersion
TestAccAWSEksNodeGroup_ReleaseVersion: resource_aws_eks_node_group_test.go:433: Step 3/3 error: Error running apply: 2020/11/11 10:20:03 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0
Error: error updating EKS Node Group (tf-acc-test-7656789780485850868:tf-acc-test-7656789780485850868) version: InvalidParameterException: Requested Nodegroup release version 1.16.13-20201007 is invalid. Allowed release version is 1.16.15-20201107
{
RespMetadata: {
StatusCode: 400,
RequestID: "17a52d81-285a-4e03-924c-874d3d895e3b"
},
ClusterName: "tf-acc-test-7656789780485850868",
Message_: "Requested Nodegroup release version 1.16.13-20201007 is invalid. Allowed release version is 1.16.15-20201107",
NodegroupName: "tf-acc-test-7656789780485850868"
}
--- FAIL: TestAccAWSEksNodeGroup_ReleaseVersion (4466.46s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Version (2424.12s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (4059.77s)
```
