### PR TITLE
tests/resource/aws_wafregional: Migrate to SDK TypeSet Function

### DIFF
--- a/aws/resource_aws_wafregional_byte_match_set_test.go
+++ b/aws/resource_aws_wafregional_byte_match_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSWafRegionalByteMatchSet_basic(t *testing.T) {
@@ -31,7 +30,7 @@ func TestAccAWSWafRegionalByteMatchSet_basic(t *testing.T) {
 						resourceName, "name", byteMatchSet),
 					resource.TestCheckResourceAttr(
 						resourceName, "byte_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -39,7 +38,7 @@ func TestAccAWSWafRegionalByteMatchSet_basic(t *testing.T) {
 						"target_string":         "badrefer1",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -77,7 +76,7 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 						resourceName, "name", byteMatchSet),
 					resource.TestCheckResourceAttr(
 						resourceName, "byte_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -85,7 +84,7 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 						"target_string":         "badrefer1",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -103,7 +102,7 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 						resourceName, "name", byteMatchSetNewName),
 					resource.TestCheckResourceAttr(
 						resourceName, "byte_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -111,7 +110,7 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 						"target_string":         "badrefer1",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
@@ -148,14 +147,14 @@ func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples(t *testing.T) {
 						resourceName, "name", byteMatchSetName),
 					resource.TestCheckResourceAttr(
 						resourceName, "byte_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
 						"positional_constraint": "CONTAINS",
 						"target_string":         "badrefer1",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",
 						"positional_constraint": "CONTAINS",
@@ -172,7 +171,7 @@ func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples(t *testing.T) {
 						resourceName, "name", byteMatchSetName),
 					resource.TestCheckResourceAttr(
 						resourceName, "byte_match_tuples.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "METHOD",
@@ -180,7 +179,7 @@ func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples(t *testing.T) {
 						"target_string":         "GET",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "byte_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "URI",

--- a/aws/resource_aws_wafregional_geo_match_set_test.go
+++ b/aws/resource_aws_wafregional_geo_match_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSWafRegionalGeoMatchSet_basic(t *testing.T) {
@@ -31,11 +30,11 @@ func TestAccAWSWafRegionalGeoMatchSet_basic(t *testing.T) {
 						resourceName, "name", geoMatchSet),
 					resource.TestCheckResourceAttr(
 						resourceName, "geo_match_constraint.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "US",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "CA",
 					}),
@@ -131,11 +130,11 @@ func TestAccAWSWafRegionalGeoMatchSet_changeConstraints(t *testing.T) {
 						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
 						resourceName, "geo_match_constraint.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "US",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "CA",
 					}),
@@ -149,11 +148,11 @@ func TestAccAWSWafRegionalGeoMatchSet_changeConstraints(t *testing.T) {
 						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
 						resourceName, "geo_match_constraint.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "RU",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "geo_match_constraint.*", map[string]string{
 						"type":  "Country",
 						"value": "CN",
 					}),

--- a/aws/resource_aws_wafregional_ipset_test.go
+++ b/aws/resource_aws_wafregional_ipset_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSWafRegionalIPSet_basic(t *testing.T) {
@@ -33,7 +32,7 @@ func TestAccAWSWafRegionalIPSet_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", ipsetName),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -86,7 +85,7 @@ func TestAccAWSWafRegionalIPSet_changeNameForceNew(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", ipsetName),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -97,7 +96,7 @@ func TestAccAWSWafRegionalIPSet_changeNameForceNew(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", ipsetNewName),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -128,7 +127,7 @@ func TestAccAWSWafRegionalIPSet_changeDescriptors(t *testing.T) {
 					testAccCheckAWSWafRegionalIPSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", ipsetName),
 					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -140,7 +139,7 @@ func TestAccAWSWafRegionalIPSet_changeDescriptors(t *testing.T) {
 					testAccCheckAWSWafRegionalIPSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", ipsetName),
 					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.8.0/24",
 					}),

--- a/aws/resource_aws_wafregional_rate_based_rule_test.go
+++ b/aws/resource_aws_wafregional_rate_based_rule_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -269,7 +268,7 @@ func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
 						"negated": "false",
 						"type":    "IPMatch",
 					}),
@@ -282,7 +281,7 @@ func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
 						"negated": "true",
 						"type":    "ByteMatch",
 					}),

