### PR TITLE
`aws_ebs_snapshot_import`: init resource

### DIFF
--- a/.changelog/16373.txt
+++ b/.changelog/16373.txt
@@ -1,0 +1,3 @@
+```release-notes:new-resource
+aws_ebs_snapshot_import
+```

--- a/aws/internal/service/ebs/waiter/status.go
+++ b/aws/internal/service/ebs/waiter/status.go
@@ -1,0 +1,40 @@
+package waiter
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
+)
+
+func EbsSnapshotImportStatus(conn *ec2.EC2, importTaskId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		params := &ec2.DescribeImportSnapshotTasksInput{
+			ImportTaskIds: []*string{aws.String(importTaskId)},
+		}
+
+		resp, err := conn.DescribeImportSnapshotTasks(params)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if task := resp.ImportSnapshotTasks[0]; task != nil {
+			detail := task.SnapshotTaskDetail
+			if aws.StringValue(detail.Status) != "" && *detail.Status == tfec2.EbsSnapshotImportDeleting {
+				if aws.StringValue(detail.StatusMessage) != "" {
+					err = fmt.Errorf("Snapshot import task is deleting: %s", aws.StringValue(detail.StatusMessage))
+				} else {
+					err = fmt.Errorf("Snapshot import task is deleting: (no status message provided)")
+				}
+
+			}
+
+			return detail, aws.StringValue(detail.Status), err
+		} else {
+			return nil, "", fmt.Errorf("AWS doesn't know about our import task ID (%s)", importTaskId)
+		}
+
+	}
+}

--- a/aws/internal/service/ebs/waiter/waiter.go
+++ b/aws/internal/service/ebs/waiter/waiter.go
@@ -1,0 +1,31 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
+)
+
+func EbsSnapshotImportCompleted(conn *ec2.EC2, importTaskID string) (*ec2.SnapshotTaskDetail, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{tfec2.EbsSnapshotImportActive,
+			tfec2.EbsSnapshotImportUpdating,
+			tfec2.EbsSnapshotImportValidating,
+			tfec2.EbsSnapshotImportValidated,
+			tfec2.EbsSnapshotImportConverting,
+		},
+		Target:  []string{tfec2.EbsSnapshotImportCompleted},
+		Refresh: EbsSnapshotImportStatus(conn, importTaskID),
+		Timeout: 60 * time.Minute,
+		Delay:   10 * time.Second,
+	}
+
+	detail, err := stateConf.WaitForState()
+	if err != nil {
+		return nil, err
+	} else {
+		return detail.(*ec2.SnapshotTaskDetail), nil
+	}
+}

--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -89,6 +89,18 @@ const (
 	ErrCodeInvalidPermissionNotFound  = "InvalidPermission.NotFound"
 )
 
