### PR TITLE
resource/aws_main_route_table_association: Prevent crash on creation when VPC main route table association is not found

### DIFF
--- a/aws/resource_aws_main_route_table_association.go
+++ b/aws/resource_aws_main_route_table_association.go
@@ -47,8 +47,13 @@ func resourceAwsMainRouteTableAssociationCreate(d *schema.ResourceData, meta int
 	log.Printf("[INFO] Creating main route table association: %s => %s", vpcId, routeTableId)
 
 	mainAssociation, err := findMainRouteTableAssociation(conn, vpcId)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error finding EC2 VPC (%s) main route table association for replacement: %w", vpcId, err)
+	}
+
+	if mainAssociation == nil {
+		return fmt.Errorf("error finding EC2 VPC (%s) main route table association for replacement: association not found", vpcId)
 	}
 
 	resp, err := conn.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationInput{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16593

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_main_route_table_association: Prevent crash on creation when VPC main route table association is not found
```

This is quick fix to replace the crash behavior with an actual error message. Additional information is needed to determine why this issue occurs (e.g. EC2 eventual consistency, problematic configurations, etc.) but this at least gives operators a better chance to continue other parts of the apply successfully and potentially just rerun the errant resource.

Output from acceptance testing:

```
--- PASS: TestAccAWSMainRouteTableAssociation_basic (62.60s)
```
