### PR TITLE
resource/s3_bucket_notification: Use flattenStringSet helper

### DIFF
--- a/aws/resource_aws_s3_bucket_notification.go
+++ b/aws/resource_aws_s3_bucket_notification.go
@@ -428,7 +428,7 @@ func flattenTopicConfigurations(configs []*s3.TopicConfiguration) []map[string]i
 		}
 
 		conf["id"] = *notification.Id
-		conf["events"] = schema.NewSet(schema.HashString, flattenStringList(notification.Events))
+		conf["events"] = flattenStringSet(notification.Events)
 		conf["topic_arn"] = *notification.TopicArn
 		topicNotifications = append(topicNotifications, conf)
 	}
@@ -447,7 +447,7 @@ func flattenQueueConfigurations(configs []*s3.QueueConfiguration) []map[string]i
 		}
 
 		conf["id"] = *notification.Id
-		conf["events"] = schema.NewSet(schema.HashString, flattenStringList(notification.Events))
+		conf["events"] = flattenStringSet(notification.Events)
 		conf["queue_arn"] = *notification.QueueArn
 		queueNotifications = append(queueNotifications, conf)
 	}
@@ -466,7 +466,7 @@ func flattenLambdaFunctionConfigurations(configs []*s3.LambdaFunctionConfigurati
 		}
 
 		conf["id"] = *notification.Id
-		conf["events"] = schema.NewSet(schema.HashString, flattenStringList(notification.Events))
+		conf["events"] = flattenStringSet(notification.Events)
 		conf["lambda_function_arn"] = *notification.LambdaFunctionArn
 		lambdaFunctionNotifications = append(lambdaFunctionNotifications, conf)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6867

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3BucketNotification'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSS3BucketNotification -timeout 120m
=== RUN   TestAccAWSS3BucketNotification_LambdaFunction
=== PAUSE TestAccAWSS3BucketNotification_LambdaFunction
=== RUN   TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias
=== PAUSE TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias
=== RUN   TestAccAWSS3BucketNotification_Queue
=== PAUSE TestAccAWSS3BucketNotification_Queue
=== RUN   TestAccAWSS3BucketNotification_Topic
=== PAUSE TestAccAWSS3BucketNotification_Topic
=== RUN   TestAccAWSS3BucketNotification_Topic_Multiple
=== PAUSE TestAccAWSS3BucketNotification_Topic_Multiple
=== RUN   TestAccAWSS3BucketNotification_update
=== PAUSE TestAccAWSS3BucketNotification_update
=== CONT  TestAccAWSS3BucketNotification_LambdaFunction
=== CONT  TestAccAWSS3BucketNotification_Topic_Multiple
=== CONT  TestAccAWSS3BucketNotification_update
--- PASS: TestAccAWSS3BucketNotification_Topic_Multiple (18.12s)
=== CONT  TestAccAWSS3BucketNotification_Queue
--- PASS: TestAccAWSS3BucketNotification_update (29.16s)
=== CONT  TestAccAWSS3BucketNotification_Topic
--- PASS: TestAccAWSS3BucketNotification_Queue (16.08s)
=== CONT  TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction (37.78s)
--- PASS: TestAccAWSS3BucketNotification_Topic (16.64s)
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias (36.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	70.552s
```
