### PR TITLE
r/backup_plan - retry on delete + validations

### DIFF
--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -42,7 +42,7 @@ func resourceAwsBackupPlan() *schema.Resource {
 							Required: true,
 							ValidateFunc: validation.All(
 								validation.StringLenBetween(1, 50),
-								validation.StringDoesNotMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]$`), ""),
+								validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]+$`), "must contain only alphanumeric characters, hyphens, underscores, and periods"),
 							),
 						},
 						"target_vault_name": {
@@ -50,7 +50,7 @@ func resourceAwsBackupPlan() *schema.Resource {
 							Required: true,
 							ValidateFunc: validation.All(
 								validation.StringLenBetween(2, 50),
-								validation.StringDoesNotMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_]$`), ""),
+								validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_]+$`), "must contain only alphanumeric characters, hyphens, and underscores"),
 							),
 						},
 						"schedule": {

--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"regexp"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
@@ -36,10 +40,18 @@ func resourceAwsBackupPlan() *schema.Resource {
 						"rule_name": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(1, 50),
+								validation.StringDoesNotMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]$`), ""),
+							),
 						},
 						"target_vault_name": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(2, 50),
+								validation.StringDoesNotMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_]$`), ""),
+							),
 						},
 						"schedule": {
 							Type:     schema.TypeString,
@@ -66,8 +78,9 @@ func resourceAwsBackupPlan() *schema.Resource {
 										Optional: true,
 									},
 									"delete_after": {
-										Type:     schema.TypeInt,
-										Optional: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(90),
 									},
 								},
 							},
@@ -88,8 +101,9 @@ func resourceAwsBackupPlan() *schema.Resource {
 													Optional: true,
 												},
 												"delete_after": {
-													Type:     schema.TypeInt,
-													Optional: true,
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(90),
 												},
 											},
 										},
@@ -120,6 +134,9 @@ func resourceAwsBackupPlan() *schema.Resource {
 						"resource_type": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"EC2",
+							}, false),
 						},
 					},
 				},
@@ -152,7 +169,7 @@ func resourceAwsBackupPlanCreate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Creating Backup Plan: %#v", input)
 	resp, err := conn.CreateBackupPlan(input)
 	if err != nil {
-		return fmt.Errorf("error creating Backup Plan: %s", err)
+		return fmt.Errorf("error creating Backup Plan: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.BackupPlanId))
@@ -173,7 +190,7 @@ func resourceAwsBackupPlanRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("error reading Backup Plan (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading Backup Plan (%s): %w", d.Id(), err)
 	}
 
 	d.Set("arn", resp.BackupPlanArn)
@@ -181,21 +198,21 @@ func resourceAwsBackupPlanRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("version", resp.VersionId)
 
 	if err := d.Set("rule", flattenBackupPlanRules(resp.BackupPlan.Rules)); err != nil {
-		return fmt.Errorf("error setting rule: %s", err)
+		return fmt.Errorf("error setting rule: %w", err)
 	}
 
 	// AdvancedBackupSettings being read direct from resp and not from under
 	// resp.BackupPlan is deliberate - the latter always contains null
 	if err := d.Set("advanced_backup_setting", flattenBackupPlanAdvancedBackupSettings(resp.AdvancedBackupSettings)); err != nil {
-		return fmt.Errorf("error setting advanced_backup_setting: %s", err)
+		return fmt.Errorf("error setting advanced_backup_setting: %w", err)
 	}
 
 	tags, err := keyvaluetags.BackupListTags(conn, d.Get("arn").(string))
 	if err != nil {
-		return fmt.Errorf("error listing tags for Backup Plan (%s): %s", d.Id(), err)
+		return fmt.Errorf("error listing tags for Backup Plan (%s): %w", d.Id(), err)
 	}
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil
@@ -217,14 +234,14 @@ func resourceAwsBackupPlanUpdate(d *schema.ResourceData, meta interface{}) error
 		log.Printf("[DEBUG] Updating Backup Plan: %#v", input)
 		_, err := conn.UpdateBackupPlan(input)
 		if err != nil {
-			return fmt.Errorf("error updating Backup Plan (%s): %s", d.Id(), err)
+			return fmt.Errorf("error updating Backup Plan (%s): %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.BackupUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating tags for Backup Plan (%s): %s", d.Id(), err)
+			return fmt.Errorf("error updating tags for Backup Plan (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -234,16 +251,34 @@ func resourceAwsBackupPlanUpdate(d *schema.ResourceData, meta interface{}) error
 func resourceAwsBackupPlanDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).backupconn
 
-	log.Printf("[DEBUG] Deleting Backup Plan: %s", d.Id())
-	_, err := conn.DeleteBackupPlan(&backup.DeleteBackupPlanInput{
+	input := &backup.DeleteBackupPlanInput{
 		BackupPlanId: aws.String(d.Id()),
-	})
-	if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
+	}
+
+	log.Printf("[DEBUG] Deleting Backup Plan: %s", d.Id())
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteBackupPlan(input)
+
+		if isAWSErr(err, backup.ErrCodeInvalidRequestException, "Related backup plan selections must be deleted prior to backup") {
+			return resource.RetryableError(err)
+		}
+
+		if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
 		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteBackupPlan(input)
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Backup Plan (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting Backup Plan (%s): %w", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10414

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_backup_plan - retry delete if selections are still attached
resource_aws_backup_plan - add plan time validations for `rule.rule_name`, `rule.target_vault_name` , `rule.lifecycle.delete_after`, `rule.copy_action.lifecycle.delete_after`, `advanced_backup_setting.resource_type 
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsBackupPlan_'
--- PASS: TestAccAwsBackupPlan_basic (51.36s)
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_NoLifecycle (130.37s)
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_SameRegion (139.68s)
--- PASS: TestAccAwsBackupPlan_withLifecycle (209.53s)
--- PASS: TestAccAwsBackupPlan_withRecoveryPointTags (176.58s)
--- PASS: TestAccAwsBackupPlan_AdvancedBackupSetting (94.81s)
--- PASS: TestAccAwsBackupPlan_disappears (37.81s)
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_CrossRegion (47.25s)
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_Multiple (47.56s)
--- PASS: TestAccAwsBackupPlan_withRules (169.26s)
--- PASS: TestAccAwsBackupPlan_withTags (123.17s)
```
