### PR TITLE
resource/s3_bucket: Fix hardcoded regions

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -655,7 +655,7 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Special case us-east-1 region and do not set the LocationConstraint.
 	// See "Request Elements: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html
-	if awsRegion != "us-east-1" {
+	if awsRegion != endpoints.UsEast1RegionID {
 		req.CreateBucketConfiguration = &s3.CreateBucketConfiguration{
 			LocationConstraint: aws.String(awsRegion),
 		}
@@ -1729,15 +1729,15 @@ func WebsiteDomainUrl(client *AWSClient, region string) string {
 
 func isOldRegion(region string) bool {
 	oldRegions := []string{
-		"ap-northeast-1",
-		"ap-southeast-1",
-		"ap-southeast-2",
-		"eu-west-1",
-		"sa-east-1",
-		"us-east-1",
-		"us-gov-west-1",
-		"us-west-1",
-		"us-west-2",
+		endpoints.ApNortheast1RegionID,
+		endpoints.ApSoutheast1RegionID,
+		endpoints.ApSoutheast2RegionID,
+		endpoints.EuWest1RegionID,
+		endpoints.SaEast1RegionID,
+		endpoints.UsEast1RegionID,
+		endpoints.UsGovWest1RegionID,
+		endpoints.UsWest1RegionID,
+		endpoints.UsWest2RegionID,
 	}
 	for _, r := range oldRegions {
 		if region == r {
@@ -2431,7 +2431,7 @@ func normalizeRegion(region string) string {
 	// Default to us-east-1 if the bucket doesn't have a region:
 	// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
 	if region == "" {
-		region = "us-east-1"
+		region = endpoints.UsEast1RegionID
 	}
 
 	return region
@@ -2441,7 +2441,7 @@ func normalizeRegion(region string) string {
 // Buckets outside of this region have to be DNS-compliant. After the same restrictions are
 // applied to buckets in the us-east-1 region, this function can be refactored as a SchemaValidateFunc
 func validateS3BucketName(value string, region string) error {
-	if region != "us-east-1" {
+	if region != endpoints.UsEast1RegionID {
 		if (len(value) < 3) || (len(value) > 63) {
 			return fmt.Errorf("%q must contain from 3 to 63 characters", value)
 		}

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
@@ -2168,7 +2169,7 @@ func TestAWSS3BucketName(t *testing.T) {
 	}
 
 	for _, v := range validDnsNames {
-		if err := validateS3BucketName(v, "us-west-2"); err != nil {
+		if err := validateS3BucketName(v, endpoints.UsWest2RegionID); err != nil {
 			t.Fatalf("%q should be a valid S3 bucket name", v)
 		}
 	}
@@ -2185,7 +2186,7 @@ func TestAWSS3BucketName(t *testing.T) {
 	}
 
 	for _, v := range invalidDnsNames {
-		if err := validateS3BucketName(v, "us-west-2"); err == nil {
+		if err := validateS3BucketName(v, endpoints.UsWest2RegionID); err == nil {
 			t.Fatalf("%q should not be a valid S3 bucket name", v)
 		}
 	}
@@ -2202,7 +2203,7 @@ func TestAWSS3BucketName(t *testing.T) {
 	}
 
 	for _, v := range validEastNames {
-		if err := validateS3BucketName(v, "us-east-1"); err != nil {
+		if err := validateS3BucketName(v, endpoints.UsEast1RegionID); err != nil {
 			t.Fatalf("%q should be a valid S3 bucket name", v)
 		}
 	}
@@ -2213,7 +2214,7 @@ func TestAWSS3BucketName(t *testing.T) {
 	}
 
 	for _, v := range invalidEastNames {
-		if err := validateS3BucketName(v, "us-east-1"); err == nil {
+		if err := validateS3BucketName(v, endpoints.UsEast1RegionID); err == nil {
 			t.Fatalf("%q should not be a valid S3 bucket name", v)
 		}
 	}
@@ -2238,24 +2239,24 @@ func TestBucketRegionalDomainName(t *testing.T) {
 			ExpectedOutput:   bucket + ".s3.custom.amazonaws.com",
 		},
 		{
-			Region:           "us-east-1",
+			Region:           endpoints.UsEast1RegionID,
 			ExpectedErrCount: 0,
 			ExpectedOutput:   bucket + ".s3.amazonaws.com",
 		},
 		{
-			Region:           "us-west-2",
+			Region:           endpoints.UsWest2RegionID,
 			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + ".s3.us-west-2.amazonaws.com",
+			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.amazonaws.com", endpoints.UsWest2RegionID),
 		},
 		{
-			Region:           "us-gov-west-1",
+			Region:           endpoints.UsGovWest1RegionID,
 			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + ".s3.us-gov-west-1.amazonaws.com",
+			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.amazonaws.com", endpoints.UsGovWest1RegionID),
 		},
 		{
-			Region:           "cn-north-1",
+			Region:           endpoints.CnNorth1RegionID,
 			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + ".s3.cn-north-1.amazonaws.com.cn",
+			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.amazonaws.com.cn", endpoints.CnNorth1RegionID),
 		},
 	}
 
@@ -2283,145 +2284,145 @@ func TestWebsiteEndpoint(t *testing.T) {
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "us-east-1",
+				region:    endpoints.UsEast1RegionID,
 			},
 			LocationConstraint: "",
-			Expected:           "bucket-name.s3-website-us-east-1.amazonaws.com",
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.UsEast1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "us-west-2",
+				region:    endpoints.UsWest2RegionID,
 			},
-			LocationConstraint: "us-west-2",
-			Expected:           "bucket-name.s3-website-us-west-2.amazonaws.com",
+			LocationConstraint: endpoints.UsWest2RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.UsWest2RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "us-west-1",
+				region:    endpoints.UsWest1RegionID,
 			},
-			LocationConstraint: "us-west-1",
-			Expected:           "bucket-name.s3-website-us-west-1.amazonaws.com",
+			LocationConstraint: endpoints.UsWest1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.UsWest1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "eu-west-1",
+				region:    endpoints.EuWest1RegionID,
 			},
-			LocationConstraint: "eu-west-1",
-			Expected:           "bucket-name.s3-website-eu-west-1.amazonaws.com",
+			LocationConstraint: endpoints.EuWest1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.EuWest1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "eu-west-3",
+				region:    endpoints.EuWest3RegionID,
 			},
-			LocationConstraint: "eu-west-3",
-			Expected:           "bucket-name.s3-website.eu-west-3.amazonaws.com"},
+			LocationConstraint: endpoints.EuWest3RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.EuWest3RegionID)},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "eu-central-1",
+				region:    endpoints.EuCentral1RegionID,
 			},
-			LocationConstraint: "eu-central-1",
-			Expected:           "bucket-name.s3-website.eu-central-1.amazonaws.com",
+			LocationConstraint: endpoints.EuCentral1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.EuCentral1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "ap-south-1",
+				region:    endpoints.ApSouth1RegionID,
 			},
-			LocationConstraint: "ap-south-1",
-			Expected:           "bucket-name.s3-website.ap-south-1.amazonaws.com",
+			LocationConstraint: endpoints.ApSouth1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.ApSouth1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "ap-southeast-1",
+				region:    endpoints.ApSoutheast1RegionID,
 			},
-			LocationConstraint: "ap-southeast-1",
-			Expected:           "bucket-name.s3-website-ap-southeast-1.amazonaws.com",
+			LocationConstraint: endpoints.ApSoutheast1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.ApSoutheast1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "ap-northeast-1",
+				region:    endpoints.ApNortheast1RegionID,
 			},
-			LocationConstraint: "ap-northeast-1",
-			Expected:           "bucket-name.s3-website-ap-northeast-1.amazonaws.com",
+			LocationConstraint: endpoints.ApNortheast1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.ApNortheast1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "ap-southeast-2",
+				region:    endpoints.ApSoutheast2RegionID,
 			},
-			LocationConstraint: "ap-southeast-2",
-			Expected:           "bucket-name.s3-website-ap-southeast-2.amazonaws.com",
+			LocationConstraint: endpoints.ApSoutheast2RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.ApSoutheast2RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "ap-northeast-2",
+				region:    endpoints.ApNortheast2RegionID,
 			},
-			LocationConstraint: "ap-northeast-2",
-			Expected:           "bucket-name.s3-website.ap-northeast-2.amazonaws.com",
+			LocationConstraint: endpoints.ApNortheast2RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.ApNortheast2RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "sa-east-1",
+				region:    endpoints.SaEast1RegionID,
 			},
