### PR TITLE
tests/provider: Migrate to SDK TypeSet Function (L-O)

### DIFF
--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -366,7 +365,7 @@ func TestAccAWSLaunchConfiguration_updateEbsBlockDevices(t *testing.T) {
 				Config: testAccAWSLaunchConfigurationWithEncryption(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
 						"volume_size": "9",
 					}),
 				),
@@ -381,7 +380,7 @@ func TestAccAWSLaunchConfiguration_updateEbsBlockDevices(t *testing.T) {
 				Config: testAccAWSLaunchConfigurationWithEncryptionUpdated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
 						"volume_size": "10",
 					}),
 				),
@@ -405,7 +404,7 @@ func TestAccAWSLaunchConfiguration_ebs_noDevice(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
 						"device_name": "/dev/sda2",
 						"no_device":   "true",
 					}),

--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestLBListenerARNFromRuleARN(t *testing.T) {
@@ -85,7 +84,7 @@ func TestAccAWSLBListenerRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.0.authenticate_cognito.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.authenticate_oidc.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":           "0",
 						"http_header.#":           "0",
 						"http_request_method.#":   "0",
@@ -94,7 +93,7 @@ func TestAccAWSLBListenerRule_basic(t *testing.T) {
 						"query_string.#":          "0",
 						"source_ip.#":             "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/static/*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/static/*"),
 				),
 			},
 		},
@@ -210,7 +209,7 @@ func TestAccAWSLBListenerRule_BackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.0.authenticate_cognito.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.authenticate_oidc.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":           "0",
 						"http_header.#":           "0",
 						"http_request_method.#":   "0",
@@ -219,7 +218,7 @@ func TestAccAWSLBListenerRule_BackwardsCompatibility(t *testing.T) {
 						"query_string.#":          "0",
 						"source_ip.#":             "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/static/*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/static/*"),
 				),
 			},
 		},
@@ -657,7 +656,7 @@ func TestAccAWSLBListenerRule_conditionHostHeader(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":          "1",
 						"host_header.0.values.#": "2",
 						"http_header.#":          "0",
@@ -666,8 +665,8 @@ func TestAccAWSLBListenerRule_conditionHostHeader(t *testing.T) {
 						"query_string.#":         "0",
 						"source_ip.#":            "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "www.example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "www.example.com"),
 				),
 			},
 		},
@@ -695,7 +694,7 @@ func TestAccAWSLBListenerRule_conditionHttpHeader(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":                  "0",
 						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "X-Forwarded-For",
@@ -705,9 +704,9 @@ func TestAccAWSLBListenerRule_conditionHttpHeader(t *testing.T) {
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "10.0.0.*"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.1.*"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "10.0.0.*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.1.*"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":                  "0",
 						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "Zz9~|_^.-+*'&%$#!0aA",
@@ -717,7 +716,7 @@ func TestAccAWSLBListenerRule_conditionHttpHeader(t *testing.T) {
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "RFC7230 Validity"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "RFC7230 Validity"),
 				),
 			},
 		},
@@ -759,7 +758,7 @@ func TestAccAWSLBListenerRule_conditionHttpRequestMethod(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":                  "0",
 						"http_header.#":                  "0",
 						"http_request_method.#":          "1",
@@ -768,8 +767,8 @@ func TestAccAWSLBListenerRule_conditionHttpRequestMethod(t *testing.T) {
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "GET"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "POST"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "GET"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "POST"),
 				),
 			},
 		},
