### PR TITLE
Use Values functions to validate SDK Enums

### DIFF
--- a/aws/data_source_aws_acm_certificate.go
+++ b/aws/data_source_aws_acm_certificate.go
@@ -32,15 +32,8 @@ func dataSourceAwsAcmCertificate() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						acm.KeyAlgorithmEcPrime256v1,
-						acm.KeyAlgorithmEcSecp384r1,
-						acm.KeyAlgorithmEcSecp521r1,
-						acm.KeyAlgorithmRsa1024,
-						acm.KeyAlgorithmRsa2048,
-						acm.KeyAlgorithmRsa4096,
-					}, false),
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(acm.KeyAlgorithm_Values(), false),
 				},
 			},
 			"types": {

--- a/aws/data_source_aws_availability_zones.go
+++ b/aws/data_source_aws_availability_zones.go
@@ -42,14 +42,9 @@ func dataSourceAwsAvailabilityZones() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"state": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.AvailabilityZoneStateAvailable,
-					ec2.AvailabilityZoneStateInformation,
-					ec2.AvailabilityZoneStateImpaired,
-					ec2.AvailabilityZoneStateUnavailable,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ec2.AvailabilityZoneState_Values(), false),
 			},
 			"zone_ids": {
 				Type:     schema.TypeList,

--- a/aws/data_source_aws_ec2_instance_type_offering.go
+++ b/aws/data_source_aws_ec2_instance_type_offering.go
@@ -20,13 +20,9 @@ func dataSourceAwsEc2InstanceTypeOffering() *schema.Resource {
 				Computed: true,
 			},
 			"location_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.LocationTypeAvailabilityZone,
-					ec2.LocationTypeAvailabilityZoneId,
-					ec2.LocationTypeRegion,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ec2.LocationType_Values(), false),
 			},
 			"preferred_instance_types": {
 				Type:     schema.TypeList,

--- a/aws/data_source_aws_ec2_instance_type_offerings.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings.go
@@ -21,13 +21,9 @@ func dataSourceAwsEc2InstanceTypeOfferings() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"location_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.LocationTypeAvailabilityZone,
-					ec2.LocationTypeAvailabilityZoneId,
-					ec2.LocationTypeRegion,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ec2.LocationType_Values(), false),
 			},
 		},
 	}

--- a/aws/data_source_aws_glue_script.go
+++ b/aws/data_source_aws_glue_script.go
@@ -77,13 +77,10 @@ func dataSourceAwsGlueScript() *schema.Resource {
 				},
 			},
 			"language": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  glue.LanguagePython,
-				ValidateFunc: validation.StringInSlice([]string{
-					glue.LanguagePython,
-					glue.LanguageScala,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      glue.LanguagePython,
+				ValidateFunc: validation.StringInSlice(glue.Language_Values(), false),
 			},
 			"python_script": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -84,9 +84,10 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 							},
 						},
 						"effect": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "Allow",
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Allow",
+							//lintignore:AWSV001 // no enum in AWS SDK
 							ValidateFunc: validation.StringInSlice([]string{"Allow", "Deny"}, false),
 						},
 						"not_actions":    setOfString,
@@ -105,6 +106,7 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "2012-10-17",
+				//lintignore:AWSV001 // no enum in AWS SDK
 				ValidateFunc: validation.StringInSlice([]string{
 					"2008-10-17",
 					"2012-10-17",

--- a/aws/data_source_aws_instances.go
+++ b/aws/data_source_aws_instances.go
@@ -22,15 +22,8 @@ func dataSourceAwsInstances() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						ec2.InstanceStateNamePending,
-						ec2.InstanceStateNameRunning,
-						ec2.InstanceStateNameShuttingDown,
-						ec2.InstanceStateNameStopped,
-						ec2.InstanceStateNameStopping,
-						ec2.InstanceStateNameTerminated,
-					}, false),
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(ec2.InstanceStateName_Values(), false),
 				},
 			},
 

