### PR TITLE
resource/codebuild_project: Use flattenStringSet helper

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -1467,8 +1467,8 @@ func flattenAwsCodeBuildVpcConfig(vpcConfig *codebuild.VpcConfig) []interface{} 
 		values := map[string]interface{}{}
 
 		values["vpc_id"] = aws.StringValue(vpcConfig.VpcId)
-		values["subnets"] = schema.NewSet(schema.HashString, flattenStringList(vpcConfig.Subnets))
-		values["security_group_ids"] = schema.NewSet(schema.HashString, flattenStringList(vpcConfig.SecurityGroupIds))
+		values["subnets"] = flattenStringSet(vpcConfig.Subnets)
+		values["security_group_ids"] = flattenStringSet(vpcConfig.SecurityGroupIds)
 
 		return []interface{}{values}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6867

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSCodeBuildProject_basic -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_basic
=== PAUSE TestAccAWSCodeBuildProject_basic
=== CONT  TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (32.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.342s
```
