### PR TITLE
tests/resource/aws_wafv2: Migrate to SDK TypeSet Function

### DIFF
--- a/aws/resource_aws_wafv2_ip_set_test.go
+++ b/aws/resource_aws_wafv2_ip_set_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/wafv2/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -168,9 +167,9 @@ func TestAccAwsWafv2IPSet_IPv6(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "ip_address_version", wafv2.IPAddressVersionIpv6),
 					resource.TestCheckResourceAttr(resourceName, "addresses.#", "3"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "addresses.*", "1234:5678:9abc:6811:0000:0000:0000:0000/64"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "addresses.*", "2001:db8::/32"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "addresses.*", "1111:0000:0000:0000:0000:0000:0000:0111/128"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "addresses.*", "1234:5678:9abc:6811:0000:0000:0000:0000/64"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "addresses.*", "2001:db8::/32"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "addresses.*", "1111:0000:0000:0000:0000:0000:0000:0111/128"),
 				),
 			},
 			{

--- a/aws/resource_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/wafv2/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -98,10 +97,10 @@ func TestAccAwsWafv2RegexPatternSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
 						"regex_string": "one",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
 						"regex_string": "two",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -116,13 +115,13 @@ func TestAccAwsWafv2RegexPatternSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated"),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.#", "3"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
 						"regex_string": "one",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
 						"regex_string": "two",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
 						"regex_string": "three",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),

--- a/aws/resource_aws_wafv2_rule_group_test.go
+++ b/aws/resource_aws_wafv2_rule_group_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/wafv2/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -157,7 +156,7 @@ func TestAccAwsWafv2RuleGroup_updateRule(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                              "rule-1",
 						"priority":                          "1",
 						"action.#":                          "1",
@@ -206,7 +205,7 @@ func TestAccAwsWafv2RuleGroup_updateRuleProperties(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":             "rule-1",
 						"priority":         "1",
 						"action.#":         "1",
@@ -238,7 +237,7 @@ func TestAccAwsWafv2RuleGroup_updateRuleProperties(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                "rule-1",
 						"priority":            "1",
 						"action.#":            "1",
@@ -253,7 +252,7 @@ func TestAccAwsWafv2RuleGroup_updateRuleProperties(t *testing.T) {
 						"statement.0.geo_match_statement.#":                 "1",
 						"statement.0.geo_match_statement.0.country_codes.#": "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                ruleName2,
 						"priority":            "2",
 						"action.#":            "1",
@@ -272,11 +271,11 @@ func TestAccAwsWafv2RuleGroup_updateRuleProperties(t *testing.T) {
 						"statement.0.size_constraint_statement.0.size":                            "50",
 						"statement.0.size_constraint_statement.0.text_transformation.#":           "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "CMD_LINE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "NONE",
 					}),
@@ -298,7 +297,7 @@ func TestAccAwsWafv2RuleGroup_updateRuleProperties(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                "rule-1",
 						"priority":            "5",
 						"action.#":            "1",
@@ -313,7 +312,7 @@ func TestAccAwsWafv2RuleGroup_updateRuleProperties(t *testing.T) {
 						"statement.0.geo_match_statement.#":                 "1",
 						"statement.0.geo_match_statement.0.country_codes.#": "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                "updated",
 						"priority":            "10",
 						"action.#":            "1",
@@ -332,11 +331,11 @@ func TestAccAwsWafv2RuleGroup_updateRuleProperties(t *testing.T) {
 						"statement.0.size_constraint_statement.0.size":                            "50",
 						"statement.0.size_constraint_statement.0.text_transformation.#":           "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "CMD_LINE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "NONE",
 					}),
@@ -368,18 +367,18 @@ func TestAccAwsWafv2RuleGroup_ByteMatchStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                        "1",
 						"statement.0.byte_match_statement.#": "1",
 						"statement.0.byte_match_statement.0.positional_constraint": "CONTAINS",
 						"statement.0.byte_match_statement.0.search_string":         "word",
 						"statement.0.byte_match_statement.0.text_transformation.#": "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "LOWERCASE",
 					}),
@@ -391,14 +390,14 @@ func TestAccAwsWafv2RuleGroup_ByteMatchStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                        "1",
 						"statement.0.byte_match_statement.#": "1",
 						"statement.0.byte_match_statement.0.positional_constraint": "EXACTLY",
 						"statement.0.byte_match_statement.0.search_string":         "sentence",
 						"statement.0.byte_match_statement.0.text_transformation.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.byte_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "3",
 						"type":     "CMD_LINE",
 					}),
@@ -430,7 +429,7 @@ func TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                         "1",
 						"statement.0.byte_match_statement.#":                  "1",
 						"statement.0.byte_match_statement.0.field_to_match.#": "1",
@@ -450,7 +449,7 @@ func TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                         "1",
 						"statement.0.byte_match_statement.#":                  "1",
 						"statement.0.byte_match_statement.0.field_to_match.#": "1",
