### PR TITLE
tests/resource/aws_autoscaling: Migrate to SDK TypeSet Function

### DIFF
--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -98,7 +97,7 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupHealthyCapacity(&group, 2),
 					testAccCheckAWSAutoScalingGroupAttributes(&group, randName),
 					testAccMatchResourceAttrRegionalARN("aws_autoscaling_group.bar", "arn", "autoscaling", regexp.MustCompile(`autoScalingGroup:.+`)),
-					tfawsresource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
+					resource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "default_cooldown", "300"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "desired_capacity", "4"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "enabled_metrics.#", "0"),
@@ -391,7 +390,7 @@ func TestAccAWSAutoScalingGroup_VpcUpdates(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "availability_zones.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
+					resource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "vpc_zone_identifier.#", "0"),
 				),
@@ -417,7 +416,7 @@ func TestAccAWSAutoScalingGroup_VpcUpdates(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupAttributesVPCZoneIdentifier(&group),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "availability_zones.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
+					resource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "vpc_zone_identifier.#", "1"),
 				),
@@ -933,7 +932,7 @@ func TestAccAWSAutoScalingGroup_initialLifecycleHook(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupHealthyCapacity(&group, 2),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "initial_lifecycle_hook.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_autoscaling_group.bar", "initial_lifecycle_hook.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs("aws_autoscaling_group.bar", "initial_lifecycle_hook.*", map[string]string{
 						"default_result": "CONTINUE",
 						"name":           "launching",
 					}),

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSAutoscalingPolicy_basic(t *testing.T) {
@@ -46,7 +45,7 @@ func TestAccAWSAutoscalingPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceStepName, "metric_aggregation_type", "Minimum"),
 					resource.TestCheckResourceAttr(resourceStepName, "estimated_instance_warmup", "200"),
 					resource.TestCheckResourceAttr(resourceStepName, "autoscaling_group_name", name),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceStepName, "step_adjustment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceStepName, "step_adjustment.*", map[string]string{
 						"scaling_adjustment": "1",
 					}),
 					testAccCheckScalingPolicyExists(resourceTargetTrackingName, &policy),
