### PR TITLE
r/glue_crawler - add support for `lineage_configuration`, `recrawl_policy` and plan time validations.

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -643,13 +643,8 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("table_prefix", crawler.TablePrefix)
 
 	if crawler.SchemaChangePolicy != nil {
-		schemaPolicy := map[string]string{
-			"delete_behavior": aws.StringValue(crawler.SchemaChangePolicy.DeleteBehavior),
-			"update_behavior": aws.StringValue(crawler.SchemaChangePolicy.UpdateBehavior),
-		}
-
-		if err := d.Set("schema_change_policy", []map[string]string{schemaPolicy}); err != nil {
-			return fmt.Errorf("error setting schema_change_policy: %s", schemaPolicy)
+		if err := d.Set("schema_change_policy", flattenGlueCrawlerSchemaChangePolicy(crawler.SchemaChangePolicy)); err != nil {
+			return fmt.Errorf("error setting schema_change_policy: %w", err)
 		}
 	}
 
@@ -775,6 +770,19 @@ func resourceAwsGlueCrawlerDelete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("error deleting Glue crawler: %w", err)
 	}
 	return nil
+}
+
+func flattenGlueCrawlerSchemaChangePolicy(cfg *glue.SchemaChangePolicy) []map[string]interface{} {
+	if cfg == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"delete_behavior": aws.StringValue(cfg.DeleteBehavior),
+		"update_behavior": aws.StringValue(cfg.UpdateBehavior),
+	}
+
+	return []map[string]interface{}{m}
 }
 
 func expandGlueCrawlerLineageConfiguration(cfg []interface{}) *glue.LineageConfiguration {

--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -264,7 +264,8 @@ func resourceAwsGlueCrawler() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"recrawl_behavior": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
+							Default:      glue.RecrawlBehaviorCrawlEverything,
 							ValidateFunc: validation.StringInSlice(glue.RecrawlBehavior_Values(), false),
 						},
 					},

--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -592,10 +592,7 @@ func resourceAwsGlueCrawlerUpdate(d *schema.ResourceData, meta interface{}) erro
 	glueConn := meta.(*AWSClient).glueconn
 	name := d.Get("name").(string)
 
-	if d.HasChanges(
-		"catalog_target", "classifiers", "configuration", "description", "dynamodb_target", "jdbc_target", "role",
-		"s3_target", "schedule", "schema_change_policy", "security_configuration", "table_prefix", "mongodb_target",
-		"lineage_configuration", "recrawl_policy") {
+	if d.HasChangesExcept("tags") {
 		updateCrawlerInput, err := updateCrawlerInput(name, d)
 		if err != nil {
 			return err

--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -222,6 +222,20 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				},
 				ValidateFunc: validation.StringIsJSON,
 			},
+			"lineage_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"crawler_lineage_settings": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(glue.CrawlerLineageSettings_Values(), false),
+						},
+					},
+				},
+			},
 			"security_configuration": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -259,7 +273,7 @@ func resourceAwsGlueCrawlerCreate(d *schema.ResourceData, meta interface{}) erro
 		_, err = glueConn.CreateCrawler(crawlerInput)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Glue crawler: %s", err)
+		return fmt.Errorf("error creating Glue crawler: %w", err)
 	}
 	d.SetId(name)
 
@@ -305,6 +319,10 @@ func createCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.Creat
 		crawlerInput.CrawlerSecurityConfiguration = aws.String(securityConfiguration.(string))
 	}
 
+	if v, ok := d.GetOk("lineage_configuration"); ok {
+		crawlerInput.LineageConfiguration = expandGlueCrawlerLineageConfiguration(v.([]interface{}))
+	}
+
 	return crawlerInput, nil
 }
 
@@ -347,6 +365,10 @@ func updateCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.Updat
 
 	if securityConfiguration, ok := d.GetOk("security_configuration"); ok {
 		crawlerInput.CrawlerSecurityConfiguration = aws.String(securityConfiguration.(string))
+	}
+
+	if v, ok := d.GetOk("lineage_configuration"); ok {
+		crawlerInput.LineageConfiguration = expandGlueCrawlerLineageConfiguration(v.([]interface{}))
 	}
 
 	return crawlerInput, nil
