### PR TITLE
tech-debt/data-sources: autofix extraneous value conversion for d.Set() of primitives

### DIFF
--- a/aws/cloudfront_cache_policy_structure.go
+++ b/aws/cloudfront_cache_policy_structure.go
@@ -224,10 +224,10 @@ func setParametersConfig(parametersConfig *cloudfront.ParametersInCacheKeyAndFor
 }
 
 func setCloudFrontCachePolicy(d *schema.ResourceData, cachePolicy *cloudfront.CachePolicyConfig) {
-	d.Set("comment", aws.StringValue(cachePolicy.Comment))
-	d.Set("default_ttl", aws.Int64Value(cachePolicy.DefaultTTL))
-	d.Set("max_ttl", aws.Int64Value(cachePolicy.MaxTTL))
-	d.Set("min_ttl", aws.Int64Value(cachePolicy.MinTTL))
-	d.Set("name", aws.StringValue(cachePolicy.Name))
+	d.Set("comment", cachePolicy.Comment)
+	d.Set("default_ttl", cachePolicy.DefaultTTL)
+	d.Set("max_ttl", cachePolicy.MaxTTL)
+	d.Set("min_ttl", cachePolicy.MinTTL)
+	d.Set("name", cachePolicy.Name)
 	d.Set("parameters_in_cache_key_and_forwarded_to_origin", setParametersConfig(cachePolicy.ParametersInCacheKeyAndForwardedToOrigin))
 }

--- a/aws/data_source_aws_acmpca_certificate.go
+++ b/aws/data_source_aws_acmpca_certificate.go
@@ -53,8 +53,8 @@ func dataSourceAwsAcmpcaCertificateRead(d *schema.ResourceData, meta interface{}
 	}
 
 	d.SetId(certificateArn)
-	d.Set("certificate", aws.StringValue(certificateOutput.Certificate))
-	d.Set("certificate_chain", aws.StringValue(certificateOutput.CertificateChain))
+	d.Set("certificate", certificateOutput.Certificate)
+	d.Set("certificate_chain", certificateOutput.CertificateChain)
 
 	return nil
 }

--- a/aws/data_source_aws_cloudfront_cache_policy.go
+++ b/aws/data_source_aws_cloudfront_cache_policy.go
@@ -156,7 +156,7 @@ func dataSourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interfa
 		if err != nil {
 			return fmt.Errorf("unable to retrieve cache policy with ID %s: %s", d.Id(), err.Error())
 		}
-		d.Set("etag", aws.StringValue(resp.ETag))
+		d.Set("etag", resp.ETag)
 
 		setCloudFrontCachePolicy(d, resp.CachePolicy.CachePolicyConfig)
 	}

--- a/aws/data_source_aws_cloudfront_origin_request_policy.go
+++ b/aws/data_source_aws_cloudfront_origin_request_policy.go
@@ -131,11 +131,11 @@ func dataSourceAwsCloudFrontOriginRequestPolicyRead(d *schema.ResourceData, meta
 			return nil
 		}
 
-		d.Set("etag", aws.StringValue(resp.ETag))
+		d.Set("etag", resp.ETag)
 
 		originRequestPolicy := resp.OriginRequestPolicy.OriginRequestPolicyConfig
-		d.Set("comment", aws.StringValue(originRequestPolicy.Comment))
-		d.Set("name", aws.StringValue(originRequestPolicy.Name))
+		d.Set("comment", originRequestPolicy.Comment)
+		d.Set("name", originRequestPolicy.Name)
 		d.Set("cookies_config", flattenCloudFrontOriginRequestPolicyCookiesConfig(originRequestPolicy.CookiesConfig))
 		d.Set("headers_config", flattenCloudFrontOriginRequestPolicyHeadersConfig(originRequestPolicy.HeadersConfig))
 		d.Set("query_strings_config", flattenCloudFrontOriginRequestPolicyQueryStringsConfig(originRequestPolicy.QueryStringsConfig))

