### PR TITLE
r/cognito_user_pool_client - add support for `application_arn` in the `analytics_configuration` block

### DIFF
--- a/.changelog/16734.txt
+++ b/.changelog/16734.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_user_pool_client: Add support for `application_arn` in the `analytics_configuration` block.
+```

--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -166,17 +166,28 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"application_id": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:          schema.TypeString,
+							Optional:      true,
+							ExactlyOneOf:  []string{"analytics_configuration.0.application_id", "analytics_configuration.0.application_arn"},
+							ConflictsWith: []string{"analytics_configuration.0.external_id", "analytics_configuration.0.role_arn"},
+						},
+						"application_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ExactlyOneOf: []string{"analytics_configuration.0.application_id", "analytics_configuration.0.application_arn"},
+							ValidateFunc: validateArn,
 						},
 						"external_id": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:          schema.TypeString,
+							ConflictsWith: []string{"analytics_configuration.0.application_arn"},
+							Optional:      true,
 						},
 						"role_arn": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateArn,
+							Type:          schema.TypeString,
+							Optional:      true,
+							Computed:      true,
+							ConflictsWith: []string{"analytics_configuration.0.application_arn"},
+							ValidateFunc:  validateArn,
 						},
 						"user_data_shared": {
 							Type:     schema.TypeBool,
@@ -424,10 +435,22 @@ func expandAwsCognitoUserPoolClientAnalyticsConfig(l []interface{}) *cognitoiden
 
 	m := l[0].(map[string]interface{})
 
-	analyticsConfig := &cognitoidentityprovider.AnalyticsConfigurationType{
-		ApplicationId: aws.String(m["application_id"].(string)),
-		ExternalId:    aws.String(m["external_id"].(string)),
-		RoleArn:       aws.String(m["role_arn"].(string)),
+	analyticsConfig := &cognitoidentityprovider.AnalyticsConfigurationType{}
+
+	if v, ok := m["role_arn"]; ok && v != "" {
+		analyticsConfig.RoleArn = aws.String(v.(string))
+	}
+
+	if v, ok := m["external_id"]; ok && v != "" {
+		analyticsConfig.ExternalId = aws.String(v.(string))
+	}
+
+	if v, ok := m["application_id"]; ok && v != "" {
+		analyticsConfig.ApplicationId = aws.String(v.(string))
+	}
+
+	if v, ok := m["application_arn"]; ok && v != "" {
+		analyticsConfig.ApplicationArn = aws.String(v.(string))
 	}
 
 	if v, ok := m["user_data_shared"]; ok {
@@ -443,10 +466,23 @@ func flattenAwsCognitoUserPoolClientAnalyticsConfig(analyticsConfig *cognitoiden
 	}
 
 	m := map[string]interface{}{
-		"application_id":   aws.StringValue(analyticsConfig.ApplicationId),
-		"external_id":      aws.StringValue(analyticsConfig.ExternalId),
-		"role_arn":         aws.StringValue(analyticsConfig.RoleArn),
 		"user_data_shared": aws.BoolValue(analyticsConfig.UserDataShared),
+	}
+
+	if analyticsConfig.ExternalId != nil {
+		m["external_id"] = aws.StringValue(analyticsConfig.ExternalId)
+	}
+
+	if analyticsConfig.RoleArn != nil {
+		m["role_arn"] = aws.StringValue(analyticsConfig.RoleArn)
+	}
+
+	if analyticsConfig.ApplicationId != nil {
+		m["application_id"] = aws.StringValue(analyticsConfig.ApplicationId)
+	}
+
+	if analyticsConfig.ApplicationArn != nil {
+		m["application_arn"] = aws.StringValue(analyticsConfig.ApplicationArn)
 	}
 
 	return []interface{}{m}

--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -51,17 +51,8 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						cognitoidentityprovider.ExplicitAuthFlowsTypeAdminNoSrpAuth,
-						cognitoidentityprovider.ExplicitAuthFlowsTypeCustomAuthFlowOnly,
-						cognitoidentityprovider.ExplicitAuthFlowsTypeUserPasswordAuth,
-						cognitoidentityprovider.ExplicitAuthFlowsTypeAllowAdminUserPasswordAuth,
-						cognitoidentityprovider.ExplicitAuthFlowsTypeAllowCustomAuth,
-						cognitoidentityprovider.ExplicitAuthFlowsTypeAllowUserPasswordAuth,
-						cognitoidentityprovider.ExplicitAuthFlowsTypeAllowUserSrpAuth,
-						cognitoidentityprovider.ExplicitAuthFlowsTypeAllowRefreshTokenAuth,
-					}, false),
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(cognitoidentityprovider.ExplicitAuthFlowsType_Values(), false),
 				},
 			},
 
@@ -93,12 +84,8 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 				Optional: true,
 				MaxItems: 3,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						cognitoidentityprovider.OAuthFlowTypeCode,
-						cognitoidentityprovider.OAuthFlowTypeImplicit,
-						cognitoidentityprovider.OAuthFlowTypeClientCredentials,
-					}, false),
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(cognitoidentityprovider.OAuthFlowType_Values(), false),
 				},
 			},
 

--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -166,16 +166,16 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"application_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ExactlyOneOf: []string{"analytics_configuration.0.application_id", "analytics_configuration.0.application_arn"},
+						},
+						"application_arn": {
 							Type:          schema.TypeString,
 							Optional:      true,
 							ExactlyOneOf:  []string{"analytics_configuration.0.application_id", "analytics_configuration.0.application_arn"},
 							ConflictsWith: []string{"analytics_configuration.0.external_id", "analytics_configuration.0.role_arn"},
-						},
-						"application_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ExactlyOneOf: []string{"analytics_configuration.0.application_id", "analytics_configuration.0.application_arn"},
-							ValidateFunc: validateArn,
+							ValidateFunc:  validateArn,
 						},
 						"external_id": {
 							Type:          schema.TypeString,

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -277,8 +277,8 @@ func TestAccAWSCognitoUserPoolClient_analyticsConfig(t *testing.T) {
 
 func TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	userPoolName := acctest.RandString(10)
+	clientName := acctest.RandString(10)
 	resourceName := "aws_cognito_user_pool_client.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -277,7 +277,7 @@ func TestAccAWSCognitoUserPoolClient_analyticsConfig(t *testing.T) {
 
 func TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+	userPoolName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resourceName := "aws_cognito_user_pool_client.test"
 

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -275,6 +275,41 @@ func TestAccAWSCognitoUserPoolClient_analyticsConfig(t *testing.T) {
 	})
 }
 
+func TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn(t *testing.T) {
+	var client cognitoidentityprovider.UserPoolClientType
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSCognitoIdentityProvider(t)
+			testAccPreCheckAWSPinpointApp(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolClientConfigAnalyticsWithArnConfig(userPoolName, clientName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "analytics_configuration.0.application_arn", "aws_pinpoint_app.test", "arn"),
+					testAccCheckResourceAttrGlobalARN(resourceName, "analytics_configuration.0.role_arn", "iam", "role/aws-service-role/cognito-idp.amazonaws.com/AWSServiceRoleForAmazonCognitoIdp"),
+					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.0.user_data_shared", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSCognitoUserPoolClientImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSCognitoUserPoolClient_disappears(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
 	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
@@ -553,6 +588,19 @@ resource "aws_cognito_user_pool_client" "test" {
     external_id      = "%[1]s"
     role_arn         = aws_iam_role.test.arn
     user_data_shared = true
+  }
+}
+`, clientName)
+}
+
+func testAccAWSCognitoUserPoolClientConfigAnalyticsWithArnConfig(userPoolName, clientName string) string {
+	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(userPoolName, clientName) + fmt.Sprintf(`
+resource "aws_cognito_user_pool_client" "test" {
+  name         = "%[1]s"
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  analytics_configuration {
+    application_arn = aws_pinpoint_app.test.arn
   }
 }
 `, clientName)

--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -133,9 +133,12 @@ The following arguments are supported:
 
 ### Analytics Configuration
 
-* `application_id` - (Required) The application ID for an Amazon Pinpoint application.
-* `external_id`  - (Required) An ID for the Analytics Configuration.
-* `role_arn` - (Required) The ARN of an IAM role that authorizes Amazon Cognito to publish events to Amazon Pinpoint analytics.
+Either `application_arn` or `application_id` is required.
+
+* `application_arn` - (Optional) The application ARN for an Amazon Pinpoint application. Conflicts with `external_id` and `role_arn`.
+* `application_id` - (Optional) The application ID for an Amazon Pinpoint application.
+* `external_id`  - (Optional) An ID for the Analytics Configuration. Conflicts with `application_arn`.
+* `role_arn` - (Optional) The ARN of an IAM role that authorizes Amazon Cognito to publish events to Amazon Pinpoint analytics. Conflicts with `application_arn`.
 * `user_data_shared` (Optional) If set to `true`, Amazon Cognito will include user data in the events it publishes to Amazon Pinpoint analytics.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16481

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cognito_user_pool_client - add support for `application_arn` in the `analytics_configuration` block.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPoolClient_'
--- PASS: TestAccAWSCognitoUserPoolClient_disappears (33.68s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (40.23s)
--- PASS: TestAccAWSCognitoUserPoolClient_basic (40.32s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn (44.65s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (63.85s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (65.76s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (65.77s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfig (102.19s)
```
