### PR TITLE
ds/cloudtrail_service_account: Fix hardcoded regions

### DIFF
--- a/aws/data_source_aws_cloudtrail_service_account.go
+++ b/aws/data_source_aws_cloudtrail_service_account.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -11,31 +12,31 @@ import (
 // See https://docs.aws.amazon.com/govcloud-us/latest/ug-east/verifying-cloudtrail.html
 // See https://docs.aws.amazon.com/govcloud-us/latest/ug-west/verifying-cloudtrail.html
 var cloudTrailServiceAccountPerRegionMap = map[string]string{
-	"af-south-1":     "525921808201",
-	"ap-east-1":      "119688915426",
-	"ap-northeast-1": "216624486486",
-	"ap-northeast-2": "492519147666",
-	"ap-northeast-3": "765225791966",
-	"ap-south-1":     "977081816279",
-	"ap-southeast-1": "903692715234",
-	"ap-southeast-2": "284668455005",
-	"ca-central-1":   "819402241893",
-	"cn-north-1":     "193415116832",
-	"cn-northwest-1": "681348832753",
-	"eu-central-1":   "035351147821",
-	"eu-north-1":     "829690693026",
-	"eu-south-1":     "669305197877",
-	"eu-west-1":      "859597730677",
-	"eu-west-2":      "282025262664",
-	"eu-west-3":      "262312530599",
-	"me-south-1":     "034638983726",
-	"sa-east-1":      "814480443879",
-	"us-east-1":      "086441151436",
-	"us-east-2":      "475085895292",
-	"us-gov-east-1":  "608710470296",
-	"us-gov-west-1":  "608710470296",
-	"us-west-1":      "388731089494",
-	"us-west-2":      "113285607260",
+	endpoints.AfSouth1RegionID:     "525921808201",
+	endpoints.ApEast1RegionID:      "119688915426",
+	endpoints.ApNortheast1RegionID: "216624486486",
+	endpoints.ApNortheast2RegionID: "492519147666",
+	"ap-northeast-3":               "765225791966", //lintignore:AWSAT003 // https://github.com/aws/aws-sdk-go/issues/1863
+	endpoints.ApSouth1RegionID:     "977081816279",
+	endpoints.ApSoutheast1RegionID: "903692715234",
+	endpoints.ApSoutheast2RegionID: "284668455005",
+	endpoints.CaCentral1RegionID:   "819402241893",
+	endpoints.CnNorth1RegionID:     "193415116832",
+	endpoints.CnNorthwest1RegionID: "681348832753",
+	endpoints.EuCentral1RegionID:   "035351147821",
+	endpoints.EuNorth1RegionID:     "829690693026",
+	endpoints.EuSouth1RegionID:     "669305197877",
+	endpoints.EuWest1RegionID:      "859597730677",
+	endpoints.EuWest2RegionID:      "282025262664",
+	endpoints.EuWest3RegionID:      "262312530599",
+	endpoints.MeSouth1RegionID:     "034638983726",
+	endpoints.SaEast1RegionID:      "814480443879",
+	endpoints.UsEast1RegionID:      "086441151436",
+	endpoints.UsEast2RegionID:      "475085895292",
+	endpoints.UsGovEast1RegionID:   "608710470296",
+	endpoints.UsGovWest1RegionID:   "608710470296",
+	endpoints.UsWest1RegionID:      "388731089494",
+	endpoints.UsWest2RegionID:      "113285607260",
 }
 
 func dataSourceAwsCloudTrailServiceAccount() *schema.Resource {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (13.34s)
--- PASS: TestAccAWSCloudTrailServiceAccount_Region (13.76s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSCloudTrailServiceAccount_Region (10.17s)
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (10.46s)
```
