### PR TITLE
increased max retention period for kinesis stream to 8760

### DIFF
--- a/aws/resource_aws_kinesis_stream.go
+++ b/aws/resource_aws_kinesis_stream.go
@@ -60,7 +60,7 @@ func resourceAwsKinesisStream() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      24,
-				ValidateFunc: validation.IntBetween(24, 168),
+				ValidateFunc: validation.IntBetween(24, 8760),
 			},
 
 			"shard_level_metrics": {

--- a/aws/resource_aws_kinesis_stream_test.go
+++ b/aws/resource_aws_kinesis_stream_test.go
@@ -293,7 +293,7 @@ func TestAccAWSKinesisStream_retentionPeriod(t *testing.T) {
 					testAccCheckKinesisStreamExists(resourceName, &stream),
 					testAccCheckAWSKinesisStreamAttributes(&stream),
 					resource.TestCheckResourceAttr(
-						resourceName, "retention_period", "100"),
+						resourceName, "retention_period", "8760"),
 				),
 			},
 
@@ -663,7 +663,7 @@ func testAccKinesisStreamConfigUpdateRetentionPeriod(rInt int) string {
 resource "aws_kinesis_stream" "test" {
   name             = "terraform-kinesis-test-%d"
   shard_count      = 2
-  retention_period = 100
+  retention_period = 8760
 
   tags = {
     Name = "tf-test"

--- a/website/docs/r/kinesis_stream.html.markdown
+++ b/website/docs/r/kinesis_stream.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `name` - (Required) A name to identify the stream. This is unique to the AWS account and region the Stream is created in.
 * `shard_count` – (Required) The number of shards that the stream will use.
 Amazon has guidelines for specifying the Stream size that should be referenced when creating a Kinesis stream. See [Amazon Kinesis Streams][2] for more.
-* `retention_period` - (Optional) Length of time data records are accessible after they are added to the stream. The maximum value of a stream's retention period is 168 hours. Minimum value is 24. Default is 24.
+* `retention_period` - (Optional) Length of time data records are accessible after they are added to the stream. The maximum value of a stream's retention period is 8760 hours. Minimum value is 24. Default is 24.
 * `shard_level_metrics` - (Optional) A list of shard-level CloudWatch metrics which can be enabled for the stream. See [Monitoring with CloudWatch][3] for more. Note that the value ALL should not be used; instead you should provide an explicit list of metrics you wish to enable.
 * `enforce_consumer_deletion` - (Optional) A boolean that indicates all registered consumers should be deregistered from the stream so that the stream can be destroyed without error. The default value is `false`.
 * `encryption_type` - (Optional) The encryption type to use. The only acceptable values are `NONE` or `KMS`. The default value is `NONE`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #16179

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_kinesis_stream: Added support for retention period up to 8760 hours.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAWSKinesisStream_retentionPeriod'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSKinesisStream_retentionPeriod -timeout 120m
=== RUN   TestAccAWSKinesisStream_retentionPeriod
=== PAUSE TestAccAWSKinesisStream_retentionPeriod
=== CONT  TestAccAWSKinesisStream_retentionPeriod
--- PASS: TestAccAWSKinesisStream_retentionPeriod (157.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       159.160s

...
```
