### PR TITLE
resource/datasync_location_smb: Use flattenStringSet helper

### DIFF
--- a/aws/datasync.go
+++ b/aws/datasync.go
@@ -106,7 +106,7 @@ func flattenDataSyncEc2Config(ec2Config *datasync.Ec2Config) []interface{} {
 	}
 
 	m := map[string]interface{}{
-		"security_group_arns": schema.NewSet(schema.HashString, flattenStringList(ec2Config.SecurityGroupArns)),
+		"security_group_arns": flattenStringSet(ec2Config.SecurityGroupArns),
 		"subnet_arn":          aws.StringValue(ec2Config.SubnetArn),
 	}
 
@@ -131,7 +131,7 @@ func flattenDataSyncOnPremConfig(onPremConfig *datasync.OnPremConfig) []interfac
 	}
 
 	m := map[string]interface{}{
-		"agent_arns": schema.NewSet(schema.HashString, flattenStringList(onPremConfig.AgentArns)),
+		"agent_arns": flattenStringSet(onPremConfig.AgentArns),
 	}
 
 	return []interface{}{m}

--- a/aws/resource_aws_datasync_location_smb.go
+++ b/aws/resource_aws_datasync_location_smb.go
@@ -167,7 +167,7 @@ func resourceAwsDataSyncLocationSmbRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("error parsing Location SMB (%s) URI (%s): %s", d.Id(), aws.StringValue(output.LocationUri), err)
 	}
 
-	d.Set("agent_arns", schema.NewSet(schema.HashString, flattenStringList(output.AgentArns)))
+	d.Set("agent_arns", flattenStringSet(output.AgentArns))
 
 	d.Set("arn", output.LocationArn)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6867

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSyncLocationSmb'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSDataSyncLocationSmb -timeout 120m
=== RUN   TestAccAWSDataSyncLocationSmb_basic
=== PAUSE TestAccAWSDataSyncLocationSmb_basic
=== RUN   TestAccAWSDataSyncLocationSmb_disappears
=== PAUSE TestAccAWSDataSyncLocationSmb_disappears
=== RUN   TestAccAWSDataSyncLocationSmb_Tags
=== PAUSE TestAccAWSDataSyncLocationSmb_Tags
=== CONT  TestAccAWSDataSyncLocationSmb_basic
=== CONT  TestAccAWSDataSyncLocationSmb_Tags
=== CONT  TestAccAWSDataSyncLocationSmb_disappears
--- PASS: TestAccAWSDataSyncLocationSmb_basic (175.82s)
--- PASS: TestAccAWSDataSyncLocationSmb_disappears (204.59s)
--- PASS: TestAccAWSDataSyncLocationSmb_Tags (225.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	225.587s
```