### PR TITLE
tests/route53: Skip PublicDNS tests

### DIFF
--- a/aws/data_source_aws_route53_delegation_set_test.go
+++ b/aws/data_source_aws_route53_delegation_set_test.go
@@ -13,7 +13,7 @@ func TestAccAWSRoute53DelegationSetDataSource_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
-		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck: testAccErrorCheckSkipRoute53(t),
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_route53_delegation_set_test.go
+++ b/aws/data_source_aws_route53_delegation_set_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceRoute53DelegationSet_basic(t *testing.T) {
+func TestAccAWSRoute53DataSourceDelegationSet_basic(t *testing.T) {
 	dataSourceName := "data.aws_route53_delegation_set.dset"
 	resourceName := "aws_route53_delegation_set.dset"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDataSourceAWSRoute53DelegationSetConfig_basic,

--- a/aws/data_source_aws_route53_delegation_set_test.go
+++ b/aws/data_source_aws_route53_delegation_set_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSRoute53DataSourceDelegationSet_basic(t *testing.T) {
+func TestAccAWSRoute53DelegationSetDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_route53_delegation_set.dset"
 	resourceName := "aws_route53_delegation_set.dset"
 

--- a/aws/data_source_aws_route53_resolver_endpoint_test.go
+++ b/aws/data_source_aws_route53_resolver_endpoint_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSRoute53DataSourceResolverEndpoint_Basic(t *testing.T) {
+func TestAccAWSRoute53ResolverEndpointDataSource_Basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	rInt := acctest.RandInt()
 	direction := "INBOUND"
@@ -38,7 +38,7 @@ func TestAccAWSRoute53DataSourceResolverEndpoint_Basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53DataSourceResolverEndpoint_Filter(t *testing.T) {
+func TestAccAWSRoute53ResolverEndpointDataSource_Filter(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	rInt := acctest.RandInt()
 	direction := "OUTBOUND"

--- a/aws/data_source_aws_route53_resolver_endpoint_test.go
+++ b/aws/data_source_aws_route53_resolver_endpoint_test.go
@@ -75,7 +75,7 @@ resource "aws_vpc" "foo" {
   enable_dns_hostnames = true
 
   tags = {
-    Name = "terraform-testacc-r53-resolver-vpc-%d"
+    Name = "terraform-testacc-r53-resolver-vpc-%[1]d"
   }
 }
 
@@ -85,7 +85,7 @@ resource "aws_subnet" "sn1" {
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "tf-acc-r53-resolver-sn1-%d"
+    Name = "tf-acc-r53-resolver-sn1-%[1]d"
   }
 }
 
@@ -95,7 +95,7 @@ resource "aws_subnet" "sn2" {
   availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
-    Name = "tf-acc-r53-resolver-sn2-%d"
+    Name = "tf-acc-r53-resolver-sn2-%[1]d"
   }
 }
 
@@ -105,28 +105,28 @@ resource "aws_subnet" "sn3" {
   availability_zone = data.aws_availability_zones.available.names[2]
 
   tags = {
-    Name = "tf-acc-r53-resolver-sn3-%d"
+    Name = "tf-acc-r53-resolver-sn3-%[1]d"
   }
 }
 
 resource "aws_security_group" "sg1" {
   vpc_id = aws_vpc.foo.id
-  name   = "tf-acc-r53-resolver-sg1-%d"
+  name   = "tf-acc-r53-resolver-sg1-%[1]d"
 
   tags = {
-    Name = "tf-acc-r53-resolver-sg1-%d"
+    Name = "tf-acc-r53-resolver-sg1-%[1]d"
   }
 }
 
 resource "aws_security_group" "sg2" {
   vpc_id = aws_vpc.foo.id
-  name   = "tf-acc-r53-resolver-sg2-%d"
+  name   = "tf-acc-r53-resolver-sg2-%[1]d"
 
   tags = {
-    Name = "tf-acc-r53-resolver-sg2-%d"
+    Name = "tf-acc-r53-resolver-sg2-%[1]d"
   }
 }
-`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+`, rInt)
 }
 
 func testAccDataSourceRoute53ResolverEndpointConfig_initial(rInt int, direction, name string) string {

--- a/aws/data_source_aws_route53_resolver_endpoint_test.go
+++ b/aws/data_source_aws_route53_resolver_endpoint_test.go
@@ -18,7 +18,7 @@ func TestAccAWSRoute53ResolverEndpointDataSource_Basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
-		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck: testAccErrorCheckSkipRoute53(t),
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -47,7 +47,7 @@ func TestAccAWSRoute53ResolverEndpointDataSource_Filter(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
-		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck: testAccErrorCheckSkipRoute53(t),
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_route53_resolver_endpoint_test.go
+++ b/aws/data_source_aws_route53_resolver_endpoint_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceAwsRoute53ResolverEndpoint_Basic(t *testing.T) {
+func TestAccAWSRoute53DataSourceResolverEndpoint_Basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	rInt := acctest.RandInt()
 	direction := "INBOUND"
@@ -17,8 +17,9 @@ func TestAccDataSourceAwsRoute53ResolverEndpoint_Basic(t *testing.T) {
 	datasourceName := "data.aws_route53_resolver_endpoint.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistent,
@@ -37,7 +38,7 @@ func TestAccDataSourceAwsRoute53ResolverEndpoint_Basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRoute53ResolverEndpoint_Filter(t *testing.T) {
+func TestAccAWSRoute53DataSourceResolverEndpoint_Filter(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	rInt := acctest.RandInt()
 	direction := "OUTBOUND"
@@ -45,8 +46,9 @@ func TestAccDataSourceAwsRoute53ResolverEndpoint_Filter(t *testing.T) {
 	datasourceName := "data.aws_route53_resolver_endpoint.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceAwsRoute53ResolverEndpointConfig_NonExistentFilter,

--- a/aws/data_source_aws_route53_resolver_rule_test.go
+++ b/aws/data_source_aws_route53_resolver_rule_test.go
@@ -18,7 +18,7 @@ func TestAccAWSRoute53ResolverRuleDataSource_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck: testAccErrorCheckSkipRoute53(t),
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -69,7 +69,7 @@ func TestAccAWSRoute53ResolverRuleDataSource_ResolverEndpointIdWithTags(t *testi
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck: testAccErrorCheckSkipRoute53(t),
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -106,7 +106,7 @@ func TestAccAWSRoute53ResolverRuleDataSource_SharedByMe(t *testing.T) {
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSRoute53Resolver(t)
 		},
-		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:        testAccErrorCheckSkipRoute53(t),
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		Steps: []resource.TestStep{
 			{
@@ -144,7 +144,7 @@ func TestAccAWSRoute53ResolverRuleDataSource_SharedWithMe(t *testing.T) {
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSRoute53Resolver(t)
 		},
-		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:        testAccErrorCheckSkipRoute53(t),
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_route53_resolver_rule_test.go
+++ b/aws/data_source_aws_route53_resolver_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestAccDataSourceAwsRoute53ResolverRule_basic(t *testing.T) {
+func TestAccAWSRoute53DataSourceResolverRule_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_resolver_rule.example"
 	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_rule_id"
@@ -17,8 +17,9 @@ func TestAccDataSourceAwsRoute53ResolverRule_basic(t *testing.T) {
 	ds3ResourceName := "data.aws_route53_resolver_rule.by_name_and_rule_type"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsRoute53ResolverRule_basic(rName),
@@ -61,14 +62,15 @@ func TestAccDataSourceAwsRoute53ResolverRule_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags(t *testing.T) {
+func TestAccAWSRoute53DataSourceResolverRule_ResolverEndpointIdWithTags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_resolver_rule.example"
 	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsRoute53ResolverRule_resolverEndpointIdWithTags(rName),
@@ -92,7 +94,7 @@ func TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags(t *testi
 	})
 }
 
-func TestAccDataSourceAwsRoute53ResolverRule_SharedByMe(t *testing.T) {
+func TestAccAWSRoute53DataSourceResolverRule_SharedByMe(t *testing.T) {
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_resolver_rule.example"
@@ -104,6 +106,7 @@ func TestAccDataSourceAwsRoute53ResolverRule_SharedByMe(t *testing.T) {
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSRoute53Resolver(t)
 		},
+		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		Steps: []resource.TestStep{
 			{
@@ -129,7 +132,7 @@ func TestAccDataSourceAwsRoute53ResolverRule_SharedByMe(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe(t *testing.T) {
+func TestAccAWSRoute53DataSourceResolverRule_SharedWithMe(t *testing.T) {
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_resolver_rule.example"
@@ -141,6 +144,7 @@ func TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe(t *testing.T) {
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSRoute53Resolver(t)
 		},
+		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_route53_resolver_rule_test.go
+++ b/aws/data_source_aws_route53_resolver_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestAccAWSRoute53DataSourceResolverRule_basic(t *testing.T) {
+func TestAccAWSRoute53ResolverRuleDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_resolver_rule.example"
 	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_rule_id"
@@ -62,7 +62,7 @@ func TestAccAWSRoute53DataSourceResolverRule_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53DataSourceResolverRule_ResolverEndpointIdWithTags(t *testing.T) {
+func TestAccAWSRoute53ResolverRuleDataSource_ResolverEndpointIdWithTags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_resolver_rule.example"
 	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
@@ -94,7 +94,7 @@ func TestAccAWSRoute53DataSourceResolverRule_ResolverEndpointIdWithTags(t *testi
 	})
 }
 
-func TestAccAWSRoute53DataSourceResolverRule_SharedByMe(t *testing.T) {
+func TestAccAWSRoute53ResolverRuleDataSource_SharedByMe(t *testing.T) {
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_resolver_rule.example"
@@ -132,7 +132,7 @@ func TestAccAWSRoute53DataSourceResolverRule_SharedByMe(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53DataSourceResolverRule_SharedWithMe(t *testing.T) {
+func TestAccAWSRoute53ResolverRuleDataSource_SharedWithMe(t *testing.T) {
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_resolver_rule.example"

--- a/aws/data_source_aws_route53_resolver_rules_test.go
+++ b/aws/data_source_aws_route53_resolver_rules_test.go
@@ -13,7 +13,7 @@ func TestAccAWSRoute53ResolverRulesDataSource_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck: testAccErrorCheckSkipRoute53(t),
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -36,7 +36,7 @@ func TestAccAWSRoute53ResolverRulesDataSource_ResolverEndpointId(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck: testAccErrorCheckSkipRoute53(t),
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_route53_resolver_rules_test.go
+++ b/aws/data_source_aws_route53_resolver_rules_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceAwsRoute53ResolverRules_basic(t *testing.T) {
+func TestAccAWSRoute53DataSourceResolverRules_basic(t *testing.T) {
 	dsResourceName := "data.aws_route53_resolver_rules.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -26,7 +26,7 @@ func TestAccDataSourceAwsRoute53ResolverRules_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId(t *testing.T) {
+func TestAccAWSRoute53DataSourceResolverRules_ResolverEndpointId(t *testing.T) {
 	rName1 := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
 	rName2 := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
 	ds1ResourceName := "data.aws_route53_resolver_rules.by_resolver_endpoint_id"
@@ -34,8 +34,9 @@ func TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId(t *testing.T) {
 	ds3ResourceName := "data.aws_route53_resolver_rules.by_invalid_owner_id"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsRoute53ResolverRules_resolverEndpointId(rName1, rName2),

--- a/aws/data_source_aws_route53_resolver_rules_test.go
+++ b/aws/data_source_aws_route53_resolver_rules_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSRoute53DataSourceResolverRules_basic(t *testing.T) {
+func TestAccAWSRoute53ResolverRulesDataSource_basic(t *testing.T) {
 	dsResourceName := "data.aws_route53_resolver_rules.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck: func(err error) error { return testAccSkipErrorCheck(err, t) },
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsRoute53ResolverRules_basic,
@@ -26,7 +27,7 @@ func TestAccAWSRoute53DataSourceResolverRules_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53DataSourceResolverRules_ResolverEndpointId(t *testing.T) {
+func TestAccAWSRoute53ResolverRulesDataSource_ResolverEndpointId(t *testing.T) {
 	rName1 := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
 	rName2 := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
 	ds1ResourceName := "data.aws_route53_resolver_rules.by_resolver_endpoint_id"

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceAwsRoute53Zone_id(t *testing.T) {
+func TestAccAWSRoute53DataSourceZone_id(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -32,13 +33,14 @@ func TestAccDataSourceAwsRoute53Zone_id(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRoute53Zone_name(t *testing.T) {
+func TestAccAWSRoute53DataSourceZone_name(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -55,13 +57,14 @@ func TestAccDataSourceAwsRoute53Zone_name(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRoute53Zone_tags(t *testing.T) {
+func TestAccAWSRoute53DataSourceZone_tags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -78,13 +81,14 @@ func TestAccDataSourceAwsRoute53Zone_tags(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRoute53Zone_vpc(t *testing.T) {
+func TestAccAWSRoute53DataSourceZone_vpc(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -101,13 +105,14 @@ func TestAccDataSourceAwsRoute53Zone_vpc(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRoute53Zone_serviceDiscovery(t *testing.T) {
+func TestAccAWSRoute53DataSourceZone_serviceDiscovery(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_service_discovery_private_dns_namespace.test"
 	dataSourceName := "data.aws_route53_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(servicediscovery.EndpointsID, t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSRoute53DataSourceZone_id(t *testing.T) {
+func TestAccAWSRoute53ZoneDataSource_id(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
@@ -33,7 +33,7 @@ func TestAccAWSRoute53DataSourceZone_id(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53DataSourceZone_name(t *testing.T) {
+func TestAccAWSRoute53ZoneDataSource_name(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
@@ -57,7 +57,7 @@ func TestAccAWSRoute53DataSourceZone_name(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53DataSourceZone_tags(t *testing.T) {
+func TestAccAWSRoute53ZoneDataSource_tags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
@@ -81,7 +81,7 @@ func TestAccAWSRoute53DataSourceZone_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53DataSourceZone_vpc(t *testing.T) {
+func TestAccAWSRoute53ZoneDataSource_vpc(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_route53_zone.test"
 	dataSourceName := "data.aws_route53_zone.test"
@@ -105,7 +105,7 @@ func TestAccAWSRoute53DataSourceZone_vpc(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53DataSourceZone_serviceDiscovery(t *testing.T) {
+func TestAccAWSRoute53ZoneDataSource_serviceDiscovery(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_service_discovery_private_dns_namespace.test"
 	dataSourceName := "data.aws_route53_zone.test"

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -131,7 +131,7 @@ func TestAccAWSRoute53ZoneDataSource_serviceDiscovery(t *testing.T) {
 func testAccDataSourceAwsRoute53ZoneConfigId(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "test" {
-  name = "terraformtestacchz-%[1]d.com."
+  name = "terraformtestacchz-%d.com."
 }
 
 data "aws_route53_zone" "test" {
@@ -143,7 +143,7 @@ data "aws_route53_zone" "test" {
 func testAccDataSourceAwsRoute53ZoneConfigName(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "test" {
-  name = "terraformtestacchz-%[1]d.com."
+  name = "terraformtestacchz-%d.com."
 }
 
 data "aws_route53_zone" "test" {

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -16,7 +16,7 @@ func TestAccAWSRoute53ZoneDataSource_id(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -40,7 +40,7 @@ func TestAccAWSRoute53ZoneDataSource_name(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -64,7 +64,7 @@ func TestAccAWSRoute53ZoneDataSource_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -88,7 +88,7 @@ func TestAccAWSRoute53ZoneDataSource_vpc(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -112,7 +112,7 @@ func TestAccAWSRoute53ZoneDataSource_serviceDiscovery(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(servicediscovery.EndpointsID, t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -131,7 +131,7 @@ func TestAccAWSRoute53ZoneDataSource_serviceDiscovery(t *testing.T) {
 func testAccDataSourceAwsRoute53ZoneConfigId(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "test" {
-  name = "terraformtestacchz-%d.com."
+  name = "terraformtestacchz-%[1]d.com."
 }
 
 data "aws_route53_zone" "test" {
@@ -143,7 +143,7 @@ data "aws_route53_zone" "test" {
 func testAccDataSourceAwsRoute53ZoneConfigName(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_route53_zone" "test" {
-  name = "terraformtestacchz-%d.com."
+  name = "terraformtestacchz-%[1]d.com."
 }
 
 data "aws_route53_zone" "test" {

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -973,19 +973,21 @@ func testAccCheckWithProviders(f func(*terraform.State, *schema.Provider) error,
 	}
 }
 
-// Skip tests based on error messages that indicate unsupported features
-func testAccSkipErrorCheck(err error, t *testing.T) error {
-	if err != nil {
-		if strings.Contains(err.Error(), "Operations related to PublicDNS") {
-			t.Skipf("skipping test; this partition (%s) does not support PublicDNS operations", testAccGetPartition())
+// testAccErrorCheckSkipMessagesContaining skips tests based on error messages that indicate unsupported features
+func testAccErrorCheckSkipMessagesContaining(t *testing.T, messages ...string) resource.ErrorCheckFunc {
+	return func(err error) error {
+		if err == nil {
+			return err
 		}
 
-		if strings.Contains(err.Error(), "Regional control plane current does not support ") {
-			t.Skipf("skipping test; this region (%s) does not support latency health check", testAccGetRegion())
+		for _, message := range messages {
+			if strings.Contains(err.Error(), message) {
+				t.Skipf("skipping test for %s/%s: %s", testAccGetPartition(), testAccGetRegion(), err.Error())
+			}
 		}
+
+		return err
 	}
-
-	return err
 }
 
 // Check service API call error for reasons to skip acceptance testing

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -973,11 +973,6 @@ func testAccCheckWithProviders(f func(*terraform.State, *schema.Provider) error,
 	}
 }
 
-const (
-	// Alternate partitions may not support Public DNS and this error results
-	providerPublicDNSErrorMessage = "Operations related to PublicDNS are not supported in this aws partition"
-)
-
 // Skip tests based on error messages that indicate unsupported features
 func testAccSkipErrorCheck(err error, t *testing.T) error {
 	if err != nil {

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -973,6 +973,26 @@ func testAccCheckWithProviders(f func(*terraform.State, *schema.Provider) error,
 	}
 }
 
+const (
+	// Alternate partitions may not support Public DNS and this error results
+	providerPublicDNSErrorMessage = "Operations related to PublicDNS are not supported in this aws partition"
+)
+
+// Skip tests based on error messages that indicate unsupported features
+func testAccSkipErrorCheck(err error, t *testing.T) error {
+	if err != nil {
+		if strings.Contains(err.Error(), "Operations related to PublicDNS") {
+			t.Skipf("skipping test; this partition (%s) does not support PublicDNS operations", testAccGetPartition())
+		}
+
+		if strings.Contains(err.Error(), "Regional control plane current does not support ") {
+			t.Skipf("skipping test; this region (%s) does not support latency health check", testAccGetRegion())
+		}
+	}
+
+	return err
+}
+
 // Check service API call error for reasons to skip acceptance testing
 // These include missing API endpoints and unsupported API calls
 func testAccPreCheckSkipError(err error) bool {

--- a/aws/resource_aws_route53_delegation_set_test.go
+++ b/aws/resource_aws_route53_delegation_set_test.go
@@ -19,6 +19,7 @@ func TestAccAWSRoute53DelegationSet_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"reference_name"},
 		Providers:       testAccProviders,
@@ -51,6 +52,7 @@ func TestAccAWSRoute53DelegationSet_withZones(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"reference_name"},
 		Providers:       testAccProviders,

--- a/aws/resource_aws_route53_delegation_set_test.go
+++ b/aws/resource_aws_route53_delegation_set_test.go
@@ -19,7 +19,7 @@ func TestAccAWSRoute53DelegationSet_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:      testAccErrorCheckSkipRoute53(t),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"reference_name"},
 		Providers:       testAccProviders,
@@ -52,7 +52,7 @@ func TestAccAWSRoute53DelegationSet_withZones(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:      testAccErrorCheckSkipRoute53(t),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"reference_name"},
 		Providers:       testAccProviders,

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -15,6 +15,7 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
@@ -51,6 +52,7 @@ func TestAccAWSRoute53HealthCheck_tags(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
@@ -94,6 +96,7 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
@@ -128,6 +131,7 @@ func TestAccAWSRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -151,6 +155,7 @@ func TestAccAWSRoute53HealthCheck_withHealthCheckRegions(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -175,6 +180,7 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -199,6 +205,7 @@ func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -227,6 +234,7 @@ func TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -251,6 +259,7 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
@@ -291,6 +300,7 @@ func TestAccAWSRoute53HealthCheck_Disabled(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -329,6 +339,7 @@ func TestAccAWSRoute53HealthCheck_disappears(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -455,7 +455,7 @@ resource "aws_route53_health_check" "test" {
   invert_healthcheck = true
 
   tags = {
-    %[1]q = %[2]q
+    %q = %q
   }
 }
 `, tag1Key, tag1Value)
@@ -474,8 +474,8 @@ resource "aws_route53_health_check" "test" {
   invert_healthcheck = true
 
   tags = {
-    %[1]q = %[2]q
-    %[3]q = %[4]q
+    %q = %q
+    %q = %q
   }
 }
 `, tag1Key, tag1Value, tagKey2, tagValue2)
@@ -690,7 +690,7 @@ resource "aws_route53_health_check" "test" {
 func testAccRoute53HealthCheckConfigDisabled(disabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_route53_health_check" "test" {
-  disabled          = %[1]t
+  disabled          = %t
   failure_threshold = "2"
   fqdn              = "dev.notexample.com"
   port              = 80

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -15,7 +15,7 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
@@ -52,7 +52,7 @@ func TestAccAWSRoute53HealthCheck_tags(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
@@ -96,7 +96,7 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
@@ -131,7 +131,7 @@ func TestAccAWSRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -155,7 +155,7 @@ func TestAccAWSRoute53HealthCheck_withHealthCheckRegions(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -180,7 +180,7 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -205,7 +205,7 @@ func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -234,7 +234,7 @@ func TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -259,7 +259,7 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
@@ -300,7 +300,7 @@ func TestAccAWSRoute53HealthCheck_Disabled(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
@@ -339,7 +339,7 @@ func TestAccAWSRoute53HealthCheck_disappears(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -455,7 +455,7 @@ resource "aws_route53_health_check" "test" {
   invert_healthcheck = true
 
   tags = {
-    %q = %q
+    %[1]q = %[2]q
   }
 }
 `, tag1Key, tag1Value)
@@ -474,8 +474,8 @@ resource "aws_route53_health_check" "test" {
   invert_healthcheck = true
 
   tags = {
-    %q = %q
-    %q = %q
+    %[1]q = %[2]q
+    %[3]q = %[4]q
   }
 }
 `, tag1Key, tag1Value, tagKey2, tagValue2)
@@ -690,7 +690,7 @@ resource "aws_route53_health_check" "test" {
 func testAccRoute53HealthCheckConfigDisabled(disabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_route53_health_check" "test" {
-  disabled          = %t
+  disabled          = %[1]t
   failure_threshold = "2"
   fqdn              = "dev.notexample.com"
   port              = 80

--- a/aws/resource_aws_route53_query_log_test.go
+++ b/aws/resource_aws_route53_query_log_test.go
@@ -76,6 +76,7 @@ func TestAccAWSRoute53QueryLog_basic(t *testing.T) {
 	var queryLoggingConfig route53.QueryLoggingConfig
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckRoute53QueryLog(t) },
+		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckRoute53QueryLogDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_query_log_test.go
+++ b/aws/resource_aws_route53_query_log_test.go
@@ -76,7 +76,7 @@ func TestAccAWSRoute53QueryLog_basic(t *testing.T) {
 	var queryLoggingConfig route53.QueryLoggingConfig
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckRoute53QueryLog(t) },
-		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:        testAccErrorCheckSkipRoute53(t),
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckRoute53QueryLogDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -109,6 +109,7 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -135,6 +136,7 @@ func TestAccAWSRoute53Record_underscored(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -161,6 +163,7 @@ func TestAccAWSRoute53Record_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -183,6 +186,7 @@ func TestAccAWSRoute53Record_disappears_MultipleRecords(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -209,6 +213,7 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -250,6 +255,7 @@ func TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -276,6 +282,7 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"zone_id"}, // just for this test
 		Providers:       testAccProviders,
@@ -303,6 +310,7 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -330,6 +338,7 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -357,6 +366,7 @@ func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -383,6 +393,7 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -417,6 +428,7 @@ func TestAccAWSRoute53Record_failover(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -444,6 +456,7 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: "aws_route53_record.www-live",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -472,6 +485,7 @@ func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -505,6 +519,7 @@ func TestAccAWSRoute53Record_Alias_Elb(t *testing.T) {
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElb, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -532,6 +547,7 @@ func TestAccAWSRoute53Record_Alias_S3(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -558,6 +574,7 @@ func TestAccAWSRoute53Record_Alias_VpcEndpoint(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -589,6 +606,7 @@ func TestAccAWSRoute53Record_Alias_Uppercase(t *testing.T) {
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElbUppercase, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -615,6 +633,7 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -652,6 +671,7 @@ func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -680,6 +700,7 @@ func TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -712,6 +733,7 @@ func TestAccAWSRoute53Record_HealthCheckId_TypeChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -744,6 +766,7 @@ func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -771,6 +794,7 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -805,6 +829,7 @@ func TestAccAWSRoute53Record_NameChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -840,6 +865,7 @@ func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -874,6 +900,7 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -908,6 +935,7 @@ func TestAccAWSRoute53Record_empty(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -929,6 +957,7 @@ func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -955,6 +984,7 @@ func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -981,6 +1011,7 @@ func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -1245,7 +1245,7 @@ resource "aws_route53_record" "default" {
 resource "aws_route53_record" "overwriting" {
   depends_on = [aws_route53_record.default]
 
-  allow_overwrite = %t
+  allow_overwrite = %[1]t
   zone_id         = aws_route53_zone.main.zone_id
   name            = "www.notexample.com"
   type            = "A"
@@ -1728,7 +1728,7 @@ resource "aws_route53_zone" "main" {
 }
 
 resource "aws_s3_bucket" "website" {
-  bucket = %q
+  bucket = %[1]q
   acl    = "public-read"
 
   website {
@@ -1771,7 +1771,7 @@ resource "aws_route53_record" "test" {
   health_check_id = aws_route53_health_check.test.id
   name            = "test"
   records         = ["127.0.0.1"]
-  set_identifier  = %q
+  set_identifier  = %[1]q
   ttl             = "5"
   type            = "A"
 

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -109,7 +109,7 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -136,7 +136,7 @@ func TestAccAWSRoute53Record_underscored(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -163,7 +163,7 @@ func TestAccAWSRoute53Record_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -186,7 +186,7 @@ func TestAccAWSRoute53Record_disappears_MultipleRecords(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -213,7 +213,7 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -255,7 +255,7 @@ func TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -282,7 +282,7 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:      testAccErrorCheckSkipRoute53(t),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"zone_id"}, // just for this test
 		Providers:       testAccProviders,
@@ -310,7 +310,7 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -338,7 +338,7 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -366,7 +366,7 @@ func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -393,7 +393,7 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -428,7 +428,7 @@ func TestAccAWSRoute53Record_failover(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -456,7 +456,7 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: "aws_route53_record.www-live",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -485,7 +485,7 @@ func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -519,7 +519,7 @@ func TestAccAWSRoute53Record_Alias_Elb(t *testing.T) {
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElb, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -547,7 +547,7 @@ func TestAccAWSRoute53Record_Alias_S3(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -574,7 +574,7 @@ func TestAccAWSRoute53Record_Alias_VpcEndpoint(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -606,7 +606,7 @@ func TestAccAWSRoute53Record_Alias_Uppercase(t *testing.T) {
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElbUppercase, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -633,7 +633,7 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -671,7 +671,7 @@ func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -700,7 +700,7 @@ func TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -733,7 +733,7 @@ func TestAccAWSRoute53Record_HealthCheckId_TypeChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -766,7 +766,7 @@ func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -794,7 +794,7 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -829,7 +829,7 @@ func TestAccAWSRoute53Record_NameChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -865,7 +865,7 @@ func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -900,7 +900,7 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -935,7 +935,7 @@ func TestAccAWSRoute53Record_empty(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -957,7 +957,7 @@ func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -984,7 +984,7 @@ func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -1005,26 +1005,10 @@ func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
 	})
 }
 
-// Skip tests based on error messages that indicate unsupported features
-func testAccAWSRoute53RecordOverwriteExpectErrorCheck(err error, t *testing.T) error {
-	err = testAccSkipErrorCheck(err, t)
-
-	if err == nil {
-		t.Fatalf("Expected an error but got none")
-	}
-
-	re := regexp.MustCompile(`Tried to create resource record set \[name='www.notexample.com.', type='A'] but it already exists`)
-	if !re.MatchString(err.Error()) {
-		t.Fatalf("Expected an error with pattern, no match on: %s", err)
-	}
-
-	return nil
-}
-
 func TestAccAWSRoute53Record_doNotAllowOverwrite(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccAWSRoute53RecordOverwriteExpectErrorCheck(err, t) },
+		ErrorCheck:   testAccAWSRoute53RecordOverwriteExpectErrorCheck(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -1041,7 +1025,7 @@ func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -1057,6 +1041,32 @@ func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testAccErrorCheckSkipRoute53 skips Route53 tests that have error messages indicating unsupported features
+func testAccErrorCheckSkipRoute53(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"Operations related to PublicDNS",
+		"Regional control plane current does not support",
+	)
+}
+
+func testAccAWSRoute53RecordOverwriteExpectErrorCheck(t *testing.T) resource.ErrorCheckFunc {
+	return func(err error) error {
+		f := testAccErrorCheckSkipRoute53(t)
+		err = f(err)
+
+		if err == nil {
+			t.Fatalf("Expected an error but got none")
+		}
+
+		re := regexp.MustCompile(`Tried to create resource record set \[name='www.notexample.com.', type='A'] but it already exists`)
+		if !re.MatchString(err.Error()) {
+			t.Fatalf("Expected an error with pattern, no match on: %s", err)
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckRoute53RecordDestroy(s *terraform.State) error {

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -1761,7 +1761,7 @@ resource "aws_route53_record" "test" {
   health_check_id = aws_route53_health_check.test.id
   name            = "test"
   records         = ["127.0.0.1"]
-  set_identifier  = %[1]q
+  set_identifier  = %q
   ttl             = "5"
   type            = "A"
 

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -82,6 +82,7 @@ func TestAccAwsRoute53ResolverEndpoint_basicInbound(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverEndpointDestroy,
 		Steps: []resource.TestStep{
@@ -114,6 +115,7 @@ func TestAccAwsRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverEndpointDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -219,7 +219,7 @@ resource "aws_vpc" "foo" {
   enable_dns_hostnames = true
 
   tags = {
-    Name = "terraform-testacc-r53-resolver-vpc-%d"
+    Name = "terraform-testacc-r53-resolver-vpc-%[1]d"
   }
 }
 
@@ -238,7 +238,7 @@ resource "aws_subnet" "sn1" {
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "tf-acc-r53-resolver-sn1-%d"
+    Name = "tf-acc-r53-resolver-sn1-%[1]d"
   }
 }
 
@@ -248,7 +248,7 @@ resource "aws_subnet" "sn2" {
   availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
-    Name = "tf-acc-r53-resolver-sn2-%d"
+    Name = "tf-acc-r53-resolver-sn2-%[1]d"
   }
 }
 
@@ -258,28 +258,28 @@ resource "aws_subnet" "sn3" {
   availability_zone = data.aws_availability_zones.available.names[2]
 
   tags = {
-    Name = "tf-acc-r53-resolver-sn3-%d"
+    Name = "tf-acc-r53-resolver-sn3-%[1]d"
   }
 }
 
 resource "aws_security_group" "sg1" {
   vpc_id = aws_vpc.foo.id
-  name   = "tf-acc-r53-resolver-sg1-%d"
+  name   = "tf-acc-r53-resolver-sg1-%[1]d"
 
   tags = {
-    Name = "tf-acc-r53-resolver-sg1-%d"
+    Name = "tf-acc-r53-resolver-sg1-%[1]d"
   }
 }
 
 resource "aws_security_group" "sg2" {
   vpc_id = aws_vpc.foo.id
-  name   = "tf-acc-r53-resolver-sg2-%d"
+  name   = "tf-acc-r53-resolver-sg2-%[1]d"
 
   tags = {
-    Name = "tf-acc-r53-resolver-sg2-%d"
+    Name = "tf-acc-r53-resolver-sg2-%[1]d"
   }
 }
-`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+`, rInt)
 }
 
 func testAccRoute53ResolverEndpointConfig_initial(rInt int, direction, name string) string {

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -82,7 +82,7 @@ func TestAccAWSRoute53ResolverEndpoint_basicInbound(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverEndpointDestroy,
 		Steps: []resource.TestStep{
@@ -115,7 +115,7 @@ func TestAccAWSRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverEndpointDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -74,7 +74,7 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 	return errors
 }
 
-func TestAccAwsRoute53ResolverEndpoint_basicInbound(t *testing.T) {
+func TestAccAWSRoute53ResolverEndpoint_basicInbound(t *testing.T) {
 	var ep route53resolver.ResolverEndpoint
 	resourceName := "aws_route53_resolver_endpoint.foo"
 	rInt := acctest.RandInt()
@@ -106,7 +106,7 @@ func TestAccAwsRoute53ResolverEndpoint_basicInbound(t *testing.T) {
 	})
 }
 
-func TestAccAwsRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
+func TestAccAWSRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 	var ep route53resolver.ResolverEndpoint
 	resourceName := "aws_route53_resolver_endpoint.foo"
 	rInt := acctest.RandInt()

--- a/aws/resource_aws_route53_resolver_query_log_config_association_test.go
+++ b/aws/resource_aws_route53_resolver_query_log_config_association_test.go
@@ -72,6 +72,7 @@ func TestAccAWSRoute53ResolverQueryLogConfigAssociation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -99,6 +100,7 @@ func TestAccAWSRoute53ResolverQueryLogConfigAssociation_disappears(t *testing.T)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_query_log_config_association_test.go
+++ b/aws/resource_aws_route53_resolver_query_log_config_association_test.go
@@ -72,7 +72,7 @@ func TestAccAWSRoute53ResolverQueryLogConfigAssociation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -100,7 +100,7 @@ func TestAccAWSRoute53ResolverQueryLogConfigAssociation_disappears(t *testing.T)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_query_log_config_test.go
+++ b/aws/resource_aws_route53_resolver_query_log_config_test.go
@@ -74,6 +74,7 @@ func TestAccAWSRoute53ResolverQueryLogConfig_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigDestroy,
 		Steps: []resource.TestStep{
@@ -104,6 +105,7 @@ func TestAccAWSRoute53ResolverQueryLogConfig_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigDestroy,
 		Steps: []resource.TestStep{
@@ -127,6 +129,7 @@ func TestAccAWSRoute53ResolverQueryLogConfig_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_query_log_config_test.go
+++ b/aws/resource_aws_route53_resolver_query_log_config_test.go
@@ -74,7 +74,7 @@ func TestAccAWSRoute53ResolverQueryLogConfig_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigDestroy,
 		Steps: []resource.TestStep{
@@ -105,7 +105,7 @@ func TestAccAWSRoute53ResolverQueryLogConfig_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigDestroy,
 		Steps: []resource.TestStep{
@@ -129,7 +129,7 @@ func TestAccAWSRoute53ResolverQueryLogConfig_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverQueryLogConfigDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_rule_association_test.go
+++ b/aws/resource_aws_route53_resolver_rule_association_test.go
@@ -76,7 +76,7 @@ func testSweepRoute53ResolverRuleAssociations(region string) error {
 	return errors
 }
 
-func TestAccAwsRoute53ResolverRuleAssociation_basic(t *testing.T) {
+func TestAccAWSRoute53ResolverRuleAssociation_basic(t *testing.T) {
 	var assn route53resolver.ResolverRuleAssociation
 	resourceNameVpc := "aws_vpc.example"
 	resourceNameRule := "aws_route53_resolver_rule.example"

--- a/aws/resource_aws_route53_resolver_rule_association_test.go
+++ b/aws/resource_aws_route53_resolver_rule_association_test.go
@@ -85,7 +85,7 @@ func TestAccAWSRoute53ResolverRuleAssociation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_rule_association_test.go
+++ b/aws/resource_aws_route53_resolver_rule_association_test.go
@@ -85,6 +85,7 @@ func TestAccAwsRoute53ResolverRuleAssociation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -591,7 +591,7 @@ resource "aws_vpc" "foo" {
   enable_dns_hostnames = true
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
@@ -610,7 +610,7 @@ resource "aws_subnet" "sn1" {
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "%s_1"
+    Name = "%[1]s_1"
   }
 }
 
@@ -620,7 +620,7 @@ resource "aws_subnet" "sn2" {
   availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
-    Name = "%s_2"
+    Name = "%[1]s_2"
   }
 }
 
@@ -630,37 +630,37 @@ resource "aws_subnet" "sn3" {
   availability_zone = data.aws_availability_zones.available.names[2]
 
   tags = {
-    Name = "%s_3"
+    Name = "%[1]s_3"
   }
 }
 
 resource "aws_security_group" "sg1" {
   vpc_id = aws_vpc.foo.id
-  name   = "%s_1"
+  name   = "%[1]s_1"
 
   tags = {
-    Name = "%s_1"
+    Name = "%[1]s_1"
   }
 }
 
 resource "aws_security_group" "sg2" {
   vpc_id = aws_vpc.foo.id
-  name   = "%s_2"
+  name   = "%[1]s_2"
 
   tags = {
-    Name = "%s_2"
+    Name = "%[1]s_2"
   }
 }
-`, name, name, name, name, name, name, name, name)
+`, name)
 }
 
 func testAccRoute53ResolverRuleConfig_resolverEndpoint(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "aws_route53_resolver_endpoint" "foo" {
   direction = "OUTBOUND"
-  name      = "%s_1"
+  name      = "%[2]s_1"
 
   security_group_ids = [
     aws_security_group.sg1.id,
@@ -677,7 +677,7 @@ resource "aws_route53_resolver_endpoint" "foo" {
 
 resource "aws_route53_resolver_endpoint" "bar" {
   direction = "OUTBOUND"
-  name      = "%s_2"
+  name      = "%[2]s_2"
 
   security_group_ids = [
     aws_security_group.sg1.id,
@@ -691,16 +691,16 @@ resource "aws_route53_resolver_endpoint" "bar" {
     subnet_id = aws_subnet.sn3.id
   }
 }
-`, testAccRoute53ResolverRuleConfig_resolverVpc(name), name, name)
+`, testAccRoute53ResolverRuleConfig_resolverVpc(name), name)
 }
 
 func testAccRoute53ResolverRuleConfig_resolverEndpointRecreate(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "aws_route53_resolver_endpoint" "foo" {
   direction = "OUTBOUND"
-  name      = "%s_1"
+  name      = "%[2]s_1"
 
   security_group_ids = [
     aws_security_group.sg2.id,
@@ -717,7 +717,7 @@ resource "aws_route53_resolver_endpoint" "foo" {
 
 resource "aws_route53_resolver_endpoint" "bar" {
   direction = "OUTBOUND"
-  name      = "%s_2"
+  name      = "%[2]s_2"
 
   security_group_ids = [
     aws_security_group.sg1.id,
@@ -731,5 +731,5 @@ resource "aws_route53_resolver_endpoint" "bar" {
     subnet_id = aws_subnet.sn3.id
   }
 }
-`, testAccRoute53ResolverRuleConfig_resolverVpc(name), name, name)
+`, testAccRoute53ResolverRuleConfig_resolverVpc(name), name)
 }

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -80,7 +80,7 @@ func testSweepRoute53ResolverRules(region string) error {
 	return errors
 }
 
-func TestAccAwsRoute53ResolverRule_basic(t *testing.T) {
+func TestAccAWSRoute53ResolverRule_basic(t *testing.T) {
 	var rule route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
 
@@ -110,7 +110,7 @@ func TestAccAwsRoute53ResolverRule_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsRoute53ResolverRule_justDotDomainName(t *testing.T) {
+func TestAccAWSRoute53ResolverRule_justDotDomainName(t *testing.T) {
 	var rule route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
 
@@ -140,7 +140,7 @@ func TestAccAwsRoute53ResolverRule_justDotDomainName(t *testing.T) {
 	})
 }
 
-func TestAccAwsRoute53ResolverRule_trailingDotDomainName(t *testing.T) {
+func TestAccAWSRoute53ResolverRule_trailingDotDomainName(t *testing.T) {
 	var rule route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
 
@@ -170,7 +170,7 @@ func TestAccAwsRoute53ResolverRule_trailingDotDomainName(t *testing.T) {
 	})
 }
 
-func TestAccAwsRoute53ResolverRule_tags(t *testing.T) {
+func TestAccAWSRoute53ResolverRule_tags(t *testing.T) {
 	var rule route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
 
@@ -221,7 +221,7 @@ func TestAccAwsRoute53ResolverRule_tags(t *testing.T) {
 	})
 }
 
-func TestAccAwsRoute53ResolverRule_updateName(t *testing.T) {
+func TestAccAWSRoute53ResolverRule_updateName(t *testing.T) {
 	var rule1, rule2 route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
 	name1 := fmt.Sprintf("terraform-testacc-r53-resolver-%d", acctest.RandInt())
@@ -261,7 +261,7 @@ func TestAccAwsRoute53ResolverRule_updateName(t *testing.T) {
 	})
 }
 
-func TestAccAwsRoute53ResolverRule_forward(t *testing.T) {
+func TestAccAWSRoute53ResolverRule_forward(t *testing.T) {
 	var rule1, rule2, rule3 route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
 	resourceNameEp1 := "aws_route53_resolver_endpoint.foo"
@@ -338,7 +338,7 @@ func TestAccAwsRoute53ResolverRule_forward(t *testing.T) {
 	})
 }
 
-func TestAccAwsRoute53ResolverRule_forwardEndpointRecreate(t *testing.T) {
+func TestAccAWSRoute53ResolverRule_forwardEndpointRecreate(t *testing.T) {
 	var rule1, rule2 route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
 	resourceNameEp := "aws_route53_resolver_endpoint.foo"

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -86,7 +86,7 @@ func TestAccAWSRoute53ResolverRule_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -116,7 +116,7 @@ func TestAccAWSRoute53ResolverRule_justDotDomainName(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -146,7 +146,7 @@ func TestAccAWSRoute53ResolverRule_trailingDotDomainName(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -176,7 +176,7 @@ func TestAccAWSRoute53ResolverRule_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -229,7 +229,7 @@ func TestAccAWSRoute53ResolverRule_updateName(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -270,7 +270,7 @@ func TestAccAWSRoute53ResolverRule_forward(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -346,7 +346,7 @@ func TestAccAWSRoute53ResolverRule_forwardEndpointRecreate(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -86,6 +86,7 @@ func TestAccAwsRoute53ResolverRule_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -115,6 +116,7 @@ func TestAccAwsRoute53ResolverRule_justDotDomainName(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -144,6 +146,7 @@ func TestAccAwsRoute53ResolverRule_trailingDotDomainName(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -173,6 +176,7 @@ func TestAccAwsRoute53ResolverRule_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -225,6 +229,7 @@ func TestAccAwsRoute53ResolverRule_updateName(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -265,6 +270,7 @@ func TestAccAwsRoute53ResolverRule_forward(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -340,6 +346,7 @@ func TestAccAwsRoute53ResolverRule_forwardEndpointRecreate(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_vpc_association_authorization_test.go
+++ b/aws/resource_aws_route53_vpc_association_authorization_test.go
@@ -20,7 +20,7 @@ func TestAccAWSRoute53VpcAssociationAuthorization_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:        testAccErrorCheckSkipRoute53(t),
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53VPCAssociationAuthorizationDestroy,
 		Steps: []resource.TestStep{
@@ -49,7 +49,7 @@ func TestAccAWSRoute53VpcAssociationAuthorization_disappears(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:        testAccErrorCheckSkipRoute53(t),
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53VPCAssociationAuthorizationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_vpc_association_authorization_test.go
+++ b/aws/resource_aws_route53_vpc_association_authorization_test.go
@@ -20,6 +20,7 @@ func TestAccAWSRoute53VpcAssociationAuthorization_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
+		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53VPCAssociationAuthorizationDestroy,
 		Steps: []resource.TestStep{
@@ -48,6 +49,7 @@ func TestAccAWSRoute53VpcAssociationAuthorization_disappears(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
+		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53VPCAssociationAuthorizationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -110,6 +110,7 @@ func TestAccAWSRoute53ZoneAssociation_CrossAccount(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
+		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -141,6 +142,7 @@ func TestAccAWSRoute53ZoneAssociation_CrossRegion(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
 		},
+		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -14,7 +14,7 @@ func TestAccAWSRoute53ZoneAssociation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -38,7 +38,7 @@ func TestAccAWSRoute53ZoneAssociation_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -60,7 +60,7 @@ func TestAccAWSRoute53ZoneAssociation_disappears_VPC(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -82,7 +82,7 @@ func TestAccAWSRoute53ZoneAssociation_disappears_Zone(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -110,7 +110,7 @@ func TestAccAWSRoute53ZoneAssociation_CrossAccount(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:        testAccErrorCheckSkipRoute53(t),
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -142,7 +142,7 @@ func TestAccAWSRoute53ZoneAssociation_CrossRegion(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ErrorCheck:        func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:        testAccErrorCheckSkipRoute53(t),
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -14,6 +14,7 @@ func TestAccAWSRoute53ZoneAssociation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -37,6 +38,7 @@ func TestAccAWSRoute53ZoneAssociation_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -58,6 +60,7 @@ func TestAccAWSRoute53ZoneAssociation_disappears_VPC(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -79,6 +82,7 @@ func TestAccAWSRoute53ZoneAssociation_disappears_Zone(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -82,6 +82,7 @@ func TestAccAWSRoute53Zone_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -114,6 +115,7 @@ func TestAccAWSRoute53Zone_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -134,6 +136,7 @@ func TestAccAWSRoute53Zone_multiple(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -165,6 +168,7 @@ func TestAccAWSRoute53Zone_Comment(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -202,6 +206,7 @@ func TestAccAWSRoute53Zone_DelegationSetID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -231,6 +236,7 @@ func TestAccAWSRoute53Zone_ForceDestroy(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -256,6 +262,7 @@ func TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -281,6 +288,7 @@ func TestAccAWSRoute53Zone_Tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -329,6 +337,7 @@ func TestAccAWSRoute53Zone_VPC_Single(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -361,6 +370,7 @@ func TestAccAWSRoute53Zone_VPC_Multiple(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -394,6 +404,7 @@ func TestAccAWSRoute53Zone_VPC_Updates(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -82,7 +82,7 @@ func TestAccAWSRoute53Zone_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -115,7 +115,7 @@ func TestAccAWSRoute53Zone_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -136,7 +136,7 @@ func TestAccAWSRoute53Zone_multiple(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -168,7 +168,7 @@ func TestAccAWSRoute53Zone_Comment(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -206,7 +206,7 @@ func TestAccAWSRoute53Zone_DelegationSetID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -236,7 +236,7 @@ func TestAccAWSRoute53Zone_ForceDestroy(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -262,7 +262,7 @@ func TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -288,7 +288,7 @@ func TestAccAWSRoute53Zone_Tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -337,7 +337,7 @@ func TestAccAWSRoute53Zone_VPC_Single(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -370,7 +370,7 @@ func TestAccAWSRoute53Zone_VPC_Multiple(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
@@ -404,7 +404,7 @@ func TestAccAWSRoute53Zone_VPC_Updates(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -704,7 +704,7 @@ resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
@@ -712,12 +712,12 @@ resource "aws_vpc" "test2" {
   cidr_block = "10.2.0.0/16"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_route53_zone" "test" {
-  name = "%s."
+  name = "%[2]s."
 
   vpc {
     vpc_id = aws_vpc.test1.id
@@ -727,5 +727,5 @@ resource "aws_route53_zone" "test" {
     vpc_id = aws_vpc.test2.id
   }
 }
-`, rName, rName, zoneName)
+`, rName, zoneName)
 }

--- a/aws/resource_aws_shield_protection_test.go
+++ b/aws/resource_aws_shield_protection_test.go
@@ -18,7 +18,11 @@ func TestAccAWSShieldProtection_GlobalAccelerator(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSShield(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(shield.EndpointsID, t)
+			testAccPreCheckAWSShield(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSShieldProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -42,7 +46,11 @@ func TestAccAWSShieldProtection_ElasticIPAddress(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSShield(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(shield.EndpointsID, t)
+			testAccPreCheckAWSShield(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSShieldProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -66,7 +74,11 @@ func TestAccAWSShieldProtection_Alb(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSShield(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(shield.EndpointsID, t)
+			testAccPreCheckAWSShield(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSShieldProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -90,7 +102,11 @@ func TestAccAWSShieldProtection_Elb(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSShield(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(shield.EndpointsID, t)
+			testAccPreCheckAWSShield(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSShieldProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -116,6 +132,7 @@ func TestAccAWSShieldProtection_Cloudfront(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(shield.EndpointsID, t)
 			testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t)
 			testAccPreCheckAWSShield(t)
 		},
@@ -144,7 +161,7 @@ func TestAccAWSShieldProtection_Route53(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t)
+			testAccPartitionHasServicePreCheck(shield.EndpointsID, t)
 			testAccPreCheckAWSShield(t)
 		},
 		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },

--- a/aws/resource_aws_shield_protection_test.go
+++ b/aws/resource_aws_shield_protection_test.go
@@ -142,7 +142,12 @@ func TestAccAWSShieldProtection_Route53(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSShield(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t)
+			testAccPreCheckAWSShield(t)
+		},
+		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSShieldProtectionDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_shield_protection_test.go
+++ b/aws/resource_aws_shield_protection_test.go
@@ -164,7 +164,7 @@ func TestAccAWSShieldProtection_Route53(t *testing.T) {
 			testAccPartitionHasServicePreCheck(shield.EndpointsID, t)
 			testAccPreCheckAWSShield(t)
 		},
-		ErrorCheck:   func(err error) error { return testAccSkipErrorCheck(err, t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSShieldProtectionDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15332

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Test query string: `TestAccAWSRoute53|TestAccAWSShieldProtection`

### Prior to this PR (GovCloud)

53 FAIL, 38 PASS, 3 SKIP
```
--- FAIL: TestAccAWSRoute53DelegationSet_basic (4.52s)
--- FAIL: TestAccAWSRoute53DelegationSet_withZones (5.12s)
--- FAIL: TestAccAWSRoute53HealthCheck_basic (4.62s)
--- FAIL: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (7.28s)
--- FAIL: TestAccAWSRoute53HealthCheck_disappears (4.50s)
--- FAIL: TestAccAWSRoute53HealthCheck_tags (4.51s)
--- FAIL: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (4.29s)
--- FAIL: TestAccAWSRoute53HealthCheck_withSearchString (4.57s)
--- FAIL: TestAccAWSRoute53HealthCheck_withSNI (4.69s)
--- FAIL: TestAccAWSRoute53Record_Alias_Elb (11.10s)
--- FAIL: TestAccAWSRoute53Record_Alias_S3 (8.47s)
--- FAIL: TestAccAWSRoute53Record_Alias_Uppercase (8.63s)
--- FAIL: TestAccAWSRoute53Record_Alias_VpcEndpoint (403.08s)
--- FAIL: TestAccAWSRoute53Record_AliasChange (7.67s)
--- FAIL: TestAccAWSRoute53Record_allowOverwrite (3.97s)
--- FAIL: TestAccAWSRoute53Record_basic (4.77s)
--- FAIL: TestAccAWSRoute53Record_basic_fqdn (5.21s)
--- FAIL: TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID (4.73s)
--- FAIL: TestAccAWSRoute53Record_caaSupport (4.84s)
--- FAIL: TestAccAWSRoute53Record_disappears (4.89s)
--- FAIL: TestAccAWSRoute53Record_disappears_MultipleRecords (5.16s)
--- FAIL: TestAccAWSRoute53Record_empty (3.73s)
--- FAIL: TestAccAWSRoute53Record_failover (7.70s)
--- FAIL: TestAccAWSRoute53Record_generatesSuffix (5.16s)
--- FAIL: TestAccAWSRoute53Record_geolocation_basic (3.67s)
--- FAIL: TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange (5.03s)
--- FAIL: TestAccAWSRoute53Record_HealthCheckId_TypeChange (5.17s)
--- FAIL: TestAccAWSRoute53Record_latency_basic (3.87s)
--- FAIL: TestAccAWSRoute53Record_longTXTrecord (3.92s)
--- FAIL: TestAccAWSRoute53Record_multivalue_answer_basic (3.70s)
--- FAIL: TestAccAWSRoute53Record_NameChange (3.82s)
--- FAIL: TestAccAWSRoute53Record_SetIdentifierChange (3.95s)
--- FAIL: TestAccAWSRoute53Record_spfSupport (5.20s)
--- FAIL: TestAccAWSRoute53Record_txtSupport (4.91s)
--- FAIL: TestAccAWSRoute53Record_TypeChange (3.94s)
--- FAIL: TestAccAWSRoute53Record_underscored (4.98s)
--- FAIL: TestAccAWSRoute53Record_weighted_alias (7.88s)
--- FAIL: TestAccAWSRoute53Record_weighted_basic (5.41s)
--- FAIL: TestAccAWSRoute53Record_weighted_to_simple_basic (5.70s)
--- FAIL: TestAccAWSRoute53Record_wildcard (4.93s)
--- FAIL: TestAccAWSRoute53Zone_basic (2.77s)
--- FAIL: TestAccAWSRoute53Zone_Comment (2.71s)
--- FAIL: TestAccAWSRoute53Zone_DelegationSetID (2.94s)
--- FAIL: TestAccAWSRoute53Zone_disappears (2.09s)
--- FAIL: TestAccAWSRoute53Zone_ForceDestroy (2.75s)
--- FAIL: TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod (2.60s)
--- FAIL: TestAccAWSRoute53Zone_multiple (2.32s)
--- FAIL: TestAccAWSRoute53Zone_Tags (2.31s)
--- FAIL: TestAccDataSourceAwsRoute53ResolverRule_SharedByMe (14.95s)
--- FAIL: TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe (14.78s)
--- FAIL: TestAccDataSourceAwsRoute53Zone_id (3.31s)
--- FAIL: TestAccDataSourceAwsRoute53Zone_name (4.03s)
--- FAIL: TestAccDataSourceRoute53DelegationSet_basic (6.92s)
--- PASS: TestAccAWSRoute53HealthCheck_Disabled (36.98s)
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (14.93s)
--- PASS: TestAccAWSRoute53HealthCheck_Ipv6Config (22.77s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (15.62s)
--- PASS: TestAccAwsRoute53ResolverEndpoint_basicInbound (55.77s)
--- PASS: TestAccAwsRoute53ResolverEndpoint_updateOutbound (333.56s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfig_basic (12.69s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfig_disappears (10.77s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfig_tags (20.94s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfigAssociation_basic (24.81s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfigAssociation_disappears (22.17s)
--- PASS: TestAccAwsRoute53ResolverRule_basic (29.55s)
--- PASS: TestAccAwsRoute53ResolverRule_forward (202.59s)
--- PASS: TestAccAwsRoute53ResolverRule_forwardEndpointRecreate (388.86s)
--- PASS: TestAccAwsRoute53ResolverRule_justDotDomainName (29.16s)
--- PASS: TestAccAwsRoute53ResolverRule_tags (43.49s)
--- PASS: TestAccAwsRoute53ResolverRule_trailingDotDomainName (30.19s)
--- PASS: TestAccAwsRoute53ResolverRule_updateName (46.87s)
--- PASS: TestAccAwsRoute53ResolverRuleAssociation_basic (130.72s)
--- PASS: TestAccAWSRoute53VpcAssociationAuthorization_basic (43.38s)
--- PASS: TestAccAWSRoute53VpcAssociationAuthorization_disappears (42.41s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (74.24s)
--- PASS: TestAccAWSRoute53Zone_VPC_Single (41.59s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (122.97s)
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (73.21s)
--- PASS: TestAccAWSRoute53ZoneAssociation_CrossAccount (75.85s)
--- PASS: TestAccAWSRoute53ZoneAssociation_CrossRegion (83.90s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears (71.41s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_VPC (71.55s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_Zone (71.03s)
--- PASS: TestAccDataSourceAwsRoute53ResolverEndpoint_Basic (82.45s)
--- PASS: TestAccDataSourceAwsRoute53ResolverEndpoint_Filter (195.29s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_basic (35.43s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags (203.25s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRules_basic (13.08s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId (213.13s)
--- PASS: TestAccDataSourceAwsRoute53Zone_tags (48.60s)
--- PASS: TestAccDataSourceAwsRoute53Zone_vpc (48.30s)
--- SKIP: TestAccAWSRoute53QueryLog_basic (0.00s)
--- SKIP: TestAccAWSShieldProtection_Route53 (0.00s)
--- SKIP: TestAccDataSourceAwsRoute53Zone_serviceDiscovery (0.00s)
```

### Output from acceptance testing (GovCloud):

8 FAIL, 35 PASS, 51 SKIP

NOTE: Hit `LimitExceededException` during testing, causing 3 tests that passed with pre-sweeping that did not in this run:
```
TestAccDataSourceAwsRoute53ResolverEndpoint_Filter (aka, TestAccAWSRoute53ResolverEndpointDataSource_Filter)
TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId (aka, TestAccAWSRoute53ResolverRulesDataSource_ResolverEndpointId)
TestAccAwsRoute53ResolverRule_forwardEndpointRecreate (aka, TestAccAWSRoute53ResolverRule_forwardEndpointRecreate)
```

```
--- FAIL: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (8.79s)
--- FAIL: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (4.67s)
--- FAIL: TestAccAWSRoute53Record_Alias_VpcEndpoint (398.56s)
--- FAIL: TestAccAWSRoute53ResolverEndpointDataSource_Filter (24.40s)
--- FAIL: TestAccAWSRoute53ResolverRule_forwardEndpointRecreate (24.83s)
--- FAIL: TestAccAWSRoute53ResolverRuleDataSource_SharedByMe (29.69s)
--- FAIL: TestAccAWSRoute53ResolverRuleDataSource_SharedWithMe (26.72s)
--- FAIL: TestAccAWSRoute53ResolverRulesDataSource_ResolverEndpointId (33.00s)
--- PASS: TestAccAWSRoute53HealthCheck_Disabled (52.18s)
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (20.22s)
--- PASS: TestAccAWSRoute53HealthCheck_Ipv6Config (30.36s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (25.36s)
--- PASS: TestAccAWSRoute53ResolverEndpoint_basicInbound (109.67s)
--- PASS: TestAccAWSRoute53ResolverEndpoint_updateOutbound (376.28s)
--- PASS: TestAccAWSRoute53ResolverEndpointDataSource_Basic (116.84s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfig_basic (34.19s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfig_disappears (29.31s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfig_tags (57.17s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfigAssociation_basic (42.71s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfigAssociation_disappears (40.98s)
--- PASS: TestAccAWSRoute53ResolverRule_basic (40.39s)
--- PASS: TestAccAWSRoute53ResolverRule_forward (305.76s)
--- PASS: TestAccAWSRoute53ResolverRule_justDotDomainName (40.10s)
--- PASS: TestAccAWSRoute53ResolverRule_tags (72.07s)
--- PASS: TestAccAWSRoute53ResolverRule_trailingDotDomainName (40.36s)
--- PASS: TestAccAWSRoute53ResolverRule_updateName (66.47s)
--- PASS: TestAccAWSRoute53ResolverRuleAssociation_basic (143.48s)
--- PASS: TestAccAWSRoute53ResolverRuleDataSource_basic (41.01s)
--- PASS: TestAccAWSRoute53ResolverRuleDataSource_ResolverEndpointIdWithTags (225.14s)
--- PASS: TestAccAWSRoute53ResolverRulesDataSource_basic (17.80s)
--- PASS: TestAccAWSRoute53VpcAssociationAuthorization_basic (65.94s)
--- PASS: TestAccAWSRoute53VpcAssociationAuthorization_disappears (68.88s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (103.51s)
--- PASS: TestAccAWSRoute53Zone_VPC_Single (78.05s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (200.72s)
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (95.87s)
--- PASS: TestAccAWSRoute53ZoneAssociation_CrossAccount (107.36s)
--- PASS: TestAccAWSRoute53ZoneAssociation_CrossRegion (121.26s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears (91.01s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_VPC (94.84s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_Zone (97.11s)
--- PASS: TestAccAWSRoute53ZoneDataSource_tags (74.71s)
--- PASS: TestAccAWSRoute53ZoneDataSource_vpc (71.69s)
--- SKIP: TestAccAWSRoute53DelegationSet_basic (4.61s)
--- SKIP: TestAccAWSRoute53DelegationSet_withZones (4.72s)
--- SKIP: TestAccAWSRoute53HealthCheck_basic (4.34s)
--- SKIP: TestAccAWSRoute53HealthCheck_disappears (5.81s)
--- SKIP: TestAccAWSRoute53HealthCheck_tags (5.37s)
--- SKIP: TestAccAWSRoute53HealthCheck_withSearchString (4.47s)
--- SKIP: TestAccAWSRoute53HealthCheck_withSNI (5.68s)
--- SKIP: TestAccAWSRoute53QueryLog_basic (0.01s)
--- SKIP: TestAccAWSRoute53Record_Alias_Elb (56.31s)
--- SKIP: TestAccAWSRoute53Record_Alias_S3 (40.65s)
--- SKIP: TestAccAWSRoute53Record_Alias_Uppercase (26.12s)
--- SKIP: TestAccAWSRoute53Record_AliasChange (13.79s)
--- SKIP: TestAccAWSRoute53Record_allowOverwrite (4.38s)
--- SKIP: TestAccAWSRoute53Record_basic (4.21s)
--- SKIP: TestAccAWSRoute53Record_basic_fqdn (4.45s)
--- SKIP: TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID (4.10s)
--- SKIP: TestAccAWSRoute53Record_caaSupport (8.43s)
--- SKIP: TestAccAWSRoute53Record_disappears (4.09s)
--- SKIP: TestAccAWSRoute53Record_disappears_MultipleRecords (4.26s)
--- SKIP: TestAccAWSRoute53Record_doNotAllowOverwrite (4.32s)
--- SKIP: TestAccAWSRoute53Record_empty (4.28s)
--- SKIP: TestAccAWSRoute53Record_failover (13.74s)
--- SKIP: TestAccAWSRoute53Record_generatesSuffix (8.71s)
--- SKIP: TestAccAWSRoute53Record_geolocation_basic (9.61s)
--- SKIP: TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange (13.60s)
--- SKIP: TestAccAWSRoute53Record_HealthCheckId_TypeChange (13.57s)
--- SKIP: TestAccAWSRoute53Record_latency_basic (5.58s)
--- SKIP: TestAccAWSRoute53Record_longTXTrecord (4.06s)
--- SKIP: TestAccAWSRoute53Record_multivalue_answer_basic (4.41s)
--- SKIP: TestAccAWSRoute53Record_NameChange (4.12s)
--- SKIP: TestAccAWSRoute53Record_SetIdentifierChange (4.42s)
--- SKIP: TestAccAWSRoute53Record_spfSupport (4.06s)
--- SKIP: TestAccAWSRoute53Record_txtSupport (4.20s)
--- SKIP: TestAccAWSRoute53Record_TypeChange (4.37s)
--- SKIP: TestAccAWSRoute53Record_underscored (4.19s)
--- SKIP: TestAccAWSRoute53Record_weighted_alias (55.66s)
--- SKIP: TestAccAWSRoute53Record_weighted_basic (8.44s)
--- SKIP: TestAccAWSRoute53Record_weighted_to_simple_basic (9.65s)
--- SKIP: TestAccAWSRoute53Record_wildcard (9.65s)
--- SKIP: TestAccAWSRoute53Zone_basic (17.13s)
--- SKIP: TestAccAWSRoute53Zone_Comment (31.84s)
--- SKIP: TestAccAWSRoute53Zone_DelegationSetID (7.62s)
--- SKIP: TestAccAWSRoute53Zone_disappears (14.72s)
--- SKIP: TestAccAWSRoute53Zone_ForceDestroy (36.72s)
--- SKIP: TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod (8.54s)
--- SKIP: TestAccAWSRoute53Zone_multiple (8.42s)
--- SKIP: TestAccAWSRoute53Zone_Tags (8.55s)
--- SKIP: TestAccAWSRoute53ZoneDataSource_id (6.58s)
--- SKIP: TestAccAWSRoute53ZoneDataSource_name (6.08s)
--- SKIP: TestAccAWSRoute53ZoneDataSource_serviceDiscovery (0.00s)
--- SKIP: TestAccAWSShieldProtection_Route53 (0.04s)
```

Output from acceptance testing (commercial):

(Note: First 5 failed in TC due to environment problems unrelated to tests or PR. Re-run appropriately, e.g., with `AWS_ALTERNATE_PROFILE` set, to show they work.)

```
--- FAIL: TestAccAWSRoute53ResolverRuleDataSource_SharedByMe (1.56s)
--- FAIL: TestAccAWSRoute53ResolverRuleDataSource_SharedWithMe (1.62s)
--- PASS: TestAccAWSRoute53VpcAssociationAuthorization_disappears (89.52s)
--- PASS: TestAccAWSRoute53VpcAssociationAuthorization_basic (91.41s)
--- PASS: TestAccAWSRoute53ZoneAssociation_CrossAccount (161.25s)

--- PASS: TestAccAWSRoute53ResolverRulesDataSource_basic (30.21s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (35.71s)
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (34.10s)
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (35.95s)
--- PASS: TestAccAWSRoute53DelegationSet_basic (37.91s)
--- PASS: TestAccAWSRoute53ResolverRuleDataSource_basic (51.05s)
--- PASS: TestAccAWSRoute53HealthCheck_disappears (15.33s)
--- PASS: TestAccAWSRoute53HealthCheck_basic (59.53s)
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (26.83s)
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (62.98s)
--- PASS: TestAccAWSRoute53HealthCheck_Ipv6Config (39.50s)
--- PASS: TestAccAWSRoute53DelegationSetDataSource_basic (76.40s)
--- PASS: TestAccAWSRoute53ZoneDataSource_name (77.33s)
--- PASS: TestAccAWSRoute53ZoneDataSource_id (78.04s)
--- PASS: TestAccAWSRoute53DelegationSet_withZones (84.02s)
--- PASS: TestAccAWSRoute53HealthCheck_tags (84.62s)
--- PASS: TestAccAWSRoute53ResolverEndpointDataSource_Basic (90.71s)
--- PASS: TestAccAWSRoute53HealthCheck_Disabled (56.25s)
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (63.33s)
--- PASS: TestAccAWSRoute53ZoneDataSource_vpc (102.13s)
--- PASS: TestAccAWSRoute53ZoneDataSource_tags (104.84s)
--- PASS: TestAccAWSRoute53QueryLog_basic (67.30s)
--- PASS: TestAccAWSRoute53ZoneDataSource_serviceDiscovery (122.28s)
--- PASS: TestAccAWSRoute53Record_underscored (120.33s)
--- PASS: TestAccAWSRoute53Record_disappears (121.15s)
--- PASS: TestAccAWSRoute53Record_basic (131.66s)
--- PASS: TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID (119.64s)
--- PASS: TestAccAWSRoute53Record_txtSupport (123.82s)
--- PASS: TestAccAWSRoute53Record_spfSupport (124.74s)
--- PASS: TestAccAWSRoute53Record_caaSupport (123.41s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (123.39s)
--- PASS: TestAccAWSRoute53Record_failover (128.65s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (169.20s)
--- PASS: TestAccAWSRoute53ResolverEndpointDataSource_Filter (232.47s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (165.39s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (140.89s)
--- PASS: TestAccAWSRoute53Record_Alias_Elb (136.14s)
--- PASS: TestAccAWSRoute53ResolverRuleDataSource_ResolverEndpointIdWithTags (241.04s)
--- PASS: TestAccAWSRoute53Record_Alias_S3 (131.71s)
--- PASS: TestAccAWSRoute53ResolverRulesDataSource_ResolverEndpointId (251.63s)
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (175.52s)
--- PASS: TestAccAWSRoute53Record_wildcard (192.48s)
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (118.28s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfigAssociation_basic (27.52s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (121.90s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfigAssociation_disappears (28.43s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfig_basic (21.67s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfig_disappears (21.07s)
--- PASS: TestAccAWSRoute53Record_latency_basic (128.48s)
--- PASS: TestAccAWSRoute53ResolverEndpoint_basicInbound (93.05s)
--- PASS: TestAccAWSRoute53ResolverQueryLogConfig_tags (40.97s)
--- PASS: TestAccAWSRoute53Record_doNotAllowOverwrite (108.54s)
--- PASS: TestAccAWSRoute53Record_empty (121.56s)
--- PASS: TestAccAWSRoute53ResolverRule_basic (34.54s)
--- PASS: TestAccAWSRoute53Record_longTXTrecord (125.61s)
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (123.09s)
--- PASS: TestAccAWSRoute53ResolverRule_justDotDomainName (36.99s)
--- PASS: TestAccAWSRoute53ResolverRule_trailingDotDomainName (35.01s)
--- PASS: TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange (185.64s)
--- PASS: TestAccAWSRoute53Record_HealthCheckId_TypeChange (181.86s)
--- PASS: TestAccAWSRoute53Record_TypeChange (183.00s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (152.83s)
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (172.63s)
--- PASS: TestAccAWSRoute53ResolverRule_tags (55.24s)
--- PASS: TestAccAWSRoute53ResolverRule_updateName (56.40s)
--- PASS: TestAccAWSRoute53Record_AliasChange (175.28s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (240.30s)
--- PASS: TestAccAWSRoute53Record_NameChange (216.10s)
--- PASS: TestAccAWSRoute53Zone_disappears (44.69s)
--- PASS: TestAccAWSRoute53Zone_basic (49.42s)
--- SKIP: TestAccAWSShieldProtection_Route53 (0.00s)
--- PASS: TestAccAWSRoute53Zone_multiple (48.75s)
--- PASS: TestAccAWSRoute53Zone_DelegationSetID (47.42s)
--- PASS: TestAccAWSRoute53Zone_Comment (57.25s)
--- PASS: TestAccAWSRoute53Zone_Tags (67.66s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears (144.56s)
--- PASS: TestAccAWSRoute53ResolverRuleAssociation_basic (196.95s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_VPC (146.04s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_Zone (146.00s)
--- PASS: TestAccAWSRoute53Zone_VPC_Single (88.78s)
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (158.19s)
--- PASS: TestAccAWSRoute53ZoneAssociation_CrossRegion (162.93s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (155.55s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (478.04s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy (204.10s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod (228.39s)
--- PASS: TestAccAWSRoute53ResolverEndpoint_updateOutbound (419.38s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (260.12s)
--- PASS: TestAccAWSRoute53ResolverRule_forward (362.09s)
--- PASS: TestAccAWSRoute53ResolverRule_forwardEndpointRecreate (459.73s)
```
