### PR TITLE
Proposal for nullable value handling

### DIFF
--- a/aws/internal/nullable/float.go
+++ b/aws/internal/nullable/float.go
@@ -66,7 +66,6 @@ func ValidateFloatBetween(min, max float64) schema.SchemaValidateFunc {
 		}
 
 		if value == "" {
-			es = append(es, fmt.Errorf("expected %s to be in the range (%f - %f), got null", k, min, max))
 			return
 		}
 
@@ -95,7 +94,6 @@ func ValidateFloatAtLeast(min float64) schema.SchemaValidateFunc {
 		}
 
 		if value == "" {
-			es = append(es, fmt.Errorf("expected %s to be at least (%f), got null", k, min))
 			return
 		}
 
@@ -124,7 +122,6 @@ func ValidateFloatAtMost(max float64) schema.SchemaValidateFunc {
 		}
 
 		if value == "" {
-			es = append(es, fmt.Errorf("expected %s to be at most (%f), got null", k, max))
 			return
 		}
 

--- a/aws/internal/nullable/float.go
+++ b/aws/internal/nullable/float.go
@@ -1,0 +1,143 @@
+package nullable
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	TypeNullableFloat = schema.TypeString
+)
+
+// Float represents a nullable floating-point value
+type Float string
+
+// IsNull returns true if the value represents a null value
+func (f Float) IsNull() bool {
+	return f == ""
+}
+
+// Value returns the following information about the variable:
+// * value - Returns the value of the variable, or 0 if it is null or an error
+// * null - Returns true if the variable is null
+// * err - Returns an error from parsing the variable, if there is one
+func (f Float) Value() (float64, bool, error) {
+	if f.IsNull() {
+		return 0, true, nil
+	}
+
+	value, err := strconv.ParseFloat(string(f), 64)
+	if err != nil {
+		return 0, false, err
+	}
+	return value, false, nil
+}
+
+// ValidateTypeStringNullableFloat provides custom error messaging for TypeString floats
+// Some arguments require a floating-point value or unspecified, empty field.
+func ValidateTypeStringNullableFloat(v interface{}, k string) (ws []string, es []error) {
+	value, ok := v.(string)
+	if !ok {
+		es = append(es, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if value == "" {
+		return
+	}
+
+	if _, err := strconv.ParseFloat(value, 64); err != nil {
+		es = append(es, fmt.Errorf("%s: cannot parse '%s' as float: %w", k, value, err))
+	}
+
+	return
+}
+
+// ValidateFloatBetween returns a SchemaValidateFunc which tests if the provided value
+// is parseable as a float and is between min and max (inclusive)
+func ValidateFloatBetween(min, max float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (ws []string, es []error) {
+		value, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if value == "" {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%f - %f), got null", k, min, max))
+			return
+		}
+
+		v, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			es = append(es, fmt.Errorf("%s: cannot parse '%s' as float: %w", k, value, err))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%f - %f), got %f", k, min, max, v))
+		}
+
+		return
+	}
+}
+
+// ValidateFloatAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is parseable as a float and is at least min (inclusive)
+func ValidateFloatAtLeast(min float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (ws []string, es []error) {
+		value, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if value == "" {
+			es = append(es, fmt.Errorf("expected %s to be at least (%f), got null", k, min))
+			return
+		}
+
+		v, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			es = append(es, fmt.Errorf("%s: cannot parse '%s' as float: %w", k, value, err))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%f), got %f", k, min, v))
+		}
+
+		return
+	}
+}
+
+// ValidateFloatAtMost returns a SchemaValidateFunc which tests if the provided value
+// is parseable as a float and is at most max (inclusive)
+func ValidateFloatAtMost(max float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (ws []string, es []error) {
+		value, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if value == "" {
+			es = append(es, fmt.Errorf("expected %s to be at most (%f), got null", k, max))
+			return
+		}
+
+		v, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			es = append(es, fmt.Errorf("%s: cannot parse '%s' as float: %w", k, value, err))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%f), got %f", k, max, v))
+		}
+
+		return
+	}
+}

