### PR TITLE
tests/transfer: Fix hardcoded regions

### DIFF
--- a/aws/data_source_aws_transfer_server_test.go
+++ b/aws/data_source_aws_transfer_server_test.go
@@ -86,7 +86,7 @@ data "aws_transfer_server" "test" {
 func testAccDataSourceAwsTransferServerConfig_service_managed(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "tf-test-transfer-server-iam-role-%s"
+  name = "tf-test-transfer-server-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -105,7 +105,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-test-transfer-server-iam-policy-%s"
+  name = "tf-test-transfer-server-iam-policy-%[1]s"
   role = aws_iam_role.test.id
 
   policy = <<POLICY
@@ -133,7 +133,7 @@ resource "aws_transfer_server" "test" {
 data "aws_transfer_server" "test" {
   server_id = aws_transfer_server.test.id
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccDataSourceAwsTransferServerConfig_apigateway(rName string) string {
@@ -184,8 +184,8 @@ resource "aws_api_gateway_deployment" "test" {
 
   rest_api_id       = aws_api_gateway_rest_api.test.id
   stage_name        = "test"
-  description       = "%s"
-  stage_description = "%s"
+  description       = "%[1]s"
+  stage_description = "%[1]s"
 
   variables = {
     "a" = "2"
@@ -193,7 +193,7 @@ resource "aws_api_gateway_deployment" "test" {
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-test-transfer-server-iam-role-for-apigateway-%s"
+  name = "tf-test-transfer-server-iam-role-for-apigateway-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -212,7 +212,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-test-transfer-server-iam-policy-%s"
+  name = "tf-test-transfer-server-iam-policy-%[1]s"
   role = aws_iam_role.test.id
 
   policy = <<POLICY
@@ -232,9 +232,11 @@ resource "aws_iam_role_policy" "test" {
 POLICY
 }
 
+data "aws_region" "current" {}
+
 resource "aws_transfer_server" "test" {
   identity_provider_type = "API_GATEWAY"
-  url                    = "https://${aws_api_gateway_rest_api.test.id}.execute-api.us-west-2.amazonaws.com${aws_api_gateway_resource.test.path}"
+  url                    = "https://${aws_api_gateway_rest_api.test.id}.execute-api.${data.aws_region.current.name}.amazonaws.com${aws_api_gateway_resource.test.path}"
   invocation_role        = aws_iam_role.test.arn
   logging_role           = aws_iam_role.test.arn
 }
@@ -242,5 +244,5 @@ resource "aws_transfer_server" "test" {
 data "aws_transfer_server" "test" {
   server_id = aws_transfer_server.test.id
 }
-`, rName, rName, rName, rName)
+`, rName)
 }

--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -422,7 +422,7 @@ resource "aws_transfer_server" "foo" {}
 func testAccAWSTransferServerConfig_basicUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-server-iam-role-%s"
+  name = "tf-test-transfer-server-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -441,7 +441,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-server-iam-policy-%s"
+  name = "tf-test-transfer-server-iam-policy-%[1]s"
   role = aws_iam_role.foo.id
 
   policy = <<POLICY
@@ -470,7 +470,7 @@ resource "aws_transfer_server" "foo" {
     ENV  = "test"
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccAWSTransferServerConfig_apigateway(rName string) string {
@@ -521,8 +521,8 @@ resource "aws_api_gateway_deployment" "test" {
 
   rest_api_id       = aws_api_gateway_rest_api.test.id
   stage_name        = "test"
-  description       = "%s"
-  stage_description = "%s"
+  description       = "%[1]s"
+  stage_description = "%[1]s"
 
   variables = {
     "a" = "2"
@@ -530,7 +530,7 @@ resource "aws_api_gateway_deployment" "test" {
 }
 
 resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-server-iam-role-for-apigateway-%s"
+  name = "tf-test-transfer-server-iam-role-for-apigateway-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -549,7 +549,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-server-iam-policy-%s"
+  name = "tf-test-transfer-server-iam-policy-%[1]s"
   role = aws_iam_role.foo.id
 
   policy = <<POLICY
@@ -569,9 +569,11 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
+data "aws_region" "current" {}
+
 resource "aws_transfer_server" "foo" {
   identity_provider_type = "API_GATEWAY"
-  url                    = "https://${aws_api_gateway_rest_api.test.id}.execute-api.us-west-2.amazonaws.com${aws_api_gateway_resource.test.path}"
+  url                    = "https://${aws_api_gateway_rest_api.test.id}.execute-api.${data.aws_region.current.name}.amazonaws.com${aws_api_gateway_resource.test.path}"
   invocation_role        = aws_iam_role.foo.arn
   logging_role           = aws_iam_role.foo.arn
 
@@ -580,7 +582,7 @@ resource "aws_transfer_server" "foo" {
     TYPE = "apigateway"
   }
 }
-`, rName, rName, rName, rName)
+`, rName)
 
 }
 
@@ -591,7 +593,7 @@ resource "aws_transfer_server" "foo" {
 }
 
 resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-user-iam-role-%s"
+  name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -610,7 +612,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-user-iam-policy-%s"
+  name = "tf-test-transfer-user-iam-policy-%[1]s"
   role = aws_iam_role.foo.id
 
   policy = <<POLICY
@@ -629,7 +631,7 @@ resource "aws_iam_role_policy" "foo" {
 }
 POLICY
 }
-`, rName, rName)
+`, rName)
 }
 
 const testAccAWSTransferServerConfig_VpcEndPoint = `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Affected tests:
```
'TestAccAWSTransferServer_|TestAccDataSourceAwsTransferServer_'
```

Output from acceptance testing (GovCloud): (Failures are pre-existing and tracked in #15761)

```
--- FAIL: TestAccAWSTransferServer_basic (6.35s)
--- FAIL: TestAccAWSTransferServer_disappears (6.83s)
--- FAIL: TestAccAWSTransferServer_forcedestroy (11.26s)
--- FAIL: TestAccAWSTransferServer_hostKey (5.56s)
--- FAIL: TestAccAWSTransferServer_vpcEndpointId (30.43s)
--- FAIL: TestAccDataSourceAwsTransferServer_basic (8.16s)
--- FAIL: TestAccDataSourceAwsTransferServer_service_managed (11.60s)
--- PASS: TestAccAWSTransferServer_Vpc (268.74s)
--- SKIP: TestAccAWSTransferServer_apigateway (1.42s)
--- SKIP: TestAccDataSourceAwsTransferServer_apigateway (1.90s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccDataSourceAwsTransferServer_basic (184.74s)
--- PASS: TestAccDataSourceAwsTransferServer_service_managed (185.18s)
--- PASS: TestAccDataSourceAwsTransferServer_apigateway (190.96s)
--- PASS: TestAccAWSTransferServer_vpcEndpointId (144.17s)
--- PASS: TestAccAWSTransferServer_disappears (182.00s)
--- PASS: TestAccAWSTransferServer_hostKey (186.14s)
--- PASS: TestAccAWSTransferServer_apigateway (193.20s)
--- PASS: TestAccAWSTransferServer_forcedestroy (198.94s)
--- PASS: TestAccAWSTransferServer_basic (207.47s)
--- PASS: TestAccAWSTransferServer_Vpc (232.51s)
```