### PR TITLE
provider: Prevent potential panics due to setting resource identifiers with raw string pointer dereferencing

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -35,6 +35,16 @@ rules:
           metavariable: '$Y'
           regex: '^"github.com/aws/aws-sdk-go/service/[^/]+"$'
     severity: WARNING
+  
+  - id: aws-go-sdk-pointer-conversion-ResourceData-SetId
+    fix: d.SetId(aws.StringValue($VALUE))
+    languages: [go]
+    message: Prefer AWS Go SDK pointer conversion aws.StringValue() function for dereferencing during d.SetId()
+    paths:
+      include:
+        - aws/
+    pattern: 'd.SetId(*$VALUE)'
+    severity: WARNING
 
   - id: helper-schema-ResourceData-GetOk-with-extraneous-conditional
     languages: [go]

--- a/aws/data_source_aws_api_gateway_resource.go
+++ b/aws/data_source_aws_api_gateway_resource.go
@@ -59,7 +59,7 @@ func dataSourceAwsApiGatewayResourceRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("no Resources with path %q found for rest api %q", target, restApiId)
 	}
 
-	d.SetId(*match.Id)
+	d.SetId(aws.StringValue(match.Id))
 	d.Set("path_part", match.PathPart)
 	d.Set("parent_id", match.ParentId)
 

--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -105,7 +105,7 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 
 	match := matchedApis[0]
 
-	d.SetId(*match.Id)
+	d.SetId(aws.StringValue(match.Id))
 
 	restApiArn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,

--- a/aws/data_source_aws_api_gateway_vpc_link.go
+++ b/aws/data_source_aws_api_gateway_vpc_link.go
@@ -76,7 +76,7 @@ func dataSourceAwsApiGatewayVpcLinkRead(d *schema.ResourceData, meta interface{}
 
 	match := matchedVpcLinks[0]
 
-	d.SetId(*match.Id)
+	d.SetId(aws.StringValue(match.Id))
 	d.Set("name", match.Name)
 	d.Set("status", match.Status)
 	d.Set("status_message", match.StatusMessage)

--- a/aws/data_source_aws_cloudformation_stack.go
+++ b/aws/data_source_aws_cloudformation_stack.go
@@ -84,7 +84,7 @@ func dataSourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Expected 1 CloudFormation stack (%s), found %d", name, l)
 	}
 	stack := out.Stacks[0]
-	d.SetId(*stack.StackId)
+	d.SetId(aws.StringValue(stack.StackId))
 
 	d.Set("description", stack.Description)
 	d.Set("disable_rollback", stack.DisableRollback)

--- a/aws/data_source_aws_db_snapshot.go
+++ b/aws/data_source_aws_db_snapshot.go
@@ -195,7 +195,7 @@ func mostRecentDbSnapshot(snapshots []*rds.DBSnapshot) *rds.DBSnapshot {
 }
 
 func dbSnapshotDescriptionAttributes(d *schema.ResourceData, snapshot *rds.DBSnapshot) error {
-	d.SetId(*snapshot.DBSnapshotIdentifier)
+	d.SetId(aws.StringValue(snapshot.DBSnapshotIdentifier))
 	d.Set("db_instance_identifier", snapshot.DBInstanceIdentifier)
 	d.Set("db_snapshot_identifier", snapshot.DBSnapshotIdentifier)
 	d.Set("snapshot_type", snapshot.SnapshotType)

--- a/aws/data_source_aws_dynamodb_table.go
+++ b/aws/data_source_aws_dynamodb_table.go
@@ -224,7 +224,7 @@ func dataSourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error retrieving DynamoDB table: %s", err)
 	}
 
-	d.SetId(*result.Table.TableName)
+	d.SetId(aws.StringValue(result.Table.TableName))
 
 	err = flattenAwsDynamoDbTableResource(d, result.Table)
 	if err != nil {

--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sort"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -129,7 +130,7 @@ func mostRecentVolume(volumes []*ec2.Volume) *ec2.Volume {
 }
 
 func volumeDescriptionAttributes(d *schema.ResourceData, client *AWSClient, volume *ec2.Volume) error {
-	d.SetId(*volume.VolumeId)
+	d.SetId(aws.StringValue(volume.VolumeId))
 	d.Set("volume_id", volume.VolumeId)
 
 	arn := arn.ARN{

--- a/aws/data_source_aws_efs_access_point.go
+++ b/aws/data_source_aws_efs_access_point.go
@@ -113,7 +113,7 @@ func dataSourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Found EFS access point: %#v", ap)
 
-	d.SetId(*ap.AccessPointId)
+	d.SetId(aws.StringValue(ap.AccessPointId))
 
 	fsARN := arn.ARN{
 		AccountID: meta.(*AWSClient).accountid,

--- a/aws/data_source_aws_elastic_beanstalk_solution_stack.go
+++ b/aws/data_source_aws_elastic_beanstalk_solution_stack.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -88,7 +89,7 @@ func mostRecentSolutionStack(solutionStacks []*string) *string {
 // populate the numerous fields that the image description returns.
 func solutionStackDescriptionAttributes(d *schema.ResourceData, solutionStack *string) error {
 	// Simple attributes first
-	d.SetId(*solutionStack)
+	d.SetId(aws.StringValue(solutionStack))
 	d.Set("name", solutionStack)
 	return nil
 }

--- a/aws/data_source_aws_elasticache_cluster.go
+++ b/aws/data_source_aws_elasticache_cluster.go
@@ -174,7 +174,7 @@ func dataSourceAwsElastiCacheClusterRead(d *schema.ResourceData, meta interface{
 
 	cluster := resp.CacheClusters[0]
 
-	d.SetId(*cluster.CacheClusterId)
+	d.SetId(aws.StringValue(cluster.CacheClusterId))
 
 	d.Set("cluster_id", cluster.CacheClusterId)
 	d.Set("node_type", cluster.CacheNodeType)

--- a/aws/data_source_aws_elasticsearch_domain.go
+++ b/aws/data_source_aws_elasticsearch_domain.go
@@ -294,7 +294,7 @@ func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface
 
 	ds := resp.DomainStatus
 
-	d.SetId(*ds.ARN)
+	d.SetId(aws.StringValue(ds.ARN))
 
 	if ds.AccessPolicies != nil && *ds.AccessPolicies != "" {
 		policies, err := structure.NormalizeJsonString(*ds.AccessPolicies)

--- a/aws/data_source_aws_elb.go
+++ b/aws/data_source_aws_elb.go
@@ -212,7 +212,7 @@ func dataSourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 	if len(resp.LoadBalancerDescriptions) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(resp.LoadBalancerDescriptions))
 	}
-	d.SetId(*resp.LoadBalancerDescriptions[0].LoadBalancerName)
+	d.SetId(aws.StringValue(resp.LoadBalancerDescriptions[0].LoadBalancerName))
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,

--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -85,7 +85,7 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("no IAM group found")
 	}
 
-	d.SetId(*group.GroupId)
+	d.SetId(aws.StringValue(group.GroupId))
 	d.Set("arn", group.Arn)
 	d.Set("path", group.Path)
 	d.Set("group_id", group.GroupId)

--- a/aws/data_source_aws_iam_instance_profile.go
+++ b/aws/data_source_aws_iam_instance_profile.go
@@ -66,7 +66,7 @@ func dataSourceAwsIAMInstanceProfileRead(d *schema.ResourceData, meta interface{
 
 	instanceProfile := resp.InstanceProfile
 
-	d.SetId(*instanceProfile.InstanceProfileId)
+	d.SetId(aws.StringValue(instanceProfile.InstanceProfileId))
 	d.Set("arn", instanceProfile.Arn)
 	d.Set("create_date", fmt.Sprintf("%v", instanceProfile.CreateDate))
 	d.Set("path", instanceProfile.Path)

--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -134,7 +134,7 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 	}
 
 	metadata := metadatas[0]
-	d.SetId(*metadata.ServerCertificateId)
+	d.SetId(aws.StringValue(metadata.ServerCertificateId))
 	d.Set("arn", metadata.Arn)
 	d.Set("path", metadata.Path)
 	d.Set("name", metadata.ServerCertificateName)

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -409,7 +409,7 @@ func dataSourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 // Populate instance attribute fields with the returned instance
 func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instance, conn *ec2.EC2, ignoreTagsConfig *keyvaluetags.IgnoreConfig) error {
-	d.SetId(*instance.InstanceId)
+	d.SetId(aws.StringValue(instance.InstanceId))
 	// Set the easy attributes
 	d.Set("instance_state", instance.State.Name)
 	if instance.Placement != nil {

--- a/aws/data_source_aws_lambda_alias.go
+++ b/aws/data_source_aws_lambda_alias.go
@@ -62,7 +62,7 @@ func dataSourceAwsLambdaAliasRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error getting Lambda alias: %s", err)
 	}
 
-	d.SetId(*aliasConfiguration.AliasArn)
+	d.SetId(aws.StringValue(aliasConfiguration.AliasArn))
 
 	d.Set("arn", aliasConfiguration.AliasArn)
 	d.Set("description", aliasConfiguration.Description)

--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -245,7 +245,7 @@ func dataSourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error
 	for _, listener := range resp.Listeners {
 		if *listener.Port == int64(port.(int)) {
 			//log.Printf("[DEBUG] get listener arn for %s:%s: %s", lbArn, port, *listener.Port)
-			d.SetId(*listener.ListenerArn)
+			d.SetId(aws.StringValue(listener.ListenerArn))
 			return resourceAwsLbListenerRead(d, meta)
 		}
 	}

--- a/aws/data_source_aws_network_interface.go
+++ b/aws/data_source_aws_network_interface.go
@@ -165,7 +165,7 @@ func dataSourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{})
 
 	eni := resp.NetworkInterfaces[0]
 
-	d.SetId(*eni.NetworkInterfaceId)
+	d.SetId(aws.StringValue(eni.NetworkInterfaceId))
 	if eni.Association != nil {
 		d.Set("association", flattenEc2NetworkInterfaceAssociation(eni.Association))
 	}

--- a/aws/data_source_aws_prefix_list.go
+++ b/aws/data_source_aws_prefix_list.go
@@ -62,7 +62,7 @@ func dataSourceAwsPrefixListRead(d *schema.ResourceData, meta interface{}) error
 
 	pl := resp.PrefixLists[0]
 
-	d.SetId(*pl.PrefixListId)
+	d.SetId(aws.StringValue(pl.PrefixListId))
 	d.Set("name", pl.PrefixListName)
 
 	cidrs := make([]string, len(pl.Cidrs))

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -90,7 +90,7 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 
 	sg := resp.SecurityGroups[0]
 
-	d.SetId(*sg.GroupId)
+	d.SetId(aws.StringValue(sg.GroupId))
 	d.Set("name", sg.GroupName)
 	d.Set("description", sg.Description)
 	d.Set("vpc_id", sg.VpcId)

--- a/aws/data_source_aws_sfn_activity.go
+++ b/aws/data_source_aws_sfn_activity.go
@@ -73,7 +73,7 @@ func dataSourceAwsSfnActivityRead(d *schema.ResourceData, meta interface{}) erro
 
 		act := acts[0]
 
-		d.SetId(*act.ActivityArn)
+		d.SetId(aws.StringValue(act.ActivityArn))
 		d.Set("name", act.Name)
 		d.Set("arn", act.ActivityArn)
 		if err := d.Set("creation_date", act.CreationDate.Format(time.RFC3339)); err != nil {
@@ -96,7 +96,7 @@ func dataSourceAwsSfnActivityRead(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("No activity found with arn %s in this region", arn)
 		}
 
-		d.SetId(*act.ActivityArn)
+		d.SetId(aws.StringValue(act.ActivityArn))
 		d.Set("name", act.Name)
 		d.Set("arn", act.ActivityArn)
 		if err := d.Set("creation_date", act.CreationDate.Format(time.RFC3339)); err != nil {

--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -63,7 +63,7 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	param := resp.Parameter
-	d.SetId(*param.Name)
+	d.SetId(aws.StringValue(param.Name))
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,

--- a/aws/data_source_aws_ssm_patch_baseline.go
+++ b/aws/data_source_aws_ssm_patch_baseline.go
@@ -107,7 +107,7 @@ func dataAwsSsmPatchBaselineRead(d *schema.ResourceData, meta interface{}) error
 
 	baseline := *filteredBaselines[0]
 
-	d.SetId(*baseline.BaselineId)
+	d.SetId(aws.StringValue(baseline.BaselineId))
 	d.Set("name", baseline.BaselineName)
 	d.Set("description", baseline.BaselineDescription)
 	d.Set("default_baseline", baseline.DefaultBaseline)

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -166,7 +166,7 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	subnet := resp.Subnets[0]
 
-	d.SetId(*subnet.SubnetId)
+	d.SetId(aws.StringValue(subnet.SubnetId))
 	d.Set("vpc_id", subnet.VpcId)
 	d.Set("availability_zone", subnet.AvailabilityZone)
 	d.Set("availability_zone_id", subnet.AvailabilityZoneId)

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -285,7 +285,7 @@ func resourceAwsAcmCertificateCreateRequested(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error requesting certificate: %s", err)
 	}
 
-	d.SetId(*resp.CertificateArn)
+	d.SetId(aws.StringValue(resp.CertificateArn))
 
 	return resourceAwsAcmCertificateRead(d, meta)
 }

--- a/aws/resource_aws_api_gateway_client_certificate.go
+++ b/aws/resource_aws_api_gateway_client_certificate.go
@@ -63,7 +63,7 @@ func resourceAwsApiGatewayClientCertificateCreate(d *schema.ResourceData, meta i
 		return fmt.Errorf("Failed to generate client certificate: %s", err)
 	}
 
-	d.SetId(*out.ClientCertificateId)
+	d.SetId(aws.StringValue(out.ClientCertificateId))
 
 	return resourceAwsApiGatewayClientCertificateRead(d, meta)
 }

--- a/aws/resource_aws_api_gateway_deployment.go
+++ b/aws/resource_aws_api_gateway_deployment.go
@@ -96,7 +96,7 @@ func resourceAwsApiGatewayDeploymentCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error creating API Gateway Deployment: %s", err)
 	}
 
-	d.SetId(*deployment.Id)
+	d.SetId(aws.StringValue(deployment.Id))
 	log.Printf("[DEBUG] API Gateway Deployment ID: %s", d.Id())
 
 	return resourceAwsApiGatewayDeploymentRead(d, meta)

--- a/aws/resource_aws_api_gateway_domain_name.go
+++ b/aws/resource_aws_api_gateway_domain_name.go
@@ -202,7 +202,7 @@ func resourceAwsApiGatewayDomainNameCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error creating API Gateway Domain Name: %s", err)
 	}
 
-	d.SetId(*domainName.DomainName)
+	d.SetId(aws.StringValue(domainName.DomainName))
 
 	return resourceAwsApiGatewayDomainNameRead(d, meta)
 }

--- a/aws/resource_aws_api_gateway_model.go
+++ b/aws/resource_aws_api_gateway_model.go
@@ -103,7 +103,7 @@ func resourceAwsApiGatewayModelCreate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating API Gateway Model: %s", err)
 	}
 
