### PR TITLE
tests/provider: Fix hardcoded regions (Validator, Structure)

### DIFF
--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -540,11 +540,11 @@ func TestFlattenOrganizationsOrganizationalUnits(t *testing.T) {
 }
 
 func TestExpandStringList(t *testing.T) {
-	expanded := []interface{}{"us-east-1a", "us-east-1b"}
+	expanded := []interface{}{"us-east-1a", "us-east-1b"} //lintignore:AWSAT003
 	stringList := expandStringList(expanded)
 	expected := []*string{
-		aws.String("us-east-1a"),
-		aws.String("us-east-1b"),
+		aws.String("us-east-1a"), //lintignore:AWSAT003
+		aws.String("us-east-1b"), //lintignore:AWSAT003
 	}
 
 	if !reflect.DeepEqual(stringList, expected) {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2135,7 +2135,7 @@ func TestValidateCognitoIdentityProvidersProviderName(t *testing.T) {
 		"foo:bar",
 		"foo/bar",
 		"foo-bar",
-		"cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu",
+		"cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu", //lintignore:AWSAT003
 		strings.Repeat("W", 128),
 	}
 
@@ -2655,8 +2655,8 @@ func TestValidateCognitoUserGroupName(t *testing.T) {
 
 func TestValidateCognitoUserPoolId(t *testing.T) {
 	validValues := []string{
-		"eu-west-1_Foo123",
-		"ap-southeast-2_BaRBaz987",
+		"eu-west-1_Foo123",         //lintignore:AWSAT003
+		"ap-southeast-2_BaRBaz987", //lintignore:AWSAT003
 	}
 
 	for _, s := range validValues {
@@ -2669,8 +2669,8 @@ func TestValidateCognitoUserPoolId(t *testing.T) {
 	invalidValues := []string{
 		"",
 		"foo",
-		"us-east-1-Foo123",
-		"eu-central-2_Bar+4",
+		"us-east-1-Foo123",   //lintignore:AWSAT003
+		"eu-central-2_Bar+4", //lintignore:AWSAT003
 	}
 
 	for _, s := range invalidValues {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestValidateCognitoIdentityProvidersProviderName (0.00s)
--- PASS: TestValidateCognitoUserPoolId (0.00s)
--- PASS: TestExpandStringList (0.00s)
--- PASS: TestExpandStringListEmptyItems (0.00s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestExpandStringListEmptyItems (0.00s)
--- PASS: TestValidateCognitoIdentityProvidersProviderName (0.00s)
--- PASS: TestValidateCognitoUserPoolId (0.00s)
--- PASS: TestExpandStringListEmptyItems (0.00s)
```