### PR TITLE
resource/aws_iam_instance_profile: Remove from state if deleted

### DIFF
--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -203,8 +203,7 @@ func resourceAwsIamInstanceProfileRead(d *schema.ResourceData, meta interface{})
 	}
 
 	result, err := iamconn.GetInstanceProfile(request)
-	if isAWSErr(err, "NoSuchEntity", "") {
-		log.Printf("[WARN] IAM Instance Profile %s is already gone", d.Id())
+	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
 		d.SetId("")
 		return nil
 	}
@@ -226,6 +225,10 @@ func resourceAwsIamInstanceProfileDelete(d *schema.ResourceData, meta interface{
 		InstanceProfileName: aws.String(d.Id()),
 	}
 	_, err := iamconn.DeleteInstanceProfile(request)
+	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+		log.Printf("[WARN] IAM Instance Profile %s is already gone", d.Id())
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("Error deleting IAM instance profile %s: %s", d.Id(), err)
 	}

--- a/aws/resource_aws_iam_instance_profile_test.go
+++ b/aws/resource_aws_iam_instance_profile_test.go
@@ -125,7 +125,7 @@ func testAccCheckAWSInstanceProfileDestroy(s *terraform.State) error {
 			return fmt.Errorf("still exist.")
 		}
 
-		if isAWSErr(err, "NoSuchEntity", "") {
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
 			continue
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_iam_instance_profile - remove from state if deleted
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSIAMInstanceProfile_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIAMInstanceProfile_basic -timeout 120m
=== RUN   TestAccAWSIAMInstanceProfile_basic
=== PAUSE TestAccAWSIAMInstanceProfile_basic
=== CONT  TestAccAWSIAMInstanceProfile_basic
--- PASS: TestAccAWSIAMInstanceProfile_basic (30.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       30.799s
```