-			LocationConstraint: "sa-east-1",
-			Expected:           "bucket-name.s3-website-sa-east-1.amazonaws.com",
+			LocationConstraint: endpoints.SaEast1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.SaEast1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "us-gov-east-1",
+				region:    endpoints.UsGovEast1RegionID,
 			},
-			LocationConstraint: "us-gov-east-1",
-			Expected:           "bucket-name.s3-website.us-gov-east-1.amazonaws.com",
+			LocationConstraint: endpoints.UsGovEast1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.UsGovEast1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
-				region:    "us-gov-west-1",
+				region:    endpoints.UsGovWest1RegionID,
 			},
-			LocationConstraint: "us-gov-west-1",
-			Expected:           "bucket-name.s3-website-us-gov-west-1.amazonaws.com",
+			LocationConstraint: endpoints.UsGovWest1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.UsGovWest1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "c2s.ic.gov",
-				region:    "us-iso-east-1",
+				region:    endpoints.UsIsoEast1RegionID,
 			},
-			LocationConstraint: "us-iso-east-1",
-			Expected:           "bucket-name.s3-website.us-iso-east-1.c2s.ic.gov",
+			LocationConstraint: endpoints.UsIsoEast1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.c2s.ic.gov", endpoints.UsIsoEast1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "sc2s.sgov.gov",
-				region:    "us-isob-east-1",
+				region:    endpoints.UsIsobEast1RegionID,
 			},
