### PR TITLE
r/aws_s3_bucket: Add support for S3 Bucket Keys

### DIFF
--- a/.changelog/16581.txt
+++ b/.changelog/16581.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+data-source/aws_s3_bucket_object: Add `bucket_key_enabled` attribute (Support S3 Bucket Keys)
+```
+
+```release-note:enhancement
+resource/aws_s3_bucket: Add `bucket_key_enabled` argument to `server_side_encryption_configuration` `rule` configuration block (Support S3 Bucket Keys)
+```
+
+```release-note:enhancement
+resource/aws_s3_bucket_object: Add `bucket_key_enabled` attribute (Support S3 Bucket Keys)
+```

--- a/aws/data_source_aws_s3_bucket_object.go
+++ b/aws/data_source_aws_s3_bucket_object.go
@@ -29,7 +29,7 @@ func dataSourceAwsS3BucketObject() *schema.Resource {
 			},
 			"bucket_key_enabled": {
 				Type:     schema.TypeBool,
-				Optional: true,
+				Computed: true,
 			},
 			"cache_control": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_s3_bucket_object.go
+++ b/aws/data_source_aws_s3_bucket_object.go
@@ -27,6 +27,10 @@ func dataSourceAwsS3BucketObject() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"bucket_key_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"cache_control": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -157,6 +161,7 @@ func dataSourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(uniqueId)
 
+	d.Set("bucket_key_enabled", out.BucketKeyEnabled)
 	d.Set("cache_control", out.CacheControl)
 	d.Set("content_disposition", out.ContentDisposition)
 	d.Set("content_encoding", out.ContentEncoding)

--- a/aws/data_source_aws_s3_bucket_object_test.go
+++ b/aws/data_source_aws_s3_bucket_object_test.go
@@ -157,6 +157,7 @@ func TestAccDataSourceAWSS3BucketObject_bucketKeyEnabled(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
+		ErrorCheck:                testAccErrorCheck(t, s3.EndpointsID),
 		Providers:                 testAccProviders,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{

--- a/aws/data_source_aws_s3_bucket_object_test.go
+++ b/aws/data_source_aws_s3_bucket_object_test.go
@@ -146,6 +146,42 @@ func TestAccDataSourceAWSS3BucketObject_kmsEncrypted(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAWSS3BucketObject_bucketKeyEnabled(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	var rObj s3.GetObjectOutput
+	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_bucket_object.object"
+	dataSourceName := "data.aws_s3_bucket_object.obj"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSourceS3ObjectConfig_bucketKeyEnabled(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
+					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "22"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "server_side_encryption", resourceName, "server_side_encryption"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sse_kms_key_id", resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "bucket_key_enabled", resourceName, "bucket_key_enabled"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckResourceAttr(dataSourceName, "body", "Keep Calm and Carry On"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -172,6 +208,7 @@ func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
 					resource.TestCheckResourceAttrPair(dataSourceName, "version_id", resourceName, "version_id"),
 					resource.TestCheckNoResourceAttr(dataSourceName, "body"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "bucket_key_enabled", resourceName, "bucket_key_enabled"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cache_control", resourceName, "cache_control"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "content_disposition", resourceName, "content_disposition"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "content_encoding", resourceName, "content_encoding"),
@@ -497,6 +534,33 @@ resource "aws_s3_bucket_object" "object" {
   content      = "Keep Calm and Carry On"
   content_type = "text/plain"
   kms_key_id   = aws_kms_key.example.arn
+}
+
+data "aws_s3_bucket_object" "obj" {
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = aws_s3_bucket_object.object.key
+}
+`, randInt)
+}
+
+func testAccAWSDataSourceS3ObjectConfig_bucketKeyEnabled(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket" {
+  bucket = "tf-object-test-bucket-%[1]d"
+}
+
+resource "aws_kms_key" "example" {
+  description             = "TF Acceptance Test KMS key"
+  deletion_window_in_days = 7
+}
+
+resource "aws_s3_bucket_object" "object" {
+  bucket             = aws_s3_bucket.object_bucket.bucket
+  key                = "tf-testing-obj-%[1]d-encrypted"
+  content            = "Keep Calm and Carry On"
+  content_type       = "text/plain"
+  kms_key_id         = aws_kms_key.example.arn
+  bucket_key_enabled = true
 }
 
 data "aws_s3_bucket_object" "obj" {

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -561,6 +561,10 @@ func resourceAwsS3Bucket() *schema.Resource {
 											},
 										},
 									},
+									"bucket_key_enabled": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
 								},
 							},
 						},
@@ -1931,6 +1935,10 @@ func resourceAwsS3BucketServerSideEncryptionConfigurationUpdate(s3conn *s3.S3, d
 			ApplyServerSideEncryptionByDefault: rcDefaultRule,
 		}
 
+		if val, ok := rr["bucket_key_enabled"].(bool); ok {
+			rcRule.BucketKeyEnabled = aws.Bool(val)
+		}
+
 		rules = append(rules, rcRule)
 	}
 
