### PR TITLE
resource/aws_instance: Automatically retry instance restart on eventual consistency error during `instance_type` in-place update

### DIFF
--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -1,6 +1,10 @@
 package ec2
 
 const (
+	ErrCodeInvalidParameterValue = "InvalidParameterValue"
+)
+
+const (
 	ErrCodeClientVpnEndpointIdNotFound        = "InvalidClientVpnEndpointId.NotFound"
 	ErrCodeClientVpnAuthorizationRuleNotFound = "InvalidClientVpnEndpointAuthorizationRuleNotFound"
 	ErrCodeClientVpnAssociationIdNotFound     = "InvalidClientVpnAssociationId.NotFound"

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -8,6 +8,11 @@ import (
 )
 
 const (
+	// Maximum amount of time to wait for EC2 Instance attribute modifications to propagate
+	InstanceAttributePropagationTimeout = 2 * time.Minute
+)
+
+const (
 	// Maximum amount of time to wait for a LocalGatewayRouteTableVpcAssociation to return Associated
 	LocalGatewayRouteTableVpcAssociationAssociatedTimeout = 5 * time.Minute
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16433

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_instance: Automatically retry instance restart on eventual consistency error during `instance_type` in-place update
```

Given that EC2 is eventually consistent in other places and AWS Support is recommending that behavior here as a cause, insert best effort retry logic.

Output from acceptance testing:

```
--- PASS: TestAccAWSInstance_changeInstanceType (178.65s)
```
