### PR TITLE
r/eks_node_group: remove drift detection from capacity_type argument

### DIFF
--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -50,8 +50,8 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 			"capacity_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
-				Default:      eks.CapacityTypesOnDemand,
 				ValidateFunc: validation.StringInSlice(eks.CapacityTypes_Values(), false),
 			},
 			"cluster_name": {

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -124,7 +124,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `ami_type` - (Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64`. Terraform will only perform drift detection if a configuration value is provided.
-* `capacity_type` - (Optional) Type of capacity associated with the EKS Node Group. Defaults to `ON_DEMAND`. Valid values: `ON_DEMAND`, `SPOT`.
+* `capacity_type` - (Optional) Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. Terraform will only perform drift detection if a configuration value is provided.
 * `disk_size` - (Optional) Disk size in GiB for worker nodes. Defaults to `20`. Terraform will only perform drift detection if a configuration value is provided.
 * `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
 * `instance_types` - (Optional) List of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16547 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/eks_node_group: remove drift detection from capacity_type argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSEksNodeGroup_AmiType (1712.65s)
--- PASS: TestAccAWSEksNodeGroup_CapacityType_Spot (1419.62s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1335.99s)
--- PASS: TestAccAWSEksNodeGroup_ForceUpdateVersion (5131.91s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Multiple (1500.45s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Single (1340.39s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1396.56s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Id (1715.12s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Name (1700.75s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Version (2425.36s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (4093.10s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1467.07s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1454.95s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1436.91s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1413.84s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1423.62s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1404.38s)
--- PASS: TestAccAWSEksNodeGroup_Version (5057.41s)
--- PASS: TestAccAWSEksNodeGroup_basic (1350.04s)
--- PASS: TestAccAWSEksNodeGroup_disappears (1335.66s)
```
