### PR TITLE
tests/vpc: Fix hardcoded regions, clean up EC2 public/private suffixes

### DIFF
--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -142,6 +141,7 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("private_ip", eip.PrivateIpAddress)
 	if eip.PrivateIpAddress != nil {
+<<<<<<< HEAD
 		dashIP := strings.Replace(*eip.PrivateIpAddress, ".", "-", -1)
 
 		if region == endpoints.UsEast1RegionID {
@@ -149,10 +149,14 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		} else {
 			d.Set("private_dns", fmt.Sprintf("ip-%s.%s.compute.internal", dashIP, region))
 		}
+=======
+		d.Set("private_dns", fmt.Sprintf("ip-%s.%s", resourceAwsEc2DashIP(*eip.PrivateIpAddress), resourceAwsEc2RegionalPrivateDnsSuffix(region)))
+>>>>>>> beae41d73 (tests/eip: Fix hardcoded region)
 	}
 
 	d.Set("public_ip", eip.PublicIp)
 	if eip.PublicIp != nil {
+<<<<<<< HEAD
 		dashIP := strings.Replace(*eip.PublicIp, ".", "-", -1)
 
 		if region == endpoints.UsEast1RegionID {
@@ -160,6 +164,9 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		} else {
 			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s.compute", dashIP, region)))
 		}
+=======
+		d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s", resourceAwsEc2DashIP(*eip.PublicIp), resourceAwsEc2RegionalPublicDnsSuffix(region))))
+>>>>>>> beae41d73 (tests/eip: Fix hardcoded region)
 	}
 	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
 	d.Set("carrier_ip", eip.CarrierIp)

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -141,32 +140,12 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("private_ip", eip.PrivateIpAddress)
 	if eip.PrivateIpAddress != nil {
-<<<<<<< HEAD
-		dashIP := strings.Replace(*eip.PrivateIpAddress, ".", "-", -1)
-
-		if region == endpoints.UsEast1RegionID {
-			d.Set("private_dns", fmt.Sprintf("ip-%s.ec2.internal", dashIP))
-		} else {
-			d.Set("private_dns", fmt.Sprintf("ip-%s.%s.compute.internal", dashIP, region))
-		}
-=======
 		d.Set("private_dns", fmt.Sprintf("ip-%s.%s", resourceAwsEc2DashIP(*eip.PrivateIpAddress), resourceAwsEc2RegionalPrivateDnsSuffix(region)))
->>>>>>> beae41d73 (tests/eip: Fix hardcoded region)
 	}
 
 	d.Set("public_ip", eip.PublicIp)
 	if eip.PublicIp != nil {
-<<<<<<< HEAD
-		dashIP := strings.Replace(*eip.PublicIp, ".", "-", -1)
-
-		if region == endpoints.UsEast1RegionID {
-			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.compute-1", dashIP)))
-		} else {
-			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s.compute", dashIP, region)))
-		}
-=======
 		d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s", resourceAwsEc2DashIP(*eip.PublicIp), resourceAwsEc2RegionalPublicDnsSuffix(region))))
->>>>>>> beae41d73 (tests/eip: Fix hardcoded region)
 	}
 	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
 	d.Set("carrier_ip", eip.CarrierIp)