@@ -2291,6 +2299,7 @@ func flattenAwsS3ServerSideEncryptionConfiguration(c *s3.ServerSideEncryptionCon
 			d["kms_master_key_id"] = aws.StringValue(v.ApplyServerSideEncryptionByDefault.KMSMasterKeyID)
 			d["sse_algorithm"] = aws.StringValue(v.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
 			r["apply_server_side_encryption_by_default"] = []map[string]interface{}{d}
+			r["bucket_key_enabled"] = aws.BoolValue(v.BucketKeyEnabled)
 			rules = append(rules, r)
 		}
 	}

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -59,6 +59,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 			"bucket_key_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 
 			"cache_control": {

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -56,6 +56,11 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(s3.ObjectCannedACL_Values(), false),
 			},
 
+			"bucket_key_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"cache_control": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -259,6 +264,10 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 		putInput.ContentDisposition = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("bucket_key_enabled"); ok {
+		putInput.BucketKeyEnabled = aws.Bool(v.(bool))
+	}
+
 	if v, ok := d.GetOk("server_side_encryption"); ok {
 		putInput.ServerSideEncryption = aws.String(v.(string))
 	}
@@ -347,6 +356,7 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Reading S3 Bucket Object meta: %s", resp)
 
+	d.Set("bucket_key_enabled", resp.BucketKeyEnabled)
 	d.Set("cache_control", resp.CacheControl)
 	d.Set("content_disposition", resp.ContentDisposition)
 	d.Set("content_encoding", resp.ContentEncoding)
@@ -537,6 +547,7 @@ func resourceAwsS3BucketObjectCustomizeDiff(_ context.Context, d *schema.Resourc
 
 func hasS3BucketObjectContentChanges(d resourceDiffer) bool {
 	for _, key := range []string{
+		"bucket_key_enabled",
 		"cache_control",
 		"content_base64",
 		"content_disposition",

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -1119,6 +1119,7 @@ func TestAccAWSS3BucketObject_objectBucketKeyEnabled(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
@@ -1141,6 +1142,7 @@ func TestAccAWSS3BucketObject_bucketBucketKeyEnabled(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -1004,6 +1004,37 @@ func TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled(
 	})
 }
 
+func TestAccAWSS3Bucket_bucketKeyEnabled(t *testing.T) {
+	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket.arbitrary"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketKeyEnabled(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", "aws:kms"),
+					resource.TestMatchResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id", regexp.MustCompile("^arn")),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.bucket_key_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+			},
+		},
+	})
+}
+
 // Test TestAccAWSS3Bucket_shouldFailNotFound is designed to fail with a "plan
 // not empty" error in Terraform, to check against regresssions.
 // See https://github.com/hashicorp/terraform/pull/2925
@@ -3537,6 +3568,29 @@ resource "aws_s3_bucket" "arbitrary" {
         kms_master_key_id = aws_kms_key.arbitrary.arn
         sse_algorithm     = "aws:kms"
       }
+    }
+  }
+}
+`, bucketName)
+}
+
+func testAccAWSS3BucketKeyEnabled(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "arbitrary" {
+  description             = "KMS Key for Bucket %[1]s"
+  deletion_window_in_days = 7
+}
+
+resource "aws_s3_bucket" "arbitrary" {
+  bucket = %[1]q
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.arbitrary.arn
+        sse_algorithm     = "aws:kms"
+      }
+      bucket_key_enabled = true
     }
   }
 }

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -1010,6 +1010,7 @@ func TestAccAWSS3Bucket_bucketKeyEnabled(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSS3BucketDestroy,
 		Steps: []resource.TestStep{

--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `body` - Object data (see **limitations above** to understand cases in which this field is actually available)
+* `bucket_key_enabled` - (Optional) Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 * `cache_control` - Specifies caching behavior along the request/reply chain.
 * `content_disposition` - Specifies presentational information for the object.
 * `content_encoding` - Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -476,6 +476,7 @@ The `server_side_encryption_configuration` object supports the following:
 The `rule` object supports the following:
 
 * `apply_server_side_encryption_by_default` - (required) A single object for setting server-side encryption by default. (documented below)
+* `bucket_key_enabled` - (Optional) Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 
 The `apply_server_side_encryption_by_default` object supports the following:
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -135,6 +135,7 @@ This attribute is not compatible with KMS encryption, `kms_key_id` or `server_si
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the KMS Key to use for object encryption. If the S3 Bucket has server-side encryption enabled, that value will automatically be used. If referencing the
 `aws_kms_key` resource, use the `arn` attribute. If referencing the `aws_kms_alias` data source or resource, use the `target_key_arn` attribute. Terraform will only perform drift detection if a configuration value
 is provided.
