### PR TITLE
resource/aws_rds_cluster: Fix an enabled_cloudwatch_logs_exports type conversion error

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -747,8 +747,8 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			createOpts.KmsKeyId = aws.String(attr.(string))
 		}
 
-		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
-			createOpts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && attr.(*schema.Set).Len() > 0 {
+			createOpts.EnableCloudwatchLogsExports = expandStringSet(attr.(*schema.Set))
 		}
 
 		if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -389,6 +389,33 @@ func TestAccAWSRDSCluster_PointInTimeRestore(t *testing.T) {
 	})
 }
 
+func TestAccAWSRDSCluster_PointInTimeRestore_EnabledCloudwatchLogsExports(t *testing.T) {
+	var v rds.DBCluster
+	var c rds.DBCluster
+
+	parentId := acctest.RandomWithPrefix("tf-acc-point-in-time-restore-seed-test")
+	restoredId := acctest.RandomWithPrefix("tf-acc-point-in-time-restored-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterConfig_pointInTimeRestoreSource_enabled_cloudwatch_logs_exports(parentId, restoredId, "audit"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.test", &v),
+					testAccCheckAWSClusterExists("aws_rds_cluster.restored_pit", &c),
+					resource.TestCheckResourceAttr("aws_rds_cluster.restored_pit", "cluster_identifier", restoredId),
+					resource.TestCheckResourceAttrPair("aws_rds_cluster.restored_pit", "engine", "aws_rds_cluster.test", "engine"),
+					resource.TestCheckResourceAttr("aws_rds_cluster.restored_pit", "enabled_cloudwatch_logs_exports.#", "1"),
+					resource.TestCheckTypeSetElemAttr("aws_rds_cluster.restored_pit", "enabled_cloudwatch_logs_exports.*", "audit"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRDSCluster_generatedName(t *testing.T) {
 	var v rds.DBCluster
 	resourceName := "aws_rds_cluster.test"
@@ -2698,10 +2725,9 @@ resource "aws_db_subnet_group" "test" {
 }
 
 resource "aws_rds_cluster" "restored_pit" {
-  cluster_identifier              = "%s"
-  skip_final_snapshot             = true
-  engine                          = aws_rds_cluster.test.engine
-  enabled_cloudwatch_logs_exports = ["audit", "error"]
+  cluster_identifier  = "%s"
+  skip_final_snapshot = true
+  engine              = aws_rds_cluster.test.engine
   restore_to_point_in_time {
     source_cluster_identifier  = aws_rds_cluster.test.cluster_identifier
     restore_type               = "full-copy"
@@ -2709,6 +2735,53 @@ resource "aws_rds_cluster" "restored_pit" {
   }
 }
 `, parentId, childId))
+}
+
+func testAccAWSClusterConfig_pointInTimeRestoreSource_enabled_cloudwatch_logs_exports(parentId, childId, enabledCloudwatchLogExports string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier   = "%[1]s"
+  master_username      = "root"
+  master_password      = "password"
+  db_subnet_group_name = aws_db_subnet_group.test.name
+  skip_final_snapshot  = true
+  engine               = "aurora-mysql"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "%[1]s-vpc"
+  }
+}
+
+resource "aws_subnet" "subnets" {
+  count             = length(data.aws_availability_zones.available.names)
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.${count.index}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  tags = {
+    Name = "%[1]s-subnet-${count.index}"
+  }
+}
+
+resource "aws_db_subnet_group" "test" {
+  name       = "%[1]s-db-subnet-group"
+  subnet_ids = aws_subnet.subnets[*].id
+}
+
+resource "aws_rds_cluster" "restored_pit" {
+  cluster_identifier              = "%s"
+  skip_final_snapshot             = true
+  engine                          = aws_rds_cluster.test.engine
+  enabled_cloudwatch_logs_exports = [%q]
+  restore_to_point_in_time {
+    source_cluster_identifier  = aws_rds_cluster.test.cluster_identifier
+    restore_type               = "full-copy"
+    use_latest_restorable_time = true
+  }
+}
+`, parentId, childId, enabledCloudwatchLogExports))
 }
 
 func testAccAWSClusterConfigTags1(rName, tagKey1, tagValue1 string) string {

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -2698,9 +2698,10 @@ resource "aws_db_subnet_group" "test" {
 }
 
 resource "aws_rds_cluster" "restored_pit" {
-  cluster_identifier  = "%s"
-  skip_final_snapshot = true
-  engine              = aws_rds_cluster.test.engine
+  cluster_identifier              = "%s"
+  skip_final_snapshot             = true
+  engine                          = aws_rds_cluster.test.engine
+  enabled_cloudwatch_logs_exports = ["audit", "error"]
   restore_to_point_in_time {
     source_cluster_identifier  = aws_rds_cluster.test.cluster_identifier
     restore_type               = "full-copy"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_rds_cluster: Fix an enabled_cloudwatch_logs_exports type conversion error
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRDSCluster_PointInTimeRestore'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRDSCluster_PointInTimeRestore -timeout 120m
=== RUN   TestAccAWSRDSCluster_PointInTimeRestore
=== PAUSE TestAccAWSRDSCluster_PointInTimeRestore
=== CONT  TestAccAWSRDSCluster_PointInTimeRestore
--- PASS: TestAccAWSRDSCluster_PointInTimeRestore (456.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	458.258s
```

When I set `restore_to_point_in_time` block with `enabled_cloudwatch_logs_exports`, terraform-aws-provider crashes. It seems `enabled_cloudwatch_logs_exports` needs to be casted to `*schema.Set` not `[]interface{}` so I fixed it.

**Terraform configuration**

```
resource "aws_rds_cluster" "xxx" {
  cluster_identifier = "xxx"
  engine             = "aurora-postgresql"
  engine_version     = "11.7"

  db_subnet_group_name   = aws_db_subnet_group.xxx.name
  vpc_security_group_ids = [aws_security_group.xxx.id]

  db_cluster_parameter_group_name = "xxx"
  database_name                   = "xxx"
  master_username                 = "xxx"
  master_password                 = "xxx"

  enabled_cloudwatch_logs_exports = ["postgresql"]

  restore_to_point_in_time {
    source_cluster_identifier  = "xxx"
    restore_type               = "copy-on-write"
    use_latest_restorable_time = true
  }
}
```

**Crash logs**

```
panic: interface conversion: interface {} is *schema.Set, not []interface {}
2020-11-26T01:14:10.048Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 
2020-11-26T01:14:10.048Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: goroutine 70 [running]:
2020-11-26T01:14:10.048Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsRDSClusterCreate(0xc001e29b80, 0x55ba9a0, 0xc000fb7b80, 0x0, 0xffffffffffffffff)
2020-11-26T01:14:10.048Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/hashicorp/terraform-provider-aws/aws/resource_aws_rds_cluster.go:750 +0x6ea1
2020-11-26T01:14:10.048Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc0008cea50, 0x6e01620, 0xc000fdaf00, 0xc001e29b80, 0x55ba9a0, 0xc000fb7b80, 0x0, 0x0, 0x0)
2020-11-26T01:14:10.048Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.3.0/helper/schema/resource.go:268 +0x88
2020-11-26T01:14:10.048Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0008cea50, 0x6e01620, 0xc000fdaf00, 0xc0008f6770, 0xc001e66300, 0x55ba9a0, 0xc000fb7b80, 0x0, 0x0, 0x0, ...)
2020-11-26T01:14:10.062Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.3.0/helper/schema/resource.go:386 +0x681
2020-11-26T01:14:10.062Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000e796a0, 0x6e01620, 0xc000fdaf00, 0xc001e42910, 0xc000fdaf00, 0xc000e8ec00, 0x6e2fc60)
2020-11-26T01:14:10.062Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.3.0/helper/schema/grpc_provider.go:951 +0x8b2
2020-11-26T01:14:10.062Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ApplyResourceChange(0xc001500840, 0x6e01620, 0xc000fdaf00, 0xc0008f64d0, 0xc001500840, 0xc0012ffef0, 0xc001530ba0)
2020-11-26T01:14:10.062Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.1.0/tfprotov5/server/server.go:331 +0xac
2020-11-26T01:14:10.062Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x6049f60, 0xc001500840, 0x6e016e0, 0xc0012ffef0, 0xc000e8ec00, 0x0, 0x6e016e0, 0xc0012ffef0, 0xc001e59500, 0x9e7)
2020-11-26T01:14:10.063Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.1.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:380 +0x217
2020-11-26T01:14:10.063Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: google.golang.org/grpc.(*Server).processUnaryRPC(0xc0005fa8c0, 0x6e25ea0, 0xc0012c6180, 0xc001e25900, 0xc00094f530, 0xa5b8da0, 0x0, 0x0, 0x0)
2020-11-26T01:14:10.063Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0x50a
2020-11-26T01:14:10.063Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: google.golang.org/grpc.(*Server).handleStream(0xc0005fa8c0, 0x6e25ea0, 0xc0012c6180, 0xc001e25900, 0x0)
2020-11-26T01:14:10.063Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0xcfd
2020-11-26T01:14:10.063Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0009b2170, 0xc0005fa8c0, 0x6e25ea0, 0xc0012c6180, 0xc001e25900)
2020-11-26T01:14:10.063Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0xa1
2020-11-26T01:14:10.063Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: created by google.golang.org/grpc.(*Server).serveStreams.func1
2020-11-26T01:14:10.063Z [DEBUG] plugin.terraform-provider-aws_v3.18.0_x5: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x204
2020-11-26T01:14:10.063Z [DEBUG] plugin: plugin process exited: path=.terraform/plugins/registry.terraform.io/hashicorp/aws/3.18.0/linux_amd64/terraform-provider-aws_v3.18.0_x5 pid=1751 error="exit status 2"
2020/11/26 01:14:10 [DEBUG] aws_rds_cluster.intake_cluster: apply errored, but we're indicating that via the Error pointer rather than returning it: rpc error: code = Unavailable desc = transport is closing
2020/11/26 01:14:10 [TRACE] eval: *terraform.EvalMaybeTainted
2020/11/26 01:14:10 [TRACE] EvalMaybeTainted: aws_rds_cluster.intake_cluster encountered an error during creation, so it is now marked as tainted
2020/11/26 01:14:10 [TRACE] eval: *terraform.EvalWriteState
2020/11/26 01:14:10 [TRACE] EvalWriteState: removing state object for aws_rds_cluster.intake_cluster
2020/11/26 01:14:10 [TRACE] eval: *terraform.EvalApplyProvisioners
2020/11/26 01:14:10 [TRACE] EvalApplyProvisioners: aws_rds_cluster.intake_cluster has no state, so skipping provisioners
2020/11/26 01:14:10 [TRACE] eval: *terraform.EvalMaybeTainted
2020/11/26 01:14:10 [TRACE] EvalMaybeTainted: aws_rds_cluster.intake_cluster encountered an error during creation, so it is now marked as tainted
2020/11/26 01:14:10 [TRACE] eval: *terraform.EvalWriteState
2020/11/26 01:14:10 [TRACE] EvalWriteState: removing state object for aws_rds_cluster.intake_cluster
2020/11/26 01:14:10 [TRACE] eval: *terraform.EvalIf
2020/11/26 01:14:10 [TRACE] eval: *terraform.EvalIf
2020/11/26 01:14:10 [TRACE] eval: *terraform.EvalWriteDiff
2020/11/26 01:14:10 [TRACE] eval: *terraform.EvalApplyPost
2020/11/26 01:14:10 [ERROR] eval: *terraform.EvalApplyPost, err: rpc error: code = Unavailable desc = transport is closing
2020/11/26 01:14:10 [ERROR] eval: *terraform.EvalSequence, err: rpc error: code = Unavailable desc = transport is closing
2020/11/26 01:14:10 [TRACE] [walkApply] Exiting eval tree: aws_rds_cluster.intake_cluster
2020/11/26 01:14:10 [TRACE] vertex "aws_rds_cluster.intake_cluster": visit complete
2020/11/26 01:14:10 [TRACE] dag/walk: upstream of "aws_rds_cluster_instance.intake_instance" errored, so skipping
2020/11/26 01:14:10 [TRACE] dag/walk: upstream of "provider[\"registry.terraform.io/hashicorp/aws\"] (close)" errored, so skipping
2020-11-26T01:14:10.062Z [WARN]  plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"
2020/11/26 01:14:10 [TRACE] dag/walk: upstream of "meta.count-boundary (EachMode fixup)" errored, so skipping
2020/11/26 01:14:10 [TRACE] dag/walk: upstream of "root" errored, so skipping
2020-11-26T01:14:10.067Z [DEBUG] plugin: plugin exited
```