+// See https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html#check-import-task-status
+const (
+	EbsSnapshotImportActive     = "active"
+	EbsSnapshotImportDeleting   = "deleting"
+	EbsSnapshotImportDeleted    = "deleted"
+	EbsSnapshotImportUpdating   = "updating"
+	EbsSnapshotImportValidating = "validating"
+	EbsSnapshotImportValidated  = "validated"
+	EbsSnapshotImportConverting = "converting"
+	EbsSnapshotImportCompleted  = "completed"
+)
+
 func UnsuccessfulItemError(apiObject *ec2.UnsuccessfulItemError) error {
 	if apiObject == nil {
 		return nil

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -688,6 +688,7 @@ func Provider() *schema.Provider {
 			"aws_ebs_encryption_by_default":                           resourceAwsEbsEncryptionByDefault(),
 			"aws_ebs_snapshot":                                        resourceAwsEbsSnapshot(),
 			"aws_ebs_snapshot_copy":                                   resourceAwsEbsSnapshotCopy(),
+			"aws_ebs_snapshot_import":                                 resourceAwsEbsSnapshotImport(),
 			"aws_ebs_volume":                                          resourceAwsEbsVolume(),
 			"aws_ec2_availability_zone_group":                         resourceAwsEc2AvailabilityZoneGroup(),
 			"aws_ec2_capacity_reservation":                            resourceAwsEc2CapacityReservation(),

--- a/aws/resource_aws_ebs_snapshot_import.go
+++ b/aws/resource_aws_ebs_snapshot_import.go
@@ -1,0 +1,431 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsEbsSnapshotImport() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEbsSnapshotImportCreate,
+		Read:   resourceAwsEbsSnapshotImportRead,
+		Update: resourceAwsEbsSnapshotImportUpdate,
+		Delete: resourceAwsEbsSnapshotImportDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"client_data": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"comment": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"upload_end": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IsRFC3339Time,
+						},
+						"upload_size": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+							ForceNew: true,
+						},
+						"upload_start": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IsRFC3339Time,
+						},
+					},
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ForceNew: true,
+			},
+			"disk_container": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"format": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ec2.DiskImageFormatVmdk,
+								ec2.DiskImageFormatVhd,
+							}, false),
+						},
+						"url": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ExactlyOneOf: []string{"disk_container.0.user_bucket", "disk_container.0.url"},
+						},
+						"user_bucket": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							ForceNew:     true,
+							ExactlyOneOf: []string{"disk_container.0.user_bucket", "disk_container.0.url"},
+							MaxItems:     1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"s3_bucket": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+									"s3_key": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"encrypted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"volume_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"role_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"data_encryption_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsEbsSnapshotImportCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	request := &ec2.ImportSnapshotInput{
+		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeImportSnapshotTask),
+	}
+
+	if v, ok := d.GetOk("client_data"); ok {
+		vL := v.([]interface{})
+		for _, v := range vL {
+			cdv := v.(map[string]interface{})
+			client_data := &ec2.ClientData{}
+
+			if v, ok := cdv["comment"].(string); ok {
+				client_data.Comment = aws.String(v)
+			}
+
+			if v, ok := cdv["upload_end"].(string); ok {
+				upload_end, err := time.Parse(time.RFC3339, v)
+				if err != nil {
+					return fmt.Errorf("error parsing upload_end to timestamp: %s", err)
+				}
+				client_data.UploadEnd = aws.Time(upload_end)
+			}
+
+			if v, ok := cdv["upload_size"].(float64); ok {
+				client_data.UploadSize = aws.Float64(v)
+			}
+
+			if v, ok := cdv["upload_start"].(string); ok {
+				upload_start, err := time.Parse(time.RFC3339, v)
+				if err != nil {
+					return fmt.Errorf("error parsing upload_start to timestamp: %s", err)
+				}
+				client_data.UploadStart = aws.Time(upload_start)
+			}
+
+			request.ClientData = client_data
+		}
+	}
+
+	request.ClientToken = aws.String(resource.UniqueId())
+
+	if v, ok := d.GetOk("description"); ok {
+		request.Description = aws.String(v.(string))
+	}
+
+	v := d.Get("disk_container")
+	vL := v.([]interface{})
+	for _, v := range vL {
+		dcv := v.(map[string]interface{})
+		disk_container := &ec2.SnapshotDiskContainer{
+			Format: aws.String(dcv["format"].(string)),
+		}
+
+		if v, ok := dcv["description"].(string); ok {
+			disk_container.Description = aws.String(v)
+		}
+
+		if v, ok := dcv["url"].(string); ok && v != "" {
+			disk_container.Url = aws.String(v)
+		}
+
+		if v, ok := dcv["user_bucket"]; ok {
+			vL := v.([]interface{})
+			for _, v := range vL {
+				ub := v.(map[string]interface{})
+				disk_container.UserBucket = &ec2.UserBucket{
+					S3Bucket: aws.String(ub["s3_bucket"].(string)),
+					S3Key:    aws.String(ub["s3_key"].(string)),
+				}
+			}
+		}
+
+		request.DiskContainer = disk_container
+	}
+
+	if v, ok := d.GetOk("encrypted"); ok {
+		request.Encrypted = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		request.KmsKeyId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("role_name"); ok {
+		request.RoleName = aws.String(v.(string))
+	}
+
+	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		var resp *ec2.ImportSnapshotOutput
+		resp, err := conn.ImportSnapshot(request)
+		// Error: InvalidParameter: The service role terraform-20201121225356951800000001 provided does not exist or does not have sufficient permissions
+		// status code: 400, request id: b0abc3d2-5b59-4e5c-b748-c1cb084020c0
+
+		if isAWSErr(err, "InvalidParameter", "provided does not exist or does not have sufficient permissions") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		importTaskId := aws.StringValue(resp.ImportTaskId)
+
+		res, err := importAwsEbsSnapshotWaiter(conn, importTaskId)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error waiting for snapshot (%s) to be imported: %s", d.Id(), err))
+		}
+
+		d.SetId(aws.StringValue(res.SnapshotId))
+
+		if err := keyvaluetags.Ec2CreateTags(conn, d.Id(), d.Get("tags").(map[string]interface{})); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("error setting tags: %s", err))
+		}
+
+		err = resourceAwsEbsSnapshotImportRead(d, meta)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		return fmt.Errorf("timeout error importing EBS Snapshot: %s", err)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error importing EBS Snapshot: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsEbsSnapshotImportRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	req := &ec2.DescribeSnapshotsInput{
+		SnapshotIds: []*string{aws.String(d.Id())},
+	}
+	res, err := conn.DescribeSnapshots(req)
+	if err != nil {
+		if isAWSErr(err, "InvalidSnapshot.NotFound", "") {
+			log.Printf("[WARN] EBS Snapshot %q Not found - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	if len(res.Snapshots) == 0 {
+		log.Printf("[WARN] EBS Snapshot %q Not found - removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	snapshot := res.Snapshots[0]
+
+	d.Set("description", snapshot.Description)
+	d.Set("owner_id", snapshot.OwnerId)
+	d.Set("encrypted", snapshot.Encrypted)
+	d.Set("owner_alias", snapshot.OwnerAlias)
+	d.Set("data_encryption_key_id", snapshot.DataEncryptionKeyId)
+	d.Set("kms_key_id", snapshot.KmsKeyId)
+	d.Set("volume_size", snapshot.VolumeSize)
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(snapshot.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	snapshotArn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("snapshot/%s", d.Id()),
+		Service:   "ec2",
+	}.String()
+
+	d.Set("arn", snapshotArn)
+
+	return nil
+}
+
+func resourceAwsEbsSnapshotImportUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	return resourceAwsEbsSnapshotImportRead(d, meta)
+}
+
+func resourceAwsEbsSnapshotImportDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	input := &ec2.DeleteSnapshotInput{
+		SnapshotId: aws.String(d.Id()),
+	}
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, err := conn.DeleteSnapshot(input)
+		if err == nil {
+			return nil
+		}
+		if isAWSErr(err, "SnapshotInUse", "") {
+			return resource.RetryableError(fmt.Errorf("EBS SnapshotInUse - trying again while it detaches"))
+		}
+		return resource.NonRetryableError(err)
+	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteSnapshot(input)
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting EBS snapshot: %s", err)
+	}
+	return nil
+}
+
+func importAwsEbsSnapshotWaiter(conn *ec2.EC2, importTaskID string) (*ec2.SnapshotTaskDetail, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{tfec2.EbsSnapshotImportActive,
+			tfec2.EbsSnapshotImportUpdating,
+			tfec2.EbsSnapshotImportValidating,
+			tfec2.EbsSnapshotImportValidated,
+			tfec2.EbsSnapshotImportConverting,
+		},
+		Target:  []string{tfec2.EbsSnapshotImportCompleted},
+		Refresh: importAwsEbsSnapshotRefreshFunc(conn, importTaskID),
+		Timeout: 60 * time.Minute,
+		Delay:   10 * time.Second,
+	}
+
+	detail, err := stateConf.WaitForState()
+	if err != nil {
+		return nil, err
+	} else {
+		return detail.(*ec2.SnapshotTaskDetail), nil
+	}
+}
+
+func importAwsEbsSnapshotRefreshFunc(conn *ec2.EC2, importTaskId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		params := &ec2.DescribeImportSnapshotTasksInput{
+			ImportTaskIds: []*string{aws.String(importTaskId)},
+		}
+
+		resp, err := conn.DescribeImportSnapshotTasks(params)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if task := resp.ImportSnapshotTasks[0]; task != nil {
+			detail := task.SnapshotTaskDetail
+			if detail.Status != nil && *detail.Status == "deleting" {
+				if detail.StatusMessage != nil {
+					err = fmt.Errorf("Snapshot import task is deleting: %s", *detail.StatusMessage)
+				} else {
+					err = fmt.Errorf("Snapshot import task is deleting: (no status message provided)")
+				}
+
+			}
+
+			return detail, aws.StringValue(detail.Status), err
+		} else {
+			return nil, "", fmt.Errorf("AWS doesn't know about our import task ID (%s)", importTaskId)
+		}
+
+	}
+}