--- a/aws/data_source_aws_codeartifact_authorization_token.go
+++ b/aws/data_source_aws_codeartifact_authorization_token.go
@@ -71,7 +71,7 @@ func dataSourceAwsCodeArtifactAuthorizationTokenRead(d *schema.ResourceData, met
 	log.Printf("[DEBUG] CodeArtifact authorization token: %#v", out)
 
 	d.SetId(fmt.Sprintf("%s:%s", domainOwner, domain))
-	d.Set("authorization_token", aws.StringValue(out.AuthorizationToken))
+	d.Set("authorization_token", out.AuthorizationToken)
 	d.Set("expiration", aws.TimeValue(out.Expiration).Format(time.RFC3339))
 	d.Set("domain_owner", domainOwner)
 

--- a/aws/data_source_aws_directory_service_directory.go
+++ b/aws/data_source_aws_directory_service_directory.go
@@ -187,7 +187,7 @@ func dataSourceAwsDirectoryServiceDirectoryRead(d *schema.ResourceData, meta int
 	} else {
 		securityGroupId = dir.VpcSettings.SecurityGroupId
 	}
-	d.Set("security_group_id", aws.StringValue(securityGroupId))
+	d.Set("security_group_id", securityGroupId)
 
 	tags, err := keyvaluetags.DirectoryserviceListTags(conn, d.Id())
 	if err != nil {

--- a/aws/data_source_aws_dx_gateway.go
+++ b/aws/data_source_aws_dx_gateway.go
@@ -65,7 +65,7 @@ func dataSourceAwsDxGatewayRead(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId(aws.StringValue(gateway.DirectConnectGatewayId))
 	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(gateway.AmazonSideAsn), 10))
-	d.Set("owner_account_id", aws.StringValue(gateway.OwnerAccount))
+	d.Set("owner_account_id", gateway.OwnerAccount)
 
 	return nil
 }

--- a/aws/data_source_aws_ec2_transit_gateway.go
+++ b/aws/data_source_aws_ec2_transit_gateway.go
@@ -110,7 +110,7 @@ func dataSourceAwsEc2TransitGatewayRead(d *schema.ResourceData, meta interface{}
 		return errors.New("error reading EC2 Transit Gateway: missing options")
 	}
 
-	d.Set("amazon_side_asn", aws.Int64Value(transitGateway.Options.AmazonSideAsn))
+	d.Set("amazon_side_asn", transitGateway.Options.AmazonSideAsn)
 	d.Set("arn", transitGateway.TransitGatewayArn)
 	d.Set("association_default_route_table_id", transitGateway.Options.AssociationDefaultRouteTableId)
 	d.Set("auto_accept_shared_attachments", transitGateway.Options.AutoAcceptSharedAttachments)

--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
@@ -89,8 +89,8 @@ func dataSourceAwsEc2TransitGatewayDxGatewayAttachmentRead(d *schema.ResourceDat
 		return fmt.Errorf("error setting tags: %w", err)
 	}
 
-	d.Set("transit_gateway_id", aws.StringValue(transitGatewayAttachment.TransitGatewayId))
-	d.Set("dx_gateway_id", aws.StringValue(transitGatewayAttachment.ResourceId))
+	d.Set("transit_gateway_id", transitGatewayAttachment.TransitGatewayId)
+	d.Set("dx_gateway_id", transitGatewayAttachment.ResourceId)
 
 	d.SetId(aws.StringValue(transitGatewayAttachment.TransitGatewayAttachmentId))
 

--- a/aws/data_source_aws_ec2_transit_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table.go
@@ -79,14 +79,14 @@ func dataSourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta i
 		return errors.New("error reading EC2 Transit Gateway Route Table: empty result")
 	}
 
-	d.Set("default_association_route_table", aws.BoolValue(transitGatewayRouteTable.DefaultAssociationRouteTable))
-	d.Set("default_propagation_route_table", aws.BoolValue(transitGatewayRouteTable.DefaultPropagationRouteTable))
+	d.Set("default_association_route_table", transitGatewayRouteTable.DefaultAssociationRouteTable)
+	d.Set("default_propagation_route_table", transitGatewayRouteTable.DefaultPropagationRouteTable)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayRouteTable.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
 
-	d.Set("transit_gateway_id", aws.StringValue(transitGatewayRouteTable.TransitGatewayId))
+	d.Set("transit_gateway_id", transitGatewayRouteTable.TransitGatewayId)
 
 	d.SetId(aws.StringValue(transitGatewayRouteTable.TransitGatewayRouteTableId))
 

--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
@@ -107,9 +107,9 @@ func dataSourceAwsEc2TransitGatewayVpcAttachmentRead(d *schema.ResourceData, met
 		return fmt.Errorf("error setting tags: %w", err)
 	}
 