-	d.SetId(*model.Id)
+	d.SetId(aws.StringValue(model.Id))
 
 	return nil
 }

--- a/aws/resource_aws_api_gateway_request_validator.go
+++ b/aws/resource_aws_api_gateway_request_validator.go
@@ -72,7 +72,7 @@ func resourceAwsApiGatewayRequestValidatorCreate(d *schema.ResourceData, meta in
 		return fmt.Errorf("Error creating Request Validator: %s", err)
 	}
 
-	d.SetId(*out.Id)
+	d.SetId(aws.StringValue(out.Id))
 
 	return nil
 }

--- a/aws/resource_aws_api_gateway_resource.go
+++ b/aws/resource_aws_api_gateway_resource.go
@@ -70,7 +70,7 @@ func resourceAwsApiGatewayResourceCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error creating API Gateway Resource: %s", err)
 	}
 
-	d.SetId(*resource.Id)
+	d.SetId(aws.StringValue(resource.Id))
 
 	return resourceAwsApiGatewayResourceRead(d, meta)
 }

--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -173,7 +173,7 @@ func resourceAwsApiGatewayRestApiCreate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error creating API Gateway: %s", err)
 	}
 
-	d.SetId(*gateway.Id)
+	d.SetId(aws.StringValue(gateway.Id))
 
 	if body, ok := d.GetOk("body"); ok {
 		log.Printf("[DEBUG] Initializing API Gateway from OpenAPI spec %s", d.Id())

--- a/aws/resource_aws_api_gateway_usage_plan_key.go
+++ b/aws/resource_aws_api_gateway_usage_plan_key.go
@@ -77,7 +77,7 @@ func resourceAwsApiGatewayUsagePlanKeyCreate(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error creating API Gateway Usage Plan Key: %s", err)
 	}
 
-	d.SetId(*up.Id)
+	d.SetId(aws.StringValue(up.Id))
 
 	return resourceAwsApiGatewayUsagePlanKeyRead(d, meta)
 }

--- a/aws/resource_aws_api_gateway_vpc_link.go
+++ b/aws/resource_aws_api_gateway_vpc_link.go
@@ -74,7 +74,7 @@ func resourceAwsApiGatewayVpcLinkCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	d.SetId(*resp.Id)
+	d.SetId(aws.StringValue(resp.Id))
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{apigateway.VpcLinkStatusPending},

--- a/aws/resource_aws_appsync_graphql_api.go
+++ b/aws/resource_aws_appsync_graphql_api.go
@@ -242,7 +242,7 @@ func resourceAwsAppsyncGraphqlApiCreate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("error creating AppSync GraphQL API: %s", err)
 	}
 
-	d.SetId(*resp.GraphqlApi.ApiId)
+	d.SetId(aws.StringValue(resp.GraphqlApi.ApiId))
 
 	if err := resourceAwsAppsyncSchemaPut(d, meta); err != nil {
 		return fmt.Errorf("error creating AppSync GraphQL API (%s) Schema: %s", d.Id(), err)

--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -68,7 +68,7 @@ func resourceAwsAthenaNamedQueryCreate(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return err
 	}
-	d.SetId(*resp.NamedQueryId)
+	d.SetId(aws.StringValue(resp.NamedQueryId))
 	return resourceAwsAthenaNamedQueryRead(d, meta)
 }
 

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -144,7 +144,7 @@ func resourceAwsBatchJobDefinitionCreate(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return fmt.Errorf("%s %q", err, name)
 	}
-	d.SetId(*out.JobDefinitionArn)
+	d.SetId(aws.StringValue(out.JobDefinitionArn))
 	d.Set("arn", out.JobDefinitionArn)
 	return resourceAwsBatchJobDefinitionRead(d, meta)
 }

--- a/aws/resource_aws_cloud9_environment_ec2.go
+++ b/aws/resource_aws_cloud9_environment_ec2.go
@@ -110,7 +110,7 @@ func resourceAwsCloud9EnvironmentEc2Create(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return fmt.Errorf("Error creating Cloud9 EC2 Environment: %s", err)
 	}