@@ -470,7 +469,7 @@ func TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                         "1",
 						"statement.0.byte_match_statement.#":                  "1",
 						"statement.0.byte_match_statement.0.field_to_match.#": "1",
@@ -490,7 +489,7 @@ func TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                         "1",
 						"statement.0.byte_match_statement.#":                  "1",
 						"statement.0.byte_match_statement.0.field_to_match.#": "1",
@@ -510,7 +509,7 @@ func TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                         "1",
 						"statement.0.byte_match_statement.#":                  "1",
 						"statement.0.byte_match_statement.0.field_to_match.#": "1",
@@ -531,7 +530,7 @@ func TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                         "1",
 						"statement.0.byte_match_statement.#":                  "1",
 						"statement.0.byte_match_statement.0.field_to_match.#": "1",
@@ -552,7 +551,7 @@ func TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                         "1",
 						"statement.0.byte_match_statement.#":                  "1",
 						"statement.0.byte_match_statement.0.field_to_match.#": "1",
@@ -753,7 +752,7 @@ func TestAccAwsWafv2RuleGroup_GeoMatchStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                             "1",
 						"statement.0.geo_match_statement.#":                       "1",
 						"statement.0.geo_match_statement.0.country_codes.#":       "2",
@@ -769,7 +768,7 @@ func TestAccAwsWafv2RuleGroup_GeoMatchStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                             "1",
 						"statement.0.geo_match_statement.#":                       "1",
 						"statement.0.geo_match_statement.0.country_codes.#":       "3",
@@ -806,7 +805,7 @@ func TestAccAwsWafv2RuleGroup_GeoMatchStatement_ForwardedIPConfig(t *testing.T) 
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                                               "1",
 						"statement.0.geo_match_statement.#":                                         "1",
 						"statement.0.geo_match_statement.0.country_codes.#":                         "2",
@@ -824,7 +823,7 @@ func TestAccAwsWafv2RuleGroup_GeoMatchStatement_ForwardedIPConfig(t *testing.T) 
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                                               "1",
 						"statement.0.geo_match_statement.#":                                         "1",
 						"statement.0.geo_match_statement.0.country_codes.#":                         "2",
@@ -862,12 +861,12 @@ func TestAccAwsWafv2RuleGroup_IpSetReferenceStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#":                              "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#": "0",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
 				),
@@ -898,14 +897,14 @@ func TestAccAwsWafv2RuleGroup_IpSetReferenceStatement_IPSetForwardedIPConfig(t *
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#": "1",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#":                   "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.fallback_behavior": "MATCH",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.header_name":       "X-Forwarded-For",
@@ -919,14 +918,14 @@ func TestAccAwsWafv2RuleGroup_IpSetReferenceStatement_IPSetForwardedIPConfig(t *
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#": "1",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#":                   "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.fallback_behavior": "NO_MATCH",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.header_name":       "X-Forwarded-For",
@@ -940,14 +939,14 @@ func TestAccAwsWafv2RuleGroup_IpSetReferenceStatement_IPSetForwardedIPConfig(t *
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#": "1",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#":                   "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.fallback_behavior": "MATCH",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.header_name":       "Updated",
@@ -961,12 +960,12 @@ func TestAccAwsWafv2RuleGroup_IpSetReferenceStatement_IPSetForwardedIPConfig(t *
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#":                              "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#": "0",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
 				),
@@ -997,7 +996,7 @@ func TestAccAwsWafv2RuleGroup_LogicalRuleStatements(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                             "1",
 						"statement.0.and_statement.#":             "1",
 						"statement.0.and_statement.0.statement.#": "2",
@@ -1012,7 +1011,7 @@ func TestAccAwsWafv2RuleGroup_LogicalRuleStatements(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                                         "1",
 						"statement.0.not_statement.#":                                         "1",
 						"statement.0.not_statement.0.statement.#":                             "1",
@@ -1029,7 +1028,7 @@ func TestAccAwsWafv2RuleGroup_LogicalRuleStatements(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                                        "1",
 						"statement.0.or_statement.#":                                         "1",
 						"statement.0.or_statement.0.statement.#":                             "2",
@@ -1099,13 +1098,13 @@ func TestAccAwsWafv2RuleGroup_RegexPatternSetReferenceStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.regex_pattern_set_reference_statement.#":                       "1",
 						"statement.0.regex_pattern_set_reference_statement.0.field_to_match.#":      "1",
 						"statement.0.regex_pattern_set_reference_statement.0.text_transformation.#": "1",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.regex_pattern_set_reference_statement.0.arn": regexp.MustCompile(`regional/regexpatternset/.+$`),
 					}),
 				),
@@ -1141,7 +1140,7 @@ func TestAccAwsWafv2RuleGroup_RuleAction(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"action.#":         "1",
 						"action.0.allow.#": "1",
 						"action.0.block.#": "0",
@@ -1160,7 +1159,7 @@ func TestAccAwsWafv2RuleGroup_RuleAction(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"action.#":         "1",
 						"action.0.allow.#": "0",
 						"action.0.block.#": "1",
@@ -1179,7 +1178,7 @@ func TestAccAwsWafv2RuleGroup_RuleAction(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"action.#":         "1",
 						"action.0.allow.#": "0",
 						"action.0.block.#": "0",
@@ -1212,7 +1211,7 @@ func TestAccAwsWafv2RuleGroup_SizeConstraintStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.size_constraint_statement.#":                           "1",
 						"statement.0.size_constraint_statement.0.comparison_operator":       "GT",
@@ -1229,7 +1228,7 @@ func TestAccAwsWafv2RuleGroup_SizeConstraintStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.size_constraint_statement.#":                                 "1",
 						"statement.0.size_constraint_statement.0.comparison_operator":             "LT",
@@ -1265,18 +1264,18 @@ func TestAccAwsWafv2RuleGroup_SqliMatchStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                         "1",
 						"statement.0.sqli_match_statement.#":                  "1",
 						"statement.0.sqli_match_statement.0.field_to_match.#": "1",
 						"statement.0.sqli_match_statement.0.field_to_match.0.all_query_arguments.#": "1",
 						"statement.0.sqli_match_statement.0.text_transformation.#":                  "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "URL_DECODE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "LOWERCASE",
 					}),
@@ -1288,22 +1287,22 @@ func TestAccAwsWafv2RuleGroup_SqliMatchStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                                "1",
 						"statement.0.sqli_match_statement.#":                         "1",
 						"statement.0.sqli_match_statement.0.field_to_match.#":        "1",
 						"statement.0.sqli_match_statement.0.field_to_match.0.body.#": "1",
 						"statement.0.sqli_match_statement.0.text_transformation.#":   "3",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "URL_DECODE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "4",
 						"type":     "HTML_ENTITY_DECODE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.sqli_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "3",
 						"type":     "COMPRESS_WHITE_SPACE",
 					}),
@@ -1383,14 +1382,14 @@ func TestAccAwsWafv2RuleGroup_XssMatchStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                               "1",
 						"statement.0.xss_match_statement.#":                         "1",
 						"statement.0.xss_match_statement.0.field_to_match.#":        "1",
 						"statement.0.xss_match_statement.0.field_to_match.0.body.#": "1",
 						"statement.0.xss_match_statement.0.text_transformation.#":   "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.xss_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.xss_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "NONE",
 					}),
