### PR TITLE
service/ec2: Add COIP support to aws_subnet resource and data source

### DIFF
--- a/.changelog/16676.txt
+++ b/.changelog/16676.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-data-source/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch attributes
+data-source/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch` attributes
 ```
 
 ```release-note:enhancement
-resource/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch attributes
+resource/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch` attributes
 ```

--- a/.changelog/16676.txt
+++ b/.changelog/16676.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch attributes
+```
+
+```release-note:enhancement
+resource/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch attributes
+```

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -77,6 +77,16 @@ func dataSourceAwsSubnet() *schema.Resource {
 				Computed: true,
 			},
 
+			"customer_owned_ipv4_pool": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"map_customer_owned_ip_on_launch": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"map_public_ip_on_launch": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -180,6 +190,8 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("assign_ipv6_address_on_creation", subnet.AssignIpv6AddressOnCreation)
+	d.Set("customer_owned_ipv4_pool", subnet.CustomerOwnedIpv4Pool)
+	d.Set("map_customer_owned_ip_on_launch", subnet.MapCustomerOwnedIpOnLaunch)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIpOnLaunch)
 
 	for _, a := range subnet.Ipv6CidrBlockAssociationSet {

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -38,6 +38,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds1ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds1ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds2ResourceName, "id", snResourceName, "id"),
@@ -48,6 +50,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds2ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds2ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds2ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds2ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds3ResourceName, "id", snResourceName, "id"),
@@ -58,6 +62,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds3ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds3ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds3ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds3ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds4ResourceName, "id", snResourceName, "id"),
@@ -68,6 +74,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds4ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds4ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds4ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds4ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds4ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds4ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds5ResourceName, "id", snResourceName, "id"),
@@ -78,6 +86,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds5ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds5ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds5ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds5ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds5ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds5ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds6ResourceName, "id", snResourceName, "id"),
@@ -88,6 +98,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds6ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds6ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds6ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds6ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds6ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds6ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 				),
 			},

--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -17,6 +17,10 @@ const (
 )
 
 const (
+	ErrCodeInvalidSubnetIDNotFound = "InvalidSubnetID.NotFound"
+)
+
+const (
 	ErrCodeInvalidVpcPeeringConnectionIDNotFound = "InvalidVpcPeeringConnectionID.NotFound"
 )
 

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -72,6 +72,25 @@ func SecurityGroupByID(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
 	return result.SecurityGroups[0], nil
 }
 
+// SubnetByID looks up a Subnet by ID. When not found, returns nil and potentially an API error.
+func SubnetByID(conn *ec2.EC2, id string) (*ec2.Subnet, error) {
+	input := &ec2.DescribeSubnetsInput{
+		SubnetIds: aws.StringSlice([]string{id}),
+	}
+
+	output, err := conn.DescribeSubnets(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.Subnets) == 0 || output.Subnets[0] == nil {
+		return nil, nil
+	}
+
+	return output.Subnets[0], nil
+}
+
 // VpcPeeringConnectionByID returns the VPC peering connection corresponding to the specified identifier.
 // Returns nil and potentially an error if no VPC peering connection is found.
 func VpcPeeringConnectionByID(conn *ec2.EC2, id string) (*ec2.VpcPeeringConnection, error) {

--- a/aws/internal/service/ec2/waiter/status.go
+++ b/aws/internal/service/ec2/waiter/status.go
@@ -3,6 +3,7 @@ package waiter
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -204,6 +205,27 @@ func SecurityGroupStatus(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 		}
 
 		return group, SecurityGroupStatusCreated, nil
+	}
+}
+
+// SubnetMapCustomerOwnedIpOnLaunch fetches the Subnet and its MapCustomerOwnedIpOnLaunch
+func SubnetMapCustomerOwnedIpOnLaunch(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		subnet, err := finder.SubnetByID(conn, id)
+
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidSubnetIDNotFound) {
+			return nil, "false", nil
+		}
+
+		if err != nil {
+			return nil, "false", err
+		}
+
+		if subnet == nil {
+			return nil, "false", nil
+		}
+
+		return subnet, strconv.FormatBool(aws.BoolValue(subnet.MapCustomerOwnedIpOnLaunch)), nil
 	}
 }
 

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter"
 )
 
 func resourceAwsSubnet() *schema.Resource {
@@ -65,6 +66,18 @@ func resourceAwsSubnet() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"availability_zone"},
+			},
+
+			"customer_owned_ipv4_pool": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"map_customer_owned_ip_on_launch", "outpost_arn"},
+			},
+
+			"map_customer_owned_ip_on_launch": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				RequiredWith: []string{"customer_owned_ipv4_pool", "outpost_arn"},
 			},
 
 			"map_public_ip_on_launch": {
@@ -153,7 +166,8 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error waiting for subnet (%s) to become ready: %w", d.Id(), err)
 	}
 
