### PR TITLE
resource/aws_lb: Fix enable_cross_zone_load_balancing argument handling with Gateway Load Balancers

### DIFF
--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -425,7 +425,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 			})
 		}
 
-	case elbv2.LoadBalancerTypeEnumNetwork:
+	case elbv2.LoadBalancerTypeEnumGateway, elbv2.LoadBalancerTypeEnumNetwork:
 		if d.HasChange("enable_cross_zone_load_balancing") || d.IsNewResource() {
 			attributes = append(attributes, &elbv2.LoadBalancerAttribute{
 				Key:   aws.String("load_balancing.cross_zone.enabled"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16311

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_lb: Fix `enable_cross_zone_load_balancing` argument handling with Gateway Load Balancers
```

Previously:

```
=== CONT  TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing
    resource_aws_lb_test.go:202: Step 1/3 error: Check failed: 1 error occurred:
        	* Check 4/4 error: aws_lb.test: Attribute 'enable_cross_zone_load_balancing' expected "true", got "false"

--- FAIL: TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing (108.37s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLB_ALB_AccessLogs (353.95s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (304.17s)
--- PASS: TestAccAWSLB_ALB_basic (179.02s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (280.99s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields (291.94s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (336.62s)
--- PASS: TestAccAWSLB_BackwardsCompatibility (227.48s)
--- PASS: TestAccAWSLB_generatedName (218.44s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (168.08s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway (106.07s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing (156.75s)
--- PASS: TestAccAWSLB_namePrefix (163.49s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (234.08s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (313.68s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (221.91s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (404.54s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (359.52s)
--- PASS: TestAccAWSLB_NLB_basic (216.80s)
--- PASS: TestAccAWSLB_NLB_privateipv4address (228.17s)
--- PASS: TestAccAWSLB_noSecurityGroup (166.60s)
--- PASS: TestAccAWSLB_tags (328.23s)
--- PASS: TestAccAWSLB_updatedIpAddressType (241.45s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (236.45s)
--- PASS: TestAccAWSLB_updatedSubnets (279.80s)
--- SKIP: TestAccAWSLB_ALB_outpost (2.65s)
```
