### PR TITLE
tests/resource/aws_appautoscaling_policy: Migrate to SDK TypeSet Func…

### DIFF
--- a/aws/resource_aws_appautoscaling_policy_test.go
+++ b/aws/resource_aws_appautoscaling_policy_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestValidateAppautoscalingPolicyImportInput(t *testing.T) {
@@ -101,7 +100,7 @@ func TestAccAWSAppautoScalingPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "step_scaling_policy_configuration.0.adjustment_type", "ChangeInCapacity"),
 					resource.TestCheckResourceAttr(resourceName, "step_scaling_policy_configuration.0.cooldown", "60"),
 					resource.TestCheckResourceAttr(resourceName, "step_scaling_policy_configuration.0.step_adjustment.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
 						"scaling_adjustment":          "1",
 						"metric_interval_lower_bound": "0",
 						"metric_interval_upper_bound": "",
@@ -158,17 +157,17 @@ func TestAccAWSAppautoScalingPolicy_scaleOutAndIn(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_out", "step_scaling_policy_configuration.0.adjustment_type", "PercentChangeInCapacity"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_out", "step_scaling_policy_configuration.0.cooldown", "60"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_out", "step_scaling_policy_configuration.0.step_adjustment.#", "3"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_out", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_out", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
 						"metric_interval_lower_bound": "3",
 						"metric_interval_upper_bound": "",
 						"scaling_adjustment":          "3",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_out", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_out", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
 						"metric_interval_lower_bound": "1",
 						"metric_interval_upper_bound": "3",
 						"scaling_adjustment":          "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_out", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_out", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
 						"metric_interval_lower_bound": "0",
 						"metric_interval_upper_bound": "1",
 						"scaling_adjustment":          "1",
@@ -182,17 +181,17 @@ func TestAccAWSAppautoScalingPolicy_scaleOutAndIn(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_in", "step_scaling_policy_configuration.0.adjustment_type", "PercentChangeInCapacity"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_in", "step_scaling_policy_configuration.0.cooldown", "60"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_in", "step_scaling_policy_configuration.0.step_adjustment.#", "3"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_in", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_in", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
 						"metric_interval_lower_bound": "-1",
 						"metric_interval_upper_bound": "0",
 						"scaling_adjustment":          "-1",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_in", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_in", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
 						"metric_interval_lower_bound": "-3",
 						"metric_interval_upper_bound": "-1",
 						"scaling_adjustment":          "-2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_in", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs("aws_appautoscaling_policy.foobar_in", "step_scaling_policy_configuration.0.step_adjustment.*", map[string]string{
 						"metric_interval_lower_bound": "",
 						"metric_interval_upper_bound": "-3",
 						"scaling_adjustment":          "-3",


### PR DESCRIPTION
…tion

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15882

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAppautoScalingPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAppautoScalingPolicy -timeout 120m
=== RUN   TestAccAWSAppautoScalingPolicy_basic
=== PAUSE TestAccAWSAppautoScalingPolicy_basic
=== RUN   TestAccAWSAppautoScalingPolicy_disappears
=== PAUSE TestAccAWSAppautoScalingPolicy_disappears
=== RUN   TestAccAWSAppautoScalingPolicy_scaleOutAndIn
=== PAUSE TestAccAWSAppautoScalingPolicy_scaleOutAndIn
=== RUN   TestAccAWSAppautoScalingPolicy_spotFleetRequest
=== PAUSE TestAccAWSAppautoScalingPolicy_spotFleetRequest
=== RUN   TestAccAWSAppautoScalingPolicy_dynamodb_table
=== PAUSE TestAccAWSAppautoScalingPolicy_dynamodb_table
=== RUN   TestAccAWSAppautoScalingPolicy_dynamodb_index
=== PAUSE TestAccAWSAppautoScalingPolicy_dynamodb_index
=== RUN   TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName
=== PAUSE TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName
=== RUN   TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource
=== PAUSE TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource
=== RUN   TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew
=== PAUSE TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew
=== CONT  TestAccAWSAppautoScalingPolicy_basic
=== CONT  TestAccAWSAppautoScalingPolicy_dynamodb_index
=== CONT  TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource
=== CONT  TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew
=== CONT  TestAccAWSAppautoScalingPolicy_dynamodb_table
=== CONT  TestAccAWSAppautoScalingPolicy_spotFleetRequest
=== CONT  TestAccAWSAppautoScalingPolicy_scaleOutAndIn
=== CONT  TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName
=== CONT  TestAccAWSAppautoScalingPolicy_disappears
--- PASS: TestAccAWSAppautoScalingPolicy_dynamodb_table (43.81s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName (44.01s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource (50.06s)
--- PASS: TestAccAWSAppautoScalingPolicy_dynamodb_index (58.55s)
--- PASS: TestAccAWSAppautoScalingPolicy_scaleOutAndIn (71.66s)
--- PASS: TestAccAWSAppautoScalingPolicy_disappears (84.96s)
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (89.06s)
--- PASS: TestAccAWSAppautoScalingPolicy_basic (100.53s)
--- PASS: TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew (125.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	125.549s
```
