### PR TITLE
Support Nitro Enclaves in aws_instance and aws_launch_template

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -318,14 +318,11 @@ func dataSourceAwsInstance() *schema.Resource {
 			},
 			"enclave_options": {
 				Type:     schema.TypeList,
-				Optional: true,
 				Computed: true,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
-							Optional: true,
 							Computed: true,
 						},
 					},

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -316,6 +316,21 @@ func dataSourceAwsInstance() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"enclave_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -533,6 +548,10 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 
 	if err := d.Set("metadata_options", flattenEc2InstanceMetadataOptions(instance.MetadataOptions)); err != nil {
 		return fmt.Errorf("error setting metadata_options: %s", err)
+	}
+
+	if err := d.Set("enclave_options", flattenEc2EnclaveOptions(instance.EnclaveOptions)); err != nil {
+		return fmt.Errorf("error setting enclave_options: %s", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -222,6 +222,18 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 					},
 				},
 			},
+			"enclave_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"monitoring": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -496,6 +508,10 @@ func dataSourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) e
 
 	if err := d.Set("metadata_options", flattenLaunchTemplateInstanceMetadataOptions(ltData.MetadataOptions)); err != nil {
 		return fmt.Errorf("error setting metadata_options: %w", err)
+	}
+
+	if err := d.Set("enclave_options", getEnclaveOptions(ltData.EnclaveOptions)); err != nil {
+		return fmt.Errorf("error setting enclave_options: %w", err)
 	}
 
 	if err := d.Set("monitoring", getMonitoring(ltData.Monitoring)); err != nil {

--- a/aws/data_source_aws_launch_template_test.go
+++ b/aws/data_source_aws_launch_template_test.go
@@ -125,6 +125,27 @@ func TestAccAWSLaunchTemplateDataSource_metadataOptions(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplateDataSource_enclaveOptions(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_launch_template.test"
+	resourceName := "aws_launch_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateDataSourceConfig_enclaveOptions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "enclave_options.#", resourceName, "enclave_options.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "enclave_options.0.enabled", resourceName, "enclave_options.0.enabled"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_launch_template.test"
@@ -265,6 +286,22 @@ resource "aws_launch_template" "test" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
+  }
+}
+
+data "aws_launch_template" "test" {
+  name = aws_launch_template.test.name
+}
+`, rName)
+}
+
+func testAccAWSLaunchTemplateDataSourceConfig_enclaveOptions(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  enclave_options {
+    enabled = true
   }
 }
 

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -580,13 +580,14 @@ func resourceAwsInstance() *schema.Resource {
 			"enclave_options": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
-							Default:  false,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 					},

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -5157,10 +5157,6 @@ resource "aws_instance" "test" {
     Name = %[1]q
   }
 }
-
-data "aws_instance" "test" {
-  instance_id = aws_instance.test.id
-}
 `, name, enabled))
 }
 

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -3110,6 +3110,41 @@ func TestAccAWSInstance_metadataOptions(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstance_enclaveOptions(t *testing.T) {
+	var instance1, instance2 ec2.Instance
+	resourceName := "aws_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfigEnclaveOptions(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &instance1),
+					resource.TestCheckResourceAttr(resourceName, "enclave_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enclave_options.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInstanceConfigEnclaveOptions(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &instance2),
+					testAccCheckInstanceRecreated(&instance1, &instance2),
+					resource.TestCheckResourceAttr(resourceName, "enclave_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enclave_options.0.enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckInstanceNotRecreated(t *testing.T,
 	before, after *ec2.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -5100,6 +5135,33 @@ resource "aws_instance" "test" {
   }
 }
 `, rName))
+}
+
+func testAccInstanceConfigEnclaveOptions(enabled bool) string {
+	name := "tf-acc-instance-enclaves"
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAwsInstanceVpcConfig(name, false),
+		testAccAvailableEc2InstanceTypeForRegion("c5a.xlarge", "c5.xlarge"),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  enclave_options {
+    enabled = %[2]t
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_instance" "test" {
+  instance_id = aws_instance.test.id
+}
+`, name, enabled))
 }
 
 func testAccAwsEc2InstanceConfigDynamicEBSBlockDevices() string {

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -399,6 +399,20 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 				},
 			},
 
+			"enclave_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+
 			"monitoring": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -791,6 +805,10 @@ func resourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error setting metadata_options: %s", err)
 	}
 