@@ -529,7 +551,8 @@ func resourceAwsGlueCrawlerUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	if d.HasChanges(
 		"catalog_target", "classifiers", "configuration", "description", "dynamodb_target", "jdbc_target", "role",
-		"s3_target", "schedule", "schema_change_policy", "security_configuration", "table_prefix", "mongodb_target") {
+		"s3_target", "schedule", "schema_change_policy", "security_configuration", "table_prefix", "mongodb_target",
+		"lineage_configuration") {
 		updateCrawlerInput, err := updateCrawlerInput(name, d)
 		if err != nil {
 			return err
@@ -556,14 +579,14 @@ func resourceAwsGlueCrawlerUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating Glue crawler: %s", err)
+			return fmt.Errorf("error updating Glue crawler: %w", err)
 		}
 	}
 
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.GlueUpdateTags(glueConn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+			return fmt.Errorf("error updating tags: %w", err)
 		}
 	}
 
@@ -586,10 +609,11 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 			return nil
 		}
 
-		return fmt.Errorf("error reading Glue crawler: %s", err.Error())
+		return fmt.Errorf("error reading Glue crawler: %w", err)
 	}
 
-	if crawlerOutput.Crawler == nil {
+	crawler := crawlerOutput.Crawler
+	if crawler == nil {
 		log.Printf("[WARN] Glue Crawler (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -603,25 +627,25 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 		Resource:  fmt.Sprintf("crawler/%s", d.Id()),
 	}.String()
 	d.Set("arn", crawlerARN)
-	d.Set("name", crawlerOutput.Crawler.Name)
-	d.Set("database_name", crawlerOutput.Crawler.DatabaseName)
-	d.Set("role", crawlerOutput.Crawler.Role)
-	d.Set("configuration", crawlerOutput.Crawler.Configuration)
-	d.Set("description", crawlerOutput.Crawler.Description)
-	d.Set("security_configuration", crawlerOutput.Crawler.CrawlerSecurityConfiguration)
+	d.Set("name", crawler.Name)
+	d.Set("database_name", crawler.DatabaseName)
+	d.Set("role", crawler.Role)
+	d.Set("configuration", crawler.Configuration)
+	d.Set("description", crawler.Description)
+	d.Set("security_configuration", crawler.CrawlerSecurityConfiguration)
 	d.Set("schedule", "")
-	if crawlerOutput.Crawler.Schedule != nil {
-		d.Set("schedule", crawlerOutput.Crawler.Schedule.ScheduleExpression)
+	if crawler.Schedule != nil {
+		d.Set("schedule", crawler.Schedule.ScheduleExpression)
 	}
-	if err := d.Set("classifiers", flattenStringList(crawlerOutput.Crawler.Classifiers)); err != nil {
-		return fmt.Errorf("error setting classifiers: %s", err)
+	if err := d.Set("classifiers", flattenStringList(crawler.Classifiers)); err != nil {
+		return fmt.Errorf("error setting classifiers: %w", err)
 	}
-	d.Set("table_prefix", crawlerOutput.Crawler.TablePrefix)
+	d.Set("table_prefix", crawler.TablePrefix)
 
-	if crawlerOutput.Crawler.SchemaChangePolicy != nil {
+	if crawler.SchemaChangePolicy != nil {
 		schemaPolicy := map[string]string{
-			"delete_behavior": aws.StringValue(crawlerOutput.Crawler.SchemaChangePolicy.DeleteBehavior),
-			"update_behavior": aws.StringValue(crawlerOutput.Crawler.SchemaChangePolicy.UpdateBehavior),
+			"delete_behavior": aws.StringValue(crawler.SchemaChangePolicy.DeleteBehavior),
+			"update_behavior": aws.StringValue(crawler.SchemaChangePolicy.UpdateBehavior),
 		}
 
 		if err := d.Set("schema_change_policy", []map[string]string{schemaPolicy}); err != nil {
@@ -629,24 +653,24 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	if crawlerOutput.Crawler.Targets != nil {
-		if err := d.Set("dynamodb_target", flattenGlueDynamoDBTargets(crawlerOutput.Crawler.Targets.DynamoDBTargets)); err != nil {
-			return fmt.Errorf("error setting dynamodb_target: %s", err)
+	if crawler.Targets != nil {
+		if err := d.Set("dynamodb_target", flattenGlueDynamoDBTargets(crawler.Targets.DynamoDBTargets)); err != nil {
+			return fmt.Errorf("error setting dynamodb_target: %w", err)
 		}
 
-		if err := d.Set("jdbc_target", flattenGlueJdbcTargets(crawlerOutput.Crawler.Targets.JdbcTargets)); err != nil {
-			return fmt.Errorf("error setting jdbc_target: %s", err)
+		if err := d.Set("jdbc_target", flattenGlueJdbcTargets(crawler.Targets.JdbcTargets)); err != nil {
+			return fmt.Errorf("error setting jdbc_target: %w", err)
 		}
 
-		if err := d.Set("s3_target", flattenGlueS3Targets(crawlerOutput.Crawler.Targets.S3Targets)); err != nil {
-			return fmt.Errorf("error setting s3_target: %s", err)
+		if err := d.Set("s3_target", flattenGlueS3Targets(crawler.Targets.S3Targets)); err != nil {
+			return fmt.Errorf("error setting s3_target: %w", err)
 		}
 
-		if err := d.Set("catalog_target", flattenGlueCatalogTargets(crawlerOutput.Crawler.Targets.CatalogTargets)); err != nil {
-			return fmt.Errorf("error setting catalog_target: %s", err)
+		if err := d.Set("catalog_target", flattenGlueCatalogTargets(crawler.Targets.CatalogTargets)); err != nil {
+			return fmt.Errorf("error setting catalog_target: %w", err)
 		}
 
-		if err := d.Set("mongodb_target", flattenGlueMongoDBTargets(crawlerOutput.Crawler.Targets.MongoDBTargets)); err != nil {
+		if err := d.Set("mongodb_target", flattenGlueMongoDBTargets(crawler.Targets.MongoDBTargets)); err != nil {
 			return fmt.Errorf("error setting mongodb_target: %w", err)
 		}
 	}
@@ -654,11 +678,15 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 	tags, err := keyvaluetags.GlueListTags(glueConn, crawlerARN)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Glue Crawler (%s): %s", crawlerARN, err)
+		return fmt.Errorf("error listing tags for Glue Crawler (%s): %w", crawlerARN, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("lineage_configuration", flattenGlueCrawlerLineageConfiguration(crawler.LineageConfiguration)); err != nil {
+		return fmt.Errorf("error setting lineage_configuration: %w", err)
 	}
 
 	return nil
@@ -744,7 +772,28 @@ func resourceAwsGlueCrawlerDelete(d *schema.ResourceData, meta interface{}) erro
 		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
 			return nil
 		}
-		return fmt.Errorf("error deleting Glue crawler: %s", err.Error())
+		return fmt.Errorf("error deleting Glue crawler: %w", err)
 	}
 	return nil
+}
+
+func expandGlueCrawlerLineageConfiguration(cfg []interface{}) *glue.LineageConfiguration {
+	m := cfg[0].(map[string]interface{})
+
+	target := &glue.LineageConfiguration{
+		CrawlerLineageSettings: aws.String(m["crawler_lineage_settings"].(string)),
+	}
+	return target
+}
+
+func flattenGlueCrawlerLineageConfiguration(cfg *glue.LineageConfiguration) []map[string]interface{} {
+	if cfg == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"crawler_lineage_settings": aws.StringValue(cfg.CrawlerLineageSettings),
+	}
+
+	return []map[string]interface{}{m}
 }

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -2433,9 +2433,9 @@ resource "aws_glue_catalog_database" "test" {
 resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
 
-  database_name          = aws_glue_catalog_database.test.name
-  name                   = %[1]q
-  role                   = aws_iam_role.test.name
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+  role          = aws_iam_role.test.name
 
   lineage_configuration {
     crawler_lineage_settings = %[2]q
@@ -2457,12 +2457,12 @@ resource "aws_glue_catalog_database" "test" {
 resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
 
-  database_name          = aws_glue_catalog_database.test.name
-  name                   = %[1]q
-  role                   = aws_iam_role.test.name
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+  role          = aws_iam_role.test.name
 
   schema_change_policy {
-	delete_behavior = "LOG"
+    delete_behavior = "LOG"
     update_behavior = "LOG"	
   }
 

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -1271,6 +1271,48 @@ func TestAccAWSGlueCrawler_SecurityConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueCrawler_lineageConfig(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerLineageConfig(rName, "ENABLE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "lineage_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lineage_configuration.0.crawler_lineage_settings", "ENABLE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGlueCrawlerLineageConfig(rName, "DISABLE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "lineage_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lineage_configuration.0.crawler_lineage_settings", "DISABLE")),
+			},
+			{
+				Config: testAccGlueCrawlerLineageConfig(rName, "ENABLE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "lineage_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lineage_configuration.0.crawler_lineage_settings", "ENABLE"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSGlueCrawlerExists(resourceName string, crawler *glue.Crawler) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -2338,4 +2380,28 @@ resource "aws_glue_crawler" "test" {
   }
 }
 `, rName, path1, path2)
+}
+
+func testAccGlueCrawlerLineageConfig(rName, lineageConfig string) string {
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_crawler" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
+
+  database_name          = aws_glue_catalog_database.test.name
+  name                   = %[1]q
+  role                   = aws_iam_role.test.name
+
+  lineage_configuration {
+    crawler_lineage_settings = %[2]q
+  }
+
+  s3_target {
+    path = "s3://bucket-name"
+  }
+}
+`, rName, lineageConfig)
 }

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -2463,7 +2463,7 @@ resource "aws_glue_crawler" "test" {
 
   schema_change_policy {
     delete_behavior = "LOG"
-    update_behavior = "LOG"	
+    update_behavior = "LOG"
   }
 
   recrawl_policy {

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -1313,6 +1313,48 @@ func TestAccAWSGlueCrawler_lineageConfig(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueCrawler_recrawlPolicy(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerRecrawlPolicyConfig(rName, "CRAWL_EVERYTHING"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "recrawl_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "recrawl_policy.0.recrawl_behavior", "CRAWL_EVERYTHING"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGlueCrawlerRecrawlPolicyConfig(rName, "CRAWL_NEW_FOLDERS_ONLY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "recrawl_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "recrawl_policy.0.recrawl_behavior", "CRAWL_NEW_FOLDERS_ONLY")),
+			},
+			{
+				Config: testAccGlueCrawlerRecrawlPolicyConfig(rName, "CRAWL_EVERYTHING"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "recrawl_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "recrawl_policy.0.recrawl_behavior", "CRAWL_EVERYTHING"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSGlueCrawlerExists(resourceName string, crawler *glue.Crawler) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -2404,4 +2446,33 @@ resource "aws_glue_crawler" "test" {
   }
 }
 `, rName, lineageConfig)
+}
+
+func testAccGlueCrawlerRecrawlPolicyConfig(rName, policy string) string {
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_crawler" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
+
+  database_name          = aws_glue_catalog_database.test.name
+  name                   = %[1]q
+  role                   = aws_iam_role.test.name
+
+  schema_change_policy {
+	delete_behavior = "LOG"
+    update_behavior = "LOG"	
+  }
+
+  recrawl_policy {
+    recrawl_behavior = %[2]q
+  }
+
+  s3_target {
+    path = "s3://bucket-name"
+  }
+}
+`, rName, policy)
 }

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -12,7 +12,7 @@ Manages a Glue Crawler. More information can be found in the [AWS Glue Developer
 
 ## Example Usage
 
-### DynamoDB Target
+### DynamoDB Target Example
 
 ```hcl
 resource "aws_glue_crawler" "example" {
@@ -26,7 +26,7 @@ resource "aws_glue_crawler" "example" {
 }
 ```
 
-### JDBC Target
+### JDBC Target Example
 
 ```hcl
 resource "aws_glue_crawler" "example" {
@@ -41,7 +41,7 @@ resource "aws_glue_crawler" "example" {
 }
 ```
 
-### S3 Target
+### S3 Target Example
 
 ```hcl
 resource "aws_glue_crawler" "example" {
@@ -56,7 +56,7 @@ resource "aws_glue_crawler" "example" {
 ```
 
 
-### Catalog Target
+### Catalog Target Example
 
 ```hcl
 resource "aws_glue_crawler" "example" {
@@ -84,7 +84,7 @@ EOF
 }
 ```
 
-### MongoDB Target
+### MongoDB Target Example
 
 ```hcl
 resource "aws_glue_crawler" "example" {
@@ -99,7 +99,7 @@ resource "aws_glue_crawler" "example" {
 }
 ```
 
-### Configuration Settings
+### Configuration Settings Example
 
 ```hcl
 resource "aws_glue_crawler" "events_crawler" {
@@ -178,6 +178,12 @@ The following arguments are supported:
 
 -> **Note:** `configuration` for catalog target crawlers will have `{ ... "Grouping": { "TableGroupingPolicy": "CombineCompatibleSchemas"} }` by default.
 
+
+### MongoDB Target
+
+* `connection_name` - (Required) The name of the connection to use to connect to the Amazon DocumentDB or MongoDB target.
+* `path` - (Required) The path of the Amazon DocumentDB or MongoDB target (database/collection).
+* `scan_all` - (Optional) Indicates whether to scan all the records, or to sample rows from the table. Scanning all the records can take a long time when the table is not a high throughput table. Default value is `true`.
 
 ### Schema Change Policy
 

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -141,7 +141,7 @@ The following arguments are supported:
 * `description` (Optional) Description of the crawler.
 * `dynamodb_target` (Optional) List of nested DynamoDB target arguments. See [Dynamodb Target](#dynamodb-target) below.
 * `jdbc_target` (Optional) List of nested JBDC target arguments. See [JDBC Target](#jdbc-target) below.
-* `s3_target` (Optional) List nested Amazon S3 target arguments. See [S# Target](#s3-target) below.
+* `s3_target` (Optional) List nested Amazon S3 target arguments. See [S3 Target](#s3-target) below.
 * `mongodb_target` (Optional) List nested MongoDB target arguments. See [MongoDB Target](#mongodb-target) below.
 * `schedule` (Optional) A cron expression used to specify the schedule. For more information, see [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html). For example, to run something every day at 12:15 UTC, you would specify: `cron(15 12 * * ? *)`.
 * `schema_change_policy` (Optional) Policy for the crawler's update and deletion behavior. See [Schema Change Policy](#schema-change-policy) below.

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -139,54 +139,58 @@ The following arguments are supported:
 * `classifiers` (Optional) List of custom classifiers. By default, all AWS classifiers are included in a crawl, but these custom classifiers always override the default classifiers for a given classification.
 * `configuration` (Optional) JSON string of configuration information. For more details see [Setting Crawler Configuration Options](https://docs.aws.amazon.com/glue/latest/dg/crawler-configuration.html).
 * `description` (Optional) Description of the crawler.
-* `dynamodb_target` (Optional) List of nested DynamoDB target arguments. See below.
-* `jdbc_target` (Optional) List of nested JBDC target arguments. See below.
-* `s3_target` (Optional) List nested Amazon S3 target arguments. See below.
-* `mongodb_target` (Optional) List nested MongoDB target arguments. See below.
+* `dynamodb_target` (Optional) List of nested DynamoDB target arguments. See [Dynamodb Target](#dynamodb-target) below.
+* `jdbc_target` (Optional) List of nested JBDC target arguments. See [JDBC Target](#jdbc-target) below.
+* `s3_target` (Optional) List nested Amazon S3 target arguments. See [S# Target](#s3-target) below.
+* `mongodb_target` (Optional) List nested MongoDB target arguments. See [MongoDB Target](#mongodb-target) below.
 * `schedule` (Optional) A cron expression used to specify the schedule. For more information, see [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html). For example, to run something every day at 12:15 UTC, you would specify: `cron(15 12 * * ? *)`.
-* `schema_change_policy` (Optional) Policy for the crawler's update and deletion behavior.
+* `schema_change_policy` (Optional) Policy for the crawler's update and deletion behavior. See [Schema Change Policy](#schema-change-policy) below.
+* `lineage_configuration` (Optional) Specifies data lineage configuration settings for the crawler. See [Lineage Configuration](#lineage-configuration) below.
+* `recrawl_policy` (Optional)  A policy that specifies whether to crawl the entire dataset again, or to crawl only folders that were added since the last crawler run.. See [Recrawl Policy](#recrawl-policy) below.
 * `security_configuration` (Optional) The name of Security Configuration to be used by the crawler
 * `table_prefix` (Optional) The table prefix used for catalog tables that are created.
 * `tags` - (Optional) Key-value map of resource tags
 
-### dynamodb_target Argument Reference
+### Dynamodb Target
 
 * `path` - (Required) The name of the DynamoDB table to crawl.
 * `scan_all` - (Optional) Indicates whether to scan all the records, or to sample rows from the table. Scanning all the records can take a long time when the table is not a high throughput table.  defaults to `true`.
 * `scan_rate` - (Optional) The percentage of the configured read capacity units to use by the AWS Glue crawler. The valid values are null or a value between 0.1 to 1.5.
 
-### jdbc_target Argument Reference
+### JDBC Target
 
 * `connection_name` - (Required) The name of the connection to use to connect to the JDBC target.
 * `path` - (Required) The path of the JDBC target.
 * `exclusions` - (Optional) A list of glob patterns used to exclude from the crawl.
 
-### s3_target Argument Reference
+### S3 Target
 
 * `path` - (Required) The path to the Amazon S3 target.
 * `connection_name` - (Optional) The name of a connection which allows crawler to access data in S3 within a VPC.
 * `exclusions` - (Optional) A list of glob patterns used to exclude from the crawl.
 
-### catalog_target Argument Reference
+### Catalog Target
 
 * `database_name` - (Required) The name of the Glue database to be synchronized.
 * `tables` - (Required) A list of catalog tables to be synchronized.
-
-### mongodb_target Argument Reference
-
-* `connection_name` - (Required) The name of the connection to use to connect to the Amazon DocumentDB or MongoDB target.
-* `path` - (Required) The path of the Amazon DocumentDB or MongoDB target (database/collection).
-* `scan_all` - (Optional) Indicates whether to scan all the records, or to sample rows from the table. Scanning all the records can take a long time when the table is not a high throughput table. Default value is `true`.
 
 ~> **Note:** `deletion_behavior` of catalog target doesn't support `DEPRECATE_IN_DATABASE`.
 
 -> **Note:** `configuration` for catalog target crawlers will have `{ ... "Grouping": { "TableGroupingPolicy": "CombineCompatibleSchemas"} }` by default.
 
 
-### schema_change_policy Argument Reference
+### Schema Change Policy
 
 * `delete_behavior` - (Optional) The deletion behavior when the crawler finds a deleted object. Valid values: `LOG`, `DELETE_FROM_DATABASE`, or `DEPRECATE_IN_DATABASE`. Defaults to `DEPRECATE_IN_DATABASE`.
 * `update_behavior` - (Optional) The update behavior when the crawler finds a changed schema. Valid values: `LOG` or `UPDATE_IN_DATABASE`. Defaults to `UPDATE_IN_DATABASE`.
+
+### Lineage Configuration
+
+* `crawler_lineage_settings` - (Optional) Specifies whether data lineage is enabled for the crawler. Valid values are: `ENABLE` and `DISABLE`. Default value is `Disable`.
+
+### Recrawl Policy
+
+* `recrawl_behavior` - (Optional) Specifies whether to crawl the entire dataset again or to crawl only folders that were added since the last crawler run. Valid Values are: `CRAWL_EVERYTHING` and `CRAWL_NEW_FOLDERS_ONLY`. Default value is `CRAWL_EVERYTHING`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16013 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_crawler - add support for `lineage_configuration` and `recrawl_policy`.
resource_aws_glue_crawler - add plan time validations to `name`, `description` and `table_prefix`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCrawler_'
--- PASS: TestAccAWSGlueCrawler_disappears (53.07s)
--- PASS: TestAccAWSGlueCrawler_S3Target_ConnectionName (89.49s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (93.09s)
--- PASS: TestAccAWSGlueCrawler_mongoDBTarget (98.45s)
--- PASS: TestAccAWSGlueCrawler_Description (98.51s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (99.57s)
--- PASS: TestAccAWSGlueCrawler_S3Target (100.08s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget (100.08s)
--- PASS: TestAccAWSGlueCrawler_Configuration (100.90s)
--- PASS: TestAccAWSGlueCrawler_RemoveTablePrefix (105.02s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Exclusions (105.25s)
--- PASS: TestAccAWSGlueCrawler_SecurityConfiguration (115.42s)
--- PASS: TestAccAWSGlueCrawler_recrawlPolicy (129.38s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Multiple (130.18s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Multiple (132.92s)
--- PASS: TestAccAWSGlueCrawler_mongoDBTarget_multiple (132.94s)
--- PASS: TestAccAWSGlueCrawler_lineageConfig (133.70s)
--- PASS: TestAccAWSGlueCrawler_mongoDBTarget_scan_all (135.81s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_Path (46.39s)
--- PASS: TestAccAWSGlueCrawler_Role_Name_Path (45.99s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_NoPath (51.22s)
--- PASS: TestAccAWSGlueCrawler_CatalogTarget (153.98s)
--- PASS: TestAccAWSGlueCrawler_Tags (116.68s)
--- PASS: TestAccAWSGlueCrawler_TablePrefix (81.87s)
--- PASS: TestAccAWSGlueCrawler_SchemaChangePolicy (86.17s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget_scanRate (116.58s)
--- PASS: TestAccAWSGlueCrawler_Schedule (121.75s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget_scanAll (115.12s)
--- PASS: TestAccAWSGlueCrawler_Classifiers (115.62s)
--- PASS: TestAccAWSGlueCrawler_CatalogTarget_Multiple (240.51s)
```
