### PR TITLE
docs/service/ec2: Include more references to aws_ec2_tag resource for EC2 Transit Gateway VPN Attachment usage

### DIFF
--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Get information on an EC2 Transit Gateway VPN Attachment.
 
+-> EC2 Transit Gateway VPN Attachments are implicitly created by VPN Connections referencing an EC2 Transit Gateway so there is no managed resource. For ease, the [`aws_vpn_connection` resource](/docs/providers/aws/r/vpn_connection.html) includes a `transit_gateway_attachment_id` attribute which can replace some usage of this data source. For tagging the attachment, see the [`aws_ec2_tag` resource](/docs/providers/aws/r/ec2_tag.html).
+
 ## Example Usage
 
 ### By Transit Gateway and VPN Connection Identifiers

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -93,7 +93,7 @@ In addition to all arguments above, the following attributes are exported:
 * `customer_gateway_configuration` - The configuration information for the VPN connection's customer gateway (in the native XML format).
 * `customer_gateway_id` - The ID of the customer gateway to which the connection is attached.
 * `static_routes_only` - Whether the VPN connection uses static routes exclusively.
-* `transit_gateway_attachment_id` - When associated with an EC2 Transit Gateway (`transit_gateway_id` argument), the attachment ID.
+* `transit_gateway_attachment_id` - When associated with an EC2 Transit Gateway (`transit_gateway_id` argument), the attachment ID. See also the [`aws_ec2_tag` resource](/docs/providers/aws/r/ec2_tag.html) for tagging the EC2 Transit Gateway VPN Attachment.
 * `tunnel1_address` - The public IP address of the first VPN tunnel.
 * `tunnel1_cgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (Customer Gateway Side).
 * `tunnel1_vgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (VPN Gateway Side).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16438

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A (documentation)
