### PR TITLE
d/aws_codeartifact_repository_endpoint: Support for NuGet

### DIFF
--- a/aws/data_source_aws_codeartifact_repository_endpoint_test.go
+++ b/aws/data_source_aws_codeartifact_repository_endpoint_test.go
@@ -18,7 +18,28 @@ func TestAccAWSCodeArtifactRepositoryEndpointDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAWSCodeArtifactRepositoryEndpointBasicConfig(rName),
+				Config: testAccCheckAWSCodeArtifactRepositoryEndpointBasicConfig(rName, "npm"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "repository_endpoint"),
+					testAccCheckResourceAttrAccountID(dataSourceName, "domain_owner"),
+				),
+			},
+			{
+				Config: testAccCheckAWSCodeArtifactRepositoryEndpointBasicConfig(rName, "pypi"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "repository_endpoint"),
+					testAccCheckResourceAttrAccountID(dataSourceName, "domain_owner"),
+				),
+			},
+			{
+				Config: testAccCheckAWSCodeArtifactRepositoryEndpointBasicConfig(rName, "maven"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "repository_endpoint"),
+					testAccCheckResourceAttrAccountID(dataSourceName, "domain_owner"),
+				),
+			},
+			{
+				Config: testAccCheckAWSCodeArtifactRepositoryEndpointBasicConfig(rName, "nuget"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "repository_endpoint"),
 					testAccCheckResourceAttrAccountID(dataSourceName, "domain_owner"),
@@ -66,19 +87,21 @@ resource "aws_codeartifact_repository" "test" {
 `, rName)
 }
 
-func testAccCheckAWSCodeArtifactRepositoryEndpointBasicConfig(rName string) string {
-	return testAccCheckAWSCodeArtifactRepositoryEndpointBaseConfig(rName) +
+func testAccCheckAWSCodeArtifactRepositoryEndpointBasicConfig(rName, format string) string {
+	return composeConfig(
+		testAccCheckAWSCodeArtifactRepositoryEndpointBaseConfig(rName),
 		fmt.Sprintf(`
 data "aws_codeartifact_repository_endpoint" "test" {
   domain     = aws_codeartifact_domain.test.domain
   repository = aws_codeartifact_repository.test.repository
-  format     = "npm"
+  format     = %[1]q
 }
-`)
+`, format))
 }
 
 func testAccCheckAWSCodeArtifactRepositoryEndpointOwnerConfig(rName string) string {
-	return testAccCheckAWSCodeArtifactRepositoryEndpointBaseConfig(rName) +
+	return composeConfig(
+		testAccCheckAWSCodeArtifactRepositoryEndpointBaseConfig(rName),
 		fmt.Sprintf(`
 data "aws_codeartifact_repository_endpoint" "test" {
   domain       = aws_codeartifact_domain.test.domain
@@ -86,5 +109,5 @@ data "aws_codeartifact_repository_endpoint" "test" {
   domain_owner = aws_codeartifact_domain.test.owner
   format       = "npm"
 }
-`)
+`))
 }

--- a/website/docs/d/codeartifact_repository_endpoint.html.markdown
+++ b/website/docs/d/codeartifact_repository_endpoint.html.markdown
@@ -26,7 +26,7 @@ The following arguments are supported:
 
 * `domain` - (Required) The name of the domain that contains the repository.
 * `repository` - (Required) The name of the repository.
-* `format` - (Required) Which endpoint of a repository to return. A repository has one endpoint for each package format: `npm`, `pypi`, and `maven`.
+* `format` - (Required) Which endpoint of a repository to return. A repository has one endpoint for each package format: `npm`, `pypi`, `maven`, and `nuget`.
 * `domain_owner` - (Optional) The account number of the AWS account that owns the domain.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/16405.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_codeartifact_repository_endpoint: Add `nuget` as a supported format
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeArtifactRepositoryEndpointDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeArtifactRepositoryEndpointDataSource_ -timeout 120m
=== RUN   TestAccAWSCodeArtifactRepositoryEndpointDataSource_basic
--- PASS: TestAccAWSCodeArtifactRepositoryEndpointDataSource_basic (60.97s)
=== RUN   TestAccAWSCodeArtifactRepositoryEndpointDataSource_owner
--- PASS: TestAccAWSCodeArtifactRepositoryEndpointDataSource_owner (18.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	79.800s
```
