### PR TITLE
aws_launch_template: AWS Wavelength support

### DIFF
--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -239,6 +239,10 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"associate_carrier_ip_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"associate_public_ip_address": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/aws/data_source_aws_launch_template_test.go
+++ b/aws/data_source_aws_launch_template_test.go
@@ -160,6 +160,41 @@ func TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplateDataSource_associateCarrierIPAddress(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_launch_template.test"
+	resourceName := "aws_launch_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateDataSourceConfig_associateCarrierIpAddress(rName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.#", resourceName, "network_interfaces.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.0.associate_carrier_ip_address", resourceName, "network_interfaces.0.associate_carrier_ip_address"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateDataSourceConfig_associateCarrierIpAddress(rName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.#", resourceName, "network_interfaces.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.0.associate_carrier_ip_address", resourceName, "network_interfaces.0.associate_carrier_ip_address"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateDataSourceConfig_associateCarrierIpAddress(rName, "null"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.#", resourceName, "network_interfaces.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.0.associate_carrier_ip_address", resourceName, "network_interfaces.0.associate_carrier_ip_address"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_launch_template.test"
@@ -288,6 +323,22 @@ data "aws_launch_template" "test" {
   name = aws_launch_template.test.name
 }
 `, rName, associatePublicIPAddress)
+}
+
+func testAccAWSLaunchTemplateDataSourceConfig_associateCarrierIpAddress(rName, associateCarrierIPAddress string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  network_interfaces {
+    associate_carrier_ip_address = %[2]s
+  }
+}
+
+data "aws_launch_template" "test" {
+  name = aws_launch_template.test.name
+}
+`, rName, associateCarrierIPAddress)
 }
 
 func testAccAWSLaunchTemplateDataSourceConfigNetworkInterfacesDeleteOnTermination(rName, deleteOnTermination string) string {

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -418,6 +418,12 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"associate_carrier_ip_address": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: suppressEquivalentTypeStringBoolean,
+							ValidateFunc:     validateTypeStringNullableBoolean,
+						},
 						"associate_public_ip_address": {
 							Type:             schema.TypeString,
 							Optional:         true,
@@ -1130,6 +1136,11 @@ func getNetworkInterfaces(n []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecifi
 			"private_ip_address":   aws.StringValue(v.PrivateIpAddress),
 			"subnet_id":            aws.StringValue(v.SubnetId),
 		}
+
+		if v.AssociateCarrierIpAddress != nil {
+			networkInterface["associate_carrier_ip_address"] = strconv.FormatBool(aws.BoolValue(v.AssociateCarrierIpAddress))
+		}
+
 		if v.AssociatePublicIpAddress != nil {
 			networkInterface["associate_public_ip_address"] = strconv.FormatBool(aws.BoolValue(v.AssociatePublicIpAddress))
 		}
@@ -1531,6 +1542,14 @@ func readNetworkInterfacesFromConfig(ni map[string]interface{}) (*ec2.LaunchTemp
 
 	if v, ok := ni["network_interface_id"].(string); ok && v != "" {
 		networkInterface.NetworkInterfaceId = aws.String(v)
+	}
+
+	if v, ok := ni["associate_carrier_ip_address"]; ok && v.(string) != "" {
+		vBool, err := strconv.ParseBool(v.(string))
+		if err != nil {
+			return nil, fmt.Errorf("error converting associate_carrier_ip_address %q from string to boolean: %s", v.(string), err)
+		}
+		networkInterface.AssociateCarrierIpAddress = aws.Bool(vBool)
 	}
 
 	if v, ok := ni["associate_public_ip_address"]; ok && v.(string) != "" {

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -289,6 +289,7 @@ Check limitations for autoscaling group in [Creating an Auto Scaling Group Using
 
 Each `network_interfaces` block supports the following:
 
+* `associate_carrier_ip_address` - Associate a Carrier IP address with `eth0` for a new network interface. Use this option when you launch an instance in a Wavelength Zone and want to associate a Carrier IP address with the network interface. Boolean value.
 * `associate_public_ip_address` - Associate a public ip address with the network interface.  Boolean value.
 * `delete_on_termination` - Whether the network interface should be destroyed on instance termination. Defaults to `false` if not set.
 * `description` - Description of the network interface.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14518.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_launch_template: Add `associate_carrier_ip_address` attribute to `network_interfaces` configuration block.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchTemplate_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== RUN   TestAccAWSLaunchTemplate_disappears
=== PAUSE TestAccAWSLaunchTemplate_disappears
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_EbsOptimized
=== PAUSE TestAccAWSLaunchTemplate_EbsOptimized
=== RUN   TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== PAUSE TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== RUN   TestAccAWSLaunchTemplate_NetworkInterfaces_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_NetworkInterfaces_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== RUN   TestAccAWSLaunchTemplate_description
=== PAUSE TestAccAWSLaunchTemplate_description
=== RUN   TestAccAWSLaunchTemplate_update
=== PAUSE TestAccAWSLaunchTemplate_update
=== RUN   TestAccAWSLaunchTemplate_tags
=== PAUSE TestAccAWSLaunchTemplate_tags
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_preference
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_preference
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_target
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_target
=== RUN   TestAccAWSLaunchTemplate_cpuOptions
=== PAUSE TestAccAWSLaunchTemplate_cpuOptions
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t2
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t3
=== RUN   TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== PAUSE TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== RUN   TestAccAWSLaunchTemplate_networkInterface
=== PAUSE TestAccAWSLaunchTemplate_networkInterface
=== RUN   TestAccAWSLaunchTemplate_networkInterfaceAddresses
=== PAUSE TestAccAWSLaunchTemplate_networkInterfaceAddresses
=== RUN   TestAccAWSLaunchTemplate_associatePublicIPAddress
=== PAUSE TestAccAWSLaunchTemplate_associatePublicIPAddress
=== RUN   TestAccAWSLaunchTemplate_associateCarrierIPAddress
=== PAUSE TestAccAWSLaunchTemplate_associateCarrierIPAddress
=== RUN   TestAccAWSLaunchTemplate_placement_partitionNum
=== PAUSE TestAccAWSLaunchTemplate_placement_partitionNum
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== RUN   TestAccAWSLaunchTemplate_instanceMarketOptions
=== PAUSE TestAccAWSLaunchTemplate_instanceMarketOptions
=== RUN   TestAccAWSLaunchTemplate_licenseSpecification
=== PAUSE TestAccAWSLaunchTemplate_licenseSpecification
=== RUN   TestAccAWSLaunchTemplate_metadataOptions
=== PAUSE TestAccAWSLaunchTemplate_metadataOptions
=== RUN   TestAccAWSLaunchTemplate_hibernation
=== PAUSE TestAccAWSLaunchTemplate_hibernation
=== RUN   TestAccAWSLaunchTemplate_defaultVersion
=== PAUSE TestAccAWSLaunchTemplate_defaultVersion
=== RUN   TestAccAWSLaunchTemplate_updateDefaultVersion
=== PAUSE TestAccAWSLaunchTemplate_updateDefaultVersion
=== CONT  TestAccAWSLaunchTemplate_basic
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t3
--- PASS: TestAccAWSLaunchTemplate_basic (14.95s)
=== CONT  TestAccAWSLaunchTemplate_updateDefaultVersion
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (15.23s)
=== CONT  TestAccAWSLaunchTemplate_defaultVersion
--- PASS: TestAccAWSLaunchTemplate_defaultVersion (34.84s)
=== CONT  TestAccAWSLaunchTemplate_hibernation
--- PASS: TestAccAWSLaunchTemplate_updateDefaultVersion (44.67s)
=== CONT  TestAccAWSLaunchTemplate_metadataOptions
--- PASS: TestAccAWSLaunchTemplate_metadataOptions (13.45s)
=== CONT  TestAccAWSLaunchTemplate_licenseSpecification
--- PASS: TestAccAWSLaunchTemplate_hibernation (35.27s)
=== CONT  TestAccAWSLaunchTemplate_instanceMarketOptions
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (15.54s)
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (14.16s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (12.97s)
=== CONT  TestAccAWSLaunchTemplate_placement_partitionNum
--- PASS: TestAccAWSLaunchTemplate_placement_partitionNum (27.10s)
=== CONT  TestAccAWSLaunchTemplate_associateCarrierIPAddress
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (57.91s)
=== CONT  TestAccAWSLaunchTemplate_associatePublicIPAddress
--- PASS: TestAccAWSLaunchTemplate_associateCarrierIPAddress (99.81s)
=== CONT  TestAccAWSLaunchTemplate_networkInterfaceAddresses
--- PASS: TestAccAWSLaunchTemplate_associatePublicIPAddress (101.87s)
=== CONT  TestAccAWSLaunchTemplate_networkInterface
--- PASS: TestAccAWSLaunchTemplate_networkInterfaceAddresses (57.78s)
=== CONT  TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
--- PASS: TestAccAWSLaunchTemplate_networkInterface (57.79s)
=== CONT  TestAccAWSLaunchTemplate_description
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (12.01s)
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t2
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (13.82s)
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
--- PASS: TestAccAWSLaunchTemplate_description (25.01s)
=== CONT  TestAccAWSLaunchTemplate_cpuOptions
--- PASS: TestAccAWSLaunchTemplate_cpuOptions (12.04s)
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_target
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (13.76s)
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_preference
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (13.26s)
=== CONT  TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (17.40s)
=== CONT  TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_tags (23.91s)
=== CONT  TestAccAWSLaunchTemplate_EbsOptimized
--- PASS: TestAccAWSLaunchTemplate_update (55.33s)
=== CONT  TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (14.49s)
=== CONT  TestAccAWSLaunchTemplate_NetworkInterfaces_DeleteOnTermination
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (53.42s)
=== CONT  TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (24.00s)
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
--- PASS: TestAccAWSLaunchTemplate_NetworkInterfaces_DeleteOnTermination (44.59s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (39.42s)
=== CONT  TestAccAWSLaunchTemplate_disappears
--- PASS: TestAccAWSLaunchTemplate_disappears (8.46s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (53.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	525.499s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchTemplateDataSource_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSLaunchTemplateDataSource_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_tags
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_tags
=== RUN   TestAccAWSLaunchTemplateDataSource_metadataOptions
=== PAUSE TestAccAWSLaunchTemplateDataSource_metadataOptions
=== RUN   TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== PAUSE TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== RUN   TestAccAWSLaunchTemplateDataSource_associateCarrierIPAddress
=== PAUSE TestAccAWSLaunchTemplateDataSource_associateCarrierIPAddress
=== RUN   TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== PAUSE TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
=== RUN   TestAccAWSLaunchTemplateDataSource_NonExistent
=== PAUSE TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_basic
=== CONT  TestAccAWSLaunchTemplateDataSource_associateCarrierIPAddress
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (14.99s)
=== CONT  TestAccAWSLaunchTemplateDataSource_NonExistent
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (1.75s)
=== CONT  TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination
--- PASS: TestAccAWSLaunchTemplateDataSource_associateCarrierIPAddress (40.41s)
=== CONT  TestAccAWSLaunchTemplateDataSource_metadataOptions
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (13.50s)
=== CONT  TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
--- PASS: TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination (39.41s)
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_tags
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_tags (13.04s)
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_basic
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_basic (13.57s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (38.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	92.861s
```
