### PR TITLE
tests/provider: Fix and enable AT009 lint check

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -88,7 +88,6 @@ awsproviderlint:
 	@awsproviderlint \
 		-c 1 \
 		-AT004=false \
-		-AT009=false \
 		-AWSAT003=false \
 		-AWSAT006=false \
 		-AWSV001=false \

--- a/aws/data_source_aws_lex_bot_alias_test.go
+++ b/aws/data_source_aws_lex_bot_alias_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func testAccDataSourceAwsLexBotAlias_basic(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	rName := acctest.RandString(8)
 	dataSourceName := "data.aws_lex_bot_alias.test"
 	resourceName := "aws_lex_bot_alias.test"
 

--- a/aws/data_source_aws_lex_bot_test.go
+++ b/aws/data_source_aws_lex_bot_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccDataSourceAwsLexBot_basic(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	rName := acctest.RandString(8)
 	dataSourceName := "data.aws_lex_bot.test"
 	resourceName := "aws_lex_bot.test"
 
@@ -46,7 +46,7 @@ func TestAccDataSourceAwsLexBot_basic(t *testing.T) {
 }
 
 func testAccDataSourceAwsLexBot_withVersion(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	rName := acctest.RandString(8)
 	dataSourceName := "data.aws_lex_bot.test"
 	resourceName := "aws_lex_bot.test"
 

--- a/aws/data_source_aws_lex_intent_test.go
+++ b/aws/data_source_aws_lex_intent_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccDataSourceAwsLexIntent_basic(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	rName := acctest.RandString(8)
 	dataSourceName := "data.aws_lex_intent.test"
 	resourceName := "aws_lex_intent.test"
 
@@ -37,7 +37,7 @@ func TestAccDataSourceAwsLexIntent_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAwsLexIntent_withVersion(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	rName := acctest.RandString(8)
 	dataSourceName := "data.aws_lex_intent.test"
 	resourceName := "aws_lex_intent.test"
 

--- a/aws/data_source_aws_lex_slot_type_test.go
+++ b/aws/data_source_aws_lex_slot_type_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccDataSourceAwsLexSlotType_basic(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	rName := acctest.RandString(8)
 	dataSourceName := "data.aws_lex_slot_type.test"
 	resourceName := "aws_lex_slot_type.test"
 
@@ -38,7 +38,7 @@ func TestAccDataSourceAwsLexSlotType_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAwsLexSlotType_withVersion(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	rName := acctest.RandString(8)
 	dataSourceName := "data.aws_lex_slot_type.test"
 	resourceName := "aws_lex_slot_type.test"
 

--- a/aws/resource_aws_appmesh_virtual_node_test.go
+++ b/aws/resource_aws_appmesh_virtual_node_test.go
@@ -132,7 +132,7 @@ func testAccAwsAppmeshVirtualNode_cloudMapServiceDiscovery(t *testing.T) {
 	meshName := acctest.RandomWithPrefix("tf-acc-test")
 	vnName := acctest.RandomWithPrefix("tf-acc-test")
 	// Avoid 'config is invalid: last character of "name" must be a letter' for aws_service_discovery_http_namespace.
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(20, acctest.CharSetAlpha))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(20))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appmesh.EndpointsID, t) },

--- a/aws/resource_aws_cloudformation_stack_set_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_test.go
@@ -260,7 +260,7 @@ func TestAccAWSCloudFormationStackSet_Name(t *testing.T) {
 				ExpectError: regexp.MustCompile(`expected length`),
 			},
 			{
-				Config:      testAccAWSCloudFormationStackSetConfigName(acctest.RandStringFromCharSet(129, acctest.CharSetAlpha)),
+				Config:      testAccAWSCloudFormationStackSetConfigName(acctest.RandString(129)),
 				ExpectError: regexp.MustCompile(`(cannot be longer|expected length)`),
 			},
 			{

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -972,7 +972,7 @@ func TestResourceAWSELB_validateHealthCheckTarget(t *testing.T) {
 		},
 		{
 			Value: fmt.Sprintf("HTTP:8080/%s%s",
-				acctest.RandStringFromCharSet(512, acctest.CharSetAlpha), randomRunes(512)),
+				acctest.RandString(512), randomRunes(512)),
 			ErrCount: 1,
 		},
 	}

--- a/aws/resource_aws_iam_role_policy_test.go
+++ b/aws/resource_aws_iam_role_policy_test.go
@@ -66,7 +66,7 @@ func TestAccAWSIAMRolePolicy_basic(t *testing.T) {
 
 func TestAccAWSIAMRolePolicy_disappears(t *testing.T) {
 	var out iam.GetRolePolicyOutput
-	suffix := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	suffix := acctest.RandString(10)
 	roleResourceName := fmt.Sprintf("aws_iam_role.role_%s", suffix)
 	rolePolicyResourceName := fmt.Sprintf("aws_iam_role_policy.test_%s", suffix)
 

--- a/aws/resource_aws_iam_user_policy_test.go
+++ b/aws/resource_aws_iam_user_policy_test.go
@@ -62,7 +62,7 @@ func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
 
 func TestAccAWSIAMUserPolicy_disappears(t *testing.T) {
 	var out iam.GetUserPolicyOutput
-	suffix := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	suffix := acctest.RandString(10)
 	resourceName := fmt.Sprintf("aws_iam_user_policy.foo_%s", suffix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -721,7 +721,7 @@ func TestAccAWSLB_noSecurityGroup(t *testing.T) {
 func TestAccAWSLB_ALB_AccessLogs(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	bucketName := fmt.Sprintf("tf-test-access-logs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
-	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlpha))
+	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandString(4))
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -809,7 +809,7 @@ func TestAccAWSLB_ALB_AccessLogs(t *testing.T) {
 func TestAccAWSLB_ALB_AccessLogs_Prefix(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	bucketName := fmt.Sprintf("tf-test-access-logs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
-	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlpha))
+	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandString(4))
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -879,7 +879,7 @@ func TestAccAWSLB_ALB_AccessLogs_Prefix(t *testing.T) {
 func TestAccAWSLB_NLB_AccessLogs(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	bucketName := fmt.Sprintf("tf-test-access-logs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
-	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlpha))
+	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandString(4))
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -967,7 +967,7 @@ func TestAccAWSLB_NLB_AccessLogs(t *testing.T) {
 func TestAccAWSLB_NLB_AccessLogs_Prefix(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	bucketName := fmt.Sprintf("tf-test-access-logs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
-	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlpha))
+	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandString(4))
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_lex_bot_alias_test.go
+++ b/aws/resource_aws_lex_bot_alias_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccAwsLexBotAlias_basic(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	resourceName := "aws_lex_bot_alias.test"
-	testBotAliasID := "test_bot_alias" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotAliasID := "test_bot_alias" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -56,7 +56,7 @@ func TestAccAwsLexBotAlias_basic(t *testing.T) {
 func testAccAwsLexBotAlias_botVersion(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	resourceName := "aws_lex_bot_alias.test"
-	testBotAliasID := "test_bot_alias" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotAliasID := "test_bot_alias" + acctest.RandString(8)
 
 	// If this test runs in parallel with other Lex Bot tests, it loses its description
 	resource.Test(t, resource.TestCase{
@@ -102,8 +102,8 @@ func testAccAwsLexBotAlias_botVersion(t *testing.T) {
 
 func TestAccAwsLexBotAlias_conversationLogsText(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotAliasOutput
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
-	testBotAliasID := "test_bot_alias" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
+	testBotAliasID := "test_bot_alias" + acctest.RandString(8)
 
 	resourceName := "aws_lex_bot_alias.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -147,8 +147,8 @@ func TestAccAwsLexBotAlias_conversationLogsText(t *testing.T) {
 
 func TestAccAwsLexBotAlias_conversationLogsAudio(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotAliasOutput
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
-	testBotAliasID := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
+	testBotAliasID := acctest.RandString(8)
 
 	resourceName := "aws_lex_bot_alias.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -193,8 +193,8 @@ func TestAccAwsLexBotAlias_conversationLogsAudio(t *testing.T) {
 
 func TestAccAwsLexBotAlias_conversationLogsBoth(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotAliasOutput
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
-	testBotAliasID := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
+	testBotAliasID := acctest.RandString(8)
 
 	resourceName := "aws_lex_bot_alias.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -246,7 +246,7 @@ func TestAccAwsLexBotAlias_conversationLogsBoth(t *testing.T) {
 func TestAccAwsLexBotAlias_description(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	resourceName := "aws_lex_bot_alias.test"
-	testBotAliasID := "test_bot_alias" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotAliasID := "test_bot_alias" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -291,7 +291,7 @@ func TestAccAwsLexBotAlias_description(t *testing.T) {
 func TestAccAwsLexBotAlias_disappears(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	resourceName := "aws_lex_bot_alias.test"
-	testBotAliasID := "test_bot_alias" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotAliasID := "test_bot_alias" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },

--- a/aws/resource_aws_lex_bot_test.go
+++ b/aws/resource_aws_lex_bot_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccAwsLexBot_basic(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -82,7 +82,7 @@ func TestAccAwsLexBot_version_serial(t *testing.T) {
 func testAccAwsLexBot_createVersion(t *testing.T) {
 	var v1, v2 lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	// If this test runs in parallel with other Lex Bot tests, it loses its description
 	resource.Test(t, resource.TestCase{
@@ -126,7 +126,7 @@ func testAccAwsLexBot_createVersion(t *testing.T) {
 func TestAccAwsLexBot_abortStatement(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -182,7 +182,7 @@ func TestAccAwsLexBot_abortStatement(t *testing.T) {
 func TestAccAwsLexBot_clarificationPrompt(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -234,7 +234,7 @@ func TestAccAwsLexBot_clarificationPrompt(t *testing.T) {
 func TestAccAwsLexBot_childDirected(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -277,7 +277,7 @@ func TestAccAwsLexBot_childDirected(t *testing.T) {
 func TestAccAwsLexBot_description(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -320,7 +320,7 @@ func TestAccAwsLexBot_description(t *testing.T) {
 func TestAccAwsLexBot_detectSentiment(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -363,7 +363,7 @@ func TestAccAwsLexBot_detectSentiment(t *testing.T) {
 func TestAccAwsLexBot_enableModelImprovements(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -407,7 +407,7 @@ func TestAccAwsLexBot_enableModelImprovements(t *testing.T) {
 func TestAccAwsLexBot_idleSessionTtlInSeconds(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -450,7 +450,7 @@ func TestAccAwsLexBot_idleSessionTtlInSeconds(t *testing.T) {
 func TestAccAwsLexBot_intents(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -493,7 +493,7 @@ func TestAccAwsLexBot_intents(t *testing.T) {
 func TestAccAwsLexBot_locale(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -536,7 +536,7 @@ func TestAccAwsLexBot_locale(t *testing.T) {
 func TestAccAwsLexBot_voiceId(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -579,7 +579,7 @@ func TestAccAwsLexBot_voiceId(t *testing.T) {
 func TestAccAwsLexBot_disappears(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput
 	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testBotID := "test_bot_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },

--- a/aws/resource_aws_lex_intent_test.go
+++ b/aws/resource_aws_lex_intent_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccAwsLexIntent_basic(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -62,7 +62,7 @@ func TestAccAwsLexIntent_basic(t *testing.T) {
 func TestAccAwsLexIntent_createVersion(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -103,7 +103,7 @@ func TestAccAwsLexIntent_createVersion(t *testing.T) {
 func TestAccAwsLexIntent_conclusionStatement(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -155,7 +155,7 @@ func TestAccAwsLexIntent_conclusionStatement(t *testing.T) {
 func TestAccAwsLexIntent_confirmationPromptAndRejectionStatement(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -217,7 +217,7 @@ func TestAccAwsLexIntent_confirmationPromptAndRejectionStatement(t *testing.T) {
 func TestAccAwsLexIntent_dialogCodeHook(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -249,7 +249,7 @@ func TestAccAwsLexIntent_dialogCodeHook(t *testing.T) {
 func TestAccAwsLexIntent_followUpPrompt(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -317,7 +317,7 @@ func TestAccAwsLexIntent_followUpPrompt(t *testing.T) {
 func TestAccAwsLexIntent_fulfillmentActivity(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -351,7 +351,7 @@ func TestAccAwsLexIntent_fulfillmentActivity(t *testing.T) {
 func TestAccAwsLexIntent_sampleUtterances(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -392,7 +392,7 @@ func TestAccAwsLexIntent_sampleUtterances(t *testing.T) {
 func TestAccAwsLexIntent_slots(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -444,7 +444,7 @@ func TestAccAwsLexIntent_slots(t *testing.T) {
 func TestAccAwsLexIntent_slotsCustom(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -487,7 +487,7 @@ func TestAccAwsLexIntent_slotsCustom(t *testing.T) {
 func TestAccAwsLexIntent_disappears(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -509,7 +509,7 @@ func TestAccAwsLexIntent_disappears(t *testing.T) {
 func TestAccAwsLexIntent_updateWithExternalChange(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput
 	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testIntentID := "test_intent_" + acctest.RandString(8)
 
 	testAccCheckAwsLexIntentUpdateDescription := func(provider *schema.Provider, _ *schema.Resource, resourceName string) resource.TestCheckFunc {
 		return func(s *terraform.State) error {

--- a/aws/resource_aws_lex_slot_type_test.go
+++ b/aws/resource_aws_lex_slot_type_test.go
@@ -16,7 +16,7 @@ import (
 func TestAccAwsLexSlotType_basic(t *testing.T) {
 	var v lexmodelbuildingservice.GetSlotTypeOutput
 	rName := "aws_lex_slot_type.test"
-	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testSlotTypeID := "test_slot_type_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -57,7 +57,7 @@ func TestAccAwsLexSlotType_basic(t *testing.T) {
 func TestAccAwsLexSlotType_createVersion(t *testing.T) {
 	var v lexmodelbuildingservice.GetSlotTypeOutput
 	rName := "aws_lex_slot_type.test"
-	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testSlotTypeID := "test_slot_type_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -99,7 +99,7 @@ func TestAccAwsLexSlotType_createVersion(t *testing.T) {
 func TestAccAwsLexSlotType_description(t *testing.T) {
 	var v lexmodelbuildingservice.GetSlotTypeOutput
 	rName := "aws_lex_slot_type.test"
-	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testSlotTypeID := "test_slot_type_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -139,7 +139,7 @@ func TestAccAwsLexSlotType_description(t *testing.T) {
 func TestAccAwsLexSlotType_enumerationValues(t *testing.T) {
 	var v lexmodelbuildingservice.GetSlotTypeOutput
 	rName := "aws_lex_slot_type.test"
-	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testSlotTypeID := "test_slot_type_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -184,8 +184,8 @@ func TestAccAwsLexSlotType_enumerationValues(t *testing.T) {
 func TestAccAwsLexSlotType_name(t *testing.T) {
 	var v lexmodelbuildingservice.GetSlotTypeOutput
 	rName := "aws_lex_slot_type.test"
-	testSlotTypeID1 := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
-	testSlotTypeID2 := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testSlotTypeID1 := "test_slot_type_" + acctest.RandString(8)
+	testSlotTypeID2 := "test_slot_type_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -225,7 +225,7 @@ func TestAccAwsLexSlotType_name(t *testing.T) {
 func TestAccAwsLexSlotType_valueSelectionStrategy(t *testing.T) {
 	var v lexmodelbuildingservice.GetSlotTypeOutput
 	rName := "aws_lex_slot_type.test"
-	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testSlotTypeID := "test_slot_type_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
@@ -265,7 +265,7 @@ func TestAccAwsLexSlotType_valueSelectionStrategy(t *testing.T) {
 func TestAccAwsLexSlotType_disappears(t *testing.T) {
 	var v lexmodelbuildingservice.GetSlotTypeOutput
 	rName := "aws_lex_slot_type.test"
-	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	testSlotTypeID := "test_slot_type_" + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },

--- a/aws/resource_aws_load_balancer_listener_policy_test.go
+++ b/aws/resource_aws_load_balancer_listener_policy_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccAWSLoadBalancerListenerPolicy_basic(t *testing.T) {
-	rChar := acctest.RandStringFromCharSet(6, acctest.CharSetAlpha)
+	rChar := acctest.RandString(6)
 	lbName := rChar
 	mcName := rChar
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_service_discovery_http_namespace_test.go
+++ b/aws/resource_aws_service_discovery_http_namespace_test.go
@@ -95,7 +95,7 @@ func testSweepServiceDiscoveryHttpNamespaces(region string) error {
 
 func TestAccAWSServiceDiscoveryHttpNamespace_basic(t *testing.T) {
 	resourceName := "aws_service_discovery_http_namespace.test"
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -124,7 +124,7 @@ func TestAccAWSServiceDiscoveryHttpNamespace_basic(t *testing.T) {
 
 func TestAccAWSServiceDiscoveryHttpNamespace_disappears(t *testing.T) {
 	resourceName := "aws_service_discovery_http_namespace.test"
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -145,7 +145,7 @@ func TestAccAWSServiceDiscoveryHttpNamespace_disappears(t *testing.T) {
 
 func TestAccAWSServiceDiscoveryHttpNamespace_Description(t *testing.T) {
 	resourceName := "aws_service_discovery_http_namespace.test"
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -170,7 +170,7 @@ func TestAccAWSServiceDiscoveryHttpNamespace_Description(t *testing.T) {
 
 func TestAccAWSServiceDiscoveryHttpNamespace_Tags(t *testing.T) {
 	resourceName := "aws_service_discovery_http_namespace.test"
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -221,7 +221,7 @@ func TestAccAWSServiceDiscoveryService_public(t *testing.T) {
 }
 
 func TestAccAWSServiceDiscoveryService_http(t *testing.T) {
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -248,7 +248,7 @@ func TestAccAWSServiceDiscoveryService_http(t *testing.T) {
 }
 
 func TestAccAWSServiceDiscoveryService_disappears(t *testing.T) {
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -269,7 +269,7 @@ func TestAccAWSServiceDiscoveryService_disappears(t *testing.T) {
 }
 
 func TestAccAWSServiceDiscoveryService_Tags(t *testing.T) {
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -198,7 +198,7 @@ func TestAccAWSVpnConnection_tunnelOptions(t *testing.T) {
 				ExpectError: regexp.MustCompile(`expected length of \w+ to be in the range \(8 - 64\)`),
 			},
 			{
-				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, acctest.RandStringFromCharSet(65, acctest.CharSetAlpha), "169.254.254.0/30"),
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, acctest.RandString(65), "169.254.254.0/30"),
 				ExpectError: regexp.MustCompile(`expected length of \w+ to be in the range \(8 - 64\)`),
 			},
 			{

--- a/aws/resource_aws_worklink_fleet_test.go
+++ b/aws/resource_aws_worklink_fleet_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccAWSWorkLinkFleet_basic(t *testing.T) {
-	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	suffix := acctest.RandString(20)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -41,7 +41,7 @@ func TestAccAWSWorkLinkFleet_basic(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_DisplayName(t *testing.T) {
-	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	suffix := acctest.RandString(20)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -73,7 +73,7 @@ func TestAccAWSWorkLinkFleet_DisplayName(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation(t *testing.T) {
-	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	suffix := acctest.RandString(20)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -105,7 +105,7 @@ func TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_AuditStreamArn(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	rName := acctest.RandString(20)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -130,7 +130,7 @@ func TestAccAWSWorkLinkFleet_AuditStreamArn(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_Network(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	rName := acctest.RandString(20)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -172,7 +172,7 @@ func TestAccAWSWorkLinkFleet_Network(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_DeviceCaCertificate(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	rName := acctest.RandString(20)
 	resourceName := "aws_worklink_fleet.test"
 	fName := "test-fixtures/worklink-device-ca-certificate.pem"
 
@@ -205,7 +205,7 @@ func TestAccAWSWorkLinkFleet_DeviceCaCertificate(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_IdentityProvider(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	rName := acctest.RandString(20)
 	resourceName := "aws_worklink_fleet.test"
 	fName := "test-fixtures/saml-metadata.xml"
 
@@ -236,7 +236,7 @@ func TestAccAWSWorkLinkFleet_IdentityProvider(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_Disappears(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	rName := acctest.RandString(20)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_worklink_website_certificate_authority_association_test.go
+++ b/aws/resource_aws_worklink_website_certificate_authority_association_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_basic(t *testing.T) {
-	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	suffix := acctest.RandString(20)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,10 +42,10 @@ func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_basic(t *t
 }
 
 func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayName(t *testing.T) {
-	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	suffix := acctest.RandString(20)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
-	displayName1 := fmt.Sprintf("tf-website-certificate-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlpha))
-	displayName2 := fmt.Sprintf("tf-website-certificate-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlpha))
+	displayName1 := fmt.Sprintf("tf-website-certificate-%s", acctest.RandString(5))
+	displayName2 := fmt.Sprintf("tf-website-certificate-%s", acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
@@ -75,7 +75,7 @@ func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayNam
 }
 
 func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears(t *testing.T) {
-	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	suffix := acctest.RandString(20)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1628,7 +1628,7 @@ func TestValidateNeptuneEventSubscriptionName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
+			Value:    acctest.RandString(256),
 			ErrCount: 1,
 		},
 	}
@@ -1658,7 +1658,7 @@ func TestValidateNeptuneEventSubscriptionNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(254, acctest.CharSetAlpha),
+			Value:    acctest.RandString(254),
 			ErrCount: 1,
 		},
 	}
@@ -1688,7 +1688,7 @@ func TestValidateDbSubnetGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(300, acctest.CharSetAlpha),
+			Value:    acctest.RandString(300),
 			ErrCount: 1,
 		},
 	}
@@ -1720,7 +1720,7 @@ func TestValidateNeptuneSubnetGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(300, acctest.CharSetAlpha),
+			Value:    acctest.RandString(300),
 			ErrCount: 1,
 		},
 	}
@@ -1748,7 +1748,7 @@ func TestValidateDbSubnetGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(230, acctest.CharSetAlpha),
+			Value:    acctest.RandString(230),
 			ErrCount: 1,
 		},
 	}
@@ -1776,7 +1776,7 @@ func TestValidateNeptuneSubnetGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(230, acctest.CharSetAlpha),
+			Value:    acctest.RandString(230),
 			ErrCount: 1,
 		},
 	}
@@ -1812,7 +1812,7 @@ func TestValidateDbOptionGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
+			Value:    acctest.RandString(256),
 			ErrCount: 1,
 		},
 	}
@@ -1844,7 +1844,7 @@ func TestValidateDbOptionGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(230, acctest.CharSetAlpha),
+			Value:    acctest.RandString(230),
 			ErrCount: 1,
 		},
 	}
@@ -1888,7 +1888,7 @@ func TestValidateDbParamGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
+			Value:    acctest.RandString(256),
 			ErrCount: 1,
 		},
 	}
@@ -2607,7 +2607,7 @@ func TestResourceAWSElastiCacheReplicationGroupAuthTokenValidation(t *testing.T)
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(129, acctest.CharSetAlpha),
+			Value:    acctest.RandString(129),
 			ErrCount: 1,
 		},
 	}
@@ -2851,7 +2851,7 @@ func TestValidateNeptuneParamGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
+			Value:    acctest.RandString(256),
 			ErrCount: 1,
 		},
 	}
@@ -2891,7 +2891,7 @@ func TestValidateNeptuneParamGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
+			Value:    acctest.RandString(256),
 			ErrCount: 1,
 		},
 	}
@@ -2919,7 +2919,7 @@ func TestValidateCloudFrontPublicKeyName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(129, acctest.CharSetAlpha),
+			Value:    acctest.RandString(129),
 			ErrCount: 1,
 		},
 	}
@@ -2947,7 +2947,7 @@ func TestValidateCloudFrontPublicKeyNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(128, acctest.CharSetAlpha),
+			Value:    acctest.RandString(128),
 			ErrCount: 1,
 		},
 	}
@@ -3016,7 +3016,7 @@ func TestValidateLbTargetGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(33, acctest.CharSetAlpha),
+			Value:    acctest.RandString(33),
 			ErrCount: 1,
 		},
 	}
@@ -3042,7 +3042,7 @@ func TestValidateLbTargetGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(32, acctest.CharSetAlpha),
+			Value:    acctest.RandString(32),
 			ErrCount: 1,
 		},
 	}
@@ -3068,7 +3068,7 @@ func TestValidateSecretManagerSecretName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(513, acctest.CharSetAlpha),
+			Value:    acctest.RandString(513),
 			ErrCount: 1,
 		},
 	}
@@ -3094,7 +3094,7 @@ func TestValidateSecretManagerSecretNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(512, acctest.CharSetAlpha),
+			Value:    acctest.RandString(512),
 			ErrCount: 1,
 		},
 	}
@@ -3120,7 +3120,7 @@ func TestValidateRoute53ResolverName(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
-			Value:    acctest.RandStringFromCharSet(65, acctest.CharSetAlpha),
+			Value:    acctest.RandString(65),
 			ErrCount: 1,
 		},
 		{
@@ -3158,11 +3158,11 @@ func TestCloudWatchEventCustomEventBusName(t *testing.T) {
 			IsValid: false,
 		},
 		{
-			Value:   acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
+			Value:   acctest.RandString(256),
 			IsValid: true,
 		},
 		{
-			Value:   acctest.RandStringFromCharSet(257, acctest.CharSetAlpha),
+			Value:   acctest.RandString(257),
 			IsValid: false,
 		},
 		{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16046

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make awsproviderlint
$
```
