### PR TITLE
r/aws_vpc_endpoint_route_table_association: Ensure that VPC endpoint to route table association can be read before Create is successful

### DIFF
--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -1,6 +1,7 @@
 package ec2
 
 const (
+	ErrCodeInvalidParameter      = "InvalidParameter"
 	ErrCodeInvalidParameterValue = "InvalidParameterValue"
 )
 
@@ -20,8 +21,16 @@ const (
 )
 
 const (
+	ErrCodeInvalidRouteTableIdNotFound = "InvalidRouteTableId.NotFound"
+)
+
+const (
 	InvalidSecurityGroupIDNotFound = "InvalidSecurityGroupID.NotFound"
 	InvalidGroupNotFound           = "InvalidGroup.NotFound"
+)
+
+const (
+	ErrCodeInvalidVpcEndpointIdNotFound = "InvalidVpcEndpointId.NotFound"
 )
 
 const (

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -110,8 +110,8 @@ func VpcEndpointByID(conn *ec2.EC2, id string) (*ec2.VpcEndpoint, error) {
 	return output.VpcEndpoints[0], nil
 }
 
-// VpcEndpointRouteTableAssociation returns whether the specified VPC endpoint and route table are associated.
-func VpcEndpointRouteTableAssociation(conn *ec2.EC2, vpcEndpointID, routeTableID string) (bool, error) {
+// VpcEndpointRouteTableAssociationExists returns whether the specified VPC endpoint/route table association exists.
+func VpcEndpointRouteTableAssociationExists(conn *ec2.EC2, vpcEndpointID, routeTableID string) (bool, error) {
 	vpcEndpoint, err := VpcEndpointByID(conn, vpcEndpointID)
 	if err != nil {
 		return false, err

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -91,6 +91,45 @@ func SecurityGroupByID(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
 	return result.SecurityGroups[0], nil
 }
 
+// VpcEndpointByID returns the VPC endpoint corresponding to the specified identifier.
+// Returns nil and potentially an error if no VPC endpoint is found.
+func VpcEndpointByID(conn *ec2.EC2, id string) (*ec2.VpcEndpoint, error) {
+	input := &ec2.DescribeVpcEndpointsInput{
+		VpcEndpointIds: aws.StringSlice([]string{id}),
+	}
+
+	output, err := conn.DescribeVpcEndpoints(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.VpcEndpoints) == 0 {
+		return nil, nil
+	}
+
+	return output.VpcEndpoints[0], nil
+}
+
+// VpcEndpointRouteTableAssociation returns whether the specified VPC endpoint and route table are associated.
+func VpcEndpointRouteTableAssociation(conn *ec2.EC2, vpcEndpointID, routeTableID string) (bool, error) {
+	vpcEndpoint, err := VpcEndpointByID(conn, vpcEndpointID)
+	if err != nil {
+		return false, err
+	}
+
+	if vpcEndpoint == nil {
+		return false, nil
+	}
+
+	for _, id := range vpcEndpoint.RouteTableIds {
+		if aws.StringValue(id) == routeTableID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // VpcPeeringConnectionByID returns the VPC peering connection corresponding to the specified identifier.
 // Returns nil and potentially an error if no VPC peering connection is found.
 func VpcPeeringConnectionByID(conn *ec2.EC2, id string) (*ec2.VpcPeeringConnection, error) {

--- a/aws/internal/service/ec2/id.go
+++ b/aws/internal/service/ec2/id.go
@@ -71,6 +71,10 @@ func ClientVpnRouteParseID(id string) (string, string, string, error) {
 			"target-subnet-id"+clientVpnRouteIDSeparator+"destination-cidr-block", id)
 }
 
+func VpcEndpointRouteTableAssociationCreateID(vpcEndpointID, routeTableID string) string {
+	return fmt.Sprintf("a-%s%d", vpcEndpointID, hashcode.String(routeTableID))
+}
+
 func VpnGatewayVpcAttachmentCreateID(vpnGatewayID, vpcID string) string {
 	return fmt.Sprintf("vpn-attachment-%x", hashcode.String(fmt.Sprintf("%s-%s", vpcID, vpnGatewayID)))
 }

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -257,18 +257,18 @@ const (
 )
 
 func VpcEndpointRouteTableAssociationCreated(conn *ec2.EC2, vpcEndpointID, routeTableID string) error {
-	associated := false
+	found := false
 
 	err := resource.Retry(VpcEndpointRouteTableAssociationCreatedTimeout, func() *resource.RetryError {
 		var err error
 
-		associated, err = finder.VpcEndpointRouteTableAssociation(conn, vpcEndpointID, routeTableID)
+		found, err = finder.VpcEndpointRouteTableAssociationExists(conn, vpcEndpointID, routeTableID)
 
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
 
-		if !associated {
+		if !found {
 			return resource.RetryableError(fmt.Errorf("VPC Endpoint (%s) not associated with Route Table (%s)", vpcEndpointID, routeTableID))
 		}
 
@@ -276,14 +276,14 @@ func VpcEndpointRouteTableAssociationCreated(conn *ec2.EC2, vpcEndpointID, route
 	})
 
 	if tfresource.TimedOut(err) {
-		associated, err = finder.VpcEndpointRouteTableAssociation(conn, vpcEndpointID, routeTableID)
+		found, err = finder.VpcEndpointRouteTableAssociationExists(conn, vpcEndpointID, routeTableID)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	if !associated {
+	if !found {
 		return fmt.Errorf("VPC Endpoint (%s) not associated with Route Table (%s)", vpcEndpointID, routeTableID)
 	}
 

--- a/aws/resource_aws_vpc_endpoint_route_table_association.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 )
 
 func resourceAwsVpcEndpointRouteTableAssociation() *schema.Resource {
@@ -55,7 +55,7 @@ func resourceAwsVpcEndpointRouteTableAssociationCreate(d *schema.ResourceData, m
 		return fmt.Errorf("Error creating VPC Endpoint/Route Table association: %s", err.Error())
 	}
 
-	d.SetId(vpcEndpointIdRouteTableIdHash(endpointId, rtId))
+	d.SetId(tfec2.VpcEndpointRouteTableAssociationCreateID(endpointId, rtId))
 
 	return resourceAwsVpcEndpointRouteTableAssociationRead(d, meta)
 }
@@ -134,7 +134,7 @@ func resourceAwsVpcEndpointRouteTableAssociationImport(d *schema.ResourceData, m
 	rtId := parts[1]
 	log.Printf("[DEBUG] Importing VPC Endpoint (%s) Route Table (%s) association", vpceId, rtId)
 
-	d.SetId(vpcEndpointIdRouteTableIdHash(vpceId, rtId))
+	d.SetId(tfec2.VpcEndpointRouteTableAssociationCreateID(vpceId, rtId))
 	d.Set("vpc_endpoint_id", vpceId)
 	d.Set("route_table_id", rtId)
 
@@ -154,8 +154,4 @@ func findResourceVpcEndpoint(conn *ec2.EC2, id string) (*ec2.VpcEndpoint, error)
 	}
 
 	return resp.VpcEndpoints[0], nil
-}
-
-func vpcEndpointIdRouteTableIdHash(endpointId, rtId string) string {
-	return fmt.Sprintf("a-%s%d", endpointId, hashcode.String(rtId))
 }

--- a/aws/resource_aws_vpc_endpoint_route_table_association.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter"
 )
 
 func resourceAwsVpcEndpointRouteTableAssociation() *schema.Resource {
@@ -62,6 +63,12 @@ func resourceAwsVpcEndpointRouteTableAssociationCreate(d *schema.ResourceData, m
 	}
 
 	d.SetId(tfec2.VpcEndpointRouteTableAssociationCreateID(vpcEndpointID, routeTableID))
+
+	err = waiter.VpcEndpointRouteTableAssociationCreated(conn, vpcEndpointID, routeTableID)
+
+	if err != nil {
+		return fmt.Errorf("error waiting for VPC Endpoint/Route Table association (%s) to be created: %w", d.Id(), err)
+	}
 
 	return resourceAwsVpcEndpointRouteTableAssociationRead(d, meta)
 }

--- a/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -4,18 +4,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
 func TestAccAWSVpcEndpointRouteTableAssociation_basic(t *testing.T) {
-	var vpce ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint_route_table_association.test"
-	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandString(16))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,7 +24,7 @@ func TestAccAWSVpcEndpointRouteTableAssociation_basic(t *testing.T) {
 			{
 				Config: testAccVpcEndpointRouteTableAssociationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcEndpointRouteTableAssociationExists(resourceName, &vpce),
+					testAccCheckVpcEndpointRouteTableAssociationExists(resourceName),
 				),
 			},
 			{
@@ -46,33 +45,22 @@ func testAccCheckVpcEndpointRouteTableAssociationDestroy(s *terraform.State) err
 			continue
 		}
 
-		// Try to find the resource
-		resp, err := conn.DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
-			VpcEndpointIds: aws.StringSlice([]string{rs.Primary.Attributes["vpc_endpoint_id"]}),
-		})
-		if err != nil {
-			// Verify the error is what we want
-			ec2err, ok := err.(awserr.Error)
-			if !ok {
-				return err
-			}
-			if ec2err.Code() != "InvalidVpcEndpointId.NotFound" {
-				return err
-			}
-			return nil
+		associated, err := finder.VpcEndpointRouteTableAssociation(conn, rs.Primary.Attributes["vpc_endpoint_id"], rs.Primary.Attributes["route_table_id"])
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidVpcEndpointIdNotFound) {
+			continue
 		}
-
-		vpce := resp.VpcEndpoints[0]
-		if len(vpce.RouteTableIds) > 0 {
-			return fmt.Errorf(
-				"VPC endpoint %s has route tables", *vpce.VpcEndpointId)
+		if err != nil {
+			return err
+		}
+		if associated {
+			return fmt.Errorf("VPC Endpoint/Route Table association still exists")
 		}
 	}
 
 	return nil
 }
 
-func testAccCheckVpcEndpointRouteTableAssociationExists(n string, vpce *ec2.VpcEndpoint) resource.TestCheckFunc {
+func testAccCheckVpcEndpointRouteTableAssociationExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -84,26 +72,12 @@ func testAccCheckVpcEndpointRouteTableAssociationExists(n string, vpce *ec2.VpcE
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
-			VpcEndpointIds: aws.StringSlice([]string{rs.Primary.Attributes["vpc_endpoint_id"]}),
-		})
+		associated, err := finder.VpcEndpointRouteTableAssociation(conn, rs.Primary.Attributes["vpc_endpoint_id"], rs.Primary.Attributes["route_table_id"])
 		if err != nil {
 			return err
 		}
-		if len(resp.VpcEndpoints) == 0 {
-			return fmt.Errorf("VPC Endpoint not found")
-		}
-
-		*vpce = *resp.VpcEndpoints[0]
-
-		if len(vpce.RouteTableIds) == 0 {
-			return fmt.Errorf("No VPC Endpoint Route Table Associations")
-		}
-
-		for _, rtId := range vpce.RouteTableIds {
-			if aws.StringValue(rtId) == rs.Primary.Attributes["route_table_id"] {
-				return nil
-			}
+		if associated {
+			return nil
 		}
 
 		return fmt.Errorf("VPC Endpoint Route Table Association not found")
@@ -137,6 +111,10 @@ data "aws_region" "current" {}
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
   service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_route_table" "test" {

--- a/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -66,14 +66,14 @@ func testAccCheckVpcEndpointRouteTableAssociationDestroy(s *terraform.State) err
 			continue
 		}
 
-		associated, err := finder.VpcEndpointRouteTableAssociation(conn, rs.Primary.Attributes["vpc_endpoint_id"], rs.Primary.Attributes["route_table_id"])
+		found, err := finder.VpcEndpointRouteTableAssociationExists(conn, rs.Primary.Attributes["vpc_endpoint_id"], rs.Primary.Attributes["route_table_id"])
 		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidVpcEndpointIdNotFound) {
 			continue
 		}
 		if err != nil {
 			return err
 		}
-		if associated {
+		if found {
 			return fmt.Errorf("VPC Endpoint/Route Table association still exists")
 		}
 	}
@@ -93,11 +93,11 @@ func testAccCheckVpcEndpointRouteTableAssociationExists(n string) resource.TestC
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		associated, err := finder.VpcEndpointRouteTableAssociation(conn, rs.Primary.Attributes["vpc_endpoint_id"], rs.Primary.Attributes["route_table_id"])
+		found, err := finder.VpcEndpointRouteTableAssociationExists(conn, rs.Primary.Attributes["vpc_endpoint_id"], rs.Primary.Attributes["route_table_id"])
 		if err != nil {
 			return err
 		}
-		if associated {
+		if found {
 			return nil
 		}
 

--- a/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -37,6 +37,27 @@ func TestAccAWSVpcEndpointRouteTableAssociation_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSVpcEndpointRouteTableAssociation_disappears(t *testing.T) {
+	resourceName := "aws_vpc_endpoint_route_table_association.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcEndpointRouteTableAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcEndpointRouteTableAssociationConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointRouteTableAssociationExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsVpcEndpointRouteTableAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckVpcEndpointRouteTableAssociationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 

--- a/aws/resource_aws_vpc_endpoint_subnet_association.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association.go
@@ -154,3 +154,18 @@ func resourceAwsVpcEndpointSubnetAssociationDelete(d *schema.ResourceData, meta 
 func vpcEndpointSubnetAssociationId(endpointId, snId string) string {
 	return fmt.Sprintf("a-%s%d", endpointId, hashcode.String(snId))
 }
+
+func findResourceVpcEndpoint(conn *ec2.EC2, id string) (*ec2.VpcEndpoint, error) {
+	resp, err := conn.DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
+		VpcEndpointIds: aws.StringSlice([]string{id}),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.VpcEndpoints == nil || len(resp.VpcEndpoints) == 0 {
+		return nil, fmt.Errorf("No VPC Endpoints were found for %s", id)
+	}
+
+	return resp.VpcEndpoints[0], nil
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/12449.
Also add a `_disappears` test: #13826.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_vpc_endpoint_route_table_association: Ensure that VPC endpoint and route table association can be read before Create is successful
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSVpcEndpointRouteTableAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSVpcEndpointRouteTableAssociation_ -timeout 120m
=== RUN   TestAccAWSVpcEndpointRouteTableAssociation_basic
=== PAUSE TestAccAWSVpcEndpointRouteTableAssociation_basic
=== RUN   TestAccAWSVpcEndpointRouteTableAssociation_disappears
=== PAUSE TestAccAWSVpcEndpointRouteTableAssociation_disappears
=== CONT  TestAccAWSVpcEndpointRouteTableAssociation_basic
=== CONT  TestAccAWSVpcEndpointRouteTableAssociation_disappears
--- PASS: TestAccAWSVpcEndpointRouteTableAssociation_disappears (36.13s)
--- PASS: TestAccAWSVpcEndpointRouteTableAssociation_basic (37.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	37.717s
```
