### PR TITLE
resource/aws_datasync_agent: Add support for VPC Endpoints

### DIFF
--- a/.changelog/16207.txt
+++ b/.changelog/16207.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_datasync_option: Add `private_link_endpoint`, `security_group_arns`, `subnet_arns` and `vpc_endpoint_id` arguments
+```

--- a/aws/internal/service/datasync/waiter/status.go
+++ b/aws/internal/service/datasync/waiter/status.go
@@ -8,6 +8,26 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
+const (
+	agentStatusReady = "ready"
+)
+
+func AgentStatus(conn *datasync.DataSync, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.AgentByARN(conn, arn)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, agentStatusReady, nil
+	}
+}
+
 func TaskStatus(conn *datasync.DataSync, arn string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := finder.TaskByARN(conn, arn)

--- a/aws/internal/service/datasync/waiter/waiter.go
+++ b/aws/internal/service/datasync/waiter/waiter.go
@@ -10,6 +10,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func AgentReady(conn *datasync.DataSync, arn string, timeout time.Duration) (*datasync.DescribeAgentOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{},
+		Target:  []string{agentStatusReady},
+		Refresh: AgentStatus(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*datasync.DescribeAgentOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func TaskAvailable(conn *datasync.DataSync, arn string, timeout time.Duration) (*datasync.DescribeTaskOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{datasync.TaskStatusCreating, datasync.TaskStatusUnavailable},

--- a/aws/resource_aws_datasync_agent.go
+++ b/aws/resource_aws_datasync_agent.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/datasync"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/datasync/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/datasync/waiter"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
@@ -38,14 +41,15 @@ func resourceAwsDataSyncAgent() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"ip_address", "private_link_endpoint"},
+				ExactlyOneOf:  []string{"activation_key", "ip_address"},
+				ConflictsWith: []string{"private_link_endpoint"},
 			},
 			"ip_address": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"activation_key"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"activation_key", "ip_address"},
 			},
 			"private_link_endpoint": {
 				Type:          schema.TypeString,
@@ -86,79 +90,75 @@ func resourceAwsDataSyncAgentCreate(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).datasyncconn
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
-	region := meta.(*AWSClient).region
 
 	activationKey := d.Get("activation_key").(string)
 	agentIpAddress := d.Get("ip_address").(string)
 
 	// Perform one time fetch of activation key from gateway IP address
 	if activationKey == "" {
-		if agentIpAddress == "" {
-			return fmt.Errorf("either activation_key or ip_address must be provided")
-		}
-
 		client := &http.Client{
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
 			Timeout: time.Second * 10,
 		}
+		region := meta.(*AWSClient).region
 
-		requestURL := fmt.Sprintf("http://%s/?gatewayType=SYNC&activationRegion=%s", agentIpAddress, region)
+		var requestURL string
 		if v, ok := d.GetOk("private_link_endpoint"); ok {
 			requestURL = fmt.Sprintf("http://%s/?gatewayType=SYNC&activationRegion=%s&endpointType=PRIVATE_LINK&privateLinkEndpoint=%s", agentIpAddress, region, v.(string))
+		} else {
+			requestURL = fmt.Sprintf("http://%s/?gatewayType=SYNC&activationRegion=%s", agentIpAddress, region)
 		}
 
-		log.Printf("[DEBUG] Creating HTTP request: %s", requestURL)
 		request, err := http.NewRequest("GET", requestURL, nil)
 		if err != nil {
-			return fmt.Errorf("error creating HTTP request: %s", err)
+			return fmt.Errorf("error creating HTTP request: %w", err)
 		}
 
 		var response *http.Response
 		err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			log.Printf("[DEBUG] Making HTTP request: %s", request.URL.String())
 			response, err = client.Do(request)
+
+			if err, ok := err.(net.Error); ok {
+				return resource.RetryableError(fmt.Errorf("error making HTTP request: %w", err))
+			}
+
 			if err != nil {
-				if err, ok := err.(net.Error); ok {
-					errMessage := fmt.Errorf("error making HTTP request: %s", err)
-					log.Printf("[DEBUG] retryable %s", errMessage)
-					return resource.RetryableError(errMessage)
-				}
-				return resource.NonRetryableError(fmt.Errorf("error making HTTP request: %s", err))
+				return resource.NonRetryableError(fmt.Errorf("error making HTTP request: %w", err))
 			}
 
 			if response == nil {
-				return resource.NonRetryableError(fmt.Errorf("Error retrieving response for activation key request: %s", err))
+				return resource.NonRetryableError(fmt.Errorf("no response for activation key request"))
 			}
 
 			log.Printf("[DEBUG] Received HTTP response: %#v", response)
-			if response.StatusCode != 302 {
-				return resource.NonRetryableError(fmt.Errorf("expected HTTP status code 302, received: %d", response.StatusCode))
+			if expected := http.StatusFound; expected != response.StatusCode {
+				return resource.NonRetryableError(fmt.Errorf("expected HTTP status code %d, received: %d", expected, response.StatusCode))
 			}
 
 			redirectURL, err := response.Location()
 			if err != nil {
-				return resource.NonRetryableError(fmt.Errorf("error extracting HTTP Location header: %s", err))
+				return resource.NonRetryableError(fmt.Errorf("error extracting HTTP Location header: %w", err))
 			}
 
-			errorType := redirectURL.Query().Get("errorType")
-			if errorType == "PRIVATE_LINK_ENDPOINT_UNREACHABLE" {
+			if errorType := redirectURL.Query().Get("errorType"); errorType == "PRIVATE_LINK_ENDPOINT_UNREACHABLE" {
 				errMessage := fmt.Errorf("got error during activation: %s", errorType)
-				log.Printf("[DEBUG] retryable %s", errMessage)
 				return resource.RetryableError(errMessage)
 			}
 
 			activationKey = redirectURL.Query().Get("activationKey")
+
 			return nil
 		})
 
 		if tfresource.TimedOut(err) {
-			return fmt.Errorf("timeout retrieving activation key from IP Address (%s): %s", agentIpAddress, err)
+			return fmt.Errorf("timeout retrieving activation key from IP Address (%s): %w", agentIpAddress, err)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error retrieving activation key from IP Address (%s): %s", agentIpAddress, err)
+			return fmt.Errorf("error retrieving activation key from IP Address (%s): %w", agentIpAddress, err)
 		}
 
 		if activationKey == "" {
@@ -175,10 +175,6 @@ func resourceAwsDataSyncAgentCreate(d *schema.ResourceData, meta interface{}) er
 		input.AgentName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("vpc_endpoint_id"); ok {
-		input.VpcEndpointId = aws.String(v.(string))
-	}
-
 	if v, ok := d.GetOk("security_group_arns"); ok {
 		input.SecurityGroupArns = expandStringSet(v.(*schema.Set))
 	}
@@ -187,35 +183,21 @@ func resourceAwsDataSyncAgentCreate(d *schema.ResourceData, meta interface{}) er
 		input.SubnetArns = expandStringSet(v.(*schema.Set))
 	}
 
+	if v, ok := d.GetOk("vpc_endpoint_id"); ok {
+		input.VpcEndpointId = aws.String(v.(string))
+	}
+
 	log.Printf("[DEBUG] Creating DataSync Agent: %s", input)
 	output, err := conn.CreateAgent(input)
+
 	if err != nil {
-		return fmt.Errorf("error creating DataSync Agent: %s", err)
+		return fmt.Errorf("error creating DataSync Agent: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.AgentArn))
 
 	// Agent activations can take a few minutes
-	descAgentInput := &datasync.DescribeAgentInput{
-		AgentArn: aws.String(d.Id()),
-	}
-	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		_, err := conn.DescribeAgent(descAgentInput)
-
-		if isAWSErr(err, "InvalidRequestException", "does not exist") {
-			return resource.RetryableError(err)
-		}
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-	if isResourceTimeoutError(err) {
-		_, err = conn.DescribeAgent(descAgentInput)
-	}
-	if err != nil {
+	if _, err := waiter.AgentReady(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("error waiting for DataSync Agent (%s) creation: %s", d.Id(), err)
 	}
 
@@ -227,38 +209,36 @@ func resourceAwsDataSyncAgentRead(d *schema.ResourceData, meta interface{}) erro
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	input := &datasync.DescribeAgentInput{
-		AgentArn: aws.String(d.Id()),
-	}
+	output, err := finder.AgentByARN(conn, d.Id())
 
-	log.Printf("[DEBUG] Reading DataSync Agent: %s", input)
-	output, err := conn.DescribeAgent(input)
-
-	if isAWSErr(err, "InvalidRequestException", "does not exist") {
-		log.Printf("[WARN] DataSync Agent %q not found - removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] DataSync Agent (%s)not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading DataSync Agent (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading DataSync Agent (%s): %w", d.Id(), err)
 	}
 
 	d.Set("arn", output.AgentArn)
 	d.Set("name", output.Name)
-
-	if output.PrivateLinkConfig != nil {
-		plc := output.PrivateLinkConfig
+	if plc := output.PrivateLinkConfig; plc != nil {
 		d.Set("private_link_endpoint", plc.PrivateLinkEndpoint)
 		d.Set("security_group_arns", flattenStringList(plc.SecurityGroupArns))
 		d.Set("subnet_arns", flattenStringList(plc.SubnetArns))
 		d.Set("vpc_endpoint_id", plc.VpcEndpointId)
+	} else {
+		d.Set("private_link_endpoint", "")
+		d.Set("security_group_arns", nil)
+		d.Set("subnet_arns", nil)
+		d.Set("vpc_endpoint_id", "")
 	}
 
 	tags, err := keyvaluetags.DatasyncListTags(conn, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for DataSync Agent (%s): %s", d.Id(), err)
+		return fmt.Errorf("error listing tags for DataSync Agent (%s): %w", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
@@ -286,8 +266,9 @@ func resourceAwsDataSyncAgentUpdate(d *schema.ResourceData, meta interface{}) er
 
 		log.Printf("[DEBUG] Updating DataSync Agent: %s", input)
 		_, err := conn.UpdateAgent(input)
+
 		if err != nil {
-			return fmt.Errorf("error updating DataSync Agent (%s): %s", d.Id(), err)
+			return fmt.Errorf("error updating DataSync Agent (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -295,7 +276,7 @@ func resourceAwsDataSyncAgentUpdate(d *schema.ResourceData, meta interface{}) er
 		o, n := d.GetChange("tags_all")
 
 		if err := keyvaluetags.DatasyncUpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating DataSync Agent (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("error updating DataSync Agent (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -305,19 +286,17 @@ func resourceAwsDataSyncAgentUpdate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsDataSyncAgentDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).datasyncconn
 
-	input := &datasync.DeleteAgentInput{
+	log.Printf("[DEBUG] Deleting DataSync Agent: %s", d.Id())
+	_, err := conn.DeleteAgent(&datasync.DeleteAgentInput{
 		AgentArn: aws.String(d.Id()),
-	}
+	})
 
-	log.Printf("[DEBUG] Deleting DataSync Agent: %s", input)
-	_, err := conn.DeleteAgent(input)
-
-	if isAWSErr(err, "InvalidRequestException", "does not exist") {
+	if tfawserr.ErrMessageContains(err, datasync.ErrCodeInvalidRequestException, "does not exist") {
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting DataSync Agent (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting DataSync Agent (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_datasync_task.go
+++ b/aws/resource_aws_datasync_task.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/datasync/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/datasync/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsDataSyncTask() *schema.Resource {
@@ -198,7 +199,7 @@ func resourceAwsDataSyncTaskRead(d *schema.ResourceData, meta interface{}) error
 
 	output, err := finder.TaskByARN(conn, d.Id())
 
-	if !d.IsNewResource() && tfawserr.ErrMessageContains(err, datasync.ErrCodeInvalidRequestException, "not found") {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] DataSync Task (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/website/docs/r/datasync_agent.html.markdown
+++ b/website/docs/r/datasync_agent.html.markdown
@@ -21,6 +21,33 @@ resource "aws_datasync_agent" "example" {
 }
 ```
 