-	d.SetId(*out.EnvironmentId)
+	d.SetId(aws.StringValue(out.EnvironmentId))
 
 	stateConf := resource.StateChangeConf{
 		Pending: []string{

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -694,7 +694,7 @@ func resourceAwsCloudFrontDistributionCreate(d *schema.ResourceData, meta interf
 		return fmt.Errorf("error creating CloudFront Distribution: %s", err)
 	}
 
-	d.SetId(*resp.Distribution.Id)
+	d.SetId(aws.StringValue(resp.Distribution.Id))
 
 	if d.Get("wait_for_deployment").(bool) {
 		log.Printf("[DEBUG] Waiting until CloudFront Distribution (%s) is deployed", d.Id())

--- a/aws/resource_aws_cloudfront_origin_access_identity.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity.go
@@ -61,7 +61,7 @@ func resourceAwsCloudFrontOriginAccessIdentityCreate(d *schema.ResourceData, met
 	if err != nil {
 		return err
 	}
-	d.SetId(*resp.CloudFrontOriginAccessIdentity.Id)
+	d.SetId(aws.StringValue(resp.CloudFrontOriginAccessIdentity.Id))
 	return resourceAwsCloudFrontOriginAccessIdentityRead(d, meta)
 }
 
@@ -84,7 +84,7 @@ func resourceAwsCloudFrontOriginAccessIdentityRead(d *schema.ResourceData, meta 
 	// Update attributes from DistributionConfig
 	flattenOriginAccessIdentityConfig(d, resp.CloudFrontOriginAccessIdentity.CloudFrontOriginAccessIdentityConfig)
 	// Update other attributes outside of DistributionConfig
-	d.SetId(*resp.CloudFrontOriginAccessIdentity.Id)
+	d.SetId(aws.StringValue(resp.CloudFrontOriginAccessIdentity.Id))
 	d.Set("etag", resp.ETag)
 	d.Set("s3_canonical_user_id", resp.CloudFrontOriginAccessIdentity.S3CanonicalUserId)
 	d.Set("cloudfront_access_identity_path", fmt.Sprintf("origin-access-identity/cloudfront/%s", *resp.CloudFrontOriginAccessIdentity.Id))

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -215,7 +215,7 @@ func resourceAwsCloudTrailCreate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] CloudTrail created: %s", t)
 
-	d.SetId(*t.Name)
+	d.SetId(aws.StringValue(t.Name))
 
 	// AWS CloudTrail sets newly-created trails to false.
 	if v, ok := d.GetOk("enable_logging"); ok && v.(bool) {

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -574,7 +574,7 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 		return fmt.Errorf("Error creating CodeDeploy deployment group: %s", err)
 	}
 
-	d.SetId(*resp.DeploymentGroupId)
+	d.SetId(aws.StringValue(resp.DeploymentGroupId))
 
 	return resourceAwsCodeDeployDeploymentGroupRead(d, meta)
 }

--- a/aws/resource_aws_cognito_identity_pool.go
+++ b/aws/resource_aws_cognito_identity_pool.go
@@ -142,7 +142,7 @@ func resourceAwsCognitoIdentityPoolCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error creating Cognito Identity Pool: %s", err)
 	}
 
-	d.SetId(*entity.IdentityPoolId)
+	d.SetId(aws.StringValue(entity.IdentityPoolId))
 
 	return resourceAwsCognitoIdentityPoolRead(d, meta)
 }

--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -261,7 +261,7 @@ func resourceAwsCognitoUserPoolClientCreate(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error creating Cognito User Pool Client: %s", err)
 	}
 
-	d.SetId(*resp.UserPoolClient.ClientId)
+	d.SetId(aws.StringValue(resp.UserPoolClient.ClientId))
 
 	return resourceAwsCognitoUserPoolClientRead(d, meta)
 }
@@ -287,7 +287,7 @@ func resourceAwsCognitoUserPoolClientRead(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	d.SetId(*resp.UserPoolClient.ClientId)
+	d.SetId(aws.StringValue(resp.UserPoolClient.ClientId))
 	d.Set("user_pool_id", resp.UserPoolClient.UserPoolId)
 	d.Set("name", resp.UserPoolClient.ClientName)
 	d.Set("explicit_auth_flows", flattenStringSet(resp.UserPoolClient.ExplicitAuthFlows))

--- a/aws/resource_aws_config_remediation_configuration.go
+++ b/aws/resource_aws_config_remediation_configuration.go
@@ -207,7 +207,7 @@ func resourceAwsConfigRemediationConfigurationRead(d *schema.ResourceData, meta 
 	d.Set("target_type", remediationConfiguration.TargetType)
 	d.Set("target_version", remediationConfiguration.TargetVersion)
 	d.Set("parameter", flattenRemediationConfigurationParameters(remediationConfiguration.Parameters))
-	d.SetId(*remediationConfiguration.ConfigRuleName)
+	d.SetId(aws.StringValue(remediationConfiguration.ConfigRuleName))
 
 	return nil
 }

--- a/aws/resource_aws_db_subnet_group.go
+++ b/aws/resource_aws_db_subnet_group.go
@@ -97,7 +97,7 @@ func resourceAwsDbSubnetGroupCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating DB Subnet Group: %s", err)
 	}
 
-	d.SetId(*createOpts.DBSubnetGroupName)
+	d.SetId(aws.StringValue(createOpts.DBSubnetGroupName))
 	log.Printf("[INFO] DB Subnet Group ID: %s", d.Id())
 	return resourceAwsDbSubnetGroupRead(d, meta)
 }

--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -184,7 +184,7 @@ func resourceAwsDefaultRouteTableRead(d *schema.ResourceData, meta interface{}) 
 	rt := resp.RouteTables[0]
 
 	d.Set("default_route_table_id", rt.RouteTableId)
-	d.SetId(*rt.RouteTableId)
+	d.SetId(aws.StringValue(rt.RouteTableId))
 
 	// re-use regular AWS Route Table READ. This is an extra API call but saves us
 	// from trying to manually keep parity

--- a/aws/resource_aws_devicefarm_project.go
+++ b/aws/resource_aws_devicefarm_project.go
@@ -54,7 +54,7 @@ func resourceAwsDevicefarmProjectCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	log.Printf("[DEBUG] Successsfully Created DeviceFarm Project: %s", *out.Project.Arn)
-	d.SetId(*out.Project.Arn)
+	d.SetId(aws.StringValue(out.Project.Arn))
 
 	return resourceAwsDevicefarmProjectRead(d, meta)
 }

--- a/aws/resource_aws_dlm_lifecycle_policy.go
+++ b/aws/resource_aws_dlm_lifecycle_policy.go
@@ -162,7 +162,7 @@ func resourceAwsDlmLifecyclePolicyCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("error creating DLM Lifecycle Policy: %s", err)
 	}
 
-	d.SetId(*out.PolicyId)
+	d.SetId(aws.StringValue(out.PolicyId))
 
 	return resourceAwsDlmLifecyclePolicyRead(d, meta)
 }

--- a/aws/resource_aws_dms_certificate.go
+++ b/aws/resource_aws_dms_certificate.go
@@ -118,7 +118,7 @@ func resourceAwsDmsCertificateDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAwsDmsCertificateSetState(d *schema.ResourceData, cert *dms.Certificate) error {
-	d.SetId(*cert.CertificateIdentifier)
+	d.SetId(aws.StringValue(cert.CertificateIdentifier))
 
 	d.Set("certificate_id", cert.CertificateIdentifier)
 	d.Set("certificate_arn", cert.CertificateArn)

--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -690,7 +690,7 @@ func resourceAwsDmsEndpointDelete(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceAwsDmsEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoint) error {
-	d.SetId(*endpoint.EndpointIdentifier)
+	d.SetId(aws.StringValue(endpoint.EndpointIdentifier))
 
 	d.Set("certificate_arn", endpoint.CertificateArn)
 	d.Set("endpoint_arn", endpoint.EndpointArn)

--- a/aws/resource_aws_dms_replication_subnet_group.go
+++ b/aws/resource_aws_dms_replication_subnet_group.go
@@ -169,7 +169,7 @@ func resourceAwsDmsReplicationSubnetGroupDelete(d *schema.ResourceData, meta int
 }
 
 func resourceAwsDmsReplicationSubnetGroupSetState(d *schema.ResourceData, group *dms.ReplicationSubnetGroup) error {
-	d.SetId(*group.ReplicationSubnetGroupIdentifier)
+	d.SetId(aws.StringValue(group.ReplicationSubnetGroupIdentifier))
 
 	subnet_ids := []string{}
 	for _, subnet := range group.Subnets {

--- a/aws/resource_aws_dms_replication_task.go
+++ b/aws/resource_aws_dms_replication_task.go
@@ -282,7 +282,7 @@ func resourceAwsDmsReplicationTaskDelete(d *schema.ResourceData, meta interface{
 }
 
 func resourceAwsDmsReplicationTaskSetState(d *schema.ResourceData, task *dms.ReplicationTask) error {
-	d.SetId(*task.ReplicationTaskIdentifier)
+	d.SetId(aws.StringValue(task.ReplicationTaskIdentifier))
 
 	d.Set("migration_type", task.MigrationType)
 	d.Set("replication_instance_arn", task.ReplicationInstanceArn)

--- a/aws/resource_aws_docdb_cluster_instance.go
+++ b/aws/resource_aws_docdb_cluster_instance.go
@@ -226,7 +226,7 @@ func resourceAwsDocDBClusterInstanceCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error creating DocDB Instance: %s", err)
 	}
 
-	d.SetId(*resp.DBInstance.DBInstanceIdentifier)
+	d.SetId(aws.StringValue(resp.DBInstance.DBInstanceIdentifier))
 
 	// reuse db_instance refresh func
 	stateConf := &resource.StateChangeConf{

--- a/aws/resource_aws_dx_connection_association.go
+++ b/aws/resource_aws_dx_connection_association.go
@@ -43,7 +43,7 @@ func resourceAwsDxConnectionAssociationCreate(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	d.SetId(*resp.ConnectionId)
+	d.SetId(aws.StringValue(resp.ConnectionId))
 	return nil
 }
 

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -160,7 +160,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 			*result.VolumeId, err)
 	}
 
-	d.SetId(*result.VolumeId)
+	d.SetId(aws.StringValue(result.VolumeId))
 
 	return resourceAwsEbsVolumeRead(d, meta)
 }

--- a/aws/resource_aws_ec2_capacity_reservation.go
+++ b/aws/resource_aws_ec2_capacity_reservation.go
@@ -158,7 +158,7 @@ func resourceAwsEc2CapacityReservationCreate(d *schema.ResourceData, meta interf
 	if err != nil {
 		return fmt.Errorf("Error creating EC2 Capacity Reservation: %s", err)
 	}
-	d.SetId(*out.CapacityReservation.CapacityReservationId)
+	d.SetId(aws.StringValue(out.CapacityReservation.CapacityReservationId))
 	return resourceAwsEc2CapacityReservationRead(d, meta)
 }
 

--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -191,7 +191,7 @@ func resourceAwsEc2ClientVpnEndpointCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error creating Client VPN endpoint: %w", err)
 	}
 
-	d.SetId(*resp.ClientVpnEndpointId)
+	d.SetId(aws.StringValue(resp.ClientVpnEndpointId))
 
 	return resourceAwsEc2ClientVpnEndpointRead(d, meta)
 }

--- a/aws/resource_aws_ec2_traffic_mirror_filter.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter.go
@@ -59,7 +59,7 @@ func resourceAwsEc2TrafficMirrorFilterCreate(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error while creating traffic filter %s", err)
 	}
 
-	d.SetId(*out.TrafficMirrorFilter.TrafficMirrorFilterId)
+	d.SetId(aws.StringValue(out.TrafficMirrorFilter.TrafficMirrorFilterId))
 
 	if v, ok := d.GetOk("network_services"); ok {
 		input := &ec2.ModifyTrafficMirrorFilterNetworkServicesInput{

--- a/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_rule.go
@@ -137,7 +137,7 @@ func resourceAwsEc2TrafficMirrorFilterRuleCreate(d *schema.ResourceData, meta in
 		return fmt.Errorf("error creating EC2 Traffic Mirror Filter Rule (%s): %w", filterId, err)
 	}
 
-	d.SetId(*out.TrafficMirrorFilterRule.TrafficMirrorFilterRuleId)
+	d.SetId(aws.StringValue(out.TrafficMirrorFilterRule.TrafficMirrorFilterRuleId))
 	return resourceAwsEc2TrafficMirrorFilterRuleRead(d, meta)
 }
 
@@ -167,7 +167,7 @@ func resourceAwsEc2TrafficMirrorFilterRuleRead(d *schema.ResourceData, meta inte
 		return nil
 	}
 
-	d.SetId(*rule.TrafficMirrorFilterRuleId)
+	d.SetId(aws.StringValue(rule.TrafficMirrorFilterRuleId))
 	d.Set("traffic_mirror_filter_id", rule.TrafficMirrorFilterId)
 	d.Set("destination_cidr_block", rule.DestinationCidrBlock)
 	d.Set("source_cidr_block", rule.SourceCidrBlock)

--- a/aws/resource_aws_ecr_lifecycle_policy.go
+++ b/aws/resource_aws_ecr_lifecycle_policy.go
@@ -50,7 +50,7 @@ func resourceAwsEcrLifecyclePolicyCreate(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return err
 	}
-	d.SetId(*resp.RepositoryName)
+	d.SetId(aws.StringValue(resp.RepositoryName))
 	d.Set("registry_id", resp.RegistryId)
 	return resourceAwsEcrLifecyclePolicyRead(d, meta)
 }

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -76,7 +76,7 @@ func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] ECR repository policy created: %s", *repositoryPolicy.RepositoryName)
 
