### PR TITLE
Sweepers: Allow skipping GuardDuty Detector

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -1059,6 +1060,14 @@ func testSweepSkipSweepError(err error) bool {
 		return true
 	}
 	return false
+}
+
+// Check sweeper API call error for reasons to skip a specific resource
+// These include AccessDenied or AccessDeniedException for individual resources, e.g. managed by central IT
+func testSweepSkipResourceError(err error) bool {
+	// Since acceptance test sweepers are best effort, we allow bypassing this error globally
+	// instead of individual test sweeper fixes.
+	return tfawserr.ErrCodeContains(err, "AccessDenied")
 }
 
 func TestAccAWSProvider_Endpoints(t *testing.T) {

--- a/aws/resource_aws_guardduty_detector_test.go
+++ b/aws/resource_aws_guardduty_detector_test.go
@@ -25,7 +25,7 @@ func testSweepGuarddutyDetectors(region string) error {
 	client, err := sharedClientForRegion(region)
 
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 
 	conn := client.(*AWSClient).guarddutyconn
@@ -41,7 +41,10 @@ func testSweepGuarddutyDetectors(region string) error {
 
 			log.Printf("[INFO] Deleting GuardDuty Detector: %s", id)
 			_, err := conn.DeleteDetector(input)
-
+			if testSweepSkipResourceError(err) {
+				log.Printf("[WARN] Skipping GuardDuty Detector (%s): %s", id, err)
+				continue
+			}
 			if err != nil {
 				sweeperErr := fmt.Errorf("error deleting GuardDuty Detector (%s): %w", id, err)
 				log.Printf("[ERROR] %s", sweeperErr)
@@ -58,7 +61,7 @@ func testSweepGuarddutyDetectors(region string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error retrieving GuardDuty Detectors: %s", err)
+		return fmt.Errorf("error retrieving GuardDuty Detectors: %w", err)
 	}
 
 	return sweeperErrs.ErrorOrNil()


### PR DESCRIPTION
Skips GuardDuty Detector resources during sweeping on `AccessDeniedException` error.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16570

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make sweep SWEEPARGS='-sweep-run=aws_guardduty_detector'

2020/12/03 14:24:10 [DEBUG] Running Sweeper (aws_guardduty_detector) in region (us-west-2)
2020/12/03 14:24:10 [INFO] Deleting GuardDuty Detector: acb123
2020/12/03 14:24:10 [WARN] Skipping GuardDuty Detector (acb123): AccessDeniedException: 
	status code: 403, request id: 
2020/12/03 14:24:10 Sweeper Tests ran successfully:
	- aws_guardduty_detector
```
