### PR TITLE
Glue catalog table empty partition keys

### DIFF
--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -450,6 +450,8 @@ func expandGlueTableInput(d *schema.ResourceData) *glue.TableInput {
 
 	if v, ok := d.GetOk("partition_keys"); ok {
 		tableInput.PartitionKeys = expandGlueColumns(v.([]interface{}))
+	} else {
+		tableInput.PartitionKeys = []*glue.Column{}
 	}
 
 	if v, ok := d.GetOk("view_original_text"); ok {

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -28,6 +28,7 @@ func TestAccAWSGlueCatalogTable_basic(t *testing.T) {
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("table/%s/%s", rName, rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.#", "0"),
 					testAccCheckResourceAttrAccountID(resourceName, "catalog_id"),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5206

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Bug: Glue table partition keys should be set to empty list instead of being unset (#16727)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCatalogTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGlueCatalogTable_ -timeout 120m
=== RUN   TestAccAWSGlueCatalogTable_basic
=== PAUSE TestAccAWSGlueCatalogTable_basic
=== RUN   TestAccAWSGlueCatalogTable_columnParameters
=== PAUSE TestAccAWSGlueCatalogTable_columnParameters
=== RUN   TestAccAWSGlueCatalogTable_full
=== PAUSE TestAccAWSGlueCatalogTable_full
=== RUN   TestAccAWSGlueCatalogTable_update_addValues
=== PAUSE TestAccAWSGlueCatalogTable_update_addValues
=== RUN   TestAccAWSGlueCatalogTable_update_replaceValues
=== PAUSE TestAccAWSGlueCatalogTable_update_replaceValues
=== RUN   TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock
=== PAUSE TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock
=== RUN   TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock
=== PAUSE TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock
=== RUN   TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_UpdateValues
=== PAUSE TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_UpdateValues
=== RUN   TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock
=== PAUSE TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock
=== RUN   TestAccAWSGlueCatalogTable_partitionIndexesSingle
=== PAUSE TestAccAWSGlueCatalogTable_partitionIndexesSingle
=== RUN   TestAccAWSGlueCatalogTable_partitionIndexesMultiple
=== PAUSE TestAccAWSGlueCatalogTable_partitionIndexesMultiple
=== RUN   TestAccAWSGlueCatalogTable_disappears
=== PAUSE TestAccAWSGlueCatalogTable_disappears
=== CONT  TestAccAWSGlueCatalogTable_basic
=== CONT  TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_UpdateValues
=== CONT  TestAccAWSGlueCatalogTable_update_replaceValues
=== CONT  TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock
=== CONT  TestAccAWSGlueCatalogTable_full
=== CONT  TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock
=== CONT  TestAccAWSGlueCatalogTable_partitionIndexesMultiple
=== CONT  TestAccAWSGlueCatalogTable_update_addValues
=== CONT  TestAccAWSGlueCatalogTable_disappears
=== CONT  TestAccAWSGlueCatalogTable_partitionIndexesSingle
=== CONT  TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock
=== CONT  TestAccAWSGlueCatalogTable_columnParameters
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock (60.13s)
--- PASS: TestAccAWSGlueCatalogTable_disappears (60.39s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock (60.48s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock (61.93s)
--- PASS: TestAccAWSGlueCatalogTable_columnParameters (66.22s)
--- PASS: TestAccAWSGlueCatalogTable_partitionIndexesMultiple (66.87s)
--- PASS: TestAccAWSGlueCatalogTable_full (69.13s)
--- PASS: TestAccAWSGlueCatalogTable_basic (71.02s)
--- PASS: TestAccAWSGlueCatalogTable_partitionIndexesSingle (71.26s)
--- PASS: TestAccAWSGlueCatalogTable_update_replaceValues (100.75s)
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (100.77s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_UpdateValues (100.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	102.539s
```