-	d.Set("transit_gateway_id", aws.StringValue(transitGatewayVpcAttachment.TransitGatewayId))
-	d.Set("vpc_id", aws.StringValue(transitGatewayVpcAttachment.VpcId))
-	d.Set("vpc_owner_id", aws.StringValue(transitGatewayVpcAttachment.VpcOwnerId))
+	d.Set("transit_gateway_id", transitGatewayVpcAttachment.TransitGatewayId)
+	d.Set("vpc_id", transitGatewayVpcAttachment.VpcId)
+	d.Set("vpc_owner_id", transitGatewayVpcAttachment.VpcOwnerId)
 
 	d.SetId(aws.StringValue(transitGatewayVpcAttachment.TransitGatewayAttachmentId))
 

--- a/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
@@ -89,8 +89,8 @@ func dataSourceAwsEc2TransitGatewayVpnAttachmentRead(d *schema.ResourceData, met
 		return fmt.Errorf("error setting tags: %w", err)
 	}
 
-	d.Set("transit_gateway_id", aws.StringValue(transitGatewayAttachment.TransitGatewayId))
-	d.Set("vpn_connection_id", aws.StringValue(transitGatewayAttachment.ResourceId))
+	d.Set("transit_gateway_id", transitGatewayAttachment.TransitGatewayId)
+	d.Set("vpn_connection_id", transitGatewayAttachment.ResourceId)
 
 	d.SetId(aws.StringValue(transitGatewayAttachment.TransitGatewayAttachmentId))
 

--- a/aws/data_source_aws_ecr_image.go
+++ b/aws/data_source_aws_ecr_image.go
@@ -98,18 +98,10 @@ func dataSourceAwsEcrImageRead(d *schema.ResourceData, meta interface{}) error {
 	image := imageDetails[0]
 
 	d.SetId(aws.StringValue(image.ImageDigest))
-	if err = d.Set("registry_id", aws.StringValue(image.RegistryId)); err != nil {
-		return fmt.Errorf("failed to set registry_id: %w", err)
-	}
-	if err = d.Set("image_digest", aws.StringValue(image.ImageDigest)); err != nil {
-		return fmt.Errorf("failed to set image_digest: %w", err)
-	}
-	if err = d.Set("image_pushed_at", image.ImagePushedAt.Unix()); err != nil {
-		return fmt.Errorf("failed to set image_pushed_at: %w", err)
-	}
-	if err = d.Set("image_size_in_bytes", aws.Int64Value(image.ImageSizeInBytes)); err != nil {
-		return fmt.Errorf("failed to set image_size_in_bytes: %w", err)
-	}
+	d.Set("registry_id", image.RegistryId)
+	d.Set("image_digest", image.ImageDigest)
+	d.Set("image_pushed_at", image.ImagePushedAt.Unix())
+	d.Set("image_size_in_bytes", image.ImageSizeInBytes)
 	if err := d.Set("image_tags", aws.StringValueSlice(image.ImageTags)); err != nil {
 		return fmt.Errorf("failed to set image_tags: %w", err)
 	}

--- a/aws/data_source_aws_ecs_container_definition.go
+++ b/aws/data_source_aws_ecs_container_definition.go
@@ -86,15 +86,15 @@ func dataSourceAwsEcsContainerDefinitionRead(d *schema.ResourceData, meta interf
 		}
 
 		d.SetId(fmt.Sprintf("%s/%s", aws.StringValue(taskDefinition.TaskDefinitionArn), d.Get("container_name").(string)))
-		d.Set("image", aws.StringValue(def.Image))
+		d.Set("image", def.Image)
 		image := aws.StringValue(def.Image)
 		if strings.Contains(image, ":") {
 			d.Set("image_digest", strings.Split(image, ":")[1])
 		}
-		d.Set("cpu", aws.Int64Value(def.Cpu))
-		d.Set("memory", aws.Int64Value(def.Memory))
-		d.Set("memory_reservation", aws.Int64Value(def.MemoryReservation))
-		d.Set("disable_networking", aws.BoolValue(def.DisableNetworking))
+		d.Set("cpu", def.Cpu)
+		d.Set("memory", def.Memory)
+		d.Set("memory_reservation", def.MemoryReservation)
+		d.Set("disable_networking", def.DisableNetworking)
 		d.Set("docker_labels", aws.StringValueMap(def.DockerLabels))
 
 		var environment = map[string]string{}

--- a/aws/data_source_aws_ecs_task_definition.go
+++ b/aws/data_source_aws_ecs_task_definition.go
@@ -63,11 +63,11 @@ func dataSourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}
 	taskDefinition := desc.TaskDefinition
 
 	d.SetId(aws.StringValue(taskDefinition.TaskDefinitionArn))