-			LocationConstraint: "us-isob-east-1",
-			Expected:           "bucket-name.s3-website.us-isob-east-1.sc2s.sgov.gov",
+			LocationConstraint: endpoints.UsIsobEast1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.sc2s.sgov.gov", endpoints.UsIsobEast1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com.cn",
-				region:    "cn-northwest-1",
+				region:    endpoints.CnNorthwest1RegionID,
 			},
-			LocationConstraint: "cn-northwest-1",
-			Expected:           "bucket-name.s3-website.cn-northwest-1.amazonaws.com.cn",
+			LocationConstraint: endpoints.CnNorthwest1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com.cn", endpoints.CnNorthwest1RegionID),
 		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com.cn",
-				region:    "cn-north-1",
+				region:    endpoints.CnNorth1RegionID,
 			},
-			LocationConstraint: "cn-north-1",
-			Expected:           "bucket-name.s3-website.cn-north-1.amazonaws.com.cn",
+			LocationConstraint: endpoints.CnNorth1RegionID,
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com.cn", endpoints.CnNorth1RegionID),
 		},
 	}
 

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -2246,12 +2246,12 @@ func TestBucketRegionalDomainName(t *testing.T) {
 		{
 			Region:           endpoints.UsWest2RegionID,
 			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.amazonaws.com", endpoints.UsWest2RegionID),
+			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.%s", endpoints.UsWest2RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			Region:           endpoints.UsGovWest1RegionID,
 			ExpectedErrCount: 0,
-			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.amazonaws.com", endpoints.UsGovWest1RegionID),
+			ExpectedOutput:   bucket + fmt.Sprintf(".s3.%s.%s", endpoints.UsGovWest1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			Region:           endpoints.CnNorth1RegionID,
@@ -2287,7 +2287,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.UsEast1RegionID,
 			},
 			LocationConstraint: "",
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.UsEast1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.UsEast1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2295,7 +2295,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.UsWest2RegionID,
 			},
 			LocationConstraint: endpoints.UsWest2RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.UsWest2RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.UsWest2RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2303,7 +2303,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.UsWest1RegionID,
 			},
 			LocationConstraint: endpoints.UsWest1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.UsWest1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.UsWest1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2311,7 +2311,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.EuWest1RegionID,
 			},
 			LocationConstraint: endpoints.EuWest1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.EuWest1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.EuWest1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2319,14 +2319,15 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.EuWest3RegionID,
 			},
 			LocationConstraint: endpoints.EuWest3RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.EuWest3RegionID)},
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.EuWest3RegionID, testAccGetPartitionDNSSuffix()),
+		},
 		{
 			AWSClient: &AWSClient{
 				dnsSuffix: "amazonaws.com",
 				region:    endpoints.EuCentral1RegionID,
 			},
 			LocationConstraint: endpoints.EuCentral1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.EuCentral1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.EuCentral1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2334,7 +2335,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.ApSouth1RegionID,
 			},
 			LocationConstraint: endpoints.ApSouth1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.ApSouth1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.ApSouth1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2342,7 +2343,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.ApSoutheast1RegionID,
 			},
 			LocationConstraint: endpoints.ApSoutheast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.ApSoutheast1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.ApSoutheast1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2350,7 +2351,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.ApNortheast1RegionID,
 			},
 			LocationConstraint: endpoints.ApNortheast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.ApNortheast1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.ApNortheast1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2358,7 +2359,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.ApSoutheast2RegionID,
 			},
 			LocationConstraint: endpoints.ApSoutheast2RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.ApSoutheast2RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.ApSoutheast2RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2366,7 +2367,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.ApNortheast2RegionID,
 			},
 			LocationConstraint: endpoints.ApNortheast2RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.ApNortheast2RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.ApNortheast2RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2374,7 +2375,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.SaEast1RegionID,
 			},
 			LocationConstraint: endpoints.SaEast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.SaEast1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.SaEast1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2382,7 +2383,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.UsGovEast1RegionID,
 			},
 			LocationConstraint: endpoints.UsGovEast1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.amazonaws.com", endpoints.UsGovEast1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website.%s.%s", endpoints.UsGovEast1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{
@@ -2390,7 +2391,7 @@ func TestWebsiteEndpoint(t *testing.T) {
 				region:    endpoints.UsGovWest1RegionID,
 			},
 			LocationConstraint: endpoints.UsGovWest1RegionID,
-			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.amazonaws.com", endpoints.UsGovWest1RegionID),
+			Expected:           fmt.Sprintf("bucket-name.s3-website-%s.%s", endpoints.UsGovWest1RegionID, testAccGetPartitionDNSSuffix()),
 		},
 		{
 			AWSClient: &AWSClient{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Test CLI:
```
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run='TestBucketRegionalDomainName|TestWebsiteEndpoint|TestAccAWSS3Bucket_|TestAccAWSS3MultiBucket|TestAWSS3BucketName' -timeout 120m
```

Output from acceptance testing (GovCloud):

Failure is pre-existing and unrelated.
```
--- FAIL: TestAccAWSS3Bucket_LifecycleBasic (85.49s)
--- PASS: TestAccAWSS3Bucket_AclToGrant (57.79s)
--- PASS: TestAccAWSS3Bucket_basic (33.91s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (34.74s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (34.41s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (36.00s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (72.38s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (65.07s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (34.94s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (38.92s)
--- PASS: TestAccAWSS3Bucket_forceDestroy (28.84s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (30.25s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (34.44s)
--- PASS: TestAccAWSS3Bucket_generatedName (37.01s)
--- PASS: TestAccAWSS3Bucket_GrantToAcl (60.92s)
--- PASS: TestAccAWSS3Bucket_ignoreTags (54.91s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (65.41s)
--- PASS: TestAccAWSS3Bucket_LifecycleRule_AbortIncompleteMultipartUploadDays_NoExpiration (35.17s)
--- PASS: TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock (26.94s)
--- PASS: TestAccAWSS3Bucket_Logging (48.49s)
--- PASS: TestAccAWSS3Bucket_namePrefix (34.55s)
--- PASS: TestAccAWSS3Bucket_objectLock (65.40s)
--- PASS: TestAccAWSS3Bucket_Policy (102.81s)
--- PASS: TestAccAWSS3Bucket_Replication (156.08s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (83.23s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation (85.55s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (14.83s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (158.96s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (48.15s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (45.72s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (66.74s)
--- PASS: TestAccAWSS3Bucket_SameRegionReplicationSchemaV2 (50.92s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (24.04s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (124.50s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (175.95s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (65.33s)
--- PASS: TestAccAWSS3Bucket_UpdateGrant (100.43s)
--- PASS: TestAccAWSS3Bucket_Versioning (96.12s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (102.46s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (105.11s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (76.48s)
--- PASS: TestAccAWSS3MultiBucket_withTags (37.88s)
--- PASS: TestAWSS3BucketName (0.00s)
--- PASS: TestBucketRegionalDomainName (0.00s)
--- PASS: TestWebsiteEndpoint (0.00s)
--- SKIP: TestAccAWSS3Bucket_acceleration (0.00s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSS3Bucket_acceleration (60.95s)
--- PASS: TestAccAWSS3Bucket_AclToGrant (49.81s)
--- PASS: TestAccAWSS3Bucket_basic (36.97s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (29.64s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (25.67s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (34.21s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (60.90s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (61.42s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (31.30s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (38.64s)
--- PASS: TestAccAWSS3Bucket_forceDestroy (34.63s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (33.71s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (37.98s)
--- PASS: TestAccAWSS3Bucket_generatedName (32.50s)
--- PASS: TestAccAWSS3Bucket_GrantToAcl (51.59s)
--- PASS: TestAccAWSS3Bucket_ignoreTags (52.50s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (96.96s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (69.51s)
--- PASS: TestAccAWSS3Bucket_LifecycleRule_AbortIncompleteMultipartUploadDays_NoExpiration (39.57s)
--- PASS: TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock (31.75s)
--- PASS: TestAccAWSS3Bucket_Logging (50.58s)
--- PASS: TestAccAWSS3Bucket_namePrefix (32.62s)
--- PASS: TestAccAWSS3Bucket_objectLock (69.79s)
--- PASS: TestAccAWSS3Bucket_Policy (86.31s)
--- PASS: TestAccAWSS3Bucket_Replication (133.83s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (81.06s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation (80.54s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (15.88s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (141.28s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (44.53s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (46.78s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (64.40s)
--- PASS: TestAccAWSS3Bucket_SameRegionReplicationSchemaV2 (54.08s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (15.48s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (110.15s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (146.07s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (62.08s)
--- PASS: TestAccAWSS3Bucket_UpdateGrant (84.61s)
--- PASS: TestAccAWSS3Bucket_Versioning (99.97s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (81.49s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (83.71s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (69.95s)
--- PASS: TestAccAWSS3MultiBucket_withTags (33.46s)
--- PASS: TestAWSS3BucketName (0.00s)
--- PASS: TestBucketRegionalDomainName (0.00s)
--- PASS: TestWebsiteEndpoint (0.00s)
```