### PR TITLE
d/aws_credentials: New Data Source

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -609,6 +609,7 @@ behavior "pull_request_path_labeler" "service_labels" {
       "aws/awserr.go",
       "aws/config.go",
       "aws/*_aws_arn*",
+      "aws/*_aws_credentials*",
       "aws/*_aws_ip_ranges*",
       "aws/*_aws_partition*",
       "aws/*_aws_region*",
@@ -624,6 +625,7 @@ behavior "pull_request_path_labeler" "service_labels" {
       "main.go",
       "website/docs/index.html.markdown",
       "website/**/arn*",
+      "website/**/credentials*",
       "website/**/ip_ranges*",
       "website/**/partition*",
       "website/**/region*"

--- a/aws/config.go
+++ b/aws/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/accessanalyzer"
@@ -238,6 +239,7 @@ type AWSClient struct {
 	cognitoidpconn                      *cognitoidentityprovider.CognitoIdentityProvider
 	configconn                          *configservice.ConfigService
 	costandusagereportconn              *costandusagereportservice.CostandUsageReportService
+	credentials                         *credentials.Credentials
 	dataexchangeconn                    *dataexchange.DataExchange
 	datapipelineconn                    *datapipeline.DataPipeline
 	datasyncconn                        *datasync.DataSync
@@ -475,6 +477,7 @@ func (c *Config) Client() (interface{}, error) {
 		cognitoidpconn:                      cognitoidentityprovider.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["cognitoidp"])})),
 		configconn:                          configservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["configservice"])})),
 		costandusagereportconn:              costandusagereportservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["cur"])})),
+		credentials:                         sess.Config.Credentials,
 		dataexchangeconn:                    dataexchange.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["dataexchange"])})),
 		datapipelineconn:                    datapipeline.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["datapipeline"])})),
 		datasyncconn:                        datasync.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["datasync"])})),

--- a/aws/data_source_aws_credentials.go
+++ b/aws/data_source_aws_credentials.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsCredentials() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCredentialsRead,
+		Schema: map[string]*schema.Schema{
+			"access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secret_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCredentialsRead(d *schema.ResourceData, meta interface{}) error {
+	providerCredentials := meta.(*AWSClient).credentials
+
+	log.Printf("[DEBUG] Reading Provider Credentials")
+
+	val, err := providerCredentials.Get()
+	if err != nil {
+		return fmt.Errorf("Error getting Provider Credentials: %v", err)
+	}
+
+	log.Printf("[DEBUG] Received Provider Credentials: %s", val.ProviderName)
+
+	d.SetId(val.ProviderName)
+
+	if val.HasKeys() {
+		log.Printf("[DEBUG] Received provider has both AccessKeyID and SecretAccessKey value set")
+		d.Set("access_key", val.AccessKeyID)
+		d.Set("secret_key", val.SecretAccessKey)
+	}
+
+	d.Set("token", val.SessionToken)
+
+	return nil
+}

--- a/aws/data_source_aws_credentials_test.go
+++ b/aws/data_source_aws_credentials_test.go
@@ -1,0 +1,60 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSCredentials_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsCredentialsConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCredentials("data.aws_credentials.current"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsCredentials(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find credentials resource: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("credentials resource ID not set.")
+		}
+
+		expected, err := testAccProvider.Meta().(*AWSClient).credentials.Get()
+		if err != nil {
+			return fmt.Errorf("Error getting test Provider Credentials: %v", err)
+		}
+
+		if rs.Primary.Attributes["access_key"] != expected.AccessKeyID {
+			return fmt.Errorf("Incorrect access_key: expected %q, got %q", expected.AccessKeyID, rs.Primary.Attributes["access_key"])
+		}
+
+		if rs.Primary.Attributes["secret_key"] != expected.SecretAccessKey {
+			return fmt.Errorf("Incorrect secret_key: expected %q, got %q", expected.SecretAccessKey, rs.Primary.Attributes["secret_key"])
+		}
+
+		if rs.Primary.Attributes["token"] != expected.SessionToken {
+			return fmt.Errorf("Incorrect token: expected %q, got %q", expected.SessionToken, rs.Primary.Attributes["token"])
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckAwsCredentialsConfig_basic = `
+data "aws_credentials" "current" {}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -196,6 +196,7 @@ func Provider() *schema.Provider {
 			"aws_codeartifact_repository_endpoint":           dataSourceAwsCodeArtifactRepositoryEndpoint(),
 			"aws_cognito_user_pools":                         dataSourceAwsCognitoUserPools(),
 			"aws_codecommit_repository":                      dataSourceAwsCodeCommitRepository(),
+			"aws_credentials":                                dataSourceAwsCredentials(),
 			"aws_cur_report_definition":                      dataSourceAwsCurReportDefinition(),
 			"aws_db_cluster_snapshot":                        dataSourceAwsDbClusterSnapshot(),
 			"aws_db_event_categories":                        dataSourceAwsDbEventCategories(),

--- a/website/docs/d/credentials.html.markdown
+++ b/website/docs/d/credentials.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: ""
+layout: "aws"
+page_title: "AWS: aws_credentials"
+description: |-
+    Get the credentials of the configured provider.
+---
+
+# Data Source: aws_arn
+
+use the `aws_credentials` data source to get access to the AWS credentials of a configured provider.
+
+~> **Note:** All attributes will be stored in
+the raw state as plain-text. [Read more about sensitive data in
+state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+data "aws_credentials" "current" {}
+
+output "access_key" {
+  value = data.aws_credentials.current.access_key
+}
+
+output "secret_key" {
+  sensitive = true
+  value     = data.aws_credentials.current.secret_key
+}
+
+output "token" {
+  sensitive = true
+  value     = data.aws_credentials.current.token
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `access_key` - The AWS access key part of the credentials.
+
+* `secret_key` - The AWS secret access key part of the credentials.
+
+* `token` - The AWS session token part of the credentials.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8242

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Data Source:** `aws_credentials`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCredentials_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20
-run=TestAccAWSCredentials_ -timeout 120m
=== RUN   TestAccAWSCredentials_basic
=== PAUSE TestAccAWSCredentials_basic
=== CONT  TestAccAWSCredentials_basic
--- PASS: TestAccAWSCredentials_basic (62.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws
64.457s

...
```
