### PR TITLE
tests/provider: Lint ignore hardcoded regions

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -61,7 +61,7 @@ func Provider() *schema.Provider {
 					"AWS_DEFAULT_REGION",
 				}, nil),
 				Description:  descriptions["region"],
-				InputDefault: "us-east-1",
+				InputDefault: "us-east-1", // lintignore:AWSAT003
 			},
 
 			"max_retries": {
@@ -1071,7 +1071,7 @@ var endpointServiceNames []string
 func init() {
 	descriptions = map[string]string{
 		"region": "The region where AWS operations will take place. Examples\n" +
-			"are us-east-1, us-west-2, etc.",
+			"are us-east-1, us-west-2, etc.", // lintignore:AWSAT003
 
 		"access_key": "The access key for API operations. You can retrieve this\n" +
 			"from the 'Security & Credentials' section of the AWS console.",

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -592,7 +592,7 @@ func testAccGetAccountID() string {
 func testAccGetRegion() string {
 	v := os.Getenv("AWS_DEFAULT_REGION")
 	if v == "" {
-		return "us-west-2"
+		return "us-west-2" // lintignore:AWSAT003
 	}
 	return v
 }
@@ -600,7 +600,7 @@ func testAccGetRegion() string {
 func testAccGetAlternateRegion() string {
 	v := os.Getenv("AWS_ALTERNATE_REGION")
 	if v == "" {
-		return "us-east-1"
+		return "us-east-1" // lintignore:AWSAT003
 	}
 	return v
 }
@@ -608,7 +608,7 @@ func testAccGetAlternateRegion() string {
 func testAccGetThirdRegion() string {
 	v := os.Getenv("AWS_THIRD_REGION")
 	if v == "" {
-		return "us-east-2"
+		return "us-east-2" // lintignore:AWSAT003
 	}
 	return v
 }
@@ -1204,7 +1204,7 @@ func TestAccAWSProvider_Region_AwsChina(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSProviderConfigRegion("cn-northwest-1"),
+				Config: testAccAWSProviderConfigRegion("cn-northwest-1"), // lintignore:AWSAT003
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSProviderDnsSuffix(&providers, "amazonaws.com.cn"),
 					testAccCheckAWSProviderPartition(&providers, "aws-cn"),
@@ -1224,7 +1224,7 @@ func TestAccAWSProvider_Region_AwsCommercial(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSProviderConfigRegion("us-west-2"),
+				Config: testAccAWSProviderConfigRegion("us-west-2"), // lintignore:AWSAT003
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSProviderDnsSuffix(&providers, "amazonaws.com"),
 					testAccCheckAWSProviderPartition(&providers, "aws"),
@@ -1244,7 +1244,7 @@ func TestAccAWSProvider_Region_AwsGovCloudUs(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSProviderConfigRegion("us-gov-west-1"),
+				Config: testAccAWSProviderConfigRegion("us-gov-west-1"), // lintignore:AWSAT003
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSProviderDnsSuffix(&providers, "amazonaws.com"),
 					testAccCheckAWSProviderPartition(&providers, "aws-us-gov"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSProvider_Region_AwsCommercial (4.09s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (4.09s)
--- PASS: TestAccAWSProvider_Region_AwsChina (4.47s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (3.85s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (3.86s)
--- PASS: TestAccAWSProvider_Region_AwsChina (3.90s)
```