### PR TITLE
provider: Ensure website PR files are labeled as documentation

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -639,6 +639,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "documentation" = [
       "docs/**/*",
+      "website/**/*",
       "*.md",
     ]
     "examples" = [


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/.hashibot/blob/b5378aeb2dbb83ec3dda1767febf21d1bc42c1f9/.hashibot.hcl#L41-L46

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Capturing hashibot behavior prior to organization transfer.

Output from acceptance testing: N/A (hashibot configuration)
