### PR TITLE
aws_eip: Add 'carrier_ip' attribute

### DIFF
--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -64,6 +64,10 @@ func dataSourceAwsEip() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"carrier_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"customer_owned_ipv4_pool": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -158,6 +162,7 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
+	d.Set("carrier_ip", eip.CarrierIp)
 	d.Set("customer_owned_ipv4_pool", eip.CustomerOwnedIpv4Pool)
 	d.Set("customer_owned_ip", eip.CustomerOwnedIp)
 

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -98,6 +98,11 @@ func resourceAwsEip() *schema.Resource {
 				Optional: true,
 			},
 
+			"carrier_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"customer_owned_ipv4_pool": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -293,6 +298,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	d.Set("public_ipv4_pool", address.PublicIpv4Pool)
+	d.Set("carrier_ip", address.CarrierIp)
 	d.Set("customer_owned_ipv4_pool", address.CustomerOwnedIpv4Pool)
 	d.Set("customer_owned_ip", address.CustomerOwnedIp)
 	d.Set("network_border_group", address.NetworkBorderGroup)
@@ -441,7 +447,8 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 	case ec2.DomainTypeVpc:
 		log.Printf("[DEBUG] EIP release (destroy) address allocation: %v", d.Id())
 		input = &ec2.ReleaseAddressInput{
-			AllocationId: aws.String(d.Id()),
+			AllocationId:       aws.String(d.Id()),
+			NetworkBorderGroup: aws.String(d.Get("network_border_group").(string)),
 		}
 	case ec2.DomainTypeStandard:
 		log.Printf("[DEBUG] EIP release (destroy) address: %v", d.Id())

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -3307,6 +3307,30 @@ data "aws_availability_zones" "available" {
 `
 }
 
+func testAccAvailableAZsWavelengthZonesExcludeConfig(excludeZoneIds ...string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  exclude_zone_ids = ["%[1]s"]
+  state            = "available"
+
+  filter {
+    name   = "zone-type"
+    values = ["wavelength-zone"]
+  }
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opted-in"]
+  }
+}
+`, strings.Join(excludeZoneIds, "\", \""))
+}
+
+func testAccAvailableAZsWavelengthZonesDefaultExcludeConfig() string {
+	// Exclude usw2-wl1-den-wlz1 as there may be problems allocating carrier IP addresses.
+	return testAccAvailableAZsWavelengthZonesExcludeConfig("usw2-wl1-den-wlz1")
+}
+
 func testAccInstanceConfigInDefaultVpcBySgName(rName string) string {
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		testAccLatestAmazonLinuxHvmEbsAmiConfig() +

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -75,6 +75,7 @@ In addition to all arguments above, the following attributes are exported:
 * `public_ip` - Public IP address of Elastic IP.
 * `public_dns` - Public DNS associated with the Elastic IP address.
 * `public_ipv4_pool` - The ID of an address pool.
+* `carrier_ip` - The carrier IP address.
 * `customer_owned_ipv4_pool` - The ID of a Customer Owned IP Pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing)
 * `customer_owned_ip` - Customer Owned IP.
 * `tags` - Key-value map of tags associated with Elastic IP.

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -127,6 +127,7 @@ In addition to all arguments above, the following attributes are exported:
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
 * `public_ipv4_pool` - EC2 IPv4 address pool identifier (if in VPC).
+* `carrier_ip` - The carrier IP address.
 * `customer_owned_ipv4_pool` - The  ID  of a customer-owned address pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing)
 * `customer_owned_ip` - Customer owned IP.
 * `domain` - Indicates if this EIP is for use in VPC (`vpc`) or EC2 Classic (`standard`).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14518.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_eip: Add `carrier_ip` attribute.
