### PR TITLE
add schedule_offset parameter to aws_ssm_maintenance_window

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window.go
+++ b/aws/resource_aws_ssm_maintenance_window.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -63,6 +64,12 @@ func resourceAwsSsmMaintenanceWindow() *schema.Resource {
 				Optional: true,
 			},
 
+			"schedule_offset": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 6),
+			},
+
 			"start_date": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -98,6 +105,10 @@ func resourceAwsSsmMaintenanceWindowCreate(d *schema.ResourceData, meta interfac
 
 	if v, ok := d.GetOk("schedule_timezone"); ok {
 		params.ScheduleTimezone = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("schedule_offset"); ok {
+		params.ScheduleOffset = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("start_date"); ok {
@@ -154,6 +165,10 @@ func resourceAwsSsmMaintenanceWindowUpdate(d *schema.ResourceData, meta interfac
 		params.ScheduleTimezone = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("schedule_offset"); ok {
+		params.ScheduleOffset = aws.Int64(int64(v.(int)))
+	}
+
 	if v, ok := d.GetOk("start_date"); ok {
 		params.StartDate = aws.String(v.(string))
 	}
@@ -208,6 +223,7 @@ func resourceAwsSsmMaintenanceWindowRead(d *schema.ResourceData, meta interface{
 	d.Set("end_date", resp.EndDate)
 	d.Set("name", resp.Name)
 	d.Set("schedule_timezone", resp.ScheduleTimezone)
+	d.Set("schedule_offset", resp.ScheduleOffset)
 	d.Set("schedule", resp.Schedule)
 	d.Set("start_date", resp.StartDate)
 	d.Set("description", resp.Description)

--- a/aws/resource_aws_ssm_maintenance_window_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_test.go
@@ -96,6 +96,7 @@ func TestAccAWSSSMMaintenanceWindow_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "end_date", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "schedule_timezone", ""),
+					resource.TestCheckResourceAttr(resourceName, "schedule_offset", "0"),
 					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(0 16 ? * TUE *)"),
 					resource.TestCheckResourceAttr(resourceName, "start_date", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -462,6 +463,39 @@ func TestAccAWSSSMMaintenanceWindow_ScheduleTimezone(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMMaintenanceWindow_ScheduleOffset(t *testing.T) {
+	var maintenanceWindow1, maintenanceWindow2 ssm.MaintenanceWindowIdentity
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigScheduleOffset(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "schedule_offset", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigScheduleOffset(rName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "schedule_offset", "5"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMMaintenanceWindow_StartDate(t *testing.T) {
 	var maintenanceWindow1, maintenanceWindow2, maintenanceWindow3 ssm.MaintenanceWindowIdentity
 	startDate1 := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
@@ -717,6 +751,19 @@ resource "aws_ssm_maintenance_window" "test" {
   schedule_timezone = %q
 }
 `, rName, scheduleTimezone)
+}
+
+func testAccAWSSSMMaintenanceWindowConfigScheduleOffset(rName string, scheduleOffset int) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff            = 1
+  duration          = 3
+  name              = %q
+  schedule          = "cron(0 16 ? * TUE *)"
+  schedule_timezone = %q
+  schedule_offset   = 3
+}
+`, rName, scheduleOffset)
 }
 
 func testAccAWSSSMMaintenanceWindowConfigStartDate(rName, startDate string) string {

--- a/aws/resource_aws_ssm_maintenance_window_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_test.go
@@ -756,12 +756,11 @@ resource "aws_ssm_maintenance_window" "test" {
 func testAccAWSSSMMaintenanceWindowConfigScheduleOffset(rName string, scheduleOffset int) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_maintenance_window" "test" {
-  cutoff            = 1
-  duration          = 3
-  name              = %q
-  schedule          = "cron(0 16 ? * TUE *)"
-  schedule_timezone = %q
-  schedule_offset   = 3
+  cutoff          = 1
+  duration        = 3
+  name            = %q
+  schedule        = "cron(0 16 ? * TUE *)"
+  schedule_offset = %d
 }
 `, rName, scheduleOffset)
 }

--- a/website/docs/r/ssm_maintenance_window.html.markdown
+++ b/website/docs/r/ssm_maintenance_window.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `enabled` - (Optional) Whether the maintenance window is enabled. Default: `true`.
 * `end_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to no longer run the maintenance window.
 * `schedule_timezone` - (Optional) Timezone for schedule in [Internet Assigned Numbers Authority (IANA) Time Zone Database format](https://www.iana.org/time-zones). For example: `America/Los_Angeles`, `etc/UTC`, or `Asia/Seoul`.
+* `schedule_offset` - (Optional) The number of days to wait after the date and time specified by a CRON expression before running the maintenance window.
 * `start_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to begin the maintenance window.
 * `tags` - (Optional) A map of tags to assign to the resource.
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
add schedule_offset parameter to aws_ssm_maintenance_window

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAWSSSMMaintenanceWindow_basic'                                                                                                 46s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSSMMaintenanceWindow_basic -timeout 120m
=== RUN   TestAccAWSSSMMaintenanceWindow_basic
=== PAUSE TestAccAWSSSMMaintenanceWindow_basic
=== CONT  TestAccAWSSSMMaintenanceWindow_basic
--- PASS: TestAccAWSSSMMaintenanceWindow_basic (37.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.163s

...
```