+## Example Usage with VPC Endpoints
+
+```hcl
+resource "aws_datasync_agent" "example" {
+  ip_address            = "1.2.3.4"
+  security_group_arns   = [aws_security_group.example.arn]
+  subnet_arns           = [aws_subnet.example.arn]
+  vpc_endpoint_id       = aws_vpc_endpoint.example.id
+  private_link_endpoint = data.aws_network_interface.example.private_ip
+  name                  = "example"
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "example" {
+  service_name       = "com.amazonaws.${data.aws_region.current.name}.datasync"
+  vpc_id             = aws_vpc.example.id
+  security_group_ids = [aws_security_group.example.id]
+  subnet_ids         = [aws_subnet.example.id]
+  vpc_endpoint_type  = "Interface"
+}
+
+data "aws_network_interface" "example" {
+  id = tolist(aws_vpc_endpoint.example.network_interface_ids)[0]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -28,7 +55,11 @@ The following arguments are supported:
 * `name` - (Required) Name of the DataSync Agent.
 * `activation_key` - (Optional) DataSync Agent activation key during resource creation. Conflicts with `ip_address`. If an `ip_address` is provided instead, Terraform will retrieve the `activation_key` as part of the resource creation.
 * `ip_address` - (Optional) DataSync Agent IP address to retrieve activation key during resource creation. Conflicts with `activation_key`. DataSync Agent must be accessible on port 80 from where Terraform is running.
+* `private_link_endpoint` - (Optional) The IP address of the VPC endpoint the agent should connect to when retrieving an activation key during resource creation. Conflicts with `activation_key`.
+* `security_group_arns` - (Optional) The ARNs of the security groups used to protect your data transfer task subnets.
+* `subnet_arns` - (Optional) The Amazon Resource Names (ARNs) of the subnets in which DataSync will create elastic network interfaces for each data transfer task.
 * `tags` - (Optional) Key-value pairs of resource tags to assign to the DataSync Agent. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `vpc_endpoint_id` - (Optional) The ID of the VPC (virtual private cloud) endpoint that the agent has access to.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9755

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_datasync_agent: Add support for VPC Endpoints ([#16207](https://github.com/hashicorp/terraform-provider-aws/issues/16207))
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TESTARGS='-run=TestAccAWSDataSyncAgent_'             
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSyncAgent_ -timeout 120m
=== RUN   TestAccAWSDataSyncAgent_basic
=== PAUSE TestAccAWSDataSyncAgent_basic
=== RUN   TestAccAWSDataSyncAgent_disappears
=== PAUSE TestAccAWSDataSyncAgent_disappears
=== RUN   TestAccAWSDataSyncAgent_AgentName
=== PAUSE TestAccAWSDataSyncAgent_AgentName
=== RUN   TestAccAWSDataSyncAgent_Tags
=== PAUSE TestAccAWSDataSyncAgent_Tags
=== RUN   TestAccAWSDataSyncAgent_VpcEndpointId
=== PAUSE TestAccAWSDataSyncAgent_VpcEndpointId
=== CONT  TestAccAWSDataSyncAgent_basic
=== CONT  TestAccAWSDataSyncAgent_Tags
=== CONT  TestAccAWSDataSyncAgent_VpcEndpointId
=== CONT  TestAccAWSDataSyncAgent_AgentName
=== CONT  TestAccAWSDataSyncAgent_disappears
--- PASS: TestAccAWSDataSyncAgent_basic (208.76s)
--- PASS: TestAccAWSDataSyncAgent_disappears (209.61s)
--- PASS: TestAccAWSDataSyncAgent_VpcEndpointId (265.29s)
--- PASS: TestAccAWSDataSyncAgent_AgentName (293.86s)
--- PASS: TestAccAWSDataSyncAgent_Tags (359.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	360.819s
```
