### PR TITLE
ds/eip ds/arn: Fix hardcoded region

### DIFF
--- a/aws/data_source_aws_arn_test.go
+++ b/aws/data_source_aws_arn_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -11,19 +13,27 @@ import (
 func TestAccDataSourceAwsArn_basic(t *testing.T) {
 	resourceName := "data.aws_arn.test"
 
+	testARN := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "db:mysql-db",
+		Service:   "rds",
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsArnConfig,
+				Config: testAccDataSourceAwsArnConfig(testARN.String()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsArn(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "partition", "aws"),
-					resource.TestCheckResourceAttr(resourceName, "service", "rds"),
-					resource.TestCheckResourceAttr(resourceName, "region", "eu-west-1"),
-					resource.TestCheckResourceAttr(resourceName, "account", "123456789012"),
-					resource.TestCheckResourceAttr(resourceName, "resource", "db:mysql-db"),
+					resource.TestCheckResourceAttr(resourceName, "account", testARN.AccountID),
+					resource.TestCheckResourceAttr(resourceName, "partition", testARN.Partition),
+					resource.TestCheckResourceAttr(resourceName, "region", testARN.Region),
+					resource.TestCheckResourceAttr(resourceName, "resource", testARN.Resource),
+					resource.TestCheckResourceAttr(resourceName, "service", testARN.Service),
 				),
 			},
 		},
@@ -41,9 +51,10 @@ func testAccDataSourceAwsArn(name string) resource.TestCheckFunc {
 	}
 }
 
-//lintignore:AWSAT003,AWSAT005
-const testAccDataSourceAwsArnConfig = `
+func testAccDataSourceAwsArnConfig(arn string) string {
+	return fmt.Sprintf(`
 data "aws_arn" "test" {
-  arn = "arn:aws:rds:eu-west-1:123456789012:db:mysql-db"
+  arn = %q
 }
-`
+`, arn)
+}

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -139,7 +140,7 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	if eip.PrivateIpAddress != nil {
 		dashIP := strings.Replace(*eip.PrivateIpAddress, ".", "-", -1)
 
-		if region == "us-east-1" {
+		if region == endpoints.UsEast1RegionID {
 			d.Set("private_dns", fmt.Sprintf("ip-%s.ec2.internal", dashIP))
 		} else {
 			d.Set("private_dns", fmt.Sprintf("ip-%s.%s.compute.internal", dashIP, region))
@@ -150,7 +151,7 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	if eip.PublicIp != nil {
 		dashIP := strings.Replace(*eip.PublicIp, ".", "-", -1)
 
-		if region == "us-east-1" {
+		if region == endpoints.UsEast1RegionID {
 			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.compute-1", dashIP)))
 		} else {
 			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s.compute", dashIP, region)))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccDataSourceAwsEip_PublicIP_EC2Classic (2.80s)
--- PASS: TestAccDataSourceAwsArn_basic (14.88s)
--- PASS: TestAccDataSourceAwsEip_Id (18.19s)
--- PASS: TestAccDataSourceAwsEip_Tags (18.73s)
--- PASS: TestAccDataSourceAwsEip_Filter (19.09s)
--- PASS: TestAccDataSourceAwsEip_PublicIP_VPC (19.11s)
--- PASS: TestAccDataSourceAwsEip_NetworkInterface (72.12s)
--- PASS: TestAccDataSourceAwsEip_Instance (121.50s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccDataSourceAwsArn_basic (9.07s)
--- PASS: TestAccDataSourceAwsEip_PublicIP_EC2Classic (9.62s)
--- PASS: TestAccDataSourceAwsEip_PublicIP_VPC (13.14s)
--- PASS: TestAccDataSourceAwsEip_Id (13.20s)
--- PASS: TestAccDataSourceAwsEip_Tags (13.78s)
--- PASS: TestAccDataSourceAwsEip_Filter (14.64s)
--- PASS: TestAccDataSourceAwsEip_NetworkInterface (68.22s)
--- PASS: TestAccDataSourceAwsEip_Instance (124.43s)
```