### PR TITLE
E adding validation to dns records

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 )
 
@@ -232,6 +231,8 @@ func resourceAwsRoute53Record() *schema.Resource {
 			"records": {
 				Type:          schema.TypeSet,
 				ConflictsWith: []string{"alias"},
+				Optional: true,
+				Set:      schema.HashString,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: validation.Any(
@@ -240,8 +241,6 @@ func resourceAwsRoute53Record() *schema.Resource {
 						validation.StringLenBetween(1, 255),
 					),
 				},
-				Optional: true,
-				Set:      schema.HashString,
 			},
 
 			"allow_overwrite": {

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -518,7 +518,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 		//we check that we have parsed the id into the correct number of segments
 		//we need at least 3 segments!
 		if parts[0] == "" || parts[1] == "" || parts[2] == "" {
-			return fmt.Errorf("Error Importing aws_route_53 record. Please make sure the record ID is in the form ZONEID_RECORDNAME_TYPE (i.e. Z4KAPRWWNC7JR_dev_A")
+			return fmt.Errorf("Error Importing aws_route_53 record. Please make sure the record ID is in the form ZONEID_RECORDNAME_TYPE_SET-IDENTIFIER (e.g. Z4KAPRWWNC7JR_dev.example.com_NS_dev), where SET-IDENTIFIER is optional")
 		}
 
 		d.Set("zone_id", parts[0])

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -1860,15 +1860,15 @@ resource "aws_route53_record" "test" {
 func testAccRoute53RecordConfigTXT(txtRecord string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "test" {
-		name = "notexample.com"
-	}
-	
-	resource "aws_route53_record" "default" {
-	zone_id = "/hostedzone/${aws_route53_zone.test.zone_id}"
-	name    = "subdomain"
-	type    = "TXT"
-	ttl     = "30"
-	records = [%s]
+  name = "notexample.com"
+}
+
+resource "aws_route53_record" "default" {
+  zone_id = "/hostedzone/${aws_route53_zone.test.zone_id}"
+  name    = "subdomain"
+  type    = "TXT"
+  ttl     = "30"
+  records = [%s]
 }
 `, txtRecord)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR adds some validation to the elements of the `records` argument. It ensures that each element is either less than 255 chars, or that it contains escaped quote marks at least every 255 characters. The regex also allows an uneven number of escaped quote marks, which is a requirement for CAA records.

Took the opportunity to address some code duplication in the acceptance tests, so I ran them before and after changing them.

Thanks in advance for your review!

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14941

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_route53_record - added validation to the elements of the records argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Before updating the acceptance tests:
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 10 -run=TestAccAWSRoute53Record_ -timeout 60m
=== RUN   TestAccAWSRoute53Record_basic
=== PAUSE TestAccAWSRoute53Record_basic
=== RUN   TestAccAWSRoute53Record_underscored
=== PAUSE TestAccAWSRoute53Record_underscored
=== RUN   TestAccAWSRoute53Record_disappears
=== PAUSE TestAccAWSRoute53Record_disappears
=== RUN   TestAccAWSRoute53Record_disappears_MultipleRecords
=== PAUSE TestAccAWSRoute53Record_disappears_MultipleRecords
=== RUN   TestAccAWSRoute53Record_basic_fqdn
=== PAUSE TestAccAWSRoute53Record_basic_fqdn
=== RUN   TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID
=== PAUSE TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID
=== RUN   TestAccAWSRoute53Record_txtSupport
=== PAUSE TestAccAWSRoute53Record_txtSupport
=== RUN   TestAccAWSRoute53Record_spfSupport
=== PAUSE TestAccAWSRoute53Record_spfSupport
=== RUN   TestAccAWSRoute53Record_caaSupport
=== PAUSE TestAccAWSRoute53Record_caaSupport
=== RUN   TestAccAWSRoute53Record_generatesSuffix
=== PAUSE TestAccAWSRoute53Record_generatesSuffix
=== RUN   TestAccAWSRoute53Record_wildcard
=== PAUSE TestAccAWSRoute53Record_wildcard
=== RUN   TestAccAWSRoute53Record_failover
=== PAUSE TestAccAWSRoute53Record_failover
=== RUN   TestAccAWSRoute53Record_weighted_basic
=== PAUSE TestAccAWSRoute53Record_weighted_basic
=== RUN   TestAccAWSRoute53Record_weighted_to_simple_basic
=== PAUSE TestAccAWSRoute53Record_weighted_to_simple_basic
=== RUN   TestAccAWSRoute53Record_Alias_Elb
=== PAUSE TestAccAWSRoute53Record_Alias_Elb
=== RUN   TestAccAWSRoute53Record_Alias_S3
=== PAUSE TestAccAWSRoute53Record_Alias_S3
=== RUN   TestAccAWSRoute53Record_Alias_VpcEndpoint
=== PAUSE TestAccAWSRoute53Record_Alias_VpcEndpoint
=== RUN   TestAccAWSRoute53Record_Alias_Uppercase
=== PAUSE TestAccAWSRoute53Record_Alias_Uppercase
=== RUN   TestAccAWSRoute53Record_weighted_alias
=== PAUSE TestAccAWSRoute53Record_weighted_alias
=== RUN   TestAccAWSRoute53Record_geolocation_basic
=== PAUSE TestAccAWSRoute53Record_geolocation_basic
=== RUN   TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange
=== PAUSE TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange
=== RUN   TestAccAWSRoute53Record_HealthCheckId_TypeChange
=== PAUSE TestAccAWSRoute53Record_HealthCheckId_TypeChange
=== RUN   TestAccAWSRoute53Record_latency_basic
=== PAUSE TestAccAWSRoute53Record_latency_basic
=== RUN   TestAccAWSRoute53Record_TypeChange
=== PAUSE TestAccAWSRoute53Record_TypeChange
=== RUN   TestAccAWSRoute53Record_NameChange
=== PAUSE TestAccAWSRoute53Record_NameChange
=== RUN   TestAccAWSRoute53Record_SetIdentifierChange
=== PAUSE TestAccAWSRoute53Record_SetIdentifierChange
=== RUN   TestAccAWSRoute53Record_AliasChange
=== PAUSE TestAccAWSRoute53Record_AliasChange
=== RUN   TestAccAWSRoute53Record_empty
=== PAUSE TestAccAWSRoute53Record_empty
=== RUN   TestAccAWSRoute53Record_longTXTrecord
=== PAUSE TestAccAWSRoute53Record_longTXTrecord
=== RUN   TestAccAWSRoute53Record_multivalue_answer_basic
=== PAUSE TestAccAWSRoute53Record_multivalue_answer_basic
=== RUN   TestAccAWSRoute53Record_allowOverwrite
=== PAUSE TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_basic
=== CONT  TestAccAWSRoute53Record_Alias_VpcEndpoint
=== CONT  TestAccAWSRoute53Record_TypeChange
=== CONT  TestAccAWSRoute53Record_latency_basic
=== CONT  TestAccAWSRoute53Record_NameChange
=== CONT  TestAccAWSRoute53Record_empty
=== CONT  TestAccAWSRoute53Record_AliasChange
=== CONT  TestAccAWSRoute53Record_SetIdentifierChange
=== CONT  TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_multivalue_answer_basic
2020/11/19 13:38:00 [DEBUG] Expanded record name: www.notexample.com
2020/11/19 13:38:00 [DEBUG] List resource records sets for zone: Z062786036LZGRUF7PSE9, opts: {
  HostedZoneId: "Z062786036LZGRUF7PSE9",
  MaxItems: "100",
  StartRecordName: "www.notexample.com.",
  StartRecordType: "CNAME"
}
--- PASS: TestAccAWSRoute53Record_empty (118.56s)
=== CONT  TestAccAWSRoute53Record_caaSupport
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (120.29s)
=== CONT  TestAccAWSRoute53Record_Alias_S3
--- PASS: TestAccAWSRoute53Record_basic (122.74s)
=== CONT  TestAccAWSRoute53Record_Alias_Elb
--- PASS: TestAccAWSRoute53Record_latency_basic (125.76s)
=== CONT  TestAccAWSRoute53Record_weighted_to_simple_basic
--- PASS: TestAccAWSRoute53Record_AliasChange (171.69s)
=== CONT  TestAccAWSRoute53Record_weighted_basic
--- PASS: TestAccAWSRoute53Record_TypeChange (174.12s)
=== CONT  TestAccAWSRoute53Record_failover
--- PASS: TestAccAWSRoute53Record_allowOverwrite (176.57s)
=== CONT  TestAccAWSRoute53Record_wildcard
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (188.46s)
=== CONT  TestAccAWSRoute53Record_generatesSuffix
--- PASS: TestAccAWSRoute53Record_NameChange (203.21s)
=== CONT  TestAccAWSRoute53Record_geolocation_basic
--- PASS: TestAccAWSRoute53Record_Alias_S3 (113.81s)
=== CONT  TestAccAWSRoute53Record_HealthCheckId_TypeChange
--- PASS: TestAccAWSRoute53Record_caaSupport (117.62s)
=== CONT  TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange
--- PASS: TestAccAWSRoute53Record_Alias_Elb (117.79s)
=== CONT  TestAccAWSRoute53Record_weighted_alias
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (160.48s)
=== CONT  TestAccAWSRoute53Record_basic_fqdn
--- PASS: TestAccAWSRoute53Record_weighted_basic (117.70s)
=== CONT  TestAccAWSRoute53Record_spfSupport
--- PASS: TestAccAWSRoute53Record_failover (117.99s)
=== CONT  TestAccAWSRoute53Record_txtSupport
--- PASS: TestAccAWSRoute53Record_generatesSuffix (117.77s)
=== CONT  TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID
--- PASS: TestAccAWSRoute53Record_geolocation_basic (117.82s)
=== CONT  TestAccAWSRoute53Record_disappears
--- PASS: TestAccAWSRoute53Record_wildcard (165.37s)
=== CONT  TestAccAWSRoute53Record_disappears_MultipleRecords
2020/11/19 13:42:33 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSRoute53Record_HealthCheckId_TypeChange (165.86s)
=== CONT  TestAccAWSRoute53Record_Alias_Uppercase
--- PASS: TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange (164.61s)
=== CONT  TestAccAWSRoute53Record_underscored
--- PASS: TestAccAWSRoute53Record_spfSupport (116.56s)
=== CONT  TestAccAWSRoute53Record_longTXTrecord
--- PASS: TestAccAWSRoute53Record_txtSupport (116.34s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (132.66s)
--- PASS: TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID (116.04s)
=== CONT  TestAccAWSRoute53Record_disappears
    resource_aws_route53_record_test.go:165: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSRoute53Record_disappears (110.60s)
=== CONT  TestAccAWSRoute53Record_disappears_MultipleRecords
    resource_aws_route53_record_test.go:187: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSRoute53Record_weighted_alias (229.92s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (488.68s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (152.13s)
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (116.86s)
--- PASS: TestAccAWSRoute53Record_underscored (120.66s)
--- PASS: TestAccAWSRoute53Record_longTXTrecord (118.77s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       524.758s
```

After updating the acceptance tests:
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 10 -run=TestAccAWSRoute53Record_ -timeout 60m
go: downloading github.com/pquerna/otp v1.3.0
=== RUN   TestAccAWSRoute53Record_basic
=== PAUSE TestAccAWSRoute53Record_basic
=== RUN   TestAccAWSRoute53Record_underscored
=== PAUSE TestAccAWSRoute53Record_underscored
=== RUN   TestAccAWSRoute53Record_disappears
=== PAUSE TestAccAWSRoute53Record_disappears
=== RUN   TestAccAWSRoute53Record_disappears_MultipleRecords
=== PAUSE TestAccAWSRoute53Record_disappears_MultipleRecords
=== RUN   TestAccAWSRoute53Record_basic_fqdn
=== PAUSE TestAccAWSRoute53Record_basic_fqdn
=== RUN   TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID
=== PAUSE TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID
=== RUN   TestAccAWSRoute53Record_txtSupport
=== PAUSE TestAccAWSRoute53Record_txtSupport
=== RUN   TestAccAWSRoute53Record_spfSupport
=== PAUSE TestAccAWSRoute53Record_spfSupport
=== RUN   TestAccAWSRoute53Record_caaSupport
=== PAUSE TestAccAWSRoute53Record_caaSupport
=== RUN   TestAccAWSRoute53Record_generatesSuffix
=== PAUSE TestAccAWSRoute53Record_generatesSuffix
=== RUN   TestAccAWSRoute53Record_wildcard
=== PAUSE TestAccAWSRoute53Record_wildcard
=== RUN   TestAccAWSRoute53Record_failover
=== PAUSE TestAccAWSRoute53Record_failover
=== RUN   TestAccAWSRoute53Record_weighted_basic
=== PAUSE TestAccAWSRoute53Record_weighted_basic
=== RUN   TestAccAWSRoute53Record_weighted_to_simple_basic
=== PAUSE TestAccAWSRoute53Record_weighted_to_simple_basic
=== RUN   TestAccAWSRoute53Record_Alias_Elb
=== PAUSE TestAccAWSRoute53Record_Alias_Elb
=== RUN   TestAccAWSRoute53Record_Alias_S3
=== PAUSE TestAccAWSRoute53Record_Alias_S3
=== RUN   TestAccAWSRoute53Record_Alias_VpcEndpoint
=== PAUSE TestAccAWSRoute53Record_Alias_VpcEndpoint
=== RUN   TestAccAWSRoute53Record_Alias_Uppercase
=== PAUSE TestAccAWSRoute53Record_Alias_Uppercase
=== RUN   TestAccAWSRoute53Record_weighted_alias
=== PAUSE TestAccAWSRoute53Record_weighted_alias
=== RUN   TestAccAWSRoute53Record_geolocation_basic
=== PAUSE TestAccAWSRoute53Record_geolocation_basic
=== RUN   TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange
=== PAUSE TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange
=== RUN   TestAccAWSRoute53Record_HealthCheckId_TypeChange
=== PAUSE TestAccAWSRoute53Record_HealthCheckId_TypeChange
=== RUN   TestAccAWSRoute53Record_latency_basic
=== PAUSE TestAccAWSRoute53Record_latency_basic
=== RUN   TestAccAWSRoute53Record_TypeChange
=== PAUSE TestAccAWSRoute53Record_TypeChange
=== RUN   TestAccAWSRoute53Record_NameChange
=== PAUSE TestAccAWSRoute53Record_NameChange
=== RUN   TestAccAWSRoute53Record_SetIdentifierChange
=== PAUSE TestAccAWSRoute53Record_SetIdentifierChange
=== RUN   TestAccAWSRoute53Record_AliasChange
=== PAUSE TestAccAWSRoute53Record_AliasChange
=== RUN   TestAccAWSRoute53Record_empty
=== PAUSE TestAccAWSRoute53Record_empty
=== RUN   TestAccAWSRoute53Record_multivalue_answer_basic
=== PAUSE TestAccAWSRoute53Record_multivalue_answer_basic
=== RUN   TestAccAWSRoute53Record_allowOverwrite
=== PAUSE TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_basic
=== CONT  TestAccAWSRoute53Record_Alias_VpcEndpoint
=== CONT  TestAccAWSRoute53Record_NameChange
=== CONT  TestAccAWSRoute53Record_geolocation_basic
=== CONT  TestAccAWSRoute53Record_weighted_alias
=== CONT  TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_latency_basic
=== CONT  TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange
=== CONT  TestAccAWSRoute53Record_TypeChange
=== CONT  TestAccAWSRoute53Record_Alias_Uppercase
--- PASS: TestAccAWSRoute53Record_basic (133.19s)
=== CONT  TestAccAWSRoute53Record_empty
2020/11/19 15:31:17 [DEBUG] setting computed for "name_servers" from ComputedKeys
2020/11/19 15:31:17 [DEBUG] Creating Route53 hosted zone: {
  CallerReference: "terraform-2020111915311755620000000c",
  HostedZoneConfig: {
    Comment: "Managed by Terraform"
  },
  Name: "notexample.com"
}
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (146.80s)
=== CONT  TestAccAWSRoute53Record_multivalue_answer_basic
--- PASS: TestAccAWSRoute53Record_latency_basic (146.96s)
=== CONT  TestAccAWSRoute53Record_HealthCheckId_TypeChange
--- PASS: TestAccAWSRoute53Record_geolocation_basic (148.85s)
=== CONT  TestAccAWSRoute53Record_weighted_basic
--- PASS: TestAccAWSRoute53Record_allowOverwrite (180.35s)
=== CONT  TestAccAWSRoute53Record_Alias_S3
--- PASS: TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange (199.38s)
=== CONT  TestAccAWSRoute53Record_Alias_Elb
--- PASS: TestAccAWSRoute53Record_TypeChange (212.28s)
=== CONT  TestAccAWSRoute53Record_weighted_to_simple_basic
--- PASS: TestAccAWSRoute53Record_NameChange (231.26s)
=== CONT  TestAccAWSRoute53Record_AliasChange
--- PASS: TestAccAWSRoute53Record_empty (116.90s)
=== CONT  TestAccAWSRoute53Record_SetIdentifierChange
--- PASS: TestAccAWSRoute53Record_weighted_alias (262.56s)
=== CONT  TestAccAWSRoute53Record_wildcard
--- PASS: TestAccAWSRoute53Record_weighted_basic (116.17s)
=== CONT  TestAccAWSRoute53Record_generatesSuffix
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (118.70s)
=== CONT  TestAccAWSRoute53Record_caaSupport
--- PASS: TestAccAWSRoute53Record_Alias_S3 (117.44s)
=== CONT  TestAccAWSRoute53Record_basic_fqdn
--- PASS: TestAccAWSRoute53Record_Alias_Elb (120.42s)
=== CONT  TestAccAWSRoute53Record_failover
--- PASS: TestAccAWSRoute53Record_HealthCheckId_TypeChange (179.58s)
=== CONT  TestAccAWSRoute53Record_spfSupport
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (175.22s)
=== CONT  TestAccAWSRoute53Record_txtSupport
--- PASS: TestAccAWSRoute53Record_caaSupport (124.91s)
=== CONT  TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID
--- PASS: TestAccAWSRoute53Record_generatesSuffix (125.45s)
=== CONT  TestAccAWSRoute53Record_disappears
--- PASS: TestAccAWSRoute53Record_AliasChange (178.75s)
=== CONT  TestAccAWSRoute53Record_disappears_MultipleRecords
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (172.43s)
=== CONT  TestAccAWSRoute53Record_underscored
--- PASS: TestAccAWSRoute53Record_wildcard (175.07s)
--- PASS: TestAccAWSRoute53Record_failover (117.93s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (140.81s)
--- PASS: TestAccAWSRoute53Record_spfSupport (114.05s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (478.60s)
--- PASS: TestAccAWSRoute53Record_disappears (108.26s)
--- PASS: TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID (120.90s)
--- PASS: TestAccAWSRoute53Record_underscored (122.29s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (151.28s)
--- PASS: TestAccAWSRoute53Record_txtSupport (246.21s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       633.768s
```