### PR TITLE
tests/provider: Fix and enable AT004 lint check

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -87,7 +87,6 @@ golangci-lint:
 awsproviderlint:
 	@awsproviderlint \
 		-c 1 \
-		-AT004=false \
 		-AT009=false \
 		-AWSAT003=false \
 		-AWSAT006=false \

--- a/aws/data_source_aws_eip_test.go
+++ b/aws/data_source_aws_eip_test.go
@@ -219,10 +219,6 @@ data "aws_eip" "test" {
 `
 
 const testAccDataSourceAwsEipConfigPublicIpEc2Classic = `
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_eip" "test" {}
 
 data "aws_eip" "test" {

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1767,7 +1767,7 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "current" {}
-`
+` //lintignore:AT004
 
 // composeConfig can be called to concatenate multiple strings to build test configurations
 func composeConfig(config ...string) string {

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -763,10 +763,6 @@ resource "aws_eip" "test" {
 
 func testAccAWSEIPConfig_tags_Ec2Classic(rName, testName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_eip" "test" {
   tags = {
     RandomName = "%[1]s"

--- a/aws/resource_aws_lightsail_domain_test.go
+++ b/aws/resource_aws_lightsail_domain_test.go
@@ -134,5 +134,5 @@ provider "aws" {
 resource "aws_lightsail_domain" "domain_test" {
   domain_name = "%s"
 }
-`, lightsailDomainName)
+`, lightsailDomainName) //lintignore:AT004
 }

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -355,7 +355,7 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
   name = "%[1]s_profile"
   role = aws_iam_role.opsworks_instance.name
 }
-`, rName, rInt) //lintignore:AWSAT003
+`, rName, rInt) //lintignore:AWSAT003,AT004
 }
 
 func testAccAwsOpsWorksStack_regional_endpoint(rName string, rInt int) string {
@@ -442,7 +442,7 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
   name = "%[1]s_profile"
   role = aws_iam_role.opsworks_instance.name
 }
-`, rName, rInt) //lintignore:AWSAT003
+`, rName, rInt) //lintignore:AWSAT003,AT004
 }
 
 ////////////////////////////


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8983

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make awsproviderlint
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsEip_PublicIP_EC2Classic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsEip_PublicIP_EC2Classic -timeout 120m
=== RUN   TestAccDataSourceAwsEip_PublicIP_EC2Classic
--- PASS: TestAccDataSourceAwsEip_PublicIP_EC2Classic (20.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	20.199s

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP_tags_Ec2Classic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEIP_tags_Ec2Classic -timeout 120m
=== RUN   TestAccAWSEIP_tags_Ec2Classic
=== PAUSE TestAccAWSEIP_tags_Ec2Classic
=== CONT  TestAccAWSEIP_tags_Ec2Classic
    TestAccAWSEIP_tags_Ec2Classic: ec2_classic_test.go:54: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccAWSEIP_tags_Ec2Classic (2.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.743s

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLightsailDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLightsailDomain_basic -timeout 120m
=== RUN   TestAccAWSLightsailDomain_basic
=== PAUSE TestAccAWSLightsailDomain_basic
=== CONT  TestAccAWSLightsailDomain_basic
--- PASS: TestAccAWSLightsailDomain_basic (18.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	19.006s

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLightsailDomain_disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLightsailDomain_disappears -timeout 120m
=== RUN   TestAccAWSLightsailDomain_disappears
=== PAUSE TestAccAWSLightsailDomain_disappears
=== CONT  TestAccAWSLightsailDomain_disappears
--- PASS: TestAccAWSLightsailDomain_disappears (18.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.520s

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSOpsWorksStack_classicEndpoints'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSOpsWorksStack_classicEndpoints -timeout 120m
=== RUN   TestAccAWSOpsWorksStack_classicEndpoints
=== PAUSE TestAccAWSOpsWorksStack_classicEndpoints
=== CONT  TestAccAWSOpsWorksStack_classicEndpoints
    TestAccAWSOpsWorksStack_classicEndpoints: provider_test.go:694: skipping tests; AWS_DEFAULT_REGION (eu-west-2) does not equal us-west-2
--- SKIP: TestAccAWSOpsWorksStack_classicEndpoints (2.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.086s
```
It looks like the only remaining instances of provider blocks in the tests are there for valid reasons; i.e. where AWS services are only available in the hard-coded region or for regression testing for when they used to be. This PR therefore simply adds `lintignore` markers to those occurrences.