### PR TITLE
adding Computed :true to id of few data sources

### DIFF
--- a/aws/data_source_aws_customer_gateway.go
+++ b/aws/data_source_aws_customer_gateway.go
@@ -21,6 +21,7 @@ func dataSourceAwsCustomerGateway() *schema.Resource {
 			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"bgp_asn": {

--- a/aws/data_source_aws_ec2_transit_gateway.go
+++ b/aws/data_source_aws_ec2_transit_gateway.go
@@ -52,6 +52,7 @@ func dataSourceAwsEc2TransitGateway() *schema.Resource {
 			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"owner_id": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_ec2_transit_gateway_peering_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_peering_attachment.go
@@ -20,6 +20,7 @@ func dataSourceAwsEc2TransitGatewayPeeringAttachment() *schema.Resource {
 			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"peer_account_id": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_ec2_transit_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table.go
@@ -33,6 +33,7 @@ func dataSourceAwsEc2TransitGatewayRouteTable() *schema.Resource {
 			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"transit_gateway_id": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
@@ -28,6 +28,7 @@ func dataSourceAwsEc2TransitGatewayVpcAttachment() *schema.Resource {
 			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"ipv6_support": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_guardduty_detector.go
+++ b/aws/data_source_aws_guardduty_detector.go
@@ -16,6 +16,7 @@ func dataSourceAwsGuarddutyDetector() *schema.Resource {
 			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"status": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Mark id within given data sources (as figured out by @bflad) as computed:

- aws_customer_gateway
- aws_ec2_transit_gateway_peering_attachment
- aws_ec2_transit_gateway_route_table
- aws_ec2_transit_gateway_vpc_attachment
- aws_ec2_transit_gateway
- aws_guardduty_detector

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11554 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-notes
Make the id attribute of given data sources a computed value.
- aws_customer_gateway
- aws_ec2_transit_gateway_peering_attachment
- aws_ec2_transit_gateway_route_table
- aws_ec2_transit_gateway_vpc_attachment
- aws_ec2_transit_gateway
- aws_guardduty_detector
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
