### PR TITLE
resource/eks_cluster: Use flattenStringSet helper

### DIFF
--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -645,9 +645,9 @@ func flattenEksVpcConfigResponse(vpcConfig *eks.VpcConfigResponse) []map[string]
 		"cluster_security_group_id": aws.StringValue(vpcConfig.ClusterSecurityGroupId),
 		"endpoint_private_access":   aws.BoolValue(vpcConfig.EndpointPrivateAccess),
 		"endpoint_public_access":    aws.BoolValue(vpcConfig.EndpointPublicAccess),
-		"security_group_ids":        schema.NewSet(schema.HashString, flattenStringList(vpcConfig.SecurityGroupIds)),
-		"subnet_ids":                schema.NewSet(schema.HashString, flattenStringList(vpcConfig.SubnetIds)),
-		"public_access_cidrs":       schema.NewSet(schema.HashString, flattenStringList(vpcConfig.PublicAccessCidrs)),
+		"security_group_ids":        flattenStringSet(vpcConfig.SecurityGroupIds),
+		"subnet_ids":                flattenStringSet(vpcConfig.SubnetIds),
+		"public_access_cidrs":       flattenStringSet(vpcConfig.PublicAccessCidrs),
 		"vpc_id":                    aws.StringValue(vpcConfig.VpcId),
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6867

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEksCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSEksCluster -timeout 120m
=== RUN   TestAccAWSEksClusterAuthDataSource_basic
=== PAUSE TestAccAWSEksClusterAuthDataSource_basic
=== RUN   TestAccAWSEksClusterDataSource_basic
=== PAUSE TestAccAWSEksClusterDataSource_basic
=== RUN   TestAccAWSEksCluster_basic
=== PAUSE TestAccAWSEksCluster_basic
=== RUN   TestAccAWSEksCluster_EncryptionConfig
=== PAUSE TestAccAWSEksCluster_EncryptionConfig
=== RUN   TestAccAWSEksCluster_Version
=== PAUSE TestAccAWSEksCluster_Version
=== RUN   TestAccAWSEksCluster_Logging
=== PAUSE TestAccAWSEksCluster_Logging
=== RUN   TestAccAWSEksCluster_Tags
=== PAUSE TestAccAWSEksCluster_Tags
=== RUN   TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== PAUSE TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== RUN   TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
=== PAUSE TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
=== RUN   TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== PAUSE TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== RUN   TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs
=== PAUSE TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs
=== CONT  TestAccAWSEksClusterAuthDataSource_basic
=== CONT  TestAccAWSEksCluster_Tags
=== CONT  TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
--- PASS: TestAccAWSEksClusterAuthDataSource_basic (10.64s)
=== CONT  TestAccAWSEksCluster_EncryptionConfig
 
--- PASS: TestAccAWSEksCluster_EncryptionConfig (860.54s)
=== CONT  TestAccAWSEksCluster_Logging
--- PASS: TestAccAWSEksCluster_Tags (884.03s)
=== CONT  TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1552.62s)
=== CONT  TestAccAWSEksCluster_Version
--- PASS: TestAccAWSEksCluster_Logging (1024.72s)
=== CONT  TestAccAWSEksCluster_basic
--- PASS: TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs (1109.41s)
=== CONT  TestAccAWSEksClusterDataSource_basic
    TestAccAWSEksClusterDataSource_basic: data_source_aws_eks_cluster_test.go:18: Step 1/1 error: Error running pre-apply plan: 
        Error: error reading EKS Cluster (tf-acc-test-whumm): ResourceNotFoundException: No cluster found for name: tf-acc-test-whumm.
        {
          RespMetadata: {
            StatusCode: 404,
            RequestID: "64849458-dd3b-459b-b29c-c0420fe6adf6"
          },
          Message_: "No cluster found for name: tf-acc-test-whumm."
        }
        
        
--- FAIL: TestAccAWSEksClusterDataSource_basic (4.35s)
=== CONT  TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
--- PASS: TestAccAWSEksCluster_basic (779.97s)
=== CONT  TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (784.21s)
--- PASS: TestAccAWSEksCluster_Version (2238.13s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (2278.96s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	4276.783s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1
```
The failure occurs on current master too.