--- a/aws/internal/nullable/float_test.go
+++ b/aws/internal/nullable/float_test.go
@@ -1,0 +1,191 @@
+package nullable
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+func TestNullableFloat(t *testing.T) {
+	cases := []struct {
+		val           string
+		expectedValue float64
+		expectedNull  bool
+		expectedErr   error
+	}{
+		{
+			val:           "1.5",
+			expectedValue: 1.5,
+			expectedNull:  false,
+		},
+		{
+			val:           "",
+			expectedValue: 0,
+			expectedNull:  true,
+		},
+		{
+			val:           "A",
+			expectedValue: 0,
+			expectedNull:  false,
+			expectedErr:   strconv.ErrSyntax,
+		},
+	}
+
+	for i, tc := range cases {
+		v := Float(tc.val)
+
+		if null := v.IsNull(); null != tc.expectedNull {
+			t.Fatalf("expected test case %d IsNull to return %t, got %t", i, null, tc.expectedNull)
+		}
+
+		value, null, err := v.Value()
+		if value != tc.expectedValue {
+			t.Fatalf("expected test case %d Value to be %f, got %f", i, tc.expectedValue, value)
+		}
+		if null != tc.expectedNull {
+			t.Fatalf("expected test case %d Value null flag to be %t, got %t", i, tc.expectedNull, null)
+		}
+		if tc.expectedErr == nil && err != nil {
+			t.Fatalf("expected test case %d to succeed, got error %s", i, err)
+		}
+		if tc.expectedErr != nil {
+			if !errors.Is(err, tc.expectedErr) {
+				t.Fatalf("expected test case %d to have error matching \"%s\", got %s", i, tc.expectedErr, err)
+			}
+		}
+	}
+}
+
+func TestValidationFloat(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "1.5",
+			f:   ValidateTypeStringNullableFloat,
+		},
+		{
+			val: "",
+			f:   ValidateTypeStringNullableFloat,
+		},
+		{
+			val:         "A",
+			f:           ValidateTypeStringNullableFloat,
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as float: .*`),
+		},
+		{
+			val:         1.5,
+			f:           ValidateTypeStringNullableFloat,
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+		},
+	})
+}
+
+func TestValidationFloatBetween(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "1.5",
+			f:   ValidateFloatBetween(1.0, 2.0),
+		},
+		{
+			// Test inclusive upper bound
+			val: "1.0",
+			f:   ValidateFloatBetween(0.0, 1.0),
+		},
+		{
+			// Test inclusive lower bound
+			val: "0.0",
+			f:   ValidateFloatBetween(0.0, 1.0),
+		},
+		{
+			val:         "0.5",
+			f:           ValidateFloatBetween(1.0, 2.0),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(1\.0\d+ - 2\.0\d+\), got 0\.5\d+`),
+		},
+		{
+			val:         "2.5",
+			f:           ValidateFloatBetween(1.0, 2.0),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(1\.0\d+ - 2\.0\d+\), got 2\.5\d+`),
+		},
+		{
+			val:         "",
+			f:           ValidateFloatBetween(1.0, 2.0),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(1\.0\d+ - 2\.0\d+\), got null`),
+		},
+		{
+			val:         "A",
+			f:           ValidateFloatBetween(1.0, 2.0),
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as float: .*`),
+		},
+		{
+			val:         1,
+			f:           ValidateFloatBetween(1.0, 2.0),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+		},
+	})
+}
+
+func TestValidationFloatAtLeast(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "2.5",
+			f:   ValidateFloatAtLeast(1.5),
+		},
+		{
+			val: "-1.0",
+			f:   ValidateFloatAtLeast(-1.5),
+		},
+		{
+			val:         "",
+			f:           ValidateFloatAtLeast(2.5),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\.5\d*\), got null`),
+		},
+		{
+			val:         "1.5",
+			f:           ValidateFloatAtLeast(2.5),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\.5\d*\), got 1\.5\d*`),
+		},
+		{
+			val:         "A",
+			f:           ValidateFloatAtLeast(2),
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as float: .*`),
+		},
+		{
+			val:         2.5,
+			f:           ValidateFloatAtLeast(1.5),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+		},
+	})
+}
+
+func TestValidationFloatAtMost(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "2.5",
+			f:   ValidateFloatAtMost(3.5),
+		},
+		{
+			val: "-1.0",
+			f:   ValidateFloatAtMost(-0.5),
+		},
+		{
+			val:         "",
+			f:           ValidateFloatAtMost(1.0),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(1\.0\d+\), got null`),
+		},
+		{
+			val:         "2.5",
+			f:           ValidateFloatAtMost(1.5),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(1\.5\d+\), got 2\.5\d+`),
+		},
+		{
+			val:         "A",
+			f:           ValidateFloatAtMost(0),
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as float: .*`),
+		},
+		{
+			val:         2.5,
+			f:           ValidateFloatAtMost(3.5),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+		},
+	})
+}

--- a/aws/internal/nullable/float_test.go
+++ b/aws/internal/nullable/float_test.go
@@ -97,6 +97,10 @@ func TestValidationFloatBetween(t *testing.T) {
 			f:   ValidateFloatBetween(0.0, 1.0),
 		},
 		{
+			val: "",
+			f:   ValidateFloatBetween(1.0, 2.0),
+		},
+		{
 			val:         "0.5",
 			f:           ValidateFloatBetween(1.0, 2.0),
 			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(1\.0\d+ - 2\.0\d+\), got 0\.5\d+`),
