### PR TITLE
aws_spot_fleet_request: gp3 volume scalable throughput 

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -118,6 +118,12 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Computed: true,
 										ForceNew: true,
 									},
+									"throughput": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
 									"volume_size": {
 										Type:     schema.TypeInt,
 										Optional: true,
@@ -187,6 +193,12 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 									},
 									"kms_key_id": {
 										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"throughput": {
+										Type:     schema.TypeInt,
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
@@ -706,6 +718,10 @@ func readSpotFleetBlockDeviceMappingsFromConfig(
 				ebs.Iops = aws.Int64(int64(v))
 			}
 
+			if v, ok := bd["throughput"].(int); ok && v > 0 {
+				ebs.Throughput = aws.Int64(int64(v))
+			}
+
 			blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
 				DeviceName: aws.String(bd["device_name"].(string)),
 				Ebs:        ebs,
@@ -753,6 +769,10 @@ func readSpotFleetBlockDeviceMappingsFromConfig(
 
 			if v, ok := bd["iops"].(int); ok && v > 0 {
 				ebs.Iops = aws.Int64(int64(v))
+			}
+
+			if v, ok := bd["throughput"].(int); ok && v > 0 {
+				ebs.Throughput = aws.Int64(int64(v))
 			}
 
 			if dn, err := fetchRootDeviceName(d["ami"].(string), conn); err == nil {
@@ -1475,6 +1495,10 @@ func ebsBlockDevicesToSet(bdm []*ec2.BlockDeviceMapping, rootDevName *string) *s
 				m["iops"] = aws.Int64Value(ebs.Iops)
 			}
 
+			if ebs.Throughput != nil {
+				m["throughput"] = aws.Int64Value(ebs.Throughput)
+			}
+
 			set.Add(m)
 		}
 	}
@@ -1533,6 +1557,10 @@ func rootBlockDeviceToSet(
 
 				if val.Ebs.Iops != nil {
 					m["iops"] = aws.Int64Value(val.Ebs.Iops)
+				}
+
+				if val.Ebs.Throughput != nil {
+					m["throughput"] = aws.Int64Value(val.Ebs.Throughput)
 				}
 
 				set.Add(m)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16514.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_spot_fleet_request: Support `volume_type` value of `gp3`. Add `throughput` attribute to `launch_specification.ebs_block_device` and `launch_specification.root_block_device` configuration blocks.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDeviceGp3\|TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDeviceGp3'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDeviceGp3\|TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDeviceGp3 -timeout 120m
=== RUN   TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDeviceGp3
=== PAUSE TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDeviceGp3
=== RUN   TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDeviceGp3
=== PAUSE TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDeviceGp3
=== CONT  TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDeviceGp3
=== CONT  TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDeviceGp3
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDeviceGp3 (124.58s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDeviceGp3 (124.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	124.908s
```