data-source/aws_eip: Add `carrier_ip` attribute.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
##### `us-west-2`

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEIP_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSEIP_ -timeout 120m
=== RUN   TestAccAWSEIP_Ec2Classic
=== PAUSE TestAccAWSEIP_Ec2Classic
=== RUN   TestAccAWSEIP_basic
=== PAUSE TestAccAWSEIP_basic
=== RUN   TestAccAWSEIP_instance
=== PAUSE TestAccAWSEIP_instance
=== RUN   TestAccAWSEIP_networkInterface
=== PAUSE TestAccAWSEIP_networkInterface
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
=== PAUSE TestAccAWSEIP_twoEIPsOneNetworkInterface
=== RUN   TestAccAWSEIP_associated_user_private_ip
=== PAUSE TestAccAWSEIP_associated_user_private_ip
=== RUN   TestAccAWSEIP_Instance_Reassociate
=== PAUSE TestAccAWSEIP_Instance_Reassociate
=== RUN   TestAccAWSEIP_disappears
=== PAUSE TestAccAWSEIP_disappears
=== RUN   TestAccAWSEIP_notAssociated
=== PAUSE TestAccAWSEIP_notAssociated
=== RUN   TestAccAWSEIP_tags_Vpc
=== PAUSE TestAccAWSEIP_tags_Vpc
=== RUN   TestAccAWSEIP_tags_Ec2Classic
=== PAUSE TestAccAWSEIP_tags_Ec2Classic
=== RUN   TestAccAWSEIP_PublicIpv4Pool_default
=== PAUSE TestAccAWSEIP_PublicIpv4Pool_default
=== RUN   TestAccAWSEIP_NetworkBorderGroup
=== PAUSE TestAccAWSEIP_NetworkBorderGroup
=== RUN   TestAccAWSEIP_CarrierIP
=== PAUSE TestAccAWSEIP_CarrierIP
=== RUN   TestAccAWSEIP_PublicIpv4Pool_custom
    resource_aws_eip_test.go:502: Environment variable AWS_EC2_EIP_PUBLIC_IPV4_POOL is not set
--- SKIP: TestAccAWSEIP_PublicIpv4Pool_custom (0.00s)
=== RUN   TestAccAWSEIP_CustomerOwnedIpv4Pool
=== PAUSE TestAccAWSEIP_CustomerOwnedIpv4Pool
=== CONT  TestAccAWSEIP_Ec2Classic
=== CONT  TestAccAWSEIP_notAssociated
    resource_aws_eip_test.go:328: Step 3/3 error: Error running apply: 2020/12/11 14:30:33 [DEBUG] Using modified User-Agent: Terraform/0.12.26 HashiCorp-terraform-exec/0.10.0
        
        Error: Failure associating EIP: Gateway.NotAttached: Network vpc-b6fbb6cf is not attached to any internet gateway
        	status code: 400, request id: af22d2a6-09f4-444e-b701-7dee0d2aa5f7
        
        
--- FAIL: TestAccAWSEIP_notAssociated (111.85s)
=== CONT  TestAccAWSEIP_CustomerOwnedIpv4Pool
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSEIP_CustomerOwnedIpv4Pool (1.52s)
=== CONT  TestAccAWSEIP_CarrierIP
--- PASS: TestAccAWSEIP_CarrierIP (16.85s)
=== CONT  TestAccAWSEIP_NetworkBorderGroup
--- PASS: TestAccAWSEIP_NetworkBorderGroup (15.02s)
=== CONT  TestAccAWSEIP_PublicIpv4Pool_default
--- PASS: TestAccAWSEIP_PublicIpv4Pool_default (14.30s)
=== CONT  TestAccAWSEIP_tags_Ec2Classic
--- PASS: TestAccAWSEIP_tags_Ec2Classic (34.44s)
=== CONT  TestAccAWSEIP_tags_Vpc
--- PASS: TestAccAWSEIP_Ec2Classic (213.33s)
=== CONT  TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_tags_Vpc (21.30s)
=== CONT  TestAccAWSEIP_disappears
--- PASS: TestAccAWSEIP_disappears (9.58s)
=== CONT  TestAccAWSEIP_Instance_Reassociate
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (75.54s)
=== CONT  TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_Instance_Reassociate (112.19s)
=== CONT  TestAccAWSEIP_instance
    resource_aws_eip_test.go:148: Step 1/2 error: Error running apply: 2020/12/11 14:35:08 [DEBUG] Using modified User-Agent: Terraform/0.12.26 HashiCorp-terraform-exec/0.10.0
        
        Error: Failure associating EIP: Gateway.NotAttached: Network vpc-b6fbb6cf is not attached to any internet gateway
        	status code: 400, request id: 279951a1-59df-47b0-aaf3-12e1778f58d4
        
        
