### PR TITLE
semgrep: add rule to remove extraneous value wrapping in d.Set()

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -228,6 +228,7 @@ rules:
     severity: WARNING
 
   - id: helper-schema-ResourceData-Set-extraneous-value-pointer-conversion
+    fix: d.Set($ATTRIBUTE, $APIOBJECT)
     languages: [go]
     message: AWS Go SDK pointer conversion function for `d.Set()` value is extraneous
     paths:

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -195,7 +195,7 @@ rules:
         - aws/
     pattern: schema.NewSet(schema.HashString, flattenStringList($APIOBJECT))
     severity: WARNING
-    
+
   - id: helper-schema-Set-extraneous-expandStringList-with-List
     languages: [go]
     message: Prefer `expandStringSet()` function for casting a set to a list of string pointers
@@ -225,6 +225,22 @@ rules:
         - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(int) > 0 { $BODY }
         - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(string) != "" { $BODY }
         - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && len($VALUE.(string)) > 0 { $BODY }
+    severity: WARNING
+
+  - id: helper-schema-ResourceData-Set-extraneous-value-pointer-conversion
+    languages: [go]
+    message: AWS Go SDK pointer conversion function for `d.Set()` value is extraneous
+    paths:
+      include:
+        - aws/
+    patterns:
+      - pattern-either:
+          - pattern: d.Set($ATTRIBUTE, aws.BoolValue($APIOBJECT))
+          - pattern: d.Set($ATTRIBUTE, aws.Float64Value($APIOBJECT))
+          - pattern: d.Set($ATTRIBUTE, aws.IntValue($APIOBJECT))
+          - pattern: d.Set($ATTRIBUTE, aws.Int64Value($APIOBJECT))
+          - pattern: d.Set($ATTRIBUTE, int(aws.Int64Value($APIOBJECT)))
+          - pattern: d.Set($ATTRIBUTE, aws.StringValue($APIOBJECT))
     severity: WARNING
 
   - id: helper-schema-ResourceData-SetId-empty-without-IsNewResource-check


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Preceded by #16655 
Preceded by #16671 
Closes #16554 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
N/A
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
CI should not report warnings in main branch
```