-	d.Set("family", aws.StringValue(taskDefinition.Family))
-	d.Set("network_mode", aws.StringValue(taskDefinition.NetworkMode))
-	d.Set("revision", aws.Int64Value(taskDefinition.Revision))
-	d.Set("status", aws.StringValue(taskDefinition.Status))
-	d.Set("task_role_arn", aws.StringValue(taskDefinition.TaskRoleArn))
+	d.Set("family", taskDefinition.Family)
+	d.Set("network_mode", taskDefinition.NetworkMode)
+	d.Set("revision", taskDefinition.Revision)
+	d.Set("status", taskDefinition.Status)
+	d.Set("task_role_arn", taskDefinition.TaskRoleArn)
 
 	if d.Id() == "" {
 		return fmt.Errorf("task definition %q not found", d.Get("task_definition").(string))

--- a/aws/data_source_aws_elasticsearch_domain.go
+++ b/aws/data_source_aws_elasticsearch_domain.go
@@ -352,7 +352,7 @@ func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface
 		}
 	} else {
 		if ds.Endpoint != nil {
-			d.Set("endpoint", aws.StringValue(ds.Endpoint))
+			d.Set("endpoint", ds.Endpoint)
 			d.Set("kibana_endpoint", getKibanaEndpoint(d))
 		}
 		if ds.Endpoints != nil {

--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -150,8 +150,8 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 	d.Set("upload_date", serverCertificateResp.ServerCertificate.ServerCertificateMetadata.UploadDate.Format(time.RFC3339))
-	d.Set("certificate_body", aws.StringValue(serverCertificateResp.ServerCertificate.CertificateBody))
-	d.Set("certificate_chain", aws.StringValue(serverCertificateResp.ServerCertificate.CertificateChain))
+	d.Set("certificate_body", serverCertificateResp.ServerCertificate.CertificateBody)
+	d.Set("certificate_chain", serverCertificateResp.ServerCertificate.CertificateChain)
 
 	return nil
 }

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -545,7 +545,7 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 		if attr != nil && attr.UserData != nil && attr.UserData.Value != nil {
 			d.Set("user_data", userDataHashSum(aws.StringValue(attr.UserData.Value)))
 			if d.Get("get_user_data").(bool) {
-				d.Set("user_data_base64", aws.StringValue(attr.UserData.Value))
+				d.Set("user_data_base64", attr.UserData.Value)
 			}
 		}
 	}

--- a/aws/data_source_aws_lambda_layer_version.go
+++ b/aws/data_source_aws_lambda_layer_version.go
@@ -123,7 +123,7 @@ func dataSourceAwsLambdaLayerVersionRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("error getting Lambda Layer Version (%s, version %d): empty response", layerName, version)
 	}
 