--- FAIL: TestAccAWSEIP_instance (75.87s)
=== CONT  TestAccAWSEIP_networkInterface
--- PASS: TestAccAWSEIP_networkInterface (73.94s)
=== CONT  TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_associated_user_private_ip (198.31s)
--- PASS: TestAccAWSEIP_basic (13.65s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	500.614s
FAIL
GNUmakefile:27: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

The 2 failures are because the default VPC in the region does not have an attached Internet Gateway.

##### `eu-central-1`

```console
$ AWS_DEFAULT_REGION=eu-central-1 make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEIP_instance\|TestAccAWSEIP_notAssociated' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSEIP_instance\|TestAccAWSEIP_notAssociated -timeout 120m
=== RUN   TestAccAWSEIP_instance
=== PAUSE TestAccAWSEIP_instance
=== RUN   TestAccAWSEIP_notAssociated
=== PAUSE TestAccAWSEIP_notAssociated
=== CONT  TestAccAWSEIP_instance
=== CONT  TestAccAWSEIP_notAssociated
--- PASS: TestAccAWSEIP_instance (108.60s)
--- PASS: TestAccAWSEIP_notAssociated (121.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	121.402s
```

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAWSEIP_\|TestAccDataSourceAwsEip_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccDataSourceAWSEIP_\|TestAccDataSourceAwsEip_ -timeout 120m
=== RUN   TestAccDataSourceAwsEip_Filter
=== PAUSE TestAccDataSourceAwsEip_Filter
=== RUN   TestAccDataSourceAwsEip_Id
=== PAUSE TestAccDataSourceAwsEip_Id
=== RUN   TestAccDataSourceAwsEip_PublicIP_EC2Classic
=== PAUSE TestAccDataSourceAwsEip_PublicIP_EC2Classic
=== RUN   TestAccDataSourceAwsEip_PublicIP_VPC
=== PAUSE TestAccDataSourceAwsEip_PublicIP_VPC
=== RUN   TestAccDataSourceAwsEip_Tags
=== PAUSE TestAccDataSourceAwsEip_Tags
=== RUN   TestAccDataSourceAwsEip_NetworkInterface
=== PAUSE TestAccDataSourceAwsEip_NetworkInterface
=== RUN   TestAccDataSourceAwsEip_Instance
=== PAUSE TestAccDataSourceAwsEip_Instance
=== RUN   TestAccDataSourceAWSEIP_CarrierIP
=== PAUSE TestAccDataSourceAWSEIP_CarrierIP
=== RUN   TestAccDataSourceAWSEIP_CustomerOwnedIpv4Pool
=== PAUSE TestAccDataSourceAWSEIP_CustomerOwnedIpv4Pool
=== CONT  TestAccDataSourceAwsEip_Filter
=== CONT  TestAccDataSourceAwsEip_NetworkInterface
--- PASS: TestAccDataSourceAwsEip_Filter (13.33s)
=== CONT  TestAccDataSourceAWSEIP_CustomerOwnedIpv4Pool
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccDataSourceAWSEIP_CustomerOwnedIpv4Pool (1.46s)
=== CONT  TestAccDataSourceAWSEIP_CarrierIP
--- PASS: TestAccDataSourceAWSEIP_CarrierIP (13.70s)
=== CONT  TestAccDataSourceAwsEip_Instance
--- PASS: TestAccDataSourceAwsEip_NetworkInterface (66.40s)
=== CONT  TestAccDataSourceAwsEip_PublicIP_VPC
--- PASS: TestAccDataSourceAwsEip_PublicIP_VPC (13.49s)
=== CONT  TestAccDataSourceAwsEip_Tags
--- PASS: TestAccDataSourceAwsEip_Tags (11.89s)
=== CONT  TestAccDataSourceAwsEip_PublicIP_EC2Classic
--- PASS: TestAccDataSourceAwsEip_PublicIP_EC2Classic (8.68s)
=== CONT  TestAccDataSourceAwsEip_Id
--- PASS: TestAccDataSourceAwsEip_Id (11.22s)
--- PASS: TestAccDataSourceAwsEip_Instance (99.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	128.440s
```