### PR TITLE
aws_ebs_volume: gp3 volume scalable throughput

### DIFF
--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -67,6 +67,10 @@ func dataSourceAwsEbsVolume() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tagsSchemaComputed(),
+			"throughput": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -150,6 +154,7 @@ func volumeDescriptionAttributes(d *schema.ResourceData, client *AWSClient, volu
 	d.Set("volume_type", volume.VolumeType)
 	d.Set("outpost_arn", volume.OutpostArn)
 	d.Set("multi_attach_enabled", volume.MultiAttachEnabled)
+	d.Set("throughput", volume.Throughput)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(volume.Tags).IgnoreAws().IgnoreConfig(client.IgnoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -25,6 +25,7 @@ func TestAccAWSEbsVolumeDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "outpost_arn", resourceName, "outpost_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "multi_attach_enabled", resourceName, "multi_attach_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "throughput", resourceName, "throughput"),
 				),
 			},
 		},

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -62,15 +62,17 @@ func resourceAwsEbsVolume() *schema.Resource {
 				ForceNew: true,
 			},
 			"size": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"size", "snapshot_id"},
 			},
 			"snapshot_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"size", "snapshot_id"},
 			},
 			"outpost_arn": {
 				Type:         schema.TypeString,
@@ -87,6 +89,7 @@ func resourceAwsEbsVolume() *schema.Resource {
 			"throughput": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(125, 1000),
 			},
 		},

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -180,8 +180,10 @@ func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 			params.Iops = aws.Int64(int64(d.Get("iops").(int)))
 		}
 
-		if d.HasChange("throughput") {
-			params.Throughput = aws.Int64(int64(d.Get("throughput").(int)))
+		// "If no throughput value is specified, the existing value is retained."
+		// Not currently correct, so always specify any non-zero throughput value.
+		if v := d.Get("throughput").(int); v > 0 {
+			params.Throughput = aws.Int64(int64(v))
 		}
 
 		result, err := conn.ModifyVolume(params)

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -275,21 +275,21 @@ func resourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		Service:   "ec2",
 	}
 	d.Set("arn", arn.String())
-	d.Set("availability_zone", aws.StringValue(volume.AvailabilityZone))
-	d.Set("encrypted", aws.BoolValue(volume.Encrypted))
-	d.Set("iops", aws.Int64Value(volume.Iops))
-	d.Set("kms_key_id", aws.StringValue(volume.KmsKeyId))
-	d.Set("size", aws.Int64Value(volume.Size))
-	d.Set("snapshot_id", aws.StringValue(volume.SnapshotId))
-	d.Set("outpost_arn", aws.StringValue(volume.OutpostArn))
+	d.Set("availability_zone", volume.AvailabilityZone)
+	d.Set("encrypted", volume.Encrypted)
+	d.Set("iops", volume.Iops)
+	d.Set("kms_key_id", volume.KmsKeyId)
+	d.Set("size", volume.Size)
+	d.Set("snapshot_id", volume.SnapshotId)
+	d.Set("outpost_arn", volume.OutpostArn)
 	d.Set("multi_attach_enabled", volume.MultiAttachEnabled)
-	d.Set("throughput", aws.Int64Value(volume.Throughput))
+	d.Set("throughput", volume.Throughput)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(volume.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
-	d.Set("type", aws.StringValue(volume.VolumeType))
+	d.Set("type", volume.VolumeType)
 
 	return nil
 }
@@ -390,7 +390,9 @@ func resourceAwsEbsVolumeCustomizeDiff(_ context.Context, diff *schema.ResourceD
 			if iops == 0 {
 				return fmt.Errorf("'iops' must be set when 'type' is '%s'", volumeType)
 			}
+
 		case ec2.VolumeTypeGp3:
+
 		default:
 			if iops != 0 {
 				return fmt.Errorf("'iops' must not be set when 'type' is '%s'", volumeType)

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -348,6 +348,21 @@ func TestAccAWSEBSVolume_InvalidIopsForType(t *testing.T) {
 	})
 }
 