@@ -105,11 +109,6 @@ func TestValidationFloatBetween(t *testing.T) {
 			val:         "2.5",
 			f:           ValidateFloatBetween(1.0, 2.0),
 			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(1\.0\d+ - 2\.0\d+\), got 2\.5\d+`),
-		},
-		{
-			val:         "",
-			f:           ValidateFloatBetween(1.0, 2.0),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(1\.0\d+ - 2\.0\d+\), got null`),
 		},
 		{
 			val:         "A",
@@ -135,9 +134,8 @@ func TestValidationFloatAtLeast(t *testing.T) {
 			f:   ValidateFloatAtLeast(-1.5),
 		},
 		{
-			val:         "",
-			f:           ValidateFloatAtLeast(2.5),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\.5\d*\), got null`),
+			val: "",
+			f:   ValidateFloatAtLeast(2.5),
 		},
 		{
 			val:         "1.5",
@@ -168,9 +166,8 @@ func TestValidationFloatAtMost(t *testing.T) {
 			f:   ValidateFloatAtMost(-0.5),
 		},
 		{
-			val:         "",
-			f:           ValidateFloatAtMost(1.0),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(1\.0\d+\), got null`),
+			val: "",
+			f:   ValidateFloatAtMost(1.0),
 		},
 		{
 			val:         "2.5",

--- a/aws/internal/nullable/int.go
+++ b/aws/internal/nullable/int.go
@@ -66,7 +66,6 @@ func ValidateIntBetween(min, max int) schema.SchemaValidateFunc {
 		}
 
 		if value == "" {
-			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got null", k, min, max))
 			return
 		}
 
@@ -95,7 +94,6 @@ func ValidateIntAtLeast(min int) schema.SchemaValidateFunc {
 		}
 
 		if value == "" {
-			es = append(es, fmt.Errorf("expected %s to be at least (%d), got null", k, min))
 			return
 		}
 
@@ -124,7 +122,6 @@ func ValidateIntAtMost(max int) schema.SchemaValidateFunc {
 		}
 
 		if value == "" {
-			es = append(es, fmt.Errorf("expected %s to be at most (%d), got null", k, max))
 			return
 		}
 

--- a/aws/internal/nullable/int.go
+++ b/aws/internal/nullable/int.go
@@ -1,0 +1,143 @@
+package nullable
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	TypeNullableInt = schema.TypeString
+)
+
+// Int represents a nullable integer value
+type Int string
+
+// IsNull returns true if the value represents a null value
+func (i Int) IsNull() bool {
+	return i == ""
+}
+
+// Value returns the following information about the variable:
+// * value - Returns the value of the variable, or 0 if it is null or an error
+// * null - Returns true if the variable is null
+// * err - Returns an error from parsing the variable, if there is one
+func (i Int) Value() (int64, bool, error) {
+	if i.IsNull() {
+		return 0, true, nil
+	}
+
+	value, err := strconv.ParseInt(string(i), 10, 64)
+	if err != nil {
+		return 0, false, err
+	}
+	return value, false, nil
+}
+
+// ValidateTypeStringNullableInt provides custom error messaging for TypeString ints
+// Some arguments require an int value or unspecified, empty field.
+func ValidateTypeStringNullableInt(v interface{}, k string) (ws []string, es []error) {
+	value, ok := v.(string)
+	if !ok {
+		es = append(es, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if value == "" {
+		return
+	}
+
+	if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+		es = append(es, fmt.Errorf("%s: cannot parse '%s' as int: %w", k, value, err))
+	}
+
+	return
+}
+
+// ValidateIntBetween returns a SchemaValidateFunc which tests if the provided value
+// is parseable as an int and is between min and max (inclusive)
+func ValidateIntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (ws []string, es []error) {
+		value, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if value == "" {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got null", k, min, max))
+			return
+		}
+
+		v, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			es = append(es, fmt.Errorf("%s: cannot parse '%s' as int: %w", k, value, err))
+			return
+		}
+
+		if v < int64(min) || v > int64(max) {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+		}
+
+		return
+	}
+}
+
+// ValidateIntAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is parseable as an int and is at least min (inclusive)
+func ValidateIntAtLeast(min int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (ws []string, es []error) {
+		value, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if value == "" {
+			es = append(es, fmt.Errorf("expected %s to be at least (%d), got null", k, min))
+			return
+		}
+
+		v, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			es = append(es, fmt.Errorf("%s: cannot parse '%s' as int: %w", k, value, err))
+			return
+		}
+
+		if v < int64(min) {
+			es = append(es, fmt.Errorf("expected %s to be at least (%d), got %d", k, min, v))
+		}
+
+		return
+	}
+}
+
+// ValidateIntAtMost returns a SchemaValidateFunc which tests if the provided value
+// is parseable as an int and is at most max (inclusive)
+func ValidateIntAtMost(max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (ws []string, es []error) {
+		value, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if value == "" {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got null", k, max))
+			return
+		}
+
+		v, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			es = append(es, fmt.Errorf("%s: cannot parse '%s' as int: %w", k, value, err))
+			return
+		}
+
+		if v > int64(max) {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, v))
+		}
+
+		return
+	}
+}

