### PR TITLE
resource/cloudformation_stack: Use flattenStringSet helper

### DIFF
--- a/aws/data_source_aws_cloudformation_stack.go
+++ b/aws/data_source_aws_cloudformation_stack.go
@@ -92,7 +92,7 @@ func dataSourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface
 	d.Set("iam_role_arn", stack.RoleARN)
 
 	if len(stack.NotificationARNs) > 0 {
-		d.Set("notification_arns", schema.NewSet(schema.HashString, flattenStringList(stack.NotificationARNs)))
+		d.Set("notification_arns", flattenStringSet(stack.NotificationARNs))
 	}
 
 	d.Set("parameters", flattenAllCloudFormationParameters(stack.Parameters))
@@ -102,7 +102,7 @@ func dataSourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface
 	d.Set("outputs", flattenCloudFormationOutputs(stack.Outputs))
 
 	if len(stack.Capabilities) > 0 {
-		d.Set("capabilities", schema.NewSet(schema.HashString, flattenStringList(stack.Capabilities)))
+		d.Set("capabilities", flattenStringSet(stack.Capabilities))
 	}
 
 	tInput := cloudformation.GetTemplateInput{

--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -322,7 +322,7 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 		d.Set("disable_rollback", stack.DisableRollback)
 	}
 	if len(stack.NotificationARNs) > 0 {
-		err = d.Set("notification_arns", schema.NewSet(schema.HashString, flattenStringList(stack.NotificationARNs)))
+		err = d.Set("notification_arns", flattenStringSet(stack.NotificationARNs))
 		if err != nil {
 			return err
 		}
@@ -344,7 +344,7 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 	}
 
 	if len(stack.Capabilities) > 0 {
-		err = d.Set("capabilities", schema.NewSet(schema.HashString, flattenStringList(stack.Capabilities)))
+		err = d.Set("capabilities", flattenStringSet(stack.Capabilities))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6867

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudFormationStack'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSCloudFormationStack -timeout 120m
=== RUN   TestAccAWSCloudFormationStack_dataSource_basic
=== PAUSE TestAccAWSCloudFormationStack_dataSource_basic
=== RUN   TestAccAWSCloudFormationStack_dataSource_yaml
=== PAUSE TestAccAWSCloudFormationStack_dataSource_yaml
=== RUN   TestAccAWSCloudFormationStackSetInstance_basic
=== PAUSE TestAccAWSCloudFormationStackSetInstance_basic
=== RUN   TestAccAWSCloudFormationStackSetInstance_disappears
=== PAUSE TestAccAWSCloudFormationStackSetInstance_disappears
=== RUN   TestAccAWSCloudFormationStackSetInstance_disappears_StackSet
=== PAUSE TestAccAWSCloudFormationStackSetInstance_disappears_StackSet
=== RUN   TestAccAWSCloudFormationStackSetInstance_ParameterOverrides
=== PAUSE TestAccAWSCloudFormationStackSetInstance_ParameterOverrides
=== RUN   TestAccAWSCloudFormationStackSetInstance_RetainStack
=== PAUSE TestAccAWSCloudFormationStackSetInstance_RetainStack
=== RUN   TestAccAWSCloudFormationStackSet_basic
=== PAUSE TestAccAWSCloudFormationStackSet_basic
=== RUN   TestAccAWSCloudFormationStackSet_disappears
=== PAUSE TestAccAWSCloudFormationStackSet_disappears
=== RUN   TestAccAWSCloudFormationStackSet_AdministrationRoleArn
=== PAUSE TestAccAWSCloudFormationStackSet_AdministrationRoleArn
=== RUN   TestAccAWSCloudFormationStackSet_Description
=== PAUSE TestAccAWSCloudFormationStackSet_Description
=== RUN   TestAccAWSCloudFormationStackSet_ExecutionRoleName
=== PAUSE TestAccAWSCloudFormationStackSet_ExecutionRoleName
=== RUN   TestAccAWSCloudFormationStackSet_Name
=== PAUSE TestAccAWSCloudFormationStackSet_Name
=== RUN   TestAccAWSCloudFormationStackSet_Parameters
=== PAUSE TestAccAWSCloudFormationStackSet_Parameters
=== RUN   TestAccAWSCloudFormationStackSet_Parameters_Default
    TestAccAWSCloudFormationStackSet_Parameters_Default: provider_test.go:55: this resource does not currently ignore unconfigured CloudFormation template parameters with the Default property
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_Default (0.00s)
=== RUN   TestAccAWSCloudFormationStackSet_Parameters_NoEcho
    TestAccAWSCloudFormationStackSet_Parameters_NoEcho: provider_test.go:55: this resource does not currently ignore CloudFormation template parameters with the NoEcho property
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_NoEcho (0.00s)
=== RUN   TestAccAWSCloudFormationStackSet_Tags
=== PAUSE TestAccAWSCloudFormationStackSet_Tags
=== RUN   TestAccAWSCloudFormationStackSet_TemplateBody
=== PAUSE TestAccAWSCloudFormationStackSet_TemplateBody
=== RUN   TestAccAWSCloudFormationStackSet_TemplateUrl
=== PAUSE TestAccAWSCloudFormationStackSet_TemplateUrl
=== RUN   TestAccAWSCloudFormationStack_basic
=== PAUSE TestAccAWSCloudFormationStack_basic
=== RUN   TestAccAWSCloudFormationStack_disappears
=== PAUSE TestAccAWSCloudFormationStack_disappears
=== RUN   TestAccAWSCloudFormationStack_yaml
=== PAUSE TestAccAWSCloudFormationStack_yaml
=== RUN   TestAccAWSCloudFormationStack_defaultParams
=== PAUSE TestAccAWSCloudFormationStack_defaultParams
=== RUN   TestAccAWSCloudFormationStack_allAttributes
=== PAUSE TestAccAWSCloudFormationStack_allAttributes
=== RUN   TestAccAWSCloudFormationStack_withParams
=== PAUSE TestAccAWSCloudFormationStack_withParams
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams
=== PAUSE TestAccAWSCloudFormationStack_withUrl_withParams
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
=== PAUSE TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
=== PAUSE TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
=== RUN   TestAccAWSCloudFormationStack_withTransform
=== PAUSE TestAccAWSCloudFormationStack_withTransform
=== CONT  TestAccAWSCloudFormationStack_dataSource_basic
=== CONT  TestAccAWSCloudFormationStackSet_Tags
=== CONT  TestAccAWSCloudFormationStack_allAttributes
    TestAccAWSCloudFormationStack_dataSource_basic: data_source_aws_cloudformation_stack_test.go:16: Step 1/1 error: Error running pre-apply plan: 
        Error: Failed describing CloudFormation stack (tf-acc-ds-basic-215160101747935250): ValidationError: Stack with id tf-acc-ds-basic-215160101747935250 does not exist
        	status code: 400, request id: 85383c67-c641-40d1-a26b-625c26e4478d
        
        
--- FAIL: TestAccAWSCloudFormationStack_dataSource_basic (4.16s)
=== CONT  TestAccAWSCloudFormationStack_withTransform
--- PASS: TestAccAWSCloudFormationStack_withTransform (35.76s)
=== CONT  TestAccAWSCloudFormationStackSet_basic
--- PASS: TestAccAWSCloudFormationStackSet_basic (16.17s)
=== CONT  TestAccAWSCloudFormationStackSet_Parameters
--- PASS: TestAccAWSCloudFormationStackSet_Tags (69.30s)
=== CONT  TestAccAWSCloudFormationStackSet_Name
--- PASS: TestAccAWSCloudFormationStack_allAttributes (76.67s)
=== CONT  TestAccAWSCloudFormationStackSet_ExecutionRoleName
--- PASS: TestAccAWSCloudFormationStackSet_Name (30.97s)
=== CONT  TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
--- PASS: TestAccAWSCloudFormationStackSet_ExecutionRoleName (32.09s)
=== CONT  TestAccAWSCloudFormationStackSet_Description
--- PASS: TestAccAWSCloudFormationStackSet_Parameters (68.37s)
=== CONT  TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
--- PASS: TestAccAWSCloudFormationStackSet_Description (34.39s)
=== CONT  TestAccAWSCloudFormationStack_withUrl_withParams
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (83.46s)
=== CONT  TestAccAWSCloudFormationStack_withParams
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (70.05s)
=== CONT  TestAccAWSCloudFormationStack_defaultParams
--- PASS: TestAccAWSCloudFormationStack_defaultParams (62.14s)
=== CONT  TestAccAWSCloudFormationStackSet_AdministrationRoleArn
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (129.51s)
=== CONT  TestAccAWSCloudFormationStackSet_disappears
--- PASS: TestAccAWSCloudFormationStackSet_disappears (13.86s)
=== CONT  TestAccAWSCloudFormationStackSetInstance_disappears_StackSet
--- PASS: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (32.75s)
=== CONT  TestAccAWSCloudFormationStackSetInstance_RetainStack
--- PASS: TestAccAWSCloudFormationStack_withParams (117.23s)
=== CONT  TestAccAWSCloudFormationStack_yaml
--- PASS: TestAccAWSCloudFormationStack_yaml (62.30s)
=== CONT  TestAccAWSCloudFormationStackSetInstance_ParameterOverrides
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (120.11s)
=== CONT  TestAccAWSCloudFormationStackSetInstance_basic

--- PASS: TestAccAWSCloudFormationStackSetInstance_RetainStack (158.44s)
=== CONT  TestAccAWSCloudFormationStackSet_TemplateUrl
--- PASS: TestAccAWSCloudFormationStackSet_TemplateUrl (41.77s)
=== CONT  TestAccAWSCloudFormationStackSetInstance_disappears
--- PASS: TestAccAWSCloudFormationStackSetInstance_basic (118.82s)
=== CONT  TestAccAWSCloudFormationStack_basic
--- PASS: TestAccAWSCloudFormationStack_basic (63.82s)
=== CONT  TestAccAWSCloudFormationStackSet_TemplateBody
--- PASS: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (230.84s)
=== CONT  TestAccAWSCloudFormationStack_dataSource_yaml
    TestAccAWSCloudFormationStack_dataSource_yaml: data_source_aws_cloudformation_stack_test.go:101: Step 1/1 error: Error running pre-apply plan: 
        Error: Failed describing CloudFormation stack (tf-acc-ds-yaml-8018489908161910833): ValidationError: Stack with id tf-acc-ds-yaml-8018489908161910833 does not exist
        	status code: 400, request id: d3d8103b-22b2-431c-ada8-3dd226c7bc88
        
        
--- FAIL: TestAccAWSCloudFormationStack_dataSource_yaml (2.74s)
=== CONT  TestAccAWSCloudFormationStack_disappears
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears (123.99s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateBody (34.58s)
--- PASS: TestAccAWSCloudFormationStack_disappears (64.17s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	661.037s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1
```
The datasource-related failures look to be latent issues; they fail in the same way on current master.