### PR TITLE
r/aws_ec2_carrier_gateway: New resource.

### DIFF
--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -5,6 +5,10 @@ const (
 )
 
 const (
+	ErrCodeInvalidCarrierGatewayIDNotFound = "InvalidCarrierGatewayID.NotFound"
+)
+
+const (
 	ErrCodeClientVpnEndpointIdNotFound        = "InvalidClientVpnEndpointId.NotFound"
 	ErrCodeClientVpnAuthorizationRuleNotFound = "InvalidClientVpnEndpointAuthorizationRuleNotFound"
 	ErrCodeClientVpnAssociationIdNotFound     = "InvalidClientVpnAssociationId.NotFound"

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -6,6 +6,25 @@ import (
 	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 )
 
+// CarrierGatewayByID returns the carrier gateway corresponding to the specified identifier.
+// Returns nil and potentially an error if no carrier gateway is found.
+func CarrierGatewayByID(conn *ec2.EC2, id string) (*ec2.CarrierGateway, error) {
+	input := &ec2.DescribeCarrierGatewaysInput{
+		CarrierGatewayIds: aws.StringSlice([]string{id}),
+	}
+
+	output, err := conn.DescribeCarrierGateways(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.CarrierGateways) == 0 {
+		return nil, nil
+	}
+
+	return output.CarrierGateways[0], nil
+}
+
 func ClientVpnAuthorizationRule(conn *ec2.EC2, endpointID, targetNetworkCidr, accessGroupID string) (*ec2.DescribeClientVpnAuthorizationRulesOutput, error) {
 	filters := map[string]string{
 		"destination-cidr": targetNetworkCidr,

--- a/aws/internal/service/ec2/waiter/status.go
+++ b/aws/internal/service/ec2/waiter/status.go
@@ -12,6 +12,30 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
+const (
+	carrierGatewayStateNotFound = "NotFound"
+	carrierGatewayStateUnknown  = "Unknown"
+)
+
+// CarrierGatewayState fetches the CarrierGateway and its State
+func CarrierGatewayState(conn *ec2.EC2, carrierGatewayID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		carrierGateway, err := finder.CarrierGatewayByID(conn, carrierGatewayID)
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidCarrierGatewayIDNotFound) {
+			return nil, carrierGatewayStateNotFound, nil
+		}
+		if err != nil {
+			return nil, carrierGatewayStateUnknown, err
+		}
+
+		if carrierGateway == nil {
+			return nil, carrierGatewayStateNotFound, nil
+		}
+
+		return carrierGateway, aws.StringValue(carrierGateway.State), nil
+	}
+}
+
 // LocalGatewayRouteTableVpcAssociationState fetches the LocalGatewayRouteTableVpcAssociation and its State
 func LocalGatewayRouteTableVpcAssociationState(conn *ec2.EC2, localGatewayRouteTableVpcAssociationID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/aws/internal/service/ec2/waiter/status.go
+++ b/aws/internal/service/ec2/waiter/status.go
@@ -32,7 +32,13 @@ func CarrierGatewayState(conn *ec2.EC2, carrierGatewayID string) resource.StateR
 			return nil, carrierGatewayStateNotFound, nil
 		}
 
-		return carrierGateway, aws.StringValue(carrierGateway.State), nil
+		state := aws.StringValue(carrierGateway.State)
+
+		if state == ec2.CarrierGatewayStateDeleted {
+			return nil, carrierGatewayStateNotFound, nil
+		}
+
+		return carrierGateway, state, nil
 	}
 }
 

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -38,7 +38,7 @@ func CarrierGatewayAvailable(conn *ec2.EC2, carrierGatewayID string) (*ec2.Carri
 func CarrierGatewayDeleted(conn *ec2.EC2, carrierGatewayID string) (*ec2.CarrierGateway, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.CarrierGatewayStateDeleting},
-		Target:  []string{ec2.CarrierGatewayStateDeleted},
+		Target:  []string{},
 		Refresh: CarrierGatewayState(conn, carrierGatewayID),
 		Timeout: CarrierGatewayDeletedTimeout,
 	}

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -13,6 +13,46 @@ const (
 )
 
 const (
+	CarrierGatewayAvailableTimeout = 5 * time.Minute
+
+	CarrierGatewayDeletedTimeout = 5 * time.Minute
+)
+
+func CarrierGatewayAvailable(conn *ec2.EC2, carrierGatewayID string) (*ec2.CarrierGateway, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.CarrierGatewayStatePending},
+		Target:  []string{ec2.CarrierGatewayStateAvailable},
+		Refresh: CarrierGatewayState(conn, carrierGatewayID),
+		Timeout: CarrierGatewayAvailableTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.CarrierGateway); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func CarrierGatewayDeleted(conn *ec2.EC2, carrierGatewayID string) (*ec2.CarrierGateway, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.CarrierGatewayStateDeleting},
+		Target:  []string{ec2.CarrierGatewayStateDeleted},
+		Refresh: CarrierGatewayState(conn, carrierGatewayID),
+		Timeout: CarrierGatewayDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.CarrierGateway); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+const (
 	// Maximum amount of time to wait for a LocalGatewayRouteTableVpcAssociation to return Associated
 	LocalGatewayRouteTableVpcAssociationAssociatedTimeout = 5 * time.Minute
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -592,6 +592,7 @@ func Provider() *schema.Provider {
 			"aws_ebs_volume":                                          resourceAwsEbsVolume(),
 			"aws_ec2_availability_zone_group":                         resourceAwsEc2AvailabilityZoneGroup(),
 			"aws_ec2_capacity_reservation":                            resourceAwsEc2CapacityReservation(),
+			"aws_ec2_carrier_gateway":                                 resourceAwsEc2CarrierGateway(),
 			"aws_ec2_client_vpn_authorization_rule":                   resourceAwsEc2ClientVpnAuthorizationRule(),
 			"aws_ec2_client_vpn_endpoint":                             resourceAwsEc2ClientVpnEndpoint(),
 			"aws_ec2_client_vpn_network_association":                  resourceAwsEc2ClientVpnNetworkAssociation(),

--- a/aws/resource_aws_ec2_carrier_gateway.go
+++ b/aws/resource_aws_ec2_carrier_gateway.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter"
+)
+
+func resourceAwsEc2CarrierGateway() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEc2CarrierGatewayCreate,
+		Read:   resourceAwsEc2CarrierGatewayRead,
+		Update: resourceAwsEc2CarrierGatewayUpdate,
+		Delete: resourceAwsEc2CarrierGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsEc2CarrierGatewayCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	input := &ec2.CreateCarrierGatewayInput{
+		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), "carrier-gateway"),
+		VpcId:             aws.String(d.Get("vpc_id").(string)),
+	}
+
+	log.Printf("[DEBUG] Creating EC2 Carrier Gateway: %s", input)
+	output, err := conn.CreateCarrierGateway(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating EC2 Carrier Gateway: %w", err)
+	}
+
+	d.SetId(aws.StringValue(output.CarrierGateway.CarrierGatewayId))
+
+	_, err = waiter.CarrierGatewayAvailable(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error waiting for EC2 Carrier Gateway (%s) to become available: %w", d.Id(), err)
+	}
+
+	return resourceAwsEc2CarrierGatewayRead(d, meta)
+}
+
+func resourceAwsEc2CarrierGatewayRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	carrierGateway, err := finder.CarrierGatewayByID(conn, d.Id())
+
+	if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidCarrierGatewayIDNotFound) {
+		log.Printf("[WARN] EC2 Carrier Gateway (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading EC2 Carrier Gateway (%s): %w", d.Id(), err)
+	}
+
+	if carrierGateway == nil || aws.StringValue(carrierGateway.State) == ec2.CarrierGatewayStateDeleted {
+		log.Printf("[WARN] EC2 Carrier Gateway (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ec2",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("carrier-gateway/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+	d.Set("owner_id", carrierGateway.OwnerId)
+	d.Set("vpc_id", carrierGateway.VpcId)
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(carrierGateway.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsEc2CarrierGatewayUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Carrier Gateway (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsEc2CarrierGatewayRead(d, meta)
+}
+
+func resourceAwsEc2CarrierGatewayDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	log.Printf("[INFO] Deleting EC2 Carrier Gateway (%s)", d.Id())
+	_, err := conn.DeleteCarrierGateway(&ec2.DeleteCarrierGatewayInput{
+		CarrierGatewayId: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidCarrierGatewayIDNotFound) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting EC2 Carrier Gateway (%s): %w", d.Id(), err)
+	}
+
+	_, err = waiter.CarrierGatewayDeleted(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error waiting for EC2 Carrier Gateway (%s) to be deleted: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_ec2_carrier_gateway_test.go
+++ b/aws/resource_aws_ec2_carrier_gateway_test.go
@@ -1,0 +1,254 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
+)
+
+func TestAccAWSEc2CarrierGateway_basic(t *testing.T) {
+	var v ec2.CarrierGateway
+	resourceName := "aws_ec2_carrier_gateway.test"
+	vpcResourceName := "aws_vpc.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckEc2CarrierGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEc2CarrierGatewayConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEc2CarrierGatewayExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`carrier-gateway/cgw-.+`)),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpcResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEc2CarrierGateway_disappears(t *testing.T) {
+	var v ec2.CarrierGateway
+	resourceName := "aws_ec2_carrier_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckEc2CarrierGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEc2CarrierGatewayConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEc2CarrierGatewayExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEc2CarrierGateway(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEc2CarrierGateway_Tags(t *testing.T) {
+	var v ec2.CarrierGateway
+	resourceName := "aws_ec2_carrier_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckEc2CarrierGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEc2CarrierGatewayConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEc2CarrierGatewayExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEc2CarrierGatewayConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEc2CarrierGatewayExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccEc2CarrierGatewayConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEc2CarrierGatewayExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEc2CarrierGatewayDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ec2_carrier_gateway" {
+			continue
+		}
+
+		out, err := finder.CarrierGatewayByID(conn, rs.Primary.ID)
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidCarrierGatewayIDNotFound) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if out == nil {
+			continue
+		}
+		if state := aws.StringValue(out.State); state != ec2.CarrierGatewayStateDeleted {
+			return fmt.Errorf("EC2 Carrier Gateway in incorrect state. Expected: %s, got: %s", ec2.CarrierGatewayStateDeleted, state)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckEc2CarrierGatewayExists(n string, v *ec2.CarrierGateway) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		out, err := finder.CarrierGatewayByID(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if out == nil {
+			return fmt.Errorf("EC2 Carrier Gateway not found")
+		}
+		if state := aws.StringValue(out.State); state != ec2.CarrierGatewayStateAvailable {
+			return fmt.Errorf("EC2 Carrier Gateway in incorrect state. Expected: %s, got: %s", ec2.CarrierGatewayStateAvailable, state)
+		}
+
+		*v = *out
+
+		return nil
+	}
+}
+
+func testAccPreCheckAWSWavelengthZoneAvailable(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	input := &ec2.DescribeAvailabilityZonesInput{
+		Filters: buildEC2AttributeFilterList(map[string]string{
+			"zone-type":     "wavelength-zone",
+			"opt-in-status": "opted-in",
+		}),
+	}
+
+	output, err := conn.DescribeAvailabilityZones(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+
+	if output == nil || len(output.AvailabilityZones) == 0 {
+		t.Skip("skipping since no Wavelength Zones are available")
+	}
+}
+
+func testAccEc2CarrierGatewayConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_carrier_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+`, rName)
+}
+
+func testAccEc2CarrierGatewayConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_carrier_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccEc2CarrierGatewayConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_carrier_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -22,6 +22,7 @@ func init() {
 	resource.AddTestSweepers("aws_vpc", &resource.Sweeper{
 		Name: "aws_vpc",
 		Dependencies: []string{
+			"aws_ec2_carrier_gateway",
 			"aws_egress_only_internet_gateway",
 			"aws_internet_gateway",
 			"aws_nat_gateway",

--- a/website/docs/r/ec2_carrier_gateway.html.markdown
+++ b/website/docs/r/ec2_carrier_gateway.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "EC2"
+layout: "aws"
+page_title: "AWS: aws_ec2_carrier_gateway"
+description: |-
+  Manages an EC2 Carrier Gateway.
+---
+
+# Resource: aws_ec2_carrier_gateway
+
+Manages an EC2 Carrier Gateway. See the AWS [documentation](https://docs.aws.amazon.com/vpc/latest/userguide/Carrier_Gateway.html) for more information.
+
+## Example Usage
+
+```hcl
+resource "aws_ec2_carrier_gateway" "example" {
+  vpc_id = aws_vpc.example.id
+
+  tags = {
+    Name = "example-carrier-gateway"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_id` - (Required) The ID of the VPC to associate with the carrier gateway.
+* `tags` - (Optional) A map of tags to assign to the resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the carrier gateway.
+* `arn` - The ARN of the carrier gateway.
+* `owner_id` - The AWS account ID of the owner of the carrier gateway.
+
+## Import
+
+`aws_ec2_carrier_gateway` can be imported using the carrier gateway's ID,
+e.g.
+
+```
+$ terraform import aws_ec2_carrier_gateway.example cgw-12345
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14518.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ec2_carrier_gateway: New resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

##### Account not enabled for Wavelength:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2CarrierGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2CarrierGateway_ -timeout 120m
=== RUN   TestAccAWSEc2CarrierGateway_basic
=== PAUSE TestAccAWSEc2CarrierGateway_basic
=== RUN   TestAccAWSEc2CarrierGateway_disappears
=== PAUSE TestAccAWSEc2CarrierGateway_disappears
=== RUN   TestAccAWSEc2CarrierGateway_Tags
=== PAUSE TestAccAWSEc2CarrierGateway_Tags
=== CONT  TestAccAWSEc2CarrierGateway_basic
=== CONT  TestAccAWSEc2CarrierGateway_Tags
=== CONT  TestAccAWSEc2CarrierGateway_disappears
    resource_aws_ec2_carrier_gateway_test.go:195: skipping since no Wavelength Zones are available
--- SKIP: TestAccAWSEc2CarrierGateway_disappears (1.33s)
=== CONT  TestAccAWSEc2CarrierGateway_basic
    resource_aws_ec2_carrier_gateway_test.go:195: skipping since no Wavelength Zones are available
--- SKIP: TestAccAWSEc2CarrierGateway_basic (1.37s)
=== CONT  TestAccAWSEc2CarrierGateway_Tags
    resource_aws_ec2_carrier_gateway_test.go:195: skipping since no Wavelength Zones are available
--- SKIP: TestAccAWSEc2CarrierGateway_Tags (1.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.419s
```

##### Account enabled for Wavelength:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2CarrierGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2CarrierGateway_ -timeout 120m
=== RUN   TestAccAWSEc2CarrierGateway_basic
=== PAUSE TestAccAWSEc2CarrierGateway_basic
=== RUN   TestAccAWSEc2CarrierGateway_disappears
=== PAUSE TestAccAWSEc2CarrierGateway_disappears
=== RUN   TestAccAWSEc2CarrierGateway_Tags
=== PAUSE TestAccAWSEc2CarrierGateway_Tags
=== CONT  TestAccAWSEc2CarrierGateway_basic
=== CONT  TestAccAWSEc2CarrierGateway_Tags
=== CONT  TestAccAWSEc2CarrierGateway_disappears
--- PASS: TestAccAWSEc2CarrierGateway_disappears (22.26s)
--- PASS: TestAccAWSEc2CarrierGateway_basic (29.77s)
--- PASS: TestAccAWSEc2CarrierGateway_Tags (71.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	71.533s
```