### PR TITLE
[aws_workspaces_directory] Fix Empty Custom Security Group ID & Default OU

### DIFF
--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -419,13 +419,21 @@ func expandWorkspaceCreationProperties(properties []interface{}) *workspaces.Wor
 
 	p := properties[0].(map[string]interface{})
 
-	return &workspaces.WorkspaceCreationProperties{
-		CustomSecurityGroupId:           aws.String(p["custom_security_group_id"].(string)),
-		DefaultOu:                       aws.String(p["default_ou"].(string)),
+	result := &workspaces.WorkspaceCreationProperties{
 		EnableInternetAccess:            aws.Bool(p["enable_internet_access"].(bool)),
 		EnableMaintenanceMode:           aws.Bool(p["enable_maintenance_mode"].(bool)),
 		UserEnabledAsLocalAdministrator: aws.Bool(p["user_enabled_as_local_administrator"].(bool)),
 	}
+
+	if p["custom_security_group_id"].(string) != "" {
+		result.CustomSecurityGroupId = aws.String(p["custom_security_group_id"].(string))
+	}
+
+	if p["default_ou"].(string) != "" {
+		result.DefaultOu = aws.String(p["default_ou"].(string))
+	}
+
+	return result
 }
 
 func flattenSelfServicePermissions(permissions *workspaces.SelfservicePermissions) []interface{} {

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -808,11 +808,6 @@ func testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurity
 	return composeConfig(
 		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
 		fmt.Sprintf(`
-resource "aws_security_group" "test" {
-  vpc_id = aws_vpc.main.id
-  name   = "tf-acctest-%[1]s"
-}
-
 resource "aws_workspaces_directory" "main" {
   directory_id = aws_directory_service_directory.main.id
 

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -717,6 +717,10 @@ func testAccWorkspacesDirectoryConfig(rName string) string {
 		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName), `
 resource "aws_workspaces_directory" "main" {
   directory_id = aws_directory_service_directory.main.id
+
+  tags = {
+    Name = "tf-testacc-workspaces-directory-%[1]s"
+  }
 }
 
 data "aws_iam_role" "workspaces-default" {
@@ -737,6 +741,10 @@ resource "aws_workspaces_directory" "main" {
     rebuild_workspace    = true
     restart_workspace    = false
     switch_running_mode  = true
+  }
+
+  tags = {
+    Name = "tf-testacc-workspaces-directory-%[1]s"
   }
 }
 `)
@@ -800,6 +808,10 @@ resource "aws_workspaces_directory" "main" {
     enable_maintenance_mode             = false
     user_enabled_as_local_administrator = false
   }
+
+  tags = {
+    Name = "tf-testacc-workspaces-directory-%[1]s"
+  }
 }
 `, rName))
 }
@@ -815,6 +827,10 @@ resource "aws_workspaces_directory" "main" {
     enable_internet_access              = true
     enable_maintenance_mode             = false
     user_enabled_as_local_administrator = false
+  }
+
+  tags = {
+    Name = "tf-testacc-workspaces-directory-%[1]s"
   }
 }
 `, rName))
@@ -839,6 +855,10 @@ resource "aws_workspaces_directory" "main" {
     enable_maintenance_mode             = false
     user_enabled_as_local_administrator = false
   }
+
+  tags = {
+    Name = "tf-testacc-workspaces-directory-%[1]s"
+  }
 }
 `, rName))
 }
