### PR TITLE
tech-debt/networkfirewall: update retry methods to include context

### DIFF
--- a/aws/resource_aws_networkfirewall_firewall_policy.go
+++ b/aws/resource_aws_networkfirewall_firewall_policy.go
@@ -217,7 +217,7 @@ func resourceAwsNetworkFirewallFirewallPolicyDelete(ctx context.Context, d *sche
 		FirewallPolicyArn: aws.String(d.Id()),
 	}
 
-	err := resource.Retry(waiter.FirewallPolicyTimeout, func() *resource.RetryError {
+	err := resource.RetryContext(ctx, waiter.FirewallPolicyTimeout, func() *resource.RetryError {
 		var err error
 		_, err = conn.DeleteFirewallPolicyWithContext(ctx, input)
 		if err != nil {

--- a/aws/resource_aws_networkfirewall_rule_group.go
+++ b/aws/resource_aws_networkfirewall_rule_group.go
@@ -537,7 +537,7 @@ func resourceAwsNetworkFirewallRuleGroupDelete(ctx context.Context, d *schema.Re
 	input := &networkfirewall.DeleteRuleGroupInput{
 		RuleGroupArn: aws.String(d.Id()),
 	}
-	err := resource.Retry(waiter.RuleGroupDeleteTimeout, func() *resource.RetryError {
+	err := resource.RetryContext(ctx, waiter.RuleGroupDeleteTimeout, func() *resource.RetryError {
 		var err error
 		_, err = conn.DeleteRuleGroupWithContext(ctx, input)
 		if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16348 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
N/A
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_basic (151.55s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_disappears (165.52s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences (197.58s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_multipleStatelessCustomActions (283.73s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences (197.71s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_statefulRuleGroupReference (154.96s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction (287.22s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_statelessCustomAction (148.51s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_statelessRuleGroupReference (198.06s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_tags (219.53s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference (212.47s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_updateStatelessCustomAction (527.85s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference (210.94s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_rules (148.67s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_rulesSourceList (147.75s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_statefulRule (150.77s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_statelessRule (146.86s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_disappears (145.48s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_rulesSourceAndRuleVariables (218.42s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statefulRule_header (250.67s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statelessRuleWithCustomAction (149.35s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_tags (164.17s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateRulesSourceList (198.35s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateStatefulRule (259.78s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateStatelessRule (155.97s)
```
