### PR TITLE
added support for disable_execute_api_endpoint to api gateway rest api

### DIFF
--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -41,6 +41,9 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the REST API
 * `description` - (Optional) The description of the REST API
+* `disable_execute_api_endpoint` - (Optional) Whether clients can invoke the API by using the default `execute-api` endpoint.
+By default, clients can invoke the API with the default `{api_id}.execute-api.{region}.amazonaws.com endpoint`.
+To require that clients use a custom domain name to invoke the API, disable the default endpoint.
 * `endpoint_configuration` - (Optional) Nested argument defining API endpoint configuration including endpoint type. Defined below.
 * `binary_media_types` - (Optional) The list of binary media types supported by the RestApi. By default, the RestApi supports only UTF-8-encoded text payloads.
 * `minimum_compression_size` - (Optional) Minimum response size to compress for the REST API. Integer between -1 and 10485760 (10MB). Setting a value greater than -1 will enable compression, -1 disables compression (default).


### PR DESCRIPTION

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15220

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_api_gateway_rest_api: Add `disable_execute_api_endpoint` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayRestApi_'

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayRestApi -timeout 120m
=== RUN   TestAccAWSAPIGatewayRestApi_basic
=== PAUSE TestAccAWSAPIGatewayRestApi_basic
=== RUN   TestAccAWSAPIGatewayRestApi_create_disable_execute_api_endpoint
=== PAUSE TestAccAWSAPIGatewayRestApi_create_disable_execute_api_endpoint
=== RUN   TestAccAWSAPIGatewayRestApi_tags
=== PAUSE TestAccAWSAPIGatewayRestApi_tags
=== RUN   TestAccAWSAPIGatewayRestApi_disappears
=== PAUSE TestAccAWSAPIGatewayRestApi_disappears
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VPCEndpoint
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VPCEndpoint
=== RUN   TestAccAWSAPIGatewayRestApi_api_key_source
=== PAUSE TestAccAWSAPIGatewayRestApi_api_key_source
=== RUN   TestAccAWSAPIGatewayRestApi_policy
=== PAUSE TestAccAWSAPIGatewayRestApi_policy
=== RUN   TestAccAWSAPIGatewayRestApi_openapi
=== PAUSE TestAccAWSAPIGatewayRestApi_openapi
=== CONT  TestAccAWSAPIGatewayRestApi_basic
=== CONT  TestAccAWSAPIGatewayRestApi_openapi
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
=== CONT  TestAccAWSAPIGatewayRestApi_api_key_source
=== CONT  TestAccAWSAPIGatewayRestApi_create_disable_execute_api_endpoint
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VPCEndpoint
=== CONT  TestAccAWSAPIGatewayRestApi_policy
=== CONT  TestAccAWSAPIGatewayRestApi_tags
=== CONT  TestAccAWSAPIGatewayRestApi_disappears
2020/11/14 15:21:40 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSAPIGatewayRestApi_disappears (40.13s)
--- PASS: TestAccAWSAPIGatewayRestApi_openapi (62.38s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private (66.72s)
--- PASS: TestAccAWSAPIGatewayRestApi_api_key_source (92.18s)
--- PASS: TestAccAWSAPIGatewayRestApi_basic (122.44s)
--- PASS: TestAccAWSAPIGatewayRestApi_tags (153.91s)
--- PASS: TestAccAWSAPIGatewayRestApi_policy (182.86s)
--- PASS: TestAccAWSAPIGatewayRestApi_create_disable_execute_api_endpoint (224.86s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration (313.89s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VPCEndpoint (420.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	420.107s


...
```