-	if err := d.Set("version", int(aws.Int64Value(output.Version))); err != nil {
+	if err := d.Set("version", output.Version); err != nil {
 		return fmt.Errorf("error setting lambda layer version: %w", err)
 	}
 	if err := d.Set("compatible_runtimes", flattenStringList(output.CompatibleRuntimes)); err != nil {

--- a/aws/data_source_aws_msk_cluster.go
+++ b/aws/data_source_aws_msk_cluster.go
@@ -102,13 +102,13 @@ func dataSourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error reading MSK Cluster (%s) bootstrap brokers: %w", aws.StringValue(cluster.ClusterArn), err)
 	}
 
-	d.Set("arn", aws.StringValue(cluster.ClusterArn))
+	d.Set("arn", cluster.ClusterArn)
 	d.Set("bootstrap_brokers", sortMskClusterEndpoints(aws.StringValue(bootstrapBrokersOutput.BootstrapBrokerString)))
 	d.Set("bootstrap_brokers_sasl_scram", sortMskClusterEndpoints(aws.StringValue(bootstrapBrokersOutput.BootstrapBrokerStringSaslScram)))
 	d.Set("bootstrap_brokers_tls", sortMskClusterEndpoints(aws.StringValue(bootstrapBrokersOutput.BootstrapBrokerStringTls)))
-	d.Set("cluster_name", aws.StringValue(cluster.ClusterName))
-	d.Set("kafka_version", aws.StringValue(cluster.CurrentBrokerSoftwareInfo.KafkaVersion))
-	d.Set("number_of_broker_nodes", aws.Int64Value(cluster.NumberOfBrokerNodes))
+	d.Set("cluster_name", cluster.ClusterName)
+	d.Set("kafka_version", cluster.CurrentBrokerSoftwareInfo.KafkaVersion)
+	d.Set("number_of_broker_nodes", cluster.NumberOfBrokerNodes)
 
 	if err := d.Set("tags", keyvaluetags.KafkaKeyValueTags(cluster.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)

--- a/aws/data_source_aws_msk_configuration.go
+++ b/aws/data_source_aws_msk_configuration.go
@@ -91,15 +91,15 @@ func dataSourceAwsMskConfigurationRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error describing MSK Configuration (%s) Revision (%d): missing result", d.Id(), aws.Int64Value(revision))
 	}
 
-	d.Set("arn", aws.StringValue(configuration.Arn))
-	d.Set("description", aws.StringValue(configuration.Description))
+	d.Set("arn", configuration.Arn)
+	d.Set("description", configuration.Description)
 
 	if err := d.Set("kafka_versions", aws.StringValueSlice(configuration.KafkaVersions)); err != nil {
 		return fmt.Errorf("error setting kafka_versions: %w", err)
 	}
 
-	d.Set("latest_revision", aws.Int64Value(revision))
-	d.Set("name", aws.StringValue(configuration.Name))
+	d.Set("latest_revision", revision)
+	d.Set("name", configuration.Name)
 	d.Set("server_properties", string(revisionOutput.ServerProperties))
 
 	d.SetId(aws.StringValue(configuration.Arn))

--- a/aws/data_source_aws_ram_resource_share.go
+++ b/aws/data_source_aws_ram_resource_share.go
@@ -103,9 +103,9 @@ func dataSourceAwsRamResourceShareRead(d *schema.ResourceData, meta interface{})
 		for _, r := range resp.ResourceShares {
 			if aws.StringValue(r.Name) == name {
 				d.SetId(aws.StringValue(r.ResourceShareArn))
-				d.Set("arn", aws.StringValue(r.ResourceShareArn))
-				d.Set("owning_account_id", aws.StringValue(r.OwningAccountId))
-				d.Set("status", aws.StringValue(r.Status))
+				d.Set("arn", r.ResourceShareArn)
+				d.Set("owning_account_id", r.OwningAccountId)
+				d.Set("status", r.Status)
 
 				if err := d.Set("tags", keyvaluetags.RamKeyValueTags(r.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 					return fmt.Errorf("error setting tags: %w", err)

--- a/aws/data_source_aws_rds_cluster.go
+++ b/aws/data_source_aws_rds_cluster.go
@@ -203,7 +203,7 @@ func dataSourceAwsRdsClusterRead(d *schema.ResourceData, meta interface{}) error
 
 	arn := dbc.DBClusterArn
 	d.Set("arn", arn)
-	d.Set("backtrack_window", int(aws.Int64Value(dbc.BacktrackWindow)))
+	d.Set("backtrack_window", dbc.BacktrackWindow)
 	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
 	d.Set("cluster_identifier", dbc.DBClusterIdentifier)
 

--- a/aws/data_source_aws_route53_resolver_endpoint.go
+++ b/aws/data_source_aws_route53_resolver_endpoint.go
@@ -117,11 +117,11 @@ func dataSourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta inter
 
 		d.SetId(aws.StringValue(resolver.Id))
 		d.Set("resolver_endpoint_id", resolver.Id)
-		d.Set("arn", aws.StringValue(resolver.Arn))
-		d.Set("status", aws.StringValue(resolver.Status))
-		d.Set("name", aws.StringValue(resolver.Name))
-		d.Set("vpc_id", aws.StringValue(resolver.HostVPCId))
-		d.Set("direction", aws.StringValue(resolver.Direction))
+		d.Set("arn", resolver.Arn)
+		d.Set("status", resolver.Status)
+		d.Set("name", resolver.Name)
+		d.Set("vpc_id", resolver.HostVPCId)
+		d.Set("direction", resolver.Direction)
 
 		if resp.NextToken == nil {
 			break

--- a/aws/data_source_aws_sqs_queue.go
+++ b/aws/data_source_aws_sqs_queue.go
@@ -53,7 +53,7 @@ func dataSourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error getting queue attributes: %w", err)
 	}
 
-	d.Set("arn", aws.StringValue(attributesOutput.Attributes[sqs.QueueAttributeNameQueueArn]))
+	d.Set("arn", attributesOutput.Attributes[sqs.QueueAttributeNameQueueArn])
 	d.Set("url", queueURL)
 	d.SetId(queueURL)
 

--- a/aws/data_source_aws_transfer_server.go
+++ b/aws/data_source_aws_transfer_server.go
@@ -66,8 +66,8 @@ func dataSourceAwsTransferServerRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("arn", resp.Server.Arn)
 	d.Set("endpoint", endpoint)
 	if resp.Server.IdentityProviderDetails != nil {
-		d.Set("invocation_role", aws.StringValue(resp.Server.IdentityProviderDetails.InvocationRole))
-		d.Set("url", aws.StringValue(resp.Server.IdentityProviderDetails.Url))
+		d.Set("invocation_role", resp.Server.IdentityProviderDetails.InvocationRole)
+		d.Set("url", resp.Server.IdentityProviderDetails.Url)
 	}
 	d.Set("identity_provider_type", resp.Server.IdentityProviderType)
 	d.Set("logging_role", resp.Server.LoggingRole)

--- a/aws/data_source_aws_vpc_dhcp_options.go
+++ b/aws/data_source_aws_vpc_dhcp_options.go
@@ -111,7 +111,7 @@ func dataSourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) e
 
 		switch key {
 		case "domain-name":
-			d.Set(tfKey, aws.StringValue(dhcpConfiguration.Values[0].Value))
+			d.Set(tfKey, dhcpConfiguration.Values[0].Value)
 		case "domain-name-servers":
 			if err := d.Set(tfKey, flattenEc2AttributeValues(dhcpConfiguration.Values)); err != nil {
 				return fmt.Errorf("error setting %s: %w", tfKey, err)
@@ -121,7 +121,7 @@ func dataSourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) e
 				return fmt.Errorf("error setting %s: %w", tfKey, err)
 			}
 		case "netbios-node-type":
-			d.Set(tfKey, aws.StringValue(dhcpConfiguration.Values[0].Value))
+			d.Set(tfKey, dhcpConfiguration.Values[0].Value)
 		case "ntp-servers":
 			if err := d.Set(tfKey, flattenEc2AttributeValues(dhcpConfiguration.Values)); err != nil {
 				return fmt.Errorf("error setting %s: %w", tfKey, err)

--- a/aws/data_source_aws_wafv2_ip_set.go
+++ b/aws/data_source_aws_wafv2_ip_set.go
@@ -99,9 +99,9 @@ func dataSourceAwsWafv2IPSetRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.SetId(aws.StringValue(resp.IPSet.Id))
-	d.Set("arn", aws.StringValue(resp.IPSet.ARN))
-	d.Set("description", aws.StringValue(resp.IPSet.Description))
-	d.Set("ip_address_version", aws.StringValue(resp.IPSet.IPAddressVersion))
+	d.Set("arn", resp.IPSet.ARN)
+	d.Set("description", resp.IPSet.Description)
+	d.Set("ip_address_version", resp.IPSet.IPAddressVersion)
 
 	if err := d.Set("addresses", flattenStringList(resp.IPSet.Addresses)); err != nil {
 		return fmt.Errorf("error setting addresses: %w", err)

--- a/aws/data_source_aws_wafv2_regex_pattern_set.go
+++ b/aws/data_source_aws_wafv2_regex_pattern_set.go
@@ -102,8 +102,8 @@ func dataSourceAwsWafv2RegexPatternSetRead(d *schema.ResourceData, meta interfac
 	}
 
 	d.SetId(aws.StringValue(resp.RegexPatternSet.Id))
-	d.Set("arn", aws.StringValue(resp.RegexPatternSet.ARN))
-	d.Set("description", aws.StringValue(resp.RegexPatternSet.Description))
+	d.Set("arn", resp.RegexPatternSet.ARN)
+	d.Set("description", resp.RegexPatternSet.Description)
 
 	if err := d.Set("regular_expression", flattenWafv2RegexPatternSet(resp.RegexPatternSet.RegularExpressionList)); err != nil {
 		return fmt.Errorf("Error setting regular_expression: %w", err)

--- a/aws/data_source_aws_wafv2_rule_group.go
+++ b/aws/data_source_aws_wafv2_rule_group.go
@@ -76,8 +76,8 @@ func dataSourceAwsWafv2RuleGroupRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.SetId(aws.StringValue(foundRuleGroup.Id))
-	d.Set("arn", aws.StringValue(foundRuleGroup.ARN))
-	d.Set("description", aws.StringValue(foundRuleGroup.Description))
+	d.Set("arn", foundRuleGroup.ARN)
+	d.Set("description", foundRuleGroup.Description)
 
 	return nil
 }

--- a/aws/data_source_aws_wafv2_web_acl.go
+++ b/aws/data_source_aws_wafv2_web_acl.go
@@ -76,8 +76,8 @@ func dataSourceAwsWafv2WebACLRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(aws.StringValue(foundWebACL.Id))
-	d.Set("arn", aws.StringValue(foundWebACL.ARN))
-	d.Set("description", aws.StringValue(foundWebACL.Description))
+	d.Set("arn", foundWebACL.ARN)
+	d.Set("description", foundWebACL.Description)
 
 	return nil
 }

--- a/aws/data_source_aws_workspaces_bundle.go
+++ b/aws/data_source_aws_workspaces_bundle.go
@@ -124,10 +124,10 @@ func dataSourceAwsWorkspaceBundleRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(aws.StringValue(bundle.BundleId))
-	d.Set("bundle_id", aws.StringValue(bundle.BundleId))
-	d.Set("description", aws.StringValue(bundle.Description))
-	d.Set("name", aws.StringValue(bundle.Name))
-	d.Set("owner", aws.StringValue(bundle.Owner))
+	d.Set("bundle_id", bundle.BundleId)
+	d.Set("description", bundle.Description)
+	d.Set("name", bundle.Name)
+	d.Set("owner", bundle.Owner)
 
 	computeType := make([]map[string]interface{}, 1)
 	if bundle.ComputeType != nil {

--- a/aws/data_source_aws_workspaces_workspace.go
+++ b/aws/data_source_aws_workspaces_workspace.go
@@ -142,15 +142,15 @@ func dataSourceAwsWorkspacesWorkspaceRead(d *schema.ResourceData, meta interface
 	}
 
 	d.SetId(aws.StringValue(workspace.WorkspaceId))
-	d.Set("bundle_id", aws.StringValue(workspace.BundleId))
-	d.Set("directory_id", aws.StringValue(workspace.DirectoryId))
-	d.Set("ip_address", aws.StringValue(workspace.IpAddress))
-	d.Set("computer_name", aws.StringValue(workspace.ComputerName))
-	d.Set("state", aws.StringValue(workspace.State))
-	d.Set("root_volume_encryption_enabled", aws.BoolValue(workspace.RootVolumeEncryptionEnabled))
-	d.Set("user_name", aws.StringValue(workspace.UserName))
-	d.Set("user_volume_encryption_enabled", aws.BoolValue(workspace.UserVolumeEncryptionEnabled))
-	d.Set("volume_encryption_key", aws.StringValue(workspace.VolumeEncryptionKey))
+	d.Set("bundle_id", workspace.BundleId)
+	d.Set("directory_id", workspace.DirectoryId)
+	d.Set("ip_address", workspace.IpAddress)
+	d.Set("computer_name", workspace.ComputerName)
+	d.Set("state", workspace.State)
+	d.Set("root_volume_encryption_enabled", workspace.RootVolumeEncryptionEnabled)
+	d.Set("user_name", workspace.UserName)
+	d.Set("user_volume_encryption_enabled", workspace.UserVolumeEncryptionEnabled)
+	d.Set("volume_encryption_key", workspace.VolumeEncryptionKey)
 	if err := d.Set("workspace_properties", flattenWorkspaceProperties(workspace.WorkspaceProperties)); err != nil {
 		return fmt.Errorf("error setting workspace properties: %w", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16554 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
N/A
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A semgrep rule (defined in https://github.com/hashicorp/terraform-provider-aws/pull/16650) should not show warning msgs for these files
```
