### PR TITLE
Fix Terminated Workspace Panic

### DIFF
--- a/aws/internal/service/workspaces/waiter/status.go
+++ b/aws/internal/service/workspaces/waiter/status.go
@@ -34,7 +34,7 @@ func WorkspaceState(conn *workspaces.WorkSpaces, workspaceID string) resource.St
 		}
 
 		if len(output.Workspaces) == 0 {
-			return nil, "", nil
+			return output, workspaces.WorkspaceStateTerminated, nil
 		}
 
 		workspace := output.Workspaces[0]

--- a/aws/internal/service/workspaces/waiter/waiter.go
+++ b/aws/internal/service/workspaces/waiter/waiter.go
@@ -109,7 +109,7 @@ func WorkspaceTerminated(conn *workspaces.WorkSpaces, workspaceID string, timeou
 			workspaces.WorkspaceStateTerminating,
 			workspaces.WorkspaceStateError,
 		},
-		Target:  []string{},
+		Target:  []string{workspaces.WorkspaceStateTerminated},
 		Refresh: WorkspaceState(conn, workspaceID),
 		Timeout: timeout,
 	}

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -89,7 +89,8 @@ func TestAccAwsWorkspacesWorkspace_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode", workspaces.RunningModeAlwaysOn),
 					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode_auto_stop_timeout_in_minutes", "0"),
 					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.user_volume_size_gib", "10"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", fmt.Sprintf("tf-testacc-workspaces-workspace-%[1]s", rName)),
 				),
 			},
 			{
@@ -544,7 +545,9 @@ resource "aws_workspaces_workspace" "test" {
 }
 
 func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesC(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
@@ -555,8 +558,12 @@ resource "aws_workspaces_workspace" "test" {
 
   workspace_properties {
   }
+
+  tags = {
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
+  }
 }
-`
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig_validateRootVolumeSize(rName string) string {

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -122,7 +122,7 @@ func TestAccAwsWorkspacesWorkspace_tags(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", fmt.Sprintf("tf-testacc-workspaces-workspace-%[1]s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "tags.Alpha", "1"),
 				),
 			},
@@ -136,7 +136,7 @@ func TestAccAwsWorkspacesWorkspace_tags(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", fmt.Sprintf("tf-testacc-workspaces-workspace-%[1]s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "tags.Beta", "2"),
 				),
 			},
@@ -145,7 +145,7 @@ func TestAccAwsWorkspacesWorkspace_tags(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", fmt.Sprintf("tf-testacc-workspaces-workspace-%[1]s", rName)),
 				),
 			},
 		},
@@ -401,32 +401,45 @@ func testAccCheckAwsWorkspacesWorkspaceExists(n string, v *workspaces.Workspace)
 func testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName string) string {
 	return composeConfig(
 		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
-		`
+		fmt.Sprintf(`
 data "aws_workspaces_bundle" "test" {
   bundle_id = "wsb-bh8rsxt14" # Value with Windows 10 (English)
 }
 
 resource "aws_workspaces_directory" "test" {
   directory_id = aws_directory_service_directory.main.id
+
+  tags = {
+    Name = "tf-testacc-workspaces-directory-%[1]s"
+  }
 }
-`)
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
+  
 
   # NOTE: WorkSpaces API doesn't allow creating users in the directory.
   # However, "Administrator"" user is always present in a bare directory.
   user_name = "Administrator"
+
+  tags = {
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
+  }
 }
-`
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig_TagsA(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
@@ -436,15 +449,17 @@ resource "aws_workspaces_workspace" "test" {
   user_name = "Administrator"
 
   tags = {
-    TerraformProviderAwsTest = true
-    Alpha                    = 1
+    Name  = "tf-testacc-workspaces-workspace-%[1]s"
+    Alpha = 1
   }
 }
-`
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig_TagsB(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
@@ -454,15 +469,17 @@ resource "aws_workspaces_workspace" "test" {
   user_name = "Administrator"
 
   tags = {
-    TerraformProviderAwsTest = true
-    Beta                     = 2
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
+    Beta = 2
   }
 }
-`
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig_TagsC(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
@@ -472,14 +489,16 @@ resource "aws_workspaces_workspace" "test" {
   user_name = "Administrator"
 
   tags = {
-    TerraformProviderAwsTest = true
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
   }
 }
-`
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesA(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
@@ -495,14 +514,16 @@ resource "aws_workspaces_workspace" "test" {
   }
 
   tags = {
-    TerraformProviderAwsTest = true
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
   }
 }
-`
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesB(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
@@ -517,10 +538,10 @@ resource "aws_workspaces_workspace" "test" {
   }
 
   tags = {
-    TerraformProviderAwsTest = true
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
   }
 }
-`
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesC(rName string) string {
@@ -540,7 +561,9 @@ resource "aws_workspaces_workspace" "test" {
 }
 
 func testAccWorkspacesWorkspaceConfig_validateRootVolumeSize(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
@@ -555,14 +578,16 @@ resource "aws_workspaces_workspace" "test" {
   }
 
   tags = {
-    TerraformProviderAwsTest = true
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
   }
 }
-`
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig_validateUserVolumeSize(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
@@ -577,14 +602,16 @@ resource "aws_workspaces_workspace" "test" {
   }
 
   tags = {
-    TerraformProviderAwsTest = true
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
   }
 }
-`
+`, rName))
 }
 
 func testAccWorkspacesWorkspaceConfig_timeout(rName string) string {
-	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName) + `
+	return composeConfig(
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
@@ -598,8 +625,12 @@ resource "aws_workspaces_workspace" "test" {
     update = "30m"
     delete = "30m"
   }
+
+  tags = {
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
+  }
 }
-`
+`, rName))
 }
 
 func TestExpandWorkspaceProperties(t *testing.T) {

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -423,7 +423,6 @@ func testAccWorkspacesWorkspaceConfig(rName string) string {
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
   directory_id = aws_workspaces_directory.test.id
-  
 
   # NOTE: WorkSpaces API doesn't allow creating users in the directory.
   # However, "Administrator"" user is always present in a bare directory.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #16654

Relates to #15945

Follow up to #15705

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
aws_workspaces_workspace: Fix panic when describe workspaces action returns empty output 
```

## Acceptance Test

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsWorkspacesWorkspace_recreate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWorkspacesWorkspace_recreate -timeout 120m
=== RUN   TestAccAwsWorkspacesWorkspace_recreate
=== PAUSE TestAccAwsWorkspacesWorkspace_recreate
=== CONT  TestAccAwsWorkspacesWorkspace_recreate
--- PASS: TestAccAwsWorkspacesWorkspace_recreate (1142.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1145.364s
```

### Improvements

- Add tags to all acc test workspace resources