### PR TITLE
resource/aws_accessanalyzer_analyzer: Adds correct validation to analyzer_name

### DIFF
--- a/aws/resource_aws_accessanalyzer_analyzer.go
+++ b/aws/resource_aws_accessanalyzer_analyzer.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -33,10 +34,13 @@ func resourceAwsAccessAnalyzerAnalyzer() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"analyzer_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_.-]*$`), ""),
+				),
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_accessanalyzer_analyzer.go
+++ b/aws/resource_aws_accessanalyzer_analyzer.go
@@ -39,7 +39,7 @@ func resourceAwsAccessAnalyzerAnalyzer() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_.-]*$`), ""),
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_.-]*$`), "must begin with a letter and contain only alphanumeric, underscore, period, or hyphen characters"),
 				),
 			},
 			"arn": {


### PR DESCRIPTION
Adds validation to `aws_accessanalyzer_analyzer` `analyzer_name`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16264

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_accessanalyzer_analyzer: Adds plan time validation to `analyzer_name`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
