### PR TITLE
EC2 / AMI / Block device's `encrypted` property can sometimes be `nil`

### DIFF
--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -402,10 +402,12 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 			ebsBlockDev := map[string]interface{}{
 				"device_name":           *blockDev.DeviceName,
 				"delete_on_termination": *blockDev.Ebs.DeleteOnTermination,
-				"encrypted":             *blockDev.Ebs.Encrypted,
 				"iops":                  0,
 				"volume_size":           int(*blockDev.Ebs.VolumeSize),
 				"volume_type":           *blockDev.Ebs.VolumeType,
+			}
+			if blockDev.Ebs.Encrypted != nil {
+				ebsBlockDev["encrypted"] = *blockDev.Ebs.Encrypted
 			}
 			if blockDev.Ebs.Iops != nil {
 				ebsBlockDev["iops"] = int(*blockDev.Ebs.Iops)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
`aws_ami` will no longer cause a panic if the `ebs_block_device.encrypted` property is missing when reading in the EC2 API response.
```

### Output from acceptance testing:

```
$ make testacc

(pending)
```