@@ -87,7 +86,7 @@ func TestAccAWSAutoscalingPolicy_basic(t *testing.T) {
 					testAccCheckScalingPolicyExists(resourceStepName, &policy),
 					resource.TestCheckResourceAttr(resourceStepName, "policy_type", "StepScaling"),
 					resource.TestCheckResourceAttr(resourceStepName, "estimated_instance_warmup", "20"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceStepName, "step_adjustment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceStepName, "step_adjustment.*", map[string]string{
 						"scaling_adjustment": "10",
 					}),
 					testAccCheckScalingPolicyExists(resourceTargetTrackingName, &policy),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15882

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAutoScalingGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoScalingGroup -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_basic
=== PAUSE TestAccAWSAutoScalingGroup_basic
=== RUN   TestAccAWSAutoScalingGroup_namePrefix
=== PAUSE TestAccAWSAutoScalingGroup_namePrefix
=== RUN   TestAccAWSAutoScalingGroup_autoGeneratedName
=== PAUSE TestAccAWSAutoScalingGroup_autoGeneratedName
=== RUN   TestAccAWSAutoScalingGroup_terminationPolicies
=== PAUSE TestAccAWSAutoScalingGroup_terminationPolicies
=== RUN   TestAccAWSAutoScalingGroup_tags
=== PAUSE TestAccAWSAutoScalingGroup_tags
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
=== PAUSE TestAccAWSAutoScalingGroup_VpcUpdates
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer
=== PAUSE TestAccAWSAutoScalingGroup_WithLoadBalancer
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup
=== PAUSE TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup
=== RUN   TestAccAWSAutoScalingGroup_withPlacementGroup
=== PAUSE TestAccAWSAutoScalingGroup_withPlacementGroup
=== RUN   TestAccAWSAutoScalingGroup_enablingMetrics
=== PAUSE TestAccAWSAutoScalingGroup_enablingMetrics
=== RUN   TestAccAWSAutoScalingGroup_suspendingProcesses
=== PAUSE TestAccAWSAutoScalingGroup_suspendingProcesses
=== RUN   TestAccAWSAutoScalingGroup_withMetrics
=== PAUSE TestAccAWSAutoScalingGroup_withMetrics
=== RUN   TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
=== PAUSE TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
=== RUN   TestAccAWSAutoScalingGroup_MaxInstanceLifetime
=== PAUSE TestAccAWSAutoScalingGroup_MaxInstanceLifetime
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups
=== PAUSE TestAccAWSAutoScalingGroup_ALB_TargetGroups
=== RUN   TestAccAWSAutoScalingGroup_TargetGroupArns
=== PAUSE TestAccAWSAutoScalingGroup_TargetGroupArns
=== RUN   TestAccAWSAutoScalingGroup_initialLifecycleHook
=== PAUSE TestAccAWSAutoScalingGroup_initialLifecycleHook
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
=== PAUSE TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
=== RUN   TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
=== PAUSE TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
=== RUN   TestAccAWSAutoScalingGroup_launchTemplate
=== PAUSE TestAccAWSAutoScalingGroup_launchTemplate
=== RUN   TestAccAWSAutoScalingGroup_launchTemplate_update
=== PAUSE TestAccAWSAutoScalingGroup_launchTemplate_update
=== RUN   TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile
=== PAUSE TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile
=== RUN   TestAccAWSAutoScalingGroup_LoadBalancers
=== PAUSE TestAccAWSAutoScalingGroup_LoadBalancers
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity
=== RUN   TestAccAWSAutoScalingGroup_launchTempPartitionNum
=== PAUSE TestAccAWSAutoScalingGroup_launchTempPartitionNum
=== CONT  TestAccAWSAutoScalingGroup_basic
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice
=== CONT  TestAccAWSAutoScalingGroup_TargetGroupArns
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy
=== CONT  TestAccAWSAutoScalingGroup_LoadBalancers
=== CONT  TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile
=== CONT  TestAccAWSAutoScalingGroup_launchTemplate_update
=== CONT  TestAccAWSAutoScalingGroup_launchTemplate
=== CONT  TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
=== CONT  TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
=== CONT  TestAccAWSAutoScalingGroup_initialLifecycleHook
=== CONT  TestAccAWSAutoScalingGroup_withPlacementGroup
=== CONT  TestAccAWSAutoScalingGroup_ALB_TargetGroups
=== CONT  TestAccAWSAutoScalingGroup_MaxInstanceLifetime
2020/11/17 00:05:55 [DEBUG] aws_ami - adding block device mapping: map[device_name:/dev/xvda ebs:map[delete_on_termination:true encrypted:false iops:0 snapshot_id:snap-00cc9115eae439720 volume_size:8 volume_type:gp2] virtual_name:]
--- FAIL: TestAccAWSAutoScalingGroup_launchTemplate (22.54s)
=== CONT  TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
--- FAIL: TestAccAWSAutoScalingGroup_launchTemplate_update (24.27s)
=== CONT  TestAccAWSAutoScalingGroup_withMetrics
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (25.76s)
=== CONT  TestAccAWSAutoScalingGroup_suspendingProcesses
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (25.94s)
=== CONT  TestAccAWSAutoScalingGroup_enablingMetrics
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (26.83s)
=== CONT  TestAccAWSAutoScalingGroup_WithLoadBalancer
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity (26.87s)
=== CONT  TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (26.87s)
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity
2020/11/17 00:06:11 [DEBUG] Launch Template deleted: lt-062d321daaeedb391
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (27.05s)
=== CONT  TestAccAWSAutoScalingGroup_launchTempPartitionNum
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (27.14s)
=== CONT  TestAccAWSAutoScalingGroup_VpcUpdates
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (28.22s)
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version
--- FAIL: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (28.76s)
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType
--- FAIL: TestAccAWSAutoScalingGroup_WithLoadBalancer (15.64s)
=== CONT
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (17.48s)
=== CONT  TestAccAWSAutoScalingGroup_autoGeneratedName
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (17.04s)
=== CONT  TestAccAWSAutoScalingGroup_tags
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (16.89s)
=== CONT  TestAccAWSAutoScalingGroup_namePrefix
--- FAIL: TestAccAWSAutoScalingGroup_launchTempPartitionNum (21.34s)
=== CONT  TestAccAWSAutoScalingGroup_terminationPolicies
--- FAIL: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (15.24s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (79.06s)
--- FAIL: TestAccAWSAutoScalingGroup_VpcUpdates (54.56s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (39.02s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (38.27s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (62.55s)
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (88.00s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (67.23s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (114.26s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (195.43s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (227.92s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (388.86s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (433.72s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (438.74s)
--- FAIL: TestAccAWSAutoScalingGroup_basic (629.98s)
--- FAIL: TestAccAWSAutoScalingGroup_initialLifecycleHook (631.81s)
--- FAIL: TestAccAWSAutoScalingGroup_withPlacementGroup (648.71s)
--- FAIL: TestAccAWSAutoScalingGroup_enablingMetrics (643.05s)
--- FAIL: TestAccAWSAutoScalingGroup_suspendingProcesses (643.39s)
--- FAIL: TestAccAWSAutoScalingGroup_tags (641.70s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	687.013s
FAIL
```
Note that the failures above are all due to me not having enough available VPCs due to small account limits, or not having a default VPC configured.