### PR TITLE
tests/provider: Migrate remaining PreConfig disappears testing to testAccCheckResourceDisappears

### DIFF
--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -639,23 +639,11 @@ func TestAccAWSEcsTaskDefinition_ExecutionRole(t *testing.T) {
 }
 
 // Regression for https://github.com/hashicorp/terraform/issues/3582#issuecomment-286409786
-func TestAccAWSEcsTaskDefinition_Inactive(t *testing.T) {
+func TestAccAWSEcsTaskDefinition_disappears(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	tdName := acctest.RandomWithPrefix("tf-acc-td-basic")
 	resourceName := "aws_ecs_task_definition.test"
-
-	markTaskDefinitionInactive := func() {
-		conn := testAccProvider.Meta().(*AWSClient).ecsconn
-
-		_, err := conn.DeregisterTaskDefinition(&ecs.DeregisterTaskDefinitionInput{
-			TaskDefinition: aws.String(fmt.Sprintf("%s:1", tdName)),
-		})
-
-		if err != nil {
-			t.Fatalf("error deregistering ECS Task Definition (%s): %s", tdName, err)
-		}
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -666,18 +654,13 @@ func TestAccAWSEcsTaskDefinition_Inactive(t *testing.T) {
 				Config: testAccAWSEcsTaskDefinition(tdName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEcsTaskDefinition(), resourceName),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
-			},
-			{
-				Config:    testAccAWSEcsTaskDefinition(tdName),
-				PreConfig: markTaskDefinitionInactive,
-				Check:     resource.TestCheckResourceAttr(resourceName, "revision", "2"), // should get re-created
+				Config: testAccAWSEcsTaskDefinition(tdName),
+				Check:  resource.TestCheckResourceAttr(resourceName, "revision", "2"), // should get re-created
 			},
 		},
 	})

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -11,41 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccAWSGlueCatalogTable_recreates(t *testing.T) {
-	resourceName := "aws_glue_catalog_table.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGlueTableDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGlueCatalogTable_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogTableExists(resourceName),
-				),
-			},
-			{
-				PreConfig: func() {
-					conn := testAccProvider.Meta().(*AWSClient).glueconn
-					input := &glue.DeleteTableInput{
-						Name:         aws.String(rName),
-						DatabaseName: aws.String(rName),
-					}
-					_, err := conn.DeleteTable(input)
-					if err != nil {
-						t.Fatalf("error deleting Glue Catalog Table: %s", err)
-					}
-				},
-				Config:             testAccGlueCatalogTable_basic(rName),
-				ExpectNonEmptyPlan: true,
-				PlanOnly:           true,
-			},
-		},
-	})
-}
-
 func TestAccAWSGlueCatalogTable_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_glue_catalog_table.test"

--- a/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -186,20 +186,3 @@ resource "aws_lb_cookie_stickiness_policy" "foo" {
 }
 `, rName))
 }
-
-// attempt to destroy the policy, but we'll delete the LB in the PreConfig
-func testAccLBCookieStickinessPolicyConfigDestroy(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
-resource "aws_elb" "lb" {
-  name               = "%s"
-  availability_zones = [data.aws_availability_zones.available.names[0]]
-
-  listener {
-    instance_port     = 8000
-    instance_protocol = "http"
-    lb_port           = 80
-    lb_protocol       = "http"
-  }
-}
-`, rName))
-}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13820

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAppCookieStickinessPolicy_disappears_ELB (16.05s)
--- PASS: TestAccAWSAppCookieStickinessPolicy_disappears (18.31s)

--- PASS: TestAccAWSEcsTaskDefinition_disappears (15.18s)

--- PASS: TestAccAWSGlueCatalogTable_disappears (10.65s)

--- PASS: TestAccAWSLBCookieStickinessPolicy_disappears_ELB (18.22s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_disappears (21.69s)

--- PASS: TestAccAWSSSMAssociation_disappears (85.35s)
```