-	d.SetId(*repositoryPolicy.RepositoryName)
+	d.SetId(aws.StringValue(repositoryPolicy.RepositoryName))
 	d.Set("registry_id", repositoryPolicy.RegistryId)
 
 	return resourceAwsEcrRepositoryPolicyRead(d, meta)
@@ -106,7 +106,7 @@ func resourceAwsEcrRepositoryPolicyRead(d *schema.ResourceData, meta interface{}
 
 	repositoryPolicy := out
 
-	d.SetId(*repositoryPolicy.RepositoryName)
+	d.SetId(aws.StringValue(repositoryPolicy.RepositoryName))
 	d.Set("repository", repositoryPolicy.RepositoryName)
 	d.Set("registry_id", repositoryPolicy.RegistryId)
 	d.Set("policy", repositoryPolicy.PolicyText)
@@ -152,7 +152,7 @@ func resourceAwsEcrRepositoryPolicyUpdate(d *schema.ResourceData, meta interface
 
 	repositoryPolicy := *out
 
-	d.SetId(*repositoryPolicy.RepositoryName)
+	d.SetId(aws.StringValue(repositoryPolicy.RepositoryName))
 	d.Set("registry_id", repositoryPolicy.RegistryId)
 
 	return nil

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -142,7 +142,7 @@ func resourceAwsEfsAccessPointCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error creating EFS Access Point for File System (%s): %w", fsId, err)
 	}
 
-	d.SetId(*ap.AccessPointId)
+	d.SetId(aws.StringValue(ap.AccessPointId))
 	log.Printf("[INFO] EFS access point ID: %s", d.Id())
 
 	stateConf := &resource.StateChangeConf{
@@ -218,7 +218,7 @@ func resourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Found EFS access point: %#v", ap)
 
-	d.SetId(*ap.AccessPointId)
+	d.SetId(aws.StringValue(ap.AccessPointId))
 
 	fsARN := arn.ARN{
 		AccountID: meta.(*AWSClient).accountid,

--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -158,7 +158,7 @@ func resourceAwsEfsFileSystemCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating EFS file system: %s", err)
 	}
 
-	d.SetId(*fs.FileSystemId)
+	d.SetId(aws.StringValue(fs.FileSystemId))
 	log.Printf("[INFO] EFS file system ID: %s", d.Id())
 
 	stateConf := &resource.StateChangeConf{

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -167,9 +167,9 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 	// it defaults to using the public IP
 	log.Printf("[DEBUG] EIP Allocate: %#v", allocResp)
 	if d.Get("domain").(string) == ec2.DomainTypeVpc {
-		d.SetId(*allocResp.AllocationId)
+		d.SetId(aws.StringValue(allocResp.AllocationId))
 	} else {
-		d.SetId(*allocResp.PublicIp)
+		d.SetId(aws.StringValue(allocResp.PublicIp))
 	}
 
 	log.Printf("[INFO] EIP ID: %s (domain: %v)", d.Id(), *allocResp.Domain)
@@ -309,7 +309,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	// This allows users to import the EIP based on the IP if they are in a VPC
 	if *address.Domain == ec2.DomainTypeVpc && net.ParseIP(id) != nil {
 		log.Printf("[DEBUG] Re-assigning EIP ID (%s) to it's Allocation ID (%s)", d.Id(), *address.AllocationId)
-		d.SetId(*address.AllocationId)
+		d.SetId(aws.StringValue(address.AllocationId))
 	}
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(address.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {

--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -284,7 +284,7 @@ func resourceAwsElasticBeanstalkEnvironmentCreate(d *schema.ResourceData, meta i
 	}
 
 	// Assign the application name as the resource ID
-	d.SetId(*resp.EnvironmentId)
+	d.SetId(aws.StringValue(resp.EnvironmentId))
 
 	waitForReadyTimeOut, err := time.ParseDuration(d.Get("wait_for_ready_timeout").(string))
 	if err != nil {

--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -225,7 +225,7 @@ func resourceAwsElasticTranscoderPipelineCreate(d *schema.ResourceData, meta int
 		return fmt.Errorf("Error creating Elastic Transcoder Pipeline: %s", err)
 	}
 
-	d.SetId(*resp.Pipeline.Id)
+	d.SetId(aws.StringValue(resp.Pipeline.Id))
 
 	for _, w := range resp.Warnings {
 		log.Printf("[WARN] Elastic Transcoder Pipeline %v: %v", *w.Code, *w.Message)

--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -348,7 +348,7 @@ func resourceAwsElasticTranscoderPresetCreate(d *schema.ResourceData, meta inter
 		log.Printf("[WARN] Elastic Transcoder Preset: %s", *resp.Warning)
 	}
 
-	d.SetId(*resp.Preset.Id)
+	d.SetId(aws.StringValue(resp.Preset.Id))
 	d.Set("arn", resp.Preset.Arn)
 
 	return nil

--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -80,7 +80,7 @@ func resourceAwsElasticacheParameterGroupCreate(d *schema.ResourceData, meta int
 		return fmt.Errorf("Error creating Cache Parameter Group: %s", err)
 	}
 
-	d.SetId(*resp.CacheParameterGroup.CacheParameterGroupName)
+	d.SetId(aws.StringValue(resp.CacheParameterGroup.CacheParameterGroupName))
 	log.Printf("[INFO] Cache Parameter Group ID: %s", d.Id())
 
 	return resourceAwsElasticacheParameterGroupUpdate(d, meta)

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -369,7 +369,7 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		return fmt.Errorf("Error creating Elasticache Replication Group: %w", err)
 	}
 
-	d.SetId(*resp.ReplicationGroup.ReplicationGroupId)
+	d.SetId(aws.StringValue(resp.ReplicationGroup.ReplicationGroupId))
 
 	pending := []string{"creating", "modifying", "restoring", "snapshotting"}
 	stateConf := &resource.StateChangeConf{

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -922,7 +922,7 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error running EMR Job Flow: %s", err)
 	}
 
-	d.SetId(*resp.JobFlowId)
+	d.SetId(aws.StringValue(resp.JobFlowId))
 	// This value can only be obtained through a deprecated function
 	d.Set("keep_job_flow_alive_when_no_steps", params.Instances.KeepJobFlowAliveWhenNoSteps)
 

--- a/aws/resource_aws_emr_instance_fleet.go
+++ b/aws/resource_aws_emr_instance_fleet.go
@@ -236,7 +236,7 @@ func resourceAwsEMRInstanceFleetCreate(d *schema.ResourceData, meta interface{})
 	if resp == nil {
 		return fmt.Errorf("error creating instance fleet: no instance fleet returned")
 	}
-	d.SetId(*resp.InstanceFleetId)
+	d.SetId(aws.StringValue(resp.InstanceFleetId))
 
 	return nil
 }

--- a/aws/resource_aws_emr_instance_group.go
+++ b/aws/resource_aws_emr_instance_group.go
@@ -185,7 +185,7 @@ func resourceAwsEMRInstanceGroupCreate(d *schema.ResourceData, meta interface{})
 	if resp == nil || len(resp.InstanceGroupIds) == 0 {
 		return fmt.Errorf("Error creating instance groups: no instance group returned")
 	}
-	d.SetId(*resp.InstanceGroupIds[0])
+	d.SetId(aws.StringValue(resp.InstanceGroupIds[0]))
 
 	if err := waitForEmrInstanceGroupStateRunning(conn, d.Get("cluster_id").(string), d.Id(), emrInstanceGroupCreateTimeout); err != nil {
 		return fmt.Errorf("error waiting for EMR Instance Group (%s) creation: %s", d.Id(), err)

--- a/aws/resource_aws_emr_security_configuration.go
+++ b/aws/resource_aws_emr_security_configuration.go
@@ -75,7 +75,7 @@ func resourceAwsEmrSecurityConfigurationCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	d.SetId(*resp.Name)
+	d.SetId(aws.StringValue(resp.Name))
 	return resourceAwsEmrSecurityConfigurationRead(d, meta)
 }
 

--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -274,7 +274,7 @@ func resourceAwsFsxWindowsFileSystemCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error creating FSx filesystem: %s", err)
 	}
 
-	d.SetId(*result.FileSystem.FileSystemId)
+	d.SetId(aws.StringValue(result.FileSystem.FileSystemId))
 
 	log.Println("[DEBUG] Waiting for filesystem to become available")
 

--- a/aws/resource_aws_gamelift_alias.go
+++ b/aws/resource_aws_gamelift_alias.go
@@ -85,7 +85,7 @@ func resourceAwsGameliftAliasCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	d.SetId(*out.Alias.AliasId)
+	d.SetId(aws.StringValue(out.Alias.AliasId))
 
 	return resourceAwsGameliftAliasRead(d, meta)
 }

--- a/aws/resource_aws_gamelift_build.go
+++ b/aws/resource_aws_gamelift_build.go
@@ -108,7 +108,7 @@ func resourceAwsGameliftBuildCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating Gamelift build client: %s", err)
 	}
 
-	d.SetId(*out.Build.BuildId)
+	d.SetId(aws.StringValue(out.Build.BuildId))
 
 	stateConf := resource.StateChangeConf{
 		Pending: []string{gamelift.BuildStatusInitialized},

--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -258,7 +258,7 @@ func resourceAwsGameliftFleetCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("error creating GameLift Fleet (%s): %w", d.Get("name").(string), err)
 	}
 
-	d.SetId(*out.FleetAttributes.FleetId)
+	d.SetId(aws.StringValue(out.FleetAttributes.FleetId))
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{

--- a/aws/resource_aws_gamelift_game_session_queue.go
+++ b/aws/resource_aws_gamelift_game_session_queue.go
@@ -81,7 +81,7 @@ func resourceAwsGameliftGameSessionQueueCreate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("error creating Gamelift Game Session Queue: %s", err)
 	}
 
-	d.SetId(*out.GameSessionQueue.Name)
+	d.SetId(aws.StringValue(out.GameSessionQueue.Name))
 
 	return resourceAwsGameliftGameSessionQueueRead(d, meta)
 }

--- a/aws/resource_aws_globalaccelerator_accelerator.go
+++ b/aws/resource_aws_globalaccelerator_accelerator.go
@@ -126,7 +126,7 @@ func resourceAwsGlobalAcceleratorAcceleratorCreate(d *schema.ResourceData, meta 
 		return fmt.Errorf("Error creating Global Accelerator accelerator: %s", err)
 	}
 
-	d.SetId(*resp.Accelerator.AcceleratorArn)
+	d.SetId(aws.StringValue(resp.Accelerator.AcceleratorArn))
 
 	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id())
 	if err != nil {

--- a/aws/resource_aws_globalaccelerator_listener.go
+++ b/aws/resource_aws_globalaccelerator_listener.go
@@ -89,7 +89,7 @@ func resourceAwsGlobalAcceleratorListenerCreate(d *schema.ResourceData, meta int
 		return fmt.Errorf("Error creating Global Accelerator listener: %s", err)
 	}
 
-	d.SetId(*resp.Listener.ListenerArn)
+	d.SetId(aws.StringValue(resp.Listener.ListenerArn))
 
 	// Creating a listener triggers the accelerator to change status to InPending
 	stateConf := &resource.StateChangeConf{

--- a/aws/resource_aws_guardduty_detector.go
+++ b/aws/resource_aws_guardduty_detector.go
@@ -70,7 +70,7 @@ func resourceAwsGuardDutyDetectorCreate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return fmt.Errorf("Creating GuardDuty Detector failed: %s", err.Error())
 	}
-	d.SetId(*output.DetectorId)
+	d.SetId(aws.StringValue(output.DetectorId))
 
 	return resourceAwsGuardDutyDetectorRead(d, meta)
 }

