### PR TITLE
r/glue_crawler - added more docs and example on `configuration` argument

### DIFF
--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -99,6 +99,34 @@ resource "aws_glue_crawler" "example" {
 }
 ```
 
+### Configuration Settings
+
+```hcl
+resource "aws_glue_crawler" "events_crawler" {
+  database_name = aws_glue_catalog_database.glue_database.name
+  schedule      = "cron(0 1 * * ? *)"
+  name          = "events_crawler_${var.environment_name}"
+  role          = aws_iam_role.glue_role.arn
+  tags          = var.tags
+
+  configuration = jsonencode(
+    {
+      Grouping = {
+        TableGroupingPolicy = "CombineCompatibleSchemas"
+      }
+      CrawlerOutput = {
+        Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
+      }
+      Version = 1
+    }
+  )
+
+  s3_target {
+    path = "s3://${aws_s3_bucket.data_lake_bucket.bucket}"
+  }
+}
+```
+
 ## Argument Reference
 
 ~> **NOTE:** Must specify at least one of `dynamodb_target`, `jdbc_target`, `s3_target` or `catalog_target`.
@@ -109,7 +137,7 @@ The following arguments are supported:
 * `name` (Required) Name of the crawler.
 * `role` (Required) The IAM role friendly name (including path without leading slash), or ARN of an IAM role, used by the crawler to access other resources.
 * `classifiers` (Optional) List of custom classifiers. By default, all AWS classifiers are included in a crawl, but these custom classifiers always override the default classifiers for a given classification.
-* `configuration` (Optional) JSON string of configuration information.
+* `configuration` (Optional) JSON string of configuration information. For more details see [Setting Crawler Configuration Options](https://docs.aws.amazon.com/glue/latest/dg/crawler-configuration.html).
 * `description` (Optional) Description of the crawler.
 * `dynamodb_target` (Optional) List of nested DynamoDB target arguments. See below.
 * `jdbc_target` (Optional) List of nested JBDC target arguments. See below.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13595

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_crawler - added more docs and example on `configuration` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
