### PR TITLE
r/lambda_function: update lambda package type check to prevent panic

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -808,25 +808,24 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 		return nil
 	}
 
-	codeSigningConfigInput := &lambda.GetFunctionCodeSigningConfigInput{
-		FunctionName: aws.String(d.Get("function_name").(string)),
-	}
-
 	// Code Signing is only supported on zip packaged lambda functions.
-	if *function.PackageType == lambda.PackageTypeZip {
+	var codeSigningConfigArn string
+
+	if aws.StringValue(function.PackageType) == lambda.PackageTypeZip {
+		codeSigningConfigInput := &lambda.GetFunctionCodeSigningConfigInput{
+			FunctionName: aws.String(d.Id()),
+		}
 		getCodeSigningConfigOutput, err := conn.GetFunctionCodeSigningConfig(codeSigningConfigInput)
 		if err != nil {
 			return fmt.Errorf("error getting Lambda Function (%s) code signing config %w", d.Id(), err)
 		}
 
-		if getCodeSigningConfigOutput == nil || getCodeSigningConfigOutput.CodeSigningConfigArn == nil {
-			d.Set("code_signing_config_arn", "")
-		} else {
-			d.Set("code_signing_config_arn", getCodeSigningConfigOutput.CodeSigningConfigArn)
+		if getCodeSigningConfigOutput != nil {
+			codeSigningConfigArn = aws.StringValue(getCodeSigningConfigOutput.CodeSigningConfigArn)
 		}
-	} else {
-		d.Set("code_signing_config_arn", "")
 	}
+
+	d.Set("code_signing_config_arn", codeSigningConfigArn)
 
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16532 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lambda_function: Prevent panic on nil function PackageType
```

Output from acceptance testing (commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn (42.85s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (12.60s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_basic (73.33s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_MaximumEventAgeInSeconds (76.18s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_AliasName (76.71s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_FunctionName_Arn (84.84s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_disappears_LambdaFunction (85.35s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_disappears_LambdaFunctionEventInvokeConfig (86.60s)
--- PASS: TestAccAWSLambdaFunction_concurrency (88.31s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_Latest (90.82s)
--- PASS: TestAccAWSLambdaFunction_disappears (97.33s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_Remove (98.17s)
--- PASS: TestAccAWSLambdaFunction_basic (98.50s)
--- SKIP: TestAccAWSLambdaFunction_imageConfig (1.22s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_Swap (107.79s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (23.52s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_OnSuccess_Destination (117.21s)
--- PASS: TestAccAWSLambdaFunction_UnpublishedCodeUpdate (131.45s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_OnFailure_Destination (131.83s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionVersion (132.54s)
--- PASS: TestAccAWSLambdaFunction_versioned (69.79s)
--- PASS: TestAccAWSLambdaFunction_codeSigningConfig (161.41s)
--- PASS: TestAccAWSLambdaFunction_Layers (61.82s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (170.87s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (70.90s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_MaximumRetryAttempts (171.89s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (103.48s)
--- PASS: TestAccAWSLambdaFunction_disablePublish (101.94s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (101.34s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (103.86s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (94.85s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (122.49s)
--- PASS: TestAccAWSLambdaFunction_enablePublish (114.77s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (86.74s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (45.33s)
--- PASS: TestAccAWSLambdaFunction_envVariables (152.86s)
--- PASS: TestAccAWSLambdaFunction_s3 (46.14s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (50.03s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (57.83s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (59.56s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (59.65s)
--- PASS: TestAccAWSLambdaFunction_tags (67.71s)
--- PASS: TestAccAWSLambdaFunction_runtimes (300.59s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (525.24s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (596.92s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (690.81s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (1923.37s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (2035.16s)

--- FAIL: TestAccAWSLambdaFunction_VPC (59.66s) --- in TC
--- PASS: TestAccAWSLambdaFunction_VPC (477.77s) -- local

```
