### PR TITLE
tests/resource/aws_acm_certificate: Migrate to SDK TypeSet function

### DIFF
--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -163,7 +162,7 @@ func TestAccAWSAcmCertificate_dnsValidation(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          domain,
 						"resource_record_type": "CNAME",
 					}),
@@ -197,7 +196,7 @@ func TestAccAWSAcmCertificate_root(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", rootDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          rootDomain,
 						"resource_record_type": "CNAME",
 					}),
@@ -283,17 +282,17 @@ func TestAccAWSAcmCertificate_rootAndWildcardSan(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", rootDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          rootDomain,
 						"resource_record_type": "CNAME",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          wildcardDomain,
 						"resource_record_type": "CNAME",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusPendingValidation),
 					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", wildcardDomain),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", wildcardDomain),
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", acm.ValidationMethodDns),
 				),
@@ -341,17 +340,17 @@ func TestAccAWSAcmCertificate_san_single(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          domain,
 						"resource_record_type": "CNAME",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          sanDomain,
 						"resource_record_type": "CNAME",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusPendingValidation),
 					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", sanDomain),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", sanDomain),
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", acm.ValidationMethodDns),
 				),
@@ -383,22 +382,22 @@ func TestAccAWSAcmCertificate_san_multiple(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "3"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          domain,
 						"resource_record_type": "CNAME",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          sanDomain1,
 						"resource_record_type": "CNAME",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          sanDomain2,
 						"resource_record_type": "CNAME",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusPendingValidation),
 					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "2"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", sanDomain1),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", sanDomain2),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", sanDomain1),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", sanDomain2),
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", acm.ValidationMethodDns),
 				),
@@ -429,17 +428,17 @@ func TestAccAWSAcmCertificate_san_TrailingPeriod(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile(`certificate/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          domain,
 						"resource_record_type": "CNAME",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          strings.TrimSuffix(sanDomain, "."),
 						"resource_record_type": "CNAME",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusPendingValidation),
 					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", strings.TrimSuffix(sanDomain, ".")),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", strings.TrimSuffix(sanDomain, ".")),
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", acm.ValidationMethodDns),
 				),
@@ -469,7 +468,7 @@ func TestAccAWSAcmCertificate_wildcard(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", wildcardDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          wildcardDomain,
 						"resource_record_type": "CNAME",
 					}),
@@ -504,17 +503,17 @@ func TestAccAWSAcmCertificate_wildcardAndRootSan(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", wildcardDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          rootDomain,
 						"resource_record_type": "CNAME",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          wildcardDomain,
 						"resource_record_type": "CNAME",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusPendingValidation),
 					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", rootDomain),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", rootDomain),
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", acm.ValidationMethodDns),
 				),
@@ -543,7 +542,7 @@ func TestAccAWSAcmCertificate_disableCTLogging(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", rootDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_options.*", map[string]string{
 						"domain_name":          rootDomain,
 						"resource_record_type": "CNAME",
 					}),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15882

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAcmCertificate'
=== RUN   TestAccAWSAcmCertificateDataSource_singleIssued
--- SKIP: TestAccAWSAcmCertificateDataSource_singleIssued (0.00s)
=== RUN   TestAccAWSAcmCertificateDataSource_multipleIssued
--- SKIP: TestAccAWSAcmCertificateDataSource_multipleIssued (0.00s)
=== RUN   TestAccAWSAcmCertificateDataSource_noMatchReturnsError
--- SKIP: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (0.00s)
=== RUN   TestAccAWSAcmCertificateDataSource_KeyTypes
=== PAUSE TestAccAWSAcmCertificateDataSource_KeyTypes
=== RUN   TestAccAWSAcmCertificate_emailValidation
--- SKIP: TestAccAWSAcmCertificate_emailValidation (0.00s)
=== RUN   TestAccAWSAcmCertificate_dnsValidation
--- SKIP: TestAccAWSAcmCertificate_dnsValidation (0.00s)
=== RUN   TestAccAWSAcmCertificate_root
--- SKIP: TestAccAWSAcmCertificate_root (0.00s)
=== RUN   TestAccAWSAcmCertificate_privateCert
=== PAUSE TestAccAWSAcmCertificate_privateCert
=== RUN   TestAccAWSAcmCertificate_root_TrailingPeriod
--- SKIP: TestAccAWSAcmCertificate_root_TrailingPeriod (0.00s)
=== RUN   TestAccAWSAcmCertificate_rootAndWildcardSan
--- SKIP: TestAccAWSAcmCertificate_rootAndWildcardSan (0.00s)
=== RUN   TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString
--- SKIP: TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString (0.00s)
=== RUN   TestAccAWSAcmCertificate_san_single
--- SKIP: TestAccAWSAcmCertificate_san_single (0.00s)
=== RUN   TestAccAWSAcmCertificate_san_multiple
--- SKIP: TestAccAWSAcmCertificate_san_multiple (0.00s)
=== RUN   TestAccAWSAcmCertificate_san_TrailingPeriod
--- SKIP: TestAccAWSAcmCertificate_san_TrailingPeriod (0.00s)
=== RUN   TestAccAWSAcmCertificate_wildcard
--- SKIP: TestAccAWSAcmCertificate_wildcard (0.00s)
=== RUN   TestAccAWSAcmCertificate_wildcardAndRootSan
--- SKIP: TestAccAWSAcmCertificate_wildcardAndRootSan (0.00s)
=== RUN   TestAccAWSAcmCertificate_disableCTLogging
--- SKIP: TestAccAWSAcmCertificate_disableCTLogging (0.00s)
=== RUN   TestAccAWSAcmCertificate_tags
--- SKIP: TestAccAWSAcmCertificate_tags (0.00s)
=== RUN   TestAccAWSAcmCertificate_imported_DomainName
=== PAUSE TestAccAWSAcmCertificate_imported_DomainName
=== RUN   TestAccAWSAcmCertificate_imported_IpAddress
=== PAUSE TestAccAWSAcmCertificate_imported_IpAddress
=== RUN   TestAccAWSAcmCertificate_PrivateKey_Tags
=== PAUSE TestAccAWSAcmCertificate_PrivateKey_Tags
=== RUN   TestAccAWSAcmCertificateValidation_basic
--- SKIP: TestAccAWSAcmCertificateValidation_basic (0.00s)
=== RUN   TestAccAWSAcmCertificateValidation_timeout
--- SKIP: TestAccAWSAcmCertificateValidation_timeout (0.00s)
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdns
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdns (0.00s)
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail (0.00s)
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot (0.00s)
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard (0.00s)
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan (0.00s)
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard (0.00s)
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot (0.00s)
=== CONT  TestAccAWSAcmCertificateDataSource_KeyTypes
=== CONT  TestAccAWSAcmCertificate_imported_IpAddress
=== CONT  TestAccAWSAcmCertificate_imported_DomainName
=== CONT  TestAccAWSAcmCertificate_PrivateKey_Tags
=== CONT  TestAccAWSAcmCertificate_privateCert
--- PASS: TestAccAWSAcmCertificate_imported_IpAddress (23.97s)
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (33.26s)
--- PASS: TestAccAWSAcmCertificate_privateCert (33.08s)
--- PASS: TestAccAWSAcmCertificate_PrivateKey_Tags (42.39s)
--- PASS: TestAccAWSAcmCertificate_imported_DomainName (71.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	72.963s
```
