### PR TITLE
r/ssm_maintainance_window_target - remove from state if deleted

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -160,7 +160,7 @@ func resourceAwsSsmMaintenanceWindowTargetRead(d *schema.ResourceData, meta inte
 			d.Set("description", t.Description)
 
 			if err := d.Set("targets", flattenAwsSsmTargets(t.Targets)); err != nil {
-				return fmt.Errorf("Error setting targets error: %w", err)
+				return fmt.Errorf("Error setting targets: %w", err)
 			}
 		}
 	}

--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -38,13 +38,10 @@ func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
 			},
 
 			"resource_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ssm.MaintenanceWindowResourceTypeInstance,
-					ssm.MaintenanceWindowResourceTypeResourceGroup,
-				}, true),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ssm.MaintenanceWindowResourceType_Values(), true),
 			},
 
 			"targets": {
@@ -56,10 +53,15 @@ func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
 						"key": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringMatch(regexp.MustCompile(`^[\p{L}\p{Z}\p{N}_.:/=\-@]*$|resource-groups:ResourceTypeFilters|resource-groups:Name$`), ""),
+								validation.StringLenBetween(1, 163),
+							),
 						},
 						"values": {
 							Type:     schema.TypeList,
 							Required: true,
+							MaxItems: 50,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
@@ -81,8 +83,9 @@ func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
 			},
 
 			"owner_information": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 128),
 			},
 		},
 	}
@@ -116,7 +119,7 @@ func resourceAwsSsmMaintenanceWindowTargetCreate(d *schema.ResourceData, meta in
 		return err
 	}
 
-	d.SetId(*resp.WindowTargetId)
+	d.SetId(aws.StringValue(resp.WindowTargetId))
 
 	return resourceAwsSsmMaintenanceWindowTargetRead(d, meta)
 }
@@ -124,8 +127,9 @@ func resourceAwsSsmMaintenanceWindowTargetCreate(d *schema.ResourceData, meta in
 func resourceAwsSsmMaintenanceWindowTargetRead(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
+	windowID := d.Get("window_id").(string)
 	params := &ssm.DescribeMaintenanceWindowTargetsInput{
-		WindowId: aws.String(d.Get("window_id").(string)),
+		WindowId: aws.String(windowID),
 		Filters: []*ssm.MaintenanceWindowFilter{
 			{
 				Key:    aws.String("WindowTargetId"),
@@ -135,13 +139,18 @@ func resourceAwsSsmMaintenanceWindowTargetRead(d *schema.ResourceData, meta inte
 	}
 
 	resp, err := ssmconn.DescribeMaintenanceWindowTargets(params)
+	if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
+		log.Printf("[WARN] Maintenance Window (%s) Target (%s) not found, removing from state", windowID, d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error getting Maintenance Window (%s) Target (%s): %w", windowID, d.Id(), err)
 	}
 
 	found := false
 	for _, t := range resp.Targets {
-		if *t.WindowTargetId == d.Id() {
+		if aws.StringValue(t.WindowTargetId) == d.Id() {
 			found = true
 
 			d.Set("owner_information", t.OwnerInformation)
@@ -151,7 +160,7 @@ func resourceAwsSsmMaintenanceWindowTargetRead(d *schema.ResourceData, meta inte
 			d.Set("description", t.Description)
 
 			if err := d.Set("targets", flattenAwsSsmTargets(t.Targets)); err != nil {
-				return fmt.Errorf("Error setting targets error: %#v", err)
+				return fmt.Errorf("Error setting targets error: %w", err)
 			}
 		}
 	}
@@ -190,7 +199,7 @@ func resourceAwsSsmMaintenanceWindowTargetUpdate(d *schema.ResourceData, meta in
 
 	_, err := ssmconn.UpdateMaintenanceWindowTarget(params)
 	if err != nil {
-		return fmt.Errorf("error updating SSM Maintenance Window Target (%s): %s", d.Id(), err)
+		return fmt.Errorf("error updating SSM Maintenance Window Target (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -207,8 +216,12 @@ func resourceAwsSsmMaintenanceWindowTargetDelete(d *schema.ResourceData, meta in
 	}
 
 	_, err := ssmconn.DeregisterTargetFromMaintenanceWindow(params)
+	if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
+		return nil
+	}
+
 	if err != nil {
-		return fmt.Errorf("error deregistering SSM Maintenance Window Target (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deregistering SSM Maintenance Window Target (%s): %w", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16451

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ssm_maintainance_window_target - remove from state if deleted
resource_aws_ssm_maintainance_window_target - add plan time validation to `targets.key`, `targets.values`, `owner_information`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMMaintenanceWindowTarget_'
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_validation (9.44s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_disappears_window (35.48s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_disappears (39.88s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_basic (47.08s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription (47.48s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_resourceGroup (47.54s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_update (89.70s)
```
