### PR TITLE
Fix data.aws_launch_template acceptance test regressions

### DIFF
--- a/aws/data_source_aws_launch_template_test.go
+++ b/aws/data_source_aws_launch_template_test.go
@@ -217,6 +217,8 @@ resource "aws_launch_template" "test" {
 
 data "aws_launch_template" "test" {
   name = aws_launch_template.test.name
+
+  depends_on = [aws_launch_template.test]
 }
 `, rName)
 }
@@ -232,6 +234,8 @@ data "aws_launch_template" "test" {
     name   = "launch-template-name"
     values = [aws_launch_template.test.name]
   }
+
+  depends_on = [aws_launch_template.test]
 }
 `, rName)
 }
@@ -252,6 +256,8 @@ data "aws_launch_template" "test" {
     Name     = aws_launch_template.test.tags["Name"]
     TestSeed = "%[2]d"
   }
+
+  depends_on = [aws_launch_template.test]
 }
 `, rName, rInt)
 }
@@ -270,6 +276,8 @@ resource "aws_launch_template" "test" {
 
 data "aws_launch_template" "test" {
   name = aws_launch_template.test.name
+
+  depends_on = [aws_launch_template.test]
 }
 `, rName)
 }
@@ -286,6 +294,8 @@ resource "aws_launch_template" "test" {
 
 data "aws_launch_template" "test" {
   name = aws_launch_template.test.name
+
+  depends_on = [aws_launch_template.test]
 }
 `, rName, associatePublicIPAddress)
 }
@@ -302,6 +312,8 @@ resource "aws_launch_template" "test" {
 
 data "aws_launch_template" "test" {
   name = aws_launch_template.test.name
+
+  depends_on = [aws_launch_template.test]
 }
 `, rName, deleteOnTermination)
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
NONE
```

This PR fixes some acceptance tests that no longer work as of Terraform v0.13.5.

Original (broken) acceptance testing output:
```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplateDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplateDataSource -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_tags
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_tags
=== RUN   TestAccAWSLaunchTemplateDataSource_metadataOptions
=== PAUSE TestAccAWSLaunchTemplateDataSource_metadataOptions
=== RUN   TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== PAUSE TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== RUN   TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== PAUSE TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== RUN   TestAccAWSLaunchTemplateDataSource_NonExistent
=== PAUSE TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_basic
=== CONT  TestAccAWSLaunchTemplateDataSource_metadataOptions
=== CONT  TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== CONT  TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_tags
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_basic
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (56.05s)
=== CONT  TestAccAWSLaunchTemplateDataSource_basic
    data_source_aws_launch_template_test.go:17: Step 1/1 error: Error running pre-apply plan:
        Error: Launch Template not found


=== CONT  TestAccAWSLaunchTemplateDataSource_metadataOptions
    data_source_aws_launch_template_test.go:110: Step 1/1 error: Error running pre-apply plan:
        Error: Launch Template not found


=== CONT  TestAccAWSLaunchTemplateDataSource_filter_basic
    data_source_aws_launch_template_test.go:41: Step 1/1 error: Error running pre-apply plan:
        Error: error reading launch template: empty output


=== CONT  TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
    data_source_aws_launch_template_test.go:189: Step 1/3 error: Error running pre-apply plan:
        Error: Launch Template not found


=== CONT  TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
    data_source_aws_launch_template_test.go:154: Step 1/3 error: Error running pre-apply plan:
        Error: Launch Template not found


=== CONT  TestAccAWSLaunchTemplateDataSource_filter_tags
    data_source_aws_launch_template_test.go:86: Step 1/1 error: Error running pre-apply plan:
        Error: error reading launch template: empty output


--- FAIL: TestAccAWSLaunchTemplateDataSource_basic (68.69s)
--- FAIL: TestAccAWSLaunchTemplateDataSource_metadataOptions (69.27s)
--- FAIL: TestAccAWSLaunchTemplateDataSource_filter_basic (69.74s)
--- FAIL: TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination (70.05s)
--- FAIL: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (70.12s)
--- FAIL: TestAccAWSLaunchTemplateDataSource_filter_tags (70.35s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	70.445s
FAIL
make: *** [testacc] Error 1
```

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplateDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplateDataSource -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_tags
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_tags
=== RUN   TestAccAWSLaunchTemplateDataSource_metadataOptions
=== PAUSE TestAccAWSLaunchTemplateDataSource_metadataOptions
=== RUN   TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== PAUSE TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== RUN   TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== PAUSE TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== RUN   TestAccAWSLaunchTemplateDataSource_NonExistent
=== PAUSE TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_basic
=== CONT  TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== CONT  TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_tags
=== CONT  TestAccAWSLaunchTemplateDataSource_metadataOptions
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_basic
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (47.99s)
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (118.02s)
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (120.90s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_tags (120.95s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_basic (122.81s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (196.32s)
--- PASS: TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination (199.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	199.146s
```