--- a/aws/data_source_aws_eip_test.go
+++ b/aws/data_source_aws_eip_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceAwsEip_Filter(t *testing.T) {
+func TestAccDataSourceAWSEIP_Filter(t *testing.T) {
 	dataSourceName := "data.aws_eip.test"
 	resourceName := "aws_eip.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -18,7 +18,7 @@ func TestAccDataSourceAwsEip_Filter(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsEipConfigFilter(rName),
+				Config: testAccDataSourceAWSEIPConfigFilter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -29,7 +29,7 @@ func TestAccDataSourceAwsEip_Filter(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsEip_Id(t *testing.T) {
+func TestAccDataSourceAWSEIP_Id(t *testing.T) {
 	dataSourceName := "data.aws_eip.test"
 	resourceName := "aws_eip.test"
 
@@ -38,7 +38,7 @@ func TestAccDataSourceAwsEip_Id(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsEipConfigId,
+				Config: testAccDataSourceAWSEIPConfigId,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -48,7 +48,7 @@ func TestAccDataSourceAwsEip_Id(t *testing.T) {
 		},
 	})
 }
-func TestAccDataSourceAwsEip_PublicIP_EC2Classic(t *testing.T) {
+func TestAccDataSourceAWSEIP_PublicIP_EC2Classic(t *testing.T) {
 	dataSourceName := "data.aws_eip.test"
 	resourceName := "aws_eip.test"
 
@@ -57,7 +57,7 @@ func TestAccDataSourceAwsEip_PublicIP_EC2Classic(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsEipConfigPublicIpEc2Classic(),
+				Config: testAccDataSourceAWSEIPConfigPublicIpEc2Classic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -68,7 +68,7 @@ func TestAccDataSourceAwsEip_PublicIP_EC2Classic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsEip_PublicIP_VPC(t *testing.T) {
+func TestAccDataSourceAWSEIP_PublicIP_VPC(t *testing.T) {
 	dataSourceName := "data.aws_eip.test"
 	resourceName := "aws_eip.test"
 
@@ -77,7 +77,7 @@ func TestAccDataSourceAwsEip_PublicIP_VPC(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsEipConfigPublicIpVpc,
+				Config: testAccDataSourceAWSEIPConfigPublicIpVpc,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -89,7 +89,7 @@ func TestAccDataSourceAwsEip_PublicIP_VPC(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsEip_Tags(t *testing.T) {
+func TestAccDataSourceAWSEIP_Tags(t *testing.T) {
 	dataSourceName := "data.aws_eip.test"
 	resourceName := "aws_eip.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -99,7 +99,7 @@ func TestAccDataSourceAwsEip_Tags(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsEipConfigTags(rName),
+				Config: testAccDataSourceAWSEIPConfigTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_dns", resourceName, "public_dns"),
@@ -110,7 +110,7 @@ func TestAccDataSourceAwsEip_Tags(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsEip_NetworkInterface(t *testing.T) {
+func TestAccDataSourceAWSEIP_NetworkInterface(t *testing.T) {
 	dataSourceName := "data.aws_eip.test"
 	resourceName := "aws_eip.test"
 
@@ -119,7 +119,7 @@ func TestAccDataSourceAwsEip_NetworkInterface(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsEipConfigNetworkInterface,
+				Config: testAccDataSourceAWSEIPConfigNetworkInterface,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "network_interface_id", resourceName, "network_interface"),
@@ -132,7 +132,7 @@ func TestAccDataSourceAwsEip_NetworkInterface(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsEip_Instance(t *testing.T) {
+func TestAccDataSourceAWSEIP_Instance(t *testing.T) {
 	dataSourceName := "data.aws_eip.test"
 	resourceName := "aws_eip.test"
 
@@ -141,7 +141,7 @@ func TestAccDataSourceAwsEip_Instance(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsEipConfigInstance,
+				Config: testAccDataSourceAWSEIPConfigInstance,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "instance_id", resourceName, "instance"),
@@ -206,7 +206,7 @@ data "aws_eip" "test" {
 `
 }
 
-func testAccDataSourceAwsEipConfigFilter(rName string) string {
+func testAccDataSourceAWSEIPConfigFilter(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
   vpc = true
@@ -225,7 +225,7 @@ data "aws_eip" "test" {
 `, rName)
 }
 
-const testAccDataSourceAwsEipConfigId = `
+const testAccDataSourceAWSEIPConfigId = `
 resource "aws_eip" "test" {
   vpc = true
 }
@@ -235,7 +235,7 @@ data "aws_eip" "test" {
 }
 `
 
-func testAccDataSourceAwsEipConfigPublicIpEc2Classic() string {
+func testAccDataSourceAWSEIPConfigPublicIpEc2Classic() string {
 	return composeConfig(
 		testAccEc2ClassicRegionProviderConfig(),
 		`
@@ -247,7 +247,7 @@ data "aws_eip" "test" {
 `)
 }
 
-const testAccDataSourceAwsEipConfigPublicIpVpc = `
+const testAccDataSourceAWSEIPConfigPublicIpVpc = `
 resource "aws_eip" "test" {
   vpc = true
 }
@@ -257,7 +257,7 @@ data "aws_eip" "test" {
 }
 `
 
-func testAccDataSourceAwsEipConfigTags(rName string) string {
+func testAccDataSourceAWSEIPConfigTags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
   vpc = true
@@ -275,7 +275,7 @@ data "aws_eip" "test" {
 `, rName)
 }
 
-const testAccDataSourceAwsEipConfigNetworkInterface = `
+const testAccDataSourceAWSEIPConfigNetworkInterface = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
@@ -306,7 +306,8 @@ data "aws_eip" "test" {
 }
 `
 
-var testAccDataSourceAwsEipConfigInstance = testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
+var testAccDataSourceAWSEIPConfigInstance = composeConfig(
+	testAccAvailableAZsNoOptInDefaultExcludeConfig(), `
 resource "aws_vpc" "test" {
   cidr_block = "10.2.0.0/16"
 }
@@ -347,7 +348,7 @@ data "aws_eip" "test" {
     values = [aws_eip.test.instance]
   }
 }
-`
+`)
 
 func testAccDataSourceAWSEIPConfigCarrierIP(rName string) string {
 	return composeConfig(

--- a/aws/resource_aws_default_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_default_vpc_dhcp_options_test.go
@@ -23,7 +23,7 @@ func TestAccAWSDefaultVpcDhcpOptions_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`dhcp-options/dopt-.+`)),
-					resource.TestCheckResourceAttr(resourceName, "domain_name", "us-west-2.compute.internal"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", resourceAwsEc2RegionalPrivateDnsSuffix(testAccGetRegion())),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_servers", "AmazonProvidedDNS"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Default DHCP Option Set"),

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -279,24 +279,14 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	region := *ec2conn.Config.Region
 	d.Set("private_ip", address.PrivateIpAddress)
 	if address.PrivateIpAddress != nil {
-		dashIP := strings.Replace(*address.PrivateIpAddress, ".", "-", -1)
-
-		if region == "us-east-1" {
-			d.Set("private_dns", fmt.Sprintf("ip-%s.ec2.internal", dashIP))
-		} else {
-			d.Set("private_dns", fmt.Sprintf("ip-%s.%s.compute.internal", dashIP, region))
-		}
+		d.Set("private_dns", fmt.Sprintf("ip-%s.%s", resourceAwsEc2DashIP(*address.PrivateIpAddress), resourceAwsEc2RegionalPrivateDnsSuffix(region)))
 	}
+
 	d.Set("public_ip", address.PublicIp)
 	if address.PublicIp != nil {
-		dashIP := strings.Replace(*address.PublicIp, ".", "-", -1)
-
-		if region == "us-east-1" {
-			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.compute-1", dashIP)))
-		} else {
-			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s.compute", dashIP, region)))
-		}
+		d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s", resourceAwsEc2DashIP(*address.PublicIp), resourceAwsEc2RegionalPublicDnsSuffix(region))))
 	}
+
 	d.Set("public_ipv4_pool", address.PublicIpv4Pool)
 	d.Set("carrier_ip", address.CarrierIp)
 	d.Set("customer_owned_ipv4_pool", address.CustomerOwnedIpv4Pool)

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -431,7 +431,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0) 
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
   vpc_id            = aws_vpc.test.id
 }
 
@@ -476,7 +476,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0) 
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
   vpc_id            = aws_vpc.test.id
 }
 

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -469,7 +469,7 @@ func testAccAWSEIPAssociationConfig_instance() string {
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
 		testAccAvailableAZsNoOptInConfig(),
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		fmt.Sprintf(`
+		`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -498,7 +498,7 @@ resource "aws_eip_association" "test" {
   allocation_id = aws_eip.test.id
   instance_id   = aws_instance.test.id
 }
-`))
+`)
 }
 
 const testAccAWSEIPAssociationConfig_networkInterface = `

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -291,16 +291,8 @@ func testAccCheckAWSEIPAssociationDestroy(s *terraform.State) error {
 
 func testAccAWSEIPAssociationConfig() string {
 	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(), `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/24"
   tags = {
@@ -367,16 +359,8 @@ resource "aws_network_interface" "test" {
 
 func testAccAWSEIPAssociationConfigDisappears() string {
 	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(), `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "main" {
   cidr_block = "192.168.0.0/24"
   tags = {
@@ -437,7 +421,35 @@ resource "aws_eip_association" "test" {
 
 func testAccAWSEIPAssociationConfig_spotInstance(rInt int) string {
 	return composeConfig(
-		testAccAWSSpotInstanceRequestConfig(rInt), `
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+resource "aws_default_subnet" "default" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  lifecycle {
+    ignore_changes = [
+      # testing environments often change the Name tag
+      tags["Name"],
+    ]
+  }
+}
+
+resource "aws_key_pair" "test" {
+  key_name   = "tmp-key-%d"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+
+resource "aws_spot_instance_request" "test" {
+  ami                  = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
+  key_name             = aws_key_pair.test.key_name
+  spot_price           = "0.10"
+  wait_for_fulfillment = true
+  subnet_id            = aws_default_subnet.default.id
+}
+
 resource "aws_eip" "test" {
   vpc = true
 }
@@ -446,19 +458,35 @@ resource "aws_eip_association" "test" {
   allocation_id = aws_eip.test.id
   instance_id   = aws_spot_instance_request.test.spot_instance_id
 }
-`)
+`, rInt))
 }
 
 func testAccAWSEIPAssociationConfig_instance() string {
 	return composeConfig(
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		testAccAvailableAZsNoOptInConfig(),
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		`
-resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "t2.small"
+		fmt.Sprintf(`
+resource "aws_default_subnet" "default" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  lifecycle {
+    ignore_changes = [
+      # testing environments often change the Name tag
+      tags["Name"],
+    ]
+  }
 }
 
-resource "aws_eip" "test" {}
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_default_subnet.default.id
+}
+
+resource "aws_eip" "test" {
+  vpc = true
+}
 
 resource "aws_eip_association" "test" {
   allocation_id = aws_eip.test.id
@@ -485,7 +513,9 @@ resource "aws_network_interface" "test" {
   subnet_id = aws_subnet.test.id
 }
 
-resource "aws_eip" "test" {}
+resource "aws_eip" "test" {
+  vpc = true
+}
 
 resource "aws_eip_association" "test" {
   allocation_id        = aws_eip.test.id

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -839,23 +839,27 @@ resource "aws_eip" "test" {
 func testAccAWSEIPInstanceConfig() string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
 		testAccAvailableAZsNoOptInConfig(),
 		`
-resource "aws_default_subnet" "default" {
-  availability_zone = data.aws_availability_zones.available.names[0]
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
 
-  lifecycle {
-    ignore_changes = [
-      # testing environments often change the Name tag
-      tags["Name"],
-    ]
-  }
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0) 
+  vpc_id            = aws_vpc.test.id
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "t2.small"
-  subnet_id     = aws_default_subnet.default.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
 }
 
 resource "aws_eip" "test" {
@@ -1177,24 +1181,27 @@ resource "aws_route_table_association" "test" {
 
 func testAccAWSEIPAssociate_not_associated() string {
 	return composeConfig(
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
 		testAccAvailableAZsNoOptInConfig(),
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(), `
-resource "aws_default_subnet" "default" {
-  availability_zone = data.aws_availability_zones.available.names[0]
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
 
-  lifecycle {
-    ignore_changes = [
-      # testing environments often change the Name tag
-      tags["Name"],
-    ]
-  }
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0) 
+  vpc_id            = aws_vpc.test.id
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  subnet_id     = aws_default_subnet.default.id
+  subnet_id     = aws_subnet.test.id
 }
 
 resource "aws_eip" "test" {
@@ -1204,24 +1211,27 @@ resource "aws_eip" "test" {
 
 func testAccAWSEIPAssociate_associated() string {
 	return composeConfig(
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
 		testAccAvailableAZsNoOptInConfig(),
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(), `
-resource "aws_default_subnet" "default" {
-  availability_zone = data.aws_availability_zones.available.names[0]
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
 
-  lifecycle {
-    ignore_changes = [
-      # testing environments often change the Name tag
-      tags["Name"],
-    ]
-  }
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0) 
+  vpc_id            = aws_vpc.test.id
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  subnet_id     = aws_default_subnet.default.id
+  subnet_id     = aws_subnet.test.id
 }
 
 resource "aws_eip" "test" {

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -712,13 +711,12 @@ func testAccCheckAWSEIPPrivateDNS(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		privateIPDashed := strings.Replace(rs.Primary.Attributes["private_ip"], ".", "-", -1)
 		privateDNS := rs.Primary.Attributes["private_dns"]
-		expectedPrivateDNS := fmt.Sprintf("ip-%s.%s.compute.internal", privateIPDashed, testAccGetRegion())
-
-		if testAccGetRegion() == "us-east-1" {
-			expectedPrivateDNS = fmt.Sprintf("ip-%s.ec2.internal", privateIPDashed)
-		}
+		expectedPrivateDNS := fmt.Sprintf(
+			"ip-%s.%s",
+			resourceAwsEc2DashIP(rs.Primary.Attributes["private_ip"]),
+			resourceAwsEc2RegionalPrivateDnsSuffix(testAccGetRegion()),
+		)
 
 		if privateDNS != expectedPrivateDNS {
 			return fmt.Errorf("expected private_dns value (%s), received: %s", expectedPrivateDNS, privateDNS)
@@ -735,13 +733,13 @@ func testAccCheckAWSEIPPublicDNS(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		publicIPDashed := strings.Replace(rs.Primary.Attributes["public_ip"], ".", "-", -1)
 		publicDNS := rs.Primary.Attributes["public_dns"]
-		expectedPublicDNS := fmt.Sprintf("ec2-%s.%s.compute.%s", publicIPDashed, testAccGetRegion(), testAccGetPartitionDNSSuffix())
-
-		if testAccGetRegion() == "us-east-1" {
-			expectedPublicDNS = fmt.Sprintf("ec2-%s.compute-1.%s", publicIPDashed, testAccGetPartitionDNSSuffix())
-		}
+		expectedPublicDNS := fmt.Sprintf(
+			"ec2-%s.%s.%s",
+			resourceAwsEc2DashIP(rs.Primary.Attributes["public_ip"]),
+			resourceAwsEc2RegionalPublicDnsSuffix(testAccGetRegion()),
+			testAccGetPartitionDNSSuffix(),
+		)
 
 		if publicDNS != expectedPublicDNS {
 			return fmt.Errorf("expected public_dns value (%s), received: %s", expectedPublicDNS, publicDNS)
@@ -758,13 +756,13 @@ func testAccCheckAWSEIPPublicDNSEc2Classic(resourceName string) resource.TestChe
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		publicIPDashed := strings.Replace(rs.Primary.Attributes["public_ip"], ".", "-", -1)
 		publicDNS := rs.Primary.Attributes["public_dns"]
-		expectedPublicDNS := fmt.Sprintf("ec2-%s.%s.compute.%s", publicIPDashed, testAccGetEc2ClassicRegion(), testAccGetPartitionDNSSuffix())
-
-		if testAccGetEc2ClassicRegion() == endpoints.UsEast1RegionID {
-			expectedPublicDNS = fmt.Sprintf("ec2-%s.compute-1.%s", publicIPDashed, testAccGetPartitionDNSSuffix())
-		}
+		expectedPublicDNS := fmt.Sprintf(
+			"ec2-%s.%s.%s",
+			resourceAwsEc2DashIP(rs.Primary.Attributes["public_ip"]),
+			resourceAwsEc2RegionalPublicDnsSuffix(testAccGetEc2ClassicRegion()),
+			testAccGetPartitionDNSSuffix(),
+		)
 
 		if publicDNS != expectedPublicDNS {
 			return fmt.Errorf("expected public_dns value (%s), received: %s", expectedPublicDNS, publicDNS)
@@ -776,12 +774,15 @@ func testAccCheckAWSEIPPublicDNSEc2Classic(resourceName string) resource.TestChe
 
 const testAccAWSEIPConfig = `
 resource "aws_eip" "test" {
+  vpc = true
 }
 `
 
 func testAccAWSEIPConfig_tags(rName, testName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
+  vpc = true
+
   tags = {
     RandomName = "%[1]s"
     TestName   = "%[2]s"
@@ -837,14 +838,29 @@ resource "aws_eip" "test" {
 
 func testAccAWSEIPInstanceConfig() string {
 	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(), `
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableAZsNoOptInConfig(),
+		`
+resource "aws_default_subnet" "default" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  lifecycle {
+    ignore_changes = [
+      # testing environments often change the Name tag
+      tags["Name"],
+    ]
+  }
+}
+
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t2.small"
+  subnet_id     = aws_default_subnet.default.id
 }
 
 resource "aws_eip" "test" {
   instance = aws_instance.test.id
+  vpc      = true
 }
 `)
 }
@@ -1161,10 +1177,24 @@ resource "aws_route_table_association" "test" {
 
 func testAccAWSEIPAssociate_not_associated() string {
 	return composeConfig(
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		testAccAvailableAZsNoOptInConfig(),
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(), `
+resource "aws_default_subnet" "default" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  lifecycle {
+    ignore_changes = [
+      # testing environments often change the Name tag
+      tags["Name"],
+    ]
+  }
+}
+
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "t2.small"
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_default_subnet.default.id
 }
 
 resource "aws_eip" "test" {
@@ -1174,14 +1204,29 @@ resource "aws_eip" "test" {
 
 func testAccAWSEIPAssociate_associated() string {
 	return composeConfig(
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		testAccAvailableAZsNoOptInConfig(),
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(), `
+resource "aws_default_subnet" "default" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  lifecycle {
+    ignore_changes = [
+      # testing environments often change the Name tag
+      tags["Name"],
+    ]
+  }
+}
+
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "t2.small"
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_default_subnet.default.id
 }
 
 resource "aws_eip" "test" {
   instance = aws_instance.test.id
+  vpc      = true
 }
 `)
 }

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -848,7 +848,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0) 
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
   vpc_id            = aws_vpc.test.id
 }
 
@@ -1190,7 +1190,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0) 
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
   vpc_id            = aws_vpc.test.id
 }
 
@@ -1220,7 +1220,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0) 
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
   vpc_id            = aws_vpc.test.id
 }
 

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -524,8 +523,9 @@ func testAccCheckAWSENIAttributes(conf *ec2.NetworkInterface) resource.TestCheck
 			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIpAddress)
 		}
 
-		if !strings.HasPrefix(*conf.PrivateDnsName, "ip-172-16-10-100.") || !strings.HasSuffix(*conf.PrivateDnsName, ".compute.internal") {
-			return fmt.Errorf("expected private dns name to be ip-172-16-10-100.<region>.compute.internal, but was %s", *conf.PrivateDnsName)
+		expectedPrivateDnsName := fmt.Sprintf("ip-%s.%s", resourceAwsEc2DashIP(*conf.PrivateIpAddress), resourceAwsEc2RegionalPrivateDnsSuffix(testAccGetRegion()))
+		if *conf.PrivateDnsName != expectedPrivateDnsName {
+			return fmt.Errorf("expected private dns name to be %s, but was %s", expectedPrivateDnsName, *conf.PrivateDnsName)
 		}
 
 		if len(*conf.MacAddress) == 0 {
@@ -573,8 +573,9 @@ func testAccCheckAWSENIAttributesWithAttachment(conf *ec2.NetworkInterface) reso
 			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIpAddress)
 		}
 
-		if !strings.HasPrefix(*conf.PrivateDnsName, "ip-172-16-10-100.") || !strings.HasSuffix(*conf.PrivateDnsName, ".compute.internal") {
-			return fmt.Errorf("expected private dns name to be ip-172-16-10-100.<region>.compute.internal, but was %s", *conf.PrivateDnsName)
+		expectedPrivateDnsName := fmt.Sprintf("ip-%s.%s", resourceAwsEc2DashIP(*conf.PrivateIpAddress), resourceAwsEc2RegionalPrivateDnsSuffix(testAccGetRegion()))
+		if *conf.PrivateDnsName != expectedPrivateDnsName {
+			return fmt.Errorf("expected private dns name to be %s, but was %s", expectedPrivateDnsName, *conf.PrivateDnsName)
 		}
 
 		return nil

--- a/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_test.go
@@ -33,11 +33,6 @@ func testSweepVpcDhcpOptions(region string) error {
 		for _, dhcpOption := range page.DhcpOptions {
 			var defaultDomainNameFound, defaultDomainNameServersFound bool
 
-			domainName := region + ".compute.internal"
-			if region == "us-east-1" {
-				domainName = "ec2.internal"
-			}
-
 			// This skips the default dhcp configurations so they don't get deleted
 			for _, dhcpConfiguration := range dhcpOption.DhcpConfigurations {
 				if aws.StringValue(dhcpConfiguration.Key) == "domain-name" {
@@ -45,7 +40,7 @@ func testSweepVpcDhcpOptions(region string) error {
 						continue
 					}
 
-					if aws.StringValue(dhcpConfiguration.Values[0].Value) == domainName {
+					if aws.StringValue(dhcpConfiguration.Values[0].Value) == resourceAwsEc2RegionalPrivateDnsSuffix(region) {
 						defaultDomainNameFound = true
 					}
 				} else if aws.StringValue(dhcpConfiguration.Key) == "domain-name-servers" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

## Next level: GovCloud & `us-west-2` & `us-east-1`

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Tests:
```
TestAccAWSDefaultVpcDhcpOptions_|TestAccAWSDHCPOptions_|TestAccAWSDHCPOptionsAssociation_|TestAccAWSEIP_|TestAccAWSEIPAssociation_|TestAccAWSENI_|TestAccDataSourceAWSEIP_
```

### GovCloud

```
--- PASS: TestAccAWSDefaultVpcDhcpOptions_basic (20.86s)
--- PASS: TestAccAWSDHCPOptions_basic (26.84s)
--- PASS: TestAccAWSDHCPOptions_deleteOptions (19.57s)
--- PASS: TestAccAWSDHCPOptions_disappears (42.21s)
--- PASS: TestAccAWSDHCPOptions_tags (54.19s)
--- PASS: TestAccAWSDHCPOptionsAssociation_basic (48.96s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_dhcp (64.31s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_vpc (50.97s)
--- PASS: TestAccAWSEIP_associated_user_private_ip (249.39s)
--- PASS: TestAccAWSEIP_basic (23.44s)
--- PASS: TestAccAWSEIP_disappears (15.88s)
--- PASS: TestAccAWSEIP_instance (106.13s)
--- PASS: TestAccAWSEIP_Instance_Reassociate (133.61s)
--- PASS: TestAccAWSEIP_NetworkBorderGroup (22.50s)
--- PASS: TestAccAWSEIP_networkInterface (107.73s)
--- PASS: TestAccAWSEIP_notAssociated (126.50s)
--- PASS: TestAccAWSEIP_PublicIpv4Pool_default (23.43s)
--- PASS: TestAccAWSEIP_tags_Vpc (33.81s)
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (83.99s)
--- PASS: TestAccAWSEIPAssociation_basic (227.77s)
--- PASS: TestAccAWSEIPAssociation_disappears (135.52s)
--- PASS: TestAccAWSEIPAssociation_instance (100.76s)
--- PASS: TestAccAWSEIPAssociation_networkInterface (74.36s)
--- PASS: TestAccAWSEIPAssociation_spotInstance (120.16s)
--- PASS: TestAccAWSENI_attached (214.61s)
--- PASS: TestAccAWSENI_basic (95.42s)
--- PASS: TestAccAWSENI_computedIPs (87.01s)
--- PASS: TestAccAWSENI_disappears (66.31s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (149.95s)
--- PASS: TestAccAWSENI_ipv6 (161.58s)
--- PASS: TestAccAWSENI_ipv6_count (185.21s)
--- PASS: TestAccAWSENI_PrivateIpsCount (157.46s)
--- PASS: TestAccAWSENI_sourceDestCheck (162.54s)
--- PASS: TestAccAWSENI_tags (128.62s)
--- PASS: TestAccAWSENI_updatedDescription (111.58s)
--- PASS: TestAccDataSourceAwsEip_Filter (35.84s)
--- PASS: TestAccDataSourceAwsEip_Id (18.10s)
--- PASS: TestAccDataSourceAwsEip_Instance (142.23s)
--- PASS: TestAccDataSourceAwsEip_NetworkInterface (73.41s)
--- PASS: TestAccDataSourceAwsEip_PublicIP_VPC (17.17s)
--- PASS: TestAccDataSourceAwsEip_Tags (21.98s)
--- SKIP: TestAccAWSEIP_CustomerOwnedIpv4Pool (2.77s)
--- SKIP: TestAccAWSEIP_Ec2Classic (2.70s)
--- SKIP: TestAccAWSEIP_PublicIpv4Pool_custom (0.00s)
--- SKIP: TestAccAWSEIP_tags_Ec2Classic (2.70s)
--- SKIP: TestAccAWSEIPAssociation_ec2Classic (0.00s)
--- SKIP: TestAccDataSourceAWSEIP_CustomerOwnedIpv4Pool (1.11s)
--- SKIP: TestAccDataSourceAwsEip_PublicIP_EC2Classic (0.00s)
```

### `us-west-2`

```
--- PASS: TestAccAWSDefaultVpcDhcpOptions_basic (11.89s)
--- PASS: TestAccAWSDHCPOptions_basic (13.81s)
--- PASS: TestAccAWSDHCPOptions_deleteOptions (9.81s)
--- PASS: TestAccAWSDHCPOptions_disappears (9.86s)
--- PASS: TestAccAWSDHCPOptions_tags (32.46s)
--- PASS: TestAccAWSDHCPOptionsAssociation_basic (24.23s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_dhcp (23.61s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_vpc (18.78s)
--- PASS: TestAccAWSEIP_associated_user_private_ip (242.77s)
--- PASS: TestAccAWSEIP_basic (19.82s)
--- PASS: TestAccAWSEIP_disappears (14.46s)
--- PASS: TestAccAWSEIP_Ec2Classic (118.48s)
--- PASS: TestAccAWSEIP_instance (97.02s)
--- PASS: TestAccAWSEIP_Instance_Reassociate (134.04s)
--- PASS: TestAccAWSEIP_NetworkBorderGroup (15.69s)
--- PASS: TestAccAWSEIP_networkInterface (84.15s)
--- PASS: TestAccAWSEIP_notAssociated (133.95s)
--- PASS: TestAccAWSEIP_PublicIpv4Pool_default (15.62s)
--- PASS: TestAccAWSEIP_tags_Ec2Classic (4.84s)
--- PASS: TestAccAWSEIP_tags_Vpc (29.52s)
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (83.55s)
--- PASS: TestAccAWSEIPAssociation_basic (157.28s)
--- PASS: TestAccAWSEIPAssociation_disappears (110.46s)
--- PASS: TestAccAWSEIPAssociation_ec2Classic (229.44s)
--- PASS: TestAccAWSEIPAssociation_instance (95.72s)
--- PASS: TestAccAWSEIPAssociation_networkInterface (69.70s)
--- PASS: TestAccAWSEIPAssociation_spotInstance (339.81s)
--- PASS: TestAccAWSENI_attached (129.09s)
--- PASS: TestAccAWSENI_basic (66.81s)
--- PASS: TestAccAWSENI_computedIPs (65.57s)
--- PASS: TestAccAWSENI_disappears (59.69s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (122.98s)
--- PASS: TestAccAWSENI_ipv6 (121.53s)
--- PASS: TestAccAWSENI_ipv6_count (145.22s)
--- PASS: TestAccAWSENI_PrivateIpsCount (118.18s)
--- PASS: TestAccAWSENI_sourceDestCheck (116.05s)
--- PASS: TestAccAWSENI_tags (117.32s)
--- PASS: TestAccAWSENI_updatedDescription (100.08s)
--- PASS: TestAccDataSourceAwsEip_Filter (19.38s)
--- PASS: TestAccDataSourceAwsEip_Id (13.60s)
--- PASS: TestAccDataSourceAwsEip_Instance (158.76s)
--- PASS: TestAccDataSourceAwsEip_NetworkInterface (72.54s)
--- PASS: TestAccDataSourceAwsEip_PublicIP_EC2Classic (8.68s)
--- PASS: TestAccDataSourceAwsEip_PublicIP_VPC (19.07s)
--- PASS: TestAccDataSourceAwsEip_Tags (19.26s)
--- SKIP: TestAccAWSEIP_CustomerOwnedIpv4Pool (1.48s)
--- SKIP: TestAccAWSEIP_PublicIpv4Pool_custom (0.00s)
--- SKIP: TestAccDataSourceAWSEIP_CustomerOwnedIpv4Pool (1.58s)
```

### `us-east-1`

```

--- PASS: TestAccAWSDefaultVpcDhcpOptions_basic (12.51s)
--- PASS: TestAccAWSDHCPOptions_basic (10.60s)
--- PASS: TestAccAWSDHCPOptions_deleteOptions (9.80s)
--- PASS: TestAccAWSDHCPOptions_disappears (10.80s)
--- PASS: TestAccAWSDHCPOptions_tags (31.88s)
--- PASS: TestAccAWSDHCPOptionsAssociation_basic (21.74s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_dhcp (38.74s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_vpc (26.03s)
--- PASS: TestAccAWSEIP_associated_user_private_ip (432.82s)
--- PASS: TestAccAWSEIP_basic (9.47s)
--- PASS: TestAccAWSEIP_disappears (11.40s)
--- PASS: TestAccAWSEIP_Ec2Classic (99.80s)
--- PASS: TestAccAWSEIP_instance (83.65s)
--- PASS: TestAccAWSEIP_Instance_Reassociate (97.33s)
--- PASS: TestAccAWSEIP_NetworkBorderGroup (16.12s)
--- PASS: TestAccAWSEIP_networkInterface (63.60s)
--- PASS: TestAccAWSEIP_notAssociated (122.94s)
--- PASS: TestAccAWSEIP_PublicIpv4Pool_default (15.83s)
--- PASS: TestAccAWSEIP_tags_Ec2Classic (8.65s)
--- PASS: TestAccAWSEIP_tags_Vpc (13.43s)
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (64.70s)
--- PASS: TestAccAWSEIPAssociation_disappears (103.91s)
--- PASS: TestAccAWSEIPAssociation_ec2Classic (98.84s)
--- PASS: TestAccAWSEIPAssociation_instance (318.94s)
--- PASS: TestAccAWSEIPAssociation_networkInterface (55.09s)
--- PASS: TestAccAWSEIPAssociation_spotInstance (319.11s)
--- PASS: TestAccAWSENI_attached (119.13s)
--- PASS: TestAccAWSENI_basic (52.12s)
--- PASS: TestAccAWSENI_computedIPs (55.00s)
--- PASS: TestAccAWSENI_disappears (48.85s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (85.51s)
--- PASS: TestAccAWSENI_ipv6 (95.56s)
--- PASS: TestAccAWSENI_ipv6_count (108.60s)
--- PASS: TestAccAWSENI_PrivateIpsCount (107.86s)
--- PASS: TestAccAWSENI_sourceDestCheck (96.71s)
--- PASS: TestAccAWSENI_tags (93.01s)
--- PASS: TestAccAWSENI_updatedDescription (92.09s)
--- PASS: TestAccDataSourceAwsEip_Filter (14.14s)
--- PASS: TestAccDataSourceAwsEip_Id (9.88s)
--- PASS: TestAccDataSourceAwsEip_Instance (147.14s)
--- PASS: TestAccDataSourceAwsEip_NetworkInterface (58.76s)
--- PASS: TestAccDataSourceAwsEip_PublicIP_EC2Classic (12.97s)
--- PASS: TestAccDataSourceAwsEip_PublicIP_VPC (18.53s)
--- PASS: TestAccDataSourceAwsEip_Tags (8.62s)
--- SKIP: TestAccAWSEIP_CustomerOwnedIpv4Pool (1.48s)
--- SKIP: TestAccAWSEIP_PublicIpv4Pool_custom (0.00s)
--- SKIP: TestAccAWSEIPAssociation_basic (0.46s)
--- SKIP: TestAccDataSourceAWSEIP_CustomerOwnedIpv4Pool (1.34s)
```