### PR TITLE
resource/aws_rds_cluster: Add validateRdsIdentifier for source_cluster_identifier in restore_to_point_in_time block

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -232,7 +232,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ForceNew:     true,
-							ValidateFunc: validateRdsIdentifier,
+							ValidateFunc: validateRestoreToPointInTimeSourceClusterIdentifier,
 						},
 
 						"restore_type": {
@@ -1474,4 +1474,16 @@ func waitForRDSClusterDeletion(conn *rds.RDS, id string, timeout time.Duration) 
 	_, err := stateConf.WaitForState()
 
 	return err
+}
+
+func validateRestoreToPointInTimeSourceClusterIdentifier(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	// A source_cluster_identifier in a restore_to_point_in_time block can be a full ARN of the source cluster when cross-account cloning
+	// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Clone.html
+	if strings.HasPrefix(value, "arn:") {
+		return validateArn(v, k)
+	}
+
+	return validateRdsIdentifier(v, k)
 }

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -229,10 +229,13 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"source_cluster_identifier": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validateRestoreToPointInTimeSourceClusterIdentifier,
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: validation.Any(
+								validateArn,
+								validateRdsIdentifier,
+							),
 						},
 
 						"restore_type": {
@@ -1474,16 +1477,4 @@ func waitForRDSClusterDeletion(conn *rds.RDS, id string, timeout time.Duration) 
 	_, err := stateConf.WaitForState()
 
 	return err
-}
-
-func validateRestoreToPointInTimeSourceClusterIdentifier(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	// A source_cluster_identifier in a restore_to_point_in_time block can be a full ARN of the source cluster when cross-account cloning
-	// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Clone.html
-	if strings.HasPrefix(value, "arn:") {
-		return validateArn(v, k)
-	}
-
-	return validateRdsIdentifier(v, k)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_rds_cluster: Add validateRdsIdentifier for source_cluster_identifier in restore_to_point_in_time block
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRDSCluster_PointInTimeRestore'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRDSCluster_PointInTimeRestore -timeout 120m
=== RUN   TestAccAWSRDSCluster_PointInTimeRestore
=== PAUSE TestAccAWSRDSCluster_PointInTimeRestore
=== CONT  TestAccAWSRDSCluster_PointInTimeRestore
--- PASS: TestAccAWSRDSCluster_PointInTimeRestore (386.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	388.621s
```

You cannot use `validateRdsIdentifier` for validating `source_cluster_identifier` in `restore_to_point_in_time` block. That is because as the document blow suggests, `source_cluster_identifier` can be a full ARN of the source cluster when cross-account cloning an Aurora cluster.

> Clone the cluster by specifying the full ARN of the source cluster in the SourceDBClusterIdentifier parameter of the RDS API operation RestoreDBClusterToPointInTime. If the ARN passed as the SourceDBClusterIdentifier hasn't been shared, then the same error is returned as if the specified cluster doesn't exist.

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Clone.html

In order to handle the case, I've defined a new validation function called `validateRestoreToPointInTimeSourceClusterIdentifier`. Thank you for your review!