### PR TITLE
VPC endpoint service private dns name support

### DIFF
--- a/aws/resource_aws_vpc_endpoint_service.go
+++ b/aws/resource_aws_vpc_endpoint_service.go
@@ -258,19 +258,19 @@ func flattenPrivateDnsNameConfiguration(privateDnsNameConfiguration *ec2.Private
 
 	if v := privateDnsNameConfiguration.Name; v != nil {
 		tfMap["name"] = aws.StringValue(v)
-    	}
+	}
 
 	if v := privateDnsNameConfiguration.State; v != nil {
 		tfMap["state"] = aws.StringValue(v)
-    	}
+	}
 
 	if v := privateDnsNameConfiguration.Type; v != nil {
 		tfMap["type"] = aws.StringValue(v)
-    	}
+	}
 
 	if v := privateDnsNameConfiguration.Value; v != nil {
 		tfMap["value"] = aws.StringValue(v)
-    	}
+	}
 
 	// The EC2 API can return a XML structure with no elements
 	if len(tfMap) == 0 {

--- a/aws/resource_aws_vpc_endpoint_service.go
+++ b/aws/resource_aws_vpc_endpoint_service.go
@@ -254,13 +254,30 @@ func flattenPrivateDnsNameConfiguration(privateDnsNameConfiguration *ec2.Private
 	if privateDnsNameConfiguration == nil {
 		return nil
 	}
-	m := map[string]interface{}{
-		"name":  aws.StringValue(privateDnsNameConfiguration.Name),
-		"state": aws.StringValue(privateDnsNameConfiguration.State),
-		"type":  aws.StringValue(privateDnsNameConfiguration.Type),
-		"value": aws.StringValue(privateDnsNameConfiguration.Value),
+	tfMap := map[string]interface{}{}
+
+	if v := privateDnsNameConfiguration.Name; v != nil {
+		tfMap["name"] = aws.StringValue(v)
+    	}
+
+	if v := privateDnsNameConfiguration.State; v != nil {
+		tfMap["state"] = aws.StringValue(v)
+    	}
+
+	if v := privateDnsNameConfiguration.Type; v != nil {
+		tfMap["type"] = aws.StringValue(v)
+    	}
+
+	if v := privateDnsNameConfiguration.Value; v != nil {
+		tfMap["value"] = aws.StringValue(v)
+    	}
+
+	// The EC2 API can return a XML structure with no elements
+	if len(tfMap) == 0 {
+		return nil
 	}
-	return []interface{}{m}
+
+	return []interface{}{tfMap}
 }
 
 func resourceAwsVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_vpc_endpoint_service.go
+++ b/aws/resource_aws_vpc_endpoint_service.go
@@ -81,7 +81,7 @@ func resourceAwsVpcEndpointService() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
-			"private_dns_name_config": {
+			"private_dns_name_configuration": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -242,9 +242,9 @@ func resourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error setting allowed_principals: %s", err)
 	}
 
-	err = d.Set("private_dns_name_config", flattenPrivateDnsNameConfiguration(svcCfg.PrivateDnsNameConfiguration))
+	err = d.Set("private_dns_name_configuration", flattenPrivateDnsNameConfiguration(svcCfg.PrivateDnsNameConfiguration))
 	if err != nil {
-		return fmt.Errorf("error setting private_dns_name_config: %w", err)
+		return fmt.Errorf("error setting private_dns_name_configuration: %w", err)
 	}
 
 	return nil
@@ -252,7 +252,7 @@ func resourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{})
 
 func flattenPrivateDnsNameConfiguration(privateDnsNameConfiguration *ec2.PrivateDnsNameConfiguration) []interface{} {
 	if privateDnsNameConfiguration == nil {
-		return []interface{}{}
+		return nil
 	}
 	m := map[string]interface{}{
 		"name":  aws.StringValue(privateDnsNameConfiguration.Name),

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -99,6 +99,11 @@ func TestAccAWSVpcEndpointService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allowed_principals.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "manages_vpc_endpoints", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.type", ""),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.name", ""),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.value", ""),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.state", ""),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpc-endpoint-service/vpce-svc-.+`)),
 				),
 			},
@@ -250,6 +255,42 @@ func TestAccAWSVpcEndpointService_tags(t *testing.T) {
 					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSVpcEndpointService_private_dns_name(t *testing.T) {
+	var svcCfg ec2.ServiceConfiguration
+	resourceName := "aws_vpc_endpoint_service.test"
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcEndpointServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcEndpointServiceConfigPrivateDnsName(rName1, rName2, "example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name", "example.com"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.type", "TXT"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccVpcEndpointServiceConfigPrivateDnsName(rName1, rName2, "changed.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name", "changed.com"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.type", "TXT"),
 				),
 			},
 		},
@@ -524,4 +565,19 @@ resource "aws_vpc_endpoint_service" "test" {
   }
 }
 `, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccVpcEndpointServiceConfigPrivateDnsName(rName1, rName2, dnsName string) string {
+	return composeConfig(
+		testAccVpcEndpointServiceConfig_base(rName1, rName2),
+		fmt.Sprintf(`
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required = false
+  private_dns_name    = "%s"
+
+  network_load_balancer_arns = [
+    aws_lb.test1.arn,
+  ]
+}
+`, dnsName))
 }

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -287,7 +287,7 @@ func TestAccAWSVpcEndpointService_private_dns_name(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
 					resource.TestCheckResourceAttr(resourceName, "private_dns_name", "changed.com"),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_name_configuration.#", "TXT"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "private_dns_name_configuration.0.type", "TXT"),
 				),
 			},

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -99,11 +99,7 @@ func TestAccAWSVpcEndpointService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allowed_principals.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "manages_vpc_endpoints", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.type", ""),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.name", ""),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.value", ""),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.state", ""),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_configuration.#", "0"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpc-endpoint-service/vpce-svc-.+`)),
 				),
 			},