@@ -1402,14 +1401,14 @@ func TestAccAwsWafv2RuleGroup_XssMatchStatement(t *testing.T) {
 					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                               "1",
 						"statement.0.xss_match_statement.#":                         "1",
 						"statement.0.xss_match_statement.0.field_to_match.#":        "1",
 						"statement.0.xss_match_statement.0.field_to_match.0.body.#": "1",
 						"statement.0.xss_match_statement.0.text_transformation.#":   "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.xss_match_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.xss_match_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "URL_DECODE",
 					}),

--- a/aws/resource_aws_wafv2_web_acl_logging_configuration_test.go
+++ b/aws/resource_aws_wafv2_web_acl_logging_configuration_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAwsWafv2WebACLLoggingConfiguration_basic(t *testing.T) {
@@ -68,10 +67,10 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_update(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"single_header.0.name": "referer",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"single_header.0.name": "user-agent",
 					}),
 				),
@@ -83,7 +82,7 @@ func TestAccAwsWafv2WebACLLoggingConfiguration_update(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", webACLResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_configs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "redacted_fields.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "redacted_fields.*", map[string]string{
 						"single_header.0.name": "user-agent",
 					}),
 				),

--- a/aws/resource_aws_wafv2_web_acl_test.go
+++ b/aws/resource_aws_wafv2_web_acl_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/wafv2/lister"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -143,7 +142,7 @@ func TestAccAwsWafv2WebACL_updateRule(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                ruleName1,
 						"priority":            "10",
 						"action.#":            "1",
@@ -162,11 +161,11 @@ func TestAccAwsWafv2WebACL_updateRule(t *testing.T) {
 						"statement.0.size_constraint_statement.0.size":                            "50",
 						"statement.0.size_constraint_statement.0.text_transformation.#":           "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "CMD_LINE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "NONE",
 					}),
