### PR TITLE
resource/aws_imagebuilder_image_recipe: Ensure proper ordering of `component` configuration blocks

### DIFF
--- a/aws/data_source_aws_imagebuilder_image_recipe.go
+++ b/aws/data_source_aws_imagebuilder_image_recipe.go
@@ -76,7 +76,7 @@ func dataSourceAwsImageBuilderImageRecipe() *schema.Resource {
 				},
 			},
 			"component": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_imagebuilder_image_recipe.go
+++ b/aws/resource_aws_imagebuilder_image_recipe.go
@@ -120,7 +120,7 @@ func resourceAwsImageBuilderImageRecipe() *schema.Resource {
 				},
 			},
 			"component": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
 				ForceNew: true,
 				MinItems: 1,
@@ -185,8 +185,8 @@ func resourceAwsImageBuilderImageRecipeCreate(d *schema.ResourceData, meta inter
 		input.BlockDeviceMappings = expandImageBuilderInstanceBlockDeviceMappings(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("component"); ok && v.(*schema.Set).Len() > 0 {
-		input.Components = expandImageBuilderComponentConfigurations(v.(*schema.Set).List())
+	if v, ok := d.GetOk("component"); ok && len(v.([]interface{})) > 0 {
+		input.Components = expandImageBuilderComponentConfigurations(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/website/docs/d/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/d/imagebuilder_image_recipe.html.markdown
@@ -40,7 +40,7 @@ In addition to all arguments above, the following attributes are exported:
         * `volume_type` - Type of the volume. For example, `gp2` or `io2`.
     * `no_device` - Whether to remove a mapping from the parent image.
     * `virtual_name` - Virtual device name. For example, `ephemeral0`. Instance store volumes are numbered starting from 0.
-* `component` - Set of objects with components for the image recipe.
+* `component` - List of objects with components for the image recipe.
     * `component_arn` - Amazon Resource Name (ARN) of the Image Builder Component.
 * `date_created` - Date the image recipe was created.
 * `description` - Description of the image recipe.

--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -38,7 +38,7 @@ resource "aws_imagebuilder_image_recipe" "example" {
 
 The following arguments are required:
 
-* `component` - (Required) Configuration block(s) with components for the image recipe. Detailed below.
+* `component` - (Required) Ordered configuration block(s) with components for the image recipe. Detailed below.
 * `name` - (Required) Name of the image recipe.
 * `parent_image` - (Required) Platform of the image recipe.
 * `version` - (Required) Version of the image recipe.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16533

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_imagebuilder_image_recipe: Ensure proper ordering of `component` attribute
resource/aws_imagebuilder_image_recipe: Ensure proper ordering of `component` configuration blocks
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAwsImageBuilderImageRecipe_basic (36.53s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_DeviceName (38.39s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_DeleteOnTermination (37.06s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_Encrypted (38.32s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_Iops (37.85s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_KmsKeyId (35.91s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_SnapshotId (47.80s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeSize (37.66s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeType (35.44s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_NoDevice (34.26s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_VirtualName (38.65s)
--- PASS: TestAccAwsImageBuilderImageRecipe_Component (44.83s)
--- PASS: TestAccAwsImageBuilderImageRecipe_Description (35.08s)
--- PASS: TestAccAwsImageBuilderImageRecipe_disappears (33.00s)
--- PASS: TestAccAwsImageBuilderImageRecipe_Tags (66.51s)

--- PASS: TestAccAwsImageBuilderImageRecipeDataSource_Arn (27.18s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAwsImageBuilderImageRecipe_basic (41.62s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_DeviceName (42.55s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_DeleteOnTermination (41.46s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_Encrypted (40.31s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_Iops (43.00s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_KmsKeyId (42.25s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_SnapshotId (49.99s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeSize (42.76s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeType (44.07s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_NoDevice (39.93s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_VirtualName (40.95s)
--- PASS: TestAccAwsImageBuilderImageRecipe_Component (43.14s)
--- PASS: TestAccAwsImageBuilderImageRecipe_Description (41.88s)
--- PASS: TestAccAwsImageBuilderImageRecipe_disappears (36.60s)
--- PASS: TestAccAwsImageBuilderImageRecipe_Tags (75.02s)

--- PASS: TestAccAwsImageBuilderImageRecipeDataSource_Arn (31.71s)
```

