### PR TITLE
Updated Amazon MQ functionality

### DIFF
--- a/aws/internal/service/mq/waiter/waiter.go
+++ b/aws/internal/service/mq/waiter/waiter.go
@@ -35,9 +35,10 @@ func BrokerCreated(conn *mq.MQ, id string) (*mq.DescribeBrokerResponse, error) {
 func BrokerDeleted(conn *mq.MQ, id string) (*mq.DescribeBrokerResponse, error) {
 	stateConf := resource.StateChangeConf{
 		Pending: []string{
-			mq.BrokerStateRunning,
-			mq.BrokerStateRebootInProgress,
+			mq.BrokerStateCreationFailed,
 			mq.BrokerStateDeletionInProgress,
+			mq.BrokerStateRebootInProgress,
+			mq.BrokerStateRunning,
 		},
 		Target:  []string{},
 		Timeout: BrokerDeleteTimeout,

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -146,7 +146,6 @@ func resourceAwsMqBroker() *schema.Resource {
 			"ldap_server_metadata": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -172,8 +171,9 @@ func resourceAwsMqBroker() *schema.Resource {
 							Optional: true,
 						},
 						"service_account_password": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
 						},
 						"service_account_username": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -511,6 +511,7 @@ func resourceAwsMqBrokerUpdate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.UpdateBroker(input); err != nil {
 			return fmt.Errorf("error updating MQ Broker (%s) LDAP server metadata: %w", d.Id(), err)
 		}
+		requiresReboot = true
 	}
 
 	if d.HasChange("security_groups") {

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -348,7 +348,7 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 		input.Logs = expandMqLogs(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("ldap_server_metadata"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.LdapServerMetadata = expandMQLDAPServerMetadata(v.([]interface{})[0].(map[string]interface{}))
+		input.LdapServerMetadata = expandMQLDAPServerMetadata(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("maintenance_window_start_time"); ok {
 		input.MaintenanceWindowStartTime = expandMqWeeklyStartTime(v.([]interface{}))
@@ -498,7 +498,7 @@ func resourceAwsMqBrokerUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if v, ok := d.GetOk("ldap_server_metadata"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.LdapServerMetadata = expandMQLDAPServerMetadata(v.([]interface{})[0].(map[string]interface{}))
+			input.LdapServerMetadata = expandMQLDAPServerMetadata(v.([]interface{}))
 		}
 
 		if _, err := conn.UpdateBroker(input); err != nil {
@@ -947,7 +947,7 @@ func expandMqLogs(l []interface{}) *mq.Logs {
 	return logs
 }
 
-func flattenMQLDAPServerMetadata(apiObject *mq.LdapServerMetadataOutput) map[string]interface{} {
+func flattenMQLDAPServerMetadata(apiObject *mq.LdapServerMetadataOutput) []interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -985,15 +985,13 @@ func flattenMQLDAPServerMetadata(apiObject *mq.LdapServerMetadataOutput) map[str
 		tfMap["user_search_subtree"] = aws.BoolValue(v)
 	}
 
-	return tfMap
+	return []interface{}{tfMap}
 }
 
-func expandMQLDAPServerMetadata(tfMap map[string]interface{}) *mq.LdapServerMetadataInput {
-	if tfMap == nil {
-		return nil
-	}
-
+func expandMQLDAPServerMetadata(tfList []interface{}) *mq.LdapServerMetadataInput {
 	apiObject := &mq.LdapServerMetadataInput{}
+
+	tfMap := tfList[0].(map[string]interface{})
 
 	if v, ok := tfMap["hosts"]; ok && len(v.([]interface{})) > 0 {
 		apiObject.Hosts = expandStringList(v.([]interface{}))

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -146,6 +146,7 @@ func resourceAwsMqBroker() *schema.Resource {
 			"ldap_server_metadata": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -327,7 +328,6 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 		AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
 		BrokerName:              aws.String(name),
 		CreatorRequestId:        aws.String(requestId),
-		EncryptionOptions:       expandMqEncryptionOptions(d.Get("encryption_options").([]interface{})),
 		EngineType:              aws.String(d.Get("engine_type").(string)),
 		EngineVersion:           aws.String(d.Get("engine_version").(string)),
 		HostInstanceType:        aws.String(d.Get("host_instance_type").(string)),
@@ -338,19 +338,22 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("authentication_strategy"); ok {
 		input.AuthenticationStrategy = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("configuration"); ok {
+	if v, ok := d.GetOk("configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.Configuration = expandMqConfigurationId(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("deployment_mode"); ok {
 		input.DeploymentMode = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("logs"); ok && len(v.([]interface{})) > 0 {
+	if v, ok := d.GetOk("encryption_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.EncryptionOptions = expandMqEncryptionOptions(d.Get("encryption_options").([]interface{}))
+	}
+	if v, ok := d.GetOk("logs"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.Logs = expandMqLogs(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("ldap_server_metadata"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.LdapServerMetadata = expandMQLDAPServerMetadata(v.([]interface{}))
 	}
-	if v, ok := d.GetOk("maintenance_window_start_time"); ok {
+	if v, ok := d.GetOk("maintenance_window_start_time"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.MaintenanceWindowStartTime = expandMqWeeklyStartTime(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("security_groups"); ok && v.(*schema.Set).Len() > 0 {

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -989,6 +989,10 @@ func flattenMQLDAPServerMetadata(apiObject *mq.LdapServerMetadataOutput) []inter
 }
 
 func expandMQLDAPServerMetadata(tfList []interface{}) *mq.LdapServerMetadataInput {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
 	apiObject := &mq.LdapServerMetadataInput{}
 
 	tfMap := tfList[0].(map[string]interface{})

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -146,6 +146,7 @@ func resourceAwsMqBroker() *schema.Resource {
 			"ldap_server_metadata": {
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -497,22 +498,6 @@ func resourceAwsMqBrokerUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).mqconn
 
 	requiresReboot := false
-
-	if d.HasChange("ldap_server_metadata") {
-		input := &mq.UpdateBrokerRequest{
-			BrokerId:           aws.String(d.Id()),
-			LdapServerMetadata: nil,
-		}
-
-		if v, ok := d.GetOk("ldap_server_metadata"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.LdapServerMetadata = expandMQLDAPServerMetadata(v.([]interface{}))
-		}
-
-		if _, err := conn.UpdateBroker(input); err != nil {
-			return fmt.Errorf("error updating MQ Broker (%s) LDAP server metadata: %w", d.Id(), err)
-		}
-		requiresReboot = true
-	}
 
 	if d.HasChange("security_groups") {
 		_, err := conn.UpdateBroker(&mq.UpdateBrokerRequest{

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -1102,27 +1102,6 @@ func TestAccAWSMqBroker_ldap(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_subtree", "true"),
 				),
 			},
-			{
-				Config: testAccMqBrokerConfig_ldap(rName, "totoro"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsMqBrokerExists(resourceName, &broker),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
-					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "ldap"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.0", "my.ldap.server-1.com"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.1", "my.ldap.server-2.com"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_base", "role.base"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_name", "role.name"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_search_matching", "role.search.matching"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_search_subtree", "true"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.service_account_username", "totoro"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_base", "user.base"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_role_name", "user.role.name"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_matching", "user.search.matching"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_subtree", "true"),
-				),
-			},
 		},
 	})
 }
@@ -1768,12 +1747,13 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
-  apply_immediately  = true
-  broker_name        = %[1]q
-  engine_type        = "ActiveMQ"
-  engine_version     = "5.15.0"
-  host_instance_type = "mq.t2.micro"
-  security_groups    = [aws_security_group.test.id]
+  apply_immediately       = true
+  authentication_strategy = "ldap"
+  broker_name             = %[1]q
+  engine_type             = "ActiveMQ"
+  engine_version          = "5.15.0"
+  host_instance_type      = "mq.t2.micro"
+  security_groups         = [aws_security_group.test.id]
 
   logs {
     general = true
@@ -1783,8 +1763,6 @@ resource "aws_mq_broker" "test" {
     username = "Test"
     password = "TestTest1234"
   }
-
-  authentication_strategy = "ldap"
 
   ldap_server_metadata {
     hosts                    = ["my.ldap.server-1.com", "my.ldap.server-2.com"]

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -1768,6 +1768,7 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_mq_broker" "test" {
+  apply_immediately  = true
   broker_name        = %[1]q
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -1082,49 +1082,11 @@ func TestAccAWSMqBroker_ldap(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqBrokerConfig_ldap(rName),
+				Config: testAccMqBrokerConfig_ldap(rName, "anyusername"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists(resourceName, &broker),
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "configuration.0.id", regexp.MustCompile(`^c-[a-z0-9-]+$`)),
-					resource.TestMatchResourceAttr(resourceName, "configuration.0.revision", regexp.MustCompile(`^[0-9]+$`)),
-					resource.TestCheckResourceAttr(resourceName, "deployment_mode", "SINGLE_INSTANCE"),
-					resource.TestCheckResourceAttr(resourceName, "encryption_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "encryption_options.0.use_aws_owned_key", "true"),
-					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
-					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t2.micro"),
-					resource.TestCheckResourceAttr(resourceName, "maintenance_window_start_time.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
-					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.time_of_day"),
-					resource.TestCheckResourceAttr(resourceName, "logs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "logs.0.general", "true"),
-					resource.TestCheckResourceAttr(resourceName, "logs.0.audit", "false"),
-					resource.TestCheckResourceAttr(resourceName, "maintenance_window_start_time.0.time_zone", "UTC"),
-					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
-					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
-						"console_access": "false",
-						"groups.#":       "0",
-						"username":       "Test",
-						"password":       "TestTest1234",
-					}),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexp.MustCompile(`broker:+.`)),
-					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "instances.0.console_url",
-						regexp.MustCompile(`^https://[a-f0-9-]+\.mq.[a-z0-9-]+.amazonaws.com:8162$`)),
-					resource.TestMatchResourceAttr(resourceName, "instances.0.ip_address",
-						regexp.MustCompile(`^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$`)),
-					resource.TestCheckResourceAttr(resourceName, "instances.0.endpoints.#", "5"),
-					resource.TestMatchResourceAttr(resourceName, "instances.0.endpoints.0", regexp.MustCompile(`^ssl://[a-z0-9-\.]+:61617$`)),
-					resource.TestMatchResourceAttr(resourceName, "instances.0.endpoints.1", regexp.MustCompile(`^amqp\+ssl://[a-z0-9-\.]+:5671$`)),
-					resource.TestMatchResourceAttr(resourceName, "instances.0.endpoints.2", regexp.MustCompile(`^stomp\+ssl://[a-z0-9-\.]+:61614$`)),
-					resource.TestMatchResourceAttr(resourceName, "instances.0.endpoints.3", regexp.MustCompile(`^mqtt\+ssl://[a-z0-9-\.]+:8883$`)),
-					resource.TestMatchResourceAttr(resourceName, "instances.0.endpoints.4", regexp.MustCompile(`^wss://[a-z0-9-\.]+:61619$`)),
 					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "ldap"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.0", "my.ldap.server-1.com"),
@@ -1133,8 +1095,7 @@ func TestAccAWSMqBroker_ldap(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_name", "role.name"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_search_matching", "role.search.matching"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_search_subtree", "true"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.service_account_password", "supersecret"),
-					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.service_account_username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.service_account_username", "anyusername"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_base", "user.base"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_role_name", "user.role.name"),
 					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_matching", "user.search.matching"),
@@ -1142,10 +1103,25 @@ func TestAccAWSMqBroker_ldap(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "user", "ldap_server_metadata"},
+				Config: testAccMqBrokerConfig_ldap(rName, "totoro"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqBrokerExists(resourceName, &broker),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "ldap"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.0", "my.ldap.server-1.com"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.hosts.1", "my.ldap.server-2.com"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_base", "role.base"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_name", "role.name"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_search_matching", "role.search.matching"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.role_search_subtree", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.service_account_username", "totoro"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_base", "user.base"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_role_name", "user.role.name"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_matching", "user.search.matching"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_server_metadata.0.user_search_subtree", "true"),
+				),
 			},
 		},
 	})
@@ -1785,7 +1761,7 @@ resource "aws_mq_broker" "test" {
 `, rName)
 }
 
-func testAccMqBrokerConfig_ldap(rName string) string {
+func testAccMqBrokerConfig_ldap(rName, ldapUsername string) string {
 	return fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name = %[1]q
@@ -1816,12 +1792,12 @@ resource "aws_mq_broker" "test" {
     role_search_matching     = "role.search.matching"
     role_search_subtree      = true
     service_account_password = "supersecret"
-    service_account_username = "admin"
+    service_account_username = %[2]q
     user_base                = "user.base"
     user_role_name           = "user.role.name"
     user_search_matching     = "user.search.matching"
     user_search_subtree      = true
   }
 }
-`, rName)
+`, rName, ldapUsername)
 }

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -1009,11 +1009,15 @@ func TestAccAWSMqBroker_rabbitmq(t *testing.T) {
 
 func TestAccAWSMqBroker_clusterRabbitMQ(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -1065,11 +1069,15 @@ func TestAccAWSMqBroker_clusterRabbitMQ(t *testing.T) {
 
 func TestAccAWSMqBroker_ldap(t *testing.T) {
 	var broker mq.DescribeBrokerResponse
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_broker.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -1802,17 +1810,17 @@ resource "aws_mq_broker" "test" {
   authentication_strategy = "ldap"
 
   ldap_server_metadata {
-    hosts = ["my.ldap.server-1.com", "my.ldap.server-2.com"]
-    role_base = "role.base"
-    role_name = "role.name"
-    role_search_matching = "role.search.matching"
-    role_search_subtree = true
+    hosts                    = ["my.ldap.server-1.com", "my.ldap.server-2.com"]
+    role_base                = "role.base"
+    role_name                = "role.name"
+    role_search_matching     = "role.search.matching"
+    role_search_subtree      = true
     service_account_password = "supersecret"
     service_account_username = "admin"
-    user_base = "user.base"
-    user_role_name = "user.role.name"
-    user_search_matching = "user.search.matching"
-    user_search_subtree = true
+    user_base                = "user.base"
+    user_role_name           = "user.role.name"
+    user_search_matching     = "user.search.matching"
+    user_search_subtree      = true
   }
 }
 `, rName)

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -89,7 +89,7 @@ The following arguments are optional:
 * `configuration` - (Optional) Configuration block for broker configuration. Applies to `engine_type` of `ActiveMQ` only. Detailed below.
 * `deployment_mode` - (Optional) Deployment mode of the broker. Valid values are `SINGLE_INSTANCE`, `ACTIVE_STANDBY_MULTI_AZ`, and `CLUSTER_MULTI_AZ`. Default is `SINGLE_INSTANCE`.
 * `encryption_options` - (Optional) Configuration block containing encryption options. Detailed below.
-* `ldap_server_metadata` - (Optional) Configuration block for the LDAP server used to authenticate and authorize connections to the broker. Not supported for `engine_type` `RabbitMQ`. Detailed below.
+* `ldap_server_metadata` - (Optional) Configuration block for the LDAP server used to authenticate and authorize connections to the broker. Not supported for `engine_type` `RabbitMQ`. Detailed below. (Currently, AWS may not process changes to LDAP server metadata.)
 * `logs` - (Optional) Configuration block for the logging configuration of the broker. Detailed below.
 * `maintenance_window_start_time` - (Optional) Configuration block for the maintenance window start time. Detailed below.
 * `publicly_accessible` - (Optional) Whether to enable connections from applications outside of the VPC that hosts the broker's subnets.


### PR DESCRIPTION
- Add support for RabbitMQ
- Add support for LDAP Authentication
- Add support for EBS storage type
- Make security groups optional since it will use the default one if omitted

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_mq_broker: Support RabbitMQ, LDAP Authentication and EBS storage.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSMqBroker'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMqBroker -timeout 120m
=== RUN   TestAccAWSMqBroker_basic
=== PAUSE TestAccAWSMqBroker_basic
=== RUN   TestAccAWSMqBroker_EBS
=== PAUSE TestAccAWSMqBroker_EBS
=== RUN   TestAccAWSMqBroker_basicRabbitMQ
=== PAUSE TestAccAWSMqBroker_basicRabbitMQ
=== RUN   TestAccAWSMqBroker_clusterRabbitMQ
=== PAUSE TestAccAWSMqBroker_clusterRabbitMQ
=== RUN   TestAccAWSMqBroker_ldap
=== PAUSE TestAccAWSMqBroker_ldap
=== RUN   TestAccAWSMqBroker_basicDefaultSecurityGroup
=== PAUSE TestAccAWSMqBroker_basicDefaultSecurityGroup
=== RUN   TestAccAWSMqBroker_allFieldsDefaultVpc
=== PAUSE TestAccAWSMqBroker_allFieldsDefaultVpc
=== RUN   TestAccAWSMqBroker_allFieldsCustomVpc
=== PAUSE TestAccAWSMqBroker_allFieldsCustomVpc
=== RUN   TestAccAWSMqBroker_EncryptionOptions_KmsKeyId
=== PAUSE TestAccAWSMqBroker_EncryptionOptions_KmsKeyId
=== RUN   TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Disabled
=== PAUSE TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Disabled
=== RUN   TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Enabled
=== PAUSE TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Enabled
=== RUN   TestAccAWSMqBroker_updateUsers
=== PAUSE TestAccAWSMqBroker_updateUsers
=== RUN   TestAccAWSMqBroker_updateTags
=== PAUSE TestAccAWSMqBroker_updateTags
=== RUN   TestAccAWSMqBroker_updateSecurityGroup
=== PAUSE TestAccAWSMqBroker_updateSecurityGroup
=== RUN   TestAccAWSMqBroker_disappears
=== PAUSE TestAccAWSMqBroker_disappears
=== CONT  TestAccAWSMqBroker_basic
=== CONT  TestAccAWSMqBroker_EncryptionOptions_KmsKeyId
=== CONT  TestAccAWSMqBroker_updateSecurityGroup
=== CONT  TestAccAWSMqBroker_ldap
=== CONT  TestAccAWSMqBroker_basicDefaultSecurityGroup
=== CONT  TestAccAWSMqBroker_basicRabbitMQ
=== CONT  TestAccAWSMqBroker_allFieldsDefaultVpc
=== CONT  TestAccAWSMqBroker_clusterRabbitMQ
=== CONT  TestAccAWSMqBroker_allFieldsCustomVpc
=== CONT  TestAccAWSMqBroker_updateTags
=== CONT  TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Enabled
=== CONT  TestAccAWSMqBroker_updateUsers
=== CONT  TestAccAWSMqBroker_disappears
=== CONT  TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Disabled
=== CONT  TestAccAWSMqBroker_EBS
2020/11/17 13:28:50 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/17 13:28:50 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/17 13:28:50 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/11/17 13:28:53 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSMqBroker_basicRabbitMQ (628.99s)
--- PASS: TestAccAWSMqBroker_clusterRabbitMQ (734.59s)
2020/11/17 13:41:31 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSMqBroker_EBS (835.84s)
--- PASS: TestAccAWSMqBroker_basicDefaultSecurityGroup (1114.85s)
--- PASS: TestAccAWSMqBroker_disappears (1151.17s)
--- PASS: TestAccAWSMqBroker_ldap (1172.08s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Enabled (1182.22s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_KmsKeyId (1205.41s)
--- PASS: TestAccAWSMqBroker_basic (1213.00s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Disabled (1253.00s)
--- PASS: TestAccAWSMqBroker_updateTags (1271.10s)
--- PASS: TestAccAWSMqBroker_updateUsers (1445.56s)
--- PASS: TestAccAWSMqBroker_updateSecurityGroup (1452.81s)
--- PASS: TestAccAWSMqBroker_allFieldsDefaultVpc (1867.78s)
--- PASS: TestAccAWSMqBroker_allFieldsCustomVpc (1882.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1886.075s


...
```
