### PR TITLE
resource/aws_eks_node_group: Add capacity_type argument and support multiple instance_types

### DIFF
--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -47,6 +47,13 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"capacity_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      eks.CapacityTypesOnDemand,
+				ValidateFunc: validation.StringInSlice(eks.CapacityTypes_Values(), false),
+			},
 			"cluster_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -68,9 +75,6 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				// Multiple instance types returns an API error currently:
-				// InvalidParameterException: Instance type list not valid, only one instance type is supported!
-				MaxItems: 1,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"labels": {
@@ -232,6 +236,10 @@ func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) err
 		input.AmiType = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("capacity_type"); ok {
+		input.CapacityType = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("disk_size"); ok {
 		input.DiskSize = aws.Int64(int64(v.(int)))
 	}
@@ -327,6 +335,7 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("ami_type", nodeGroup.AmiType)
 	d.Set("arn", nodeGroup.NodegroupArn)
+	d.Set("capacity_type", nodeGroup.CapacityType)
 	d.Set("cluster_name", nodeGroup.ClusterName)
 	d.Set("disk_size", nodeGroup.DiskSize)
 

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -124,9 +124,10 @@ The following arguments are required:
 The following arguments are optional:
 
 * `ami_type` - (Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64`. Terraform will only perform drift detection if a configuration value is provided.
+* `capacity_type` - (Optional) Type of capacity associated with the EKS Node Group. Defaults to `ON_DEMAND`. Valid values: `ON_DEMAND`, `SPOT`.
 * `disk_size` - (Optional) Disk size in GiB for worker nodes. Defaults to `20`. Terraform will only perform drift detection if a configuration value is provided.
 * `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
-* `instance_types` - (Optional) Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
+* `instance_types` - (Optional) List of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
 * `labels` - (Optional) Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
 * `launch_template` - (Optional) Configuration block with Launch Template settings. Detailed below.
 * `release_version` – (Optional) AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_eks_node_group: Add `capacity_type` argument and support multiple `instance_types`
```

Output from acceptance testing (failure unrelated):

```
--- PASS: TestAccAWSEksNodeGroup_disappears (1137.64s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Single (1146.91s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1158.65s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1169.90s)
--- PASS: TestAccAWSEksNodeGroup_CapacityType_Spot (1189.79s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1212.94s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1252.51s)
--- FAIL: TestAccAWSEksNodeGroup_AmiType (1273.27s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1314.53s)
--- PASS: TestAccAWSEksNodeGroup_basic (1328.29s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1334.23s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1362.48s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1399.97s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Multiple (1406.37s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Id (1769.34s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Name (1894.86s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Version (2031.79s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (4389.64s)
--- PASS: TestAccAWSEksNodeGroup_Version (5102.97s)
--- PASS: TestAccAWSEksNodeGroup_ForceUpdateVersion (5206.07s)
```