-	// You cannot modify multiple subnet attributes in the same request.
+	// You cannot modify multiple subnet attributes in the same request,
+	// except CustomerOwnedIpv4Pool and MapCustomerOwnedIpOnLaunch.
 	// Reference: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySubnetAttribute.html
 
 	if d.Get("assign_ipv6_address_on_creation").(bool) {
@@ -166,6 +180,24 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 
 		if _, err := conn.ModifySubnetAttribute(input); err != nil {
 			return fmt.Errorf("error enabling EC2 Subnet (%s) assign IPv6 address on creation: %w", d.Id(), err)
+		}
+	}
+
+	if v, ok := d.GetOk("customer_owned_ipv4_pool"); ok {
+		input := &ec2.ModifySubnetAttributeInput{
+			CustomerOwnedIpv4Pool: aws.String(v.(string)),
+			MapCustomerOwnedIpOnLaunch: &ec2.AttributeBooleanValue{
+				Value: aws.Bool(d.Get("map_customer_owned_ip_on_launch").(bool)),
+			},
+			SubnetId: aws.String(d.Id()),
+		}
+
+		if _, err := conn.ModifySubnetAttribute(input); err != nil {
+			return fmt.Errorf("error setting EC2 Subnet (%s) customer owned IPv4 pool and map customer owned IP on launch: %w", d.Id(), err)
+		}
+
+		if _, err := waiter.SubnetMapCustomerOwnedIpOnLaunchUpdated(conn, d.Id(), d.Get("map_customer_owned_ip_on_launch").(bool)); err != nil {
+			return fmt.Errorf("error waiting for EC2 Subnet (%s) map customer owned IP on launch update: %w", d.Id(), err)
 		}
 	}
 
@@ -211,6 +243,8 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("availability_zone", subnet.AvailabilityZone)
 	d.Set("availability_zone_id", subnet.AvailabilityZoneId)
 	d.Set("cidr_block", subnet.CidrBlock)
+	d.Set("customer_owned_ipv4_pool", subnet.CustomerOwnedIpv4Pool)
+	d.Set("map_customer_owned_ip_on_launch", subnet.MapCustomerOwnedIpOnLaunch)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIpOnLaunch)
 	d.Set("assign_ipv6_address_on_creation", subnet.AssignIpv6AddressOnCreation)
 	d.Set("outpost_arn", subnet.OutpostArn)
@@ -246,6 +280,31 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating EC2 Subnet (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	// You cannot modify multiple subnet attributes in the same request,
+	// except CustomerOwnedIpv4Pool and MapCustomerOwnedIpOnLaunch.
+	// Reference: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySubnetAttribute.html
+
+	if d.HasChanges("customer_owned_ipv4_pool", "map_customer_owned_ip_on_launch") {
+		input := &ec2.ModifySubnetAttributeInput{
+			MapCustomerOwnedIpOnLaunch: &ec2.AttributeBooleanValue{
+				Value: aws.Bool(d.Get("map_customer_owned_ip_on_launch").(bool)),
+			},
+			SubnetId: aws.String(d.Id()),
+		}
+
+		if v, ok := d.GetOk("customer_owned_ipv4_pool"); ok {
+			input.CustomerOwnedIpv4Pool = aws.String(v.(string))
+		}
+
+		if _, err := conn.ModifySubnetAttribute(input); err != nil {
+			return fmt.Errorf("error updating EC2 Subnet (%s) customer owned IPv4 pool and map customer owned IP on launch: %w", d.Id(), err)
+		}
+
+		if _, err := waiter.SubnetMapCustomerOwnedIpOnLaunchUpdated(conn, d.Id(), d.Get("map_customer_owned_ip_on_launch").(bool)); err != nil {
+			return fmt.Errorf("error waiting for EC2 Subnet (%s) map customer owned IP on launch update: %w", d.Id(), err)
 		}
 	}
 

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -97,5 +97,8 @@ the selected subnet.
 In addition the following attributes are exported:
 
 * `arn` - The ARN of the subnet.
+* `customer_owned_ipv4_pool` - Identifier of customer owned IPv4 address pool.
+* `map_customer_owned_ip_on_launch` - Whether customer owned IP addresses are assigned on network interface creation.
+* `map_public_ip_on_launch` - Whether public IP addresses are assigned on instance launch.
 * `owner_id` - The ID of the AWS account that owns the subnet.
 * `outpost_arn` - The Amazon Resource Name (ARN) of the Outpost.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -51,8 +51,10 @@ The following arguments are supported:
 * `availability_zone` - (Optional) The AZ for the subnet.
 * `availability_zone_id` - (Optional) The AZ ID of the subnet.
 * `cidr_block` - (Required) The CIDR block for the subnet.
+* `customer_owned_ipv4_pool` - (Optional) The customer owned IPv4 address pool. Typically used with the `map_customer_owned_ip_on_launch` argument. The `outpost_arn` argument must be specified when configured.
 * `ipv6_cidr_block` - (Optional) The IPv6 network range for the subnet,
     in CIDR notation. The subnet size must use a /64 prefix length.
+* `map_customer_owned_ip_on_launch` -  (Optional) Specify `true` to indicate that network interfaces created in the subnet should be assigned a customer owned IP address. The `customer_owned_ipv4_pool` and `outpost_arn` arguments must be specified when set to `true`. Default is `false`.
 * `map_public_ip_on_launch` -  (Optional) Specify true to indicate
     that instances launched into the subnet should be assigned
     a public IP address. Default is `false`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13170
Closes #13171

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch attributes
* resource/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch attributes
```

Output from acceptance testing in OTL account:

```
--- PASS: TestAccDataSourceAwsSubnet_basic (25.67s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock (46.37s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter (51.83s)

--- PASS: TestAccAWSSubnet_availabilityZoneId (29.12s)
--- PASS: TestAccAWSSubnet_basic (31.04s)
--- PASS: TestAccAWSSubnet_CustomerOwnedIpv4Pool (63.80s)
--- PASS: TestAccAWSSubnet_disappears (21.79s)
--- PASS: TestAccAWSSubnet_enableIpv6 (79.03s)
--- PASS: TestAccAWSSubnet_ignoreTags (45.48s)
--- PASS: TestAccAWSSubnet_ipv6 (90.26s)
--- PASS: TestAccAWSSubnet_MapCustomerOwnedIpOnLaunch (49.07s)
--- PASS: TestAccAWSSubnet_outpost (47.45s)
--- PASS: TestAccAWSSubnet_tags (68.74s)
```
