### PR TITLE
tests/datasync: Fix hardcoded regions

### DIFF
--- a/aws/datasync_test.go
+++ b/aws/datasync_test.go
@@ -10,11 +10,11 @@ func TestDataSyncParseLocationURI(t *testing.T) {
 		Subdirectory string
 	}{
 		{
-			LocationURI:  "efs://us-east-2.fs-abcd1234/",
+			LocationURI:  "efs://us-east-2.fs-abcd1234/", // lintignore:AWSAT003
 			Subdirectory: "/",
 		},
 		{
-			LocationURI:  "efs://us-east-2.fs-abcd1234/path",
+			LocationURI:  "efs://us-east-2.fs-abcd1234/path", // lintignore:AWSAT003
 			Subdirectory: "/path",
 		},
 		{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Affected tests:
```
'TestDataSyncParseLocationURI'
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestDataSyncParseLocationURI (0.00s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestDataSyncParseLocationURI (0.00s)
```