--- a/aws/data_source_aws_iot_endpoint.go
+++ b/aws/data_source_aws_iot_endpoint.go
@@ -20,6 +20,7 @@ func dataSourceAwsIotEndpoint() *schema.Resource {
 			"endpoint_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				//lintignore:AWSV001 // no enum in AWS SDK
 				ValidateFunc: validation.StringInSlice([]string{
 					"iot:CredentialProvider",
 					"iot:Data",

--- a/aws/data_source_aws_ram_resource_share.go
+++ b/aws/data_source_aws_ram_resource_share.go
@@ -34,12 +34,9 @@ func dataSourceAwsRamResourceShare() *schema.Resource {
 			},
 
 			"resource_owner": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ram.ResourceOwnerOtherAccounts,
-					ram.ResourceOwnerSelf,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(ram.ResourceOwner_Values(), false),
 			},
 
 			"name": {

--- a/aws/data_source_aws_route53_resolver_rule.go
+++ b/aws/data_source_aws_route53_resolver_rule.go
@@ -57,14 +57,10 @@ func dataSourceAwsRoute53ResolverRule() *schema.Resource {
 			},
 
 			"rule_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					route53resolver.RuleTypeOptionForward,
-					route53resolver.RuleTypeOptionSystem,
-					route53resolver.RuleTypeOptionRecursive,
-				}, false),
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validation.StringInSlice(route53resolver.RuleTypeOption_Values(), false),
 				ConflictsWith: []string{"resolver_rule_id"},
 			},
 

--- a/aws/data_source_aws_route53_resolver_rules.go
+++ b/aws/data_source_aws_route53_resolver_rules.go
@@ -18,6 +18,7 @@ func dataSourceAwsRoute53ResolverRules() *schema.Resource {
 			"owner_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				//lintignore:AWSV001 // no enum in AWS SDK
 				ValidateFunc: validation.Any(
 					validateAwsAccountId,
 					// The owner of the default Internet Resolver rule.
@@ -38,23 +39,15 @@ func dataSourceAwsRoute53ResolverRules() *schema.Resource {
 			},
 
 			"rule_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					route53resolver.RuleTypeOptionForward,
-					route53resolver.RuleTypeOptionSystem,
-					route53resolver.RuleTypeOptionRecursive,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(route53resolver.RuleTypeOption_Values(), false),
 			},
 
 			"share_status": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					route53resolver.ShareStatusNotShared,
-					route53resolver.ShareStatusSharedWithMe,
-					route53resolver.ShareStatusSharedByMe,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(route53resolver.ShareStatus_Values(), false),
 			},
 		},
 	}

--- a/aws/data_source_aws_sagemaker_prebuilt_ecr_image.go
+++ b/aws/data_source_aws_sagemaker_prebuilt_ecr_image.go
@@ -264,6 +264,7 @@ func dataSourceAwsSageMakerPrebuiltECRImage() *schema.Resource {
 			"repository_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				//lintignore:AWSV001 // no enum in AWS SDK
 				ValidateFunc: validation.StringInSlice([]string{
 					sageMakerRepositoryBlazingText,
 					sageMakerRepositoryDeepARForecasting,

--- a/aws/data_source_aws_ssm_document.go
+++ b/aws/data_source_aws_ssm_document.go
@@ -24,13 +24,10 @@ func dataSourceAwsSsmDocument() *schema.Resource {
 				Computed: true,
 			},
 			"document_format": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  ssm.DocumentFormatJson,
-				ValidateFunc: validation.StringInSlice([]string{
-					ssm.DocumentFormatJson,
-					ssm.DocumentFormatYaml,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ssm.DocumentFormatJson,
+				ValidateFunc: validation.StringInSlice(ssm.DocumentFormat_Values(), false),
 			},
 			"document_type": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_wafv2_ip_set.go
+++ b/aws/data_source_aws_wafv2_ip_set.go
@@ -36,12 +36,9 @@ func dataSourceAwsWafv2IPSet() *schema.Resource {
 				Required: true,
 			},
 			"scope": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					wafv2.ScopeCloudfront,
-					wafv2.ScopeRegional,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
 			},
 		},
 	}

--- a/aws/data_source_aws_wafv2_regex_pattern_set.go
+++ b/aws/data_source_aws_wafv2_regex_pattern_set.go
@@ -39,12 +39,9 @@ func dataSourceAwsWafv2RegexPatternSet() *schema.Resource {
 				},
 			},
 			"scope": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					wafv2.ScopeCloudfront,
