### PR TITLE
tests/resource/aws_waf: Migrate to SDK TypeSet Function

### DIFF
--- a/aws/resource_aws_waf_byte_match_set_test.go
+++ b/aws/resource_aws_waf_byte_match_set_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -107,7 +106,7 @@ func TestAccAWSWafByteMatchSet_basic(t *testing.T) {
 					testAccCheckAWSWafByteMatchSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", byteMatchSet),
 					resource.TestCheckResourceAttr(resourceName, "byte_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -115,7 +114,7 @@ func TestAccAWSWafByteMatchSet_basic(t *testing.T) {
 						"target_string":         "badrefer1",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -186,7 +185,7 @@ func TestAccAWSWafByteMatchSet_changeTuples(t *testing.T) {
 					testAccCheckAWSWafByteMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", byteMatchSetName),
 					resource.TestCheckResourceAttr(resourceName, "byte_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -194,7 +193,7 @@ func TestAccAWSWafByteMatchSet_changeTuples(t *testing.T) {
 						"target_string":         "badrefer1",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -210,7 +209,7 @@ func TestAccAWSWafByteMatchSet_changeTuples(t *testing.T) {
 					testAccCheckAWSWafByteMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", byteMatchSetName),
 					resource.TestCheckResourceAttr(resourceName, "byte_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -218,7 +217,7 @@ func TestAccAWSWafByteMatchSet_changeTuples(t *testing.T) {
 						"target_string":         "badrefer1",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "METHOD",

--- a/aws/resource_aws_waf_geo_match_set_test.go
+++ b/aws/resource_aws_waf_geo_match_set_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -108,11 +107,11 @@ func TestAccAWSWafGeoMatchSet_basic(t *testing.T) {
 					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "waf", regexp.MustCompile(`geomatchset/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", geoMatchSet),
 					resource.TestCheckResourceAttr(resourceName, "geo_match_constraint.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "US",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "CA",
 					}),
@@ -201,11 +200,11 @@ func TestAccAWSWafGeoMatchSet_changeConstraints(t *testing.T) {
 					testAccCheckAWSWafGeoMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", setName),
 					resource.TestCheckResourceAttr(resourceName, "geo_match_constraint.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "US",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "CA",
 					}),
@@ -217,11 +216,11 @@ func TestAccAWSWafGeoMatchSet_changeConstraints(t *testing.T) {
 					testAccCheckAWSWafGeoMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", setName),
 					resource.TestCheckResourceAttr(resourceName, "geo_match_constraint.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "RU",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "CN",
 					}),

--- a/aws/resource_aws_waf_ipset_test.go
+++ b/aws/resource_aws_waf_ipset_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -109,7 +108,7 @@ func TestAccAWSWafIPSet_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -163,7 +162,7 @@ func TestAccAWSWafIPSet_changeNameForceNew(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -179,7 +178,7 @@ func TestAccAWSWafIPSet_changeNameForceNew(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", uName),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -205,7 +204,7 @@ func TestAccAWSWafIPSet_changeDescriptors(t *testing.T) {
 					testAccCheckAWSWafIPSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -222,7 +221,7 @@ func TestAccAWSWafIPSet_changeDescriptors(t *testing.T) {
 					testAccCheckAWSWafIPSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.8.0/24",
 					}),

--- a/aws/resource_aws_waf_rate_based_rule_test.go
+++ b/aws/resource_aws_waf_rate_based_rule_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -200,7 +199,7 @@ func TestAccAWSWafRateBasedRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRateBasedRuleExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "false",
 						"type":    "IPMatch",
 					}),
@@ -213,7 +212,7 @@ func TestAccAWSWafRateBasedRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRateBasedRuleExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "true",
 						"type":    "ByteMatch",
 					}),
@@ -248,7 +247,7 @@ func TestAccAWSWafRateBasedRule_changeRateLimit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "rate_limit", "4000"),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "false",
 						"type":    "IPMatch",
 					}),
@@ -262,7 +261,7 @@ func TestAccAWSWafRateBasedRule_changeRateLimit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "rate_limit", "3000"),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "false",
 						"type":    "IPMatch",
 					}),

--- a/aws/resource_aws_waf_regex_match_set_test.go
+++ b/aws/resource_aws_waf_regex_match_set_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -137,7 +136,7 @@ func testAccAWSWafRegexMatchSet_basic(t *testing.T) {
 					computeWafRegexMatchSetTuple(&patternSet, &fieldToMatch, "NONE", &idx),
 					resource.TestCheckResourceAttr(resourceName, "name", matchSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "user-agent",
 						"field_to_match.0.type": "HEADER",
@@ -176,7 +175,7 @@ func testAccAWSWafRegexMatchSet_changePatterns(t *testing.T) {
 					computeWafRegexMatchSetTuple(&patternSet, &waf.FieldToMatch{Data: aws.String("User-Agent"), Type: aws.String("HEADER")}, "NONE", &idx1),
 					resource.TestCheckResourceAttr(resourceName, "name", matchSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "user-agent",
 						"field_to_match.0.type": "HEADER",
@@ -192,7 +191,7 @@ func testAccAWSWafRegexMatchSet_changePatterns(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "1"),
 
 					computeWafRegexMatchSetTuple(&patternSet, &waf.FieldToMatch{Data: aws.String("Referer"), Type: aws.String("HEADER")}, "COMPRESS_WHITE_SPACE", &idx2),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",

--- a/aws/resource_aws_waf_regex_pattern_set_test.go
+++ b/aws/resource_aws_waf_regex_pattern_set_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -126,8 +125,8 @@ func testAccAWSWafRegexPatternSet_basic(t *testing.T) {
 					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "waf", regexp.MustCompile(`regexpatternset/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "2"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "one"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "one"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
 				),
 			},
 			{
@@ -155,8 +154,8 @@ func testAccAWSWafRegexPatternSet_changePatterns(t *testing.T) {
 					testAccCheckAWSWafRegexPatternSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "2"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "one"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "one"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
 				),
 			},
 			{
@@ -165,9 +164,9 @@ func testAccAWSWafRegexPatternSet_changePatterns(t *testing.T) {
 					testAccCheckAWSWafRegexPatternSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "3"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "three"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "four"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "three"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "four"),
 				),
 			},
 			{

--- a/aws/resource_aws_waf_rule_group_test.go
+++ b/aws/resource_aws_waf_rule_group_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -113,7 +112,7 @@ func TestAccAWSWafRuleGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric_name", groupName),
 					computeWafActivatedRuleWithRuleId(&rule, "COUNT", 50, &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "COUNT",
 						"priority":      "50",
 						"type":          waf.WafRuleTypeRegular,
@@ -217,7 +216,7 @@ func TestAccAWSWafRuleGroup_changeActivatedRules(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
 					computeWafActivatedRuleWithRuleId(&rule0, "COUNT", 50, &idx0),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "COUNT",
 						"priority":      "50",
 						"type":          waf.WafRuleTypeRegular,
@@ -233,7 +232,7 @@ func TestAccAWSWafRuleGroup_changeActivatedRules(t *testing.T) {
 
 					testAccCheckAWSWafRuleExists("aws_waf_rule.test", &rule1),
 					computeWafActivatedRuleWithRuleId(&rule1, "BLOCK", 10, &idx1),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "BLOCK",
 						"priority":      "10",
 						"type":          waf.WafRuleTypeRegular,
@@ -241,7 +240,7 @@ func TestAccAWSWafRuleGroup_changeActivatedRules(t *testing.T) {
 
 					testAccCheckAWSWafRuleExists("aws_waf_rule.test2", &rule2),
 					computeWafActivatedRuleWithRuleId(&rule2, "COUNT", 1, &idx2),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "COUNT",
 						"priority":      "1",
 						"type":          waf.WafRuleTypeRegular,
@@ -249,7 +248,7 @@ func TestAccAWSWafRuleGroup_changeActivatedRules(t *testing.T) {
 
 					testAccCheckAWSWafRuleExists("aws_waf_rule.test3", &rule3),
 					computeWafActivatedRuleWithRuleId(&rule3, "BLOCK", 15, &idx3),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "BLOCK",
 						"priority":      "15",
 						"type":          waf.WafRuleTypeRegular,

--- a/aws/resource_aws_waf_rule_test.go
+++ b/aws/resource_aws_waf_rule_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -197,7 +196,7 @@ func TestAccAWSWafRule_changePredicates(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
 					computeWafRulePredicateWithIpSet(&ipset, false, "IPMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "false",
 						"type":    "IPMatch",
 					}),
@@ -211,7 +210,7 @@ func TestAccAWSWafRule_changePredicates(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
 					computeWafRulePredicateWithByteMatchSet(&byteMatchSet, true, "ByteMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "true",
 						"type":    "ByteMatch",
 					}),
@@ -242,7 +241,7 @@ func TestAccAWSWafRule_geoMatchSetPredicate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
 					computeWafRulePredicateWithGeoMatchSet(&geoMatchSet, true, "GeoMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "true",
 						"type":    "GeoMatch",
 					}),

--- a/aws/resource_aws_waf_size_constraint_set_test.go
+++ b/aws/resource_aws_waf_size_constraint_set_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -109,13 +108,13 @@ func TestAccAWSWafSizeConstraintSet_basic(t *testing.T) {
 					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "waf", regexp.MustCompile(`sizeconstraintset/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", sizeConstraintSet),
 					resource.TestCheckResourceAttr(resourceName, "size_constraints.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
 						"comparison_operator": "EQ",
 						"field_to_match.#":    "1",
 						"size":                "4096",
 						"text_transformation": "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
 						"data": "",
 						"type": "BODY",
 					}),
@@ -204,13 +203,13 @@ func TestAccAWSWafSizeConstraintSet_changeConstraints(t *testing.T) {
 					testAccCheckAWSWafSizeConstraintSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", setName),
 					resource.TestCheckResourceAttr(resourceName, "size_constraints.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
 						"comparison_operator": "EQ",
 						"field_to_match.#":    "1",
 						"size":                "4096",
 						"text_transformation": "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
 						"data": "",
 						"type": "BODY",
 					}),
@@ -222,13 +221,13 @@ func TestAccAWSWafSizeConstraintSet_changeConstraints(t *testing.T) {
 					testAccCheckAWSWafSizeConstraintSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", setName),
 					resource.TestCheckResourceAttr(resourceName, "size_constraints.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
 						"comparison_operator": "GE",
 						"field_to_match.#":    "1",
 						"size":                "1024",
 						"text_transformation": "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
 						"data": "",
 						"type": "BODY",
 					}),

--- a/aws/resource_aws_waf_sql_injection_match_set_test.go
+++ b/aws/resource_aws_waf_sql_injection_match_set_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -106,7 +105,7 @@ func TestAccAWSWafSqlInjectionMatchSet_basic(t *testing.T) {
 					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "QUERY_STRING",
@@ -197,7 +196,7 @@ func TestAccAWSWafSqlInjectionMatchSet_changeTuples(t *testing.T) {
 					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "QUERY_STRING",

--- a/aws/resource_aws_waf_xss_match_set_test.go
+++ b/aws/resource_aws_waf_xss_match_set_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -108,13 +107,13 @@ func TestAccAWSWafXssMatchSet_basic(t *testing.T) {
 					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "waf", regexp.MustCompile(`xssmatchset/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "URI",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "QUERY_STRING",
@@ -205,13 +204,13 @@ func TestAccAWSWafXssMatchSet_changeTuples(t *testing.T) {
 					testAccCheckAWSWafXssMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", setName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "QUERY_STRING",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "URI",
@@ -225,13 +224,13 @@ func TestAccAWSWafXssMatchSet_changeTuples(t *testing.T) {
 					testAccCheckAWSWafXssMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", setName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "METHOD",
 						"text_transformation":   "HTML_ENTITY_DECODE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "BODY",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15882

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSWaf'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSWaf -timeout 120m
=== RUN   TestAccAWSWafByteMatchSet_basic
=== PAUSE TestAccAWSWafByteMatchSet_basic
=== RUN   TestAccAWSWafByteMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafByteMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafByteMatchSet_changeTuples
=== PAUSE TestAccAWSWafByteMatchSet_changeTuples
=== RUN   TestAccAWSWafByteMatchSet_noTuples
=== PAUSE TestAccAWSWafByteMatchSet_noTuples
=== RUN   TestAccAWSWafByteMatchSet_disappears
=== PAUSE TestAccAWSWafByteMatchSet_disappears
=== RUN   TestAccAWSWafGeoMatchSet_basic
=== PAUSE TestAccAWSWafGeoMatchSet_basic
=== RUN   TestAccAWSWafGeoMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafGeoMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafGeoMatchSet_disappears
=== PAUSE TestAccAWSWafGeoMatchSet_disappears
=== RUN   TestAccAWSWafGeoMatchSet_changeConstraints
=== PAUSE TestAccAWSWafGeoMatchSet_changeConstraints
=== RUN   TestAccAWSWafGeoMatchSet_noConstraints
=== PAUSE TestAccAWSWafGeoMatchSet_noConstraints
=== RUN   TestAccAWSWafIPSet_basic
=== PAUSE TestAccAWSWafIPSet_basic
=== RUN   TestAccAWSWafIPSet_disappears
=== PAUSE TestAccAWSWafIPSet_disappears
=== RUN   TestAccAWSWafIPSet_changeNameForceNew
=== PAUSE TestAccAWSWafIPSet_changeNameForceNew
=== RUN   TestAccAWSWafIPSet_changeDescriptors
=== PAUSE TestAccAWSWafIPSet_changeDescriptors
=== RUN   TestAccAWSWafIPSet_noDescriptors
=== PAUSE TestAccAWSWafIPSet_noDescriptors
=== RUN   TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit
=== PAUSE TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit
=== RUN   TestAccAWSWafIPSet_ipv6
=== PAUSE TestAccAWSWafIPSet_ipv6
=== RUN   TestAccAWSWafRateBasedRule_basic
=== PAUSE TestAccAWSWafRateBasedRule_basic
=== RUN   TestAccAWSWafRateBasedRule_changeNameForceNew
=== PAUSE TestAccAWSWafRateBasedRule_changeNameForceNew
=== RUN   TestAccAWSWafRateBasedRule_disappears
=== PAUSE TestAccAWSWafRateBasedRule_disappears
=== RUN   TestAccAWSWafRateBasedRule_changePredicates
=== PAUSE TestAccAWSWafRateBasedRule_changePredicates
=== RUN   TestAccAWSWafRateBasedRule_changeRateLimit
=== PAUSE TestAccAWSWafRateBasedRule_changeRateLimit
=== RUN   TestAccAWSWafRateBasedRule_noPredicates
=== PAUSE TestAccAWSWafRateBasedRule_noPredicates
=== RUN   TestAccAWSWafRateBasedRule_Tags
=== PAUSE TestAccAWSWafRateBasedRule_Tags
=== RUN   TestAccAWSWafRegexMatchSet_serial
=== RUN   TestAccAWSWafRegexMatchSet_serial/disappears
=== RUN   TestAccAWSWafRegexMatchSet_serial/basic
=== RUN   TestAccAWSWafRegexMatchSet_serial/changePatterns
=== RUN   TestAccAWSWafRegexMatchSet_serial/noPatterns
--- PASS: TestAccAWSWafRegexMatchSet_serial (118.67s)
    --- PASS: TestAccAWSWafRegexMatchSet_serial/disappears (29.30s)
    --- PASS: TestAccAWSWafRegexMatchSet_serial/basic (28.68s)
    --- PASS: TestAccAWSWafRegexMatchSet_serial/changePatterns (42.83s)
    --- PASS: TestAccAWSWafRegexMatchSet_serial/noPatterns (17.87s)
=== RUN   TestAccAWSWafRegexPatternSet_serial
=== RUN   TestAccAWSWafRegexPatternSet_serial/basic
=== RUN   TestAccAWSWafRegexPatternSet_serial/changePatterns
=== RUN   TestAccAWSWafRegexPatternSet_serial/noPatterns
=== RUN   TestAccAWSWafRegexPatternSet_serial/disappears
--- PASS: TestAccAWSWafRegexPatternSet_serial (92.83s)
    --- PASS: TestAccAWSWafRegexPatternSet_serial/basic (19.52s)
    --- PASS: TestAccAWSWafRegexPatternSet_serial/changePatterns (38.46s)
    --- PASS: TestAccAWSWafRegexPatternSet_serial/noPatterns (19.16s)
    --- PASS: TestAccAWSWafRegexPatternSet_serial/disappears (15.69s)
=== RUN   TestAccAWSWafRuleGroup_basic
=== PAUSE TestAccAWSWafRuleGroup_basic
=== RUN   TestAccAWSWafRuleGroup_changeNameForceNew
=== PAUSE TestAccAWSWafRuleGroup_changeNameForceNew
=== RUN   TestAccAWSWafRuleGroup_disappears
=== PAUSE TestAccAWSWafRuleGroup_disappears
=== RUN   TestAccAWSWafRuleGroup_changeActivatedRules
=== PAUSE TestAccAWSWafRuleGroup_changeActivatedRules
=== RUN   TestAccAWSWafRuleGroup_Tags
=== PAUSE TestAccAWSWafRuleGroup_Tags
=== RUN   TestAccAWSWafRuleGroup_noActivatedRules
=== PAUSE TestAccAWSWafRuleGroup_noActivatedRules
=== RUN   TestAccAWSWafRule_basic
=== PAUSE TestAccAWSWafRule_basic
=== RUN   TestAccAWSWafRule_changeNameForceNew
=== PAUSE TestAccAWSWafRule_changeNameForceNew
=== RUN   TestAccAWSWafRule_disappears
=== PAUSE TestAccAWSWafRule_disappears
=== RUN   TestAccAWSWafRule_changePredicates
=== PAUSE TestAccAWSWafRule_changePredicates
=== RUN   TestAccAWSWafRule_geoMatchSetPredicate
=== PAUSE TestAccAWSWafRule_geoMatchSetPredicate
=== RUN   TestAccAWSWafRule_noPredicates
=== PAUSE TestAccAWSWafRule_noPredicates
=== RUN   TestAccAWSWafRule_Tags
=== PAUSE TestAccAWSWafRule_Tags
=== RUN   TestAccAWSWafSizeConstraintSet_basic
=== PAUSE TestAccAWSWafSizeConstraintSet_basic
=== RUN   TestAccAWSWafSizeConstraintSet_changeNameForceNew
=== PAUSE TestAccAWSWafSizeConstraintSet_changeNameForceNew
=== RUN   TestAccAWSWafSizeConstraintSet_disappears
=== PAUSE TestAccAWSWafSizeConstraintSet_disappears
=== RUN   TestAccAWSWafSizeConstraintSet_changeConstraints
=== PAUSE TestAccAWSWafSizeConstraintSet_changeConstraints
=== RUN   TestAccAWSWafSizeConstraintSet_noConstraints
=== PAUSE TestAccAWSWafSizeConstraintSet_noConstraints
=== RUN   TestAccAWSWafSqlInjectionMatchSet_basic
=== PAUSE TestAccAWSWafSqlInjectionMatchSet_basic
=== RUN   TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafSqlInjectionMatchSet_disappears
=== PAUSE TestAccAWSWafSqlInjectionMatchSet_disappears
=== RUN   TestAccAWSWafSqlInjectionMatchSet_changeTuples
=== PAUSE TestAccAWSWafSqlInjectionMatchSet_changeTuples
=== RUN   TestAccAWSWafSqlInjectionMatchSet_noTuples
=== PAUSE TestAccAWSWafSqlInjectionMatchSet_noTuples
=== RUN   TestAccAWSWafWebAcl_basic
=== PAUSE TestAccAWSWafWebAcl_basic
=== RUN   TestAccAWSWafWebAcl_changeNameForceNew
=== PAUSE TestAccAWSWafWebAcl_changeNameForceNew
=== RUN   TestAccAWSWafWebAcl_DefaultAction
=== PAUSE TestAccAWSWafWebAcl_DefaultAction
=== RUN   TestAccAWSWafWebAcl_Rules
=== PAUSE TestAccAWSWafWebAcl_Rules
=== RUN   TestAccAWSWafWebAcl_LoggingConfiguration
=== PAUSE TestAccAWSWafWebAcl_LoggingConfiguration
=== RUN   TestAccAWSWafWebAcl_disappears
=== PAUSE TestAccAWSWafWebAcl_disappears
=== RUN   TestAccAWSWafWebAcl_Tags
=== PAUSE TestAccAWSWafWebAcl_Tags
=== RUN   TestAccAWSWafXssMatchSet_basic
=== PAUSE TestAccAWSWafXssMatchSet_basic
=== RUN   TestAccAWSWafXssMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafXssMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafXssMatchSet_disappears
=== PAUSE TestAccAWSWafXssMatchSet_disappears
=== RUN   TestAccAWSWafXssMatchSet_changeTuples
=== PAUSE TestAccAWSWafXssMatchSet_changeTuples
=== RUN   TestAccAWSWafXssMatchSet_noTuples
=== PAUSE TestAccAWSWafXssMatchSet_noTuples
=== RUN   TestAccAWSWafRegionalByteMatchSet_basic
=== PAUSE TestAccAWSWafRegionalByteMatchSet_basic
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
=== PAUSE TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
=== RUN   TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
=== PAUSE TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
=== RUN   TestAccAWSWafRegionalByteMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalByteMatchSet_disappears
=== RUN   TestAccAWSWafRegionalGeoMatchSet_basic
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_basic
=== RUN   TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalGeoMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_disappears
=== RUN   TestAccAWSWafRegionalGeoMatchSet_changeConstraints
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_changeConstraints
=== RUN   TestAccAWSWafRegionalGeoMatchSet_noConstraints
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_noConstraints
=== RUN   TestAccAWSWafRegionalIPSet_basic
=== PAUSE TestAccAWSWafRegionalIPSet_basic
=== RUN   TestAccAWSWafRegionalIPSet_disappears
=== PAUSE TestAccAWSWafRegionalIPSet_disappears
=== RUN   TestAccAWSWafRegionalIPSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalIPSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalIPSet_changeDescriptors
=== PAUSE TestAccAWSWafRegionalIPSet_changeDescriptors
=== RUN   TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit
=== PAUSE TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit
=== RUN   TestAccAWSWafRegionalIPSet_noDescriptors
=== PAUSE TestAccAWSWafRegionalIPSet_noDescriptors
=== RUN   TestAccAWSWafRegionalRateBasedRule_basic
=== PAUSE TestAccAWSWafRegionalRateBasedRule_basic
=== RUN   TestAccAWSWafRegionalRateBasedRule_tags
=== PAUSE TestAccAWSWafRegionalRateBasedRule_tags
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
=== RUN   TestAccAWSWafRegionalRateBasedRule_disappears
=== PAUSE TestAccAWSWafRegionalRateBasedRule_disappears
=== RUN   TestAccAWSWafRegionalRateBasedRule_changePredicates
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changePredicates
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeRateLimit
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changeRateLimit
=== RUN   TestAccAWSWafRegionalRateBasedRule_noPredicates
=== PAUSE TestAccAWSWafRegionalRateBasedRule_noPredicates
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial/basic
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial/changePatterns
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial/noPatterns
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial/disappears
--- PASS: TestAccAWSWafRegionalRegexMatchSet_serial (78.93s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/basic (17.50s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/changePatterns (31.95s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/noPatterns (13.96s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/disappears (15.52s)
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial/noPatterns
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial/disappears
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial/basic
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial/changePatterns
--- PASS: TestAccAWSWafRegionalRegexPatternSet_serial (59.29s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet_serial/noPatterns (11.75s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet_serial/disappears (10.54s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet_serial/basic (14.10s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet_serial/changePatterns (22.91s)
=== RUN   TestAccAWSWafRegionalRuleGroup_basic
=== PAUSE TestAccAWSWafRegionalRuleGroup_basic
=== RUN   TestAccAWSWafRegionalRuleGroup_tags
=== PAUSE TestAccAWSWafRegionalRuleGroup_tags
=== RUN   TestAccAWSWafRegionalRuleGroup_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalRuleGroup_changeNameForceNew
=== RUN   TestAccAWSWafRegionalRuleGroup_disappears
=== PAUSE TestAccAWSWafRegionalRuleGroup_disappears
=== RUN   TestAccAWSWafRegionalRuleGroup_changeActivatedRules
=== PAUSE TestAccAWSWafRegionalRuleGroup_changeActivatedRules
=== RUN   TestAccAWSWafRegionalRuleGroup_noActivatedRules
=== PAUSE TestAccAWSWafRegionalRuleGroup_noActivatedRules
=== RUN   TestAccAWSWafRegionalRule_basic
=== PAUSE TestAccAWSWafRegionalRule_basic
=== RUN   TestAccAWSWafRegionalRule_tags
=== PAUSE TestAccAWSWafRegionalRule_tags
=== RUN   TestAccAWSWafRegionalRule_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalRule_changeNameForceNew
=== RUN   TestAccAWSWafRegionalRule_disappears
=== PAUSE TestAccAWSWafRegionalRule_disappears
=== RUN   TestAccAWSWafRegionalRule_noPredicates
=== PAUSE TestAccAWSWafRegionalRule_noPredicates
=== RUN   TestAccAWSWafRegionalRule_changePredicates
=== PAUSE TestAccAWSWafRegionalRule_changePredicates
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_basic
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_basic
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_disappears
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_disappears
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_noConstraints
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_noConstraints
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_basic
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_basic
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
=== RUN   TestAccAWSWafRegionalWebAclAssociation_basic
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_basic
=== RUN   TestAccAWSWafRegionalWebAclAssociation_disappears
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_disappears
=== RUN   TestAccAWSWafRegionalWebAclAssociation_multipleAssociations
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_multipleAssociations
=== RUN   TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage
=== RUN   TestAccAWSWafRegionalWebAcl_basic
=== PAUSE TestAccAWSWafRegionalWebAcl_basic
=== RUN   TestAccAWSWafRegionalWebAcl_tags
=== PAUSE TestAccAWSWafRegionalWebAcl_tags
=== RUN   TestAccAWSWafRegionalWebAcl_createRateBased
=== PAUSE TestAccAWSWafRegionalWebAcl_createRateBased
=== RUN   TestAccAWSWafRegionalWebAcl_createGroup
=== PAUSE TestAccAWSWafRegionalWebAcl_createGroup
=== RUN   TestAccAWSWafRegionalWebAcl_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalWebAcl_changeNameForceNew
=== RUN   TestAccAWSWafRegionalWebAcl_changeDefaultAction
=== PAUSE TestAccAWSWafRegionalWebAcl_changeDefaultAction
=== RUN   TestAccAWSWafRegionalWebAcl_disappears
=== PAUSE TestAccAWSWafRegionalWebAcl_disappears
=== RUN   TestAccAWSWafRegionalWebAcl_noRules
=== PAUSE TestAccAWSWafRegionalWebAcl_noRules
=== RUN   TestAccAWSWafRegionalWebAcl_changeRules
=== PAUSE TestAccAWSWafRegionalWebAcl_changeRules
=== RUN   TestAccAWSWafRegionalWebAcl_LoggingConfiguration
=== PAUSE TestAccAWSWafRegionalWebAcl_LoggingConfiguration
=== RUN   TestAccAWSWafRegionalXssMatchSet_basic
=== PAUSE TestAccAWSWafRegionalXssMatchSet_basic
=== RUN   TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalXssMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalXssMatchSet_disappears
=== RUN   TestAccAWSWafRegionalXssMatchSet_changeTuples
=== PAUSE TestAccAWSWafRegionalXssMatchSet_changeTuples
=== RUN   TestAccAWSWafRegionalXssMatchSet_noTuples
=== PAUSE TestAccAWSWafRegionalXssMatchSet_noTuples
=== CONT  TestAccAWSWafByteMatchSet_basic
=== CONT  TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
=== CONT  TestAccAWSWafRule_changeNameForceNew
=== CONT  TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
=== CONT  TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
=== CONT  TestAccAWSWafRegionalByteMatchSet_basic
=== CONT  TestAccAWSWafXssMatchSet_noTuples
=== CONT  TestAccAWSWafIPSet_ipv6
=== CONT  TestAccAWSWafXssMatchSet_changeTuples
=== CONT  TestAccAWSWafSqlInjectionMatchSet_changeTuples
=== CONT  TestAccAWSWafRegionalRule_changePredicates
=== CONT  TestAccAWSWafRegionalXssMatchSet_noTuples
=== CONT  TestAccAWSWafRegionalXssMatchSet_changeTuples
=== CONT  TestAccAWSWafRegionalXssMatchSet_disappears
=== CONT  TestAccAWSWafRegionalXssMatchSet_basic
=== CONT  TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
=== CONT  TestAccAWSWafRegionalWebAcl_changeRules
=== CONT  TestAccAWSWafRegionalWebAcl_noRules
=== CONT  TestAccAWSWafRegionalWebAcl_disappears
=== CONT  TestAccAWSWafRegionalWebAcl_LoggingConfiguration
--- PASS: TestAccAWSWafRegionalXssMatchSet_noTuples (23.94s)
=== CONT  TestAccAWSWafRegionalWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafRegionalWebAcl_noRules (25.96s)
=== CONT  TestAccAWSWafRegionalWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafIPSet_ipv6 (27.52s)
=== CONT  TestAccAWSWafRegionalWebAcl_createGroup
--- PASS: TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples (28.61s)
=== CONT  TestAccAWSWafRegionalWebAcl_createRateBased
--- PASS: TestAccAWSWafRegionalByteMatchSet_basic (29.31s)
=== CONT  TestAccAWSWafRegionalWebAcl_tags
--- PASS: TestAccAWSWafXssMatchSet_noTuples (30.54s)
=== CONT  TestAccAWSWafRegionalWebAcl_basic
2020/11/17 09:18:36 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSWafRegionalXssMatchSet_basic (36.05s)
=== CONT  TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage
2020/11/17 09:18:42 [DEBUG] Unlocking "eu-west-2"
2020/11/17 09:18:42 [DEBUG] Locked "eu-west-2"
2020/11/17 09:18:42 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSWafRegionalXssMatchSet_disappears (38.31s)
=== CONT  TestAccAWSWafRegionalWebAclAssociation_multipleAssociations
--- PASS: TestAccAWSWafByteMatchSet_basic (39.24s)
=== CONT  TestAccAWSWafRegionalWebAclAssociation_disappears
2020/11/17 09:18:55 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSWafRegionalWebAcl_disappears (51.14s)
=== CONT  TestAccAWSWafRegionalWebAclAssociation_basic
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeTuples (55.06s)
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
--- PASS: TestAccAWSWafXssMatchSet_changeTuples (59.43s)
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples (59.72s)
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeTuples (60.30s)
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
2020/11/17 09:19:22 [DEBUG] Locking "WafRetryer"
2020/11/17 09:19:22 [DEBUG] Locked "WafRetryer"
2020/11/17 09:19:22 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSWafRegionalWebAcl_changeRules (76.87s)
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_basic
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples (25.93s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_noConstraints
--- PASS: TestAccAWSWafRegionalWebAcl_createRateBased (53.40s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
--- PASS: TestAccAWSWafRule_changeNameForceNew (83.10s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_disappears
--- PASS: TestAccAWSWafRegionalWebAcl_createGroup (56.31s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeNameForceNew (84.35s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_basic
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeNameForceNew (84.96s)
=== CONT  TestAccAWSWafRuleGroup_basic
--- PASS: TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage (51.43s)
=== CONT  TestAccAWSWafRule_basic
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_disappears (34.01s)
=== CONT  TestAccAWSWafRuleGroup_noActivatedRules
--- PASS: TestAccAWSWafRegionalWebAcl_basic (65.97s)
=== CONT  TestAccAWSWafRuleGroup_Tags
--- PASS: TestAccAWSWafRegionalRule_changePredicates (103.11s)
=== CONT  TestAccAWSWafRuleGroup_changeActivatedRules
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_noConstraints (23.20s)
=== CONT  TestAccAWSWafSqlInjectionMatchSet_disappears
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples (51.21s)
=== CONT  TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_basic (35.57s)
=== CONT  TestAccAWSWafSqlInjectionMatchSet_basic
--- PASS: TestAccAWSWafRegionalWebAcl_tags (83.71s)
=== CONT  TestAccAWSWafSizeConstraintSet_noConstraints
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_disappears (32.05s)
=== CONT  TestAccAWSWafRuleGroup_disappears
--- PASS: TestAccAWSWafRegionalWebAcl_changeDefaultAction (91.45s)
=== CONT  TestAccAWSWafSizeConstraintSet_changeConstraints
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_basic (32.26s)
=== CONT  TestAccAWSWafRuleGroup_changeNameForceNew
--- PASS: TestAccAWSWafRuleGroup_noActivatedRules (26.93s)
=== CONT  TestAccAWSWafSizeConstraintSet_disappears
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew (60.85s)
=== CONT  TestAccAWSWafSizeConstraintSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_changeConstraints (42.61s)
=== CONT  TestAccAWSWafRule_noPredicates
--- PASS: TestAccAWSWafRegionalWebAcl_changeNameForceNew (101.51s)
=== CONT  TestAccAWSWafRule_geoMatchSetPredicate
--- PASS: TestAccAWSWafSqlInjectionMatchSet_disappears (23.30s)
=== CONT  TestAccAWSWafSizeConstraintSet_basic
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew (45.41s)
=== CONT  TestAccAWSWafRule_Tags
--- PASS: TestAccAWSWafRuleGroup_basic (55.95s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_disappears
2020/11/17 09:20:35 [DEBUG] Locked "eu-west-2"
2020/11/17 09:20:35 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSWafRegionalWebAcl_LoggingConfiguration (150.80s)
=== CONT  TestAccAWSWafRule_changePredicates
--- PASS: TestAccAWSWafSizeConstraintSet_noConstraints (42.95s)
=== CONT  TestAccAWSWafRule_disappears
--- PASS: TestAccAWSWafRegionalRateBasedRule_disappears (16.07s)
=== CONT  TestAccAWSWafRegionalRule_noPredicates
--- PASS: TestAccAWSWafRule_basic (72.96s)
=== CONT  TestAccAWSWafWebAcl_LoggingConfiguration
--- PASS: TestAccAWSWafRuleGroup_Tags (67.71s)
=== CONT  TestAccAWSWafRegionalRule_disappears
--- PASS: TestAccAWSWafRegionalRule_noPredicates (12.41s)
=== CONT  TestAccAWSWafXssMatchSet_disappears
--- PASS: TestAccAWSWafRule_noPredicates (45.15s)
=== CONT  TestAccAWSWafXssMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRule_disappears (15.51s)
=== CONT  TestAccAWSWafXssMatchSet_basic
--- PASS: TestAccAWSWafSqlInjectionMatchSet_basic (68.77s)
=== CONT  TestAccAWSWafWebAcl_Tags
--- PASS: TestAccAWSWafSizeConstraintSet_disappears (78.76s)
=== CONT  TestAccAWSWafRegionalRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalWebAclAssociation_basic (156.03s)
=== CONT  TestAccAWSWafWebAcl_disappears
--- PASS: TestAccAWSWafRegionalWebAclAssociation_disappears (174.12s)
=== CONT  TestAccAWSWafRegionalRule_tags
--- PASS: TestAccAWSWafSizeConstraintSet_basic (88.72s)
=== CONT  TestAccAWSWafRegionalRule_basic
--- PASS: TestAccAWSWafRegionalWebAclAssociation_multipleAssociations (182.45s)
=== CONT  TestAccAWSWafRegionalRuleGroup_tags
--- PASS: TestAccAWSWafRuleGroup_disappears (106.74s)
=== CONT  TestAccAWSWafRegionalRuleGroup_basic
--- PASS: TestAccAWSWafSizeConstraintSet_changeConstraints (109.32s)
=== CONT  TestAccAWSWafRegionalRuleGroup_noActivatedRules
2020/11/17 09:22:04 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSWafRegionalRule_basic (22.04s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_noPredicates
2020/11/17 09:22:04 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSWafRegionalRuleGroup_noActivatedRules (14.56s)
=== CONT  TestAccAWSWafRegionalRuleGroup_changeActivatedRules
--- PASS: TestAccAWSWafRuleGroup_changeActivatedRules (137.91s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_changeRateLimit
2020/11/17 09:22:07 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSWafRegionalRule_changeNameForceNew (43.81s)
=== CONT  TestAccAWSWafRegionalRuleGroup_disappears
2020/11/17 09:22:13 [DEBUG] Unlocked "eu-west-2"
2020/11/17 09:22:13 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSWafRegionalRuleGroup_basic (26.72s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_changePredicates
--- PASS: TestAccAWSWafXssMatchSet_disappears (81.55s)
=== CONT  TestAccAWSWafRegionalRuleGroup_changeNameForceNew
--- PASS: TestAccAWSWafWebAcl_disappears (49.08s)
=== CONT  TestAccAWSWafRateBasedRule_changePredicates
--- PASS: TestAccAWSWafWebAcl_Tags (75.24s)
=== CONT  TestAccAWSWafGeoMatchSet_changeConstraints
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew (147.12s)
=== CONT  TestAccAWSWafRateBasedRule_Tags
--- PASS: TestAccAWSWafRegionalRateBasedRule_noPredicates (20.52s)
=== CONT  TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit
--- PASS: TestAccAWSWafXssMatchSet_basic (79.35s)
=== CONT  TestAccAWSWafRateBasedRule_noPredicates
--- PASS: TestAccAWSWafRegionalRuleGroup_disappears (24.52s)
=== CONT  TestAccAWSWafIPSet_noDescriptors
--- PASS: TestAccAWSWafRegionalRuleGroup_tags (49.74s)
=== CONT  TestAccAWSWafRateBasedRule_changeRateLimit
--- PASS: TestAccAWSWafRule_geoMatchSetPredicate (149.01s)
=== CONT  TestAccAWSWafIPSet_changeDescriptors
--- PASS: TestAccAWSWafSizeConstraintSet_changeNameForceNew (159.65s)
=== CONT  TestAccAWSWafIPSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRateBasedRule_changePredicates (40.61s)
=== CONT  TestAccAWSWafIPSet_basic
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeRateLimit (59.82s)
=== CONT  TestAccAWSWafIPSet_disappears
--- PASS: TestAccAWSWafRule_disappears (145.89s)
=== CONT  TestAccAWSWafWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRuleGroup_changeActivatedRules (64.17s)
=== CONT  TestAccAWSWafWebAcl_Rules
--- PASS: TestAccAWSWafRegionalRuleGroup_changeNameForceNew (58.92s)
=== CONT  TestAccAWSWafWebAcl_DefaultAction
--- PASS: TestAccAWSWafRateBasedRule_noPredicates (51.26s)
=== CONT  TestAccAWSWafRateBasedRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRule_tags (106.00s)
=== CONT  TestAccAWSWafRateBasedRule_disappears
--- PASS: TestAccAWSWafRule_Tags (190.61s)
=== CONT  TestAccAWSWafGeoMatchSet_noConstraints
2020/11/17 09:23:34 [DEBUG] Unlocking "WafRetryer"
2020/11/17 09:23:34 [DEBUG] Locked "WafRetryer"
2020/11/17 09:23:34 [DEBUG] Unlocked "WafRetryer"
2020/11/17 09:23:34 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSWafIPSet_noDescriptors (60.91s)
=== CONT  TestAccAWSWafByteMatchSet_disappears
2020/11/17 09:23:40 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSWafRuleGroup_changeNameForceNew (222.43s)
=== CONT  TestAccAWSWafByteMatchSet_changeTuples
--- PASS: TestAccAWSWafXssMatchSet_changeNameForceNew (174.90s)
=== CONT  TestAccAWSWafGeoMatchSet_disappears
--- PASS: TestAccAWSWafRateBasedRule_Tags (91.03s)
=== CONT  TestAccAWSWafByteMatchSet_noTuples
--- PASS: TestAccAWSWafWebAcl_LoggingConfiguration (221.92s)
=== CONT  TestAccAWSWafGeoMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafGeoMatchSet_changeConstraints (132.18s)
=== CONT  TestAccAWSWafGeoMatchSet_basic
--- PASS: TestAccAWSWafGeoMatchSet_noConstraints (69.98s)
=== CONT  TestAccAWSWafRateBasedRule_basic
--- PASS: TestAccAWSWafRule_changePredicates (248.69s)
=== CONT  TestAccAWSWafWebAcl_basic
--- PASS: TestAccAWSWafIPSet_basic (117.08s)
=== CONT  TestAccAWSWafSqlInjectionMatchSet_noTuples
--- PASS: TestAccAWSWafIPSet_disappears (115.00s)
=== CONT  TestAccAWSWafRegionalIPSet_disappears
--- PASS: TestAccAWSWafByteMatchSet_noTuples (68.42s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
--- PASS: TestAccAWSWafWebAcl_DefaultAction (113.44s)
=== CONT  TestAccAWSWafByteMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalIPSet_disappears (10.97s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_tags
--- PASS: TestAccAWSWafIPSet_changeDescriptors (151.05s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_basic
--- PASS: TestAccAWSWafWebAcl_changeNameForceNew (135.57s)
=== CONT  TestAccAWSWafRegionalGeoMatchSet_disappears
--- PASS: TestAccAWSWafByteMatchSet_disappears (115.09s)
=== CONT  TestAccAWSWafRegionalIPSet_basic
2020/11/17 09:25:35 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSWafRegionalRateBasedRule_basic (26.92s)
=== CONT  TestAccAWSWafRegionalGeoMatchSet_noConstraints
--- PASS: TestAccAWSWafRegionalGeoMatchSet_disappears (17.87s)
=== CONT  TestAccAWSWafRegionalGeoMatchSet_changeConstraints
--- PASS: TestAccAWSWafGeoMatchSet_disappears (113.08s)
=== CONT  TestAccAWSWafRegionalIPSet_noDescriptors
--- PASS: TestAccAWSWafRegionalIPSet_basic (21.43s)
=== CONT  TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeNameForceNew (48.48s)
=== CONT  TestAccAWSWafRegionalIPSet_changeDescriptors
--- PASS: TestAccAWSWafRegionalGeoMatchSet_noConstraints (16.27s)
=== CONT  TestAccAWSWafRegionalIPSet_changeNameForceNew
--- PASS: TestAccAWSWafWebAcl_basic (74.52s)
=== CONT  TestAccAWSWafRegionalGeoMatchSet_basic
--- PASS: TestAccAWSWafRegionalIPSet_noDescriptors (16.87s)
=== CONT  TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafSqlInjectionMatchSet_noTuples (69.04s)
=== CONT  TestAccAWSWafRegionalByteMatchSet_disappears
--- PASS: TestAccAWSWafRegionalRateBasedRule_tags (49.10s)
2020/11/17 09:26:02 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/11/17 09:26:07 [DEBUG] Unlocking "eu-west-2"
2020/11/17 09:26:07 [DEBUG] Unlocked "eu-west-2"
2020/11/17 09:26:08 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/11/17 09:26:10 [DEBUG] Locked "eu-west-2"
2020/11/17 09:26:10 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSWafRegionalGeoMatchSet_changeConstraints (30.17s)
--- PASS: TestAccAWSWafRegionalByteMatchSet_disappears (14.80s)
--- PASS: TestAccAWSWafRegionalGeoMatchSet_basic (16.71s)
--- PASS: TestAccAWSWafByteMatchSet_changeTuples (154.66s)
--- PASS: TestAccAWSWafRegionalIPSet_changeDescriptors (29.44s)
--- PASS: TestAccAWSWafIPSet_changeNameForceNew (218.18s)
--- PASS: TestAccAWSWafRegionalIPSet_changeNameForceNew (31.86s)
--- PASS: TestAccAWSWafGeoMatchSet_basic (116.09s)
--- PASS: TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew (30.75s)
--- PASS: TestAccAWSWafRateBasedRule_changeRateLimit (238.43s)
--- PASS: TestAccAWSWafRateBasedRule_disappears (195.60s)
--- PASS: TestAccAWSWafRateBasedRule_changePredicates (259.97s)
--- PASS: TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit (266.09s)
--- PASS: TestAccAWSWafRateBasedRule_basic (146.01s)
--- PASS: TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit (74.24s)
--- PASS: TestAccAWSWafGeoMatchSet_changeNameForceNew (159.10s)
    TestAccAWSWafWebAcl_Rules: resource_aws_waf_web_acl_test.go:232: Step 3/4 error: Error running apply: 
        Error: Error deleting WAF Rule: WAFReferencedItemException: This entity is still referenced by other entities.
        
        
--- PASS: TestAccAWSWafByteMatchSet_changeNameForceNew (122.40s)
    TestAccAWSWafWebAcl_Rules: testing_new.go:63: Error running post-test destroy, there may be dangling resources: 
        Error: Error updating WAF Rule Predicates: Error Updating WAF Rule: WAFInvalidOperationException: Operation is invalid for this entity.
        
        
--- FAIL: TestAccAWSWafWebAcl_Rules (252.09s)
--- PASS: TestAccAWSWafRateBasedRule_changeNameForceNew (250.41s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	910.521s
FAIL
```
The failure is a known issue being tracked under #14957