+	if err := d.Set("enclave_options", getEnclaveOptions(ltData.EnclaveOptions)); err != nil {
+		return fmt.Errorf("error setting enclave_options: %s", err)
+	}
+
 	if err := d.Set("monitoring", getMonitoring(ltData.Monitoring)); err != nil {
 		return fmt.Errorf("error setting monitoring: %s", err)
 	}
@@ -1105,6 +1123,17 @@ func flattenLaunchTemplateInstanceMetadataOptions(opts *ec2.LaunchTemplateInstan
 	return []interface{}{m}
 }
 
+func getEnclaveOptions(m *ec2.LaunchTemplateEnclaveOptions) []interface{} {
+	s := []interface{}{}
+	if m != nil {
+		mo := map[string]interface{}{
+			"enabled": aws.BoolValue(m.Enabled),
+		}
+		s = append(s, mo)
+	}
+	return s
+}
+
 func getMonitoring(m *ec2.LaunchTemplatesMonitoring) []interface{} {
 	s := []interface{}{}
 	if m != nil {
@@ -1371,6 +1400,17 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 
 	if v, ok := d.GetOk("metadata_options"); ok {
 		opts.MetadataOptions = expandLaunchTemplateInstanceMetadataOptions(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("enclave_options"); ok {
+		m := v.([]interface{})
+		if len(m) > 0 && m[0] != nil {
+			mData := m[0].(map[string]interface{})
+			enclaveOptions := &ec2.LaunchTemplateEnclaveOptionsRequest{
+				Enabled: aws.Bool(mData["enabled"].(bool)),
+			}
+			opts.EnclaveOptions = enclaveOptions
+		}
 	}
 
 	if v, ok := d.GetOk("monitoring"); ok {
@@ -1784,6 +1824,7 @@ var updateKeys = []string{
 	"ebs_optimized",
 	"elastic_gpu_specifications",
 	"elastic_inference_accelerator",
+	"enclave_options",
 	"hibernation_options",
 	"iam_instance_profile",
 	"image_id",

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -957,6 +957,46 @@ func TestAccAWSLaunchTemplate_metadataOptions(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_enclaveOptions(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resourceName := "aws_launch_template.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_enclaveOptions(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "enclave_options.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_enclaveOptions(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "enclave_options.0.enabled", "false"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_enclaveOptions(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "enclave_options.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplate_hibernation(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"
@@ -1805,6 +1845,18 @@ resource "aws_launch_template" "test" {
   }
 }
 `, rName)
+}
+
+func testAccAWSLaunchTemplateConfig_enclaveOptions(rName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  enclave_options {
+    enabled = %[2]t
+  }
+}
+`, rName, enabled)
 }
 
 func testAccAWSLaunchTemplateConfigHibernation(rName string, enabled bool) string {

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -119,5 +119,7 @@ interpolation.
     * `http_endpoint` - The state of the metadata service: `enabled`, `disabled`.
     * `http_tokens` - If session tokens are required: `optional`, `required`.
     * `http_put_response_hop_limit` - The desired HTTP PUT response hop limit for instance metadata requests.
+* `enclave_options` - The enclave options of the Instance.
+    * `enabled` - Whether Nitro Enclaves are enabled.
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html

--- a/website/docs/d/launch_template.html.markdown
+++ b/website/docs/d/launch_template.html.markdown
@@ -87,4 +87,6 @@ In addition to all arguments above, the following attributes are exported:
 * `tags` - (Optional) A map of tags to assign to the launch template.
 * `user_data` - The Base64-encoded user data to provide when launching the instance.
 * `hibernation_options` - The hibernation options for the instance.
+* `enclave_options` - The enclave options of the Instance.
+    * `enabled` - Whether Nitro Enclaves are enabled.
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -108,6 +108,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
 * `credit_specification` - (Optional) Customize the credit specification of the instance. See [Credit Specification](#credit-specification) below for more details.
 * `hibernation` - (Optional) If true, the launched EC2 instance will support hibernation.
 * `metadata_options` - (Optional) Customize the metadata options of the instance. See [Metadata Options](#metadata-options) below for more details.
+* `enclave_options` - (Optional) Enable Nitro Enclaves on launched instances. See [Enclave Options](#enclave-options) below for more details.
 
 ### Timeouts
 
@@ -210,6 +211,19 @@ The `metadata_options` block supports the following:
 * `http_put_response_hop_limit` - (Optional) The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from `1` to `64`. (Default: `1`).
 
 For more information, see the documentation on the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+
+### Enclave Options
+
+-> **NOTE:** Changing `enabled` will cause the resource to be destroyed and re-created.
+
+Enclave options apply to the instance at boot time.
+
+The `enclave_options` block supports the following:
+
+* `enabled` - (Optional) Whether Nitro Enclaves will be enabled on the instance. (Default: `"false"`).
+
+For more information, see the documentation on [Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html).
+
 
 ### Example
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -224,7 +224,6 @@ The `enclave_options` block supports the following:
 
 For more information, see the documentation on [Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html).
 
-
 ### Example
 
 ```hcl

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -152,7 +152,6 @@ The following arguments are supported:
 * `hibernation_options` - The hibernation options for the instance. See [Hibernation Options](#hibernation-options) below for more details.
 * `enclave_options` - (Optional) Enable Nitro Enclaves on launched instances. See [Enclave Options](#enclave-options) below for more details.
 
-
 ### Block devices
 
 Configure additional volumes of the instance besides specified by the AMI. It's a good idea to familiarize yourself with

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -150,6 +150,8 @@ The following arguments are supported:
 * `tags` - (Optional) A map of tags to assign to the launch template.
 * `user_data` - The Base64-encoded user data to provide when launching the instance.
 * `hibernation_options` - The hibernation options for the instance. See [Hibernation Options](#hibernation-options) below for more details.
+* `enclave_options` - (Optional) Enable Nitro Enclaves on launched instances. See [Enclave Options](#enclave-options) below for more details.
+
 
 ### Block devices
 
@@ -321,6 +323,14 @@ The `placement` block supports the following:
 The `hibernation_options` block supports the following:
 
 * `configured` - If set to `true`, the launched EC2 instance will hibernation enabled.
+
+### Enclave Options
+
+The `enclave_options` block supports the following:
+
+* `enabled` - If set to `true`, Nitro Enclaves will be enabled on the instance.
+
+For more information, see the documentation on [Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html).
 
 ### Tag Specifications
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #15909.

This PR is largely based upon similar EC2 features like `hibernation` and `metadata_options`. We're already using a modern-enough version of the AWS SDK to get the new enclave-related structs. It's worth noting that Launch Configurations are not supported by Nitro Enclaves, only Launch Templates.

In addition to the acceptance tests, I've done local manual testing to ensure that resource replacement functions as expected. Note that the instance type (`c5{a,}.xlarge`) is relatively expensive, but it's currently the cheapest instance that Nitro Enclaves work on.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
* data/aws_instance: Add support for Nitro Enclaves via `enclave_options` block ([#15909](https://github.com/hashicorp/terraform-provider-aws/issues/15909))
* data/aws_launch_template: Add support for Nitro Enclaves via `enclave_options` block ([#15909](https://github.com/hashicorp/terraform-provider-aws/issues/15909))
* resource/aws_instance: Add support for Nitro Enclaves via `enclave_options` block ([#15909](https://github.com/hashicorp/terraform-provider-aws/issues/15909))
* resource/aws_launch_template: Add support for Nitro Enclaves via `enclave_options` block ([#15909](https://github.com/hashicorp/terraform-provider-aws/issues/15909))
```

Output from acceptance testing against Terraform v0.12.29:
```
$ make testacc TESTARGS='-run=_enclaveOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=_enclaveOptions -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_enclaveOptions
=== PAUSE TestAccAWSInstanceDataSource_enclaveOptions
=== RUN   TestAccAWSLaunchTemplateDataSource_enclaveOptions
=== PAUSE TestAccAWSLaunchTemplateDataSource_enclaveOptions
=== RUN   TestAccAWSInstance_enclaveOptions
=== PAUSE TestAccAWSInstance_enclaveOptions
=== RUN   TestAccAWSLaunchTemplate_enclaveOptions
=== PAUSE TestAccAWSLaunchTemplate_enclaveOptions
=== CONT  TestAccAWSInstanceDataSource_enclaveOptions
=== CONT  TestAccAWSLaunchTemplate_enclaveOptions
=== CONT  TestAccAWSInstance_enclaveOptions
=== CONT  TestAccAWSLaunchTemplateDataSource_enclaveOptions
--- PASS: TestAccAWSLaunchTemplateDataSource_enclaveOptions (64.67s)
--- PASS: TestAccAWSInstanceDataSource_enclaveOptions (126.09s)
--- PASS: TestAccAWSLaunchTemplate_enclaveOptions (156.54s)
--- PASS: TestAccAWSInstance_enclaveOptions (259.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	259.389s
```