--- a/aws/internal/nullable/int_test.go
+++ b/aws/internal/nullable/int_test.go
@@ -1,0 +1,180 @@
+package nullable
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+func TestNullableInt(t *testing.T) {
+	cases := []struct {
+		val           string
+		expectedValue int64
+		expectedNull  bool
+		expectedErr   error
+	}{
+		{
+			val:           "1",
+			expectedValue: 1,
+			expectedNull:  false,
+		},
+		{
+			val:           "",
+			expectedValue: 0,
+			expectedNull:  true,
+		},
+		{
+			val:           "A",
+			expectedValue: 0,
+			expectedNull:  false,
+			expectedErr:   strconv.ErrSyntax,
+		},
+	}
+
+	for i, tc := range cases {
+		v := Int(tc.val)
+
+		if null := v.IsNull(); null != tc.expectedNull {
+			t.Fatalf("expected test case %d IsNull to return %t, got %t", i, null, tc.expectedNull)
+		}
+
+		value, null, err := v.Value()
+		if value != tc.expectedValue {
+			t.Fatalf("expected test case %d Value to be %d, got %d", i, tc.expectedValue, value)
+		}
+		if null != tc.expectedNull {
+			t.Fatalf("expected test case %d Value null flag to be %t, got %t", i, tc.expectedNull, null)
+		}
+		if tc.expectedErr == nil && err != nil {
+			t.Fatalf("expected test case %d to succeed, got error %s", i, err)
+		}
+		if tc.expectedErr != nil {
+			if !errors.Is(err, tc.expectedErr) {
+				t.Fatalf("expected test case %d to have error matching \"%s\", got %s", i, tc.expectedErr, err)
+			}
+		}
+	}
+}
+
+func TestValidationInt(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "1",
+			f:   ValidateTypeStringNullableInt,
+		},
+		{
+			val: "",
+			f:   ValidateTypeStringNullableInt,
+		},
+		{
+			val:         "A",
+			f:           ValidateTypeStringNullableInt,
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as int: .*`),
+		},
+		{
+			val:         1,
+			f:           ValidateTypeStringNullableInt,
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+		},
+	})
+}
+
+func TestValidationIntBetween(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "1",
+			f:   ValidateIntBetween(1, 1),
+		},
+		{
+			val: "1",
+			f:   ValidateIntBetween(0, 2),
+		},
+		{
+			val:         "",
+			f:           ValidateIntBetween(2, 3),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(2 - 3\), got null`),
+		},
+		{
+			val:         "1",
+			f:           ValidateIntBetween(2, 3),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(2 - 3\), got 1`),
+		},
+		{
+			val:         "A",
+			f:           ValidateIntBetween(2, 3),
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as int: .*`),
+		},
+		{
+			val:         1,
+			f:           ValidateIntBetween(2, 3),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+		},
+	})
+}
+
+func TestValidationIntAtLeast(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "1",
+			f:   ValidateIntAtLeast(1),
+		},
+		{
+			val: "1",
+			f:   ValidateIntAtLeast(0),
+		},
+		{
+			val:         "",
+			f:           ValidateIntAtLeast(2),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\), got null`),
+		},
+		{
+			val:         "1",
+			f:           ValidateIntAtLeast(2),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\), got 1`),
+		},
+		{
+			val:         "A",
+			f:           ValidateIntAtLeast(2),
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as int: .*`),
+		},
+		{
+			val:         1,
+			f:           ValidateIntAtLeast(2),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+		},
+	})
+}
+
+func TestValidationIntAtMost(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "1",
+			f:   ValidateIntAtMost(1),
+		},
+		{
+			val: "1",
+			f:   ValidateIntAtMost(2),
+		},
+		{
+			val:         "",
+			f:           ValidateIntAtMost(0),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(0\), got null`),
+		},
+		{
+			val:         "1",
+			f:           ValidateIntAtMost(0),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(0\), got 1`),
+		},
+		{
+			val:         "A",
+			f:           ValidateIntAtMost(0),
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as int: .*`),
+		},
+		{
+			val:         1,
+			f:           ValidateIntAtMost(0),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+		},
+	})
+}

