### PR TITLE
aws_ami: gp3 volume scalable throughtput

### DIFF
--- a/aws/data_source_aws_ami.go
+++ b/aws/data_source_aws_ami.go
@@ -329,6 +329,7 @@ func amiBlockDeviceMappings(m []*ec2.BlockDeviceMapping) *schema.Set {
 				"delete_on_termination": fmt.Sprintf("%t", aws.BoolValue(v.Ebs.DeleteOnTermination)),
 				"encrypted":             fmt.Sprintf("%t", aws.BoolValue(v.Ebs.Encrypted)),
 				"iops":                  fmt.Sprintf("%d", aws.Int64Value(v.Ebs.Iops)),
+				"throughput":            fmt.Sprintf("%d", aws.Int64Value(v.Ebs.Throughput)),
 				"volume_size":           fmt.Sprintf("%d", aws.Int64Value(v.Ebs.VolumeSize)),
 				"snapshot_id":           aws.StringValue(v.Ebs.SnapshotId),
 				"volume_type":           aws.StringValue(v.Ebs.VolumeType),

--- a/aws/data_source_aws_ami_test.go
+++ b/aws/data_source_aws_ami_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -55,6 +56,7 @@ func TestAccAWSAmiDataSource_natInstance(t *testing.T) {
 		},
 	})
 }
