### PR TITLE
update the default creation timeout for fsx windows file system

### DIFF
--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -29,7 +29,7 @@ func resourceAwsFsxWindowsFileSystem() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(45 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/website/docs/r/fsx_windows_file_system.html.markdown
+++ b/website/docs/r/fsx_windows_file_system.html.markdown
@@ -98,7 +98,7 @@ In addition to all arguments above, the following attributes are exported:
 `aws_fsx_windows_file_system` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
 configuration options:
 
-* `create` - (Default `30m`) How long to wait for the file system to be created.
+* `create` - (Default `45m`) How long to wait for the file system to be created.
 * `delete` - (Default `30m`) How long to wait for the file system to be deleted.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16315

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
* default timeout for creation of fsx windows file system updated to 45 minutes.

```release-note

```

I could not run the acceptance test because of a VPC limit in my lab.
