### PR TITLE
tests/res/security_group_rule: Fix hardcoded region

### DIFF
--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -679,7 +679,7 @@ func TestAccAWSSecurityGroupRule_PrefixListEgress(t *testing.T) {
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.egress", &group),
 					// lookup info on the VPC Endpoint created, to populate the expected
 					// IP Perm
-					testAccCheckVpcEndpointExists("aws_vpc_endpoint.s3-us-west-2", &endpoint),
+					testAccCheckVpcEndpointExists("aws_vpc_endpoint.s3_endpoint", &endpoint),
 					setupSG,
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, &p, "egress"),
 				),
@@ -1075,7 +1075,7 @@ func TestAccAWSSecurityGroupRule_MultiDescription(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.worker", &group),
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.nat", &nat),
-					testAccCheckVpcEndpointExists("aws_vpc_endpoint.s3-us-west-2", &endpoint),
+					testAccCheckVpcEndpointExists("aws_vpc_endpoint.s3_endpoint", &endpoint),
 
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.rule_1", &group, &rule1, "ingress"),
 					resource.TestCheckResourceAttr("aws_security_group_rule.rule_1", "description", "CIDR Description"),
@@ -1111,7 +1111,7 @@ func TestAccAWSSecurityGroupRule_MultiDescription(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.worker", &group),
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.nat", &nat),
-					testAccCheckVpcEndpointExists("aws_vpc_endpoint.s3-us-west-2", &endpoint),
+					testAccCheckVpcEndpointExists("aws_vpc_endpoint.s3_endpoint", &endpoint),
 
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.rule_1", &group, &rule1, "egress"),
 					resource.TestCheckResourceAttr("aws_security_group_rule.rule_1", "description", "CIDR Description"),
@@ -1588,9 +1588,11 @@ resource "aws_vpc" "tf_sgrule_description_test" {
   }
 }
 
-resource "aws_vpc_endpoint" "s3-us-west-2" {
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "s3_endpoint" {
   vpc_id       = aws_vpc.tf_sgrule_description_test.id
-  service_name = "com.amazonaws.us-west-2.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
 }
 
 resource "aws_security_group" "worker" {
@@ -1649,7 +1651,7 @@ resource "aws_security_group_rule" "rule_4" {
   protocol          = "tcp"
   from_port         = 22
   to_port           = 22
-  prefix_list_ids   = [aws_vpc_endpoint.s3-us-west-2.prefix_list_id]
+  prefix_list_ids   = [aws_vpc_endpoint.s3_endpoint.prefix_list_id]
 }
 `)
 	}
@@ -1798,7 +1800,6 @@ resource "aws_security_group_rule" "other_ingress" {
 }
 
 const testAccAWSSecurityGroupRulePrefixListEgressConfig = `
-
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
   cidr_block = "10.0.0.0/16"
 
@@ -1811,9 +1812,11 @@ resource "aws_route_table" "default" {
   vpc_id = aws_vpc.tf_sg_prefix_list_egress_test.id
 }
 
-resource "aws_vpc_endpoint" "s3-us-west-2" {
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "s3_endpoint" {
   vpc_id          = aws_vpc.tf_sg_prefix_list_egress_test.id
-  service_name    = "com.amazonaws.us-west-2.s3"
+  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
   route_table_ids = [aws_route_table.default.id]
 
   policy = <<POLICY
@@ -1843,7 +1846,7 @@ resource "aws_security_group_rule" "egress_1" {
   protocol          = "-1"
   from_port         = 0
   to_port           = 0
-  prefix_list_ids   = [aws_vpc_endpoint.s3-us-west-2.prefix_list_id]
+  prefix_list_ids   = [aws_vpc_endpoint.s3_endpoint.prefix_list_id]
   security_group_id = aws_security_group.egress.id
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Acceptance Tests in GovCloud (`us-gov-west-1`)

```
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (45.16s)
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (87.58s)
```

### Acceptance Tests in `us-west-2`

```
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (44.89s)
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (80.54s)
```
