### PR TITLE
.github/workflows: Remove --quiet flag from terrafmt

### DIFF
--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -30,7 +30,7 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - run: cd tools && go install github.com/katbyte/terrafmt
-      # - run: terrafmt diff ./aws --check --pattern '*_test.go' --quiet --fmtcompat
+      # - run: terrafmt diff ./aws --check --pattern '*_test.go' --fmtcompat
       - run: |
           find ./aws -type f -name '*_test.go' \
             | sort -u \
@@ -42,7 +42,7 @@ jobs:
             | grep -v resource_aws_quicksight_user_test.go \
             | grep -v resource_aws_s3_bucket_object_test.go \
             | grep -v resource_aws_sns_platform_application_test.go \
-            | xargs -I {} terrafmt diff --check --quiet --fmtcompat {}
+            | xargs -I {} terrafmt diff --check --fmtcompat {}
 
   validate-terraform:
     runs-on: ubuntu-latest

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -77,7 +77,7 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - run: cd tools && go install github.com/katbyte/terrafmt
-      - run: terrafmt diff ./website --check --pattern '*.markdown' --quiet
+      - run: terrafmt diff ./website --check --pattern '*.markdown'
   validate-terraform:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

To make the `terrafmt` reports clearer for contributors and maintainers. e.g.

```console
$ terrafmt diff --check --fmtcompat aws/resource_aws_kinesis_stream_test.go
aws/resource_aws_kinesis_stream_test.go:769
 resource "aws_kms_key" "key" {
   count = 2

-  description             = "KMS key ${count.index+1}"
+  description             = "KMS key ${count.index + 1}"
   deletion_window_in_days = 10
 }

 resource "aws_kinesis_stream" "test" {
   name            = "test_stream-%[1]d"
   shard_count     = 1
   encryption_type = "KMS"
   kms_key_id      = aws_kms_key.key[%[2]d].id
 }
```

Output from acceptance testing: N/A (CI)