+func TestAccAWSEBSVolume_InvalidThroughputForType(t *testing.T) {
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAwsEbsVolumeConfigWithInvalidThroughputForType,
+				ExpectError: regexp.MustCompile(`'throughput' must not be set when 'type' is`),
+			},
+		},
+	})
+}
+
 func TestAccAWSEBSVolume_withTags(t *testing.T) {
 	var v ec2.Volume
 	resourceName := "aws_ebs_volume.test"
@@ -1026,6 +1041,29 @@ resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   size              = 10
   iops              = 100
+
+  tags = {
+    Name = "TerraformTest"
+  }
+}
+`
+
+const testAccAwsEbsVolumeConfigWithInvalidThroughputForType = `
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  size              = 10
+  iops              = 100
+  throughput        = 500
+  type              = "io1"
 
   tags = {
     Name = "TerraformTest"

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -342,7 +342,7 @@ func TestAccAWSEBSVolume_InvalidIopsForType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAwsEbsVolumeConfigWithInvalidIopsForType,
-				ExpectError: regexp.MustCompile(`error creating ebs_volume: iops attribute not supported for type gp2`),
+				ExpectError: regexp.MustCompile(`'iops' must not be set when 'type' is`),
 			},
 		},
 	})

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -89,6 +89,7 @@ func TestAccAWSEBSVolume_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "gp2"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "multi_attach_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 			{
@@ -115,6 +116,7 @@ func TestAccAWSEBSVolume_updateAttachedEbsVolume(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 			{
@@ -127,6 +129,7 @@ func TestAccAWSEBSVolume_updateAttachedEbsVolume(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "size", "20"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 		},
@@ -148,6 +151,7 @@ func TestAccAWSEBSVolume_updateSize(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 			{
@@ -160,6 +164,7 @@ func TestAccAWSEBSVolume_updateSize(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 		},
@@ -181,6 +186,7 @@ func TestAccAWSEBSVolume_updateType(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 			{
@@ -193,6 +199,7 @@ func TestAccAWSEBSVolume_updateType(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "type", "sc1"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 		},
@@ -214,6 +221,7 @@ func TestAccAWSEBSVolume_updateIops_Io1(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "100"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 			{
@@ -226,6 +234,7 @@ func TestAccAWSEBSVolume_updateIops_Io1(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "200"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 		},
@@ -247,6 +256,7 @@ func TestAccAWSEBSVolume_updateIops_Io2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "100"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 			{
@@ -259,6 +269,7 @@ func TestAccAWSEBSVolume_updateIops_Io2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "200"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 		},
@@ -284,6 +295,7 @@ func TestAccAWSEBSVolume_kmsKey(t *testing.T) {
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "encrypted", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 			{
@@ -308,6 +320,7 @@ func TestAccAWSEBSVolume_NoIops(t *testing.T) {
 				Config: testAccAwsEbsVolumeConfigWithNoIops,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 			{
@@ -378,6 +391,7 @@ func TestAccAWSEBSVolume_multiAttach(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "multi_attach_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
 				),
 			},
 			{

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -57,5 +57,6 @@ In addition to all arguments above, the following attributes are exported:
 * `volume_type` - The type of EBS volume.
 * `kms_key_id` - The ARN for the KMS encryption key.
 * `tags` - A map of tags for the resource.
+* `throughput` - The throughput that the volume supports, in MiB/s.
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-volumes.html

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `availability_zone` - (Required) The AZ where the EBS volume will exist.
 * `encrypted` - (Optional) If true, the disk will be encrypted.
-* `iops` - (Optional) The amount of IOPS to provision for the disk. Only valid for `type` of `io1` or `io2`.
+* `iops` - (Optional) The amount of IOPS to provision for the disk. Only valid for `type` of `io1`, `io2` or `gp3`.
 * `multi_attach_enabled` - (Optional) Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported exclusively on `io1` volumes.
 * `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `tags` - (Optional) A map of tags to assign to the resource.
 * `throughput` - (Optional) The throughput that the volume supports, in MiB/s. Only valid for `type` of `gp3`.
 
-~> **NOTE**: When changing the `size`, `iops` or `type` of an instance, there are [considerations](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/considerations.html) to be aware of that Amazon have written about this.
+~> **NOTE**: When changing the `size`, `iops` or `type` of an instance, there are [considerations](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/considerations.html) to be aware of.
 
 ## Attributes Reference
 

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -36,9 +36,10 @@ The following arguments are supported:
 * `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
 * `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost.
-* `type` - (Optional) The type of EBS volume. Can be "standard", "gp2", "io1", "io2", "sc1" or "st1" (Default: "gp2").
+* `type` - (Optional) The type of EBS volume. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true.
 * `tags` - (Optional) A map of tags to assign to the resource.
+* `throughput` - (Optional) The throughput that the volume supports, in MiB/s. Only valid for `type` of `gp3`.
 
 ~> **NOTE**: When changing the `size`, `iops` or `type` of an instance, there are [considerations](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/considerations.html) to be aware of that Amazon have written about this.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16514.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ebs_volume: Support `type` value of `gp3`. Add `throughput` attribute.
resource/aws_ebs_volume: Add `throughput` attribute.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEBSVolume_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEBSVolume_ -timeout 120m
=== RUN   TestAccAWSEBSVolume_basic
=== PAUSE TestAccAWSEBSVolume_basic
=== RUN   TestAccAWSEBSVolume_updateAttachedEbsVolume
=== PAUSE TestAccAWSEBSVolume_updateAttachedEbsVolume
=== RUN   TestAccAWSEBSVolume_updateSize
=== PAUSE TestAccAWSEBSVolume_updateSize
=== RUN   TestAccAWSEBSVolume_updateType
=== PAUSE TestAccAWSEBSVolume_updateType
=== RUN   TestAccAWSEBSVolume_updateIops_Io1
=== PAUSE TestAccAWSEBSVolume_updateIops_Io1
=== RUN   TestAccAWSEBSVolume_updateIops_Io2
=== PAUSE TestAccAWSEBSVolume_updateIops_Io2
=== RUN   TestAccAWSEBSVolume_kmsKey
=== PAUSE TestAccAWSEBSVolume_kmsKey
=== RUN   TestAccAWSEBSVolume_NoIops
=== PAUSE TestAccAWSEBSVolume_NoIops
=== RUN   TestAccAWSEBSVolume_InvalidIopsForType
=== PAUSE TestAccAWSEBSVolume_InvalidIopsForType
=== RUN   TestAccAWSEBSVolume_withTags
=== PAUSE TestAccAWSEBSVolume_withTags
=== RUN   TestAccAWSEBSVolume_multiAttach
=== PAUSE TestAccAWSEBSVolume_multiAttach
=== RUN   TestAccAWSEBSVolume_outpost
=== PAUSE TestAccAWSEBSVolume_outpost
=== RUN   TestAccAWSEBSVolume_gp3_basic
=== PAUSE TestAccAWSEBSVolume_gp3_basic
=== RUN   TestAccAWSEBSVolume_gp3_iops
=== PAUSE TestAccAWSEBSVolume_gp3_iops
=== RUN   TestAccAWSEBSVolume_gp3_throughput
=== PAUSE TestAccAWSEBSVolume_gp3_throughput
=== RUN   TestAccAWSEBSVolume_disappears
=== PAUSE TestAccAWSEBSVolume_disappears
=== CONT  TestAccAWSEBSVolume_basic
=== CONT  TestAccAWSEBSVolume_withTags
=== CONT  TestAccAWSEBSVolume_disappears
=== CONT  TestAccAWSEBSVolume_gp3_throughput
=== CONT  TestAccAWSEBSVolume_gp3_iops
=== CONT  TestAccAWSEBSVolume_gp3_basic
=== CONT  TestAccAWSEBSVolume_outpost
=== CONT  TestAccAWSEBSVolume_multiAttach
=== CONT  TestAccAWSEBSVolume_updateIops_Io2
=== CONT  TestAccAWSEBSVolume_InvalidIopsForType
=== CONT  TestAccAWSEBSVolume_NoIops
=== CONT  TestAccAWSEBSVolume_kmsKey
=== CONT  TestAccAWSEBSVolume_updateType
=== CONT  TestAccAWSEBSVolume_updateIops_Io1
=== CONT  TestAccAWSEBSVolume_updateSize
=== CONT  TestAccAWSEBSVolume_updateAttachedEbsVolume
=== CONT  TestAccAWSEBSVolume_outpost
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSEBSVolume_outpost (2.13s)
--- PASS: TestAccAWSEBSVolume_InvalidIopsForType (17.40s)
--- PASS: TestAccAWSEBSVolume_disappears (52.68s)
--- PASS: TestAccAWSEBSVolume_NoIops (55.37s)
--- PASS: TestAccAWSEBSVolume_gp3_basic (64.85s)
--- PASS: TestAccAWSEBSVolume_basic (65.87s)
--- PASS: TestAccAWSEBSVolume_multiAttach (66.08s)
--- PASS: TestAccAWSEBSVolume_withTags (66.99s)
--- PASS: TestAccAWSEBSVolume_kmsKey (67.13s)
--- PASS: TestAccAWSEBSVolume_updateIops_Io1 (95.66s)
--- PASS: TestAccAWSEBSVolume_gp3_iops (96.68s)
--- PASS: TestAccAWSEBSVolume_updateType (98.48s)
--- PASS: TestAccAWSEBSVolume_updateIops_Io2 (98.71s)
--- PASS: TestAccAWSEBSVolume_gp3_throughput (99.21s)
--- PASS: TestAccAWSEBSVolume_updateSize (99.32s)
--- PASS: TestAccAWSEBSVolume_updateAttachedEbsVolume (181.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	181.371s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEbsVolumeDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEbsVolumeDataSource_ -timeout 120m
=== RUN   TestAccAWSEbsVolumeDataSource_basic
=== PAUSE TestAccAWSEbsVolumeDataSource_basic
=== RUN   TestAccAWSEbsVolumeDataSource_multipleFilters
=== PAUSE TestAccAWSEbsVolumeDataSource_multipleFilters
=== CONT  TestAccAWSEbsVolumeDataSource_basic
=== CONT  TestAccAWSEbsVolumeDataSource_multipleFilters
--- PASS: TestAccAWSEbsVolumeDataSource_basic (25.19s)
--- PASS: TestAccAWSEbsVolumeDataSource_multipleFilters (26.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	26.219s
```