+* `bucket_key_enabled` - (Optional) Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 * `metadata` - (Optional) A map of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-`, note that only lowercase label are currently supported by the AWS Go API).
 * `tags` - (Optional) A map of tags to assign to the object.
 * `force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16536

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_s3_bucket: Add support for S3 Bucket Keys [GH-16536]
resource/aws_s3_bucket_object: Add support for S3 Bucket Keys [GH-16536]
datasource/aws_s3_bucket_object: Add support for S3 Bucket Keys [GH-16536]
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSS3Bucket'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket -timeout 120m
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_basic
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_basic
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_removed
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_removed
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_updateBasic
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_updateBasic
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Prefix
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Prefix
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_SingleTag
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_SingleTag
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_MultipleTags
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_MultipleTags
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_PrefixAndTags
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_PrefixAndTags
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Remove
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Remove
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Default
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Default
=== RUN   TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Full
=== PAUSE TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Full
=== RUN   TestAccAWSS3BucketInventory_basic
=== PAUSE TestAccAWSS3BucketInventory_basic
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSES3
=== PAUSE TestAccAWSS3BucketInventory_encryptWithSSES3
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSEKMS
=== PAUSE TestAccAWSS3BucketInventory_encryptWithSSEKMS
=== RUN   TestAccAWSS3BucketMetric_basic
=== PAUSE TestAccAWSS3BucketMetric_basic
=== RUN   TestAccAWSS3BucketMetric_WithEmptyFilter
=== PAUSE TestAccAWSS3BucketMetric_WithEmptyFilter
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefix
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefix
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== RUN   TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== PAUSE TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== RUN   TestAccAWSS3BucketMetric_WithFilterSingleTag
=== PAUSE TestAccAWSS3BucketMetric_WithFilterSingleTag
=== RUN   TestAccAWSS3BucketNotification_LambdaFunction
=== PAUSE TestAccAWSS3BucketNotification_LambdaFunction
=== RUN   TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias
=== PAUSE TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias
=== RUN   TestAccAWSS3BucketNotification_Queue
=== PAUSE TestAccAWSS3BucketNotification_Queue
=== RUN   TestAccAWSS3BucketNotification_Topic
=== PAUSE TestAccAWSS3BucketNotification_Topic
=== RUN   TestAccAWSS3BucketNotification_Topic_Multiple
=== PAUSE TestAccAWSS3BucketNotification_Topic_Multiple
=== RUN   TestAccAWSS3BucketNotification_update
=== PAUSE TestAccAWSS3BucketNotification_update
=== RUN   TestAccAWSS3BucketObject_noNameNoKey
=== PAUSE TestAccAWSS3BucketObject_noNameNoKey
=== RUN   TestAccAWSS3BucketObject_empty
=== PAUSE TestAccAWSS3BucketObject_empty
=== RUN   TestAccAWSS3BucketObject_source
=== PAUSE TestAccAWSS3BucketObject_source
=== RUN   TestAccAWSS3BucketObject_content
=== PAUSE TestAccAWSS3BucketObject_content
=== RUN   TestAccAWSS3BucketObject_etagEncryption
=== PAUSE TestAccAWSS3BucketObject_etagEncryption
=== RUN   TestAccAWSS3BucketObject_contentBase64
=== PAUSE TestAccAWSS3BucketObject_contentBase64
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
=== PAUSE TestAccAWSS3BucketObject_withContentCharacteristics
=== RUN   TestAccAWSS3BucketObject_NonVersioned
=== PAUSE TestAccAWSS3BucketObject_NonVersioned
=== RUN   TestAccAWSS3BucketObject_updates
=== PAUSE TestAccAWSS3BucketObject_updates
=== RUN   TestAccAWSS3BucketObject_updateSameFile
=== PAUSE TestAccAWSS3BucketObject_updateSameFile
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioning
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== RUN   TestAccAWSS3BucketObject_kms
=== PAUSE TestAccAWSS3BucketObject_kms
=== RUN   TestAccAWSS3BucketObject_sse
=== PAUSE TestAccAWSS3BucketObject_sse
=== RUN   TestAccAWSS3BucketObject_acl
=== PAUSE TestAccAWSS3BucketObject_acl
=== RUN   TestAccAWSS3BucketObject_metadata
=== PAUSE TestAccAWSS3BucketObject_metadata
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== RUN   TestAccAWSS3BucketObject_tags
=== PAUSE TestAccAWSS3BucketObject_tags
=== RUN   TestAccAWSS3BucketObject_tagsLeadingSlash
=== PAUSE TestAccAWSS3BucketObject_tagsLeadingSlash
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== RUN   TestAccAWSS3BucketObject_defaultBucketSSE
=== PAUSE TestAccAWSS3BucketObject_defaultBucketSSE
=== RUN   TestAccAWSS3BucketObject_ignoreTags
=== PAUSE TestAccAWSS3BucketObject_ignoreTags
=== RUN   TestAccAWSS3BucketOwnershipControls_basic
=== PAUSE TestAccAWSS3BucketOwnershipControls_basic
=== RUN   TestAccAWSS3BucketOwnershipControls_disappears
=== PAUSE TestAccAWSS3BucketOwnershipControls_disappears
=== RUN   TestAccAWSS3BucketOwnershipControls_disappears_Bucket
=== PAUSE TestAccAWSS3BucketOwnershipControls_disappears_Bucket
=== RUN   TestAccAWSS3BucketOwnershipControls_Rule_ObjectOwnership
=== PAUSE TestAccAWSS3BucketOwnershipControls_Rule_ObjectOwnership
=== RUN   TestAccAWSS3BucketPolicy_basic
=== PAUSE TestAccAWSS3BucketPolicy_basic
=== RUN   TestAccAWSS3BucketPolicy_policyUpdate
=== PAUSE TestAccAWSS3BucketPolicy_policyUpdate
=== RUN   TestAccAWSS3BucketPublicAccessBlock_basic
=== PAUSE TestAccAWSS3BucketPublicAccessBlock_basic
=== RUN   TestAccAWSS3BucketPublicAccessBlock_disappears
=== PAUSE TestAccAWSS3BucketPublicAccessBlock_disappears
=== RUN   TestAccAWSS3BucketPublicAccessBlock_bucketDisappears
=== PAUSE TestAccAWSS3BucketPublicAccessBlock_bucketDisappears
=== RUN   TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls
=== PAUSE TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls
=== RUN   TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy
=== PAUSE TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy
=== RUN   TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls
=== PAUSE TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls
=== RUN   TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets
=== PAUSE TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets
=== RUN   TestAccAWSS3Bucket_basic
=== PAUSE TestAccAWSS3Bucket_basic
=== RUN   TestAccAWSS3Bucket_Bucket_EmptyString
=== PAUSE TestAccAWSS3Bucket_Bucket_EmptyString
=== RUN   TestAccAWSS3Bucket_tagsWithNoSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithNoSystemTags
=== RUN   TestAccAWSS3Bucket_tagsWithSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithSystemTags
=== RUN   TestAccAWSS3Bucket_ignoreTags
=== PAUSE TestAccAWSS3Bucket_ignoreTags
=== RUN   TestAccAWSS3Bucket_namePrefix
=== PAUSE TestAccAWSS3Bucket_namePrefix
=== RUN   TestAccAWSS3Bucket_generatedName
=== PAUSE TestAccAWSS3Bucket_generatedName
=== RUN   TestAccAWSS3Bucket_acceleration
=== PAUSE TestAccAWSS3Bucket_acceleration
=== RUN   TestAccAWSS3Bucket_RequestPayer
=== PAUSE TestAccAWSS3Bucket_RequestPayer
=== RUN   TestAccAWSS3Bucket_Policy
=== PAUSE TestAccAWSS3Bucket_Policy
=== RUN   TestAccAWSS3Bucket_UpdateAcl
=== PAUSE TestAccAWSS3Bucket_UpdateAcl
=== RUN   TestAccAWSS3Bucket_UpdateGrant
=== PAUSE TestAccAWSS3Bucket_UpdateGrant
=== RUN   TestAccAWSS3Bucket_AclToGrant
=== PAUSE TestAccAWSS3Bucket_AclToGrant
=== RUN   TestAccAWSS3Bucket_GrantToAcl
=== PAUSE TestAccAWSS3Bucket_GrantToAcl
=== RUN   TestAccAWSS3Bucket_Website_Simple
=== PAUSE TestAccAWSS3Bucket_Website_Simple
=== RUN   TestAccAWSS3Bucket_WebsiteRedirect
=== PAUSE TestAccAWSS3Bucket_WebsiteRedirect
=== RUN   TestAccAWSS3Bucket_WebsiteRoutingRules
=== PAUSE TestAccAWSS3Bucket_WebsiteRoutingRules
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== RUN   TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== PAUSE TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== RUN   TestAccAWSS3Bucket_bucketKeyEnabled
=== PAUSE TestAccAWSS3Bucket_bucketKeyEnabled
=== RUN   TestAccAWSS3Bucket_shouldFailNotFound
=== PAUSE TestAccAWSS3Bucket_shouldFailNotFound
=== RUN   TestAccAWSS3Bucket_Versioning
=== PAUSE TestAccAWSS3Bucket_Versioning
=== RUN   TestAccAWSS3Bucket_Cors_Update
=== PAUSE TestAccAWSS3Bucket_Cors_Update
=== RUN   TestAccAWSS3Bucket_Cors_Delete
=== PAUSE TestAccAWSS3Bucket_Cors_Delete
=== RUN   TestAccAWSS3Bucket_Cors_EmptyOrigin
=== PAUSE TestAccAWSS3Bucket_Cors_EmptyOrigin
=== RUN   TestAccAWSS3Bucket_Logging
=== PAUSE TestAccAWSS3Bucket_Logging
=== RUN   TestAccAWSS3Bucket_LifecycleBasic
=== PAUSE TestAccAWSS3Bucket_LifecycleBasic
=== RUN   TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== PAUSE TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== RUN   TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock
=== PAUSE TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock
=== RUN   TestAccAWSS3Bucket_LifecycleRule_AbortIncompleteMultipartUploadDays_NoExpiration
=== PAUSE TestAccAWSS3Bucket_LifecycleRule_AbortIncompleteMultipartUploadDays_NoExpiration
=== RUN   TestAccAWSS3Bucket_Replication
=== PAUSE TestAccAWSS3Bucket_Replication
=== RUN   TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== PAUSE TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== RUN   TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation
=== PAUSE TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== PAUSE TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== RUN   TestAccAWSS3Bucket_ReplicationSchemaV2
=== PAUSE TestAccAWSS3Bucket_ReplicationSchemaV2
=== RUN   TestAccAWSS3Bucket_SameRegionReplicationSchemaV2
=== PAUSE TestAccAWSS3Bucket_SameRegionReplicationSchemaV2
=== RUN   TestAccAWSS3Bucket_objectLock
=== PAUSE TestAccAWSS3Bucket_objectLock
=== RUN   TestAccAWSS3Bucket_forceDestroy
=== PAUSE TestAccAWSS3Bucket_forceDestroy
=== RUN   TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes
=== PAUSE TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes
=== RUN   TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled
=== PAUSE TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_basic
=== CONT  TestAccAWSS3BucketOwnershipControls_disappears_Bucket
=== CONT  TestAccAWSS3BucketObject_noNameNoKey
=== CONT  TestAccAWSS3BucketObject_acl
=== CONT  TestAccAWSS3BucketObject_sse
=== CONT  TestAccAWSS3BucketOwnershipControls_disappears
=== CONT  TestAccAWSS3BucketOwnershipControls_basic
=== CONT  TestAccAWSS3BucketObject_ignoreTags
=== CONT  TestAccAWSS3BucketObject_defaultBucketSSE
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== CONT  TestAccAWSS3BucketObject_kms
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioning
=== CONT  TestAccAWSS3BucketObject_tagsLeadingSlash
=== CONT  TestAccAWSS3BucketObject_updateSameFile
=== CONT  TestAccAWSS3BucketObject_tags
=== CONT  TestAccAWSS3BucketObject_updates
=== CONT  TestAccAWSS3BucketObject_storageClass
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (6.92s)
2020/12/03 22:48:00 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
--- PASS: TestAccAWSS3BucketOwnershipControls_disappears_Bucket (34.73s)
=== CONT  TestAccAWSS3BucketObject_metadata
    TestAccAWSS3BucketObject_ignoreTags: resource_aws_s3_bucket_object_test.go:986: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_s3_bucket_object.object will be updated in-place
          ~ resource "aws_s3_bucket_object" "object" {
                acl           = "private"
                bucket        = "tf-object-test-bucket-3818638075570841295"
                content       = "stuff"
                content_type  = "binary/octet-stream"
                etag          = "c13d88cb4cb02003daedb8a84e5d272a"
                force_destroy = false
                id            = "test-key"
                key           = "test-key"
                metadata      = {}
                storage_class = "STANDARD"
              ~ tags          = {
                  - "ignorekey1" = "ignorevalue1" -> null
                }
                version_id    = "kh_halIeJ9x2NQgFQRgULEE2Xfj2WGZR"
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccAWSS3BucketObject_sse (48.96s)
=== CONT  TestAccAWSS3BucketObject_etagEncryption
--- PASS: TestAccAWSS3BucketOwnershipControls_basic (51.15s)
=== CONT  TestAccAWSS3BucketObject_NonVersioned
    TestAccAWSS3BucketObject_NonVersioned: provider_test.go:1785: skipping tests; TF_ACC_ASSUME_ROLE_ARN must be set
=== CONT  TestAccAWSS3BucketObject_content
--- SKIP: TestAccAWSS3BucketObject_NonVersioned (0.00s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_basic (51.29s)
=== CONT  TestAccAWSS3BucketObject_withContentCharacteristics
--- PASS: TestAccAWSS3BucketObject_kms (52.00s)
=== CONT  TestAccAWSS3BucketObject_source
--- FAIL: TestAccAWSS3BucketObject_ignoreTags (53.03s)
=== CONT  TestAccAWSS3BucketObject_contentBase64
2020/12/03 22:48:51 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3BucketOwnershipControls_disappears (77.99s)
=== CONT  TestAccAWSS3BucketObject_empty
--- PASS: TestAccAWSS3BucketObject_defaultBucketSSE (87.48s)
=== CONT  TestAccAWSS3BucketMetric_WithFilterSingleTag
--- PASS: TestAccAWSS3BucketObject_updateSameFile (87.49s)
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (89.40s)
=== CONT  TestAccAWSS3BucketInventory_encryptWithSSEKMS
--- PASS: TestAccAWSS3BucketObject_etagEncryption (41.09s)
=== CONT  TestAccAWSS3BucketNotification_update
2020/12/03 22:49:22 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (93.03s)
=== CONT  TestAccAWSS3BucketMetric_WithFilterMultipleTags
--- PASS: TestAccAWSS3BucketObject_content (42.21s)
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefix
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (42.34s)
=== CONT  TestAccAWSS3BucketNotification_Topic_Multiple
--- PASS: TestAccAWSS3BucketObject_source (41.97s)
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
--- PASS: TestAccAWSS3BucketObject_contentBase64 (41.66s)
=== CONT  TestAccAWSS3BucketMetric_WithEmptyFilter
--- PASS: TestAccAWSS3BucketMetric_WithEmptyFilter (1.23s)
=== CONT  TestAccAWSS3BucketNotification_Topic
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (101.57s)
=== CONT  TestAccAWSS3BucketMetric_basic
--- PASS: TestAccAWSS3BucketObject_empty (40.79s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_PrefixAndTags
--- PASS: TestAccAWSS3BucketObject_updates (120.33s)
=== CONT  TestAccAWSS3BucketNotification_Queue
2020/12/03 22:49:54 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (129.75s)
=== CONT  TestAccAWSS3BucketNotification_LambdaFunction
--- PASS: TestAccAWSS3BucketObject_acl (132.81s)
=== CONT  TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (43.53s)
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (139.42s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Prefix
--- PASS: TestAccAWSS3BucketMetric_basic (40.44s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_MultipleTags
--- PASS: TestAccAWSS3BucketNotification_Topic (51.52s)
=== CONT  TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled
--- PASS: TestAccAWSS3BucketNotification_Topic_Multiple (53.88s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_SingleTag
--- PASS: TestAccAWSS3BucketObject_metadata (118.73s)
=== CONT  TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes
2020/12/03 22:50:28 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (77.16s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_updateBasic
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (78.14s)
=== CONT  TestAccAWSS3Bucket_forceDestroy
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (77.39s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (170.78s)
=== CONT  TestAccAWSS3Bucket_UpdateAcl
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefix (77.58s)
=== CONT  TestAccAWSS3Bucket_WebsiteRoutingRules
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty (0.64s)
=== CONT  TestAccAWSS3Bucket_objectLock
--- PASS: TestAccAWSS3BucketObject_tags (171.15s)
=== CONT  TestAccAWSS3Bucket_WebsiteRedirect
2020/12/03 22:50:43 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (77.49s)
=== CONT  TestAccAWSS3Bucket_SameRegionReplicationSchemaV2
--- PASS: TestAccAWSS3BucketNotification_Queue (51.20s)
=== CONT  TestAccAWSS3Bucket_Website_Simple
2020/12/03 22:50:45 [DEBUG] Waiting for state to become: [success]
2020/12/03 22:50:46 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSS3BucketNotification_update (88.89s)
=== CONT  TestAccAWSS3Bucket_ReplicationSchemaV2
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (179.74s)
=== CONT  TestAccAWSS3BucketInventory_encryptWithSSES3
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction (54.66s)
=== CONT  TestAccAWSS3BucketInventory_basic
2020/12/03 22:50:57 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (58.15s)
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutPrefix
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (41.74s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Full
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias (62.79s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Default
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (48.19s)
=== CONT  TestAccAWSS3Bucket_GrantToAcl
2020/12/03 22:51:09 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_PrefixAndTags (81.49s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty (0.82s)
=== CONT  TestAccAWSS3Bucket_tagsWithSystemTags
--- PASS: TestAccAWSS3BucketObject_storageClass (197.43s)
=== CONT  TestAccAWSS3Bucket_Policy
2020/12/03 22:51:16 [DEBUG] Waiting for state to become: [success]
2020/12/03 22:51:16 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3Bucket_forceDestroy (42.33s)
=== CONT  TestAccAWSS3Bucket_AclToGrant
2020/12/03 22:51:29 [DEBUG] Waiting for state to become: [success]
2020/12/03 22:51:32 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (42.51s)
=== CONT  TestAccAWSS3Bucket_UpdateGrant
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Prefix (82.92s)
=== CONT  TestAccAWSS3Bucket_generatedName
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_MultipleTags (80.44s)
=== CONT  TestAccAWSS3Bucket_acceleration
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_SingleTag (79.32s)
=== CONT  TestAccAWSS3Bucket_RequestPayer
--- PASS: TestAccAWSS3BucketInventory_basic (43.99s)
=== CONT  TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Full (42.83s)
=== CONT  TestAccAWSS3Bucket_namePrefix
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Default (44.33s)
=== CONT  TestAccAWSS3Bucket_tagsWithNoSystemTags
--- PASS: TestAccAWSS3Bucket_SameRegionReplicationSchemaV2 (77.50s)
=== CONT  TestAccAWSS3Bucket_ignoreTags
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (69.35s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Remove
--- PASS: TestAccAWSS3Bucket_UpdateAcl (91.06s)
=== CONT  TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls
2020/12/03 22:52:18 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3Bucket_objectLock (96.67s)
=== CONT  TestAccAWSS3BucketAnalyticsConfiguration_removed
2020/12/03 22:52:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSS3Bucket_generatedName (48.47s)
=== CONT  TestAccAWSS3Bucket_Logging
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (100.44s)
=== CONT  TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
2020/12/03 22:52:25 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3Bucket_GrantToAcl (85.57s)
=== CONT  TestAccAWSS3Bucket_LifecycleRule_AbortIncompleteMultipartUploadDays_NoExpiration
--- PASS: TestAccAWSS3Bucket_namePrefix (46.97s)
=== CONT  TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy
--- PASS: TestAccAWSS3Bucket_AclToGrant (82.04s)
=== CONT  TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (22.26s)
=== CONT  TestAccAWSS3Bucket_Bucket_EmptyString
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_updateBasic (129.32s)
=== CONT  TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (141.14s)
=== CONT  TestAccAWSS3Bucket_LifecycleBasic
--- PASS: TestAccAWSS3Bucket_Website_Simple (143.60s)
=== CONT  TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation
--- PASS: TestAccAWSS3Bucket_acceleration (94.30s)
=== CONT  TestAccAWSS3Bucket_Cors_EmptyOrigin
--- PASS: TestAccAWSS3Bucket_RequestPayer (93.96s)
=== CONT  TestAccAWSS3BucketPublicAccessBlock_basic
--- PASS: TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock (37.96s)
=== CONT  TestAccAWSS3Bucket_Cors_Delete
--- PASS: TestAccAWSS3Bucket_LifecycleRule_AbortIncompleteMultipartUploadDays_NoExpiration (49.66s)
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutStorageClass
--- PASS: TestAccAWSS3Bucket_ignoreTags (84.50s)
=== CONT  TestAccAWSS3Bucket_Cors_Update
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Remove (78.65s)
=== CONT  TestAccAWSS3Bucket_Replication
=== CONT  TestAccAWSS3BucketPolicy_basic
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_removed (73.53s)
--- PASS: TestAccAWSS3Bucket_Logging (71.46s)
=== CONT  TestAccAWSS3Bucket_Versioning
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (49.42s)
=== CONT  TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
--- PASS: TestAccAWSS3Bucket_Policy (141.18s)
=== CONT  TestAccAWSS3Bucket_shouldFailNotFound
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls (119.29s)
=== CONT  TestAccAWSS3BucketPublicAccessBlock_bucketDisappears
2020/12/03 22:53:54 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (51.12s)
=== CONT  TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
--- PASS: TestAccAWSS3Bucket_UpdateGrant (145.82s)
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
--- PASS: TestAccAWSS3BucketPublicAccessBlock_basic (47.33s)
=== CONT  TestAccAWSS3BucketPolicy_policyUpdate
--- PASS: TestAccAWSS3Bucket_Cors_Delete (40.55s)
=== CONT  TestAccAWSS3BucketPublicAccessBlock_disappears
2020/12/03 22:54:01 [DEBUG] Waiting for state to become: [success]
2020/12/03 22:54:02 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (26.47s)
=== CONT  TestAccAWSS3Bucket_bucketKeyEnabled
2020/12/03 22:54:05 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls (119.04s)
=== CONT  TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets
2020/12/03 22:54:14 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (95.39s)
=== CONT  TestAccAWSS3BucketOwnershipControls_Rule_ObjectOwnership
--- PASS: TestAccAWSS3BucketPolicy_basic (48.65s)
=== CONT  TestAccAWSS3Bucket_basic
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (72.41s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy (120.89s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_disappears (43.54s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (51.05s)
2020/12/03 22:54:52 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (184.52s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (226.37s)
--- PASS: TestAccAWSS3Bucket_bucketKeyEnabled (56.92s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (96.99s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (252.48s)
--- PASS: TestAccAWSS3Bucket_basic (48.42s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation (130.99s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (138.24s)
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (83.01s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (92.84s)
--- PASS: TestAccAWSS3BucketOwnershipControls_Rule_ObjectOwnership (78.50s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (130.69s)
--- PASS: TestAccAWSS3Bucket_Versioning (138.02s)
    TestAccAWSS3BucketPublicAccessBlock_bucketDisappears: resource_aws_s3_bucket_public_access_block_test.go:76: Step 1/1 error: Error running post-apply refresh: 
        Error: error getting S3 Bucket (tf-test-bucket-3423184648064820769) ACL: NoSuchBucket: The specified bucket does not exist
        	status code: 404, request id: 264C367D5176609D, host id: He/sneXPerbJiC8xwBoPBo1wC0xpsQ0dbFgnUVDRH6kl3fL9v6S/FwshSthJKmEzyfDoCvL3vJs=
        
        
--- PASS: TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets (113.35s)
--- FAIL: TestAccAWSS3BucketPublicAccessBlock_bucketDisappears (150.91s)
--- PASS: TestAccAWSS3Bucket_Replication (247.73s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	586.987s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

$ make testacc TESTARGS='-run=TestAccAWSS3BucketObject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketObject -timeout 120m
=== RUN   TestAccAWSS3BucketObject_noNameNoKey
=== PAUSE TestAccAWSS3BucketObject_noNameNoKey
=== RUN   TestAccAWSS3BucketObject_empty
=== PAUSE TestAccAWSS3BucketObject_empty
=== RUN   TestAccAWSS3BucketObject_source
=== PAUSE TestAccAWSS3BucketObject_source
=== RUN   TestAccAWSS3BucketObject_content
=== PAUSE TestAccAWSS3BucketObject_content
=== RUN   TestAccAWSS3BucketObject_etagEncryption
=== PAUSE TestAccAWSS3BucketObject_etagEncryption
=== RUN   TestAccAWSS3BucketObject_contentBase64
=== PAUSE TestAccAWSS3BucketObject_contentBase64
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
=== PAUSE TestAccAWSS3BucketObject_withContentCharacteristics
=== RUN   TestAccAWSS3BucketObject_NonVersioned
=== PAUSE TestAccAWSS3BucketObject_NonVersioned
=== RUN   TestAccAWSS3BucketObject_updates
=== PAUSE TestAccAWSS3BucketObject_updates
=== RUN   TestAccAWSS3BucketObject_updateSameFile
=== PAUSE TestAccAWSS3BucketObject_updateSameFile
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioning
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== RUN   TestAccAWSS3BucketObject_kms
=== PAUSE TestAccAWSS3BucketObject_kms
=== RUN   TestAccAWSS3BucketObject_sse
=== PAUSE TestAccAWSS3BucketObject_sse
=== RUN   TestAccAWSS3BucketObject_acl
=== PAUSE TestAccAWSS3BucketObject_acl
=== RUN   TestAccAWSS3BucketObject_metadata
=== PAUSE TestAccAWSS3BucketObject_metadata
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== RUN   TestAccAWSS3BucketObject_tags
=== PAUSE TestAccAWSS3BucketObject_tags
=== RUN   TestAccAWSS3BucketObject_tagsLeadingSlash
=== PAUSE TestAccAWSS3BucketObject_tagsLeadingSlash
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== RUN   TestAccAWSS3BucketObject_bucketKeyEnabled
=== PAUSE TestAccAWSS3BucketObject_bucketKeyEnabled
=== RUN   TestAccAWSS3BucketObject_defaultBucketSSE
=== PAUSE TestAccAWSS3BucketObject_defaultBucketSSE
=== RUN   TestAccAWSS3BucketObject_ignoreTags
=== PAUSE TestAccAWSS3BucketObject_ignoreTags
=== CONT  TestAccAWSS3BucketObject_noNameNoKey
=== CONT  TestAccAWSS3BucketObject_acl
=== CONT  TestAccAWSS3BucketObject_updates
=== CONT  TestAccAWSS3BucketObject_NonVersioned
=== CONT  TestAccAWSS3BucketObject_sse
=== CONT  TestAccAWSS3BucketObject_kms
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioning
=== CONT  TestAccAWSS3BucketObject_updateSameFile
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== CONT  TestAccAWSS3BucketObject_ignoreTags
=== CONT  TestAccAWSS3BucketObject_defaultBucketSSE
=== CONT  TestAccAWSS3BucketObject_bucketKeyEnabled
=== CONT  TestAccAWSS3BucketObject_tagsLeadingSlash
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== CONT  TestAccAWSS3BucketObject_etagEncryption
=== CONT  TestAccAWSS3BucketObject_withContentCharacteristics
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== CONT  TestAccAWSS3BucketObject_contentBase64
    TestAccAWSS3BucketObject_NonVersioned: provider_test.go:1785: skipping tests; TF_ACC_ASSUME_ROLE_ARN must be set
--- SKIP: TestAccAWSS3BucketObject_NonVersioned (1.79s)
=== CONT  TestAccAWSS3BucketObject_storageClass
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (5.73s)
=== CONT  TestAccAWSS3BucketObject_tags
    TestAccAWSS3BucketObject_ignoreTags: resource_aws_s3_bucket_object_test.go:1008: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_s3_bucket_object.object will be updated in-place
          ~ resource "aws_s3_bucket_object" "object" {
                acl                = "private"
                bucket             = "tf-object-test-bucket-2599782128901604921"
                bucket_key_enabled = false
                content            = "stuff"
                content_type       = "binary/octet-stream"
                etag               = "c13d88cb4cb02003daedb8a84e5d272a"
                force_destroy      = false
                id                 = "test-key"
                key                = "test-key"
                metadata           = {}
                storage_class      = "STANDARD"
              ~ tags               = {
                  - "ignorekey1" = "ignorevalue1" -> null
                }
                version_id         = "_SemtQlM0vkyzXkvjmYQjcG8M887xV4m"
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccAWSS3BucketObject_etagEncryption (56.01s)
=== CONT  TestAccAWSS3BucketObject_content
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (58.64s)
=== CONT  TestAccAWSS3BucketObject_empty
--- PASS: TestAccAWSS3BucketObject_sse (58.84s)
=== CONT  TestAccAWSS3BucketObject_source
--- PASS: TestAccAWSS3BucketObject_bucketKeyEnabled (59.36s)
=== CONT  TestAccAWSS3BucketObject_metadata
2020/12/05 18:09:49 [DEBUG] Waiting for state to become: [success]
--- PASS: TestAccAWSS3BucketObject_contentBase64 (60.81s)
--- FAIL: TestAccAWSS3BucketObject_ignoreTags (60.98s)
--- PASS: TestAccAWSS3BucketObject_kms (61.04s)
--- PASS: TestAccAWSS3BucketObject_defaultBucketSSE (66.41s)
2020/12/05 18:10:07 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
--- PASS: TestAccAWSS3BucketObject_updates (98.95s)
--- PASS: TestAccAWSS3BucketObject_content (45.05s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (102.88s)
--- PASS: TestAccAWSS3BucketObject_empty (45.13s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (105.68s)
--- PASS: TestAccAWSS3BucketObject_source (47.32s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (106.26s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (116.88s)
--- PASS: TestAccAWSS3BucketObject_acl (144.47s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (146.01s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (146.47s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (188.69s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (190.27s)
--- PASS: TestAccAWSS3BucketObject_tags (185.25s)
--- PASS: TestAccAWSS3BucketObject_metadata (140.70s)
--- PASS: TestAccAWSS3BucketObject_storageClass (226.82s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	228.652s
FAIL
make: *** [GNUmakefile:28: testacc] Error 1

```

All failures look like they're latent to me.