### PR TITLE
Feature to update maximum_batching_window_in_seconds in aws lambda event source mapping for SQS event source type

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -352,10 +352,11 @@ func resourceAwsLambdaEventSourceMappingUpdate(d *schema.ResourceData, meta inte
 	log.Printf("[DEBUG] Updating Lambda event source mapping: %s", d.Id())
 
 	params := &lambda.UpdateEventSourceMappingInput{
-		UUID:         aws.String(d.Id()),
-		BatchSize:    aws.Int64(int64(d.Get("batch_size").(int))),
-		FunctionName: aws.String(d.Get("function_name").(string)),
-		Enabled:      aws.Bool(d.Get("enabled").(bool)),
+		UUID:                           aws.String(d.Id()),
+		BatchSize:                      aws.Int64(int64(d.Get("batch_size").(int))),
+		FunctionName:                   aws.String(d.Get("function_name").(string)),
+		Enabled:                        aws.Bool(d.Get("enabled").(bool)),
+		MaximumBatchingWindowInSeconds: aws.Int64(int64(d.Get("maximum_batching_window_in_seconds").(int))),
 	}
 
 	// AWS API will fail if this parameter is set (even as default value) for sqs event source.  Ideally this should be implemented in GO SDK or AWS API itself.
@@ -363,8 +364,6 @@ func resourceAwsLambdaEventSourceMappingUpdate(d *schema.ResourceData, meta inte
 	if err != nil {
 		return fmt.Errorf("Error updating event source mapping: %s", err)
 	}
-
-	params.MaximumBatchingWindowInSeconds = aws.Int64(int64(d.Get("maximum_batching_window_in_seconds").(int)))
 
 	if eventSourceArn.Service != "sqs" {
 		if parallelizationFactor, ok := d.GetOk("parallelization_factor"); ok {

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -364,9 +364,9 @@ func resourceAwsLambdaEventSourceMappingUpdate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error updating event source mapping: %s", err)
 	}
 
-	if eventSourceArn.Service != "sqs" {
-		params.MaximumBatchingWindowInSeconds = aws.Int64(int64(d.Get("maximum_batching_window_in_seconds").(int)))
+	params.MaximumBatchingWindowInSeconds = aws.Int64(int64(d.Get("maximum_batching_window_in_seconds").(int)))
 
+	if eventSourceArn.Service != "sqs" {
 		if parallelizationFactor, ok := d.GetOk("parallelization_factor"); ok {
 			params.SetParallelizationFactor(int64(parallelizationFactor.(int)))
 		}

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -362,7 +362,7 @@ func TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp(t *testing.T) 
 	})
 }
 
-func TestAccAWSLambdaEventSourceMapping_BatchWindow(t *testing.T) {
+func TestAccAWSLambdaEventSourceMapping_KinesisBatchWindow(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lambda_event_source_mapping.test"

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -1531,7 +1531,7 @@ EOF
 }
 
 resource "aws_sqs_queue" "test" {
-  name        = %q
+  name = %q
 }
 
 resource "aws_lambda_function" "test" {

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -209,6 +209,43 @@ func TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName(t *testing.T) {
 	})
 }
 
+func TestAccAWSLambdaEventSourceMapping_SQSBatchWindow(t *testing.T) {
+	var conf lambda.EventSourceMappingConfiguration
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lambda_event_source_mapping.test"
+	batchWindow := int64(0)
+	batchWindowUpdate := int64(100)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaEventSourceMappingConfigSqsWithBatchWindow(rName, batchWindow),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "maximum_batching_window_in_seconds", strconv.Itoa(int(batchWindow))),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enabled", "starting_position"},
+			},
+			{
+				Config: testAccAWSLambdaEventSourceMappingConfigSqsWithBatchWindow(rName, batchWindowUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "maximum_batching_window_in_seconds", strconv.Itoa(int(batchWindowUpdate))),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLambdaEventSourceMapping_kinesis_disappears(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
 
@@ -1450,4 +1487,71 @@ resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
   function_name    = "%[5]s"
 }
 `, roleName, policyName, attName, streamName, funcName)
+}
+
+func testAccAWSLambdaEventSourceMappingConfigSQSBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sqs:*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_sqs_queue" "test" {
+  name        = %q
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %q
+  handler       = "exports.example"
+  role          = aws_iam_role.test.arn
+  runtime       = "nodejs12.x"
+}
+`, rName, rName, rName)
+}
+
+func testAccAWSLambdaEventSourceMappingConfigSqsWithBatchWindow(rName string, batchWindow int64) string {
+	return testAccAWSLambdaEventSourceMappingConfigSQSBase(rName) + fmt.Sprintf(`
+resource "aws_lambda_event_source_mapping" "test" {
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = %d
+  event_source_arn                   = aws_sqs_queue.test.arn
+  enabled                            = false
+  function_name                      = aws_lambda_function.test.arn
+}
+`, batchWindow)
 }

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -1492,7 +1492,7 @@ resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
 func testAccAWSLambdaEventSourceMappingConfigSQSBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = %q
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -1531,21 +1531,21 @@ EOF
 }
 
 resource "aws_sqs_queue" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