--- a/aws/resource_aws_ebs_snapshot_import_test.go
+++ b/aws/resource_aws_ebs_snapshot_import_test.go
@@ -1,0 +1,218 @@
+package aws
+
+import (
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSEBSSnapshotImport_basic(t *testing.T) {
+	var v ec2.Snapshot
+	rName := fmt.Sprintf("tf-acc-ebs-snapshot-import-basic-%s", acctest.RandString(7))
+	resourceName := "aws_ebs_snapshot_import.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEbsSnapshotImportDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEbsSnapshotImportConfigBasic(rName, t),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotImportExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSnapshotImportExists(n string, v *ec2.Snapshot) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		request := &ec2.DescribeSnapshotsInput{
+			SnapshotIds: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		response, err := conn.DescribeSnapshots(request)
+		if err == nil {
+			if response.Snapshots != nil && len(response.Snapshots) > 0 {
+				*v = *response.Snapshots[0]
+				return nil
+			}
+		}
+		return fmt.Errorf("Error finding EC2 Snapshot %s", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSEbsSnapshotImportDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ebs_snapshot_import" {
+			continue
+		}
+		input := &ec2.DescribeSnapshotsInput{
+			SnapshotIds: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		output, err := conn.DescribeSnapshots(input)
+		if err != nil {
+			if isAWSErr(err, "InvalidSnapshot.NotFound", "") {
+				continue
+			}
+			return err
+		}
+		if output != nil && len(output.Snapshots) > 0 && aws.StringValue(output.Snapshots[0].SnapshotId) == rs.Primary.ID {
+			return fmt.Errorf("EBS Snapshot %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccAwsEbsSnapshotImportConfigBasic(rName string, t *testing.T) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "images" {
+  bucket_prefix = "images-"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_object" "image" {
+  bucket         = aws_s3_bucket.images.id
+  key            = "diskimage.vhd"
+  content_base64 = %[1]q
+}
+
+# The following resources are for the *vmimport service user*
+# See: https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role
+resource "aws_iam_role" "vmimport" {
+  assume_role_policy = data.aws_iam_policy_document.vmimport-trust.json
+}
+
+resource "aws_iam_role_policy" "vmimport-access" {
+  role   = aws_iam_role.vmimport.id
+  policy = data.aws_iam_policy_document.vmimport-access.json
+}
+
+data "aws_iam_policy_document" "vmimport-access" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.images.arn,
+      "${aws_s3_bucket.images.arn}/*"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:ModifySnapshotAttribute",
+      "ec2:CopySnapshot",
+      "ec2:RegisterImage",
+      "ec2:Describe*"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+}
+
+
+data "aws_iam_policy_document" "vmimport-trust" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["vmie.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = ["vmimport"]
+    }
+  }
+}
+
+resource "aws_ebs_snapshot_import" "test" {
+  disk_container {
+    description = %[2]q
+    format      = "VHD"
+    user_bucket {
+      s3_bucket = aws_s3_bucket.images.id
+      s3_key    = aws_s3_bucket_object.image.key
+    }
+  }
+
+  role_name = aws_iam_role.vmimport.name
+
+  timeouts {
+    create = "10m"
+    delete = "10m"
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testAccAwsEbsSnapshotDisk(t), rName)
+}
+func testAccAwsEbsSnapshotDisk(t *testing.T) string {
+	// Take a compressed then base64'd disk image,
+	// base64 decode, then decompress, then re-base64
+	// the image, so it can be uploaded to s3.
+
+	// little vmdk built by:
+	// $ VBoxManage createmedium disk --filename ./image.vhd --sizebytes 512 --format vhd
+	// $ cat image.vhd | gzip --best | base64
+	b64_compressed := "H4sIAAAAAAACA0vOz0tNLsmsYGBgYGJgZIACJgZ1789hZUn5FQxsDIzhmUbZMHEEzSIIJJj///+QlV1rMXFVnLzHwteXYmWDDfYxjIIhA5IrigsSi4pT/0MBRJSNAZoWGBkUGBj+//9SNhpSo2AUDD+AyPOjYESW/6P1/4gGAAvDpVcACgAA"
+
+	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64_compressed))
+
+	zr, err := gzip.NewReader(decoder)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	encoder := base64.NewEncoder(base64.StdEncoding, &out)
+
+	_, err = io.Copy(encoder, zr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoder.Close()
+
+	return out.String()
+}

