### PR TITLE
resource/ecs_service: Use flattenStringSet helper

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -731,8 +731,8 @@ func flattenEcsNetworkConfiguration(nc *ecs.NetworkConfiguration) []interface{} 
 	}
 
 	result := make(map[string]interface{})
-	result["security_groups"] = schema.NewSet(schema.HashString, flattenStringList(nc.AwsvpcConfiguration.SecurityGroups))
-	result["subnets"] = schema.NewSet(schema.HashString, flattenStringList(nc.AwsvpcConfiguration.Subnets))
+	result["security_groups"] = flattenStringSet(nc.AwsvpcConfiguration.SecurityGroups)
+	result["subnets"] = flattenStringSet(nc.AwsvpcConfiguration.Subnets)
 
 	if nc.AwsvpcConfiguration.AssignPublicIp != nil {
 		result["assign_public_ip"] = *nc.AwsvpcConfiguration.AssignPublicIp == ecs.AssignPublicIpEnabled


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6867

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsService'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSEcsService -timeout 120m
=== RUN   TestAccAWSEcsServiceDataSource_basic
=== PAUSE TestAccAWSEcsServiceDataSource_basic
=== RUN   TestAccAWSEcsService_withARN
=== PAUSE TestAccAWSEcsService_withARN
=== RUN   TestAccAWSEcsService_basicImport
=== PAUSE TestAccAWSEcsService_basicImport
=== RUN   TestAccAWSEcsService_disappears
=== PAUSE TestAccAWSEcsService_disappears
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== PAUSE TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== RUN   TestAccAWSEcsService_withCapacityProviderStrategy
=== PAUSE TestAccAWSEcsService_withCapacityProviderStrategy
=== RUN   TestAccAWSEcsService_withMultipleCapacityProviderStrategies
=== PAUSE TestAccAWSEcsService_withMultipleCapacityProviderStrategies
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
=== PAUSE TestAccAWSEcsService_withFamilyAndRevision
=== RUN   TestAccAWSEcsService_withRenamedCluster
=== PAUSE TestAccAWSEcsService_withRenamedCluster
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== PAUSE TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== RUN   TestAccAWSEcsService_withIamRole
=== PAUSE TestAccAWSEcsService_withIamRole
=== RUN   TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== PAUSE TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== RUN   TestAccAWSEcsService_withDeploymentController_Type_External
=== PAUSE TestAccAWSEcsService_withDeploymentController_Type_External
=== RUN   TestAccAWSEcsService_withDeploymentValues
=== PAUSE TestAccAWSEcsService_withDeploymentValues
=== RUN   TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== PAUSE TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== RUN   TestAccAWSEcsService_withLbChanges
=== PAUSE TestAccAWSEcsService_withLbChanges
=== RUN   TestAccAWSEcsService_withEcsClusterName
=== PAUSE TestAccAWSEcsService_withEcsClusterName
=== RUN   TestAccAWSEcsService_withAlb
=== PAUSE TestAccAWSEcsService_withAlb
=== RUN   TestAccAWSEcsService_withMultipleTargetGroups
=== PAUSE TestAccAWSEcsService_withMultipleTargetGroups
=== RUN   TestAccAWSEcsService_withForceNewDeployment
=== PAUSE TestAccAWSEcsService_withForceNewDeployment
=== RUN   TestAccAWSEcsService_withPlacementStrategy
=== PAUSE TestAccAWSEcsService_withPlacementStrategy
=== RUN   TestAccAWSEcsService_withPlacementStrategy_Type_Missing
=== PAUSE TestAccAWSEcsService_withPlacementStrategy_Type_Missing
=== RUN   TestAccAWSEcsService_withPlacementConstraints
=== PAUSE TestAccAWSEcsService_withPlacementConstraints
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== PAUSE TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargate
=== RUN   TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== RUN   TestAccAWSEcsService_withLaunchTypeFargateAndWaitForSteadyState
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargateAndWaitForSteadyState
=== RUN   TestAccAWSEcsService_withLaunchTypeFargateAndUpdateWaitForSteadyState
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargateAndUpdateWaitForSteadyState
=== RUN   TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== PAUSE TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategy
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== RUN   TestAccAWSEcsService_withReplicaSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withReplicaSchedulingStrategy
=== RUN   TestAccAWSEcsService_withServiceRegistries
=== PAUSE TestAccAWSEcsService_withServiceRegistries
=== RUN   TestAccAWSEcsService_withServiceRegistries_container
=== PAUSE TestAccAWSEcsService_withServiceRegistries_container
=== RUN   TestAccAWSEcsService_Tags
=== PAUSE TestAccAWSEcsService_Tags
=== RUN   TestAccAWSEcsService_ManagedTags
=== PAUSE TestAccAWSEcsService_ManagedTags
=== RUN   TestAccAWSEcsService_PropagateTags
=== PAUSE TestAccAWSEcsService_PropagateTags
=== CONT  TestAccAWSEcsServiceDataSource_basic
=== CONT  TestAccAWSEcsService_withForceNewDeployment
=== CONT  TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withForceNewDeployment (77.11s)
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategy
--- PASS: TestAccAWSEcsServiceDataSource_basic (88.96s)
=== CONT  TestAccAWSEcsService_PropagateTags
2020/11/18 18:45:41 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (35.53s)
=== CONT  TestAccAWSEcsService_ManagedTags
--- PASS: TestAccAWSEcsService_withIamRole (132.31s)
=== CONT  TestAccAWSEcsService_Tags
--- PASS: TestAccAWSEcsService_ManagedTags (86.63s)
=== CONT  TestAccAWSEcsService_withServiceRegistries_container
--- PASS: TestAccAWSEcsService_Tags (96.12s)
=== CONT  TestAccAWSEcsService_withServiceRegistries
--- PASS: TestAccAWSEcsService_PropagateTags (187.25s)
=== CONT  TestAccAWSEcsService_withCapacityProviderStrategy
    TestAccAWSEcsService_withCapacityProviderStrategy: resource_aws_ecs_service_test.go:242: Step 1/2 error: Error running apply: 
        Error: Error creating AutoScaling Group: ValidationError: You must use a valid fully-formed launch template. No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.
        	status code: 400, request id: 08850244-e762-4d30-a496-2ab6191ea1c6
        
        
--- FAIL: TestAccAWSEcsService_withCapacityProviderStrategy (16.99s)
=== CONT  TestAccAWSEcsService_withReplicaSchedulingStrategy
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (161.28s)
=== CONT  TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (76.72s)
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
--- PASS: TestAccAWSEcsService_withServiceRegistries (159.47s)
=== CONT  TestAccAWSEcsService_withRenamedCluster
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (46.00s)
=== CONT  TestAccAWSEcsService_withLaunchTypeFargate
--- PASS: TestAccAWSEcsService_withRenamedCluster (152.82s)
=== CONT  TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (125.43s)
=== CONT  TestAccAWSEcsService_withLaunchTypeFargateAndUpdateWaitForSteadyState
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (80.89s)
=== CONT  TestAccAWSEcsService_withLaunchTypeFargateAndWaitForSteadyState
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (272.88s)
=== CONT  TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndUpdateWaitForSteadyState (158.34s)
=== CONT  TestAccAWSEcsService_withPlacementStrategy_Type_Missing
--- PASS: TestAccAWSEcsService_withPlacementStrategy_Type_Missing (0.42s)
=== CONT  TestAccAWSEcsService_withLbChanges
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (104.46s)
=== CONT  TestAccAWSEcsService_withPlacementStrategy
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndWaitForSteadyState (166.66s)
=== CONT  TestAccAWSEcsService_withMultipleTargetGroups
--- PASS: TestAccAWSEcsService_withPlacementStrategy (112.21s)
=== CONT  TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withLbChanges (221.27s)
=== CONT  TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups (216.09s)
=== CONT  TestAccAWSEcsService_withMultipleCapacityProviderStrategies
--- PASS: TestAccAWSEcsService_withEcsClusterName (86.29s)
=== CONT  TestAccAWSEcsService_withPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsService_withAlb (223.40s)
=== CONT  TestAccAWSEcsService_disappears
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (66.02s)
=== CONT  TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsService_withMultipleCapacityProviderStrategies (114.60s)
=== CONT  TestAccAWSEcsService_withARN
--- PASS: TestAccAWSEcsService_disappears (66.19s)
=== CONT  TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (76.64s)
=== CONT  TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
--- PASS: TestAccAWSEcsService_withARN (85.42s)
=== CONT  TestAccAWSEcsService_withFamilyAndRevision
--- PASS: TestAccAWSEcsService_withDeploymentValues (76.54s)
=== CONT  TestAccAWSEcsService_withDeploymentController_Type_External
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (67.35s)
=== CONT  TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_External (36.80s)
=== CONT  TestAccAWSEcsService_basicImport
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (74.70s)
=== CONT  TestAccAWSEcsService_withPlacementConstraints
--- PASS: TestAccAWSEcsService_basicImport (78.98s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (85.42s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (254.32s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	1472.042s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1
```
The failure here is just because of the lack of default VPC in my account.