### PR TITLE
r/aws_instance: Correct 'TestAccAWSInstance_EbsRootDevice_ModifyType'

### DIFF
--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1540,7 +1540,7 @@ func TestAccAWSInstance_EbsRootDevice_ModifyType(t *testing.T) {
 	deleteOnTermination := "true"
 
 	originalType := "gp2"
-	updatedType := "io1"
+	updatedType := "standard"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/16700.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_EbsRootDevice_ModifyType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSInstance_EbsRootDevice_ModifyType -timeout 120m
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyType
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyType
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyType
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (126.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	126.110s
```
