### PR TITLE
r/backup_global_settings - add new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -462,6 +462,7 @@ func Provider() *schema.Provider {
 			"aws_autoscaling_policy":                                  resourceAwsAutoscalingPolicy(),
 			"aws_autoscaling_schedule":                                resourceAwsAutoscalingSchedule(),
 			"aws_autoscalingplans_scaling_plan":                       resourceAwsAutoScalingPlansScalingPlan(),
+			"aws_backup_global_settings":                              resourceAwsBackupGlobalSettings(),
 			"aws_backup_plan":                                         resourceAwsBackupPlan(),
 			"aws_backup_region_settings":                              resourceAwsBackupRegionSettings(),
 			"aws_backup_selection":                                    resourceAwsBackupSelection(),

--- a/aws/resource_aws_backup_global_settings.go
+++ b/aws/resource_aws_backup_global_settings.go
@@ -37,7 +37,7 @@ func resourceAwsBackupGlobalSettingsUpdate(d *schema.ResourceData, meta interfac
 
 	_, err := conn.UpdateGlobalSettings(input)
 	if err != nil {
-		return fmt.Errorf("error setting Backup Global Settings (%s): %w", d.Id(), err)
+		return fmt.Errorf("error setting Backup Global Settings (%s): %w", meta.(*AWSClient).accountid, err)
 	}
 
 	d.SetId(meta.(*AWSClient).accountid)

--- a/aws/resource_aws_backup_global_settings.go
+++ b/aws/resource_aws_backup_global_settings.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsBackupGlobalSettings() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsBackupGlobalSettingsUpdate,
+		Update: resourceAwsBackupGlobalSettingsUpdate,
+		Read:   resourceAwsBackupGlobalSettingsRead,
+		Delete: schema.Noop,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"global_settings": {
+				Type:     schema.TypeMap,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceAwsBackupGlobalSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	input := &backup.UpdateGlobalSettingsInput{
+		GlobalSettings: stringMapToPointers(d.Get("global_settings").(map[string]interface{})),
+	}
+
+	_, err := conn.UpdateGlobalSettings(input)
+	if err != nil {
+		return fmt.Errorf("error setting Backup Global Settings (%s): %w", d.Id(), err)
+	}
+
+	d.SetId(meta.(*AWSClient).accountid)
+
+	return resourceAwsBackupGlobalSettingsRead(d, meta)
+}
+
+func resourceAwsBackupGlobalSettingsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	resp, err := conn.DescribeGlobalSettings(&backup.DescribeGlobalSettingsInput{})
+	if err != nil {
+		return fmt.Errorf("error reading Backup Global Settings (%s): %w", d.Id(), err)
+	}
+
+	d.Set("global_settings", aws.StringValueMap(resp.GlobalSettings))
+
+	return nil
+}

--- a/aws/resource_aws_backup_global_settings.go
+++ b/aws/resource_aws_backup_global_settings.go
@@ -53,7 +53,9 @@ func resourceAwsBackupGlobalSettingsRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("error reading Backup Global Settings (%s): %w", d.Id(), err)
 	}
 
-	d.Set("global_settings", aws.StringValueMap(resp.GlobalSettings))
+	if err := d.Set("global_settings", aws.StringValueMap(resp.GlobalSettings)); err != nil {
+		return fmt.Errorf("error setting global_settings: %w", err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_backup_global_settings_test.go
+++ b/aws/resource_aws_backup_global_settings_test.go
@@ -1,0 +1,80 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsBackupGlobalSettings_basic(t *testing.T) {
+	var settings backup.DescribeGlobalSettingsOutput
+
+	resourceName := "aws_backup_global_settings.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSBackup(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupGlobalSettingsConfig("true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupGlobalSettingsExists(&settings),
+					resource.TestCheckResourceAttr(resourceName, "global_settings.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "global_settings.isCrossAccountBackupEnabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupGlobalSettingsConfig("false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupGlobalSettingsExists(&settings),
+					resource.TestCheckResourceAttr(resourceName, "global_settings.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "global_settings.isCrossAccountBackupEnabled", "false"),
+				),
+			},
+			{
+				Config: testAccBackupGlobalSettingsConfig("true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupGlobalSettingsExists(&settings),
+					resource.TestCheckResourceAttr(resourceName, "global_settings.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "global_settings.isCrossAccountBackupEnabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsBackupGlobalSettingsExists(settings *backup.DescribeGlobalSettingsOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		conn := testAccProvider.Meta().(*AWSClient).backupconn
+		resp, err := conn.DescribeGlobalSettings(&backup.DescribeGlobalSettingsInput{})
+		if err != nil {
+			return err
+		}
+
+		*settings = *resp
+
+		return nil
+	}
+}
+
+func testAccBackupGlobalSettingsConfig(setting string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_global_settings" "test" {
+  global_settings = {
+    "isCrossAccountBackupEnabled" = %[1]q
+  }
+}
+`, setting)
+}

--- a/website/docs/r/backup_global_settings.html.markdown
+++ b/website/docs/r/backup_global_settings.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Backup"
+layout: "aws"
+page_title: "AWS: aws_backup_global_settings"
+description: |-
+  Provides an AWS Backup Global Settings resource.
+---
+
+# Resource: aws_backup_global_settings
+
+Provides an AWS Backup Global Settings resource.
+
+## Example Usage
+
+```hcl
+resource "aws_backup_global_settings" "test" {
+  global_settings = {
+    "isCrossAccountBackupEnabled" = "true"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_type_opt_in_preference` - (Required) A list of resources along with the opt-in preferences for the account.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The AWS Account ID.
+
+## Import
+
+Backup Global Settings can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_backup_global_settings.example 123456789012
+```

--- a/website/docs/r/backup_global_settings.html.markdown
+++ b/website/docs/r/backup_global_settings.html.markdown
@@ -24,7 +24,7 @@ resource "aws_backup_global_settings" "test" {
 
 The following arguments are supported:
 
-* `resource_type_opt_in_preference` - (Required) A list of resources along with the opt-in preferences for the account.
+* `global_settings` - (Required) A list of resources along with the opt-in preferences for the account.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16343

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_backup_global_settings - add new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsBackupGlobalSettings_basic'
--- PASS: TestAccAwsBackupGlobalSettings_basic (104.31s)
```
