### PR TITLE
tests/provider: Add API Gateway EDGE PreCheck

### DIFF
--- a/aws/data_source_aws_api_gateway_resource_test.go
+++ b/aws/data_source_aws_api_gateway_resource_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceAwsApiGatewayResource_basic(t *testing.T) {
 	dataSourceName2 := "data.aws_api_gateway_resource.example_v1_endpoint"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -12,7 +12,7 @@ func TestAccDataSourceAwsApiGatewayRestApi_basic(t *testing.T) {
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
 	resourceName := "aws_api_gateway_rest_api.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_transfer_server_test.go
+++ b/aws/data_source_aws_transfer_server_test.go
@@ -57,7 +57,7 @@ func TestAccDataSourceAwsTransferServer_apigateway(t *testing.T) {
 	datasourceName := "data.aws_transfer_server.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -423,7 +423,7 @@ func TestAccAWSAPIGatewayUsagePlan_apiStages_multiple(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -251,7 +251,7 @@ func TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -280,7 +280,7 @@ func TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint(t *testing.T) 
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -159,7 +159,7 @@ func TestAccAWSTransferServer_apigateway(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferServerDestroy,

--- a/aws/resource_aws_wafregional_web_acl_association_test.go
+++ b/aws/resource_aws_wafregional_web_acl_association_test.go
@@ -81,7 +81,11 @@ func TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage(t *testi
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(wafregional.EndpointsID, t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(wafregional.EndpointsID, t)
+			testAccAPIGatewayTypeEDGEPreCheck(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckWafRegionalWebAclAssociationDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSAPIGatewayUsagePlan_apiStages_multiple (1.54s)
--- SKIP: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (1.53s)
--- SKIP: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (1.54s)
--- SKIP: TestAccAWSTransferServer_apigateway (1.53s)
--- SKIP: TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage (1.54s)
--- SKIP: TestAccDataSourceAwsApiGatewayResource_basic (1.52s)
--- SKIP: TestAccDataSourceAwsApiGatewayRestApi_basic (1.54s)
--- SKIP: TestAccDataSourceAwsTransferServer_apigateway (2.00s)
```

Output from acceptance testing (commercial):

```
--- FAIL: TestAccDataSourceAwsApiGatewayRestApi_basic (4.17s)
--- PASS: TestAccDataSourceAwsApiGatewayResource_basic (17.05s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages_multiple (51.06s)
--- PASS: TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage (79.71s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (79.75s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (160.90s)
--- PASS: TestAccAWSTransferServer_apigateway (193.23s)
--- PASS: TestAccDataSourceAwsTransferServer_apigateway (223.65s)
```