### PR TITLE
resource/cloudfront_distribution: Use flattenStringSet helper

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -514,7 +514,7 @@ func expandAllowedMethods(s *schema.Set) *cloudfront.AllowedMethods {
 
 func flattenAllowedMethods(am *cloudfront.AllowedMethods) *schema.Set {
 	if am.Items != nil {
-		return schema.NewSet(schema.HashString, flattenStringList(am.Items))
+		return flattenStringSet(am.Items)
 	}
 	return nil
 }
@@ -528,7 +528,7 @@ func expandCachedMethods(s *schema.Set) *cloudfront.CachedMethods {
 
 func flattenCachedMethods(cm *cloudfront.CachedMethods) *schema.Set {
 	if cm.Items != nil {
-		return schema.NewSet(schema.HashString, flattenStringList(cm.Items))
+		return flattenStringSet(cm.Items)
 	}
 	return nil
 }
@@ -877,7 +877,7 @@ func expandCustomOriginConfigSSL(s []interface{}) *cloudfront.OriginSslProtocols
 }
 
 func flattenCustomOriginConfigSSL(osp *cloudfront.OriginSslProtocols) *schema.Set {
-	return schema.NewSet(schema.HashString, flattenStringList(osp.Items))
+	return flattenStringSet(osp.Items)
 }
 
 func expandS3OriginConfig(m map[string]interface{}) *cloudfront.S3OriginConfig {
@@ -1014,7 +1014,7 @@ func expandAliases(as *schema.Set) *cloudfront.Aliases {
 
 func flattenAliases(aliases *cloudfront.Aliases) *schema.Set {
 	if aliases.Items != nil {
-		return schema.NewSet(aliasesHash, flattenStringList(aliases.Items))
+		return flattenStringSet(aliases.Items)
 	}
 	return schema.NewSet(aliasesHash, []interface{}{})
 }
@@ -1058,7 +1058,7 @@ func flattenGeoRestriction(gr *cloudfront.GeoRestriction) map[string]interface{}
 
 	m["restriction_type"] = aws.StringValue(gr.RestrictionType)
 	if gr.Items != nil {
-		m["locations"] = schema.NewSet(schema.HashString, flattenStringList(gr.Items))
+		m["locations"] = flattenStringSet(gr.Items)
 	}
 	return m
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6867

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceCloudFrontDistribution'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceCloudFrontDistribution -timeout 120m
=== RUN   TestAccAWSDataSourceCloudFrontDistribution_basic
=== PAUSE TestAccAWSDataSourceCloudFrontDistribution_basic
=== CONT  TestAccAWSDataSourceCloudFrontDistribution_basic
--- PASS: TestAccAWSDataSourceCloudFrontDistribution_basic (349.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	350.003s
```
