### PR TITLE
resource/storagegateway_smb_file_share: Use flattenStringSet helper

### DIFF
--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -292,7 +292,7 @@ func resourceAwsStorageGatewaySmbFileShareRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("error setting valid_user_list: %w", err)
 	}
 
-	if err := d.Set("admin_user_list", schema.NewSet(schema.HashString, flattenStringList(fileshare.AdminUserList))); err != nil {
+	if err := d.Set("admin_user_list", flattenStringSet(fileshare.AdminUserList)); err != nil {
 		return fmt.Errorf("error setting admin_user_list: %s", err)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6867

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSStorageGatewaySmbFileShare'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSStorageGatewaySmbFileShare -timeout 120m
=== RUN   TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory
=== RUN   TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess
=== RUN   TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass
=== RUN   TestAccAWSStorageGatewaySmbFileShare_FileShareName
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_FileShareName
=== RUN   TestAccAWSStorageGatewaySmbFileShare_Tags
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_Tags
=== RUN   TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled
=== RUN   TestAccAWSStorageGatewaySmbFileShare_InvalidUserList
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_InvalidUserList
=== RUN   TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted
=== RUN   TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn
=== RUN   TestAccAWSStorageGatewaySmbFileShare_ObjectACL
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_ObjectACL
=== RUN   TestAccAWSStorageGatewaySmbFileShare_ReadOnly
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_ReadOnly
=== RUN   TestAccAWSStorageGatewaySmbFileShare_RequesterPays
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_RequesterPays
=== RUN   TestAccAWSStorageGatewaySmbFileShare_ValidUserList
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_ValidUserList
=== RUN   TestAccAWSStorageGatewaySmbFileShare_smb_acl
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_smb_acl
=== RUN   TestAccAWSStorageGatewaySmbFileShare_audit
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_audit
=== RUN   TestAccAWSStorageGatewaySmbFileShare_cacheAttributes
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_cacheAttributes
=== RUN   TestAccAWSStorageGatewaySmbFileShare_caseSensitivity
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_caseSensitivity
=== RUN   TestAccAWSStorageGatewaySmbFileShare_disappears
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_disappears
=== RUN   TestAccAWSStorageGatewaySmbFileShare_AdminUserList
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_AdminUserList
=== CONT  TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory
=== CONT  TestAccAWSStorageGatewaySmbFileShare_ReadOnly
=== CONT  TestAccAWSStorageGatewaySmbFileShare_cacheAttributes
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ReadOnly (394.99s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_smb_acl
--- PASS: TestAccAWSStorageGatewaySmbFileShare_cacheAttributes (417.04s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_audit
--- PASS: TestAccAWSStorageGatewaySmbFileShare_audit (378.14s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_ValidUserList
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory (978.79s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled
--- PASS: TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled (375.58s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_ObjectACL
--- PASS: TestAccAWSStorageGatewaySmbFileShare_smb_acl (1018.34s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ObjectACL (403.00s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ValidUserList (1084.79s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_InvalidUserList
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn (496.83s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_AdminUserList
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted (293.48s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_disappears
--- PASS: TestAccAWSStorageGatewaySmbFileShare_disappears (285.80s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_RequesterPays
--- PASS: TestAccAWSStorageGatewaySmbFileShare_RequesterPays (401.34s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_caseSensitivity
--- PASS: TestAccAWSStorageGatewaySmbFileShare_InvalidUserList (1061.22s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_FileShareName
--- PASS: TestAccAWSStorageGatewaySmbFileShare_AdminUserList (1055.66s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_Tags
--- PASS: TestAccAWSStorageGatewaySmbFileShare_caseSensitivity (441.49s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess
--- PASS: TestAccAWSStorageGatewaySmbFileShare_FileShareName (369.95s)
=== CONT  TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Tags (371.61s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess (308.31s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass (393.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3705.109s
```
