### PR TITLE
tests/resource/aws_securityhub_member: Handle BadRequestException in CheckDestroy

### DIFF
--- a/aws/internal/service/securityhub/errors.go
+++ b/aws/internal/service/securityhub/errors.go
@@ -1,0 +1,5 @@
+package securityhub
+
+const (
+	ErrCodeBadRequestException = "BadRequestException"
+)

--- a/aws/resource_aws_securityhub_member_test.go
+++ b/aws/resource_aws_securityhub_member_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfsecurityhub "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/securityhub"
 )
 
 func testAccAWSSecurityHubMember_basic(t *testing.T) {
@@ -99,11 +101,16 @@ func testAccCheckAWSSecurityHubMemberDestroy(s *terraform.State) error {
 			AccountIds: []*string{aws.String(rs.Primary.ID)},
 		})
 
+		if tfawserr.ErrCodeEquals(err, tfsecurityhub.ErrCodeBadRequestException) {
+			continue
+		}
+
+		if tfawserr.ErrCodeEquals(err, securityhub.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
 		if err != nil {
-			if isAWSErr(err, securityhub.ErrCodeResourceNotFoundException, "") {
-				return nil
-			}
-			return err
+			return fmt.Errorf("error getting Security Hub Member (%s): %w", rs.Primary.ID, err)
 		}
 
 		if len(resp.Members) != 0 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/pull/16404 (will fix the acceptance testing prior to testing this change)
Reference: https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_ListMembers.html

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously the test would pass but the CheckDestroy would fail:

```
=== RUN   TestAccAWSSecurityHub_serial/Member/invite
TestAccAWSSecurityHub_serial/Member/invite: testing_new.go:63: Error running post-test destroy, there may be dangling resources: BadRequestException:
  status code: 400, request id: 34dfc5cd-16bb-4e31-9924-6b060f6f30b7
=== RUN   TestAccAWSSecurityHub_serial/Member/basic
TestAccAWSSecurityHub_serial/Member/basic: testing_new.go:63: Error running post-test destroy, there may be dangling resources: BadRequestException:
  status code: 400, request id: 5049c5b7-be35-4fd2-93d3-4b58e13c7140
```

This error code is not listed in the API Reference, but the same exact call is used in the CheckExists function, so seems related to only when SecurityHub has been disabled after the test has been completed.

Output from acceptance testing:

```
--- PASS: TestAccAWSSecurityHub_serial (28.16s)
    --- PASS: TestAccAWSSecurityHub_serial/Member (28.16s)
        --- PASS: TestAccAWSSecurityHub_serial/Member/invite (14.81s)
        --- PASS: TestAccAWSSecurityHub_serial/Member/basic (13.35s)
```
