### PR TITLE
ds/partition: Add reverse DNS prefix

### DIFF
--- a/aws/data_source_aws_partition.go
+++ b/aws/data_source_aws_partition.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"log"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -15,7 +17,13 @@ func dataSourceAwsPartition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"dns_suffix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"service_prefix": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -34,6 +42,12 @@ func dataSourceAwsPartitionRead(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] Setting AWS URL Suffix to %s.", client.dnsSuffix)
 	d.Set("dns_suffix", meta.(*AWSClient).dnsSuffix)
+
+	dnsParts := strings.Split(meta.(*AWSClient).dnsSuffix, ".")
+	sort.Sort(sort.Reverse(sort.StringSlice(dnsParts)))
+	servicePrefix := strings.Join(dnsParts, ".")
+	d.Set("service_prefix", servicePrefix)
+	log.Printf("[DEBUG] Setting service prefix to %s.", servicePrefix)
 
 	return nil
 }

--- a/aws/data_source_aws_partition.go
+++ b/aws/data_source_aws_partition.go
@@ -23,7 +23,7 @@ func dataSourceAwsPartition() *schema.Resource {
 				Computed: true,
 			},
 
-			"service_prefix": {
+			"reverse_dns_prefix": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -46,7 +46,7 @@ func dataSourceAwsPartitionRead(d *schema.ResourceData, meta interface{}) error 
 	dnsParts := strings.Split(meta.(*AWSClient).dnsSuffix, ".")
 	sort.Sort(sort.Reverse(sort.StringSlice(dnsParts)))
 	servicePrefix := strings.Join(dnsParts, ".")
-	d.Set("service_prefix", servicePrefix)
+	d.Set("reverse_dns_prefix", servicePrefix)
 	log.Printf("[DEBUG] Setting service prefix to %s.", servicePrefix)
 
 	return nil

--- a/aws/data_source_aws_partition_test.go
+++ b/aws/data_source_aws_partition_test.go
@@ -18,6 +18,7 @@ func TestAccAWSPartition_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsPartition("data.aws_partition.current"),
 					testAccCheckAwsDnsSuffix("data.aws_partition.current"),
+					resource.TestCheckResourceAttr("data.aws_partition.current", "service_prefix", testAccGetPartitionReverseDNSPrefix()),
 				),
 			},
 		},

--- a/aws/data_source_aws_partition_test.go
+++ b/aws/data_source_aws_partition_test.go
@@ -18,7 +18,7 @@ func TestAccAWSPartition_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsPartition("data.aws_partition.current"),
 					testAccCheckAwsDnsSuffix("data.aws_partition.current"),
-					resource.TestCheckResourceAttr("data.aws_partition.current", "service_prefix", testAccGetPartitionReverseDNSPrefix()),
+					resource.TestCheckResourceAttr("data.aws_partition.current", "reverse_dns_prefix", testAccGetPartitionReverseDNSPrefix()),
 				),
 			},
 		},

--- a/website/docs/d/partition.html.markdown
+++ b/website/docs/d/partition.html.markdown
@@ -40,3 +40,4 @@ There are no arguments available for this data source.
 * `dns_suffix` - Base DNS domain name for the current partition (e.g. `amazonaws.com` in AWS Commercial, `amazonaws.com.cn` in AWS China).
 * `id` - Identifier of the current partition (e.g. `aws` in AWS Commercial, `aws-cn` in AWS China).
 * `partition` - Identifier of the current partition (e.g. `aws` in AWS Commercial, `aws-cn` in AWS China).
+* `service_prefix` - Prefix of service names (e.g. `com.amazonaws` in AWS Commercial, `cn.com.amazonaws` in AWS China).

--- a/website/docs/d/partition.html.markdown
+++ b/website/docs/d/partition.html.markdown
@@ -40,4 +40,4 @@ There are no arguments available for this data source.
 * `dns_suffix` - Base DNS domain name for the current partition (e.g. `amazonaws.com` in AWS Commercial, `amazonaws.com.cn` in AWS China).
 * `id` - Identifier of the current partition (e.g. `aws` in AWS Commercial, `aws-cn` in AWS China).
 * `partition` - Identifier of the current partition (e.g. `aws` in AWS Commercial, `aws-cn` in AWS China).
-* `service_prefix` - Prefix of service names (e.g. `com.amazonaws` in AWS Commercial, `cn.com.amazonaws` in AWS China).
+* `reverse_dns_prefix` - Prefix of service names (e.g. `com.amazonaws` in AWS Commercial, `cn.com.amazonaws` in AWS China).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16639

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_partition: Add `reverse_dns_prefix` attribute (#16638)
```

### Acceptance Tests in GovCloud (`us-gov-west-1`)

```
--- PASS: TestAccAWSPartition_basic (14.28s)
```

### Acceptance Tests in `us-west-2`

```
--- PASS: TestAccAWSPartition_basic (11.16s)
```

### Acceptance Tests in `us-east-1`

```
--- PASS: TestAccAWSPartition_basic (10.02s)
```
