### PR TITLE
r/lb_listner_certificate - import support

### DIFF
--- a/.changelog/16474.txt
+++ b/.changelog/16474.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lb_listner_certificate: Add import support
+```

--- a/.changelog/16474.txt
+++ b/.changelog/16474.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_lb_listner_certificate: Add import support
+resource/aws_lb_listener_certificate: Add import support
 ```

--- a/aws/internal/service/elbv2/id.go
+++ b/aws/internal/service/elbv2/id.go
@@ -19,5 +19,5 @@ func ListenerCertificateParseID(id string) (string, string, error) {
 }
 
 func ListenerCertificateCreateID(listenerArn, certificateArn string) string {
-	return fmt.Sprintf("%s_%s", listenerArn, certificateArn)
+	return fmt.Sprintf("%s%s%s", listenerArn, listenerCertificateIDSeparator, certificateArn)
 }

--- a/aws/internal/service/elbv2/id.go
+++ b/aws/internal/service/elbv2/id.go
@@ -1,0 +1,19 @@
+package elbv2
+
+import (
+	"fmt"
+	"strings"
+)
+
+const listnerCertificateIDSeparator = "_"
+
+func ListnerCertificateParseID(id string) (string, string, error) {
+	parts := strings.Split(id, listnerCertificateIDSeparator)
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1], nil
+	}
+
+	return "", "",
+		fmt.Errorf("unexpected format for ID (%q), expected listner-arn"+listnerCertificateIDSeparator+
+			"certificate-arn", id)
+}

--- a/aws/internal/service/elbv2/id.go
+++ b/aws/internal/service/elbv2/id.go
@@ -19,5 +19,5 @@ func ListenerCertificateParseID(id string) (string, string, error) {
 }
 
 func ListenerCertificateCreateID(listenerArn, certificateArn string) string {
-	return fmt.Sprintf("%s%s%s", listenerArn, listenerCertificateIDSeparator, certificateArn)
+	return strings.Join([]string{listenerArn, listenerCertificateIDSeparator, certificateArn}, "")
 }

--- a/aws/internal/service/elbv2/id.go
+++ b/aws/internal/service/elbv2/id.go
@@ -17,3 +17,7 @@ func ListenerCertificateParseID(id string) (string, string, error) {
 		fmt.Errorf("unexpected format for ID (%q), expected listener-arn"+listenerCertificateIDSeparator+
 			"certificate-arn", id)
 }
+
+func ListenerCertificateCreateID(listenerArn, certificateArn string) string {
+	return fmt.Sprintf("%s_%s", listenerArn, certificateArn)
+}

--- a/aws/internal/service/elbv2/id.go
+++ b/aws/internal/service/elbv2/id.go
@@ -5,15 +5,15 @@ import (
 	"strings"
 )
 
-const listnerCertificateIDSeparator = "_"
+const listenerCertificateIDSeparator = "_"
 
