### PR TITLE
ds/ec2_instance_type_offering locations: Add locations attribute

### DIFF
--- a/.changelog/16704.txt
+++ b/.changelog/16704.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ec2_instance_type_offerings: Add `locations` and `location_types` attributes
+```

--- a/aws/data_source_aws_ec2_instance_type_offerings.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings.go
@@ -20,14 +20,20 @@ func dataSourceAwsEc2InstanceTypeOfferings() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"locations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"location_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.LocationTypeAvailabilityZone,
-					ec2.LocationTypeAvailabilityZoneId,
-					ec2.LocationTypeRegion,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ec2.LocationType_Values(), false),
+			},
+			"location_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
@@ -48,40 +54,38 @@ func dataSourceAwsEc2InstanceTypeOfferingsRead(d *schema.ResourceData, meta inte
 
 	var instanceTypes []string
 	var locations []string
+	var locationTypes []string
 
-	for {
-		output, err := conn.DescribeInstanceTypeOfferings(input)
-
-		if err != nil {
-			return fmt.Errorf("error reading EC2 Instance Type Offerings: %w", err)
+	err := conn.DescribeInstanceTypeOfferingsPages(input, func(page *ec2.DescribeInstanceTypeOfferingsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
 		}
 
-		if output == nil {
-			break
-		}
-
-		for _, instanceTypeOffering := range output.InstanceTypeOfferings {
+		for _, instanceTypeOffering := range page.InstanceTypeOfferings {
 			if instanceTypeOffering == nil {
 				continue
 			}
 
 			instanceTypes = append(instanceTypes, aws.StringValue(instanceTypeOffering.InstanceType))
 			locations = append(locations, aws.StringValue(instanceTypeOffering.Location))
+			locationTypes = append(locationTypes, aws.StringValue(instanceTypeOffering.LocationType))
 		}
 
-		if aws.StringValue(output.NextToken) == "" {
-			break
-		}
+		return !lastPage
+	})
 
-		input.NextToken = output.NextToken
+	if err != nil {
+		return fmt.Errorf("error reading EC2 Instance Type Offerings: %w", err)
 	}
 
 	if err := d.Set("instance_types", instanceTypes); err != nil {
 		return fmt.Errorf("error setting instance_types: %w", err)
 	}
-
 	if err := d.Set("locations", locations); err != nil {
-		return fmt.Errorf("error setting locations: %s", err)
+		return fmt.Errorf("error setting locations: %w", err)
+	}
+	if err := d.Set("location_types", locationTypes); err != nil {
+		return fmt.Errorf("error setting location_types: %w", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)

--- a/aws/data_source_aws_ec2_instance_type_offerings.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings.go
@@ -47,6 +47,7 @@ func dataSourceAwsEc2InstanceTypeOfferingsRead(d *schema.ResourceData, meta inte
 	}
 
 	var instanceTypes []string
+	var locations []string
 
 	for {
 		output, err := conn.DescribeInstanceTypeOfferings(input)
@@ -65,6 +66,7 @@ func dataSourceAwsEc2InstanceTypeOfferingsRead(d *schema.ResourceData, meta inte
 			}
 
 			instanceTypes = append(instanceTypes, aws.StringValue(instanceTypeOffering.InstanceType))
+			locations = append(locations, aws.StringValue(instanceTypeOffering.Location))
 		}
 
 		if aws.StringValue(output.NextToken) == "" {
@@ -76,6 +78,10 @@ func dataSourceAwsEc2InstanceTypeOfferingsRead(d *schema.ResourceData, meta inte
 
 	if err := d.Set("instance_types", instanceTypes); err != nil {
 		return fmt.Errorf("error setting instance_types: %w", err)
+	}
+
+	if err := d.Set("locations", locations); err != nil {
+		return fmt.Errorf("error setting locations: %s", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)

--- a/aws/data_source_aws_ec2_instance_type_offerings.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings.go
@@ -21,7 +21,7 @@ func dataSourceAwsEc2InstanceTypeOfferings() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"locations": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -31,7 +31,7 @@ func dataSourceAwsEc2InstanceTypeOfferings() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(ec2.LocationType_Values(), false),
 			},
 			"location_types": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/aws/data_source_aws_ec2_instance_type_offerings_test.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings_test.go
@@ -42,6 +42,7 @@ func TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType(t *testing.T) {
 				Config: testAccAWSEc2InstanceTypeOfferingsDataSourceConfigLocationType(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEc2InstanceTypeOfferingsInstanceTypes(dataSourceName),
+					testAccCheckEc2InstanceTypeOfferingsLocations(dataSourceName),
 				),
 			},
 		},
@@ -57,6 +58,21 @@ func testAccCheckEc2InstanceTypeOfferingsInstanceTypes(dataSourceName string) re
 
 		if v := rs.Primary.Attributes["instance_types.#"]; v == "0" {
 			return fmt.Errorf("expected at least one instance_types result, got none")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckEc2InstanceTypeOfferingsLocations(dataSourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", dataSourceName)
+		}
+
+		if v := rs.Primary.Attributes["locations.#"]; v == "0" {
+			return fmt.Errorf("expected at least one locations result, got none")
 		}
 
 		return nil

--- a/aws/data_source_aws_ec2_instance_type_offerings_test.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings_test.go
@@ -60,6 +60,14 @@ func testAccCheckEc2InstanceTypeOfferingsInstanceTypes(dataSourceName string) re
 			return fmt.Errorf("expected at least one instance_types result, got none")
 		}
 
+		if v := rs.Primary.Attributes["locations.#"]; v == "0" {
+			return fmt.Errorf("expected at least one locations result, got none")
+		}
+
+		if v := rs.Primary.Attributes["location_types.#"]; v == "0" {
+			return fmt.Errorf("expected at least one location_types result, got none")
+		}
+
 		return nil
 	}
 }

--- a/website/docs/d/ec2_instance_type_offerings.html.markdown
+++ b/website/docs/d/ec2_instance_type_offerings.html.markdown
@@ -46,3 +46,5 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - AWS Region.
 * `instance_types` - Set of EC2 Instance Types.
+* `locations` - Set of locations.
+* `location_types` - Set of location types.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #16703

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_ec2_instance_type_offerings - add locations attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