+
 func TestAccAWSAmiDataSource_windowsInstance(t *testing.T) {
 	resourceName := "data.aws_ami.windows_ami"
 	resource.ParallelTest(t, resource.TestCase{
@@ -141,6 +143,37 @@ func TestAccAWSAmiDataSource_localNameFilter(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAmiDataSourceID("data.aws_ami.name_regex_filtered_ami"),
 					resource.TestMatchResourceAttr("data.aws_ami.name_regex_filtered_ami", "image_id", regexp.MustCompile("^ami-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAmiDataSource_Gp3BlockDevice(t *testing.T) {
+	resourceName := "aws_ami.test"
+	datasourceName := "data.aws_ami.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAmiDataSourceConfigGp3BlockDevice(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAmiDataSourceID(datasourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "architecture", resourceName, "architecture"),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "block_device_mappings.#", resourceName, "ebs_block_device.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "image_id", resourceName, "id"),
+					testAccCheckResourceAttrAccountID(datasourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "root_device_name", resourceName, "root_device_name"),
+					resource.TestCheckResourceAttr(datasourceName, "root_device_type", "ebs"),
+					resource.TestCheckResourceAttrPair(datasourceName, "root_snapshot_id", resourceName, "root_snapshot_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "sriov_net_support", resourceName, "sriov_net_support"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "virtualization_type", resourceName, "virtualization_type"),
 				),
 			},
 		},
@@ -234,3 +267,20 @@ data "aws_ami" "name_regex_filtered_ami" {
   name_regex = "^amzn-ami-min[a-z]{4}-hvm"
 }
 `
+
+func testAccAmiDataSourceConfigGp3BlockDevice(rName string) string {
+	return composeConfig(
+		testAccAmiConfigGp3BlockDevice(rName),
+		`
+data "aws_caller_identity" "current" {}
+
+data "aws_ami" "test" {
+  owners = [data.aws_caller_identity.current.account_id]
+
+  filter {
+    name   = "image-id"
+    values = [aws_ami.test.id]
+  }
+}
+`)
+}

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -591,6 +591,7 @@ func flattenAmiEbsBlockDeviceMappings(blockDeviceMappings []*ec2.BlockDeviceMapp
 				"encrypted":             aws.BoolValue(ebsBlockDevice.Encrypted),
 				"iops":                  int(aws.Int64Value(ebsBlockDevice.Iops)),
 				"snapshot_id":           aws.StringValue(ebsBlockDevice.SnapshotId),
+				"throughput":            int(aws.Int64Value(ebsBlockDevice.Throughput)),
 				"volume_size":           int(aws.Int64Value(ebsBlockDevice.VolumeSize)),
 				"volume_type":           aws.StringValue(ebsBlockDevice.VolumeType),
 			}

--- a/aws/resource_aws_ami_copy.go
+++ b/aws/resource_aws_ami_copy.go
@@ -67,6 +67,11 @@ func resourceAwsAmiCopy() *schema.Resource {
 							Computed: true,
 						},
 
+						"throughput": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
 						"volume_size": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -215,17 +220,16 @@ func resourceAwsAmiCopyCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	id := *res.ImageId
-	d.SetId(id)
+	d.SetId(aws.StringValue(res.ImageId))
 	d.Set("manage_ebs_snapshots", true)
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
-		if err := keyvaluetags.Ec2CreateTags(client, id, v); err != nil {
+		if err := keyvaluetags.Ec2CreateTags(client, d.Id(), v); err != nil {
 			return fmt.Errorf("error adding tags: %s", err)
 		}
 	}
 
-	_, err = resourceAwsAmiWaitForAvailable(d.Timeout(schema.TimeoutCreate), id, client)
+	_, err = resourceAwsAmiWaitForAvailable(d.Timeout(schema.TimeoutCreate), d.Id(), client)
 	if err != nil {
 		return err
 	}

--- a/aws/resource_aws_ami_test.go
+++ b/aws/resource_aws_ami_test.go
@@ -17,6 +17,7 @@ import (
 func TestAccAWSAMI_basic(t *testing.T) {
 	var ami ec2.Image
 	resourceName := "aws_ami.test"
+	snapshotResourceName := "aws_ebs_snapshot.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -25,15 +26,30 @@ func TestAccAWSAMI_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAmiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAmiConfigBasic(rName, 8),
+				Config: testAccAmiConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAmiExists(resourceName, &ami),
-					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`image/ami-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
+						"delete_on_termination": "true",
+						"device_name":           "/dev/sda1",
+						"encrypted":             "false",
+						"iops":                  "0",
+						"throughput":            "0",
+						"volume_size":           "8",
+						"volume_type":           "standard",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "ebs_block_device.*.snapshot_id", snapshotResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kernel_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/sda1"),
-					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
 					resource.TestMatchResourceAttr(resourceName, "root_snapshot_id", regexp.MustCompile("^snap-")),
+					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
+					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -52,6 +68,7 @@ func TestAccAWSAMI_basic(t *testing.T) {
 func TestAccAWSAMI_description(t *testing.T) {
 	var ami ec2.Image
 	resourceName := "aws_ami.test"
+	snapshotResourceName := "aws_ebs_snapshot.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	desc := acctest.RandomWithPrefix("desc")
 	descUpdated := acctest.RandomWithPrefix("desc-updated")
@@ -62,10 +79,31 @@ func TestAccAWSAMI_description(t *testing.T) {
 		CheckDestroy: testAccCheckAmiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAmiConfigDesc(rName, desc, 8),
+				Config: testAccAmiConfigDesc(rName, desc),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAmiExists(resourceName, &ami),
+					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`image/ami-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", desc),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
+						"delete_on_termination": "true",
+						"device_name":           "/dev/sda1",
+						"encrypted":             "false",
+						"iops":                  "0",
+						"throughput":            "0",
+						"volume_size":           "8",
+						"volume_type":           "standard",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "ebs_block_device.*.snapshot_id", snapshotResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kernel_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/sda1"),
+					resource.TestMatchResourceAttr(resourceName, "root_snapshot_id", regexp.MustCompile("^snap-")),
+					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
+					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -77,10 +115,31 @@ func TestAccAWSAMI_description(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAmiConfigDesc(rName, descUpdated, 8),
+				Config: testAccAmiConfigDesc(rName, descUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAmiExists(resourceName, &ami),
+					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`image/ami-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", descUpdated),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
+						"delete_on_termination": "true",
+						"device_name":           "/dev/sda1",
+						"encrypted":             "false",
+						"iops":                  "0",
+						"throughput":            "0",
+						"volume_size":           "8",
+						"volume_type":           "standard",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "ebs_block_device.*.snapshot_id", snapshotResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kernel_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/sda1"),
+					resource.TestMatchResourceAttr(resourceName, "root_snapshot_id", regexp.MustCompile("^snap-")),
+					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
+					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -98,7 +157,7 @@ func TestAccAWSAMI_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAmiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAmiConfigBasic(rName, 8),
+				Config: testAccAmiConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAmiExists(resourceName, &ami),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsAmi(), resourceName),
@@ -120,7 +179,7 @@ func TestAccAWSAMI_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAmiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAmiConfigTags1(rName, "key1", "value1", 8),
+				Config: testAccAmiConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAmiExists(resourceName, &ami),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -136,7 +195,7 @@ func TestAccAWSAMI_tags(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAmiConfigTags2(rName, "key1", "value1updated", "key2", "value2", 8),
+				Config: testAccAmiConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAmiExists(resourceName, &ami),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -145,53 +204,12 @@ func TestAccAWSAMI_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAmiConfigTags1(rName, "key2", "value2", 8),
+				Config: testAccAmiConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAmiExists(resourceName, &ami),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAMI_snapshotSize(t *testing.T) {
-	var ami ec2.Image
-	var bd ec2.BlockDeviceMapping
-	resourceName := "aws_ami.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	expectedDevice := &ec2.EbsBlockDevice{
-		DeleteOnTermination: aws.Bool(true),
-		Encrypted:           aws.Bool(false),
-		Iops:                aws.Int64(0),
-		VolumeSize:          aws.Int64(20),
-		VolumeType:          aws.String("standard"),
-	}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAmiDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAmiConfigBasic(rName, 20),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAmiExists(resourceName, &ami),
-					testAccCheckAmiBlockDevice(&ami, &bd, "/dev/sda1"),
-					testAccCheckAmiEbsBlockDevice(&bd, expectedDevice),
-					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"manage_ebs_snapshots",
-				},
 			},
 		},
 	})
@@ -270,80 +288,16 @@ func testAccCheckAmiExists(n string, ami *ec2.Image) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckAmiBlockDevice(ami *ec2.Image, blockDevice *ec2.BlockDeviceMapping, n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		devices := make(map[string]*ec2.BlockDeviceMapping)
-		for _, device := range ami.BlockDeviceMappings {
-			devices[*device.DeviceName] = device
-		}
-
-		// Check if the block device exists
-		if _, ok := devices[n]; !ok {
-			return fmt.Errorf("block device doesn't exist: %s", n)
-		}
-
-		*blockDevice = *devices[n]
-		return nil
-	}
-}
-
-func testAccCheckAmiEbsBlockDevice(bd *ec2.BlockDeviceMapping, ed *ec2.EbsBlockDevice) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// Test for things that ed has, don't care about unset values
-		cd := bd.Ebs
-		if ed.VolumeType != nil {
-			if *ed.VolumeType != *cd.VolumeType {
-				return fmt.Errorf("Volume type mismatch. Expected: %s Got: %s",
-					*ed.VolumeType, *cd.VolumeType)
-			}
-		}
-		if ed.DeleteOnTermination != nil {
-			if *ed.DeleteOnTermination != *cd.DeleteOnTermination {
-				return fmt.Errorf("DeleteOnTermination mismatch. Expected: %t Got: %t",
-					*ed.DeleteOnTermination, *cd.DeleteOnTermination)
-			}
-		}
-		if ed.Encrypted != nil {
-			if *ed.Encrypted != *cd.Encrypted {
-				return fmt.Errorf("Encrypted mismatch. Expected: %t Got: %t",
-					*ed.Encrypted, *cd.Encrypted)
-			}
-		}
-		// Integer defaults need to not be `0` so we don't get a panic
-		if ed.Iops != nil && *ed.Iops != 0 {
-			if *ed.Iops != *cd.Iops {
-				return fmt.Errorf("IOPS mismatch. Expected: %d Got: %d",
-					*ed.Iops, *cd.Iops)
-			}
-		}
-		if ed.VolumeSize != nil && *ed.VolumeSize != 0 {
-			if *ed.VolumeSize != *cd.VolumeSize {
-				return fmt.Errorf("Volume Size mismatch. Expected: %d Got: %d",
-					*ed.VolumeSize, *cd.VolumeSize)
-			}
-		}
-
-		return nil
-	}
-}
-
-func testAccAmiConfigBase(rName string, size int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+func testAccAmiConfigBase(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  size              = %d
+  size              = 8
 
   tags = {
-    Name = "%[2]s"
+    Name = %[1]q
   }
 }
 
@@ -351,15 +305,16 @@ resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
 
   tags = {
-    Name = "%[2]s"
+    Name = %[1]q
   }
 }
