### PR TITLE
tests/provider: Add Gateway LB precheck to tests

### DIFF
--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -277,7 +277,7 @@ func TestAccAWSLBTargetGroup_Protocol_Geneve(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -399,7 +399,7 @@ func TestAccAWSRouteTable_Route_VpcEndpointId(t *testing.T) {
 	resourceName := "aws_route_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -508,7 +508,7 @@ func TestAccAWSRoute_VpcEndpointId(t *testing.T) {
 	vpcEndpointResourceName := "aws_vpc_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -184,7 +184,7 @@ func TestAccAWSVpcEndpointService_GatewayLoadBalancerArns(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tfacctest") // 32 character limit
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVpcEndpointServiceDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -511,7 +511,7 @@ func TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVpcEndpointDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16322
Relates #16314

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer (2.06s)
--- SKIP: TestAccAWSLBTargetGroup_Protocol_Geneve (2.07s)
--- SKIP: TestAccAWSVpcEndpointService_GatewayLoadBalancerArns (2.07s)
--- SKIP: TestAccAWSRoute_VpcEndpointId (2.07s)
--- SKIP: TestAccAWSRouteTable_Route_VpcEndpointId (2.07s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSLBTargetGroup_Protocol_Geneve (27.18s)
--- PASS: TestAccAWSVpcEndpointService_GatewayLoadBalancerArns (203.42s)
--- PASS: TestAccAWSRouteTable_Route_VpcEndpointId (287.94s)
--- PASS: TestAccAWSRoute_VpcEndpointId (297.28s)
--- PASS: TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer (298.97s)
```