-					wafv2.ScopeRegional,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
 			},
 		},
 	}

--- a/aws/data_source_aws_wafv2_rule_group.go
+++ b/aws/data_source_aws_wafv2_rule_group.go
@@ -27,12 +27,9 @@ func dataSourceAwsWafv2RuleGroup() *schema.Resource {
 				Required: true,
 			},
 			"scope": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					wafv2.ScopeCloudfront,
-					wafv2.ScopeRegional,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
 			},
 		},
 	}

--- a/aws/data_source_aws_wafv2_web_acl.go
+++ b/aws/data_source_aws_wafv2_web_acl.go
@@ -27,12 +27,9 @@ func dataSourceAwsWafv2WebACL() *schema.Resource {
 				Required: true,
 			},
 			"scope": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					wafv2.ScopeCloudfront,
-					wafv2.ScopeRegional,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
 			},
 		},
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14601

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_ssm_document: Add `text` as a supported format
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS=-run=TestAccAWSAcmCertificateDataSource
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAcmCertificateDataSource -timeout 120m
=== RUN   TestAccAWSAcmCertificateDataSource_singleIssued
=== PAUSE TestAccAWSAcmCertificateDataSource_singleIssued
=== RUN   TestAccAWSAcmCertificateDataSource_multipleIssued
=== PAUSE TestAccAWSAcmCertificateDataSource_multipleIssued
=== RUN   TestAccAWSAcmCertificateDataSource_noMatchReturnsError
=== PAUSE TestAccAWSAcmCertificateDataSource_noMatchReturnsError
=== RUN   TestAccAWSAcmCertificateDataSource_KeyTypes
=== PAUSE TestAccAWSAcmCertificateDataSource_KeyTypes
=== CONT  TestAccAWSAcmCertificateDataSource_singleIssued
=== CONT  TestAccAWSAcmCertificateDataSource_KeyTypes
=== CONT  TestAccAWSAcmCertificateDataSource_noMatchReturnsError
=== CONT  TestAccAWSAcmCertificateDataSource_multipleIssued
    TestAccAWSAcmCertificateDataSource_singleIssued: data_source_aws_acm_certificate_test.go:38: Step 1/6 error: Error running pre-apply refresh: 
        Error: No certificate for domain "tf-acc-single-issued.burgess-it.com" found in this region
        
        
--- FAIL: TestAccAWSAcmCertificateDataSource_singleIssued (37.66s)
    TestAccAWSAcmCertificateDataSource_multipleIssued: data_source_aws_acm_certificate_test.go:110: Step 1/6, expected an error with pattern, no match on: Error running pre-apply refresh: 
        Error: No certificate for domain "tf-acc-multiple-issued.burgess-it.com" found in this region
        
        
