### PR TITLE
Update documentation to include required parameter

### DIFF
--- a/website/docs/r/ecs_capacity_provider.html.markdown
+++ b/website/docs/r/ecs_capacity_provider.html.markdown
@@ -20,6 +20,7 @@ resource "aws_autoscaling_group" "test" {
 
   tag {
     key                 = "AmazonECSManaged"
+    value               = ""
     propagate_at_launch = true
   }
 }


### PR DESCRIPTION
When setting tags on an `aws_autoscaling_group` using the `tag` attribute, `value` is a required parameter. Updates documentation to reflect this.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16214

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

N/A