### PR TITLE
provider: Followup items from initial Code Signing release

### DIFF
--- a/aws/data_source_aws_signer_signing_job_test.go
+++ b/aws/data_source_aws_signer_signing_job_test.go
@@ -9,17 +9,16 @@ import (
 )
 
 func TestAccDataSourceAWSSignerSigningJob_basic(t *testing.T) {
-	rString := acctest.RandString(48)
-	profileName := fmt.Sprintf("tf_acc_sp_basic_%s", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_signer_signing_job.test"
-	resourceName := "aws_signer_signing_job.job_test"
+	resourceName := "aws_signer_signing_job.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSSignerSigningJobConfigBasic(profileName),
+				Config: testAccDataSourceAWSSignerSigningJobConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "status", resourceName, "status"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "job_owner", resourceName, "job_owner"),
@@ -31,17 +30,17 @@ func TestAccDataSourceAWSSignerSigningJob_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAWSSignerSigningJobConfigBasic(profileName string) string {
+func testAccDataSourceAWSSignerSigningJobConfigBasic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
-resource "aws_signer_signing_profile" "test_sp" {
+resource "aws_signer_signing_profile" "test" {
   platform_id = "AWSLambda-SHA384-ECDSA"
-  name        = "%s"
+  name        = replace(%[1]q, "-", "_")
 }
 
-resource "aws_s3_bucket" "bucket" {
-  bucket = "tf-signer-signing-bucket"
+resource "aws_s3_bucket" "source" {
+  bucket = "%[1]s-source"
 
   versioning {
     enabled = true
@@ -50,36 +49,37 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket" "dest_bucket" {
-  bucket        = "tf-signer-signing-dest-bucket"
+resource "aws_s3_bucket" "destination" {
+  bucket        = "%[1]s-destination"
   force_destroy = true
 }
 
-resource "aws_s3_bucket_object" "lambda_signing_code" {
-  bucket = aws_s3_bucket.bucket.bucket
+resource "aws_s3_bucket_object" "source" {
+  bucket = aws_s3_bucket.source.bucket
   key    = "lambdatest.zip"
   source = "test-fixtures/lambdatest.zip"
 }
 
-resource "aws_signer_signing_job" "job_test" {
-  profile_name = aws_signer_signing_profile.test_sp.name
+resource "aws_signer_signing_job" "test" {
+  profile_name = aws_signer_signing_profile.test.name
 
   source {
     s3 {
-      bucket  = aws_s3_bucket.bucket.bucket
-      key     = aws_s3_bucket_object.lambda_signing_code.key
-      version = aws_s3_bucket_object.lambda_signing_code.version_id
+      bucket  = aws_s3_bucket_object.source.bucket
+      key     = aws_s3_bucket_object.source.key
+      version = aws_s3_bucket_object.source.version_id
     }
   }
 
   destination {
     s3 {
-      bucket = aws_s3_bucket.dest_bucket.bucket
+      bucket = aws_s3_bucket.destination.bucket
     }
   }
 }
 
 data "aws_signer_signing_job" "test" {
-  job_id = aws_signer_signing_job.job_test.job_id
-}`, profileName)
+  job_id = aws_signer_signing_job.test.job_id
+}
+`, rName)
 }

--- a/aws/data_source_aws_signer_signing_job_test.go
+++ b/aws/data_source_aws_signer_signing_job_test.go
@@ -36,7 +36,6 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_signer_signing_profile" "test" {
   platform_id = "AWSLambda-SHA384-ECDSA"
-  name        = replace(%[1]q, "-", "_")
 }
 
 resource "aws_s3_bucket" "source" {

--- a/aws/data_source_aws_signer_signing_profile_test.go
+++ b/aws/data_source_aws_signer_signing_profile_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceAWSSignerSigningProfile_basic(t *testing.T) {
 	profileName := fmt.Sprintf("tf_acc_sp_basic_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -191,7 +191,7 @@ func TestAccAWSLambdaFunction_codeSigningConfig(t *testing.T) {
 	cscUpdateResourceName := "aws_lambda_code_signing_config.code_signing_config_2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_signer_signing_job_test.go
+++ b/aws/resource_aws_signer_signing_job_test.go
@@ -45,7 +45,6 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_signer_signing_profile" "test" {
   platform_id = "AWSLambda-SHA384-ECDSA"
-  name        = replace(%[1]q, "-", "_")
 }
 
 resource "aws_s3_bucket" "source" {

--- a/aws/resource_aws_signer_signing_job_test.go
+++ b/aws/resource_aws_signer_signing_job_test.go
@@ -12,23 +12,22 @@ import (
 )
 
 func TestAccAWSSignerSigningJob_basic(t *testing.T) {
-	resourceName := "aws_signer_signing_job.test_job"
-	profileResourceName := "aws_signer_signing_profile.test_sp"
-	rString := acctest.RandString(48)
-	profileName := fmt.Sprintf("tf_acc_sp_basic_%s", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_signer_signing_job.test"
+	profileResourceName := "aws_signer_signing_profile.test"
 
 	var job signer.DescribeSigningJobOutput
 	var conf signer.GetSigningProfileOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSignerSigningJobConfig(profileName),
+				Config: testAccAWSSignerSigningJobConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileExists(profileResourceName, profileName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(profileResourceName, &conf),
 					testAccCheckAWSSignerSigningJobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "platform_id", "AWSLambda-SHA384-ECDSA"),
 					resource.TestCheckResourceAttr(resourceName, "platform_display_name", "AWS Lambda"),
@@ -40,17 +39,17 @@ func TestAccAWSSignerSigningJob_basic(t *testing.T) {
 
 }
 
-func testAccAWSSignerSigningJobConfig(profileName string) string {
+func testAccAWSSignerSigningJobConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
-resource "aws_signer_signing_profile" "test_sp" {
+resource "aws_signer_signing_profile" "test" {
   platform_id = "AWSLambda-SHA384-ECDSA"
-  name        = "%s"
+  name        = replace(%[1]q, "-", "_")
 }
 
-resource "aws_s3_bucket" "bucket" {
-  bucket = "tf-signer-signing-bucket"
+resource "aws_s3_bucket" "source" {
+  bucket = "%[1]s-source"
 
   versioning {
     enabled = true
@@ -59,34 +58,35 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket" "dest_bucket" {
-  bucket        = "tf-signer-signing-dest-bucket"
+resource "aws_s3_bucket" "destination" {
+  bucket        = "%[1]s"
   force_destroy = true
 }
 
-resource "aws_s3_bucket_object" "lambda_signing_code" {
-  bucket = aws_s3_bucket.bucket.bucket
+resource "aws_s3_bucket_object" "source" {
+  bucket = aws_s3_bucket.source.bucket
   key    = "lambdatest.zip"
   source = "test-fixtures/lambdatest.zip"
 }
 
-resource "aws_signer_signing_job" "test_job" {
-  profile_name = aws_signer_signing_profile.test_sp.name
+resource "aws_signer_signing_job" "test" {
+  profile_name = aws_signer_signing_profile.test.name
 
   source {
     s3 {
-      bucket  = aws_s3_bucket.bucket.bucket
-      key     = aws_s3_bucket_object.lambda_signing_code.key
-      version = aws_s3_bucket_object.lambda_signing_code.version_id
+      bucket  = aws_s3_bucket_object.source.bucket
+      key     = aws_s3_bucket_object.source.key
+      version = aws_s3_bucket_object.source.version_id
     }
   }
 
   destination {
     s3 {
-      bucket = aws_s3_bucket.dest_bucket.bucket
+      bucket = aws_s3_bucket.destination.bucket
     }
   }
-}`, profileName)
+}
+`, rName)
 }
 
 func testAccCheckAWSSignerSigningJobExists(res string, job *signer.DescribeSigningJobOutput) resource.TestCheckFunc {

--- a/aws/resource_aws_signer_signing_profile_permission_test.go
+++ b/aws/resource_aws_signer_signing_profile_permission_test.go
@@ -22,7 +22,7 @@ func TestAccAWSSignerSigningProfilePermission_basic(t *testing.T) {
 	var sppconf signer.ListProfilePermissionsOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSignerSigningProfileDestroy,
 		Steps: []resource.TestStep{
@@ -30,7 +30,7 @@ func TestAccAWSSignerSigningProfilePermission_basic(t *testing.T) {
 				Config:  testAccAWSSignerSigningProfilePermissionConfig(profileName),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileExists(profileResourceName, profileName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(profileResourceName, &conf),
 					testAccCheckAWSSignerSigningProfilePermissionExists(resourceName, profileName, &sppconf),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "statement_id"),
 				),
@@ -55,7 +55,7 @@ func TestAccAWSSignerSigningProfilePermission_GetSigningProfile(t *testing.T) {
 	var sppconf signer.ListProfilePermissionsOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSignerSigningProfileDestroy,
 		Steps: []resource.TestStep{
@@ -63,7 +63,7 @@ func TestAccAWSSignerSigningProfilePermission_GetSigningProfile(t *testing.T) {
 				Config:  testAccAWSSignerSigningProfilePermissionGetSP(profileName),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileExists(profileResourceName, profileName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(profileResourceName, &conf),
 					testAccCheckAWSSignerSigningProfilePermissionExists(resourceName, profileName, &sppconf),
 				),
 			},
@@ -77,7 +77,7 @@ func TestAccAWSSignerSigningProfilePermission_GetSigningProfile(t *testing.T) {
 				Config:  testAccAWSSignerSigningProfilePermissionRevokeSignature(profileName),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileExists(profileResourceName, profileName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(profileResourceName, &conf),
 					testAccCheckAWSSignerSigningProfilePermissionExists(resourceName, profileName, &sppconf),
 				),
 			},
@@ -96,14 +96,14 @@ func TestAccAWSSignerSigningProfilePermission_StartSigningJob_GetSP(t *testing.T
 	var sppconf signer.ListProfilePermissionsOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSignerSigningProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSignerSigningProfilePermissionStartSigningJobGetSP(profileName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileExists(profileResourceName, profileName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(profileResourceName, &conf),
 					testAccCheckAWSSignerSigningProfilePermissionExists(resourceName1, profileName, &sppconf),
 					testAccCheckAWSSignerSigningProfilePermissionExists(resourceName2, profileName, &sppconf),
 				),
@@ -129,7 +129,7 @@ func TestAccAWSSignerSigningProfilePermission_StatementPrefix(t *testing.T) {
 	var sppconf signer.ListProfilePermissionsOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSignerSigningProfileDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_signer_signing_profile_test.go
+++ b/aws/resource_aws_signer_signing_profile_test.go
@@ -21,14 +21,14 @@ func TestAccAWSSignerSigningProfile_basic(t *testing.T) {
 	var conf signer.GetSigningProfileOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSignerSigningProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSignerSigningProfileConfigProvidedName(profileName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileExists(resourceName, profileName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(resourceName, &conf),
 					resource.TestMatchResourceAttr(resourceName, "name",
 						regexp.MustCompile("^[a-zA-Z0-9_]{0,64}$")),
 					resource.TestCheckResourceAttr(resourceName, "platform_id", "AWSLambda-SHA384-ECDSA"),
@@ -51,14 +51,14 @@ func TestAccAWSSignerSigningProfile_GenerateNameWithNamePrefix(t *testing.T) {
 	var conf signer.GetSigningProfileOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSignerSigningProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSignerSigningProfileConfig(namePrefix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileGeneratedNameExists(resourceName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "platform_id", "AWSLambda-SHA384-ECDSA"),
 				),
 			},
@@ -72,14 +72,14 @@ func TestAccAWSSignerSigningProfile_GenerateName(t *testing.T) {
 	var conf signer.GetSigningProfileOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSignerSigningProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSignerSigningProfileConfigGenerateName(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileGeneratedNameExists(resourceName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "platform_id", "AWSLambda-SHA384-ECDSA"),
 				),
 			},
@@ -94,14 +94,14 @@ func TestAccAWSSignerSigningProfile_tags(t *testing.T) {
 	var conf signer.GetSigningProfileOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSignerSigningProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSignerSigningProfileConfigTags(namePrefix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileGeneratedNameExists(resourceName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.tag1", "value1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.tag2", "value2"),
 				),
@@ -109,7 +109,7 @@ func TestAccAWSSignerSigningProfile_tags(t *testing.T) {
 			{
 				Config: testAccAWSSignerSigningProfileUpdateTags(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileGeneratedNameExists(resourceName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.tag1", "prod"),
 				),
 			},
@@ -124,14 +124,14 @@ func TestAccAWSSignerSigningProfile_SignatureValidityPeriod(t *testing.T) {
 	var conf signer.GetSigningProfileOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckSingerSigningProfile(t, "AWSLambda-SHA384-ECDSA") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSignerSigningProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSignerSigningProfileConfigSVP(namePrefix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileGeneratedNameExists(resourceName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "signature_validity_period.0.type", "DAYS"),
 					resource.TestCheckResourceAttr(resourceName, "signature_validity_period.0.value", "10"),
 				),
@@ -139,13 +139,45 @@ func TestAccAWSSignerSigningProfile_SignatureValidityPeriod(t *testing.T) {
 			{
 				Config: testAccAWSSignerSigningProfileUpdateSVP(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSignerSigningProfileGeneratedNameExists(resourceName, &conf),
+					testAccCheckAWSSignerSigningProfileExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "signature_validity_period.0.type", "MONTHS"),
 					resource.TestCheckResourceAttr(resourceName, "signature_validity_period.0.value", "10"),
 				),
 			},
 		},
 	})
+}
+
+func testAccPreCheckSingerSigningProfile(t *testing.T, platformID string) {
+	conn := testAccProvider.Meta().(*AWSClient).signerconn
+
+	input := &signer.ListSigningPlatformsInput{}
+
+	output, err := conn.ListSigningPlatforms(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+
+	if output == nil {
+		t.Skip("skipping acceptance testing: empty response")
+	}
+
+	for _, platform := range output.Platforms {
+		if platform == nil {
+			continue
+		}
+
+		if aws.StringValue(platform.PlatformId) == platformID {
+			return
+		}
+	}
+
+	t.Skipf("skipping acceptance testing: Signing Platform (%s) not found", platformID)
 }
 
 func testAccAWSSignerSigningProfileConfig(namePrefix string) string {
@@ -226,35 +258,7 @@ resource "aws_signer_signing_profile" "test_sp" {
 `, namePrefix)
 }
 
-func testAccCheckAWSSignerSigningProfileExists(res, profileName string, sp *signer.GetSigningProfileOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[res]
-		if !ok {
-			return fmt.Errorf("Signing profile not found: %s", res)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Signing Profile with that ARN does not exist")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).signerconn
-
-		params := &signer.GetSigningProfileInput{
-			ProfileName: aws.String(profileName),
-		}
-
-		getSp, err := conn.GetSigningProfile(params)
-		if err != nil {
-			return err
-		}
-
-		*sp = *getSp
-
-		return nil
-	}
-}
-
-func testAccCheckAWSSignerSigningProfileGeneratedNameExists(res string, sp *signer.GetSigningProfileOutput) resource.TestCheckFunc {
+func testAccCheckAWSSignerSigningProfileExists(res string, sp *signer.GetSigningProfileOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[res]
 		if !ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/pull/16383#pullrequestreview-536809923
Reference: https://github.com/hashicorp/terraform-provider-aws/pull/16384#pullrequestreview-536838934
Closes #16398

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_lambda_function: Prevent Lambda `GetFunctionCodeSigningConfig` API call error outside AWS Commercial regions
* resource/aws_lambda_function: Prevent Lambda `GetFunctionCodeSigningConfig` API call error outside AWS Commercial regions
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSLambdaFunction_basic (660.06s)
--- PASS: TestAccAWSLambdaFunction_codeSigningConfig (1207.31s)
--- PASS: TestAccAWSLambdaFunction_concurrency (1032.30s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (1057.54s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (132.39s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (138.81s)
--- PASS: TestAccAWSLambdaFunction_disablePublish (88.73s)
--- PASS: TestAccAWSLambdaFunction_disappears (1220.09s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (86.77s)
--- PASS: TestAccAWSLambdaFunction_enablePublish (129.99s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (145.89s)
--- PASS: TestAccAWSLambdaFunction_envVariables (718.17s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (14.86s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (3046.40s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (1370.29s)
--- PASS: TestAccAWSLambdaFunction_Layers (1016.49s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (160.26s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (505.56s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (503.80s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (48.16s)
--- PASS: TestAccAWSLambdaFunction_runtimes (1695.07s)
--- PASS: TestAccAWSLambdaFunction_s3 (40.08s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (64.03s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (64.88s)
--- PASS: TestAccAWSLambdaFunction_tags (1238.40s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (89.38s)
--- PASS: TestAccAWSLambdaFunction_UnpublishedCodeUpdate (737.76s)
--- PASS: TestAccAWSLambdaFunction_versioned (101.60s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (1113.10s)
--- PASS: TestAccAWSLambdaFunction_VPC (1412.53s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (989.01s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (623.72s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (1977.57s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (2715.08s)

--- PASS: TestAccAWSSignerSigningJob_basic (35.73s)

--- PASS: TestAccAWSSignerSigningProfile_basic (18.48s)
--- PASS: TestAccAWSSignerSigningProfile_GenerateName (18.16s)
--- PASS: TestAccAWSSignerSigningProfile_GenerateNameWithNamePrefix (18.17s)
--- PASS: TestAccAWSSignerSigningProfile_SignatureValidityPeriod (25.69s)
--- PASS: TestAccAWSSignerSigningProfile_tags (30.83s)

--- PASS: TestAccAWSSignerSigningProfilePermission_basic (23.93s)
--- PASS: TestAccAWSSignerSigningProfilePermission_GetSigningProfile (39.86s)
--- PASS: TestAccAWSSignerSigningProfilePermission_StartSigningJob_GetSP (25.33s)
--- PASS: TestAccAWSSignerSigningProfilePermission_StatementPrefix (28.76s)

--- PASS: TestAccDataSourceAWSLambdaFunction_alias (1211.85s)
--- PASS: TestAccDataSourceAWSLambdaFunction_basic (54.11s)
--- PASS: TestAccDataSourceAWSLambdaFunction_environment (1182.31s)
--- PASS: TestAccDataSourceAWSLambdaFunction_fileSystemConfig (1941.83s)
--- PASS: TestAccDataSourceAWSLambdaFunction_layers (1106.50s)
--- PASS: TestAccDataSourceAWSLambdaFunction_version (966.75s)
--- PASS: TestAccDataSourceAWSLambdaFunction_vpc (1697.94s)

--- PASS: TestAccDataSourceAWSSignerSigningJob_basic (30.06s)

--- PASS: TestAccDataSourceAWSSignerSigningProfile_basic (12.39s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSLambdaFunction_basic (60.15s)
--- PASS: TestAccAWSLambdaFunction_concurrency (86.67s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (138.48s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (152.23s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (138.97s)
--- PASS: TestAccAWSLambdaFunction_disablePublish (72.75s)
--- PASS: TestAccAWSLambdaFunction_disappears (104.35s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (918.89s)
--- PASS: TestAccAWSLambdaFunction_enablePublish (111.27s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (156.43s)
--- PASS: TestAccAWSLambdaFunction_envVariables (168.64s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (25.56s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (1546.53s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (891.68s)
--- PASS: TestAccAWSLambdaFunction_Layers (916.74s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (401.14s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (1074.54s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (1062.94s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (888.61s)
--- PASS: TestAccAWSLambdaFunction_runtimes (1187.08s)
--- PASS: TestAccAWSLambdaFunction_s3 (35.88s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (64.64s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (62.12s)
--- PASS: TestAccAWSLambdaFunction_tags (859.06s)
--- PASS: TestAccAWSLambdaFunction_UnpublishedCodeUpdate (541.36s)
--- PASS: TestAccAWSLambdaFunction_versioned (148.92s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (692.93s)
--- PASS: TestAccAWSLambdaFunction_VPC (1181.39s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (703.33s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (455.69s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (994.78s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (1224.48s)
--- SKIP: TestAccAWSLambdaFunction_codeSigningConfig (2.22s)

--- SKIP: TestAccAWSSignerSigningJob_basic (7.57s)

--- SKIP: TestAccAWSSignerSigningProfile_basic (7.52s)
--- SKIP: TestAccAWSSignerSigningProfile_GenerateName (7.44s)
--- SKIP: TestAccAWSSignerSigningProfile_GenerateNameWithNamePrefix (1.85s)
--- SKIP: TestAccAWSSignerSigningProfile_SignatureValidityPeriod (7.35s)
--- SKIP: TestAccAWSSignerSigningProfile_tags (7.87s)

--- SKIP: TestAccAWSSignerSigningProfilePermission_basic (7.66s)
--- SKIP: TestAccAWSSignerSigningProfilePermission_GetSigningProfile (7.65s)
--- SKIP: TestAccAWSSignerSigningProfilePermission_StartSigningJob_GetSP (1.84s)
--- SKIP: TestAccAWSSignerSigningProfilePermission_StatementPrefix (1.86s)

--- PASS: TestAccDataSourceAWSLambdaFunction_alias (42.58s)
--- PASS: TestAccDataSourceAWSLambdaFunction_basic (34.49s)
--- PASS: TestAccDataSourceAWSLambdaFunction_environment (113.95s)
--- PASS: TestAccDataSourceAWSLambdaFunction_fileSystemConfig (961.20s)
--- PASS: TestAccDataSourceAWSLambdaFunction_layers (136.12s)
--- PASS: TestAccDataSourceAWSLambdaFunction_version (248.84s)
--- PASS: TestAccDataSourceAWSLambdaFunction_vpc (598.98s)

--- SKIP: TestAccDataSourceAWSSignerSigningJob_basic (7.44s)

--- SKIP: TestAccDataSourceAWSSignerSigningProfile_basic (7.37s)
```
