### PR TITLE
tests/config: Fix hardcoded regions

### DIFF
--- a/aws/config_test.go
+++ b/aws/config_test.go
@@ -55,19 +55,19 @@ func TestAWSClientRegionalHostname(t *testing.T) {
 			Name: "AWS Commercial",
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "us-west-2",
+				region:    "us-west-2", //lintignore:AWSAT003
 			},
 			Prefix:   "test",
-			Expected: "test.us-west-2.amazonaws.com",
+			Expected: "test.us-west-2.amazonaws.com", //lintignore:AWSAT003
 		},
 		{
 			Name: "AWS China",
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com.cn",
-				region:    "cn-northwest-1",
+				region:    "cn-northwest-1", //lintignore:AWSAT003
 			},
 			Prefix:   "test",
-			Expected: "test.cn-northwest-1.amazonaws.com.cn",
+			Expected: "test.cn-northwest-1.amazonaws.com.cn", //lintignore:AWSAT003
 		},
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAWSClientRegionalHostname (0.00s)
    --- PASS: TestAWSClientRegionalHostname/AWS_Commercial (0.00s)
    --- PASS: TestAWSClientRegionalHostname/AWS_China (0.00s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAWSClientRegionalHostname (0.00s)
    --- PASS: TestAWSClientRegionalHostname/AWS_Commercial (0.00s)
    --- PASS: TestAWSClientRegionalHostname/AWS_China (0.00s)
```
