### PR TITLE
docs: Remediate and enable MD010 lint

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -4,6 +4,8 @@
 default: true
 MD007:
   indent: 4
+MD010:
+  code_blocks: false
 
 # Disabled Rules
 # https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md
@@ -11,7 +13,6 @@ MD007:
 MD001: false
 MD004: false
 MD006: false
-MD010: false
 MD012: false
 MD013: false
 MD014: false

--- a/website/docs/d/elasticsearch_domain.html.markdown
+++ b/website/docs/d/elasticsearch_domain.html.markdown
@@ -60,7 +60,7 @@ The following attributes are exported:
     * `volume_type` - The type of EBS volumes attached to data nodes.
     * `volume_size` - The size of EBS volumes attached to data nodes (in GB).
     * `iops` - The baseline input/output (I/O) performance of EBS volumes
-	attached to data nodes.
+ attached to data nodes.
 * `elasticsearch_version` – ElasticSearch version for the domain.
 * `encryption_at_rest` - Domain encryption at rest related options.
     * `enabled` - Whether encryption at rest is enabled in the domain.
@@ -76,7 +76,7 @@ The following attributes are exported:
 * `processing` – Status of a configuration change in the domain.
 * `snapshot_options` – Domain snapshot related options.
     * `automated_snapshot_start_hour` - Hour during which the service takes an automated daily
-	snapshot of the indices in the domain.
+ snapshot of the indices in the domain.
 * `tags` - The tags assigned to the domain.
 * `vpc_options` - VPC Options for private Elasticsearch domains.
     * `availability_zones` - The availability zones used by the domain.

--- a/website/docs/d/elasticsearch_domain.html.markdown
+++ b/website/docs/d/elasticsearch_domain.html.markdown
@@ -59,8 +59,7 @@ The following attributes are exported:
     * `ebs_enabled` - Whether EBS volumes are attached to data nodes in the domain.
     * `volume_type` - The type of EBS volumes attached to data nodes.
     * `volume_size` - The size of EBS volumes attached to data nodes (in GB).
-    * `iops` - The baseline input/output (I/O) performance of EBS volumes
- attached to data nodes.
+    * `iops` - The baseline input/output (I/O) performance of EBS volumes attached to data nodes.
 * `elasticsearch_version` – ElasticSearch version for the domain.
 * `encryption_at_rest` - Domain encryption at rest related options.
     * `enabled` - Whether encryption at rest is enabled in the domain.
@@ -75,8 +74,7 @@ The following attributes are exported:
     * `enabled` - Whether node to node encryption is enabled.
 * `processing` – Status of a configuration change in the domain.
 * `snapshot_options` – Domain snapshot related options.
-    * `automated_snapshot_start_hour` - Hour during which the service takes an automated daily
- snapshot of the indices in the domain.
+    * `automated_snapshot_start_hour` - Hour during which the service takes an automated daily snapshot of the indices in the domain.
 * `tags` - The tags assigned to the domain.
 * `vpc_options` - VPC Options for private Elasticsearch domains.
     * `availability_zones` - The availability zones used by the domain.

--- a/website/docs/r/api_gateway_account.html.markdown
+++ b/website/docs/r/api_gateway_account.html.markdown
@@ -70,9 +70,7 @@ EOF
 
 The following argument is supported:
 
