### PR TITLE
provider: Add -debug flag to main binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,31 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/terraform-providers/terraform-provider-aws/aws"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: aws.Provider})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{ProviderFunc: aws.Provider}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/hashicorp/aws", opts)
+
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-scaffolding/blob/3c87a86ff2eeb6b0835e26b16f2bf8bc293622fd/main.go#L22-L38

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

To match recent updates to the scaffold provider, this allows easier usage of Go debugging tooling, such as delve, via a provider reattachment mode. This is primarily for provider developers and does not affect practitioner usage.

Example usage:

```console
$ go run . -debug
{"@level":"debug","@message":"plugin address","@timestamp":"2020-12-02T21:23:22.095285-05:00","address":"/var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/plugin326120673","network":"unix"}
Provider started, to attach Terraform set the TF_REATTACH_PROVIDERS env var:

	TF_REATTACH_PROVIDERS='{"registry.terraform.io/hashicorp/aws":{"Protocol":"grpc","Pid":45042,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/plugin326120673"}}}'
```

Output from acceptance testing: N/A (plugin binary update)