### PR TITLE
resource/networkfirewall_firewall: add vpc endpoint information (FirewallStatus)

### DIFF
--- a/aws/internal/service/networkfirewall/waiter/waiter.go
+++ b/aws/internal/service/networkfirewall/waiter/waiter.go
@@ -40,6 +40,7 @@ func FirewallUpdated(ctx context.Context, conn *networkfirewall.NetworkFirewall,
 		Target:  []string{networkfirewall.FirewallStatusValueReady},
 		Refresh: FirewallUpdatedStatus(ctx, conn, arn),
 		Timeout: FirewallTimeout,
+		Delay:   30 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/internal/service/networkfirewall/waiter/waiter.go
+++ b/aws/internal/service/networkfirewall/waiter/waiter.go
@@ -40,7 +40,10 @@ func FirewallUpdated(ctx context.Context, conn *networkfirewall.NetworkFirewall,
 		Target:  []string{networkfirewall.FirewallStatusValueReady},
 		Refresh: FirewallUpdatedStatus(ctx, conn, arn),
 		Timeout: FirewallTimeout,
-		Delay:   30 * time.Second,
+		// Delay added to account for Associate/DisassociateSubnet calls that return
+		// a READY status immediately after the method is called instead of immediately
+		// returning PROVISIONING
+		Delay: 30 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/resource_aws_networkfirewall_firewall.go
+++ b/aws/resource_aws_networkfirewall_firewall.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/networkfirewall"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -26,6 +27,12 @@ func resourceAwsNetworkFirewallFirewall() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		CustomizeDiff: customdiff.Sequence(
+			customdiff.ComputedIf("firewall_status", func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("subnet_mapping")
+			}),
+		),
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
@@ -56,7 +63,7 @@ func resourceAwsNetworkFirewallFirewall() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"sync_states": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_networkfirewall_firewall_test.go
+++ b/aws/resource_aws_networkfirewall_firewall_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -97,11 +98,19 @@ func TestAccAwsNetworkFirewallFirewall_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "delete_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "firewall_policy_arn", policyResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_status.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_status.0.sync_states.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.availability_zone", subnetResourceName, "availability_zone"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "firewall_status.0.sync_states.*", map[string]*regexp.Regexp{
+						"attachment.0.endpoint_id": regexp.MustCompile(`vpce-`),
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.attachment.0.subnet_id", subnetResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpcResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_mapping.#", "1"),
 					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_mapping.*.subnet_id", subnetResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "update_token"),
 				),
 			},
 			{
@@ -216,6 +225,13 @@ func TestAccAwsNetworkFirewallFirewall_subnetMappings_updateSubnet(t *testing.T)
 				Config: testAccNetworkFirewallFirewall_updateSubnet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsNetworkFirewallFirewallExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "firewall_status.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_status.0.sync_states.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.availability_zone", updateSubnetResourceName, "availability_zone"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "firewall_status.0.sync_states.*", map[string]*regexp.Regexp{
+						"attachment.0.endpoint_id": regexp.MustCompile(`vpce-`),
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.attachment.0.subnet_id", updateSubnetResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_mapping.#", "1"),
 					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_mapping.*.subnet_id", updateSubnetResourceName, "id"),
 				),
@@ -252,6 +268,12 @@ func TestAccAwsNetworkFirewallFirewall_subnetMappings_updateMultipleSubnets(t *t
 				Config: testAccNetworkFirewallFirewall_updateMultipleSubnets(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsNetworkFirewallFirewallExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "firewall_status.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_status.0.sync_states.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.availability_zone", subnetResourceName, "availability_zone"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.attachment.0.subnet_id", subnetResourceName, "id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.availability_zone", updateSubnetResourceName, "availability_zone"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.attachment.0.subnet_id", updateSubnetResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_mapping.#", "2"),
 					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_mapping.*.subnet_id", subnetResourceName, "id"),
 					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_mapping.*.subnet_id", updateSubnetResourceName, "id"),
@@ -261,6 +283,13 @@ func TestAccAwsNetworkFirewallFirewall_subnetMappings_updateMultipleSubnets(t *t
 				Config: testAccNetworkFirewallFirewall_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsNetworkFirewallFirewallExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "firewall_status.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_status.0.sync_states.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.availability_zone", subnetResourceName, "availability_zone"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "firewall_status.0.sync_states.*", map[string]*regexp.Regexp{
+						"attachment.0.endpoint_id": regexp.MustCompile(`vpce-`),
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_status.0.sync_states.*.attachment.0.subnet_id", subnetResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_mapping.#", "1"),
 					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_mapping.*.subnet_id", subnetResourceName, "id"),
 				),

--- a/website/docs/r/networkfirewall_firewall.html.markdown
+++ b/website/docs/r/networkfirewall_firewall.html.markdown
@@ -64,6 +64,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) that identifies the firewall.
 
+* `firewall_status` - Nested list of information about the current status of the firewall.
+    * `sync_states` - List of subnets configured for use by the firewall.
+        * `attachment` - Nested list describing the attachment status of the firewall's association with a single VPC subnet.
+            * `endpoint_id` - The identifier of the firewall endpoint that AWS Network Firewall has instantiated in the subnet. You use this to identify the firewall endpoint in the VPC route tables, when you redirect the VPC traffic through the endpoint.
+            * `subnet_id` - The unique identifier of the subnet that you've specified to be used for a firewall endpoint.
+        * `availability_zone` - The Availability Zone where the subnet is configured.
+
 * `update_token` - A string token used when updating a firewall.
 
 ## Import

--- a/website/docs/r/networkfirewall_firewall.html.markdown
+++ b/website/docs/r/networkfirewall_firewall.html.markdown
@@ -65,7 +65,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The Amazon Resource Name (ARN) that identifies the firewall.
 
 * `firewall_status` - Nested list of information about the current status of the firewall.
-    * `sync_states` - List of subnets configured for use by the firewall.
+    * `sync_states` - Set of subnets configured for use by the firewall.
         * `attachment` - Nested list describing the attachment status of the firewall's association with a single VPC subnet.
             * `endpoint_id` - The identifier of the firewall endpoint that AWS Network Firewall has instantiated in the subnet. You use this to identify the firewall endpoint in the VPC route tables, when you redirect the VPC traffic through the endpoint.
             * `subnet_id` - The unique identifier of the subnet that you've specified to be used for a firewall endpoint.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16350 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/networkfirewall_firewall: add `firewall_status` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsNetworkFirewallFirewall_basic (700.66s)
--- PASS: TestAccAwsNetworkFirewallFirewall_subnetMappings_updateSubnet (1281.57s)
--- PASS: TestAccAwsNetworkFirewallFirewall_subnetMappings_updateMultipleSubnets (1353.09s)
```