-* `cloudwatch_role_arn` - (Optional) The ARN of an IAM role for CloudWatch (to allow logging & monitoring).
- See more [in AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-stage-settings.html#how-to-stage-settings-console).
- Logging & monitoring can be enabled/disabled and otherwise tuned on the API Gateway Stage level.
+* `cloudwatch_role_arn` - (Optional) The ARN of an IAM role for CloudWatch (to allow logging & monitoring). See more [in AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-stage-settings.html#how-to-stage-settings-console). Logging & monitoring can be enabled/disabled and otherwise tuned on the API Gateway Stage level.
 
 ## Attributes Reference
 

--- a/website/docs/r/api_gateway_account.html.markdown
+++ b/website/docs/r/api_gateway_account.html.markdown
@@ -71,8 +71,8 @@ EOF
 The following argument is supported:
 
 * `cloudwatch_role_arn` - (Optional) The ARN of an IAM role for CloudWatch (to allow logging & monitoring).
-	See more [in AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-stage-settings.html#how-to-stage-settings-console).
-	Logging & monitoring can be enabled/disabled and otherwise tuned on the API Gateway Stage level.
+ See more [in AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-stage-settings.html#how-to-stage-settings-console).
+ Logging & monitoring can be enabled/disabled and otherwise tuned on the API Gateway Stage level.
 
 ## Attributes Reference
 

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -97,25 +97,16 @@ resource "aws_lambda_function" "authorizer" {
 
 The following arguments are supported:
 
-* `authorizer_uri` - (Optional, required for type `TOKEN`/`REQUEST`) The authorizer's Uniform Resource Identifier (URI).
- This must be a well-formed Lambda function URI in the form of `arn:aws:apigateway:{region}:lambda:path/{service_api}`,
+* `authorizer_uri` - (Optional, required for type `TOKEN`/`REQUEST`) The authorizer's Uniform Resource Identifier (URI). This must be a well-formed Lambda function URI in the form of `arn:aws:apigateway:{region}:lambda:path/{service_api}`,
  e.g. `arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:012345678912:function:my-function/invocations`
 * `name` - (Required) The name of the authorizer
 * `rest_api_id` - (Required) The ID of the associated REST API
-* `identity_source` - (Optional) The source of the identity in an incoming request.
- Defaults to `method.request.header.Authorization`. For `REQUEST` type, this may be a comma-separated list of values, including headers, query string parameters and stage variables - e.g. `"method.request.header.SomeHeaderName,method.request.querystring.SomeQueryStringName,stageVariables.SomeStageVariableName"`
-* `type` - (Optional) The type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool.
- Defaults to `TOKEN`.
-* `authorizer_credentials` - (Optional) The credentials required for the authorizer.
- To specify an IAM Role for API Gateway to assume, use the IAM Role ARN.
-* `authorizer_result_ttl_in_seconds` - (Optional) The TTL of cached authorizer results in seconds.
- Defaults to `300`.
-* `identity_validation_expression` - (Optional) A validation expression for the incoming identity.
- For `TOKEN` type, this value should be a regular expression. The incoming token from the client is matched
- against this expression, and will proceed if the token matches. If the token doesn't match,
- the client receives a 401 Unauthorized response.
-* `provider_arns` - (Optional, required for type `COGNITO_USER_POOLS`) A list of the Amazon Cognito user pool ARNs.
- Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.
+* `identity_source` - (Optional) The source of the identity in an incoming request. Defaults to `method.request.header.Authorization`. For `REQUEST` type, this may be a comma-separated list of values, including headers, query string parameters and stage variables - e.g. `"method.request.header.SomeHeaderName,method.request.querystring.SomeQueryStringName,stageVariables.SomeStageVariableName"`
+* `type` - (Optional) The type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool. Defaults to `TOKEN`.
+* `authorizer_credentials` - (Optional) The credentials required for the authorizer. To specify an IAM Role for API Gateway to assume, use the IAM Role ARN.
+* `authorizer_result_ttl_in_seconds` - (Optional) The TTL of cached authorizer results in seconds. Defaults to `300`.
+* `identity_validation_expression` - (Optional) A validation expression for the incoming identity. For `TOKEN` type, this value should be a regular expression. The incoming token from the client is matched against this expression, and will proceed if the token matches. If the token doesn't match, the client receives a 401 Unauthorized response.
+* `provider_arns` - (Optional, required for type `COGNITO_USER_POOLS`) A list of the Amazon Cognito user pool ARNs. Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.
 
 ## Attributes Reference
 

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -98,24 +98,24 @@ resource "aws_lambda_function" "authorizer" {
 The following arguments are supported:
 
 * `authorizer_uri` - (Optional, required for type `TOKEN`/`REQUEST`) The authorizer's Uniform Resource Identifier (URI).
-	This must be a well-formed Lambda function URI in the form of `arn:aws:apigateway:{region}:lambda:path/{service_api}`,
-	e.g. `arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:012345678912:function:my-function/invocations`
+ This must be a well-formed Lambda function URI in the form of `arn:aws:apigateway:{region}:lambda:path/{service_api}`,
+ e.g. `arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:012345678912:function:my-function/invocations`
 * `name` - (Required) The name of the authorizer
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `identity_source` - (Optional) The source of the identity in an incoming request.
-	Defaults to `method.request.header.Authorization`. For `REQUEST` type, this may be a comma-separated list of values, including headers, query string parameters and stage variables - e.g. `"method.request.header.SomeHeaderName,method.request.querystring.SomeQueryStringName,stageVariables.SomeStageVariableName"`
+ Defaults to `method.request.header.Authorization`. For `REQUEST` type, this may be a comma-separated list of values, including headers, query string parameters and stage variables - e.g. `"method.request.header.SomeHeaderName,method.request.querystring.SomeQueryStringName,stageVariables.SomeStageVariableName"`
 * `type` - (Optional) The type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool.
-	Defaults to `TOKEN`.
+ Defaults to `TOKEN`.
 * `authorizer_credentials` - (Optional) The credentials required for the authorizer.
-	To specify an IAM Role for API Gateway to assume, use the IAM Role ARN.
+ To specify an IAM Role for API Gateway to assume, use the IAM Role ARN.
 * `authorizer_result_ttl_in_seconds` - (Optional) The TTL of cached authorizer results in seconds.
-	Defaults to `300`.
+ Defaults to `300`.
 * `identity_validation_expression` - (Optional) A validation expression for the incoming identity.
-	For `TOKEN` type, this value should be a regular expression. The incoming token from the client is matched
-	against this expression, and will proceed if the token matches. If the token doesn't match,
-	the client receives a 401 Unauthorized response.
+ For `TOKEN` type, this value should be a regular expression. The incoming token from the client is matched
+ against this expression, and will proceed if the token matches. If the token doesn't match,
+ the client receives a 401 Unauthorized response.
 * `provider_arns` - (Optional, required for type `COGNITO_USER_POOLS`) A list of the Amazon Cognito user pool ARNs.
-	Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.
+ Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.
 
 ## Attributes Reference
 

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -102,7 +102,7 @@ The following arguments are supported:
 * `access_log_settings` - (Optional) Enables access logs for the API stage. Detailed below.
 * `cache_cluster_enabled` - (Optional) Specifies whether a cache cluster is enabled for the stage
 * `cache_cluster_size` - (Optional) The size of the cache cluster for the stage, if enabled.
-	Allowed values include `0.5`, `1.6`, `6.1`, `13.5`, `28.4`, `58.2`, `118` and `237`.
+ Allowed values include `0.5`, `1.6`, `6.1`, `13.5`, `28.4`, `58.2`, `118` and `237`.
 * `client_certificate_id` - (Optional) The identifier of a client certificate for the stage.
 * `description` - (Optional) The description of the stage
 * `documentation_version` - (Optional) The version of the associated API documentation

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -101,8 +101,7 @@ The following arguments are supported:
 * `deployment_id` - (Required) The ID of the deployment that the stage points to
 * `access_log_settings` - (Optional) Enables access logs for the API stage. Detailed below.
 * `cache_cluster_enabled` - (Optional) Specifies whether a cache cluster is enabled for the stage
-* `cache_cluster_size` - (Optional) The size of the cache cluster for the stage, if enabled.
- Allowed values include `0.5`, `1.6`, `6.1`, `13.5`, `28.4`, `58.2`, `118` and `237`.
+* `cache_cluster_size` - (Optional) The size of the cache cluster for the stage, if enabled. Allowed values include `0.5`, `1.6`, `6.1`, `13.5`, `28.4`, `58.2`, `118` and `237`.
 * `client_certificate_id` - (Optional) The identifier of a client certificate for the stage.
 * `description` - (Optional) The description of the stage
 * `documentation_version` - (Optional) The version of the associated API documentation

--- a/website/docs/r/cloudwatch_event_bus.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus.html.markdown
@@ -25,9 +25,7 @@ resource "aws_cloudwatch_event_bus" "messenger" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the new event bus.
- The names of custom event buses can't contain the / character.
- Please note that a partner event bus is not supported at the moment.
+* `name` - (Required) The name of the new event bus. The names of custom event buses can't contain the / character. Please note that a partner event bus is not supported at the moment.
 * `tags` - (Optional)  A map of tags to assign to the resource.
 
 ## Attributes Reference

--- a/website/docs/r/cloudwatch_event_bus.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus.html.markdown
@@ -26,8 +26,8 @@ resource "aws_cloudwatch_event_bus" "messenger" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the new event bus.
-	The names of custom event buses can't contain the / character.
-	Please note that a partner event bus is not supported at the moment.
+ The names of custom event buses can't contain the / character.
+ Please note that a partner event bus is not supported at the moment.
 * `tags` - (Optional)  A map of tags to assign to the resource.
 
 ## Attributes Reference

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -65,10 +65,10 @@ The following arguments are supported:
 * `name` - (Optional) The name of the rule. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `schedule_expression` - (Optional) The scheduling expression.
-	For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`. At least one of `schedule_expression` or `event_pattern` is required. Can only be used on the default event bus.
+ For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`. At least one of `schedule_expression` or `event_pattern` is required. Can only be used on the default event bus.
 * `event_bus_name` - (Optional) The event bus to associate with this rule. If you omit this, the `default` event bus is used.
 * `event_pattern` - (Optional) The event pattern described a JSON object. At least one of `schedule_expression` or `event_pattern` is required.
-	See full documentation of [Events and Event Patterns in EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html) for details.
+ See full documentation of [Events and Event Patterns in EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html) for details.
 * `description` - (Optional) The description of the rule.
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) associated with the role that is used for target invocation.
 * `is_enabled` - (Optional) Whether the rule should be enabled (defaults to `true`).

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -64,11 +64,9 @@ The following arguments are supported:
 
 * `name` - (Optional) The name of the rule. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
-* `schedule_expression` - (Optional) The scheduling expression.
- For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`. At least one of `schedule_expression` or `event_pattern` is required. Can only be used on the default event bus.
+* `schedule_expression` - (Optional) The scheduling expression. For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`. At least one of `schedule_expression` or `event_pattern` is required. Can only be used on the default event bus.
 * `event_bus_name` - (Optional) The event bus to associate with this rule. If you omit this, the `default` event bus is used.
-* `event_pattern` - (Optional) The event pattern described a JSON object. At least one of `schedule_expression` or `event_pattern` is required.
- See full documentation of [Events and Event Patterns in EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html) for details.
+* `event_pattern` - (Optional) The event pattern described a JSON object. At least one of `schedule_expression` or `event_pattern` is required. See full documentation of [Events and Event Patterns in EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html) for details.
 * `description` - (Optional) The description of the rule.
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) associated with the role that is used for target invocation.
 * `is_enabled` - (Optional) Whether the rule should be enabled (defaults to `true`).

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -299,8 +299,7 @@ The following arguments are supported:
 * `target_id` - (Optional) The unique target assignment ID.  If missing, will generate a random, unique id.
 * `arn` - (Required) The Amazon Resource Name (ARN) associated of the target.
 * `input` - (Optional) Valid JSON text passed to the target. Conflicts with `input_path` and `input_transformer`.
-* `input_path` - (Optional) The value of the [JSONPath](http://goessner.net/articles/JsonPath/)
- that is used for extracting part of the matched event when passing it to the target. Conflicts with `input` and `input_transformer`.
+* `input_path` - (Optional) The value of the [JSONPath](http://goessner.net/articles/JsonPath/) that is used for extracting part of the matched event when passing it to the target. Conflicts with `input` and `input_transformer`.
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered. Required if `ecs_target` is used.
 * `run_command_targets` - (Optional) Parameters used when you are using the rule to invoke Amazon EC2 Run Command. Documented below. A maximum of 5 are allowed.
 * `ecs_target` - (Optional) Parameters used when you are using the rule to invoke Amazon ECS Task. Documented below. A maximum of 1 are allowed.

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -300,7 +300,7 @@ The following arguments are supported:
 * `arn` - (Required) The Amazon Resource Name (ARN) associated of the target.
 * `input` - (Optional) Valid JSON text passed to the target. Conflicts with `input_path` and `input_transformer`.
 * `input_path` - (Optional) The value of the [JSONPath](http://goessner.net/articles/JsonPath/)
-	that is used for extracting part of the matched event when passing it to the target. Conflicts with `input` and `input_transformer`.
+ that is used for extracting part of the matched event when passing it to the target. Conflicts with `input` and `input_transformer`.
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered. Required if `ecs_target` is used.
 * `run_command_targets` - (Optional) Parameters used when you are using the rule to invoke Amazon EC2 Run Command. Documented below. A maximum of 5 are allowed.
 * `ecs_target` - (Optional) Parameters used when you are using the rule to invoke Amazon ECS Task. Documented below. A maximum of 1 are allowed.

--- a/website/docs/r/cloudwatch_log_metric_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_metric_filter.html.markdown
@@ -38,8 +38,7 @@ The following arguments are supported:
 * `pattern` - (Required) A valid [CloudWatch Logs filter pattern](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/FilterAndPatternSyntax.html)
   for extracting metric data out of ingested log events.
 * `log_group_name` - (Required) The name of the log group to associate the metric filter with.
-* `metric_transformation` - (Required) A block defining collection of information
- needed to define how metric data gets emitted. See below.
+* `metric_transformation` - (Required) A block defining collection of information needed to define how metric data gets emitted. See below.
 
 The `metric_transformation` block supports the following arguments:
 

--- a/website/docs/r/cloudwatch_log_metric_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_metric_filter.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
   for extracting metric data out of ingested log events.
 * `log_group_name` - (Required) The name of the log group to associate the metric filter with.
 * `metric_transformation` - (Required) A block defining collection of information
-	needed to define how metric data gets emitted. See below.
+ needed to define how metric data gets emitted. See below.
 
 The `metric_transformation` block supports the following arguments:
 

--- a/website/docs/r/config_config_rule.html.markdown
+++ b/website/docs/r/config_config_rule.html.markdown
@@ -120,7 +120,7 @@ The following arguments are supported:
 * `maximum_execution_frequency` - (Optional) The maximum frequency with which AWS Config runs evaluations for a rule.
 * `scope` - (Optional) Scope defines which resources can trigger an evaluation for the rule as documented below.
 * `source` - (Required) Source specifies the rule owner, the rule identifier, and the notifications that cause
-	the function to evaluate your AWS resources as documented below.
+ the function to evaluate your AWS resources as documented below.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ### `scope`
@@ -129,12 +129,12 @@ Defines which resources can trigger an evaluation for the rule.
 If you do not specify a scope, evaluations are triggered when any resource in the recording group changes.
 
 * `compliance_resource_id` - (Optional) The IDs of the only AWS resource that you want to trigger an evaluation for the rule.
-	If you specify a resource ID, you must specify one resource type for `compliance_resource_types`.
+ If you specify a resource ID, you must specify one resource type for `compliance_resource_types`.
 * `compliance_resource_types` - (Optional) A list of resource types of only those AWS resources that you want to trigger an
-	evaluation for the rule. e.g. `AWS::EC2::Instance`. You can only specify one type if you also specify
-	a resource ID for `compliance_resource_id`. See [relevant part of AWS Docs](http://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType) for available types.
+ evaluation for the rule. e.g. `AWS::EC2::Instance`. You can only specify one type if you also specify
+ a resource ID for `compliance_resource_id`. See [relevant part of AWS Docs](http://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType) for available types.
 * `tag_key` - (Optional, Required if `tag_value` is specified) The tag key that is applied to only those AWS resources that you want you
-	want to trigger an evaluation for the rule.
+ want to trigger an evaluation for the rule.
 * `tag_value` - (Optional) The tag value applied to only those AWS resources that you want to trigger an evaluation for the rule.
 
 ### `source`
@@ -145,20 +145,20 @@ Provides the rule owner (AWS or customer), the rule identifier, and the notifica
 * `source_identifier` - (Required) For AWS Config managed rules, a predefined identifier, e.g `IAM_PASSWORD_POLICY`. For custom Lambda rules, the identifier is the ARN of the Lambda Function, such as `arn:aws:lambda:us-east-1:123456789012:function:custom_rule_name` or the [`arn` attribute of the `aws_lambda_function` resource](/docs/providers/aws/r/lambda_function.html#arn).
 * `source_detail` - (Optional) Provides the source and type of the event that causes AWS Config to evaluate your AWS resources. Only valid if `owner` is `CUSTOM_LAMBDA`.
     * `event_source` - (Optional) The source of the event, such as an AWS service, that triggers AWS Config
-		to evaluate your AWS resources. This defaults to `aws.config` and is the only valid value.
+  to evaluate your AWS resources. This defaults to `aws.config` and is the only valid value.
     * `maximum_execution_frequency` - (Optional) The frequency that you want AWS Config to run evaluations for a rule that
-		is triggered periodically. If specified, requires `message_type` to be `ScheduledNotification`.
+  is triggered periodically. If specified, requires `message_type` to be `ScheduledNotification`.
     * `message_type` - (Optional) The type of notification that triggers AWS Config to run an evaluation for a rule. You can specify the following notification types:
         * `ConfigurationItemChangeNotification` - Triggers an evaluation when AWS
-	    	Config delivers a configuration item as a result of a resource change.
+      Config delivers a configuration item as a result of a resource change.
         * `OversizedConfigurationItemChangeNotification` - Triggers an evaluation
-	    	when AWS Config delivers an oversized configuration item. AWS Config may
-	    	generate this notification type when a resource changes and the notification
-	    	exceeds the maximum size allowed by Amazon SNS.
+      when AWS Config delivers an oversized configuration item. AWS Config may
+      generate this notification type when a resource changes and the notification
+      exceeds the maximum size allowed by Amazon SNS.
         * `ScheduledNotification` - Triggers a periodic evaluation at the frequency
-	    	specified for `maximum_execution_frequency`.
+      specified for `maximum_execution_frequency`.
         * `ConfigurationSnapshotDeliveryCompleted` - Triggers a periodic evaluation
-	    	when AWS Config delivers a configuration snapshot.
+      when AWS Config delivers a configuration snapshot.
 
 ## Attributes Reference
 

--- a/website/docs/r/config_config_rule.html.markdown
+++ b/website/docs/r/config_config_rule.html.markdown
@@ -119,8 +119,7 @@ The following arguments are supported:
 * `input_parameters` - (Optional) A string in JSON format that is passed to the AWS Config rule Lambda function.
 * `maximum_execution_frequency` - (Optional) The maximum frequency with which AWS Config runs evaluations for a rule.
 * `scope` - (Optional) Scope defines which resources can trigger an evaluation for the rule as documented below.
-* `source` - (Required) Source specifies the rule owner, the rule identifier, and the notifications that cause
- the function to evaluate your AWS resources as documented below.
+* `source` - (Required) Source specifies the rule owner, the rule identifier, and the notifications that cause the function to evaluate your AWS resources as documented below.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ### `scope`
@@ -128,13 +127,9 @@ The following arguments are supported:
 Defines which resources can trigger an evaluation for the rule.
 If you do not specify a scope, evaluations are triggered when any resource in the recording group changes.
 
-* `compliance_resource_id` - (Optional) The IDs of the only AWS resource that you want to trigger an evaluation for the rule.
- If you specify a resource ID, you must specify one resource type for `compliance_resource_types`.
-* `compliance_resource_types` - (Optional) A list of resource types of only those AWS resources that you want to trigger an
- evaluation for the rule. e.g. `AWS::EC2::Instance`. You can only specify one type if you also specify
- a resource ID for `compliance_resource_id`. See [relevant part of AWS Docs](http://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType) for available types.
-* `tag_key` - (Optional, Required if `tag_value` is specified) The tag key that is applied to only those AWS resources that you want you
- want to trigger an evaluation for the rule.
+* `compliance_resource_id` - (Optional) The IDs of the only AWS resource that you want to trigger an evaluation for the rule. If you specify a resource ID, you must specify one resource type for `compliance_resource_types`.
+* `compliance_resource_types` - (Optional) A list of resource types of only those AWS resources that you want to trigger an evaluation for the rule. e.g. `AWS::EC2::Instance`. You can only specify one type if you also specify a resource ID for `compliance_resource_id`. See [relevant part of AWS Docs](http://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType) for available types.
+* `tag_key` - (Optional, Required if `tag_value` is specified) The tag key that is applied to only those AWS resources that you want you want to trigger an evaluation for the rule.
 * `tag_value` - (Optional) The tag value applied to only those AWS resources that you want to trigger an evaluation for the rule.
 
 ### `source`
@@ -144,21 +139,13 @@ Provides the rule owner (AWS or customer), the rule identifier, and the notifica
 * `owner` - (Required) Indicates whether AWS or the customer owns and manages the AWS Config rule. Valid values are `AWS` or `CUSTOM_LAMBDA`. For more information about managed rules, see the [AWS Config Managed Rules documentation](https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_use-managed-rules.html). For more information about custom rules, see the [AWS Config Custom Rules documentation](https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_develop-rules.html). Custom Lambda Functions require permissions to allow the AWS Config service to invoke them, e.g. via the [`aws_lambda_permission` resource](/docs/providers/aws/r/lambda_permission.html).
 * `source_identifier` - (Required) For AWS Config managed rules, a predefined identifier, e.g `IAM_PASSWORD_POLICY`. For custom Lambda rules, the identifier is the ARN of the Lambda Function, such as `arn:aws:lambda:us-east-1:123456789012:function:custom_rule_name` or the [`arn` attribute of the `aws_lambda_function` resource](/docs/providers/aws/r/lambda_function.html#arn).
 * `source_detail` - (Optional) Provides the source and type of the event that causes AWS Config to evaluate your AWS resources. Only valid if `owner` is `CUSTOM_LAMBDA`.
-    * `event_source` - (Optional) The source of the event, such as an AWS service, that triggers AWS Config
-  to evaluate your AWS resources. This defaults to `aws.config` and is the only valid value.
-    * `maximum_execution_frequency` - (Optional) The frequency that you want AWS Config to run evaluations for a rule that
-  is triggered periodically. If specified, requires `message_type` to be `ScheduledNotification`.
+    * `event_source` - (Optional) The source of the event, such as an AWS service, that triggers AWS Config to evaluate your AWS resources. This defaults to `aws.config` and is the only valid value.
+    * `maximum_execution_frequency` - (Optional) The frequency that you want AWS Config to run evaluations for a rule that is triggered periodically. If specified, requires `message_type` to be `ScheduledNotification`.
     * `message_type` - (Optional) The type of notification that triggers AWS Config to run an evaluation for a rule. You can specify the following notification types:
-        * `ConfigurationItemChangeNotification` - Triggers an evaluation when AWS
-      Config delivers a configuration item as a result of a resource change.
-        * `OversizedConfigurationItemChangeNotification` - Triggers an evaluation
-      when AWS Config delivers an oversized configuration item. AWS Config may
-      generate this notification type when a resource changes and the notification
-      exceeds the maximum size allowed by Amazon SNS.
-        * `ScheduledNotification` - Triggers a periodic evaluation at the frequency
-      specified for `maximum_execution_frequency`.
-        * `ConfigurationSnapshotDeliveryCompleted` - Triggers a periodic evaluation
-      when AWS Config delivers a configuration snapshot.
+        * `ConfigurationItemChangeNotification` - Triggers an evaluation when AWS Config delivers a configuration item as a result of a resource change.
+        * `OversizedConfigurationItemChangeNotification` - Triggers an evaluation when AWS Config delivers an oversized configuration item. AWS Config may generate this notification type when a resource changes and the notification exceeds the maximum size allowed by Amazon SNS.
+        * `ScheduledNotification` - Triggers a periodic evaluation at the frequency specified for `maximum_execution_frequency`.
+        * `ConfigurationSnapshotDeliveryCompleted` - Triggers a periodic evaluation when AWS Config delivers a configuration snapshot.
 
 ## Attributes Reference
 

--- a/website/docs/r/config_configuration_recorder.html.markdown
+++ b/website/docs/r/config_configuration_recorder.html.markdown
@@ -47,19 +47,19 @@ The following arguments are supported:
 
 * `name` - (Optional) The name of the recorder. Defaults to `default`. Changing it recreates the resource.
 * `role_arn` - (Required) Amazon Resource Name (ARN) of the IAM role.
-	used to make read or write requests to the delivery channel and to describe the AWS resources associated with the account.
-	See [AWS Docs](http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html) for more details.
+ used to make read or write requests to the delivery channel and to describe the AWS resources associated with the account.
+ See [AWS Docs](http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html) for more details.
 * `recording_group` - (Optional) Recording group - see below.
 
 ### `recording_group`
 
 * `all_supported` - (Optional) Specifies whether AWS Config records configuration changes
-	for every supported type of regional resource (which includes any new type that will become supported in the future).
-	Conflicts with `resource_types`. Defaults to `true`.
+ for every supported type of regional resource (which includes any new type that will become supported in the future).
+ Conflicts with `resource_types`. Defaults to `true`.
 * `include_global_resource_types` - (Optional) Specifies whether AWS Config includes all supported types of *global resources*
-	with the resources that it records. Requires `all_supported = true`. Conflicts with `resource_types`.
+ with the resources that it records. Requires `all_supported = true`. Conflicts with `resource_types`.
 * `resource_types` - (Optional) A list that specifies the types of AWS resources for which
-	AWS Config records configuration changes (for example, `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`).
+ AWS Config records configuration changes (for example, `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`).
   See [relevant part of AWS Docs](http://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType) for available types.
 
 ## Attributes Reference

--- a/website/docs/r/config_configuration_recorder.html.markdown
+++ b/website/docs/r/config_configuration_recorder.html.markdown
@@ -46,21 +46,14 @@ POLICY
 The following arguments are supported:
 
 * `name` - (Optional) The name of the recorder. Defaults to `default`. Changing it recreates the resource.
-* `role_arn` - (Required) Amazon Resource Name (ARN) of the IAM role.
- used to make read or write requests to the delivery channel and to describe the AWS resources associated with the account.
- See [AWS Docs](http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html) for more details.
+* `role_arn` - (Required) Amazon Resource Name (ARN) of the IAM role. Used to make read or write requests to the delivery channel and to describe the AWS resources associated with the account. See [AWS Docs](http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html) for more details.
 * `recording_group` - (Optional) Recording group - see below.
 
 ### `recording_group`
 
-* `all_supported` - (Optional) Specifies whether AWS Config records configuration changes
- for every supported type of regional resource (which includes any new type that will become supported in the future).
- Conflicts with `resource_types`. Defaults to `true`.
-* `include_global_resource_types` - (Optional) Specifies whether AWS Config includes all supported types of *global resources*
- with the resources that it records. Requires `all_supported = true`. Conflicts with `resource_types`.
-* `resource_types` - (Optional) A list that specifies the types of AWS resources for which
- AWS Config records configuration changes (for example, `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`).
-  See [relevant part of AWS Docs](http://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType) for available types.
+* `all_supported` - (Optional) Specifies whether AWS Config records configuration changes for every supported type of regional resource (which includes any new type that will become supported in the future). Conflicts with `resource_types`. Defaults to `true`.
+* `include_global_resource_types` - (Optional) Specifies whether AWS Config includes all supported types of *global resources* with the resources that it records. Requires `all_supported = true`. Conflicts with `resource_types`.
+* `resource_types` - (Optional) A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`). See [relevant part of AWS Docs](http://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType) for available types.
 
 ## Attributes Reference
 

--- a/website/docs/r/config_delivery_channel.html.markdown
+++ b/website/docs/r/config_delivery_channel.html.markdown
@@ -88,8 +88,8 @@ The following arguments are supported:
 ### `snapshot_delivery_properties`
 
 * `delivery_frequency` - (Optional) - The frequency with which AWS Config recurringly delivers configuration snapshots.
-	e.g. `One_Hour` or `Three_Hours`.
-	Valid values are listed [here](https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html#API_ConfigSnapshotDeliveryProperties_Contents).
+ e.g. `One_Hour` or `Three_Hours`.
+ Valid values are listed [here](https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html#API_ConfigSnapshotDeliveryProperties_Contents).
 
 ## Attributes Reference
 

--- a/website/docs/r/config_delivery_channel.html.markdown
+++ b/website/docs/r/config_delivery_channel.html.markdown
@@ -87,9 +87,7 @@ The following arguments are supported:
 
 ### `snapshot_delivery_properties`
 
-* `delivery_frequency` - (Optional) - The frequency with which AWS Config recurringly delivers configuration snapshots.
- e.g. `One_Hour` or `Three_Hours`.
- Valid values are listed [here](https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html#API_ConfigSnapshotDeliveryProperties_Contents).
+* `delivery_frequency` - (Optional) - The frequency with which AWS Config recurringly delivers configuration snapshots. e.g. `One_Hour` or `Three_Hours`. Valid values are listed [here](https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html#API_ConfigSnapshotDeliveryProperties_Contents).
 
 ## Attributes Reference
 

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -242,8 +242,7 @@ The **advanced_security_options** block supports the following attributes:
 * `volume_type` - (Optional) The type of EBS volumes attached to data nodes.
 * `volume_size` - The size of EBS volumes attached to data nodes (in GiB).
 **Required** if `ebs_enabled` is set to `true`.
-* `iops` - (Optional) The baseline input/output (I/O) performance of EBS volumes
- attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.
+* `iops` - (Optional) The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.
 
 **encrypt_at_rest** supports the following attributes:
 
@@ -291,8 +290,7 @@ Security Groups and Subnets referenced in these attributes must all be within th
 
 **snapshot_options** supports the following attribute:
 
-* `automated_snapshot_start_hour` - (Required) Hour during which the service takes an automated daily
- snapshot of the indices in the domain.
+* `automated_snapshot_start_hour` - (Required) Hour during which the service takes an automated daily snapshot of the indices in the domain.
 
 **log_publishing_options** supports the following attribute:
 

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -243,7 +243,7 @@ The **advanced_security_options** block supports the following attributes:
 * `volume_size` - The size of EBS volumes attached to data nodes (in GiB).
 **Required** if `ebs_enabled` is set to `true`.
 * `iops` - (Optional) The baseline input/output (I/O) performance of EBS volumes
-	attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.
+ attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.
 
 **encrypt_at_rest** supports the following attributes:
 
@@ -292,7 +292,7 @@ Security Groups and Subnets referenced in these attributes must all be within th
 **snapshot_options** supports the following attribute:
 
 * `automated_snapshot_start_hour` - (Required) Hour during which the service takes an automated daily
-	snapshot of the indices in the domain.
+ snapshot of the indices in the domain.
 
 **log_publishing_options** supports the following attribute:
 

--- a/website/docs/r/iam_account_password_policy.html.markdown
+++ b/website/docs/r/iam_account_password_policy.html.markdown
@@ -32,8 +32,7 @@ resource "aws_iam_account_password_policy" "strict" {
 The following arguments are supported:
 
 * `allow_users_to_change_password` - (Optional) Whether to allow users to change their own password
-* `hard_expiry` - (Optional) Whether users are prevented from setting a new password after their password has expired
- (i.e. require administrator reset)
+* `hard_expiry` - (Optional) Whether users are prevented from setting a new password after their password has expired (i.e. require administrator reset)
 * `max_password_age` - (Optional) The number of days that an user password is valid.
 * `minimum_password_length` - (Optional) Minimum length to require for user passwords.
 * `password_reuse_prevention` - (Optional) The number of previous passwords that users are prevented from reusing.
@@ -46,9 +45,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `expire_passwords` - Indicates whether passwords in the account expire.
- Returns `true` if `max_password_age` contains a value greater than `0`.
- Returns `false` if it is `0` or _not present_.
+* `expire_passwords` - Indicates whether passwords in the account expire. Returns `true` if `max_password_age` contains a value greater than `0`. Returns `false` if it is `0` or _not present_.
 
 
 ## Import

--- a/website/docs/r/iam_account_password_policy.html.markdown
+++ b/website/docs/r/iam_account_password_policy.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `allow_users_to_change_password` - (Optional) Whether to allow users to change their own password
 * `hard_expiry` - (Optional) Whether users are prevented from setting a new password after their password has expired
-	(i.e. require administrator reset)
+ (i.e. require administrator reset)
 * `max_password_age` - (Optional) The number of days that an user password is valid.
 * `minimum_password_length` - (Optional) Minimum length to require for user passwords.
 * `password_reuse_prevention` - (Optional) The number of previous passwords that users are prevented from reusing.
@@ -47,8 +47,8 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `expire_passwords` - Indicates whether passwords in the account expire.
-	Returns `true` if `max_password_age` contains a value greater than `0`.
-	Returns `false` if it is `0` or _not present_.
+ Returns `true` if `max_password_age` contains a value greater than `0`.
+ Returns `false` if it is `0` or _not present_.
 
 
 ## Import

--- a/website/docs/r/iam_role_policy_attachment.markdown
+++ b/website/docs/r/iam_role_policy_attachment.markdown
@@ -65,8 +65,8 @@ resource "aws_iam_role_policy_attachment" "test-attach" {
 
 The following arguments are supported:
 
-* `role`		(Required) - The role the policy should be applied to
-* `policy_arn`	(Required) - The ARN of the policy you want to apply
+* `role`  (Required) - The role the policy should be applied to
+* `policy_arn` (Required) - The ARN of the policy you want to apply
 
 ## Import
 

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -30,10 +30,10 @@ Defaults to `ENCRYPT_DECRYPT`.
 Valid values: `SYMMETRIC_DEFAULT`,  `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. Defaults to `SYMMETRIC_DEFAULT`. For help with choosing a key spec, see the [AWS KMS Developer Guide](https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html).
 * `policy` - (Optional) A valid policy JSON document. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
 * `deletion_window_in_days` - (Optional) Duration in days after which the key is deleted
-	after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days.
+ after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days.
 * `is_enabled` - (Optional) Specifies whether the key is enabled. Defaults to true.
 * `enable_key_rotation` - (Optional) Specifies whether [key rotation](http://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
-	is enabled. Defaults to false.
+ is enabled. Defaults to false.
 * `tags` - (Optional) A map of tags to assign to the object.
 
 ## Attributes Reference

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -29,11 +29,9 @@ Defaults to `ENCRYPT_DECRYPT`.
 * `customer_master_key_spec` - (Optional) Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports.
 Valid values: `SYMMETRIC_DEFAULT`,  `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. Defaults to `SYMMETRIC_DEFAULT`. For help with choosing a key spec, see the [AWS KMS Developer Guide](https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html).
 * `policy` - (Optional) A valid policy JSON document. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
-* `deletion_window_in_days` - (Optional) Duration in days after which the key is deleted
- after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days.
+* `deletion_window_in_days` - (Optional) Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days.
 * `is_enabled` - (Optional) Specifies whether the key is enabled. Defaults to true.
-* `enable_key_rotation` - (Optional) Specifies whether [key rotation](http://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
- is enabled. Defaults to false.
+* `enable_key_rotation` - (Optional) Specifies whether [key rotation](http://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) is enabled. Defaults to false.
 * `tags` - (Optional) A map of tags to assign to the object.
 
 ## Attributes Reference

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -134,11 +134,11 @@ resource "aws_lambda_permission" "lambda_permission" {
 * `event_source_token` - (Optional) The Event Source Token to validate.  Used with [Alexa Skills][1].
 * `function_name` - (Required) Name of the Lambda function whose resource policy you are updating
 * `principal` - (Required) The principal who is getting this permission.
- 	e.g. `s3.amazonaws.com`, an AWS account ID, or any valid AWS service principal
- 	such as `events.amazonaws.com` or `sns.amazonaws.com`.
+  e.g. `s3.amazonaws.com`, an AWS account ID, or any valid AWS service principal
+  such as `events.amazonaws.com` or `sns.amazonaws.com`.
 * `qualifier` - (Optional) Query parameter to specify function version or alias name.
- 	The permission will then apply to the specific qualified ARN.
- 	e.g. `arn:aws:lambda:aws-region:acct-id:function:function-name:2`
+  The permission will then apply to the specific qualified ARN.
+  e.g. `arn:aws:lambda:aws-region:acct-id:function:function-name:2`
 * `source_account` - (Optional) This parameter is used for S3 and SES. The AWS account ID (without a hyphen) of the source owner.
 * `source_arn` - (Optional) When the principal is an AWS service, the ARN of the specific resource within that service to grant permission to.
   Without this, any resource from `principal` will be granted permission – even if that resource is from another account.

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -133,12 +133,8 @@ resource "aws_lambda_permission" "lambda_permission" {
 * `action` - (Required) The AWS Lambda action you want to allow in this statement. (e.g. `lambda:InvokeFunction`)
 * `event_source_token` - (Optional) The Event Source Token to validate.  Used with [Alexa Skills][1].
 * `function_name` - (Required) Name of the Lambda function whose resource policy you are updating
-* `principal` - (Required) The principal who is getting this permission.
-  e.g. `s3.amazonaws.com`, an AWS account ID, or any valid AWS service principal
-  such as `events.amazonaws.com` or `sns.amazonaws.com`.
-* `qualifier` - (Optional) Query parameter to specify function version or alias name.
-  The permission will then apply to the specific qualified ARN.
-  e.g. `arn:aws:lambda:aws-region:acct-id:function:function-name:2`
+* `principal` - (Required) The principal who is getting this permission. e.g. `s3.amazonaws.com`, an AWS account ID, or any valid AWS service principal such as `events.amazonaws.com` or `sns.amazonaws.com`.
+* `qualifier` - (Optional) Query parameter to specify function version or alias name. The permission will then apply to the specific qualified ARN. e.g. `arn:aws:lambda:aws-region:acct-id:function:function-name:2`
 * `source_account` - (Optional) This parameter is used for S3 and SES. The AWS account ID (without a hyphen) of the source owner.
 * `source_arn` - (Optional) When the principal is an AWS service, the ARN of the specific resource within that service to grant permission to.
   Without this, any resource from `principal` will be granted permission – even if that resource is from another account.

--- a/website/docs/r/waf_ipset.html.markdown
+++ b/website/docs/r/waf_ipset.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `type` - (Required) Type of the IP address - `IPV4` or `IPV6`.
 * `value` - (Required) An IPv4 or IPv6 address specified via CIDR notation.
-	e.g. `192.0.2.44/32` or `1111:0000:0000:0000:0000:0000:0000:0000/64`
+ e.g. `192.0.2.44/32` or `1111:0000:0000:0000:0000:0000:0000:0000/64`
 
 ## Attributes Reference
 

--- a/website/docs/r/waf_ipset.html.markdown
+++ b/website/docs/r/waf_ipset.html.markdown
@@ -42,8 +42,7 @@ The following arguments are supported:
 #### Arguments
 
 * `type` - (Required) Type of the IP address - `IPV4` or `IPV6`.
-* `value` - (Required) An IPv4 or IPv6 address specified via CIDR notation.
- e.g. `192.0.2.44/32` or `1111:0000:0000:0000:0000:0000:0000:0000/64`
+* `value` - (Required) An IPv4 or IPv6 address specified via CIDR notation. e.g. `192.0.2.44/32` or `1111:0000:0000:0000:0000:0000:0000:0000/64`
 
 ## Attributes Reference
 

--- a/website/docs/r/waf_regex_match_set.html.markdown
+++ b/website/docs/r/waf_regex_match_set.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name or description of the Regex Match Set.
 * `regex_match_tuple` - (Required) The regular expression pattern that you want AWS WAF to search for in web requests,
-	the location in requests that you want AWS WAF to search, and other settings. See below.
+ the location in requests that you want AWS WAF to search, and other settings. See below.
 
 ### Nested Arguments
 

--- a/website/docs/r/waf_regex_match_set.html.markdown
+++ b/website/docs/r/waf_regex_match_set.html.markdown
@@ -38,8 +38,7 @@ resource "aws_waf_regex_pattern_set" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name or description of the Regex Match Set.
-* `regex_match_tuple` - (Required) The regular expression pattern that you want AWS WAF to search for in web requests,
- the location in requests that you want AWS WAF to search, and other settings. See below.
+* `regex_match_tuple` - (Required) The regular expression pattern that you want AWS WAF to search for in web requests, the location in requests that you want AWS WAF to search, and other settings. See below.
 
 ### Nested Arguments
 

--- a/website/docs/r/wafregional_regex_match_set.html.markdown
+++ b/website/docs/r/wafregional_regex_match_set.html.markdown
@@ -38,8 +38,7 @@ resource "aws_wafregional_regex_pattern_set" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name or description of the Regex Match Set.
-* `regex_match_tuple` - (Required) The regular expression pattern that you want AWS WAF to search for in web requests,
- the location in requests that you want AWS WAF to search, and other settings. See below.
+* `regex_match_tuple` - (Required) The regular expression pattern that you want AWS WAF to search for in web requests, the location in requests that you want AWS WAF to search, and other settings. See below.
 
 ### Nested Arguments
 

--- a/website/docs/r/wafregional_regex_match_set.html.markdown
+++ b/website/docs/r/wafregional_regex_match_set.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name or description of the Regex Match Set.
 * `regex_match_tuple` - (Required) The regular expression pattern that you want AWS WAF to search for in web requests,
-	the location in requests that you want AWS WAF to search, and other settings. See below.
+ the location in requests that you want AWS WAF to search, and other settings. See below.
 
 ### Nested Arguments
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14979

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make docs-lint website-lint
==> Checking docs against linters...
==> Checking website against linters...
```
Note that I don't particularly care for the fix of replacing a tab with a single space; I think it looks better if the 'hanging' line is indented to align with the 1st character of the bullet; i.e. 2-spaces in most cases in this diff. I'm happy to fix that up if others agree (it still passes the linter either way), but am just as happy to leave it as-is.