-
-`, size, rName)
+`, rName))
 }
 
-func testAccAmiConfigBasic(rName string, size int) string {
-	return testAccAmiConfigBase(rName, size) + fmt.Sprintf(`
+func testAccAmiConfigBasic(rName string) string {
+	return composeConfig(
+		testAccAmiConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_ami" "test" {
   ena_support         = true
   name                = %[1]q
@@ -371,11 +326,13 @@ resource "aws_ami" "test" {
     snapshot_id = aws_ebs_snapshot.test.id
   }
 }
-`, rName)
+`, rName))
 }
 
-func testAccAmiConfigDesc(rName, desc string, size int) string {
-	return testAccAmiConfigBase(rName, size) + fmt.Sprintf(`
+func testAccAmiConfigDesc(rName, desc string) string {
+	return composeConfig(
+		testAccAmiConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_ami" "test" {
   ena_support         = true
   name                = %[1]q
@@ -388,11 +345,13 @@ resource "aws_ami" "test" {
     snapshot_id = aws_ebs_snapshot.test.id
   }
 }
-`, rName, desc)
+`, rName, desc))
 }
 
-func testAccAmiConfigTags1(rName, tagKey1, tagValue1 string, size int) string {
-	return testAccAmiConfigBase(rName, size) + fmt.Sprintf(`
+func testAccAmiConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return composeConfig(
+		testAccAmiConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_ami" "test" {
   ena_support         = true
   name                = %[1]q
@@ -408,11 +367,13 @@ resource "aws_ami" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccAmiConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string, size int) string {
-	return testAccAmiConfigBase(rName, size) + fmt.Sprintf(`
+func testAccAmiConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return composeConfig(
+		testAccAmiConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_ami" "test" {
   ena_support         = true
   name                = %[1]q
@@ -429,5 +390,5 @@ resource "aws_ami" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -82,6 +82,7 @@ interpolation.
     not a provisioned IOPS image, otherwise the supported IOPS count.
     * `block_device_mappings.#.ebs.snapshot_id` - The ID of the snapshot.
     * `block_device_mappings.#.ebs.volume_size` - The size of the volume, in GiB.
+    * `block_device_mappings.#.ebs.throughput` - The throughput that the EBS volume supports, in MiB/s.
     * `block_device_mappings.#.ebs.volume_type` - The volume type.
     * `block_device_mappings.#.no_device` - Suppresses the specified device
     included in the block device mapping of the AMI.

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -74,16 +74,16 @@ Nested `ebs_block_device` blocks have the following structure:
 * `delete_on_termination` - (Optional) Boolean controlling whether the EBS volumes created to
   support each created instance will be deleted once that instance is terminated.
 * `encrypted` - (Optional) Boolean controlling whether the created EBS volumes will be encrypted. Can't be used with `snapshot_id`.
-* `iops` - (Required only when `volume_type` is "io1/io2") Number of I/O operations per second the
+* `iops` - (Required only when `volume_type` is `io1` or `io2`) Number of I/O operations per second the
   created volumes will support.
 * `snapshot_id` - (Optional) The id of an EBS snapshot that will be used to initialize the created
   EBS volumes. If set, the `volume_size` attribute must be at least as large as the referenced
   snapshot.
+* `throughput` - (Optional) The throughput that the EBS volume supports, in MiB/s. Only valid for `volume_type` of `gp3`.
 * `volume_size` - (Required unless `snapshot_id` is set) The size of created volumes in GiB.
   If `snapshot_id` is set and `volume_size` is omitted then the volume will have the same size
   as the selected snapshot.
-* `volume_type` - (Optional) The type of EBS volume to create. Can be one of "standard" (the
-  default), "io1", "io2" or "gp2".
+* `volume_type` - (Optional) The type of EBS volume to create. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `standard`).
 * `kms_key_id` - (Optional) The full ARN of the AWS Key Management Service (AWS KMS) CMK to use when encrypting the snapshots of
 an image during a copy operation. This parameter is only required if you want to use a non-default CMK;
 if this parameter is not specified, the default CMK for EBS is used


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16514.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ami: Support `volume_type` value of `gp3`. Add `throughput` attribute to `ebs_block_device` configuration.
data-source/aws_ami: Add `throughput` value to `block_device_mappings.ebs` mapping.
resource/aws_ami_copy: Add `throughput` attribute to `ebs_block_device` configuration.
resource/aws_ami_from_instance: Add `throughput` attribute to `ebs_block_device` configuration.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAMI_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAMI_ -timeout 120m
=== RUN   TestAccAWSAMI_basic
=== PAUSE TestAccAWSAMI_basic
=== RUN   TestAccAWSAMI_description
=== PAUSE TestAccAWSAMI_description
=== RUN   TestAccAWSAMI_disappears
=== PAUSE TestAccAWSAMI_disappears
=== RUN   TestAccAWSAMI_EphemeralBlockDevices
=== PAUSE TestAccAWSAMI_EphemeralBlockDevices
=== RUN   TestAccAWSAMI_Gp3BlockDevice
=== PAUSE TestAccAWSAMI_Gp3BlockDevice
=== RUN   TestAccAWSAMI_tags
=== PAUSE TestAccAWSAMI_tags
=== CONT  TestAccAWSAMI_description
=== CONT  TestAccAWSAMI_basic
=== CONT  TestAccAWSAMI_Gp3BlockDevice
=== CONT  TestAccAWSAMI_tags
=== CONT  TestAccAWSAMI_EphemeralBlockDevices
=== CONT  TestAccAWSAMI_disappears
--- PASS: TestAccAWSAMI_description (57.76s)
--- PASS: TestAccAWSAMI_disappears (61.16s)
--- PASS: TestAccAWSAMI_EphemeralBlockDevices (64.17s)
--- PASS: TestAccAWSAMI_basic (64.66s)
--- PASS: TestAccAWSAMI_Gp3BlockDevice (65.80s)
--- PASS: TestAccAWSAMI_tags (86.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	86.928s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAmiDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAmiDataSource_ -timeout 120m
=== RUN   TestAccAWSAmiDataSource_natInstance
=== PAUSE TestAccAWSAmiDataSource_natInstance
=== RUN   TestAccAWSAmiDataSource_windowsInstance
=== PAUSE TestAccAWSAmiDataSource_windowsInstance
=== RUN   TestAccAWSAmiDataSource_instanceStore
=== PAUSE TestAccAWSAmiDataSource_instanceStore
=== RUN   TestAccAWSAmiDataSource_localNameFilter
=== PAUSE TestAccAWSAmiDataSource_localNameFilter
=== RUN   TestAccAWSAmiDataSource_Gp3BlockDevice
=== PAUSE TestAccAWSAmiDataSource_Gp3BlockDevice
=== CONT  TestAccAWSAmiDataSource_natInstance
=== CONT  TestAccAWSAmiDataSource_localNameFilter
=== CONT  TestAccAWSAmiDataSource_Gp3BlockDevice
=== CONT  TestAccAWSAmiDataSource_instanceStore
=== CONT  TestAccAWSAmiDataSource_windowsInstance
--- PASS: TestAccAWSAmiDataSource_natInstance (16.66s)
--- PASS: TestAccAWSAmiDataSource_instanceStore (16.93s)
--- PASS: TestAccAWSAmiDataSource_windowsInstance (17.75s)
--- PASS: TestAccAWSAmiDataSource_localNameFilter (18.27s)
--- PASS: TestAccAWSAmiDataSource_Gp3BlockDevice (56.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	56.257s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAMICopy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAMICopy_ -timeout 120m
=== RUN   TestAccAWSAMICopy_basic
=== PAUSE TestAccAWSAMICopy_basic
=== RUN   TestAccAWSAMICopy_Description
=== PAUSE TestAccAWSAMICopy_Description
=== RUN   TestAccAWSAMICopy_EnaSupport
=== PAUSE TestAccAWSAMICopy_EnaSupport
=== RUN   TestAccAWSAMICopy_tags
=== PAUSE TestAccAWSAMICopy_tags
=== CONT  TestAccAWSAMICopy_basic
=== CONT  TestAccAWSAMICopy_tags
=== CONT  TestAccAWSAMICopy_EnaSupport
=== CONT  TestAccAWSAMICopy_Description
--- PASS: TestAccAWSAMICopy_EnaSupport (385.38s)
--- PASS: TestAccAWSAMICopy_basic (386.46s)
--- PASS: TestAccAWSAMICopy_Description (397.85s)
--- PASS: TestAccAWSAMICopy_tags (411.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	411.151s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAMIFromInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAMIFromInstance_ -timeout 120m
=== RUN   TestAccAWSAMIFromInstance_basic
=== PAUSE TestAccAWSAMIFromInstance_basic
=== RUN   TestAccAWSAMIFromInstance_tags
=== PAUSE TestAccAWSAMIFromInstance_tags
=== CONT  TestAccAWSAMIFromInstance_basic
=== CONT  TestAccAWSAMIFromInstance_tags
--- PASS: TestAccAWSAMIFromInstance_basic (243.32s)
--- PASS: TestAccAWSAMIFromInstance_tags (302.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	303.062s
```