--- a/aws/resource_aws_wafregional_regex_match_set_test.go
+++ b/aws/resource_aws_wafregional_regex_match_set_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/wafregional/finder"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -132,7 +131,7 @@ func testAccAWSWafRegionalRegexMatchSet_basic(t *testing.T) {
 					computeWafRegexMatchSetTuple(&patternSet, &fieldToMatch, "NONE", &idx),
 					resource.TestCheckResourceAttr(resourceName, "name", matchSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "user-agent",
 						"field_to_match.0.type": "HEADER",
@@ -171,7 +170,7 @@ func testAccAWSWafRegionalRegexMatchSet_changePatterns(t *testing.T) {
 					computeWafRegexMatchSetTuple(&patternSet, &waf.FieldToMatch{Data: aws.String("User-Agent"), Type: aws.String("HEADER")}, "NONE", &idx1),
 					resource.TestCheckResourceAttr(resourceName, "name", matchSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "user-agent",
 						"field_to_match.0.type": "HEADER",
@@ -187,7 +186,7 @@ func testAccAWSWafRegionalRegexMatchSet_changePatterns(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "1"),
 
 					computeWafRegexMatchSetTuple(&patternSet, &waf.FieldToMatch{Data: aws.String("Referer"), Type: aws.String("HEADER")}, "COMPRESS_WHITE_SPACE", &idx2),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regex_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "referer",
 						"field_to_match.0.type": "HEADER",

--- a/aws/resource_aws_wafregional_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafregional_regex_pattern_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 // Serialized acceptance tests due to WAF account limits
@@ -47,8 +46,8 @@ func testAccAWSWafRegionalRegexPatternSet_basic(t *testing.T) {
 					testAccCheckAWSWafRegionalRegexPatternSetExists(resourceName, &patternSet),
 					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "2"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "one"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "one"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
 				),
 			},
 			{
@@ -76,8 +75,8 @@ func testAccAWSWafRegionalRegexPatternSet_changePatterns(t *testing.T) {
 					testAccCheckAWSWafRegionalRegexPatternSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "2"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "one"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "one"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
 				),
 			},
 			{
@@ -86,9 +85,9 @@ func testAccAWSWafRegionalRegexPatternSet_changePatterns(t *testing.T) {
 					testAccCheckAWSWafRegionalRegexPatternSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
 					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "3"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "three"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "four"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "two"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "three"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "regex_pattern_strings.*", "four"),
 				),
 			},
 			{

--- a/aws/resource_aws_wafregional_rule_group_test.go
+++ b/aws/resource_aws_wafregional_rule_group_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -85,7 +84,7 @@ func TestAccAWSWafRegionalRuleGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric_name", groupName),
 					computeWafActivatedRuleWithRuleId(&rule, "COUNT", 50, &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "COUNT",
 						"priority":      "50",
 						"type":          waf.WafRuleTypeRegular,
@@ -238,7 +237,7 @@ func TestAccAWSWafRegionalRuleGroup_changeActivatedRules(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
 					computeWafActivatedRuleWithRuleId(&rule0, "COUNT", 50, &idx0),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "COUNT",
 						"priority":      "50",
 						"type":          waf.WafRuleTypeRegular,
@@ -254,7 +253,7 @@ func TestAccAWSWafRegionalRuleGroup_changeActivatedRules(t *testing.T) {
 
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.test", &rule1),
 					computeWafActivatedRuleWithRuleId(&rule1, "BLOCK", 10, &idx1),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "BLOCK",
 						"priority":      "10",
 						"type":          waf.WafRuleTypeRegular,
@@ -262,7 +261,7 @@ func TestAccAWSWafRegionalRuleGroup_changeActivatedRules(t *testing.T) {
 
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.test2", &rule2),
 					computeWafActivatedRuleWithRuleId(&rule2, "COUNT", 1, &idx2),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "COUNT",
 						"priority":      "1",
 						"type":          waf.WafRuleTypeRegular,
@@ -270,7 +269,7 @@ func TestAccAWSWafRegionalRuleGroup_changeActivatedRules(t *testing.T) {
 
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.test3", &rule3),
 					computeWafActivatedRuleWithRuleId(&rule3, "BLOCK", 15, &idx3),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "activated_rule.*", map[string]string{
 						"action.0.type": "BLOCK",
 						"priority":      "15",
 						"type":          waf.WafRuleTypeRegular,

--- a/aws/resource_aws_wafregional_rule_test.go
+++ b/aws/resource_aws_wafregional_rule_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -300,7 +299,7 @@ func TestAccAWSWafRegionalRule_changePredicates(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
 					computeWafRegionalRulePredicate(&ipset.IPSetId, false, "IPMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
 						"negated": "false",
 						"type":    "IPMatch",
 					}),
@@ -314,12 +313,12 @@ func TestAccAWSWafRegionalRule_changePredicates(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicate.#", "2"),
 					computeWafRegionalRulePredicate(&xssMatchSet.XssMatchSetId, true, "XssMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
 						"negated": "true",
 						"type":    "XssMatch",
 					}),
 					computeWafRegionalRulePredicate(&ipset.IPSetId, true, "IPMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
 						"negated": "true",
 						"type":    "IPMatch",
 					}),

--- a/aws/resource_aws_wafregional_size_constraint_set_test.go
+++ b/aws/resource_aws_wafregional_size_constraint_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSWafRegionalSizeConstraintSet_basic(t *testing.T) {
@@ -31,13 +30,13 @@ func TestAccAWSWafRegionalSizeConstraintSet_basic(t *testing.T) {
 						resourceName, "name", sizeConstraintSet),
 					resource.TestCheckResourceAttr(
 						resourceName, "size_constraints.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
 						"comparison_operator": "EQ",
 						"field_to_match.#":    "1",
 						"size":                "4096",
 						"text_transformation": "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
 						"data": "",
 						"type": "BODY",
 					}),
@@ -132,13 +131,13 @@ func TestAccAWSWafRegionalSizeConstraintSet_changeConstraints(t *testing.T) {
 						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
 						resourceName, "size_constraints.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
 						"comparison_operator": "EQ",
 						"field_to_match.#":    "1",
 						"size":                "4096",
 						"text_transformation": "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
 						"data": "",
 						"type": "BODY",
 					}),
@@ -152,13 +151,13 @@ func TestAccAWSWafRegionalSizeConstraintSet_changeConstraints(t *testing.T) {
 						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
 						resourceName, "size_constraints.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*", map[string]string{
 						"comparison_operator": "GE",
 						"field_to_match.#":    "1",
 						"size":                "1024",
 						"text_transformation": "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "size_constraints.*.field_to_match.*", map[string]string{
 						"data": "",
 						"type": "BODY",
 					}),

--- a/aws/resource_aws_wafregional_sql_injection_match_set_test.go
+++ b/aws/resource_aws_wafregional_sql_injection_match_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSWafRegionalSqlInjectionMatchSet_basic(t *testing.T) {
@@ -29,7 +28,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_basic(t *testing.T) {
 					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
 						resourceName, "name", sqlInjectionMatchSet),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "QUERY_STRING",
@@ -126,7 +125,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples(t *testing.T) {
 						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
 						resourceName, "sql_injection_match_tuple.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "QUERY_STRING",
@@ -142,7 +141,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples(t *testing.T) {
 						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
 						resourceName, "sql_injection_match_tuple.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sql_injection_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "user-agent",
 						"field_to_match.0.type": "HEADER",

--- a/aws/resource_aws_wafregional_web_acl_test.go
+++ b/aws/resource_aws_wafregional_web_acl_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -409,7 +408,7 @@ func TestAccAWSWafRegionalWebAcl_changeRules(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
 					computeWafRegionalWebAclRuleIndex(&r.RuleId, 1, "REGULAR", "BLOCK", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"priority": "1",
 					}),
 				),

--- a/aws/resource_aws_wafregional_xss_match_set_test.go
+++ b/aws/resource_aws_wafregional_xss_match_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSWafRegionalXssMatchSet_basic(t *testing.T) {
@@ -29,13 +28,13 @@ func TestAccAWSWafRegionalXssMatchSet_basic(t *testing.T) {
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "QUERY_STRING",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "URI",
@@ -126,13 +125,13 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "QUERY_STRING",
 						"text_transformation":   "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "URI",
@@ -151,13 +150,13 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "METHOD",
 						"text_transformation":   "HTML_ENTITY_DECODE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
 						"field_to_match.0.data": "",
 						"field_to_match.0.type": "BODY",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relate #15882

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSWafRegional'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSWafRegional -timeout 120m
=== RUN   TestAccAWSWafRegionalByteMatchSet_basic
=== PAUSE TestAccAWSWafRegionalByteMatchSet_basic
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
=== PAUSE TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
=== RUN   TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
=== PAUSE TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
=== RUN   TestAccAWSWafRegionalByteMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalByteMatchSet_disappears
=== RUN   TestAccAWSWafRegionalGeoMatchSet_basic
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_basic
=== RUN   TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalGeoMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_disappears
=== RUN   TestAccAWSWafRegionalGeoMatchSet_changeConstraints
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_changeConstraints
=== RUN   TestAccAWSWafRegionalGeoMatchSet_noConstraints
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_noConstraints
=== RUN   TestAccAWSWafRegionalIPSet_basic
=== PAUSE TestAccAWSWafRegionalIPSet_basic
=== RUN   TestAccAWSWafRegionalIPSet_disappears
=== PAUSE TestAccAWSWafRegionalIPSet_disappears
=== RUN   TestAccAWSWafRegionalIPSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalIPSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalIPSet_changeDescriptors
=== PAUSE TestAccAWSWafRegionalIPSet_changeDescriptors
=== RUN   TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit
=== PAUSE TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit
=== RUN   TestAccAWSWafRegionalIPSet_noDescriptors
=== PAUSE TestAccAWSWafRegionalIPSet_noDescriptors
=== RUN   TestAccAWSWafRegionalRateBasedRule_basic
=== PAUSE TestAccAWSWafRegionalRateBasedRule_basic
=== RUN   TestAccAWSWafRegionalRateBasedRule_tags
=== PAUSE TestAccAWSWafRegionalRateBasedRule_tags
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
=== RUN   TestAccAWSWafRegionalRateBasedRule_disappears
=== PAUSE TestAccAWSWafRegionalRateBasedRule_disappears
=== RUN   TestAccAWSWafRegionalRateBasedRule_changePredicates
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changePredicates
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeRateLimit
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changeRateLimit
=== RUN   TestAccAWSWafRegionalRateBasedRule_noPredicates
=== PAUSE TestAccAWSWafRegionalRateBasedRule_noPredicates
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial/basic
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial/changePatterns
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial/noPatterns
=== RUN   TestAccAWSWafRegionalRegexMatchSet_serial/disappears
--- PASS: TestAccAWSWafRegionalRegexMatchSet_serial (76.61s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/basic (18.95s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/changePatterns (28.53s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/noPatterns (13.18s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/disappears (15.95s)
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial/changePatterns
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial/noPatterns
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial/disappears
=== RUN   TestAccAWSWafRegionalRegexPatternSet_serial/basic
--- PASS: TestAccAWSWafRegionalRegexPatternSet_serial (62.01s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet_serial/changePatterns (23.97s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet_serial/noPatterns (13.13s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet_serial/disappears (11.37s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet_serial/basic (13.53s)
=== RUN   TestAccAWSWafRegionalRuleGroup_basic
=== PAUSE TestAccAWSWafRegionalRuleGroup_basic
=== RUN   TestAccAWSWafRegionalRuleGroup_tags
=== PAUSE TestAccAWSWafRegionalRuleGroup_tags
=== RUN   TestAccAWSWafRegionalRuleGroup_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalRuleGroup_changeNameForceNew
=== RUN   TestAccAWSWafRegionalRuleGroup_disappears
=== PAUSE TestAccAWSWafRegionalRuleGroup_disappears
=== RUN   TestAccAWSWafRegionalRuleGroup_changeActivatedRules
=== PAUSE TestAccAWSWafRegionalRuleGroup_changeActivatedRules
=== RUN   TestAccAWSWafRegionalRuleGroup_noActivatedRules
=== PAUSE TestAccAWSWafRegionalRuleGroup_noActivatedRules
=== RUN   TestAccAWSWafRegionalRule_basic
=== PAUSE TestAccAWSWafRegionalRule_basic
=== RUN   TestAccAWSWafRegionalRule_tags
=== PAUSE TestAccAWSWafRegionalRule_tags
=== RUN   TestAccAWSWafRegionalRule_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalRule_changeNameForceNew
=== RUN   TestAccAWSWafRegionalRule_disappears
=== PAUSE TestAccAWSWafRegionalRule_disappears
=== RUN   TestAccAWSWafRegionalRule_noPredicates
=== PAUSE TestAccAWSWafRegionalRule_noPredicates
=== RUN   TestAccAWSWafRegionalRule_changePredicates
=== PAUSE TestAccAWSWafRegionalRule_changePredicates
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_basic
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_basic
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_disappears
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_disappears
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_noConstraints
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_noConstraints
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_basic
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_basic
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
=== RUN   TestAccAWSWafRegionalWebAclAssociation_basic
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_basic
=== RUN   TestAccAWSWafRegionalWebAclAssociation_disappears
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_disappears
=== RUN   TestAccAWSWafRegionalWebAclAssociation_multipleAssociations
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_multipleAssociations
=== RUN   TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage
=== RUN   TestAccAWSWafRegionalWebAcl_basic
=== PAUSE TestAccAWSWafRegionalWebAcl_basic
=== RUN   TestAccAWSWafRegionalWebAcl_tags
=== PAUSE TestAccAWSWafRegionalWebAcl_tags
=== RUN   TestAccAWSWafRegionalWebAcl_createRateBased
=== PAUSE TestAccAWSWafRegionalWebAcl_createRateBased
=== RUN   TestAccAWSWafRegionalWebAcl_createGroup
=== PAUSE TestAccAWSWafRegionalWebAcl_createGroup
=== RUN   TestAccAWSWafRegionalWebAcl_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalWebAcl_changeNameForceNew
=== RUN   TestAccAWSWafRegionalWebAcl_changeDefaultAction
=== PAUSE TestAccAWSWafRegionalWebAcl_changeDefaultAction
=== RUN   TestAccAWSWafRegionalWebAcl_disappears
=== PAUSE TestAccAWSWafRegionalWebAcl_disappears
=== RUN   TestAccAWSWafRegionalWebAcl_noRules
=== PAUSE TestAccAWSWafRegionalWebAcl_noRules
=== RUN   TestAccAWSWafRegionalWebAcl_changeRules
=== PAUSE TestAccAWSWafRegionalWebAcl_changeRules
=== RUN   TestAccAWSWafRegionalWebAcl_LoggingConfiguration
=== PAUSE TestAccAWSWafRegionalWebAcl_LoggingConfiguration
=== RUN   TestAccAWSWafRegionalXssMatchSet_basic
=== PAUSE TestAccAWSWafRegionalXssMatchSet_basic
=== RUN   TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalXssMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalXssMatchSet_disappears
=== RUN   TestAccAWSWafRegionalXssMatchSet_changeTuples
=== PAUSE TestAccAWSWafRegionalXssMatchSet_changeTuples
=== RUN   TestAccAWSWafRegionalXssMatchSet_noTuples
=== PAUSE TestAccAWSWafRegionalXssMatchSet_noTuples
=== CONT  TestAccAWSWafRegionalByteMatchSet_basic
=== CONT  TestAccAWSWafRegionalRule_noPredicates
=== CONT  TestAccAWSWafRegionalRateBasedRule_tags
=== CONT  TestAccAWSWafRegionalRateBasedRule_basic
=== CONT  TestAccAWSWafRegionalGeoMatchSet_basic
=== CONT  TestAccAWSWafRegionalWebAcl_basic
=== CONT  TestAccAWSWafRegionalGeoMatchSet_noConstraints
=== CONT  TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
=== CONT  TestAccAWSWafRegionalByteMatchSet_disappears
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
=== CONT  TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage
=== CONT  TestAccAWSWafRegionalWebAclAssociation_disappears
=== CONT  TestAccAWSWafRegionalWebAclAssociation_multipleAssociations
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
=== CONT  TestAccAWSWafRegionalWebAclAssociation_basic
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
=== CONT  TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
=== CONT  TestAccAWSWafRegionalWebAcl_changeRules
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
=== CONT  TestAccAWSWafRegionalXssMatchSet_noTuples
2020/11/17 09:50:10 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/17 09:50:10 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2020/11/17 09:50:22 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples (26.65s)
=== CONT  TestAccAWSWafRegionalXssMatchSet_changeTuples
--- PASS: TestAccAWSWafRegionalRule_noPredicates (28.43s)
=== CONT  TestAccAWSWafRegionalXssMatchSet_disappears
--- PASS: TestAccAWSWafRegionalXssMatchSet_noTuples (31.71s)
=== CONT  TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalGeoMatchSet_noConstraints (34.26s)
=== CONT  TestAccAWSWafRegionalXssMatchSet_basic
2020/11/17 09:50:39 [INFO] Creating regional WAF XSS Match Set: tf-acc-test-6148524428226126587
2020/11/17 09:50:39 [DEBUG] Locking "eu-west-2"
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples (34.75s)
=== CONT  TestAccAWSWafRegionalWebAcl_LoggingConfiguration
--- PASS: TestAccAWSWafRegionalGeoMatchSet_basic (50.11s)
=== CONT  TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalByteMatchSet_basic (50.62s)
=== CONT  TestAccAWSWafRegionalWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_disappears (52.17s)
=== CONT  TestAccAWSWafRegionalWebAcl_noRules
--- PASS: TestAccAWSWafRegionalByteMatchSet_disappears (53.51s)
=== CONT  TestAccAWSWafRegionalWebAcl_disappears
--- PASS: TestAccAWSWafRegionalWebAcl_basic (57.05s)
=== CONT  TestAccAWSWafRegionalWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples (57.57s)
=== CONT  TestAccAWSWafRegionalWebAcl_createRateBased
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples (60.93s)
=== CONT  TestAccAWSWafRegionalWebAcl_createGroup
--- PASS: TestAccAWSWafRegionalXssMatchSet_disappears (33.87s)
=== CONT  TestAccAWSWafRegionalGeoMatchSet_disappears
2020/11/17 09:51:08 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage (63.79s)
=== CONT  TestAccAWSWafRegionalGeoMatchSet_changeConstraints
2020/11/17 09:51:10 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/11/17 09:51:14 [INFO] Updating IPSet descriptor: {
  ChangeToken: "456f663f-a13d-4562-8e6b-fdc5a707723b",
  IPSetId: "3ded560c-b23e-4188-87e3-0a07312a7ab0",
  Updates: [{
      Action: "DELETE",
      IPSetDescriptor: {
        Type: "IPV4",
        Value: "192.0.7.0/24"
      }
    }]
}
--- PASS: TestAccAWSWafRegionalXssMatchSet_basic (42.46s)
=== CONT  TestAccAWSWafRegionalIPSet_changeDescriptors
--- PASS: TestAccAWSWafRegionalRateBasedRule_basic (77.86s)
=== CONT  TestAccAWSWafRegionalIPSet_noDescriptors
--- PASS: TestAccAWSWafRegionalWebAcl_noRules (26.81s)
=== CONT  TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew (85.82s)
=== CONT  TestAccAWSWafRegionalRule_basic
--- PASS: TestAccAWSWafRegionalWebAcl_changeRules (86.33s)
=== CONT  TestAccAWSWafRegionalRule_disappears
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeTuples (66.11s)
=== CONT  TestAccAWSWafRegionalRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRateBasedRule_tags (94.72s)
=== CONT  TestAccAWSWafRegionalRule_tags
2020/11/17 09:51:41 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSWafRegionalGeoMatchSet_disappears (41.87s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_disappears
--- PASS: TestAccAWSWafRegionalIPSet_noDescriptors (28.19s)
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_basic
--- PASS: TestAccAWSWafRegionalWebAcl_disappears (54.25s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_noConstraints
--- PASS: TestAccAWSWafRegionalWebAcl_createRateBased (58.84s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeNameForceNew (89.89s)
=== CONT  TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalWebAcl_createGroup (63.38s)
=== CONT  TestAccAWSWafRegionalWebAcl_tags
--- PASS: TestAccAWSWafRegionalGeoMatchSet_changeConstraints (61.87s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_changeRateLimit
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeNameForceNew (84.91s)
=== CONT  TestAccAWSWafRegionalIPSet_disappears
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_noConstraints (29.98s)
=== CONT  TestAccAWSWafRegionalRuleGroup_tags
--- PASS: TestAccAWSWafRegionalIPSet_changeDescriptors (65.52s)
=== CONT  TestAccAWSWafRegionalIPSet_changeNameForceNew
2020/11/17 09:52:30 [DEBUG] Unlocked "eu-west-2"
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_disappears (47.62s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_basic
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_basic (46.25s)
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
=== CONT  TestAccAWSWafRegionalRuleGroup_basic
--- PASS: TestAccAWSWafRegionalRule_basic (73.25s)
--- PASS: TestAccAWSWafRegionalRule_disappears (73.72s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_noPredicates
--- PASS: TestAccAWSWafRegionalWebAcl_LoggingConfiguration (128.57s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_changePredicates
--- PASS: TestAccAWSWafRegionalWebAcl_changeNameForceNew (116.54s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalWebAclAssociation_disappears (169.01s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_disappears
--- PASS: TestAccAWSWafRegionalWebAclAssociation_basic (175.14s)
=== CONT  TestAccAWSWafRegionalRuleGroup_changeActivatedRules
--- PASS: TestAccAWSWafRegionalWebAcl_changeDefaultAction (122.63s)
=== CONT  TestAccAWSWafRegionalRuleGroup_noActivatedRules
--- PASS: TestAccAWSWafRegionalIPSet_disappears (44.97s)
=== CONT  TestAccAWSWafRegionalRule_changePredicates
--- PASS: TestAccAWSWafRegionalWebAclAssociation_multipleAssociations (184.58s)
=== CONT  TestAccAWSWafRegionalIPSet_basic
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_changeConstraints (68.48s)
=== CONT  TestAccAWSWafRegionalRuleGroup_disappears
--- PASS: TestAccAWSWafRegionalRateBasedRule_noPredicates (30.12s)
=== CONT  TestAccAWSWafRegionalRuleGroup_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeRateLimit (71.76s)
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_basic (50.86s)
--- PASS: TestAccAWSWafRegionalRule_tags (111.44s)
--- PASS: TestAccAWSWafRegionalRuleGroup_noActivatedRules (30.68s)
--- PASS: TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew (95.26s)
--- PASS: TestAccAWSWafRegionalWebAcl_tags (94.46s)
--- PASS: TestAccAWSWafRegionalRuleGroup_basic (65.91s)
2020/11/17 09:53:52 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSWafRegionalRuleGroup_tags (92.78s)
--- PASS: TestAccAWSWafRegionalIPSet_basic (46.56s)
--- PASS: TestAccAWSWafRegionalIPSet_changeNameForceNew (92.11s)
--- PASS: TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit (157.38s)
--- PASS: TestAccAWSWafRegionalRule_changeNameForceNew (147.99s)
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew (88.86s)
--- PASS: TestAccAWSWafRegionalRuleGroup_disappears (58.00s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_disappears (74.53s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_changePredicates (90.31s)
--- PASS: TestAccAWSWafRegionalRuleGroup_changeActivatedRules (80.22s)
--- PASS: TestAccAWSWafRegionalRuleGroup_changeNameForceNew (69.84s)
--- PASS: TestAccAWSWafRegionalRule_changePredicates (81.09s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeNameForceNew (99.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	405.727s
```