--- a/aws/resource_aws_iam_access_key.go
+++ b/aws/resource_aws_iam_access_key.go
@@ -79,7 +79,7 @@ func resourceAwsIamAccessKeyCreate(d *schema.ResourceData, meta interface{}) err
 		)
 	}
 
-	d.SetId(*createResp.AccessKey.AccessKeyId)
+	d.SetId(aws.StringValue(createResp.AccessKey.AccessKeyId))
 
 	if createResp.AccessKey == nil || createResp.AccessKey.SecretAccessKey == nil {
 		return fmt.Errorf("CreateAccessKey response did not contain a Secret Access Key as expected")
@@ -147,7 +147,7 @@ func resourceAwsIamAccessKeyRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsIamAccessKeyReadResult(d *schema.ResourceData, key *iam.AccessKeyMetadata) error {
-	d.SetId(*key.AccessKeyId)
+	d.SetId(aws.StringValue(key.AccessKeyId))
 	if err := d.Set("user", key.UserName); err != nil {
 		return err
 	}

--- a/aws/resource_aws_iam_group.go
+++ b/aws/resource_aws_iam_group.go
@@ -61,7 +61,7 @@ func resourceAwsIamGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error creating IAM Group %s: %s", name, err)
 	}
-	d.SetId(*createResp.Group.GroupName)
+	d.SetId(aws.StringValue(createResp.Group.GroupName))
 
 	return resourceAwsIamGroupReadResult(d, createResp.Group)
 }

--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -234,7 +234,7 @@ func resourceAwsIamInstanceProfileDelete(d *schema.ResourceData, meta interface{
 }
 
 func instanceProfileReadResult(d *schema.ResourceData, result *iam.InstanceProfile) error {
-	d.SetId(*result.InstanceProfileName)
+	d.SetId(aws.StringValue(result.InstanceProfileName))
 	if err := d.Set("name", result.InstanceProfileName); err != nil {
 		return err
 	}

--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -95,7 +95,7 @@ func resourceAwsIamPolicyCreate(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error creating IAM policy %s: %s", name, err)
 	}
 
-	d.SetId(*response.Policy.Arn)
+	d.SetId(aws.StringValue(response.Policy.Arn))
 
 	return resourceAwsIamPolicyRead(d, meta)
 }

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -172,7 +172,7 @@ func resourceAwsIamRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error creating IAM Role %s: %s", name, err)
 	}
-	d.SetId(*createResp.Role.RoleName)
+	d.SetId(aws.StringValue(createResp.Role.RoleName))
 	return resourceAwsIamRoleRead(d, meta)
 }
 

--- a/aws/resource_aws_iam_service_linked_role.go
+++ b/aws/resource_aws_iam_service_linked_role.go
@@ -100,7 +100,7 @@ func resourceAwsIamServiceLinkedRoleCreate(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return fmt.Errorf("Error creating service-linked role with name %s: %s", serviceName, err)
 	}
-	d.SetId(*resp.Role.Arn)
+	d.SetId(aws.StringValue(resp.Role.Arn))
 
 	return resourceAwsIamServiceLinkedRoleRead(d, meta)
 }

--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -155,7 +155,7 @@ func resourceAwsIamUserLoginProfileCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error creating IAM User Login Profile for %q: %s", username, err)
 	}
 
-	d.SetId(*createResp.LoginProfile.UserName)
+	d.SetId(aws.StringValue(createResp.LoginProfile.UserName))
 	d.Set("key_fingerprint", fingerprint)
 	d.Set("encrypted_password", encrypted)
 	return nil

--- a/aws/resource_aws_iam_user_ssh_key.go
+++ b/aws/resource_aws_iam_user_ssh_key.go
@@ -84,7 +84,7 @@ func resourceAwsIamUserSshKeyCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating IAM User SSH Key %s: %s", username, err)
 	}
 
-	d.SetId(*createResp.SSHPublicKey.SSHPublicKeyId)
+	d.SetId(aws.StringValue(createResp.SSHPublicKey.SSHPublicKeyId))
 
 	return resourceAwsIamUserSshKeyUpdate(d, meta)
 }

--- a/aws/resource_aws_inspector_assessment_target.go
+++ b/aws/resource_aws_inspector_assessment_target.go
@@ -55,7 +55,7 @@ func resourceAwsInspectorAssessmentTargetCreate(d *schema.ResourceData, meta int
 		return fmt.Errorf("error creating Inspector Assessment Target: %s", err)
 	}
 
-	d.SetId(*resp.AssessmentTargetArn)
+	d.SetId(aws.StringValue(resp.AssessmentTargetArn))
 
 	return resourceAwsInspectorAssessmentTargetRead(d, meta)
 }

--- a/aws/resource_aws_internet_gateway.go
+++ b/aws/resource_aws_internet_gateway.go
@@ -58,7 +58,7 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 
 	// Get the ID and store it
 	ig := *resp.InternetGateway
-	d.SetId(*ig.InternetGatewayId)
+	d.SetId(aws.StringValue(ig.InternetGatewayId))
 	log.Printf("[INFO] InternetGateway ID: %s", d.Id())
 	var igRaw interface{}
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {

--- a/aws/resource_aws_iot_thing.go
+++ b/aws/resource_aws_iot_thing.go
@@ -75,7 +75,7 @@ func resourceAwsIotThingCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(*out.ThingName)
+	d.SetId(aws.StringValue(out.ThingName))
 
 	return resourceAwsIotThingRead(d, meta)
 }

--- a/aws/resource_aws_iot_thing_type.go
+++ b/aws/resource_aws_iot_thing_type.go
@@ -96,7 +96,7 @@ func resourceAwsIotThingTypeCreate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	d.SetId(*out.ThingTypeName)
+	d.SetId(aws.StringValue(out.ThingTypeName))
 
 	if v := d.Get("deprecated").(bool); v {
 		params := &iot.DeprecateThingTypeInput{

--- a/aws/resource_aws_lambda_alias.go
+++ b/aws/resource_aws_lambda_alias.go
@@ -96,7 +96,7 @@ func resourceAwsLambdaAliasCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error creating Lambda alias: %s", err)
 	}
 
-	d.SetId(*aliasConfiguration.AliasArn)
+	d.SetId(aws.StringValue(aliasConfiguration.AliasArn))
 
 	return resourceAwsLambdaAliasRead(d, meta)
 }
