### PR TITLE
Allow looking up launch templates by ID in aws_launch_template data source

### DIFF
--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -29,6 +29,11 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"default_version": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -383,12 +388,16 @@ func dataSourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) e
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	filters, filtersOk := d.GetOk("filter")
+	id, idOk := d.GetOk("id")
 	name, nameOk := d.GetOk("name")
 	tags, tagsOk := d.GetOk("tags")
 
 	params := &ec2.DescribeLaunchTemplatesInput{}
 	if filtersOk {
 		params.Filters = buildAwsDataSourceFilters(filters.(*schema.Set))
+	}
+	if idOk {
+		params.LaunchTemplateIds = []*string{aws.String(id.(string))}
 	}
 	if nameOk {
 		params.LaunchTemplateNames = []*string{aws.String(name.(string))}

--- a/aws/data_source_aws_launch_template_test.go
+++ b/aws/data_source_aws_launch_template_test.go
@@ -33,6 +33,30 @@ func TestAccAWSLaunchTemplateDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplateDataSource_id_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_launch_template.test"
+	resourceName := "aws_launch_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateDataSourceConfig_BasicId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "default_version", dataSourceName, "default_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "latest_version", dataSourceName, "latest_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "hibernation_options", dataSourceName, "hibernation_options"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplateDataSource_filter_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_launch_template.test"
@@ -217,6 +241,18 @@ resource "aws_launch_template" "test" {
 
 data "aws_launch_template" "test" {
   name = aws_launch_template.test.name
+}
+`, rName)
+}
+
+func testAccAWSLaunchTemplateDataSourceConfig_BasicId(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %q
+}
+
+data "aws_launch_template" "test" {
+  id = aws_launch_template.test.id
 }
 `, rName)
 }

--- a/website/docs/d/launch_template.html.markdown
+++ b/website/docs/d/launch_template.html.markdown
@@ -34,6 +34,7 @@ data "aws_launch_template" "test" {
 The following arguments are supported:
 
 * `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+* `id` - (Optional) The ID of the specific launch template to retrieve.
 * `name` - (Optional) The name of the launch template.
 * `tags` - (Optional) A map of tags, each pair of which must exactly match a pair on the desired Launch Template.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_launch_template: Support looking up Launch Template by `id` field.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplateDataSource_id_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplateDataSource_id_basic -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_id_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_id_basic
=== CONT  TestAccAWSLaunchTemplateDataSource_id_basic
--- PASS: TestAccAWSLaunchTemplateDataSource_id_basic (27.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       30.250s
```