--- a/aws/resource_aws_ebs_snapshot_import_test.go
+++ b/aws/resource_aws_ebs_snapshot_import_test.go
@@ -23,6 +23,7 @@ func TestAccAWSEBSSnapshotImport_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEbsSnapshotImportDestroy,
 		Steps: []resource.TestStep{
@@ -47,6 +48,7 @@ func TestAccAWSEBSSnapshotImport_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEbsSnapshotImportDestroy,
 		Steps: []resource.TestStep{
@@ -92,6 +94,7 @@ func TestAccAWSEBSSnapshotImport_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEbsSnapshotImportDestroy,
 		Steps: []resource.TestStep{
@@ -118,6 +121,7 @@ func TestAccAWSEBSSnapshotImport_disappears_S3BucketObject(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEbsSnapshotImportDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ebs_snapshot_import_test.go
+++ b/aws/resource_aws_ebs_snapshot_import_test.go
@@ -269,7 +269,7 @@ data "aws_iam_policy_document" "vmimport-trust" {
 }
 
 func testAccAwsEbsSnapshotImportConfigBasic(rName string, t *testing.T) string {
-	return testAccAwsEbsSnapshotImportConfig_Base(t) + fmt.Sprintf(`
+	return composeConfig(testAccAwsEbsSnapshotImportConfig_Base(t), fmt.Sprintf(`
 resource "aws_ebs_snapshot_import" "test" {
   disk_container {
     description = %[1]q
@@ -287,11 +287,11 @@ resource "aws_ebs_snapshot_import" "test" {
     delete = "10m"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAwsEbsSnapshotImportConfigTags1(rName string, t *testing.T, tagKey1 string, tagValue1 string) string {
-	return testAccAwsEbsSnapshotImportConfig_Base(t) + fmt.Sprintf(`
+	return composeConfig(testAccAwsEbsSnapshotImportConfig_Base(t), fmt.Sprintf(`
 resource "aws_ebs_snapshot_import" "test" {
   disk_container {
     description = %[1]q
@@ -313,11 +313,11 @@ resource "aws_ebs_snapshot_import" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccAwsEbsSnapshotImportConfigTags2(rName string, t *testing.T, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
-	return testAccAwsEbsSnapshotImportConfig_Base(t) + fmt.Sprintf(`
+	return composeConfig(testAccAwsEbsSnapshotImportConfig_Base(t), fmt.Sprintf(`
 resource "aws_ebs_snapshot_import" "test" {
   disk_container {
     description = %[1]q
@@ -340,7 +340,7 @@ resource "aws_ebs_snapshot_import" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccAwsEbsSnapshotDisk(t *testing.T) string {

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -1,0 +1,84 @@
+---
+subcategory: "EC2"
+layout: "aws"
+page_title: "AWS: aws_ebs_snapshot_import"
+description: |-
+  Provides an elastic block storage snapshot import resource.
+---
+
+# Resource: aws_ebs_snapshot_import
+
+Imports a disk image from S3 as a Snapshot.
+
+## Example Usage
+
+```hcl
+resource "aws_ebs_snapshot_import" "example" {
+  disk_container {
+    format = "VHD"
+    user_bucket {
+      s3_bucket = "disk-images"
+      s3_key    = "source.vhd"
+    }
+  }
+
+  role_name = "disk-image-import"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}
+```
+
+## Argument Reference
+
+
+The following arguments are supported:
+
+* `client_data` - (Optional) The client-specific data. Detailed below.
+* `description` - (Optional) A description of what the snapshot is.
+* `disk_container` - (Required) Information about the disk container. Detailed below.
+* `encrypted` - (Optional) Whether the snapshot is encrypted.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key.
+* `role_name` - (Optional) The name of the IAM Role the VM Import/Export service will assume. This role needs certain permissions. See https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role. Default: `vmimport`
+* `tags` - (Optional) A map of tags to assign to the snapshot
+
+### client_data Configuration Block
+
+* `comment` - (Optional) A user-defined comment about the disk upload.
+* `upload_start` - (Optional) The time that the disk upload starts.
+* `upload_end` - (Optional) The time that the disk upload ends.
+* `upload_size` - (Optional) The size of the uploaded disk image, in GiB.
+
+### disk_container Configuration Block
+
+* `description` - (Optional) The description of the disk image being imported.
+* `format` - (Required) The format of the disk image being imported. One of `VHD` or `VMDK`.
+* `url` - (Optional) The URL to the Amazon S3-based disk image being imported. It can either be a https URL (https://..) or an Amazon S3 URL (s3://..). One of `url` or `user_bucket` must be set.
+* `user_bucket` - (Optional) The Amazon S3 bucket for the disk image. One of `url` or `user_bucket` must be set. Detailed below.
+
+### user_bucket Configuration Block
+
+* `s3_bucket` - The name of the Amazon S3 bucket where the disk image is located.
+* `s3_key` - The file name of the disk image.
+
+### Timeouts
+
+`aws_ebs_snapshot_import` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `60 minutes`) Used for importing the EBS snapshot
+- `delete` - (Default `10 minutes`) Used for deleting the EBS snapshot
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the EBS Snapshot.
+* `id` - The snapshot ID (e.g. snap-59fcb34e).
+* `owner_id` - The AWS account ID of the EBS snapshot owner.
+* `owner_alias` - Value from an Amazon-maintained list (`amazon`, `aws-marketplace`, `microsoft`) of snapshot owners.
+* `volume_size` - The size of the drive in GiBs.
+* `data_encryption_key_id` - The data encryption key identifier for the snapshot.
+* `tags` - A map of tags for the snapshot.
+

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -12,7 +12,7 @@ Imports a disk image from S3 as a Snapshot.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "aws_ebs_snapshot_import" "example" {
   disk_container {
     format = "VHD"

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -36,12 +36,12 @@ resource "aws_ebs_snapshot_import" "example" {
 The following arguments are supported:
 
 * `client_data` - (Optional) The client-specific data. Detailed below.
-* `description` - (Optional) A description of what the snapshot is.
+* `description` - (Optional) The description string for the import snapshot task.
 * `disk_container` - (Required) Information about the disk container. Detailed below.
-* `encrypted` - (Optional) Whether the snapshot is encrypted.
-* `kms_key_id` - (Optional) The ARN for the KMS encryption key.
+* `encrypted` - (Optional) Specifies whether the destination snapshot of the imported image should be encrypted. The default KMS key for EBS is used unless you specify a non-default KMS key using KmsKeyId.
+* `kms_key_id` - (Optional) An identifier for the symmetric KMS key to use when creating the encrypted snapshot. This parameter is only required if you want to use a non-default KMS key; if this parameter is not specified, the default KMS key for EBS is used. If a KmsKeyId is specified, the Encrypted flag must also be set.
 * `role_name` - (Optional) The name of the IAM Role the VM Import/Export service will assume. This role needs certain permissions. See https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role. Default: `vmimport`
-* `tags` - (Optional) A map of tags to assign to the snapshot
+* `tags` - (Optional) A map of tags to assign to the snapshot.
 
 ### client_data Configuration Block
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** aws_ebs_snapshot_import  (#16373)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ time make fmt testacc TESTARGS='-run=TestAccAWSEBSSnapshotImport'
==> Fixing source code with gofmt...
gofmt -s -w ./aws ./awsproviderlint/helper ./awsproviderlint/main.go ./awsproviderlint/passes
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEBSSnapshotImport -timeout 120m
=== RUN   TestAccAWSEBSSnapshotImport_basic
=== PAUSE TestAccAWSEBSSnapshotImport_basic
=== CONT  TestAccAWSEBSSnapshotImport_basic
--- PASS: TestAccAWSEBSSnapshotImport_basic (625.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.694s

real	12m33.506s
user	2m43.535s
sys	2m7.373s

```


---

I don't feel incredibly comfortable that the code I wrote is good or totally right, but I gave it my best. I'm not much of a Go programmer, and started with the ebs_snapshot resource. Note I didn't add support for importing, because it seems the data around the import parameters are "Disappeared" once the import task completes.

My use case here is combining aws_ebs_snapshot_import with aws_ami and aws_ami_copy to upload, register, and distribute AMIs to a variety of regions. I use Terraform to support the pruning of images over time.