### PR TITLE
r/aws_elasticsearchdomain: add support for saml_options

### DIFF
--- a/aws/data_source_aws_elasticsearch_domain.go
+++ b/aws/data_source_aws_elasticsearch_domain.go
@@ -313,7 +313,7 @@ func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface
 	d.Set("endpoint", ds.Endpoint)
 	d.Set("kibana_endpoint", getKibanaEndpoint(d))
 
-	if err := d.Set("advanced_security_options", flattenAdvancedSecurityOptions(ds.AdvancedSecurityOptions)); err != nil {
+	if err := d.Set("advanced_security_options", flattenAdvancedSecurityOptions(d, ds.AdvancedSecurityOptions)); err != nil {
 		return fmt.Errorf("error setting advanced_security_options: %w", err)
 	}
 

--- a/aws/elasticsearch_domain_structure.go
+++ b/aws/elasticsearch_domain_structure.go
@@ -57,13 +57,13 @@ func expandAdvancedSecurityOptions(m []interface{}, create bool) *elasticsearch.
 								if v, ok := SAMLOptions["master_user_name"].(string); ok && v != "" {
 									options.MasterUserName = aws.String(v)
 								}
-								if v, ok := SAMLOptions["roles_key"].(string); ok && v != "" {
+								if v, ok := SAMLOptions["roles_key"].(string); ok {
 									options.RolesKey = aws.String(v)
 								}
 								if v, ok := SAMLOptions["session_timeout_minutes"].(int); ok {
 									options.SessionTimeoutMinutes = aws.Int64(int64(v))
 								}
-								if v, ok := SAMLOptions["subject_key"].(string); ok && v != "" {
+								if v, ok := SAMLOptions["subject_key"].(string); ok {
 									options.SubjectKey = aws.String(v)
 								}
 							}

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -771,7 +771,7 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 	// values from resource; additionally, append MasterUserOptions
 	// from resource as they are not returned from the API
 	if ds.AdvancedSecurityOptions != nil {
-		advSecOpts := flattenAdvancedSecurityOptions(ds.AdvancedSecurityOptions)
+		advSecOpts := flattenAdvancedSecurityOptions(d, ds.AdvancedSecurityOptions)
 		if !aws.BoolValue(ds.AdvancedSecurityOptions.Enabled) {
 			advSecOpts[0]["internal_user_database_enabled"] = getUserDBEnabled(d)
 		}

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -450,7 +450,7 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 				Optional:         true,
 				ForceNew:         false,
 				MaxItems:         1,
-				ConflictsWith:    []string{"advanced_security_options.saml_options"},
+				ConflictsWith:    []string{"advanced_security_options.0.saml_options"},
 				DiffSuppressFunc: esCognitoOptionsDiffSuppress,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -1224,13 +1224,13 @@ func testAccCheckAdvancedSecurityOptions(enabled bool, userDbEnabled bool, SAMLE
 				)
 			}
 
-			// if *conf.SAMLOptions.Enabled != SAMLEnabled {
-			// 	return fmt.Errorf(
-			// 		"AdvancedSecurityOptions.SAMLOptions not set properly. Given: %t, Expected: %t",
-			// 		aws.BoolValue(conf.SAMLOptions.Enabled),
-			// 		SAMLEnabled,
-			// 	)
-			// }
+			if conf.SAMLOptions != nil && aws.BoolValue(conf.SAMLOptions.Enabled) != SAMLEnabled {
+				return fmt.Errorf(
+					"AdvancedSecurityOptions.SAMLOptions not set properly. Given: %t, Expected: %t",
+					aws.BoolValue(conf.SAMLOptions.Enabled),
+					SAMLEnabled,
+				)
+			}
 		}
 
 		return nil

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -551,11 +551,12 @@ func TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_SAML(t *testing.T) {
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccESDomainConfig_AdvancedSecurityOptionsSAML(userName, domainName, false),
+				Config: testAccESDomainConfig_AdvancedSecurityOptionsSAML(userName, domainName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists(resourceName, &domain),
 					testAccCheckAdvancedSecurityOptions(true, false, false, &domain),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				ResourceName:      resourceName,
@@ -566,6 +567,8 @@ func TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_SAML(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"advanced_security_options.0.internal_user_database_enabled",
 					"advanced_security_options.0.master_user_options",
+					"advanced_security_options.0.saml_options.0.master_backend_role",
+					"advanced_security_options.0.saml_options.0.master_user_name",
 				},
 			},
 			{
@@ -574,8 +577,6 @@ func TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_SAML(t *testing.T) {
 					testAccCheckESDomainExists(resourceName, &domain),
 					testAccCheckAdvancedSecurityOptions(true, false, true, &domain),
 				),
-				// You cannot specify SAML options during domain creation.
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -235,6 +235,16 @@ The **advanced_security_options** block supports the following attributes:
     * `master_user_arn` - (Optional) ARN for the master user. Only specify if `internal_user_database_enabled` is not set or set to `false`)
     * `master_user_name` - (Optional) The master user's username, which is stored in the Amazon Elasticsearch Service domain's internal database. Only specify if `internal_user_database_enabled` is set to `true`.
     * `master_user_password` - (Optional) The master user's password, which is stored in the Amazon Elasticsearch Service domain's internal database. Only specify if `internal_user_database_enabled` is set to `true`.
+* `saml_options` - (Optional) Credentials for the master user: username and password, or ARN
+    * `enabled` - (Optional) Whether SAML application configuration is enabled.
+    * `idp` - (Optional) Specifies the SAML Identity Provider's information.
+        * `entity_id` - (Optional) The unique Entity ID of the application in the SAML Identity Provider.
+        * `metadata_content` - (Optional) The Metadata of the SAML application in xml format.
+    * `master_backend_role` - (Optional) The backend role to which the SAML master user is mapped to.
+    * `master_user_name` - (Optional) The SAML master username, which is stored in the AMazon Elasticsearch Service domain's internal database.
+    * `roles_key` - (Optional) The key to use for matching the SAML Roles attribute.
+    * `session_timeout_minutes` - (Optional) The duration, in minutes, after which a user session becomes inactive. Acceptable values are between 1 and 1440, and the default value is 60.
+    * `subject_key` - (Optional) The key to use for matching the SAML subject attribute.
 
 **ebs_options** supports the following attributes:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes #16259 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_elasticsearch_domain: Support `saml_options` advanced_security_option ([#16259](https://github.com/hashicorp/terraform-provider-aws/issues/16259))
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_SAML'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_SAML -timeout 120m
=== RUN   TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_SAML
=== PAUSE TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_SAML
=== CONT  TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_SAML
--- PASS: TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_SAML (985.80s)
PASS
ok           github.com/terraform-providers/terraform-provider-aws/aws     987.358s
...
```

The overall structure is ready, but I still have an issue with `You cannot specify SAML options during domain creation`.  The second apply in the create test results in a non-empty plan.  I couldn't find another resource in the repo which restricts parameters on creation.  I would greatly appreciate any guidance for this two-step creation process.