@@ -797,7 +796,7 @@ func TestAccAWSLBListenerRule_conditionPathPattern(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":           "0",
 						"http_header.#":           "0",
 						"http_request_method.#":   "0",
@@ -806,8 +805,8 @@ func TestAccAWSLBListenerRule_conditionPathPattern(t *testing.T) {
 						"query_string.#":          "0",
 						"source_ip.#":             "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/cgi-bin/*"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/cgi-bin/*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
 				),
 			},
 		},
@@ -835,7 +834,7 @@ func TestAccAWSLBListenerRule_conditionQueryString(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":         "0",
 						"http_header.#":         "0",
 						"http_request_method.#": "0",
@@ -843,18 +842,18 @@ func TestAccAWSLBListenerRule_conditionQueryString(t *testing.T) {
 						"query_string.#":        "2",
 						"source_ip.#":           "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
 						"key":   "",
 						"value": "surprise",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
 						"key":   "",
 						"value": "blank",
 					}),
 					// TODO: TypeSet check helpers cannot make distinction between the 2 set items
 					// because we had to write a new check for the "downstream" nested set
 					// a distinguishing attribute on the outer set would be solve this.
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":         "0",
 						"http_header.#":         "0",
 						"http_request_method.#": "0",
@@ -862,11 +861,11 @@ func TestAccAWSLBListenerRule_conditionQueryString(t *testing.T) {
 						"query_string.#":        "2",
 						"source_ip.#":           "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
 						"key":   "foo",
 						"value": "baz",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
 						"key":   "foo",
 						"value": "bar",
 					}),
@@ -897,7 +896,7 @@ func TestAccAWSLBListenerRule_conditionSourceIp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":         "0",
 						"http_header.#":         "0",
 						"http_request_method.#": "0",
@@ -906,8 +905,8 @@ func TestAccAWSLBListenerRule_conditionSourceIp(t *testing.T) {
 						"source_ip.#":           "1",
 						"source_ip.0.values.#":  "2",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "dead:cafe::/64"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "dead:cafe::/64"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
 				),
 			},
 		},
@@ -934,15 +933,15 @@ func TestAccAWSLBListenerRule_conditionUpdateMixed(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"path_pattern.#":          "1",
 						"path_pattern.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"source_ip.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
 				),
 			},
 			{
@@ -953,15 +952,15 @@ func TestAccAWSLBListenerRule_conditionUpdateMixed(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"path_pattern.#":          "1",
 						"path_pattern.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"source_ip.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "dead:cafe::/64"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "dead:cafe::/64"),
 				),
 			},
 			{
@@ -972,15 +971,15 @@ func TestAccAWSLBListenerRule_conditionUpdateMixed(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"path_pattern.#":          "1",
 						"path_pattern.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/cgi-bin/*"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/cgi-bin/*"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"source_ip.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "dead:cafe::/64"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "dead:cafe::/64"),
 				),
 			},
 		},
@@ -1008,7 +1007,7 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "5"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":                  "0",
 						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "X-Forwarded-For",
@@ -1018,9 +1017,9 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.1.*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.1.*"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":         "0",
 						"http_header.#":         "0",
 						"http_request_method.#": "0",
@@ -1029,9 +1028,9 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"source_ip.#":           "1",
 						"source_ip.0.values.#":  "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":                  "0",
 						"http_header.#":                  "0",
 						"http_request_method.#":          "1",
@@ -1040,9 +1039,9 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "GET"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "GET"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":           "0",
 						"http_header.#":           "0",
 						"http_request_method.#":   "0",
@@ -1051,9 +1050,9 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"query_string.#":          "0",
 						"source_ip.#":             "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":          "1",
 						"host_header.0.values.#": "1",
 						"http_header.#":          "0",
@@ -1062,7 +1061,7 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"query_string.#":         "0",
 						"source_ip.#":            "0",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
 				),
 			},
 		},
@@ -1089,36 +1088,36 @@ func TestAccAWSLBListenerRule_conditionUpdateMultiple(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "5"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "X-Forwarded-For",
 						"http_header.0.values.#":         "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.1.*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.1.*"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"source_ip.#":          "1",
 						"source_ip.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"http_request_method.#":          "1",
 						"http_request_method.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "GET"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "GET"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"path_pattern.#":          "1",
 						"path_pattern.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":          "1",
 						"host_header.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
 				),
 			},
 			{
@@ -1129,36 +1128,36 @@ func TestAccAWSLBListenerRule_conditionUpdateMultiple(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "5"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "X-Forwarded-For",
 						"http_header.0.values.#":         "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.2.*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.2.*"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"source_ip.#":          "1",
 						"source_ip.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/24"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/24"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"http_request_method.#":          "1",
 						"http_request_method.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "POST"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "POST"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"path_pattern.#":          "1",
 						"path_pattern.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/2/*"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/2/*"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
 						"host_header.#":          "1",
 						"host_header.0.values.#": "1",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "foobar.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "foobar.com"),
 				),
 			},
 		},

--- a/aws/resource_aws_lex_bot_alias_test.go
+++ b/aws/resource_aws_lex_bot_alias_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAwsLexBotAlias_basic(t *testing.T) {
@@ -125,13 +124,13 @@ func TestAccAwsLexBotAlias_conversationLogsText(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bot_version", LexBotVersionLatest),
 					resource.TestCheckResourceAttrPair(resourceName, "conversation_logs.0.iam_role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "conversation_logs.0.log_settings.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
 						"destination": "CLOUDWATCH_LOGS",
 						"log_type":    "TEXT",
 						"kms_key_arn": "",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", cloudwatchLogGroupResourceName, "arn"),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]*regexp.Regexp{
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", cloudwatchLogGroupResourceName, "arn"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]*regexp.Regexp{
 						"resource_prefix": regexp.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasID, LexBotVersionLatest))),
 					}),
 				),
@@ -171,13 +170,13 @@ func TestAccAwsLexBotAlias_conversationLogsAudio(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bot_version", LexBotVersionLatest),
 					resource.TestCheckResourceAttrPair(resourceName, "conversation_logs.0.iam_role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "conversation_logs.0.log_settings.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
 						"destination": "S3",
 						"log_type":    "AUDIO",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", s3BucketResourceName, "arn"),
-					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.kms_key_arn", kmsKeyResourceName, "arn"),
-					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]*regexp.Regexp{
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", s3BucketResourceName, "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.kms_key_arn", kmsKeyResourceName, "arn"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]*regexp.Regexp{
 						"resource_prefix": regexp.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasID, LexBotVersionLatest))),
 					}),
 				),
@@ -219,19 +218,19 @@ func TestAccAwsLexBotAlias_conversationLogsBoth(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "conversation_logs.0.iam_role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "conversation_logs.0.log_settings.#", "2"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
 						"destination": "CLOUDWATCH_LOGS",
 						"log_type":    "TEXT",
 						"kms_key_arn": "",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", cloudwatchLogGroupResourceName, "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", cloudwatchLogGroupResourceName, "arn"),
 
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
 						"destination": "S3",
 						"log_type":    "AUDIO",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", s3BucketResourceName, "arn"),
-					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.kms_key_arn", kmsKeyResourceName, "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", s3BucketResourceName, "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.kms_key_arn", kmsKeyResourceName, "arn"),
 				),
 			},
 			{

--- a/aws/resource_aws_lex_slot_type_test.go
+++ b/aws/resource_aws_lex_slot_type_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAwsLexSlotType_basic(t *testing.T) {
@@ -31,11 +30,11 @@ func TestAccAwsLexSlotType_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "create_version", "false"),
 					resource.TestCheckResourceAttr(rName, "description", ""),
 					resource.TestCheckResourceAttr(rName, "enumeration_value.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(rName, "enumeration_value.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "enumeration_value.*", map[string]string{
 						"value": "lilies",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(rName, "enumeration_value.*.synonyms.*", "Lirium"),
-					tfawsresource.TestCheckTypeSetElemAttr(rName, "enumeration_value.*.synonyms.*", "Martagon"),
+					resource.TestCheckTypeSetElemAttr(rName, "enumeration_value.*.synonyms.*", "Lirium"),
+					resource.TestCheckTypeSetElemAttr(rName, "enumeration_value.*.synonyms.*", "Martagon"),
 					resource.TestCheckResourceAttr(rName, "name", testSlotTypeID),
 					resource.TestCheckResourceAttr(rName, "value_selection_strategy", lexmodelbuildingservice.SlotValueSelectionStrategyOriginalValue),
 					resource.TestCheckResourceAttrSet(rName, "checksum"),
@@ -164,11 +163,11 @@ func TestAccAwsLexSlotType_enumerationValues(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsLexSlotTypeExists(rName, &v),
 					resource.TestCheckResourceAttr(rName, "enumeration_value.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(rName, "enumeration_value.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "enumeration_value.*", map[string]string{
 						"value": "tulips",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(rName, "enumeration_value.*.synonyms.*", "Eduardoregelia"),
-					tfawsresource.TestCheckTypeSetElemAttr(rName, "enumeration_value.*.synonyms.*", "Podonix"),
+					resource.TestCheckTypeSetElemAttr(rName, "enumeration_value.*.synonyms.*", "Eduardoregelia"),
+					resource.TestCheckTypeSetElemAttr(rName, "enumeration_value.*.synonyms.*", "Podonix"),
 				),
 			},
 			{

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -271,7 +270,7 @@ func TestAccAWSMqBroker_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "false",
 						"groups.#":       "0",
 						"username":       "Test",
@@ -350,16 +349,16 @@ func TestAccAWSMqBroker_allFieldsDefaultVpc(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "true",
 						"groups.#":       "3",
 						"username":       "SecondTest",
 						"password":       "SecondTestTest1234",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "first"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "second"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "third"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "first"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "second"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "third"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "false",
 						"groups.#":       "0",
 						"username":       "Test",
@@ -470,16 +469,16 @@ func TestAccAWSMqBroker_allFieldsCustomVpc(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "true",
 						"groups.#":       "3",
 						"username":       "SecondTest",
 						"password":       "SecondTestTest1234",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "first"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "second"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "third"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "first"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "second"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "third"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "false",
 						"groups.#":       "0",
 						"username":       "Test",
@@ -643,7 +642,7 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "false",
 						"groups.#":       "0",
 						"username":       "first",
@@ -663,13 +662,13 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "false",
 						"groups.#":       "0",
 						"username":       "second",
 						"password":       "TestTest2222",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "true",
 						"groups.#":       "0",
 						"username":       "first",
@@ -683,13 +682,13 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"console_access": "false",
 						"groups.#":       "1",
 						"username":       "second",
 						"password":       "TestTest2222",
 					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "admin"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user.*.groups.*", "admin"),
 				),
 			},
 		},
@@ -783,7 +782,7 @@ func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
 						"username": "Test",
 						"password": "TestTest9999",
 					}),

--- a/aws/resource_aws_neptune_cluster_parameter_group_test.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSNeptuneClusterParameterGroup_basic(t *testing.T) {
@@ -147,7 +146,7 @@ func TestAccAWSNeptuneClusterParameterGroup_Parameter(t *testing.T) {
 					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"apply_method": "pending-reboot",
 						"name":         "neptune_enable_audit_log",
 						"value":        "1",
@@ -165,7 +164,7 @@ func TestAccAWSNeptuneClusterParameterGroup_Parameter(t *testing.T) {
 					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"apply_method": "pending-reboot",
 						"name":         "neptune_enable_audit_log",
 						"value":        "0",

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSNeptuneCluster_basic(t *testing.T) {
@@ -377,7 +376,7 @@ func TestAccAWSNeptuneCluster_updateCloudwatchLogsExports(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNeptuneClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "enable_cloudwatch_logs_exports.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "enable_cloudwatch_logs_exports.*", "audit"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "enable_cloudwatch_logs_exports.*", "audit"),
 				),
 			},
 			{

--- a/aws/resource_aws_neptune_parameter_group_test.go
+++ b/aws/resource_aws_neptune_parameter_group_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSNeptuneParameterGroup_basic(t *testing.T) {
@@ -88,7 +87,7 @@ func TestAccAWSNeptuneParameterGroup_Parameter(t *testing.T) {
 					testAccCheckAWSNeptuneParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneParameterGroupAttributes(&v, rName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"apply_method": "pending-reboot",
 						"name":         "neptune_query_timeout",
 						"value":        "25",

--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -313,7 +312,7 @@ func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 				Config: testAccAWSNetworkAclEgressNIngressConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
 						"protocol":   "6",
 						"rule_no":    "1",
 						"from_port":  "80",
@@ -321,7 +320,7 @@ func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 						"action":     "allow",
 						"cidr_block": "10.3.0.0/18",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "egress.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "egress.*", map[string]string{
 						"protocol":   "6",
 						"rule_no":    "2",
 						"from_port":  "443",
@@ -355,7 +354,7 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_basic(t *testing.T) {
 				Config: testAccAWSNetworkAclIngressConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
 						"protocol":   "6",
 						"rule_no":    "2",
 						"from_port":  "443",
@@ -390,14 +389,14 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_update(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					testIngressRuleLength(&networkAcl, 2),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
 						"protocol":  "6",
 						"rule_no":   "1",
 						"from_port": "0",
 						"to_port":   "22",
 						"action":    "deny",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
 						"cidr_block": "10.2.0.0/18",
 						"from_port":  "443",
 						"rule_no":    "2",
@@ -415,7 +414,7 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_update(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					testIngressRuleLength(&networkAcl, 1),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
 						"protocol":   "6",
 						"rule_no":    "1",
 						"from_port":  "0",
@@ -628,7 +627,7 @@ func TestAccAWSNetworkAcl_ipv6Rules(t *testing.T) {
 					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					resource.TestCheckResourceAttr(
 						resourceName, "ingress.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
 						"protocol":        "6",
 						"rule_no":         "1",
 						"from_port":       "0",
@@ -683,7 +682,7 @@ func TestAccAWSNetworkAcl_ipv6VpcRules(t *testing.T) {
 					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					resource.TestCheckResourceAttr(
 						resourceName, "ingress.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
 						"ipv6_cidr_block": "2600:1f16:d1e:9a00::/56",
 					}),
 				),

--- a/aws/resource_aws_opsworks_application_test.go
+++ b/aws/resource_aws_opsworks_application_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSOpsworksApplication_basic(t *testing.T) {
@@ -35,7 +34,7 @@ func TestAccAWSOpsworksApplication_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "ssl_configuration"),
 					resource.TestCheckNoResourceAttr(resourceName, "domains"),
 					resource.TestCheckNoResourceAttr(resourceName, "app_source"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "environment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "environment.*", map[string]string{
 						"key":    "key1",
 						"value":  "value1",
 						"secret": "",
@@ -68,12 +67,12 @@ func TestAccAWSOpsworksApplication_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "app_source.0.type", "git"),
 					resource.TestCheckResourceAttr(resourceName, "app_source.0.url", "https://github.com/aws/example.git"),
 					resource.TestCheckResourceAttr(resourceName, "app_source.0.username", ""),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "environment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "environment.*", map[string]string{
 						"key":    "key2",
 						"value":  "value2",
 						"secure": "true",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "environment.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "environment.*", map[string]string{
 						"key":    "key1",
 						"value":  "value1",
 						"secret": "",

--- a/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/aws/resource_aws_opsworks_custom_layer_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 // These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
@@ -37,10 +36,10 @@ func TestAccAWSOpsworksCustomLayer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_shutdown_timeout", "300"),
 					resource.TestCheckResourceAttr(resourceName, "custom_security_group_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "system_packages.#", "2"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "git"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "golang"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "git"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "golang"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_volume.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_volume.*", map[string]string{
 						"type":            "gp2",
 						"number_of_disks": "2",
 						"mount_point":     "/home",
@@ -124,10 +123,10 @@ func TestAccAWSOpsworksCustomLayer_noVPC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_shutdown_timeout", "300"),
 					resource.TestCheckResourceAttr(resourceName, "custom_security_group_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "system_packages.#", "2"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "git"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "golang"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "git"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "golang"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_volume.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_volume.*", map[string]string{
 						"type":            "gp2",
 						"number_of_disks": "2",
 						"mount_point":     "/home",
@@ -144,17 +143,17 @@ func TestAccAWSOpsworksCustomLayer_noVPC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_shutdown_timeout", "120"),
 					resource.TestCheckResourceAttr(resourceName, "custom_security_group_ids.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "system_packages.#", "3"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "git"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "golang"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "subversion"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "git"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "golang"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "system_packages.*", "subversion"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.#", "2"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_volume.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_volume.*", map[string]string{
 						"type":            "gp2",
 						"number_of_disks": "2",
 						"mount_point":     "/home",
 						"size":            "100",
 					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_volume.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_volume.*", map[string]string{
 						"type":            "io1",
 						"number_of_disks": "4",
 						"mount_point":     "/var",

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func testAccAwsOrganizationsOrganization_basic(t *testing.T) {
@@ -66,7 +65,7 @@ func testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals(t *testing.T
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "config.amazonaws.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "config.amazonaws.com"),
 				),
 			},
 			{
@@ -79,8 +78,8 @@ func testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals(t *testing.T
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "2"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "config.amazonaws.com"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "ds.amazonaws.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "config.amazonaws.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "ds.amazonaws.com"),
 				),
 			},
 			{
@@ -88,7 +87,7 @@ func testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals(t *testing.T
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "fms.amazonaws.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "fms.amazonaws.com"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15882

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
