### PR TITLE
resource/aws_db_proxy_default_target_group: Make connection_pool_config Optional

### DIFF
--- a/aws/resource_aws_db_proxy_default_target_group.go
+++ b/aws/resource_aws_db_proxy_default_target_group.go
@@ -44,7 +44,8 @@ func resourceAwsDbProxyDefaultTargetGroup() *schema.Resource {
 			},
 			"connection_pool_config": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
The documentation for `aws_db_proxy_default_target_group` states that `connection_pool_config` is optional and the API does not require it. 

Closes #16285

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_db_proxy_default_target_group: Make `connection_pool_config` optional
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDBProxyDefaultTargetGroup_'

--- PASS: TestAccAWSDBProxyDefaultTargetGroup_disappears (663.38s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_EmptyConnectionPoolConfig (674.40s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_MaxConnectionsPercent (697.92s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_ConnectionBorrowTimeout (776.49s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_SessionPinningFilters (793.09s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_MaxIdleConnectionsPercent (795.58s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_Basic (795.63s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_InitQuery (835.42s)
```