@@ -857,6 +877,10 @@ resource "aws_workspaces_directory" "test" {
   ip_group_ids = [
     aws_workspaces_ip_group.test_alpha.id
   ]
+
+  tags = {
+    Name = "tf-testacc-workspaces-directory-%[1]s"
+  }
 }
 `, rName))
 }
@@ -880,6 +904,10 @@ resource "aws_workspaces_directory" "test" {
     aws_workspaces_ip_group.test_beta.id,
     aws_workspaces_ip_group.test_gamma.id
   ]
+
+  tags = {
+    Name = "tf-testacc-workspaces-directory-%[1]s"
+  }
 }
 `, rName))
 }

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -323,8 +323,8 @@ func TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGro
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "workspace_creation_properties.0.custom_security_group_id", resourceSecurityGroup, "id"),
-					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.0.default_ou", "OU=AWS,DC=Workgroup,DC=Example,DC=com"),
+					resource.TestCheckResourceAttrSet(resourceName, "workspace_creation_properties.0.custom_security_group_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "workspace_creation_properties.0.default_ou"),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -283,6 +283,55 @@ func TestAccAwsWorkspacesDirectory_workspaceCreationProperties(t *testing.T) {
 	})
 }
 
+func TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGroupId_defaultOu(t *testing.T) {
+	var v workspaces.WorkspaceDirectory
+	rName := acctest.RandString(8)
+
+	resourceName := "aws_workspaces_directory.main"
+	resourceSecurityGroup := "aws_security_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Absent(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.0.custom_security_group_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.0.default_ou", ""),
+				),
+			},
+			{
+				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Present(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_creation_properties.0.custom_security_group_id", resourceSecurityGroup, "id"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.0.default_ou", "OU=AWS,DC=Workgroup,DC=Example,DC=com"),
+				),
+			},
+			{
+				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Absent(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_creation_properties.0.custom_security_group_id", resourceSecurityGroup, "id"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.0.default_ou", "OU=AWS,DC=Workgroup,DC=Example,DC=com"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAwsWorkspacesDirectory_ipGroupIds(t *testing.T) {
 	var v workspaces.WorkspaceDirectory
 	rName := acctest.RandString(8)
@@ -323,6 +372,181 @@ func TestAccAwsWorkspacesDirectory_ipGroupIds(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestExpandSelfServicePermissions(t *testing.T) {
+	cases := []struct {
+		input    []interface{}
+		expected *workspaces.SelfservicePermissions
+	}{
+		// Empty
+		{
+			input:    []interface{}{},
+			expected: nil,
+		},
+		// Full
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"change_compute_type":  false,
+					"increase_volume_size": false,
+					"rebuild_workspace":    true,
+					"restart_workspace":    true,
+					"switch_running_mode":  true,
+				},
+			},
+			expected: &workspaces.SelfservicePermissions{
+				ChangeComputeType:  aws.String(workspaces.ReconnectEnumDisabled),
+				IncreaseVolumeSize: aws.String(workspaces.ReconnectEnumDisabled),
+				RebuildWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
+				RestartWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
+				SwitchRunningMode:  aws.String(workspaces.ReconnectEnumEnabled),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := expandSelfServicePermissions(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
+		}
+	}
+}
+
+func TestFlattenSelfServicePermissions(t *testing.T) {
+	cases := []struct {
+		input    *workspaces.SelfservicePermissions
+		expected []interface{}
+	}{
+		// Empty
+		{
+			input:    nil,
+			expected: []interface{}{},
+		},
+		// Full
+		{
+			input: &workspaces.SelfservicePermissions{
+				ChangeComputeType:  aws.String(workspaces.ReconnectEnumDisabled),
+				IncreaseVolumeSize: aws.String(workspaces.ReconnectEnumDisabled),
+				RebuildWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
+				RestartWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
+				SwitchRunningMode:  aws.String(workspaces.ReconnectEnumEnabled),
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"change_compute_type":  false,
+					"increase_volume_size": false,
+					"rebuild_workspace":    true,
+					"restart_workspace":    true,
+					"switch_running_mode":  true,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := flattenSelfServicePermissions(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
+		}
+	}
+}
+
+func TestExpandWorkspaceCreationProperties(t *testing.T) {
+	cases := []struct {
+		input    []interface{}
+		expected *workspaces.WorkspaceCreationProperties
+	}{
+		// Empty
+		{
+			input:    []interface{}{},
+			expected: nil,
+		},
+		// Full
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"custom_security_group_id":            "sg-123456789012",
+					"default_ou":                          "OU=AWS,DC=Workgroup,DC=Example,DC=com",
+					"enable_internet_access":              true,
+					"enable_maintenance_mode":             true,
+					"user_enabled_as_local_administrator": true,
+				},
+			},
+			expected: &workspaces.WorkspaceCreationProperties{
+				CustomSecurityGroupId:           aws.String("sg-123456789012"),
+				DefaultOu:                       aws.String("OU=AWS,DC=Workgroup,DC=Example,DC=com"),
+				EnableInternetAccess:            aws.Bool(true),
+				EnableMaintenanceMode:           aws.Bool(true),
+				UserEnabledAsLocalAdministrator: aws.Bool(true),
+			},
+		},
+		// Without Custom Security Group ID & Default OU
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"custom_security_group_id":            "",
+					"default_ou":                          "",
+					"enable_internet_access":              true,
+					"enable_maintenance_mode":             true,
+					"user_enabled_as_local_administrator": true,
+				},
+			},
+			expected: &workspaces.WorkspaceCreationProperties{
+				CustomSecurityGroupId:           nil,
+				DefaultOu:                       nil,
+				EnableInternetAccess:            aws.Bool(true),
+				EnableMaintenanceMode:           aws.Bool(true),
+				UserEnabledAsLocalAdministrator: aws.Bool(true),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := expandWorkspaceCreationProperties(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
+		}
+	}
+}
+
+func TestFlattenWorkspaceCreationProperties(t *testing.T) {
+	cases := []struct {
+		input    *workspaces.DefaultWorkspaceCreationProperties
+		expected []interface{}
+	}{
+		// Empty
+		{
+			input:    nil,
+			expected: []interface{}{},
+		},
+		// Full
+		{
+			input: &workspaces.DefaultWorkspaceCreationProperties{
+				CustomSecurityGroupId:           aws.String("sg-123456789012"),
+				DefaultOu:                       aws.String("OU=AWS,DC=Workgroup,DC=Example,DC=com"),
+				EnableInternetAccess:            aws.Bool(true),
+				EnableMaintenanceMode:           aws.Bool(true),
+				UserEnabledAsLocalAdministrator: aws.Bool(true),
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"custom_security_group_id":            "sg-123456789012",
+					"default_ou":                          "OU=AWS,DC=Workgroup,DC=Example,DC=com",
+					"enable_internet_access":              true,
+					"enable_maintenance_mode":             true,
+					"user_enabled_as_local_administrator": true,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := flattenWorkspaceCreationProperties(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
+		}
+	}
 }
 
 func testAccPreCheckHasIAMRole(t *testing.T, roleName string) {
@@ -403,84 +627,6 @@ func testAccCheckAwsWorkspacesDirectoryExists(n string, v *workspaces.WorkspaceD
 		}
 
 		return fmt.Errorf("workspaces directory %q is not found", rs.Primary.ID)
-	}
-}
-
-func TestExpandSelfServicePermissions(t *testing.T) {
-	cases := []struct {
-		input    []interface{}
-		expected *workspaces.SelfservicePermissions
-	}{
-		// Empty
-		{
-			input:    []interface{}{},
-			expected: nil,
-		},
-		// Full
-		{
-			input: []interface{}{
-				map[string]interface{}{
-					"change_compute_type":  false,
-					"increase_volume_size": false,
-					"rebuild_workspace":    true,
-					"restart_workspace":    true,
-					"switch_running_mode":  true,
-				},
-			},
-			expected: &workspaces.SelfservicePermissions{
-				ChangeComputeType:  aws.String(workspaces.ReconnectEnumDisabled),
-				IncreaseVolumeSize: aws.String(workspaces.ReconnectEnumDisabled),
-				RebuildWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
-				RestartWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
-				SwitchRunningMode:  aws.String(workspaces.ReconnectEnumEnabled),
-			},
-		},
-	}
-
-	for _, c := range cases {
-		actual := expandSelfServicePermissions(c.input)
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
-		}
-	}
-}
-
-func TestFlattenSelfServicePermissions(t *testing.T) {
-	cases := []struct {
-		input    *workspaces.SelfservicePermissions
-		expected []interface{}
-	}{
-		// Empty
-		{
-			input:    nil,
-			expected: []interface{}{},
-		},
-		// Full
-		{
-			input: &workspaces.SelfservicePermissions{
-				ChangeComputeType:  aws.String(workspaces.ReconnectEnumDisabled),
-				IncreaseVolumeSize: aws.String(workspaces.ReconnectEnumDisabled),
-				RebuildWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
-				RestartWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
-				SwitchRunningMode:  aws.String(workspaces.ReconnectEnumEnabled),
-			},
-			expected: []interface{}{
-				map[string]interface{}{
-					"change_compute_type":  false,
-					"increase_volume_size": false,
-					"rebuild_workspace":    true,
-					"restart_workspace":    true,
-					"switch_running_mode":  true,
-				},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		actual := flattenSelfServicePermissions(c.input)
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
-		}
 	}
 }
 
@@ -642,6 +788,50 @@ func testAccWorkspacesDirectoryConfig_workspaceCreationProperties(rName string) 
 resource "aws_security_group" "test" {
   name   = "tf-acctest-%[1]s"
   vpc_id = aws_vpc.main.id
+}
+
+resource "aws_workspaces_directory" "main" {
+  directory_id = aws_directory_service_directory.main.id
+
+  workspace_creation_properties {
+    custom_security_group_id            = aws_security_group.test.id
+    default_ou                          = "OU=AWS,DC=Workgroup,DC=Example,DC=com"
+    enable_internet_access              = true
+    enable_maintenance_mode             = false
+    user_enabled_as_local_administrator = false
+  }
+}
+`, rName))
+}
+
+func testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Absent(rName string) string {
+	return composeConfig(
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.main.id
+  name   = "tf-acctest-%[1]s"
+}
+
+resource "aws_workspaces_directory" "main" {
+  directory_id = aws_directory_service_directory.main.id
+
+  workspace_creation_properties {
+    enable_internet_access              = true
+    enable_maintenance_mode             = false
+    user_enabled_as_local_administrator = false
+  }
+}
+`, rName))
+}
+
+func testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Present(rName string) string {
+	return composeConfig(
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.main.id
+  name   = "tf-acctest-%[1]s"
 }
 
 resource "aws_workspaces_directory" "main" {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #16122

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
aws_workspaces_directory: Fix empty custom_security_group_id & default_ou
```

### Unit Tests

```
$ make test TEST=./aws TESTARGS='-run=TestExpandWorkspaceCreationProperties'
==> Checking that code complies with gofmt requirements...
go test ./aws -run=TestExpandWorkspaceCreationProperties -timeout=5m -parallel=4
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.729s
$ make test TEST=./aws TESTARGS='-run=TestFlattenWorkspaceCreationProperties'
==> Checking that code complies with gofmt requirements...
go test ./aws -run=TestFlattenWorkspaceCreationProperties -timeout=5m -parallel=4
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3.002s
```

### Acceptance Tests

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsWorkspacesDirectory_workspaceCreationProperties'
AWS_REGION=us-east-1 make testacc TEST=./aws TESTARGS='-run=TestAccAwsWorkspacesDirectory_workspaceCreationProperties'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWorkspacesDirectory_workspaceCreationProperties -timeout 120m
=== RUN   TestAccAwsWorkspacesDirectory_workspaceCreationProperties
=== PAUSE TestAccAwsWorkspacesDirectory_workspaceCreationProperties
=== RUN   TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGroupId_defaultOu
=== PAUSE TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGroupId_defaultOu
=== CONT  TestAccAwsWorkspacesDirectory_workspaceCreationProperties
=== CONT  TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGroupId_defaultOu
--- PASS: TestAccAwsWorkspacesDirectory_workspaceCreationProperties (1070.72s)
--- PASS: TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGroupId_defaultOu (1120.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1123.562s
```
