### PR TITLE
tests/ds/ip_ranges: Lint ignore hardcoded regions

### DIFF
--- a/aws/data_source_aws_ip_ranges_test.go
+++ b/aws/data_source_aws_ip_ranges_test.go
@@ -81,6 +81,7 @@ func testAccAWSIPRangesCheckAttributes(n string) resource.TestCheckFunc {
 
 			if regionMember.MatchString(k) {
 
+				// lintignore:AWSAT003
 				if !(v == "eu-west-1" || v == "eu-central-1") {
 					return fmt.Errorf("unexpected region %s", v)
 				}
@@ -128,7 +129,7 @@ func testAccAWSIPRangesCheckCidrBlocksAttribute(name, attribute string) resource
 		}
 
 		if cidrBlockSize < 5 {
-			return fmt.Errorf("%s for eu-west-1 seem suspiciously low: %d", attribute, cidrBlockSize)
+			return fmt.Errorf("%s for eu-west-1 seem suspiciously low: %d", attribute, cidrBlockSize) // lintignore:AWSAT003
 		}
 
 		cidrBlocks = make([]string, cidrBlockSize)
@@ -152,6 +153,7 @@ func testAccAWSIPRangesCheckCidrBlocksAttribute(name, attribute string) resource
 	}
 }
 
+// lintignore:AWSAT003
 const testAccAWSIPRangesConfig = `
 data "aws_ip_ranges" "some" {
   regions  = ["eu-west-1", "eu-central-1"]
@@ -159,6 +161,7 @@ data "aws_ip_ranges" "some" {
 }
 `
 
+// lintignore:AWSAT003
 const testAccAWSIPRangesConfigUrl = `
 data "aws_ip_ranges" "some" {
   regions  = ["eu-west-1", "eu-central-1"]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSIPRanges_basic (14.12s)
--- PASS: TestAccAWSIPRanges_Url (14.13s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSIPRanges_basic (8.64s)
--- PASS: TestAccAWSIPRanges_Url (8.66s)

```