### PR TITLE
aws_launch_template: gp3 volume scalable throughput

### DIFF
--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -79,6 +79,10 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"throughput": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
 									"volume_size": {
 										Type:     schema.TypeInt,
 										Computed: true,

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -133,6 +133,12 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
+									"throughput": {
+										Type:         schema.TypeInt,
+										Computed:     true,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(125, 1000),
+									},
 									"volume_size": {
 										Type:     schema.TypeInt,
 										Optional: true,
@@ -929,6 +935,9 @@ func getBlockDeviceMappings(m []*ec2.LaunchTemplateBlockDeviceMapping) []interfa
 			if v.Ebs.SnapshotId != nil {
 				ebs["snapshot_id"] = aws.StringValue(v.Ebs.SnapshotId)
 			}
+			if v.Ebs.Throughput != nil {
+				ebs["throughput"] = aws.Int64Value(v.Ebs.Throughput)
+			}
 
 			mapping["ebs"] = []interface{}{ebs}
 		}
@@ -1494,6 +1503,10 @@ func readEbsBlockDeviceFromConfig(ebs map[string]interface{}) (*ec2.LaunchTempla
 
 	if v := ebs["snapshot_id"].(string); v != "" {
 		ebsDevice.SnapshotId = aws.String(v)
+	}
+
+	if v := ebs["throughput"].(int); v > 0 {
+		ebsDevice.Throughput = aws.Int64(int64(v))
 	}
 
 	if v := ebs["volume_size"]; v != nil {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -143,6 +143,7 @@ func TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.device_name", "/dev/xvda"),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.throughput", "0"),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.volume_size", "15"),
 				),
 			},
@@ -185,6 +186,38 @@ func TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination(t *tes
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.delete_on_termination", "false"),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.volume_size", "15"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_Gp3(t *testing.T) {
+	var template ec2.LaunchTemplate
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_launch_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_BlockDeviceMappings_EBS_Gp3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.device_name", "/dev/xvda"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.iops", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.throughput", "500"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.volume_size", "15"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.volume_type", "gp3"),
 				),
 			},
 			{
@@ -1268,6 +1301,46 @@ resource "aws_autoscaling_group" "test" {
   }
 }
 `, rName, deleteOnTermination))
+}
+
+func testAccAWSLaunchTemplateConfig_BlockDeviceMappings_EBS_Gp3(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableAZsNoOptInConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  name          = %[1]q
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      iops        = 4000
+      throughput  = 500
+      volume_size = 15
+      volume_type = "gp3"
+    }
+  }
+}
+
+# Creating an AutoScaling Group verifies the launch template
+# ValidationError: You must use a valid fully-formed launch template. the encrypted flag cannot be specified since device /dev/sda1 has a snapshot specified.
+resource "aws_autoscaling_group" "test" {
+  availability_zones = [data.aws_availability_zones.available.names[0]]
+  desired_capacity   = 0
+  max_size           = 0
+  min_size           = 0
+  name               = %[1]q
+
+  launch_template {
+    id      = aws_launch_template.test.id
+    version = aws_launch_template.test.default_version
+  }
+}
+`, rName))
 }
 
 func testAccAWSLaunchTemplateConfig_NetworkInterfaces_DeleteOnTermination(rName string, deleteOnTermination string) string {

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -179,8 +179,9 @@ The `ebs` block supports the following:
 * `kms_key_id` - The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume.
  `encrypted` must be set to `true` when this is set.
 * `snapshot_id` - The Snapshot ID to mount.
+* `thoughput` - The throughput to provision for a `gp3` volume, with a maximum of 1,000 MiB/s.
 * `volume_size` - The size of the volume in gigabytes.
-* `volume_type` - The type of volume. Can be `"standard"`, `"gp2"`, `"io1"` or `"io2"`. (Default: `"standard"`).
+* `volume_type` - The volume type. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
 
 ### Capacity Reservation Specification
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16514.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_launch_template: Support `volume_type` value of `gp3`. Add `throughput` attribute to `block_device_mappings.ebs` configuration block.
data-source/aws_launch_template: Add `throughput` attribute to `block_device_mappings.ebs` configuration block.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_Gp3
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_Gp3
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_Gp3
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_Gp3 (35.81s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (35.94s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (68.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	68.946s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchTemplateDataSource_' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplateDataSource_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_tags
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_tags
=== RUN   TestAccAWSLaunchTemplateDataSource_metadataOptions
=== PAUSE TestAccAWSLaunchTemplateDataSource_metadataOptions
=== RUN   TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== PAUSE TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== RUN   TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== PAUSE TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== RUN   TestAccAWSLaunchTemplateDataSource_NonExistent
=== PAUSE TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== CONT  TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_basic
=== CONT  TestAccAWSLaunchTemplateDataSource_metadataOptions
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_tags
=== CONT  TestAccAWSLaunchTemplateDataSource_basic
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (4.66s)
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (22.81s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_basic (23.91s)
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (24.09s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_tags (25.09s)
--- PASS: TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination (47.45s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (48.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.749s
```
