### PR TITLE
Updated network association timeout from 10 min to 30 min

### DIFF
--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -113,11 +113,11 @@ func ClientVpnAuthorizationRuleRevoked(conn *ec2.EC2, authorizationRuleID string
 }
 
 const (
-	ClientVpnNetworkAssociationAssociatedTimeout = 10 * time.Minute
+	ClientVpnNetworkAssociationAssociatedTimeout = 30 * time.Minute
 
 	ClientVpnNetworkAssociationAssociatedDelay = 4 * time.Minute
 
-	ClientVpnNetworkAssociationDisassociatedTimeout = 10 * time.Minute
+	ClientVpnNetworkAssociationDisassociatedTimeout = 30 * time.Minute
 
 	ClientVpnNetworkAssociationDisassociatedDelay = 4 * time.Minute
 


### PR DESCRIPTION
Updated ClientVpnNetworkAssociationAssociatedTimeout and ClientVpnNetworkAssociationDisassociatedTimeout from 10 min to 30 min. 
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/hashicorp/terraform-provider-aws/issues/15680

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ec2_client_vpn_network_association: Update timeout from 10min to 30min
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2ClientVpnNetworkAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2ClientVpnNetworkAssociation_ -timeout 120m
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3.062s [no tests to run]
```
