### PR TITLE
r/backup_plan - remove validation

### DIFF
--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -78,9 +78,8 @@ func resourceAwsBackupPlan() *schema.Resource {
 										Optional: true,
 									},
 									"delete_after": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ValidateFunc: validation.IntAtLeast(90),
+										Type:     schema.TypeInt,
+										Optional: true,
 									},
 								},
 							},

--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -101,9 +101,8 @@ func resourceAwsBackupPlan() *schema.Resource {
 													Optional: true,
 												},
 												"delete_after": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntAtLeast(90),
+													Type:     schema.TypeInt,
+													Optional: true,
 												},
 											},
 										},
@@ -314,19 +313,8 @@ func expandBackupPlanRules(vRules *schema.Set) []*backup.RuleInput {
 			rule.RecoveryPointTags = keyvaluetags.New(vRecoveryPointTags).IgnoreAws().BackupTags()
 		}
 
-		if vLifecycle, ok := mRule["lifecycle"].([]interface{}); ok && len(vLifecycle) > 0 && vLifecycle[0] != nil {
-			lifecycle := &backup.Lifecycle{}
-
-			mLifecycle := vLifecycle[0].(map[string]interface{})
-
-			if vDeleteAfter, ok := mLifecycle["delete_after"].(int); ok && vDeleteAfter > 0 {
-				lifecycle.DeleteAfterDays = aws.Int64(int64(vDeleteAfter))
-			}
-			if vColdStorageAfter, ok := mLifecycle["cold_storage_after"].(int); ok && vColdStorageAfter > 0 {
-				lifecycle.MoveToColdStorageAfterDays = aws.Int64(int64(vColdStorageAfter))
-			}
-
-			rule.Lifecycle = lifecycle
+		if vLifecycle, ok := mRule["lifecycle"].([]interface{}); ok && len(vLifecycle) > 0 {
+			rule.Lifecycle = expandBackupPlanLifecycle(vLifecycle)
 		}
 
 		if vCopyActions := expandBackupPlanCopyActions(mRule["copy_action"].(*schema.Set).List()); len(vCopyActions) > 0 {
@@ -409,12 +397,7 @@ func flattenBackupPlanRules(rules []*backup.Rule) *schema.Set {
 		}
 
 		if lifecycle := rule.Lifecycle; lifecycle != nil {
-			mRule["lifecycle"] = []interface{}{
-				map[string]interface{}{
-					"delete_after":       int(aws.Int64Value(lifecycle.DeleteAfterDays)),
-					"cold_storage_after": int(aws.Int64Value(lifecycle.MoveToColdStorageAfterDays)),
-				},
-			}
+			mRule["lifecycle"] = flattenBackupPlanCopyActionLifecycle(lifecycle)
 		}
 
 		mRule["copy_action"] = flattenBackupPlanCopyActions(rule.CopyActions)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16583

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_backup_plan - remove validation for `delete_after`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsBackupPlan_'
--- PASS: TestAccAwsBackupPlan_disappears (40.75s)
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_CrossRegion (46.57s)
--- PASS: TestAccAwsBackupPlan_basic (47.20s)
--- PASS: TestAccAwsBackupPlan_AdvancedBackupSetting (50.51s)
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_Multiple (50.55s)
--- PASS: TestAccAwsBackupPlan_withRules (109.77s)
--- PASS: TestAccAwsBackupPlan_withRecoveryPointTags (111.09s)
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_NoLifecycle (112.12s)
--- PASS: TestAccAwsBackupPlan_withTags (112.96s)
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_SameRegion (115.59s)
--- PASS: TestAccAwsBackupPlan_withLifecycle (142.01s)
```
