### PR TITLE
r/aws_elasticsearch_domain: Add custom endpoint support 

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -160,13 +160,6 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 						"custom_endpoint": {
 							Type:     schema.TypeString,
 							Optional: true,
-							StateFunc: func(v interface{}) string {
-								// AWS Provider aws_acm_certification.domain_validation_options.resource_record_name
-								// references (and perhaps others) contain a trailing period, requiring a custom StateFunc
-								// to trim the string to prevent Route53 API error
-								value := strings.TrimSuffix(v.(string), ".")
-								return strings.ToLower(value)
-							},
 							DiffSuppressFunc: isCustomEndpointDisabled,
 						},
 						"custom_endpoint_certificate_arn": {

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -158,8 +158,8 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 							Default:  false,
 						},
 						"custom_endpoint": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:             schema.TypeString,
+							Optional:         true,
 							DiffSuppressFunc: isCustomEndpointDisabled,
 						},
 						"custom_endpoint_certificate_arn": {

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -151,6 +151,20 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 								elasticsearch.TLSSecurityPolicyPolicyMinTls12201907,
 							}, false),
 						},
+						"custom_endpoint_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"custom_endpoint": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringDoesNotMatch(regexp.MustCompile(`\.$`), "cannot end with a period"),
+						},
+						"custom_endpoint_certificate_arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -140,7 +140,8 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"enforce_https": {
 							Type:     schema.TypeBool,
-							Required: true,
+							Optional: true,
+							Default:  true,
 						},
 						"tls_security_policy": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -134,6 +134,7 @@ func TestAccAWSElasticSearchDomain_CustomEndpoint(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticsearch.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -122,6 +122,57 @@ func TestAccAWSElasticSearchDomain_RequireHTTPS(t *testing.T) {
 	})
 }
 
+func TestAccAWSElasticSearchDomain_CustomEndpoint(t *testing.T) {
+	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
+	resourceId := fmt.Sprintf("tf-test-%d", ri)
+	resourceName := "aws_elasticsearch_domain.example"
+	customEndpoint := fmt.Sprintf("%s.example.com", resourceId)
+	certResourceName := "aws_acm_certificate.example"
+	certKey := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(certKey, customEndpoint)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccESDomainConfig_CustomEndpoint(ri, true, "Policy-Min-TLS-1-0-2019-07", true, customEndpoint, certKey, certificate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain_endpoint_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "domain_endpoint_options.0.custom_endpoint_enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_endpoint_options.0.custom_endpoint"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_endpoint_options.0.custom_endpoint_certificate_arn", certResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     resourceId,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccESDomainConfig_CustomEndpoint(ri, true, "Policy-Min-TLS-1-0-2019-07", true, customEndpoint, certKey, certificate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists(resourceName, &domain),
+					testAccCheckESDomainEndpointOptions(true, "Policy-Min-TLS-1-0-2019-07", &domain),
+					testAccCheckESCustomEndpoint(resourceName, true, customEndpoint, &domain),
+				),
+			},
+			{
+				Config: testAccESDomainConfig_CustomEndpoint(ri, true, "Policy-Min-TLS-1-0-2019-07", false, customEndpoint, certKey, certificate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists(resourceName, &domain),
+					testAccCheckESDomainEndpointOptions(true, "Policy-Min-TLS-1-0-2019-07", &domain),
+					testAccCheckESCustomEndpoint(resourceName, false, customEndpoint, &domain),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig(t *testing.T) {
 	var domain1, domain2, domain3, domain4 elasticsearch.ElasticsearchDomainStatus
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum)) // len = 28
@@ -1092,6 +1143,29 @@ func testAccCheckESDomainEndpointOptions(enforceHTTPS bool, tls string, status *
 	}
 }
 
+func testAccCheckESCustomEndpoint(n string, customEndpointEnabled bool, customEndpoint string, status *elasticsearch.ElasticsearchDomainStatus) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		options := status.DomainEndpointOptions
+		if *options.CustomEndpointEnabled != customEndpointEnabled {
+			return fmt.Errorf("CustomEndpointEnabled differ. Given: %t, Expected: %t", *options.CustomEndpointEnabled, customEndpointEnabled)
+		}
+		if *options.CustomEndpointEnabled {
+			if *options.CustomEndpoint != customEndpoint {
+				return fmt.Errorf("CustomEndpoint differ. Given: %s, Expected: %s", *options.CustomEndpoint, customEndpoint)
+			}
+			customEndpointCertificateArn := rs.Primary.Attributes["domain_endpoint_options.0.custom_endpoint_certificate_arn"]
+			if *options.CustomEndpointCertificateArn != customEndpointCertificateArn {
+				return fmt.Errorf("CustomEndpointCertificateArn differ. Given: %s, Expected: %s", *options.CustomEndpointCertificateArn, customEndpointCertificateArn)
+			}
+		}
+		return nil
+	}
+}
+
 func testAccCheckESNumberOfSecurityGroups(numberOfSecurityGroups int, status *elasticsearch.ElasticsearchDomainStatus) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		count := len(status.VPCOptions.SecurityGroupIds)