@@ -128,7 +128,7 @@ func resourceAwsLambdaAliasRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("function_version", aliasConfiguration.FunctionVersion)
 	d.Set("name", aliasConfiguration.Name)
 	d.Set("arn", aliasConfiguration.AliasArn)
-	d.SetId(*aliasConfiguration.AliasArn)
+	d.SetId(aws.StringValue(aliasConfiguration.AliasArn))
 
 	invokeArn := lambdaFunctionInvokeArn(*aliasConfiguration.AliasArn, meta)
 	d.Set("invoke_arn", invokeArn)

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -255,7 +255,7 @@ func resourceAwsLambdaEventSourceMappingCreate(d *schema.ResourceData, meta inte
 
 	// No error
 	d.Set("uuid", eventSourceMappingConfiguration.UUID)
-	d.SetId(*eventSourceMappingConfiguration.UUID)
+	d.SetId(aws.StringValue(eventSourceMappingConfiguration.UUID))
 	return resourceAwsLambdaEventSourceMappingRead(d, meta)
 }
 

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -654,7 +654,7 @@ func resourceAwsLaunchTemplateCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	launchTemplate := resp.LaunchTemplate
-	d.SetId(*launchTemplate.LaunchTemplateId)
+	d.SetId(aws.StringValue(launchTemplate.LaunchTemplateId))
 
 	log.Printf("[DEBUG] Launch Template created: %q (version %d)",
 		*launchTemplate.LaunchTemplateId, *launchTemplate.LatestVersionNumber)

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -564,7 +564,7 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error creating ELBv2 Listener: no listeners returned in response")
 	}
 
-	d.SetId(*resp.Listeners[0].ListenerArn)
+	d.SetId(aws.StringValue(resp.Listeners[0].ListenerArn))
 
 	return resourceAwsLbListenerRead(d, meta)
 }

--- a/aws/resource_aws_licensemanager_license_configuration.go
+++ b/aws/resource_aws_licensemanager_license_configuration.go
@@ -99,7 +99,7 @@ func resourceAwsLicenseManagerLicenseConfigurationCreate(d *schema.ResourceData,
 	if err != nil {
 		return fmt.Errorf("Error creating License Manager license configuration: %s", err)
 	}
-	d.SetId(*resp.LicenseConfigurationArn)
+	d.SetId(aws.StringValue(resp.LicenseConfigurationArn))
 	return resourceAwsLicenseManagerLicenseConfigurationRead(d, meta)
 }
 

--- a/aws/resource_aws_main_route_table_association.go
+++ b/aws/resource_aws_main_route_table_association.go
@@ -60,7 +60,7 @@ func resourceAwsMainRouteTableAssociationCreate(d *schema.ResourceData, meta int
 	}
 
 	d.Set("original_route_table_id", mainAssociation.RouteTableId)
-	d.SetId(*resp.NewAssociationId)
+	d.SetId(aws.StringValue(resp.NewAssociationId))
 	log.Printf("[INFO] New main route table association ID: %s", d.Id())
 
 	return nil
@@ -102,7 +102,7 @@ func resourceAwsMainRouteTableAssociationUpdate(d *schema.ResourceData, meta int
 		return err
 	}
 
-	d.SetId(*resp.NewAssociationId)
+	d.SetId(aws.StringValue(resp.NewAssociationId))
 	log.Printf("[INFO] New main route table association ID: %s", d.Id())
 
 	return nil

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -298,7 +298,7 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(*out.BrokerId)
+	d.SetId(aws.StringValue(out.BrokerId))
 	d.Set("arn", out.BrokerArn)
 
 	stateConf := resource.StateChangeConf{

--- a/aws/resource_aws_mq_configuration.go
+++ b/aws/resource_aws_mq_configuration.go
@@ -97,7 +97,7 @@ func resourceAwsMqConfigurationCreate(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	d.SetId(*out.Id)
+	d.SetId(aws.StringValue(out.Id))
 	d.Set("arn", out.Arn)
 
 	return resourceAwsMqConfigurationUpdate(d, meta)

--- a/aws/resource_aws_nat_gateway.go
+++ b/aws/resource_aws_nat_gateway.go
@@ -75,7 +75,7 @@ func resourceAwsNatGatewayCreate(d *schema.ResourceData, meta interface{}) error
 
 	// Get the ID and store it
 	ng := natResp.NatGateway
-	d.SetId(*ng.NatGatewayId)
+	d.SetId(aws.StringValue(ng.NatGatewayId))
 	log.Printf("[INFO] NAT Gateway ID: %s", d.Id())
 
 	// Wait for the NAT Gateway to become available

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -170,7 +170,7 @@ func resourceAwsNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error creating ENI: %s", err)
 	}
 
-	d.SetId(*resp.NetworkInterface.NetworkInterfaceId)
+	d.SetId(aws.StringValue(resp.NetworkInterface.NetworkInterfaceId))
 
 	if err := waitForNetworkInterfaceCreation(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("error waiting for Network Interface (%s) creation: %s", d.Id(), err)

--- a/aws/resource_aws_network_interface_attachment.go
+++ b/aws/resource_aws_network_interface_attachment.go
@@ -88,7 +88,7 @@ func resourceAwsNetworkInterfaceAttachmentCreate(d *schema.ResourceData, meta in
 			"Error waiting for Volume (%s) to attach to Instance: %s, error: %s", network_interface_id, instance_id, err)
 	}
 
-	d.SetId(*resp.AttachmentId)
+	d.SetId(aws.StringValue(resp.AttachmentId))
 	return resourceAwsNetworkInterfaceAttachmentRead(d, meta)
 }
 

--- a/aws/resource_aws_opsworks_user_profile.go
+++ b/aws/resource_aws_opsworks_user_profile.go
@@ -91,7 +91,7 @@ func resourceAwsOpsworksUserProfileCreate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	d.SetId(*resp.IamUserArn)
+	d.SetId(aws.StringValue(resp.IamUserArn))
 
 	return resourceAwsOpsworksUserProfileUpdate(d, meta)
 }

--- a/aws/resource_aws_organizations_account.go
+++ b/aws/resource_aws_organizations_account.go
@@ -143,7 +143,7 @@ func resourceAwsOrganizationsAccountCreate(d *schema.ResourceData, meta interfac
 
 	// Store the ID
 	accountId := stateResp.(*organizations.CreateAccountStatus).AccountId
-	d.SetId(*accountId)
+	d.SetId(aws.StringValue(accountId))
 
 	if v, ok := d.GetOk("parent_id"); ok {
 		newParentID := v.(string)

--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -179,7 +179,7 @@ func resourceAwsOrganizationsOrganizationCreate(d *schema.ResourceData, meta int
 	}
 
 	org := resp.Organization
-	d.SetId(*org.Id)
+	d.SetId(aws.StringValue(org.Id))
 
 	awsServiceAccessPrincipals := d.Get("aws_service_access_principals").(*schema.Set).List()
 	for _, principalRaw := range awsServiceAccessPrincipals {

--- a/aws/resource_aws_organizations_organizational_unit.go
+++ b/aws/resource_aws_organizations_organizational_unit.go
@@ -105,7 +105,7 @@ func resourceAwsOrganizationsOrganizationalUnitCreate(d *schema.ResourceData, me
 
 	// Store the ID
 	ouId := resp.OrganizationalUnit.Id
-	d.SetId(*ouId)
+	d.SetId(aws.StringValue(ouId))
 
 	return resourceAwsOrganizationsOrganizationalUnitRead(d, meta)
 }

--- a/aws/resource_aws_qldb_ledger.go
+++ b/aws/resource_aws_qldb_ledger.go
@@ -82,7 +82,7 @@ func resourceAwsQLDBLedgerCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// Set QLDB ledger name
-	d.SetId(*qldbResp.Name)
+	d.SetId(aws.StringValue(qldbResp.Name))
 
 	log.Printf("[INFO] QLDB Ledger name: %s", d.Id())
 

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -300,7 +300,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("error creating RDS Cluster (%s) Instance: %w", d.Get("cluster_identifier").(string), err)
 	}
 
-	d.SetId(*resp.DBInstance.DBInstanceIdentifier)
+	d.SetId(aws.StringValue(resp.DBInstance.DBInstanceIdentifier))
 
 	// reuse db_instance refresh func
 	stateConf := &resource.StateChangeConf{

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -112,7 +112,7 @@ func resourceAwsRDSClusterParameterGroupCreate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error creating DB Cluster Parameter Group: %s", err)
 	}
 
-	d.SetId(*createOpts.DBClusterParameterGroupName)
+	d.SetId(aws.StringValue(createOpts.DBClusterParameterGroupName))
 	log.Printf("[INFO] DB Cluster Parameter Group ID: %s", d.Id())
 
 	// Set for update

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -405,7 +405,7 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 			return err
 		}
 
-		d.SetId(*resp.Cluster.ClusterIdentifier)
+		d.SetId(aws.StringValue(resp.Cluster.ClusterIdentifier))
 
 	} else {
 		if _, ok := d.GetOk("master_password"); !ok {
@@ -489,7 +489,7 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		}
 
 		log.Printf("[DEBUG]: Cluster create response: %s", resp)
-		d.SetId(*resp.Cluster.ClusterIdentifier)
+		d.SetId(aws.StringValue(resp.Cluster.ClusterIdentifier))
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/aws/resource_aws_redshift_parameter_group.go
+++ b/aws/resource_aws_redshift_parameter_group.go
@@ -98,7 +98,7 @@ func resourceAwsRedshiftParameterGroupCreate(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error creating Redshift Parameter Group: %s", err)
 	}
 
-	d.SetId(*createOpts.ParameterGroupName)
+	d.SetId(aws.StringValue(createOpts.ParameterGroupName))
 
 	if v := d.Get("parameter").(*schema.Set); v.Len() > 0 {
 		parameters := expandRedshiftParameters(v.List())

--- a/aws/resource_aws_redshift_subnet_group.go
+++ b/aws/resource_aws_redshift_subnet_group.go
@@ -81,7 +81,7 @@ func resourceAwsRedshiftSubnetGroupCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error creating Redshift Subnet Group: %s", err)
 	}
 
-	d.SetId(*createOpts.ClusterSubnetGroupName)
+	d.SetId(aws.StringValue(createOpts.ClusterSubnetGroupName))
 	log.Printf("[INFO] Redshift Subnet Group ID: %s", d.Id())
 	return resourceAwsRedshiftSubnetGroupRead(d, meta)
 }

