### PR TITLE
ds/redshift_service_account: Fix hardcoded regions

### DIFF
--- a/aws/data_source_aws_redshift_service_account.go
+++ b/aws/data_source_aws_redshift_service_account.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -11,31 +12,31 @@ import (
 // See https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-redshift.html
 // See https://docs.amazonaws.cn/en_us/redshift/latest/mgmt/db-auditing.html#db-auditing-bucket-permissions
 var redshiftServiceAccountPerRegionMap = map[string]string{
-	"us-east-1":      "193672423079",
-	"us-east-2":      "391106570357",
-	"us-west-1":      "262260360010",
-	"us-west-2":      "902366379725",
-	"af-south-1":     "365689465814",
-	"ap-east-1":      "313564881002",
-	"ap-south-1":     "865932855811",
-	"ap-northeast-3": "090321488786",
-	"ap-northeast-2": "760740231472",
-	"ap-southeast-1": "361669875840",
-	"ap-southeast-2": "762762565011",
-	"ap-northeast-1": "404641285394",
-	"ca-central-1":   "907379612154",
-	"cn-north-1":     "111890595117",
-	"cn-northwest-1": "660998842044",
-	"eu-central-1":   "053454850223",
-	"eu-west-1":      "210876761215",
-	"eu-west-2":      "307160386991",
-	"eu-west-3":      "915173422425",
-	"eu-north-1":     "729911121831",
-	"eu-south-1":     "945612479654",
-	"me-south-1":     "013126148197",
-	"sa-east-1":      "075028567923",
-	"us-gov-east-1":  "665727464434",
-	"us-gov-west-1":  "665727464434",
+	endpoints.AfSouth1RegionID:     "365689465814",
+	endpoints.ApEast1RegionID:      "313564881002",
+	endpoints.ApNortheast1RegionID: "404641285394",
+	endpoints.ApNortheast2RegionID: "760740231472",
+	"ap-northeast-3":               "090321488786", //lintignore:AWSAT003 // https://github.com/aws/aws-sdk-go/issues/1863
+	endpoints.ApSouth1RegionID:     "865932855811",
+	endpoints.ApSoutheast1RegionID: "361669875840",
+	endpoints.ApSoutheast2RegionID: "762762565011",
+	endpoints.CaCentral1RegionID:   "907379612154",
+	endpoints.CnNorth1RegionID:     "111890595117",
+	endpoints.CnNorthwest1RegionID: "660998842044",
+	endpoints.EuCentral1RegionID:   "053454850223",
+	endpoints.EuNorth1RegionID:     "729911121831",
+	endpoints.EuSouth1RegionID:     "945612479654",
+	endpoints.EuWest1RegionID:      "210876761215",
+	endpoints.EuWest2RegionID:      "307160386991",
+	endpoints.EuWest3RegionID:      "915173422425",
+	endpoints.MeSouth1RegionID:     "013126148197",
+	endpoints.SaEast1RegionID:      "075028567923",
+	endpoints.UsEast1RegionID:      "193672423079",
+	endpoints.UsEast2RegionID:      "391106570357",
+	endpoints.UsGovEast1RegionID:   "665727464434",
+	endpoints.UsGovWest1RegionID:   "665727464434",
+	endpoints.UsWest1RegionID:      "262260360010",
+	endpoints.UsWest2RegionID:      "902366379725",
 }
 
 func dataSourceAwsRedshiftServiceAccount() *schema.Resource {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSRedshiftServiceAccount_Region (12.94s)
--- PASS: TestAccAWSRedshiftServiceAccount_basic (13.29s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSRedshiftServiceAccount_Region (8.76s)
--- PASS: TestAccAWSRedshiftServiceAccount_basic (8.94s)
```