### PR TITLE
resource/codedeploy_deployment_group: Use flattenStringSet helper

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -1167,7 +1167,7 @@ func triggerConfigsToMap(list []*codedeploy.TriggerConfig) []map[string]interfac
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, tc := range list {
 		item := make(map[string]interface{})
-		item["trigger_events"] = schema.NewSet(schema.HashString, flattenStringList(tc.TriggerEvents))
+		item["trigger_events"] = flattenStringSet(tc.TriggerEvents)
 		item["trigger_name"] = *tc.TriggerName
 		item["trigger_target_arn"] = *tc.TriggerTargetArn
 		result = append(result, item)
@@ -1185,7 +1185,7 @@ func autoRollbackConfigToMap(config *codedeploy.AutoRollbackConfiguration) []map
 	if config != nil && (*config.Enabled || len(config.Events) > 0) {
 		item := make(map[string]interface{})
 		item["enabled"] = *config.Enabled
-		item["events"] = schema.NewSet(schema.HashString, flattenStringList(config.Events))
+		item["events"] = flattenStringSet(config.Events)
 		result = append(result, item)
 	}
 
@@ -1206,7 +1206,7 @@ func alarmConfigToMap(config *codedeploy.AlarmConfiguration) []map[string]interf
 		}
 
 		item := make(map[string]interface{})
-		item["alarms"] = schema.NewSet(schema.HashString, flattenStringList(names))
+		item["alarms"] = flattenStringSet(names)
 		item["enabled"] = *config.Enabled
 		item["ignore_poll_alarm_failure"] = *config.IgnorePollAlarmFailure
 
@@ -1297,7 +1297,7 @@ func flattenCodeDeployTrafficRoute(trafficRoute *codedeploy.TrafficRoute) []inte
 	}
 
 	m := map[string]interface{}{
-		"listener_arns": schema.NewSet(schema.HashString, flattenStringList(trafficRoute.ListenerArns)),
+		"listener_arns": flattenStringSet(trafficRoute.ListenerArns),
 	}
 
 	return []interface{}{m}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6867

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSCodeDeployDeploymentGroup -timeout 120m
=== RUN   TestAccAWSCodeDeployDeploymentGroup_basic
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_basic
=== RUN   TestAccAWSCodeDeployDeploymentGroup_basic_tagSet
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_basic_tagSet
=== RUN   TestAccAWSCodeDeployDeploymentGroup_onPremiseTag
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_onPremiseTag
=== RUN   TestAccAWSCodeDeployDeploymentGroup_disappears
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_disappears
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple
=== RUN   TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable
=== RUN   TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable
=== RUN   TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default
=== RUN   TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen
=== CONT  TestAccAWSCodeDeployDeploymentGroup_basic
=== CONT  TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete
=== CONT  TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (36.07s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (36.14s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (56.01s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (41.06s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (41.28s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (31.15s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (22.39s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (41.67s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (40.80s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (32.30s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (31.93s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (35.12s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (42.01s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (41.68s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (30.92s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (30.35s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (30.42s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_onPremiseTag
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (41.33s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (33.77s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (22.56s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (41.49s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (41.83s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg
    TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg: resource_aws_codedeploy_deployment_group_test.go:1247: Step 1/2 error: Error running pre-apply refresh: 
        Error: no matching subnet found
        
        
--- FAIL: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (2.34s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (41.07s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (39.25s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
    TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create: resource_aws_codedeploy_deployment_group_test.go:1193: Step 1/2 error: Error running pre-apply refresh: 
        Error: no matching subnet found
        
        
--- FAIL: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (2.65s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (33.65s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_disappears
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (41.28s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_basic_tagSet
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (31.35s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (51.45s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (31.68s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (268.72s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	514.380s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1
```
The failures here are latent; they happen against current master too.