--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -339,7 +339,7 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	d.SetId(*resp.HealthCheck.Id)
+	d.SetId(aws.StringValue(resp.HealthCheck.Id))
 
 	if err := keyvaluetags.Route53UpdateTags(conn, d.Id(), route53.TagResourceTypeHealthcheck, map[string]interface{}{}, d.Get("tags").(map[string]interface{})); err != nil {
 		return fmt.Errorf("error setting Route53 Health Check (%s) tags: %s", d.Id(), err)

--- a/aws/resource_aws_route53_query_log.go
+++ b/aws/resource_aws_route53_query_log.go
@@ -50,7 +50,7 @@ func resourceAwsRoute53QueryLogCreate(d *schema.ResourceData, meta interface{}) 
 	}
 	log.Printf("[DEBUG] Route53 query logging configuration created: %#v", out)
 
-	d.SetId(*out.QueryLoggingConfig.Id)
+	d.SetId(aws.StringValue(out.QueryLoggingConfig.Id))
 
 	return resourceAwsRoute53QueryLogRead(d, meta)
 }

--- a/aws/resource_aws_route_table_association.go
+++ b/aws/resource_aws_route_table_association.go
@@ -157,7 +157,7 @@ func resourceAwsRouteTableAssociationUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	// Update the ID
-	d.SetId(*resp.NewAssociationId)
+	d.SetId(aws.StringValue(resp.NewAssociationId))
 	log.Printf("[INFO] Association ID: %s", d.Id())
 
 	return nil

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -262,7 +262,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating Security Group: %s", err)
 	}
 
-	d.SetId(*createResp.GroupId)
+	d.SetId(aws.StringValue(createResp.GroupId))
 
 	log.Printf("[INFO] Security Group ID: %s", d.Id())
 

--- a/aws/resource_aws_securityhub_standards_subscription.go
+++ b/aws/resource_aws_securityhub_standards_subscription.go
@@ -47,7 +47,7 @@ func resourceAwsSecurityHubStandardsSubscriptionCreate(d *schema.ResourceData, m
 
 	standardsSubscription := resp.StandardsSubscriptions[0]
 
-	d.SetId(*standardsSubscription.StandardsSubscriptionArn)
+	d.SetId(aws.StringValue(standardsSubscription.StandardsSubscriptionArn))
 
 	return resourceAwsSecurityHubStandardsSubscriptionRead(d, meta)
 }

--- a/aws/resource_aws_servicecatalog_portfolio.go
+++ b/aws/resource_aws_servicecatalog_portfolio.go
@@ -82,7 +82,7 @@ func resourceAwsServiceCatalogPortfolioCreate(d *schema.ResourceData, meta inter
 	if err != nil {
 		return fmt.Errorf("Creating Service Catalog Portfolio failed: %s", err.Error())
 	}
-	d.SetId(*resp.PortfolioDetail.Id)
+	d.SetId(aws.StringValue(resp.PortfolioDetail.Id))
 
 	return resourceAwsServiceCatalogPortfolioRead(d, meta)
 }

--- a/aws/resource_aws_sfn_activity.go
+++ b/aws/resource_aws_sfn_activity.go
@@ -54,7 +54,7 @@ func resourceAwsSfnActivityCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error creating Step Function Activity: %s", err)
 	}
 
-	d.SetId(*activity.ActivityArn)
+	d.SetId(aws.StringValue(activity.ActivityArn))
 
 	return resourceAwsSfnActivityRead(d, meta)
 }

--- a/aws/resource_aws_shield_protection.go
+++ b/aws/resource_aws_shield_protection.go
@@ -45,7 +45,7 @@ func resourceAwsShieldProtectionCreate(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return fmt.Errorf("error creating Shield Protection: %s", err)
 	}
-	d.SetId(*resp.ProtectionId)
+	d.SetId(aws.StringValue(resp.ProtectionId))
 	return resourceAwsShieldProtectionRead(d, meta)
 }
 

--- a/aws/resource_aws_sns_platform_application.go
+++ b/aws/resource_aws_sns_platform_application.go
@@ -116,7 +116,7 @@ func resourceAwsSnsPlatformApplicationCreate(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error creating SNS platform application: %s", err)
 	}
 
-	d.SetId(*output.PlatformApplicationArn)
+	d.SetId(aws.StringValue(output.PlatformApplicationArn))
 
 	return resourceAwsSnsPlatformApplicationUpdate(d, meta)
 }

--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -154,7 +154,7 @@ func resourceAwsSnsTopicCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating SNS topic: %s", err)
 	}
 
-	d.SetId(*output.TopicArn)
+	d.SetId(aws.StringValue(output.TopicArn))
 
 	// update mutable attributes
 	if d.HasChange("application_failure_feedback_role_arn") {

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -111,7 +111,7 @@ func resourceAwsSnsTopicSubscriptionCreate(d *schema.ResourceData, meta interfac
 	}
 
 	log.Printf("New subscription ARN: %s", *output.SubscriptionArn)
-	d.SetId(*output.SubscriptionArn)
+	d.SetId(aws.StringValue(output.SubscriptionArn))
 
 	// Write the ARN to the 'arn' field for export
 	d.Set("arn", output.SubscriptionArn)

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1047,7 +1047,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error requesting spot fleet: %s", err)
 	}
 
-	d.SetId(*resp.SpotFleetRequestId)
+	d.SetId(aws.StringValue(resp.SpotFleetRequestId))
 
 	log.Printf("[INFO] Spot Fleet Request ID: %s", d.Id())
 	log.Println("[INFO] Waiting for Spot Fleet Request to be active")
@@ -1209,7 +1209,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
-	d.SetId(*sfr.SpotFleetRequestId)
+	d.SetId(aws.StringValue(sfr.SpotFleetRequestId))
 	d.Set("spot_request_state", aws.StringValue(sfr.SpotFleetRequestState))
 
 	config := sfr.SpotFleetRequestConfig

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -211,7 +211,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 	}
 
 	sir := *resp.SpotInstanceRequests[0]
-	d.SetId(*sir.SpotInstanceRequestId)
+	d.SetId(aws.StringValue(sir.SpotInstanceRequestId))
 
 	if d.Get("wait_for_fulfillment").(bool) {
 		spotStateConf := &resource.StateChangeConf{

--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -130,7 +130,7 @@ func resourceAwsSsmActivationCreate(d *schema.ResourceData, meta interface{}) er
 	if resp.ActivationId == nil {
 		return fmt.Errorf("ActivationId was nil")
 	}
-	d.SetId(*resp.ActivationId)
+	d.SetId(aws.StringValue(resp.ActivationId))
 	d.Set("activation_code", resp.ActivationCode)
 
 	return resourceAwsSsmActivationRead(d, meta)

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -186,7 +186,7 @@ func resourceAwsSsmAssociationCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("AssociationDescription was nil")
 	}
 
-	d.SetId(*resp.AssociationDescription.AssociationId)
+	d.SetId(aws.StringValue(resp.AssociationDescription.AssociationId))
 	d.Set("association_id", resp.AssociationDescription.AssociationId)
 
 	return resourceAwsSsmAssociationRead(d, meta)

--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -214,7 +214,7 @@ func resourceAwsSsmDocumentCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error creating SSM document: %s", err)
 	}
 
-	d.SetId(*resp.DocumentDescription.Name)
+	d.SetId(aws.StringValue(resp.DocumentDescription.Name))
 
 	if v, ok := d.GetOk("permissions"); ok && v != nil {
 		if err := setDocumentPermissions(d, meta); err != nil {

--- a/aws/resource_aws_ssm_maintenance_window.go
+++ b/aws/resource_aws_ssm_maintenance_window.go
@@ -113,7 +113,7 @@ func resourceAwsSsmMaintenanceWindowCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error creating SSM Maintenance Window: %s", err)
 	}
 
-	d.SetId(*resp.WindowId)
+	d.SetId(aws.StringValue(resp.WindowId))
 
 	if !d.Get("enabled").(bool) {
 		input := &ssm.UpdateMaintenanceWindowInput{

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -604,7 +604,7 @@ func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	d.SetId(*resp.WindowTaskId)
+	d.SetId(aws.StringValue(resp.WindowTaskId))
 
 	return resourceAwsSsmMaintenanceWindowTaskRead(d, meta)
 }

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -167,7 +167,7 @@ func resourceAwsSsmPatchBaselineCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	d.SetId(*resp.BaselineId)
+	d.SetId(aws.StringValue(resp.BaselineId))
 	return resourceAwsSsmPatchBaselineRead(d, meta)
 }
 

--- a/aws/resource_aws_ssm_patch_group.go
+++ b/aws/resource_aws_ssm_patch_group.go
@@ -43,7 +43,7 @@ func resourceAwsSsmPatchGroupCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	d.SetId(*resp.PatchGroup)
+	d.SetId(aws.StringValue(resp.PatchGroup))
 	return resourceAwsSsmPatchGroupRead(d, meta)
 }
 

--- a/aws/resource_aws_transfer_server.go
+++ b/aws/resource_aws_transfer_server.go
@@ -190,7 +190,7 @@ func resourceAwsTransferServerCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error creating Transfer Server: %s", err)
 	}
 
-	d.SetId(*resp.ServerId)
+	d.SetId(aws.StringValue(resp.ServerId))
 
 	stateChangeConf := &resource.StateChangeConf{
 		Pending: []string{transfer.StateStarting},

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -145,7 +145,7 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Get the ID and store it
 	vpc := vpcResp.Vpc
-	d.SetId(*vpc.VpcId)
+	d.SetId(aws.StringValue(vpc.VpcId))
 	log.Printf("[INFO] VPC ID: %s", d.Id())
 
 	// Wait for the VPC to become available

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -98,7 +98,7 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 
 	// Get the ID and store it
 	rt := resp.VpcPeeringConnection
-	d.SetId(*rt.VpcPeeringConnectionId)
+	d.SetId(aws.StringValue(rt.VpcPeeringConnectionId))
 	log.Printf("[INFO] VPC Peering Connection ID: %s", d.Id())
 
 	err = vpcPeeringConnectionWaitUntilAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate))