--- a/aws/internal/nullable/int_test.go
+++ b/aws/internal/nullable/int_test.go
@@ -91,9 +91,8 @@ func TestValidationIntBetween(t *testing.T) {
 			f:   ValidateIntBetween(0, 2),
 		},
 		{
-			val:         "",
-			f:           ValidateIntBetween(2, 3),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(2 - 3\), got null`),
+			val: "",
+			f:   ValidateIntBetween(2, 3),
 		},
 		{
 			val:         "1",
@@ -124,9 +123,8 @@ func TestValidationIntAtLeast(t *testing.T) {
 			f:   ValidateIntAtLeast(0),
 		},
 		{
-			val:         "",
-			f:           ValidateIntAtLeast(2),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\), got null`),
+			val: "",
+			f:   ValidateIntAtLeast(2),
 		},
 		{
 			val:         "1",
@@ -157,9 +155,8 @@ func TestValidationIntAtMost(t *testing.T) {
 			f:   ValidateIntAtMost(2),
 		},
 		{
-			val:         "",
-			f:           ValidateIntAtMost(0),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(0\), got null`),
+			val: "",
+			f:   ValidateIntAtMost(0),
 		},
 		{
 			val:         "1",

--- a/aws/internal/nullable/testing.go
+++ b/aws/internal/nullable/testing.go
@@ -1,0 +1,45 @@
+package nullable
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	testing "github.com/mitchellh/go-testing-interface"
+)
+
+type testCase struct {
+	val         interface{}
+	f           schema.SchemaValidateFunc
+	expectedErr *regexp.Regexp
+}
+
+func runTestCases(t testing.T, cases []testCase) {
+	t.Helper()
+
+	matchErr := func(errs []error, r *regexp.Regexp) bool {
+		// err must match one provided
+		for _, err := range errs {
+			if r.MatchString(err.Error()) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for i, tc := range cases {
+		_, errs := tc.f(tc.val, "test_property")
+
+		if len(errs) == 0 && tc.expectedErr == nil {
+			continue
+		}
+
+		if len(errs) != 0 && tc.expectedErr == nil {
+			t.Fatalf("expected test case %d to produce no errors, got %v", i, errs)
+		}
+
+		if !matchErr(errs, tc.expectedErr) {
+			t.Fatalf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-testing-interface v1.0.4
 	github.com/pquerna/otp v1.3.0
 	github.com/stretchr/testify v1.6.1 // indirect
 	gopkg.in/yaml.v2 v2.3.0


### PR DESCRIPTION
A proposal for handling of nullable int and float values. This should be extended for nullable booleans as well. After evaluation in the AWS Provider, it could be moved to the Plugin SDK.

`nullable.ValidateTypeStringNullableFloat()` replaces the existing `validateTypeStringNullableFloat()` in the AWS Provider. There is currently no Int equivalent in the AWS Provider, but there is one in the Kubernetes Provider (https://github.com/hashicorp/terraform-provider-kubernetes/blob/aae2fefb5bbe8fde1c2083d11ab2eaaaa63de657/kubernetes/validators.go#L204-L220).

Adds nullable value equivalents to `validation.<Type>Between()`, `validation.<Type>AtLeast()`, and `validation.<Type>AtMost()`. Could be extended with equivalents to `validation.IntDivisibleBy()`, `validation.IntInSlice()`, and `validation.IntNotInSlice()`.

Adds `nullable.TypeNullableInt` and `nullable.TypeNullableFloat` as aliases for `schema.TypeString` to make intention more clear and potentially guide linting, e.g. to require one of the appropriate validation functions.

Implements Go types to wrap the string representations of nullable values and adds functions `IsNull()` and `Value()`.

Using the type wrapper, we could replace the following code

```go
if v, ok := m["instance_warmup"]; ok {
	if s, ok := v.(string); ok && s != "" {
		i, _ := strconv.ParseInt(s, 10, 64)
		refreshPreferences.InstanceWarmup = aws.Int64(i)
	}
}
```

with

```go
if v, ok := m["instance_warmup"]; ok {
	if i, null, _ := nullable.Int(v.(string)).Value(); !null {
		refreshPreferences.InstanceWarmup = aws.Int64(i)
	}
}
```

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

N/A