--- FAIL: TestAccAWSAcmCertificateDataSource_multipleIssued (38.56s)
--- PASS: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (49.82s)
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (66.74s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	66.782s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

$ make testacc TESTARGS=-run=TestAccDataSourceAwsAvailabilityZone
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsAvailabilityZone -timeout 120m
=== RUN   TestAccDataSourceAwsAvailabilityZone_AllAvailabilityZones
=== PAUSE TestAccDataSourceAwsAvailabilityZone_AllAvailabilityZones
=== RUN   TestAccDataSourceAwsAvailabilityZone_Filter
=== PAUSE TestAccDataSourceAwsAvailabilityZone_Filter
=== RUN   TestAccDataSourceAwsAvailabilityZone_Name
=== PAUSE TestAccDataSourceAwsAvailabilityZone_Name
=== RUN   TestAccDataSourceAwsAvailabilityZone_ZoneId
=== PAUSE TestAccDataSourceAwsAvailabilityZone_ZoneId
=== CONT  TestAccDataSourceAwsAvailabilityZone_AllAvailabilityZones
=== CONT  TestAccDataSourceAwsAvailabilityZone_ZoneId
=== CONT  TestAccDataSourceAwsAvailabilityZone_Name
=== CONT  TestAccDataSourceAwsAvailabilityZone_Filter
--- PASS: TestAccDataSourceAwsAvailabilityZone_ZoneId (53.95s)
--- PASS: TestAccDataSourceAwsAvailabilityZone_AllAvailabilityZones (61.57s)
--- PASS: TestAccDataSourceAwsAvailabilityZone_Filter (64.08s)
--- PASS: TestAccDataSourceAwsAvailabilityZone_Name (64.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	64.546s

$ make testacc TESTARGS=-run=TestAccAWSEc2InstanceTypeOfferingDataSource
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2InstanceTypeOfferingDataSource -timeout 120m
=== RUN   TestAccAWSEc2InstanceTypeOfferingDataSource_Filter
=== PAUSE TestAccAWSEc2InstanceTypeOfferingDataSource_Filter
=== RUN   TestAccAWSEc2InstanceTypeOfferingDataSource_LocationType
=== PAUSE TestAccAWSEc2InstanceTypeOfferingDataSource_LocationType
=== RUN   TestAccAWSEc2InstanceTypeOfferingDataSource_PreferredInstanceTypes
=== PAUSE TestAccAWSEc2InstanceTypeOfferingDataSource_PreferredInstanceTypes
=== CONT  TestAccAWSEc2InstanceTypeOfferingDataSource_Filter
=== CONT  TestAccAWSEc2InstanceTypeOfferingDataSource_PreferredInstanceTypes
=== CONT  TestAccAWSEc2InstanceTypeOfferingDataSource_LocationType
--- PASS: TestAccAWSEc2InstanceTypeOfferingDataSource_PreferredInstanceTypes (49.04s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingDataSource_Filter (53.56s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingDataSource_LocationType (54.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	54.833s

$ make testacc TESTARGS=-run=TestAccAWSEc2InstanceTypeOfferingsDataSource
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2InstanceTypeOfferingsDataSource -timeout 120m
=== RUN   TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter
=== PAUSE TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter
=== RUN   TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType
=== PAUSE TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType
=== CONT  TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter
=== CONT  TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType
--- PASS: TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter (42.83s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType (48.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.088s

$ make testacc TESTARGS=-run=TestAccDataSourceAWSGlueScript
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSGlueScript -timeout 120m
=== RUN   TestAccDataSourceAWSGlueScript_Language_Python
=== PAUSE TestAccDataSourceAWSGlueScript_Language_Python
=== RUN   TestAccDataSourceAWSGlueScript_Language_Scala
=== PAUSE TestAccDataSourceAWSGlueScript_Language_Scala
=== CONT  TestAccDataSourceAWSGlueScript_Language_Python
=== CONT  TestAccDataSourceAWSGlueScript_Language_Scala
--- PASS: TestAccDataSourceAWSGlueScript_Language_Python (41.48s)
--- PASS: TestAccDataSourceAWSGlueScript_Language_Scala (42.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.878s

$ make testacc TESTARGS=-run=TestAccAWSDataSourceIAMPolicyDocument
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMPolicyDocument -timeout 120m
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_basic
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_basic
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_source
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_source
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_override
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_override
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsGov
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsGov
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_basic
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_override
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_source
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsGov
    TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsGov: provider_test.go:701: skipping tests; current partition (aws) does not equal aws-us-gov
--- SKIP: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsGov (2.02s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (119.39s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (121.17s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (123.92s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (125.08s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals (126.17s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (127.56s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice (129.82s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (130.15s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Version_20081017 (137.31s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (140.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	140.686s

$ make testacc TESTARGS=-run=TestAccAWSInstancesDataSource
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSInstancesDataSource -timeout 120m
=== RUN   TestAccAWSInstancesDataSource_basic
=== PAUSE TestAccAWSInstancesDataSource_basic
=== RUN   TestAccAWSInstancesDataSource_tags
=== PAUSE TestAccAWSInstancesDataSource_tags
=== RUN   TestAccAWSInstancesDataSource_instanceStateNames
=== PAUSE TestAccAWSInstancesDataSource_instanceStateNames
=== CONT  TestAccAWSInstancesDataSource_basic
=== CONT  TestAccAWSInstancesDataSource_instanceStateNames
=== CONT  TestAccAWSInstancesDataSource_tags
    TestAccAWSInstancesDataSource_tags: data_source_aws_instances_test.go:34: Step 1/1 error: Error running apply: 
        Error: Error launching source instance: VPCIdNotSpecified: No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.
        	status code: 400, request id: 790e3d8d-5b19-4d46-bb9f-328f9eaac7d2
        
        
        
        Error: Error launching source instance: VPCIdNotSpecified: No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.
        	status code: 400, request id: 310e2801-a086-4741-b003-9d7b5cb5cc8e
        
        
    TestAccAWSInstancesDataSource_basic: data_source_aws_instances_test.go:14: Step 1/1 error: Error running apply: 
        Error: Error launching source instance: VPCIdNotSpecified: No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.
        	status code: 400, request id: 4b2d3214-5773-41f1-a2f1-aa9484015772
        
        
        
        Error: Error launching source instance: VPCIdNotSpecified: No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.
        	status code: 400, request id: afece6d8-e28e-427a-8a4e-8620cf0487ac
        
        
        
        Error: Error launching source instance: VPCIdNotSpecified: No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.
        	status code: 400, request id: 9cda1b95-e460-4641-9c9c-708982d91e80
        
        
    TestAccAWSInstancesDataSource_instanceStateNames: data_source_aws_instances_test.go:51: Step 1/1 error: Error running apply: 
        Error: Error launching source instance: VPCIdNotSpecified: No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.
        	status code: 400, request id: f940dee5-a48a-4c27-a5b3-3a383f2c57d2
        
        
        
        Error: Error launching source instance: VPCIdNotSpecified: No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.
        	status code: 400, request id: 3677e2d3-8040-4425-b7ba-6faa7ccc60e0
        
        
--- FAIL: TestAccAWSInstancesDataSource_basic (47.02s)
--- FAIL: TestAccAWSInstancesDataSource_tags (47.08s)
--- FAIL: TestAccAWSInstancesDataSource_instanceStateNames (47.62s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	47.667s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

$ make testacc TESTARGS=-run=TestAccAWSIotEndpointDataSource
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIotEndpointDataSource -timeout 120m
=== RUN   TestAccAWSIotEndpointDataSource_basic
=== PAUSE TestAccAWSIotEndpointDataSource_basic
=== RUN   TestAccAWSIotEndpointDataSource_EndpointType_IOTCredentialProvider
=== PAUSE TestAccAWSIotEndpointDataSource_EndpointType_IOTCredentialProvider
=== RUN   TestAccAWSIotEndpointDataSource_EndpointType_IOTData
=== PAUSE TestAccAWSIotEndpointDataSource_EndpointType_IOTData
=== RUN   TestAccAWSIotEndpointDataSource_EndpointType_IOTDataATS
=== PAUSE TestAccAWSIotEndpointDataSource_EndpointType_IOTDataATS
=== RUN   TestAccAWSIotEndpointDataSource_EndpointType_IOTJobs
=== PAUSE TestAccAWSIotEndpointDataSource_EndpointType_IOTJobs
=== CONT  TestAccAWSIotEndpointDataSource_basic
=== CONT  TestAccAWSIotEndpointDataSource_EndpointType_IOTDataATS
=== CONT  TestAccAWSIotEndpointDataSource_EndpointType_IOTData
=== CONT  TestAccAWSIotEndpointDataSource_EndpointType_IOTCredentialProvider
=== CONT  TestAccAWSIotEndpointDataSource_EndpointType_IOTJobs
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTCredentialProvider (66.54s)
--- PASS: TestAccAWSIotEndpointDataSource_basic (66.98s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTData (67.42s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTJobs (68.31s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTDataATS (71.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	71.120s

$ make testacc TESTARGS=-run=TestAccDataSourceAwsRamResourceShare
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsRamResourceShare -timeout 120m
=== RUN   TestAccDataSourceAwsRamResourceShare_basic
=== PAUSE TestAccDataSourceAwsRamResourceShare_basic
=== RUN   TestAccDataSourceAwsRamResourceShare_Tags
=== PAUSE TestAccDataSourceAwsRamResourceShare_Tags
=== CONT  TestAccDataSourceAwsRamResourceShare_basic
=== CONT  TestAccDataSourceAwsRamResourceShare_Tags
    TestAccDataSourceAwsRamResourceShare_Tags: data_source_aws_ram_resource_share_test.go:42: Step 1/1 error: Error running pre-apply plan: 
        Error: No matching resource found: %!s(<nil>)
        
        
--- FAIL: TestAccDataSourceAwsRamResourceShare_Tags (23.68s)
    TestAccDataSourceAwsRamResourceShare_basic: data_source_aws_ram_resource_share_test.go:17: Step 2/2 error: Error running pre-apply plan: 
        Error: No matching resource found: %!s(<nil>)
        
        
--- FAIL: TestAccDataSourceAwsRamResourceShare_basic (30.08s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	30.124s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

$ make testacc TESTARGS=-run=TestAccDataSourceAwsRoute53ResolverRule
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsRoute53ResolverRule -timeout 120m
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_basic
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_basic
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_SharedByMe
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_SharedByMe
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe
=== RUN   TestAccDataSourceAwsRoute53ResolverRules_basic
=== PAUSE TestAccDataSourceAwsRoute53ResolverRules_basic
=== RUN   TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId
=== PAUSE TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_basic
=== CONT  TestAccDataSourceAwsRoute53ResolverRules_basic
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_SharedByMe
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags
=== CONT  TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId
    TestAccDataSourceAwsRoute53ResolverRule_SharedByMe: provider_test.go:635: AWS_ALTERNATE_ACCESS_KEY_ID or AWS_ALTERNATE_PROFILE must be set for acceptance tests
--- FAIL: TestAccDataSourceAwsRoute53ResolverRule_SharedByMe (1.74s)
    TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe: provider_test.go:635: AWS_ALTERNATE_ACCESS_KEY_ID or AWS_ALTERNATE_PROFILE must be set for acceptance tests
--- FAIL: TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe (1.76s)
    TestAccDataSourceAwsRoute53ResolverRule_basic: data_source_aws_route53_resolver_rule_test.go:19: Step 1/1 error: Error running pre-apply plan: 
        Error: no Route53 Resolver rules matched
        
        
        
        Error: no Route53 Resolver rules matched
        
        
--- FAIL: TestAccDataSourceAwsRoute53ResolverRule_basic (41.91s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRules_basic (53.29s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId (297.40s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags (298.57s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	298.726s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

$ make testacc TESTARGS=-run=TestAccAWSSageMakerPrebuiltECRImage
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSageMakerPrebuiltECRImage -timeout 120m
=== RUN   TestAccAWSSageMakerPrebuiltECRImage_basic
=== PAUSE TestAccAWSSageMakerPrebuiltECRImage_basic
=== RUN   TestAccAWSSageMakerPrebuiltECRImage_region
=== PAUSE TestAccAWSSageMakerPrebuiltECRImage_region
=== CONT  TestAccAWSSageMakerPrebuiltECRImage_basic
=== CONT  TestAccAWSSageMakerPrebuiltECRImage_region
--- PASS: TestAccAWSSageMakerPrebuiltECRImage_basic (48.27s)
--- PASS: TestAccAWSSageMakerPrebuiltECRImage_region (48.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.315s

$ make testacc TESTARGS=-run=TestAccAWSSsmDocumentDataSource
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSsmDocumentDataSource -timeout 120m
=== RUN   TestAccAWSSsmDocumentDataSource_basic
=== PAUSE TestAccAWSSsmDocumentDataSource_basic
=== CONT  TestAccAWSSsmDocumentDataSource_basic
    TestAccAWSSsmDocumentDataSource_basic: data_source_aws_ssm_document_test.go:15: Step 1/2 error: Error running pre-apply plan: 
        Error: Error reading SSM Document: InvalidDocument: Document with name test_document-3180281793031338437 does not exist.
        
        
--- FAIL: TestAccAWSSsmDocumentDataSource_basic (22.38s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	22.423s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

$ make testacc TESTARGS=-run=TestAccDataSourceAwsWafv2IPSet
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2IPSet -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2IPSet_basic
=== PAUSE TestAccDataSourceAwsWafv2IPSet_basic
=== CONT  TestAccDataSourceAwsWafv2IPSet_basic
    TestAccDataSourceAwsWafv2IPSet_basic: data_source_aws_wafv2_ip_set_test.go:17: Step 2/2 error: Error running pre-apply plan: 
        Error: WAFv2 IPSet not found for name: tf-acc-test-9135216113694825427
        
        
--- FAIL: TestAccDataSourceAwsWafv2IPSet_basic (28.70s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	28.748s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

$ make testacc TESTARGS=-run=TestAccDataSourceAwsWafv2RegexPatternSet
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2RegexPatternSet -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2RegexPatternSet_basic
=== PAUSE TestAccDataSourceAwsWafv2RegexPatternSet_basic
=== CONT  TestAccDataSourceAwsWafv2RegexPatternSet_basic
    TestAccDataSourceAwsWafv2RegexPatternSet_basic: data_source_aws_wafv2_regex_pattern_set_test.go:17: Step 2/2 error: Error running pre-apply plan: 
        Error: WAFv2 RegexPatternSet not found for name: tf-acc-test-4591174332572380147
        
        
--- FAIL: TestAccDataSourceAwsWafv2RegexPatternSet_basic (34.89s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	34.937s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

$ make testacc TESTARGS=-run=TestAccDataSourceAwsWafv2RuleGroup
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2RuleGroup -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2RuleGroup_basic
=== PAUSE TestAccDataSourceAwsWafv2RuleGroup_basic
=== CONT  TestAccDataSourceAwsWafv2RuleGroup_basic
    TestAccDataSourceAwsWafv2RuleGroup_basic: data_source_aws_wafv2_rule_group_test.go:17: Step 2/2 error: Error running pre-apply plan: 
        Error: WAFv2 RuleGroup not found for name: tf-acc-test-2692137326599199224
        
        
--- FAIL: TestAccDataSourceAwsWafv2RuleGroup_basic (28.74s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	28.787s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

$ make testacc TESTARGS=-run=TestAccDataSourceAwsWafv2WebACL
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2WebACL -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2WebACL_basic
=== PAUSE TestAccDataSourceAwsWafv2WebACL_basic
=== CONT  TestAccDataSourceAwsWafv2WebACL_basic
    TestAccDataSourceAwsWafv2WebACL_basic: data_source_aws_wafv2_web_acl_test.go:17: Step 2/2 error: Error running pre-apply plan: 
        Error: WAFv2 WebACL not found for name: tf-acc-test-5507665605718285947
        
        
--- FAIL: TestAccDataSourceAwsWafv2WebACL_basic (41.27s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	41.317s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1
```