@@ -1353,6 +1427,32 @@ resource "aws_elasticsearch_domain" "example" {
   }
 }
 `, randInt, enforceHttps, tlsSecurityPolicy)
+}
+
+func testAccESDomainConfig_CustomEndpoint(randInt int, enforceHttps bool, tlsSecurityPolicy string, customEndpointEnabled bool, customEndpoint string, certKey string, certBody string) string {
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "example" {
+	private_key      = "%[6]s"
+	certificate_body = "%[7]s"
+}
+
+resource "aws_elasticsearch_domain" "example" {
+  domain_name = "tf-test-%[1]d"
+
+  domain_endpoint_options {
+	enforce_https                   = %[2]t
+	tls_security_policy             = %[3]q
+	custom_endpoint_enabled         = %[4]t
+    custom_endpoint                 = "%[5]s"
+    custom_endpoint_certificate_arn = aws_acm_certificate.example.arn
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+}
+`, randInt, enforceHttps, tlsSecurityPolicy, customEndpointEnabled, customEndpoint, tlsPemEscapeNewlines(certKey), tlsPemEscapeNewlines(certBody))
 }
 
 func testAccESDomainConfig_ClusterConfig_ZoneAwarenessConfig_AvailabilityZoneCount(rName string, availabilityZoneCount int) string {

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -1432,17 +1432,17 @@ resource "aws_elasticsearch_domain" "example" {
 func testAccESDomainConfig_CustomEndpoint(randInt int, enforceHttps bool, tlsSecurityPolicy string, customEndpointEnabled bool, customEndpoint string, certKey string, certBody string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "example" {
-	private_key      = "%[6]s"
-	certificate_body = "%[7]s"
+  private_key      = "%[6]s"
+  certificate_body = "%[7]s"
 }
 
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%[1]d"
 
   domain_endpoint_options {
-	enforce_https                   = %[2]t
-	tls_security_policy             = %[3]q
-	custom_endpoint_enabled         = %[4]t
+    enforce_https                   = %[2]t
+    tls_security_policy             = %[3]q
+    custom_endpoint_enabled         = %[4]t
     custom_endpoint                 = "%[5]s"
     custom_endpoint_certificate_arn = aws_acm_certificate.example.arn
   }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1376,16 +1376,18 @@ func expandESDomainEndpointOptions(l []interface{}) *elasticsearch.DomainEndpoin
 		domainEndpointOptions.TLSSecurityPolicy = aws.String(v)
 	}
 
-	if v, ok := m["custom_endpoint_enabled"].(bool); ok {
-		domainEndpointOptions.CustomEndpointEnabled = aws.Bool(v)
-	}
+	if customEndpointEnabled, ok := m["custom_endpoint_enabled"]; ok {
+		domainEndpointOptions.CustomEndpointEnabled = aws.Bool(customEndpointEnabled.(bool))
 
-	if v, ok := m["custom_endpoint"].(string); ok {
-		domainEndpointOptions.CustomEndpoint = aws.String(v)
-	}
+		if customEndpointEnabled.(bool) {
+			if v, ok := m["custom_endpoint"].(string); ok && v != "" {
+				domainEndpointOptions.CustomEndpoint = aws.String(v)
+			}
 
-	if v, ok := m["custom_endpoint_certificate_arn"].(string); ok {
-		domainEndpointOptions.CustomEndpointCertificateArn = aws.String(v)
+			if v, ok := m["custom_endpoint_certificate_arn"].(string); ok && v != "" {
+				domainEndpointOptions.CustomEndpointCertificateArn = aws.String(v)
+			}
+		}
 	}
 
 	return domainEndpointOptions
@@ -1397,11 +1399,17 @@ func flattenESDomainEndpointOptions(domainEndpointOptions *elasticsearch.DomainE
 	}
 
 	m := map[string]interface{}{
-		"enforce_https":                   aws.BoolValue(domainEndpointOptions.EnforceHTTPS),
-		"tls_security_policy":             aws.StringValue(domainEndpointOptions.TLSSecurityPolicy),
-		"custom_endpoint_enabled":         aws.BoolValue(domainEndpointOptions.CustomEndpointEnabled),
-		"custom_endpoint":                 aws.StringValue(domainEndpointOptions.CustomEndpoint),
-		"custom_endpoint_certificate_arn": aws.StringValue(domainEndpointOptions.CustomEndpointCertificateArn),
+		"enforce_https":           aws.BoolValue(domainEndpointOptions.EnforceHTTPS),
+		"tls_security_policy":     aws.StringValue(domainEndpointOptions.TLSSecurityPolicy),
+		"custom_endpoint_enabled": aws.BoolValue(domainEndpointOptions.CustomEndpointEnabled),
+	}
+	if aws.BoolValue(domainEndpointOptions.CustomEndpointEnabled) {
+		if domainEndpointOptions.CustomEndpoint != nil {
+			m["custom_endpoint"] = aws.StringValue(domainEndpointOptions.CustomEndpoint)
+		}
+		if domainEndpointOptions.CustomEndpointCertificateArn != nil {
+			m["custom_endpoint_certificate_arn"] = aws.StringValue(domainEndpointOptions.CustomEndpointCertificateArn)
+		}
 	}
 
 	return []interface{}{m}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1376,6 +1376,18 @@ func expandESDomainEndpointOptions(l []interface{}) *elasticsearch.DomainEndpoin
 		domainEndpointOptions.TLSSecurityPolicy = aws.String(v)
 	}
 
+	if v, ok := m["custom_endpoint_enabled"].(bool); ok {
+		domainEndpointOptions.CustomEndpointEnabled = aws.Bool(v)
+	}
+
+	if v, ok := m["custom_endpoint"].(string); ok {
+		domainEndpointOptions.CustomEndpoint = aws.String(v)
+	}
+
+	if v, ok := m["custom_endpoint_certificate_arn"].(string); ok {
+		domainEndpointOptions.CustomEndpointCertificateArn = aws.String(v)
+	}
+
 	return domainEndpointOptions
 }
 
@@ -1385,8 +1397,11 @@ func flattenESDomainEndpointOptions(domainEndpointOptions *elasticsearch.DomainE
 	}
 
 	m := map[string]interface{}{
-		"enforce_https":       aws.BoolValue(domainEndpointOptions.EnforceHTTPS),
-		"tls_security_policy": aws.StringValue(domainEndpointOptions.TLSSecurityPolicy),
+		"enforce_https":                   aws.BoolValue(domainEndpointOptions.EnforceHTTPS),
+		"tls_security_policy":             aws.StringValue(domainEndpointOptions.TLSSecurityPolicy),
+		"custom_endpoint_enabled":         aws.BoolValue(domainEndpointOptions.CustomEndpointEnabled),
+		"custom_endpoint":                 aws.StringValue(domainEndpointOptions.CustomEndpoint),
+		"custom_endpoint_certificate_arn": aws.StringValue(domainEndpointOptions.CustomEndpointCertificateArn),
 	}
 
 	return []interface{}{m}

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -252,7 +252,7 @@ The **advanced_security_options** block supports the following attributes:
 
 **domain_endpoint_options** supports the following attributes:
 
-* `enforce_https` - (Optional) Whether or not to require HTTPS
+* `enforce_https` - (Optional) Whether or not to require HTTPS. Defaults to `true`.
 * `tls_security_policy` - (Optional) The name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07` and `Policy-Min-TLS-1-2-2019-07`. Terraform will only perform drift detection if a configuration value is provided.
 * `custom_endpoint_enabled` - (Optional) Whether to enable custom endpoint for the Elasticsearch domain
 * `custom_endpoint` - (Optional) Fully qualified domain for your custom endpoint

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -252,8 +252,11 @@ The **advanced_security_options** block supports the following attributes:
 
 **domain_endpoint_options** supports the following attributes:
 
-* `enforce_https` - (Required) Whether or not to require HTTPS
+* `enforce_https` - (Optional) Whether or not to require HTTPS
 * `tls_security_policy` - (Optional) The name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07` and `Policy-Min-TLS-1-2-2019-07`. Terraform will only perform drift detection if a configuration value is provided.
+* `custom_endpoint_enabled` - (Optional) Whether to enable custom endpoint for the Elasticsearch domain
+* `custom_endpoint` - (Optional) Fully qualified domain for your custom endpoint
+* `custom_endpoint_certificate_arn` - (Optional) ACM certificate ARN for your custom endpoint
 
 **cluster_config** supports the following attributes:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

Add support to define a custom endpoint for your Elasticsearch domain and associate an SSL certificate from AWS ACM.
[AWS announcement](https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-elasticsearch-service-now-supports-defining-a-custom-name-for-your-domain-endpoint)

The following attributes under `domain_endpoint_options` were added:
- `custom_endpoint_enabled`
- `custom_endpoint`
- `custom_endpoint_certificate_arn`


```hcl
resource "aws_elasticsearch_domain" "example" {
  domain_endpoint_options {
    custom_endpoint_enabled         = true
    custom_endpoint                 = "example.com"
    custom_endpoint_certificate_arn = aws_acm_certificate.example.arn
  }
}
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16059

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_elasticsearch_domain: Add custom endpoint support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSElasticSearchDomain_CustomEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticSearchDomain_CustomEndpoint -timeout 120m
=== RUN   TestAccAWSElasticSearchDomain_CustomEndpoint
=== PAUSE TestAccAWSElasticSearchDomain_CustomEndpoint
=== CONT  TestAccAWSElasticSearchDomain_CustomEndpoint
--- PASS: TestAccAWSElasticSearchDomain_CustomEndpoint (1134.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1134.713s
```