-func ListnerCertificateParseID(id string) (string, string, error) {
-	parts := strings.Split(id, listnerCertificateIDSeparator)
+func ListenerCertificateParseID(id string) (string, string, error) {
+	parts := strings.Split(id, listenerCertificateIDSeparator)
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil
 	}
 
 	return "", "",
-		fmt.Errorf("unexpected format for ID (%q), expected listner-arn"+listnerCertificateIDSeparator+
+		fmt.Errorf("unexpected format for ID (%q), expected listener-arn"+listenerCertificateIDSeparator+
 			"certificate-arn", id)
 }

--- a/aws/resource_aws_lb_listener_certificate.go
+++ b/aws/resource_aws_lb_listener_certificate.go
@@ -88,7 +88,7 @@ func resourceAwsLbListenerCertificateRead(d *schema.ResourceData, meta interface
 
 	listenerArn, certificateArn, err := tfelbv2.ListenerCertificateParseID(d.Id())
 	if err != nil {
-		return err
+		return fmt.Errorf("error parsing ELBv2 Listener Certificate ID (%s): %w", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Reading certificate: %s of listener: %s", certificateArn, listenerArn)

--- a/aws/resource_aws_lb_listener_certificate.go
+++ b/aws/resource_aws_lb_listener_certificate.go
@@ -41,11 +41,11 @@ func resourceAwsLbListenerCertificate() *schema.Resource {
 func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elbv2conn
 
-	listnerArn := d.Get("listener_arn").(string)
+	listenerArn := d.Get("listener_arn").(string)
 	certificateArn := d.Get("certificate_arn").(string)
 
 	params := &elbv2.AddListenerCertificatesInput{
-		ListenerArn: aws.String(listnerArn),
+		ListenerArn: aws.String(listenerArn),
 		Certificates: []*elbv2.Certificate{
 			{
 				CertificateArn: aws.String(certificateArn),
@@ -53,7 +53,7 @@ func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interfa
 		},
 	}
 
-	log.Printf("[DEBUG] Adding certificate: %s of listener: %s", certificateArn, listnerArn)
+	log.Printf("[DEBUG] Adding certificate: %s of listener: %s", certificateArn, listenerArn)
 
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		_, err := conn.AddListenerCertificates(params)
@@ -78,7 +78,7 @@ func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("error adding LB Listener Certificate: %w", err)
 	}
 
-	d.SetId(fmt.Sprintf("%s_%s", listnerArn, certificateArn))
+	d.SetId(tfelbv2.ListenerCertificateCreateID(listenerArn, certificateArn))
 
 	return resourceAwsLbListenerCertificateRead(d, meta)
 }
@@ -86,7 +86,7 @@ func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interfa
 func resourceAwsLbListenerCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elbv2conn
 
-	listenerArn, certificateArn, err := tfelbv2.ListnerCertificateParseID(d.Id())
+	listenerArn, certificateArn, err := tfelbv2.ListenerCertificateParseID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/aws/resource_aws_lb_listener_certificate.go
+++ b/aws/resource_aws_lb_listener_certificate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfelbv2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elbv2"
 )
 
 func resourceAwsLbListenerCertificate() *schema.Resource {
@@ -16,17 +17,22 @@ func resourceAwsLbListenerCertificate() *schema.Resource {
 		Create: resourceAwsLbListenerCertificateCreate,
 		Read:   resourceAwsLbListenerCertificateRead,
 		Delete: resourceAwsLbListenerCertificateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"listener_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 			"certificate_arn": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 		},
 	}
@@ -35,16 +41,19 @@ func resourceAwsLbListenerCertificate() *schema.Resource {
 func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elbv2conn
 
+	listnerArn := d.Get("listener_arn").(string)
+	certificateArn := d.Get("certificate_arn").(string)
+
 	params := &elbv2.AddListenerCertificatesInput{
-		ListenerArn: aws.String(d.Get("listener_arn").(string)),
+		ListenerArn: aws.String(listnerArn),
 		Certificates: []*elbv2.Certificate{
 			{
-				CertificateArn: aws.String(d.Get("certificate_arn").(string)),
+				CertificateArn: aws.String(certificateArn),
 			},
 		},
 	}
 
-	log.Printf("[DEBUG] Adding certificate: %s of listener: %s", d.Get("certificate_arn").(string), d.Get("listener_arn").(string))
+	log.Printf("[DEBUG] Adding certificate: %s of listener: %s", certificateArn, listnerArn)
 
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		_, err := conn.AddListenerCertificates(params)
@@ -66,10 +75,10 @@ func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interfa
 	}
 
 	if err != nil {
-		return fmt.Errorf("error adding LB Listener Certificate: %s", err)
+		return fmt.Errorf("error adding LB Listener Certificate: %w", err)
 	}
 
-	d.SetId(d.Get("listener_arn").(string) + "_" + d.Get("certificate_arn").(string))
+	d.SetId(fmt.Sprintf("%s_%s", listnerArn, certificateArn))
 
 	return resourceAwsLbListenerCertificateRead(d, meta)
 }
@@ -77,13 +86,15 @@ func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interfa
 func resourceAwsLbListenerCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elbv2conn
 
-	certificateArn := d.Get("certificate_arn").(string)
-	listenerArn := d.Get("listener_arn").(string)
+	listenerArn, certificateArn, err := tfelbv2.ListnerCertificateParseID(d.Id())
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[DEBUG] Reading certificate: %s of listener: %s", certificateArn, listenerArn)
 
 	var certificate *elbv2.Certificate
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
 		var err error
 		certificate, err = findAwsLbListenerCertificate(certificateArn, listenerArn, true, nil, conn)
 		if err != nil {
@@ -112,18 +123,25 @@ func resourceAwsLbListenerCertificateRead(d *schema.ResourceData, meta interface
 		return err
 	}
 
+	d.Set("certificate_arn", certificateArn)
+	d.Set("listener_arn", listenerArn)
+
 	return nil
 }
 
 func resourceAwsLbListenerCertificateDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elbv2conn
-	log.Printf("[DEBUG] Deleting certificate: %s of listener: %s", d.Get("certificate_arn").(string), d.Get("listener_arn").(string))
+
+	certificateArn := d.Get("certificate_arn").(string)
+	listenerArn := d.Get("listener_arn").(string)
+
+	log.Printf("[DEBUG] Deleting certificate: %s of listener: %s", certificateArn, listenerArn)
 
 	params := &elbv2.RemoveListenerCertificatesInput{
-		ListenerArn: aws.String(d.Get("listener_arn").(string)),
+		ListenerArn: aws.String(listenerArn),
 		Certificates: []*elbv2.Certificate{
 			{
-				CertificateArn: aws.String(d.Get("certificate_arn").(string)),
+				CertificateArn: aws.String(certificateArn),
 			},
 		},
 	}
@@ -136,7 +154,7 @@ func resourceAwsLbListenerCertificateDelete(d *schema.ResourceData, meta interfa
 		if isAWSErr(err, elbv2.ErrCodeListenerNotFoundException, "") {
 			return nil
 		}
-		return fmt.Errorf("Error removing LB Listener Certificate: %s", err)
+		return fmt.Errorf("Error removing LB Listener Certificate: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_lb_listener_certificate_test.go
+++ b/aws/resource_aws_lb_listener_certificate_test.go
@@ -33,6 +33,11 @@ func TestAccAwsLbListenerCertificate_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", lbListenerResourceName, "arn"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -46,6 +51,7 @@ func TestAccAwsLbListenerCertificate_multiple(t *testing.T) {
 	}
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lb_listener_certificate.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -65,6 +71,11 @@ func TestAccAwsLbListenerCertificate_multiple(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lb_listener_certificate.additional_2", "listener_arn"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener_certificate.additional_2", "certificate_arn"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccLbListenerCertificateConfigMultipleAddNew(rName, keys, certificates),

--- a/aws/resource_aws_lb_listener_certificate_test.go
+++ b/aws/resource_aws_lb_listener_certificate_test.go
@@ -102,6 +102,29 @@ func TestAccAwsLbListenerCertificate_multiple(t *testing.T) {
 	})
 }
 
+func TestAccAwsLbListenerCertificate_disappears(t *testing.T) {
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
+	resourceName := "aws_lb_listener_certificate.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsLbListenerCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLbListenerCertificateConfig(rName, key, certificate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLbListenerCertificateExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsLbListenerCertificate(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsLbListenerCertificateDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).elbv2conn
 

--- a/website/docs/r/lb_listener_certificate.html.markdown
+++ b/website/docs/r/lb_listener_certificate.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The `listener_arn` and `certificate_arn` seperated by a `_`.
+* `id` - The `listener_arn` and `certificate_arn` separated by a `_`.
 
 ## Import
 

--- a/website/docs/r/lb_listener_certificate.html.markdown
+++ b/website/docs/r/lb_listener_certificate.html.markdown
@@ -41,3 +41,17 @@ The following arguments are supported:
 
 * `listener_arn` - (Required, Forces New Resource) The ARN of the listener to which to attach the certificate.
 * `certificate_arn` - (Required, Forces New Resource) The ARN of the certificate to attach to the listener.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The `listener_arn` and `certificate_arn` seperated by a `_`.
+
+## Import
+
+Listner Certificates can be imported using their id, e.g.
+
+```
+$ terraform import aws_lb_listener_certificate.example arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b_arn:aws:iam::123456789012:server-certificate/tf-acc-test-6453083910015726063
+```

--- a/website/docs/r/lb_listener_certificate.html.markdown
+++ b/website/docs/r/lb_listener_certificate.html.markdown
@@ -50,7 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Listner Certificates can be imported using their id, e.g.
+Listener Certificates can be imported using their id, e.g.
 
 ```
 $ terraform import aws_lb_listener_certificate.example arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b_arn:aws:iam::123456789012:server-certificate/tf-acc-test-6453083910015726063


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13610

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_lb_listner_certificate - import support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsLbListenerCertificate_'
--- PASS: TestAccAwsLbListenerCertificate_basic (266.40s)
--- PASS: TestAccAwsLbListenerCertificate_multiple (450.33s)
--- PASS: TestAccAwsLbListenerCertificate_disappears (265.82s)
```
