### PR TITLE
infrastructure/repository: Bump Terraform CLI to 0.13.5 and use remote backend

### DIFF
--- a/infrastructure/repository/main.tf
+++ b/infrastructure/repository/main.tf
@@ -1,13 +1,20 @@
 terraform {
-  backend "atlas" {
-    name = "hashicorp-v2/terraform-provider-aws-repository"
+  backend "remote" {
+    organization = "hashicorp-v2"
+
+    workspaces {
+      name = "terraform-provider-aws-repository"
+    }
   }
 
   required_providers {
-    github = "3.1.0"
+    github = {
+      source  = "hashicorp/github"
+      version = "3.1.0"
+    }
   }
 
-  required_version = "~> 0.12.24"
+  required_version = ">= 0.13.5"
 }
 
 provider "github" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The `atlas` backend is legacy so migrated to `remote`. Upgraded the Terraform CLI version in Terraform Cloud and verified locally with TFC token:

```console
$ terraform plan
...
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```

Output from acceptance testing: N/A
