### PR TITLE
d/remove invalid values in CodeBuild second_artifacts.type

### DIFF
--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -326,7 +326,7 @@ The following arguments are supported:
 
 `secondary_artifacts` supports the following:
 
-* `type` - (Required) The build output artifact's type. Valid values for this parameter are: `CODEPIPELINE`, `NO_ARTIFACTS` or `S3`.
+* `type` - (Required) The build output artifact's type. The only valid value is `S3`.
 * `artifact_identifier` - (Required) The artifact identifier. Must be the same specified inside AWS CodeBuild buildspec.
 * `encryption_disabled` - (Optional) If set to true, output artifacts will not be encrypted. If `type` is set to `NO_ARTIFACTS` then this value will be ignored. Defaults to `false`.
 * `override_artifact_name` (Optional) If set to true, a name specified in the build spec file overrides the artifact name.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

aws_codebuild_project.secondary_artifacts.type doesn't accept the values `CODEPIPELINE` and `NO_ARTIFACT`.
This PR made the documentation reflect the actual behavior.

When you try to use them, `terraform plan` gives errors.
```
# NO_ARTIFACTS
Error: expected secondary_artifacts.0.type to be one of [S3], got NO_ARTIFACTS
# CODEPIPELINE
Error: expected secondary_artifacts.0.type to be one of [S3], got CODEPIPELINE
```

Apparently terraform might have accepted them before but now it's fixed by this PR.
https://github.com/hashicorp/terraform-provider-aws/pull/9652/files

NOTE: Also this is the expected behavior you can see in the AWS doc. 
https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectArtifacts.html

> Note
> The CODEPIPELINE type is not supported for secondaryArtifacts.

---

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10176

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