--- a/aws/resource_aws_waf_geo_match_set.go
+++ b/aws/resource_aws_waf_geo_match_set.go
@@ -69,7 +69,7 @@ func resourceAwsWafGeoMatchSetCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	resp := out.(*waf.CreateGeoMatchSetOutput)
 
-	d.SetId(*resp.GeoMatchSet.GeoMatchSetId)
+	d.SetId(aws.StringValue(resp.GeoMatchSet.GeoMatchSetId))
 
 	return resourceAwsWafGeoMatchSetUpdate(d, meta)
 }

--- a/aws/resource_aws_waf_ipset.go
+++ b/aws/resource_aws_waf_ipset.go
@@ -74,7 +74,7 @@ func resourceAwsWafIPSetCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	resp := out.(*waf.CreateIPSetOutput)
-	d.SetId(*resp.IPSet.IPSetId)
+	d.SetId(aws.StringValue(resp.IPSet.IPSetId))
 
 	if v, ok := d.GetOk("ip_set_descriptors"); ok && v.(*schema.Set).Len() > 0 {
 

--- a/aws/resource_aws_waf_rate_based_rule.go
+++ b/aws/resource_aws_waf_rate_based_rule.go
@@ -99,7 +99,7 @@ func resourceAwsWafRateBasedRuleCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 	resp := out.(*waf.CreateRateBasedRuleOutput)
-	d.SetId(*resp.Rule.RuleId)
+	d.SetId(aws.StringValue(resp.Rule.RuleId))
 
 	newPredicates := d.Get("predicates").(*schema.Set).List()
 	if len(newPredicates) > 0 {

--- a/aws/resource_aws_waf_regex_match_set.go
+++ b/aws/resource_aws_waf_regex_match_set.go
@@ -90,7 +90,7 @@ func resourceAwsWafRegexMatchSetCreate(d *schema.ResourceData, meta interface{})
 	}
 	resp := out.(*waf.CreateRegexMatchSetOutput)
 
-	d.SetId(*resp.RegexMatchSet.RegexMatchSetId)
+	d.SetId(aws.StringValue(resp.RegexMatchSet.RegexMatchSetId))
 
 	return resourceAwsWafRegexMatchSetUpdate(d, meta)
 }

--- a/aws/resource_aws_waf_regex_pattern_set.go
+++ b/aws/resource_aws_waf_regex_pattern_set.go
@@ -57,7 +57,7 @@ func resourceAwsWafRegexPatternSetCreate(d *schema.ResourceData, meta interface{
 	}
 	resp := out.(*waf.CreateRegexPatternSetOutput)
 
-	d.SetId(*resp.RegexPatternSet.RegexPatternSetId)
+	d.SetId(aws.StringValue(resp.RegexPatternSet.RegexPatternSetId))
 
 	return resourceAwsWafRegexPatternSetUpdate(d, meta)
 }

--- a/aws/resource_aws_waf_rule.go
+++ b/aws/resource_aws_waf_rule.go
@@ -88,7 +88,7 @@ func resourceAwsWafRuleCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	resp := out.(*waf.CreateRuleOutput)
-	d.SetId(*resp.Rule.RuleId)
+	d.SetId(aws.StringValue(resp.Rule.RuleId))
 
 	newPredicates := d.Get("predicates").(*schema.Set).List()
 	if len(newPredicates) > 0 {

--- a/aws/resource_aws_waf_rule_group.go
+++ b/aws/resource_aws_waf_rule_group.go
@@ -98,7 +98,7 @@ func resourceAwsWafRuleGroupCreate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	resp := out.(*waf.CreateRuleGroupOutput)
-	d.SetId(*resp.RuleGroup.RuleGroupId)
+	d.SetId(aws.StringValue(resp.RuleGroup.RuleGroupId))
 
 	activatedRules := d.Get("activated_rule").(*schema.Set).List()
 	if len(activatedRules) > 0 {

--- a/aws/resource_aws_waf_size_constraint_set.go
+++ b/aws/resource_aws_waf_size_constraint_set.go
@@ -44,7 +44,7 @@ func resourceAwsWafSizeConstraintSetCreate(d *schema.ResourceData, meta interfac
 	}
 	resp := out.(*waf.CreateSizeConstraintSetOutput)
 
-	d.SetId(*resp.SizeConstraintSet.SizeConstraintSetId)
+	d.SetId(aws.StringValue(resp.SizeConstraintSet.SizeConstraintSetId))
 
 	return resourceAwsWafSizeConstraintSetUpdate(d, meta)
 }

--- a/aws/resource_aws_waf_sql_injection_match_set.go
+++ b/aws/resource_aws_waf_sql_injection_match_set.go
@@ -76,7 +76,7 @@ func resourceAwsWafSqlInjectionMatchSetCreate(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error creating SqlInjectionMatchSet: %s", err)
 	}
 	resp := out.(*waf.CreateSqlInjectionMatchSetOutput)
-	d.SetId(*resp.SqlInjectionMatchSet.SqlInjectionMatchSetId)
+	d.SetId(aws.StringValue(resp.SqlInjectionMatchSet.SqlInjectionMatchSetId))
 
 	return resourceAwsWafSqlInjectionMatchSetUpdate(d, meta)
 }

--- a/aws/resource_aws_waf_web_acl.go
+++ b/aws/resource_aws_waf_web_acl.go
@@ -169,7 +169,7 @@ func resourceAwsWafWebAclCreate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 	resp := out.(*waf.CreateWebACLOutput)
-	d.SetId(*resp.WebACL.WebACLId)
+	d.SetId(aws.StringValue(resp.WebACL.WebACLId))
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,

--- a/aws/resource_aws_wafregional_byte_match_set.go
+++ b/aws/resource_aws_wafregional_byte_match_set.go
@@ -87,7 +87,7 @@ func resourceAwsWafRegionalByteMatchSetCreate(d *schema.ResourceData, meta inter
 	}
 	resp := out.(*waf.CreateByteMatchSetOutput)
 
-	d.SetId(*resp.ByteMatchSet.ByteMatchSetId)
+	d.SetId(aws.StringValue(resp.ByteMatchSet.ByteMatchSetId))
 
 	return resourceAwsWafRegionalByteMatchSetUpdate(d, meta)
 }

--- a/aws/resource_aws_wafregional_geo_match_set.go
+++ b/aws/resource_aws_wafregional_geo_match_set.go
@@ -66,7 +66,7 @@ func resourceAwsWafRegionalGeoMatchSetCreate(d *schema.ResourceData, meta interf
 	}
 	resp := out.(*waf.CreateGeoMatchSetOutput)
 
-	d.SetId(*resp.GeoMatchSet.GeoMatchSetId)
+	d.SetId(aws.StringValue(resp.GeoMatchSet.GeoMatchSetId))
 
 	return resourceAwsWafRegionalGeoMatchSetUpdate(d, meta)
 }

--- a/aws/resource_aws_wafregional_ipset.go
+++ b/aws/resource_aws_wafregional_ipset.go
@@ -68,7 +68,7 @@ func resourceAwsWafRegionalIPSetCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 	resp := out.(*waf.CreateIPSetOutput)
-	d.SetId(*resp.IPSet.IPSetId)
+	d.SetId(aws.StringValue(resp.IPSet.IPSetId))
 	return resourceAwsWafRegionalIPSetUpdate(d, meta)
 }
 

--- a/aws/resource_aws_wafregional_rate_based_rule.go
+++ b/aws/resource_aws_wafregional_rate_based_rule.go
@@ -100,7 +100,7 @@ func resourceAwsWafRegionalRateBasedRuleCreate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error creating WAF Regional Rate Based Rule (%s): %s", d.Id(), err)
 	}
 	resp := out.(*waf.CreateRateBasedRuleOutput)
-	d.SetId(*resp.Rule.RuleId)
+	d.SetId(aws.StringValue(resp.Rule.RuleId))
 
 	newPredicates := d.Get("predicate").(*schema.Set).List()
 	if len(newPredicates) > 0 {

--- a/aws/resource_aws_wafregional_rule.go
+++ b/aws/resource_aws_wafregional_rule.go
@@ -88,7 +88,7 @@ func resourceAwsWafRegionalRuleCreate(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 	resp := out.(*waf.CreateRuleOutput)
-	d.SetId(*resp.Rule.RuleId)
+	d.SetId(aws.StringValue(resp.Rule.RuleId))
 
 	newPredicates := d.Get("predicate").(*schema.Set).List()
 	if len(newPredicates) > 0 {

--- a/aws/resource_aws_wafregional_rule_group.go
+++ b/aws/resource_aws_wafregional_rule_group.go
@@ -100,7 +100,7 @@ func resourceAwsWafRegionalRuleGroupCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 	resp := out.(*waf.CreateRuleGroupOutput)
-	d.SetId(*resp.RuleGroup.RuleGroupId)
+	d.SetId(aws.StringValue(resp.RuleGroup.RuleGroupId))
 
 	activatedRule := d.Get("activated_rule").(*schema.Set).List()
 	if len(activatedRule) > 0 {

--- a/aws/resource_aws_wafregional_web_acl.go
+++ b/aws/resource_aws_wafregional_web_acl.go
@@ -194,7 +194,7 @@ func resourceAwsWafRegionalWebAclCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 	resp := out.(*waf.CreateWebACLOutput)
-	d.SetId(*resp.WebACL.WebACLId)
+	d.SetId(aws.StringValue(resp.WebACL.WebACLId))
 
 	// The WAF API currently omits this, but use it when it becomes available
 	webACLARN := aws.StringValue(resp.WebACL.WebACLArn)

--- a/aws/resource_aws_workspaces_ip_group.go
+++ b/aws/resource_aws_workspaces_ip_group.go
@@ -72,7 +72,7 @@ func resourceAwsWorkspacesIpGroupCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	d.SetId(*resp.GroupId)
+	d.SetId(aws.StringValue(resp.GroupId))
 
 	return resourceAwsWorkspacesIpGroupRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12992

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

These fixes were automatically applied by `semgrep --autofix` and are always safe since `(helper/schema.ResourceData).SetId()` only accepts a `string` type. Other types would generate a Go compilation error.

Output from acceptance testing (provided as a smoke test):

```
--- PASS: TestAccDataSourceAwsApiGatewayRestApi_basic (24.51s)
```