@@ -277,7 +273,8 @@ func TestAccAWSVpcEndpointService_private_dns_name(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
 					resource.TestCheckResourceAttr(resourceName, "private_dns_name", "example.com"),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.type", "TXT"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_configuration.0.type", "TXT"),
 				),
 			},
 			{
@@ -290,7 +287,8 @@ func TestAccAWSVpcEndpointService_private_dns_name(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcEndpointServiceExists(resourceName, &svcCfg),
 					resource.TestCheckResourceAttr(resourceName, "private_dns_name", "changed.com"),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_name_config.0.type", "TXT"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_configuration.#", "TXT"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_configuration.0.type", "TXT"),
 				),
 			},
 		},

--- a/website/docs/r/vpc_endpoint_service.html.markdown
+++ b/website/docs/r/vpc_endpoint_service.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
 * `gateway_load_balancer_arns` - (Optional) Amazon Resource Names (ARNs) of one or more Gateway Load Balancers for the endpoint service.
 * `network_load_balancer_arns` - (Optional) Amazon Resource Names (ARNs) of one or more Network Load Balancers for the endpoint service.
 * `tags` - (Optional) A map of tags to assign to the resource.
+* `private_dns_name` - (Optional) The private DNS name for the service.
 
 ## Attributes Reference
 
@@ -56,10 +57,17 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The Amazon Resource Name (ARN) of the VPC endpoint service.
 * `base_endpoint_dns_names` - The DNS names for the service.
 * `manages_vpc_endpoints` - Whether or not the service manages its VPC endpoints - `true` or `false`.
-* `private_dns_name` - The private DNS name for the service.
 * `service_name` - The service name.
 * `service_type` - The service type, `Gateway` or `Interface`.
 * `state` - The state of the VPC endpoint service.
+* `private_dns_name_config` - The private dns name config when supplying a private dns name.
+
+The `private_dns_name_config` object exports the following attributes:
+
+* `name` - the name of the record subdomain the service provider needs to create
+* `state` - the verification state of the VPC endpoint service
+* `type` - the endpoint service verification type, for example TXT
+* `value` - the value the service provider adds to the private DNS name domain record before verification
 
 ## Import
 

--- a/website/docs/r/vpc_endpoint_service.html.markdown
+++ b/website/docs/r/vpc_endpoint_service.html.markdown
@@ -60,14 +60,11 @@ In addition to all arguments above, the following attributes are exported:
 * `service_name` - The service name.
 * `service_type` - The service type, `Gateway` or `Interface`.
 * `state` - The state of the VPC endpoint service.
-* `private_dns_name_config` - The private dns name config when supplying a private dns name.
-
-The `private_dns_name_config` object exports the following attributes:
-
-* `name` - the name of the record subdomain the service provider needs to create
-* `state` - the verification state of the VPC endpoint service
-* `type` - the endpoint service verification type, for example TXT
-* `value` - the value the service provider adds to the private DNS name domain record before verification
+* `private_dns_name_configuration` - List of objects containing information about the endpoint service private DNS name configuration.
+    * `name` - Name of the record subdomain the service provider needs to create.
+    * `state` - Verification state of the VPC endpoint service. Consumers of the endpoint service can use the private name only when the state is `verified`.
+    * `type` - Endpoint service verification type, for example `TXT`.
+    * `value` - Value the service provider adds to the private DNS name domain record before verification.
 
 ## Import
 


### PR DESCRIPTION
Added support for setting the private dns name
in an endpoint service. We also return the config
that is required for users to set in their route53
configuration.

Signed-off-by: Stijn De Haes <stijndehaes@gmail.com>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16568

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_vpc_endpoint_service: Support setting a private dns name
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSVpcEndpointService_private_dns_name'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSVpcEndpointService_private_dns_name -timeout 120m
=== RUN   TestAccAWSVpcEndpointService_private_dns_name
=== PAUSE TestAccAWSVpcEndpointService_private_dns_name
=== CONT  TestAccAWSVpcEndpointService_private_dns_name
--- PASS: TestAccAWSVpcEndpointService_private_dns_name (313.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       313.900s


make testacc TEST=./aws TESTARGS='-run=TestAccAWSVpcEndpointService_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSVpcEndpointService_basic -timeout 120m
=== RUN   TestAccAWSVpcEndpointService_basic
=== PAUSE TestAccAWSVpcEndpointService_basic
=== CONT  TestAccAWSVpcEndpointService_basic
--- PASS: TestAccAWSVpcEndpointService_basic (260.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       260.062s

```