-  function_name = %q
+  function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
   runtime       = "nodejs12.x"
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccAWSLambdaEventSourceMappingConfigSqsWithBatchWindow(rName string, batchWindow int64) string {
-	return testAccAWSLambdaEventSourceMappingConfigSQSBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSLambdaEventSourceMappingConfigSQSBase(rName), fmt.Sprintf(`
 resource "aws_lambda_event_source_mapping" "test" {
   batch_size                         = 10
   maximum_batching_window_in_seconds = %d
@@ -1553,5 +1553,5 @@ resource "aws_lambda_event_source_mapping" "test" {
   enabled                            = false
   function_name                      = aws_lambda_function.test.arn
 }
-`, batchWindow)
+`, batchWindow))
 }

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -47,7 +47,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 ## Argument Reference
 
 * `batch_size` - (Optional) The largest number of records that Lambda will retrieve from your event source at the time of invocation. Defaults to `100` for DynamoDB and Kinesis, `10` for SQS.
-* `maximum_batching_window_in_seconds` - (Optional) The maximum amount of time to gather records before invoking the function, in seconds.  Records will continue to buffer until either `maximum_batching_window_in_seconds` expires or `batch_size` has been met. Defaults to as soon as records are available in the stream. If the batch it reads from the stream only has one record in it, Lambda only sends one record to the function.
+* `maximum_batching_window_in_seconds` - (Optional) The maximum amount of time to gather records before invoking the function, in seconds (between 0 and 300). Records will continue to buffer (or accumulate in the case of an SQS queue event source) until either `maximum_batching_window_in_seconds` expires or `batch_size` has been met. For streaming event sources, defaults to as soon as records are available in the stream. If the batch it reads from the stream/queue only has one record in it, Lambda only sends one record to the function.
 * `event_source_arn` - (Required) The event source ARN - can be a Kinesis stream, DynamoDB stream, or SQS queue.
 * `enabled` - (Optional) Determines if the mapping will be enabled on creation. Defaults to `true`.
 * `function_name` - (Required) The name or the ARN of the Lambda function that will be subscribing to events.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #16503

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lambda_event_source_mapping: Updating maximum_batching_window_in_seconds for SQS event source type

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make testacc TESTARGS='-run=TestAccAWSLambdaEventSourceMapping_SQSBatchWindow'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaEventSourceMapping_SQSBatchWindow -timeout 120m
=== RUN   TestAccAWSLambdaEventSourceMapping_SQSBatchWindow
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQSBatchWindow
=== CONT  TestAccAWSLambdaEventSourceMapping_SQSBatchWindow
--- PASS: TestAccAWSLambdaEventSourceMapping_SQSBatchWindow (85.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       87.373s

...
```