@@ -190,7 +189,7 @@ func TestAccAwsWafv2WebACL_updateRule(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                ruleName1,
 						"priority":            "10",
 						"action.#":            "1",
@@ -209,15 +208,15 @@ func TestAccAwsWafv2WebACL_updateRule(t *testing.T) {
 						"statement.0.size_constraint_statement.0.size":                            "50",
 						"statement.0.size_constraint_statement.0.text_transformation.#":           "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "CMD_LINE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                ruleName2,
 						"priority":            "5",
 						"action.#":            "1",
@@ -273,7 +272,7 @@ func TestAccAwsWafv2WebACL_UpdateRuleProperties(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                ruleName1,
 						"priority":            "5",
 						"action.#":            "1",
@@ -292,15 +291,15 @@ func TestAccAwsWafv2WebACL_UpdateRuleProperties(t *testing.T) {
 						"statement.0.size_constraint_statement.0.size":                            "50",
 						"statement.0.size_constraint_statement.0.text_transformation.#":           "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "CMD_LINE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                ruleName2,
 						"priority":            "10",
 						"action.#":            "1",
@@ -334,7 +333,7 @@ func TestAccAwsWafv2WebACL_UpdateRuleProperties(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                ruleName1,
 						"priority":            "10",
 						"action.#":            "1",
@@ -353,15 +352,15 @@ func TestAccAwsWafv2WebACL_UpdateRuleProperties(t *testing.T) {
 						"statement.0.size_constraint_statement.0.size":                            "50",
 						"statement.0.size_constraint_statement.0.text_transformation.#":           "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "CMD_LINE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                ruleName2,
 						"priority":            "5",
 						"action.#":            "1",
@@ -395,7 +394,7 @@ func TestAccAwsWafv2WebACL_UpdateRuleProperties(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                ruleName1,
 						"priority":            "10",
 						"action.#":            "1",
@@ -414,15 +413,15 @@ func TestAccAwsWafv2WebACL_UpdateRuleProperties(t *testing.T) {
 						"statement.0.size_constraint_statement.0.size":                            "50",
 						"statement.0.size_constraint_statement.0.text_transformation.#":           "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "2",
 						"type":     "CMD_LINE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.statement.0.size_constraint_statement.0.text_transformation.*", map[string]string{
 						"priority": "5",
 						"type":     "NONE",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                "updated",
 						"priority":            "5",
 						"action.#":            "1",
@@ -539,7 +538,7 @@ func TestAccAwsWafv2WebACL_ManagedRuleGroupStatement(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                      "rule-1",
 						"action.#":                  "0",
 						"override_action.#":         "1",
@@ -560,7 +559,7 @@ func TestAccAwsWafv2WebACL_ManagedRuleGroupStatement(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                      "rule-1",
 						"action.#":                  "0",
 						"override_action.#":         "1",
@@ -635,7 +634,7 @@ func TestAccAwsWafv2WebACL_RateBasedStatement(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                               "rule-1",
 						"action.#":                           "1",
 						"action.0.allow.#":                   "0",
@@ -657,7 +656,7 @@ func TestAccAwsWafv2WebACL_RateBasedStatement(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                               "rule-1",
 						"action.#":                           "1",
 						"action.0.allow.#":                   "0",
@@ -709,7 +708,7 @@ func TestAccAwsWafv2WebACL_GeoMatchStatement(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scope", "REGIONAL"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                              "rule-1",
 						"action.#":                          "1",
 						"action.0.allow.#":                  "0",
@@ -743,7 +742,7 @@ func TestAccAwsWafv2WebACL_GeoMatchStatement(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scope", "REGIONAL"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                              "rule-1",
 						"action.#":                          "1",
 						"action.0.allow.#":                  "0",
@@ -794,7 +793,7 @@ func TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                            "1",
 						"statement.0.or_statement.#":             "1",
 						"statement.0.or_statement.0.statement.#": "2",
@@ -816,7 +815,7 @@ func TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                            "1",
 						"statement.0.or_statement.#":             "1",
 						"statement.0.or_statement.0.statement.#": "2",
@@ -858,7 +857,7 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#":                              "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#": "0",
@@ -867,7 +866,7 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement(t *testing.T) {
 						"visibility_config.0.metric_name":                "friendly-rule-metric-name",
 						"visibility_config.0.sampled_requests_enabled":   "false",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
@@ -903,14 +902,14 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *tes
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#": "1",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#":                   "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.fallback_behavior": "MATCH",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.header_name":       "X-Forwarded-For",
@@ -925,14 +924,14 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *tes
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#": "1",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#":                   "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.fallback_behavior": "NO_MATCH",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.header_name":       "X-Forwarded-For",
@@ -947,14 +946,14 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *tes
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#": "1",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#":                   "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.fallback_behavior": "MATCH",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.0.header_name":       "Updated",
@@ -969,12 +968,12 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *tes
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#": "1",
 						"statement.0.ip_set_reference_statement.#":                              "1",
 						"statement.0.ip_set_reference_statement.0.ip_set_forwarded_ip_config.#": "0",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.ip_set_reference_statement.0.arn": regexp.MustCompile(`regional/ipset/.+$`),
 					}),
 				),
@@ -1006,7 +1005,7 @@ func TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                               "rule-1",
 						"action.#":                           "1",
 						"action.0.allow.#":                   "0",
@@ -1030,7 +1029,7 @@ func TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                               "rule-1",
 						"action.#":                           "1",
 						"action.0.allow.#":                   "0",
@@ -1074,7 +1073,7 @@ func TestAccAwsWafv2WebACL_RuleGroupReferenceStatement(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                      "rule-1",
 						"override_action.#":         "1",
 						"override_action.0.count.#": "1",
@@ -1083,7 +1082,7 @@ func TestAccAwsWafv2WebACL_RuleGroupReferenceStatement(t *testing.T) {
 						"statement.0.rule_group_reference_statement.#":                 "1",
 						"statement.0.rule_group_reference_statement.0.excluded_rule.#": "0",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.rule_group_reference_statement.0.arn": regexp.MustCompile(`regional/rulegroup/.+$`),
 					}),
 				),
@@ -1095,7 +1094,7 @@ func TestAccAwsWafv2WebACL_RuleGroupReferenceStatement(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"name":                      "rule-1",
 						"override_action.#":         "1",
 						"override_action.0.count.#": "1",
@@ -1106,7 +1105,7 @@ func TestAccAwsWafv2WebACL_RuleGroupReferenceStatement(t *testing.T) {
 						"statement.0.rule_group_reference_statement.0.excluded_rule.0.name": "rule-to-exclude-b",
 						"statement.0.rule_group_reference_statement.0.excluded_rule.1.name": "rule-to-exclude-a",
 					}),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]*regexp.Regexp{
 						"statement.0.rule_group_reference_statement.0.arn": regexp.MustCompile(`regional/rulegroup/.+$`),
 					}),
 				),
@@ -1187,7 +1186,7 @@ func TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                                                                                      "1",
 						"statement.0.rate_based_statement.#":                                                                               "1",
 						"statement.0.rate_based_statement.0.limit":                                                                         "300",
@@ -1229,7 +1228,7 @@ func TestAccAwsWafv2WebACL_MaxNestedOperatorStatements(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"statement.#":                                                                                    "1",
 						"statement.0.and_statement.#":                                                                    "1",
 						"statement.0.and_statement.0.statement.#":                                                        "2",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15882

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsWafv2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWafv2 -timeout 120m
=== RUN   TestAccAwsWafv2IPSet_basic
=== PAUSE TestAccAwsWafv2IPSet_basic
=== RUN   TestAccAwsWafv2IPSet_Disappears
=== PAUSE TestAccAwsWafv2IPSet_Disappears
=== RUN   TestAccAwsWafv2IPSet_IPv6
=== PAUSE TestAccAwsWafv2IPSet_IPv6
=== RUN   TestAccAwsWafv2IPSet_Minimal
=== PAUSE TestAccAwsWafv2IPSet_Minimal
=== RUN   TestAccAwsWafv2IPSet_ChangeNameForceNew
=== PAUSE TestAccAwsWafv2IPSet_ChangeNameForceNew
=== RUN   TestAccAwsWafv2IPSet_Tags
=== PAUSE TestAccAwsWafv2IPSet_Tags
=== RUN   TestAccAwsWafv2IPSet_Large
=== PAUSE TestAccAwsWafv2IPSet_Large
=== RUN   TestAccAwsWafv2RegexPatternSet_basic
=== PAUSE TestAccAwsWafv2RegexPatternSet_basic
=== RUN   TestAccAwsWafv2RegexPatternSet_Disappears
=== PAUSE TestAccAwsWafv2RegexPatternSet_Disappears
=== RUN   TestAccAwsWafv2RegexPatternSet_Minimal
=== PAUSE TestAccAwsWafv2RegexPatternSet_Minimal
=== RUN   TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew
=== PAUSE TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew
=== RUN   TestAccAwsWafv2RegexPatternSet_Tags
=== PAUSE TestAccAwsWafv2RegexPatternSet_Tags
=== RUN   TestAccAwsWafv2RuleGroup_basic
=== PAUSE TestAccAwsWafv2RuleGroup_basic
=== RUN   TestAccAwsWafv2RuleGroup_updateRule
=== PAUSE TestAccAwsWafv2RuleGroup_updateRule
=== RUN   TestAccAwsWafv2RuleGroup_updateRuleProperties
=== PAUSE TestAccAwsWafv2RuleGroup_updateRuleProperties
=== RUN   TestAccAwsWafv2RuleGroup_ByteMatchStatement
=== PAUSE TestAccAwsWafv2RuleGroup_ByteMatchStatement
=== RUN   TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch
=== PAUSE TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch
=== RUN   TestAccAwsWafv2RuleGroup_ChangeNameForceNew
=== PAUSE TestAccAwsWafv2RuleGroup_ChangeNameForceNew
=== RUN   TestAccAwsWafv2RuleGroup_ChangeCapacityForceNew
=== PAUSE TestAccAwsWafv2RuleGroup_ChangeCapacityForceNew
=== RUN   TestAccAwsWafv2RuleGroup_ChangeMetricNameForceNew
=== PAUSE TestAccAwsWafv2RuleGroup_ChangeMetricNameForceNew
=== RUN   TestAccAwsWafv2RuleGroup_Disappears
=== PAUSE TestAccAwsWafv2RuleGroup_Disappears
=== RUN   TestAccAwsWafv2RuleGroup_GeoMatchStatement
=== PAUSE TestAccAwsWafv2RuleGroup_GeoMatchStatement
=== RUN   TestAccAwsWafv2RuleGroup_GeoMatchStatement_ForwardedIPConfig
=== PAUSE TestAccAwsWafv2RuleGroup_GeoMatchStatement_ForwardedIPConfig
=== RUN   TestAccAwsWafv2RuleGroup_IpSetReferenceStatement
=== PAUSE TestAccAwsWafv2RuleGroup_IpSetReferenceStatement
=== RUN   TestAccAwsWafv2RuleGroup_IpSetReferenceStatement_IPSetForwardedIPConfig
=== PAUSE TestAccAwsWafv2RuleGroup_IpSetReferenceStatement_IPSetForwardedIPConfig
=== RUN   TestAccAwsWafv2RuleGroup_LogicalRuleStatements
=== PAUSE TestAccAwsWafv2RuleGroup_LogicalRuleStatements
=== RUN   TestAccAwsWafv2RuleGroup_Minimal
=== PAUSE TestAccAwsWafv2RuleGroup_Minimal
=== RUN   TestAccAwsWafv2RuleGroup_RegexPatternSetReferenceStatement
=== PAUSE TestAccAwsWafv2RuleGroup_RegexPatternSetReferenceStatement
=== RUN   TestAccAwsWafv2RuleGroup_RuleAction
=== PAUSE TestAccAwsWafv2RuleGroup_RuleAction
=== RUN   TestAccAwsWafv2RuleGroup_SizeConstraintStatement
=== PAUSE TestAccAwsWafv2RuleGroup_SizeConstraintStatement
=== RUN   TestAccAwsWafv2RuleGroup_SqliMatchStatement
=== PAUSE TestAccAwsWafv2RuleGroup_SqliMatchStatement
=== RUN   TestAccAwsWafv2RuleGroup_Tags
=== PAUSE TestAccAwsWafv2RuleGroup_Tags
=== RUN   TestAccAwsWafv2RuleGroup_XssMatchStatement
=== PAUSE TestAccAwsWafv2RuleGroup_XssMatchStatement
=== RUN   TestAccAwsWafv2WebACLAssociation_basic
=== PAUSE TestAccAwsWafv2WebACLAssociation_basic
=== RUN   TestAccAwsWafv2WebACLAssociation_Disappears
=== PAUSE TestAccAwsWafv2WebACLAssociation_Disappears
=== RUN   TestAccAwsWafv2WebACLLoggingConfiguration_basic
=== PAUSE TestAccAwsWafv2WebACLLoggingConfiguration_basic
=== RUN   TestAccAwsWafv2WebACLLoggingConfiguration_update
=== PAUSE TestAccAwsWafv2WebACLLoggingConfiguration_update
=== RUN   TestAccAwsWafv2WebACLLoggingConfiguration_changeResourceARNForceNew
=== PAUSE TestAccAwsWafv2WebACLLoggingConfiguration_changeResourceARNForceNew
=== RUN   TestAccAwsWafv2WebACLLoggingConfiguration_changeLogDestinationConfigsForceNew
=== PAUSE TestAccAwsWafv2WebACLLoggingConfiguration_changeLogDestinationConfigsForceNew
=== RUN   TestAccAwsWafv2WebACLLoggingConfiguration_disappears
=== PAUSE TestAccAwsWafv2WebACLLoggingConfiguration_disappears
=== RUN   TestAccAwsWafv2WebACLLoggingConfiguration_webACLDisappears
=== PAUSE TestAccAwsWafv2WebACLLoggingConfiguration_webACLDisappears
=== RUN   TestAccAwsWafv2WebACL_basic
=== PAUSE TestAccAwsWafv2WebACL_basic
=== RUN   TestAccAwsWafv2WebACL_updateRule
=== PAUSE TestAccAwsWafv2WebACL_updateRule
=== RUN   TestAccAwsWafv2WebACL_UpdateRuleProperties
=== PAUSE TestAccAwsWafv2WebACL_UpdateRuleProperties
=== RUN   TestAccAwsWafv2WebACL_ChangeNameForceNew
=== PAUSE TestAccAwsWafv2WebACL_ChangeNameForceNew
=== RUN   TestAccAwsWafv2WebACL_Disappears
=== PAUSE TestAccAwsWafv2WebACL_Disappears
=== RUN   TestAccAwsWafv2WebACL_ManagedRuleGroupStatement
=== PAUSE TestAccAwsWafv2WebACL_ManagedRuleGroupStatement
=== RUN   TestAccAwsWafv2WebACL_Minimal
=== PAUSE TestAccAwsWafv2WebACL_Minimal
=== RUN   TestAccAwsWafv2WebACL_RateBasedStatement
=== PAUSE TestAccAwsWafv2WebACL_RateBasedStatement
=== RUN   TestAccAwsWafv2WebACL_GeoMatchStatement
=== PAUSE TestAccAwsWafv2WebACL_GeoMatchStatement
=== RUN   TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig
=== PAUSE TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig
=== RUN   TestAccAwsWafv2WebACL_IPSetReferenceStatement
=== PAUSE TestAccAwsWafv2WebACL_IPSetReferenceStatement
=== RUN   TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig
=== PAUSE TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig
=== RUN   TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig
=== PAUSE TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig
=== RUN   TestAccAwsWafv2WebACL_RuleGroupReferenceStatement
=== PAUSE TestAccAwsWafv2WebACL_RuleGroupReferenceStatement
=== RUN   TestAccAwsWafv2WebACL_Tags
=== PAUSE TestAccAwsWafv2WebACL_Tags
=== RUN   TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements
=== PAUSE TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements
=== RUN   TestAccAwsWafv2WebACL_MaxNestedOperatorStatements
=== PAUSE TestAccAwsWafv2WebACL_MaxNestedOperatorStatements
=== CONT  TestAccAwsWafv2IPSet_basic
=== CONT  TestAccAwsWafv2RuleGroup_SqliMatchStatement
=== CONT  TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch
=== CONT  TestAccAwsWafv2RuleGroup_ByteMatchStatement
=== CONT  TestAccAwsWafv2RuleGroup_GeoMatchStatement_ForwardedIPConfig
=== CONT  TestAccAwsWafv2RuleGroup_GeoMatchStatement
=== CONT  TestAccAwsWafv2RuleGroup_IpSetReferenceStatement
=== CONT  TestAccAwsWafv2RuleGroup_Disappears
=== CONT  TestAccAwsWafv2RuleGroup_ChangeMetricNameForceNew
=== CONT  TestAccAwsWafv2RuleGroup_SizeConstraintStatement
=== CONT  TestAccAwsWafv2RuleGroup_ChangeCapacityForceNew
=== CONT  TestAccAwsWafv2RuleGroup_ChangeNameForceNew
=== CONT  TestAccAwsWafv2RuleGroup_RuleAction
=== CONT  TestAccAwsWafv2RuleGroup_RegexPatternSetReferenceStatement
=== CONT  TestAccAwsWafv2WebACL_Disappears
=== CONT  TestAccAwsWafv2RuleGroup_Minimal
=== CONT  TestAccAwsWafv2WebACL_MaxNestedOperatorStatements
=== CONT  TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements
=== CONT  TestAccAwsWafv2WebACL_Tags
=== CONT  TestAccAwsWafv2RuleGroup_LogicalRuleStatements
2020/11/17 10:02:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/11/17 10:02:20 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2020/11/17 10:02:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
=== CONT  TestAccAwsWafv2WebACL_RuleGroupReferenceStatement
--- PASS: TestAccAwsWafv2WebACL_Disappears (15.53s)
--- PASS: TestAccAwsWafv2RuleGroup_RegexPatternSetReferenceStatement (33.72s)
=== CONT  TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig
--- PASS: TestAccAwsWafv2RuleGroup_GeoMatchStatement_ForwardedIPConfig (34.71s)
=== CONT  TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig
--- PASS: TestAccAwsWafv2RuleGroup_Minimal (41.12s)
=== CONT  TestAccAwsWafv2WebACL_IPSetReferenceStatement
--- PASS: TestAccAwsWafv2RuleGroup_GeoMatchStatement (46.34s)
=== CONT  TestAccAwsWafv2RuleGroup_IpSetReferenceStatement_IPSetForwardedIPConfig
--- PASS: TestAccAwsWafv2RuleGroup_ByteMatchStatement (66.60s)
=== CONT  TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig
--- PASS: TestAccAwsWafv2RuleGroup_Disappears (67.82s)
=== CONT  TestAccAwsWafv2WebACL_GeoMatchStatement
--- PASS: TestAccAwsWafv2RuleGroup_ChangeMetricNameForceNew (95.93s)
=== CONT  TestAccAwsWafv2WebACL_RateBasedStatement
--- PASS: TestAccAwsWafv2RuleGroup_ChangeCapacityForceNew (106.82s)
=== CONT  TestAccAwsWafv2WebACL_Minimal
--- PASS: TestAccAwsWafv2RuleGroup_LogicalRuleStatements (109.17s)
=== CONT  TestAccAwsWafv2WebACL_ManagedRuleGroupStatement
--- PASS: TestAccAwsWafv2WebACL_IPSetReferenceStatement (71.50s)
=== CONT  TestAccAwsWafv2WebACLLoggingConfiguration_changeLogDestinationConfigsForceNew
--- PASS: TestAccAwsWafv2RuleGroup_RuleAction (115.04s)
=== CONT  TestAccAwsWafv2WebACL_ChangeNameForceNew
--- PASS: TestAccAwsWafv2WebACL_Minimal (14.09s)
=== CONT  TestAccAwsWafv2WebACL_UpdateRuleProperties
--- PASS: TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements (133.59s)
=== CONT  TestAccAwsWafv2WebACLLoggingConfiguration_webACLDisappears
--- PASS: TestAccAwsWafv2IPSet_basic (153.23s)
=== CONT  TestAccAwsWafv2WebACL_basic
--- PASS: TestAccAwsWafv2RuleGroup_SqliMatchStatement (155.85s)
=== CONT  TestAccAwsWafv2WebACLLoggingConfiguration_disappears
--- PASS: TestAccAwsWafv2RuleGroup_ChangeNameForceNew (157.11s)
=== CONT  TestAccAwsWafv2WebACLAssociation_Disappears
--- PASS: TestAccAwsWafv2WebACL_ManagedRuleGroupStatement (54.80s)
=== CONT  TestAccAwsWafv2WebACLLoggingConfiguration_update
--- PASS: TestAccAwsWafv2WebACL_ChangeNameForceNew (51.42s)
=== CONT  TestAccAwsWafv2WebACLLoggingConfiguration_basic
--- PASS: TestAccAwsWafv2WebACL_basic (14.42s)
=== CONT  TestAccAwsWafv2WebACLLoggingConfiguration_changeResourceARNForceNew
--- PASS: TestAccAwsWafv2WebACL_UpdateRuleProperties (48.49s)
=== CONT  TestAccAwsWafv2RuleGroup_XssMatchStatement
2020/11/17 10:05:01 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAwsWafv2WebACL_GeoMatchStatement (105.10s)
=== CONT  TestAccAwsWafv2RegexPatternSet_Disappears
--- PASS: TestAccAwsWafv2RegexPatternSet_Disappears (9.14s)
=== CONT  TestAccAwsWafv2WebACLAssociation_basic
--- PASS: TestAccAwsWafv2WebACL_Tags (186.96s)
=== CONT  TestAccAwsWafv2WebACL_updateRule
--- PASS: TestAccAwsWafv2RuleGroup_XssMatchStatement (25.34s)
=== CONT  TestAccAwsWafv2RuleGroup_updateRuleProperties
--- PASS: TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig (163.18s)
=== CONT  TestAccAwsWafv2RuleGroup_updateRule
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_webACLDisappears (71.72s)
=== CONT  TestAccAwsWafv2RuleGroup_Tags
--- PASS: TestAccAwsWafv2WebACL_MaxNestedOperatorStatements (208.51s)
=== CONT  TestAccAwsWafv2RegexPatternSet_Tags
--- PASS: TestAccAwsWafv2RuleGroup_IpSetReferenceStatement_IPSetForwardedIPConfig (165.56s)
=== CONT  TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew
2020/11/17 10:05:50 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig (158.50s)
=== CONT  TestAccAwsWafv2RegexPatternSet_Minimal
--- PASS: TestAccAwsWafv2RegexPatternSet_Minimal (15.02s)
=== CONT  TestAccAwsWafv2IPSet_ChangeNameForceNew
--- PASS: TestAccAwsWafv2WebACL_updateRule (54.74s)
=== CONT  TestAccAwsWafv2IPSet_IPv6
--- PASS: TestAccAwsWafv2WebACLAssociation_basic (60.24s)
=== CONT  TestAccAwsWafv2RuleGroup_basic
--- PASS: TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew (34.37s)
=== CONT  TestAccAwsWafv2RegexPatternSet_basic
--- PASS: TestAccAwsWafv2RuleGroup_updateRuleProperties (57.24s)
=== CONT  TestAccAwsWafv2IPSet_Minimal
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_basic (90.22s)
=== CONT  TestAccAwsWafv2IPSet_Disappears
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_disappears (100.88s)
=== CONT  TestAccAwsWafv2IPSet_Large
--- PASS: TestAccAwsWafv2WebACL_RateBasedStatement (162.55s)
=== CONT  TestAccAwsWafv2IPSet_Tags
--- PASS: TestAccAwsWafv2RuleGroup_basic (19.86s)
--- PASS: TestAccAwsWafv2WebACLAssociation_Disappears (108.14s)
--- PASS: TestAccAwsWafv2RegexPatternSet_Tags (58.35s)
--- PASS: TestAccAwsWafv2RuleGroup_Tags (66.04s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_update (110.74s)
--- PASS: TestAccAwsWafv2IPSet_Disappears (21.65s)
--- PASS: TestAccAwsWafv2IPSet_Large (22.36s)
--- PASS: TestAccAwsWafv2RuleGroup_IpSetReferenceStatement (281.27s)
--- PASS: TestAccAwsWafv2IPSet_ChangeNameForceNew (43.99s)
--- PASS: TestAccAwsWafv2IPSet_Minimal (35.77s)
--- PASS: TestAccAwsWafv2RegexPatternSet_basic (45.99s)
--- PASS: TestAccAwsWafv2IPSet_IPv6 (55.70s)
--- PASS: TestAccAwsWafv2RuleGroup_SizeConstraintStatement (312.36s)
--- PASS: TestAccAwsWafv2IPSet_Tags (56.04s)
--- PASS: TestAccAwsWafv2RuleGroup_updateRule (128.80s)
--- PASS: TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch (343.21s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_changeLogDestinationConfigsForceNew (256.75s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_changeResourceARNForceNew (255.59s)
--- PASS: TestAccAwsWafv2WebACL_RuleGroupReferenceStatement (414.96s)
--- PASS: TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig (462.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	496.918s
```
