### PR TITLE
resource/aws_lb_listener: Mark port argument as optional and only default protocol argument to HTTP for Application Load Balancers (Support Gateway Load Balancer)

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -109,6 +109,8 @@ jobs:
               "--disable-rule=aws_iam_saml_provider_invalid_saml_metadata_document"
               "--disable-rule=aws_iam_server_certificate_invalid_certificate_body"
               "--disable-rule=aws_iam_server_certificate_invalid_private_key"
+              "--disable-rule=aws_lb_invalid_load_balancer_type"
+              "--disable-rule=aws_lb_target_group_invalid_protocol"
               "--disable-rule=aws_transfer_ssh_key_invalid_body"
               "--disable-rule=aws_worklink_website_certificate_authority_association_invalid_certificate"
           )

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -168,14 +168,47 @@ resource "aws_lb_listener" "front_end" {
 }
 ```
 
+### Gateway Load Balancer Listener
+
+```hcl
+resource "aws_lb" "example" {
+  load_balancer_type = "gateway"
+  name               = "example"
+
+  subnet_mapping {
+    subnet_id = aws_subnet.example.id
+  }
+}
+
+resource "aws_lb_target_group" "example" {
+  name     = "example"
+  port     = 6081
+  protocol = "GENEVE"
+  vpc_id   = aws_vpc.example.id
+
+  health_check {
+    port     = 80
+    protocol = "HTTP"
+  }
+}
+
+resource "aws_lb_listener" "example" {
+  load_balancer_arn = aws_lb.example.id
+
+  default_action {
+    target_group_arn = aws_lb_target_group.example.id
+    type             = "forward"
+  }
+}
+```
 
 ## Argument Reference
 
 The following arguments are supported:
 
 * `load_balancer_arn` - (Required, Forces New Resource) The ARN of the load balancer.
-* `port` - (Required) The port on which the load balancer is listening.
-* `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `TLS`, `UDP`, `TCP_UDP`, `HTTP` and `HTTPS`. Defaults to `HTTP`.
+* `port` - (Optional) The port on which the load balancer is listening. Not valid for Gateway Load Balancers.
+* `protocol` - (Optional) The protocol for connections from clients to the load balancer. For Application Load Balancers, valid values are `HTTP` and `HTTPS`, with a default of `HTTP`. For Network Load Balancers, valid values are `TCP`, `TLS`, `UDP`, and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled. Not valid for Gateway Load Balancers.
 * `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS` or `TLS`.
 * `certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
 * `default_action` - (Required) An Action block. Action blocks are documented below.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16228

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_lb_listener: Mark `port` argument as optional and only default `protocol` argument to `HTTP` for Application Load Balancers (Support Gateway Load Balancer)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLBListener_BackwardsCompatibility (164.54s)
--- PASS: TestAccAWSLBListener_basic (216.95s)
--- PASS: TestAccAWSLBListener_basicUdp (353.16s)
--- PASS: TestAccAWSLBListener_cognito (175.47s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order (179.98s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order_Recreates (210.11s)
--- PASS: TestAccAWSLBListener_fixedResponse (205.74s)
--- PASS: TestAccAWSLBListener_forwardWeighted (254.29s)
--- PASS: TestAccAWSLBListener_https (177.85s)
--- PASS: TestAccAWSLBListener_LoadBalancerArn_GatewayLoadBalancer (104.60s)
--- PASS: TestAccAWSLBListener_oidc (224.41s)
--- PASS: TestAccAWSLBListener_Protocol_Tls (338.84s)
--- PASS: TestAccAWSLBListener_redirect (215.20s)

--- PASS: TestAccAWSLBListenerRule_Action_Order (173.51s)
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (190.92s)
--- PASS: TestAccAWSLBListenerRule_BackwardsCompatibility (215.63s)
--- PASS: TestAccAWSLBListenerRule_basic (205.27s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (241.13s)
--- PASS: TestAccAWSLBListenerRule_cognito (204.34s)
--- PASS: TestAccAWSLBListenerRule_conditionAttributesCount (14.00s)
--- PASS: TestAccAWSLBListenerRule_conditionHostHeader (213.13s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader (258.35s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader_invalid (0.56s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpRequestMethod (180.34s)
--- PASS: TestAccAWSLBListenerRule_conditionMultiple (193.68s)
--- PASS: TestAccAWSLBListenerRule_conditionPathPattern (205.29s)
--- PASS: TestAccAWSLBListenerRule_conditionQueryString (245.64s)
--- PASS: TestAccAWSLBListenerRule_conditionSourceIp (203.60s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMixed (239.41s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMultiple (174.24s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (244.72s)
--- PASS: TestAccAWSLBListenerRule_forwardWeighted (298.68s)
--- PASS: TestAccAWSLBListenerRule_oidc (226.14s)
--- PASS: TestAccAWSLBListenerRule_priority (352.95s)
--- PASS: TestAccAWSLBListenerRule_redirect (162.81s)
--- PASS: TestAccAWSLBListenerRule_updateFixedResponse (233.36s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (204.08s)
```