### PR TITLE
r/aws_route_table: Refactor acceptance test configuration generator so as avoid 'terrafmt' linting exclusion

### DIFF
--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -40,7 +40,6 @@ jobs:
             | grep -v resource_aws_kinesis_stream_test.go \
             | grep -v resource_aws_kms_grant_test.go \
             | grep -v resource_aws_quicksight_user_test.go \
-            | grep -v resource_aws_route_table_test.go \
             | grep -v resource_aws_s3_bucket_object_test.go \
             | grep -v resource_aws_sns_platform_application_test.go \
             | xargs -I {} terrafmt diff --check --fmtcompat {}
@@ -71,7 +70,6 @@ jobs:
             | grep -v resource_aws_kms_grant_test.go \
             | grep -v resource_aws_lambda_permission_test.go \
             | grep -v resource_aws_quicksight_user_test.go \
-            | grep -v resource_aws_route_table_test.go \
             | grep -v resource_aws_s3_bucket_object_test.go \
             | grep -v resource_aws_sns_platform_application_test.go \
             | ./scripts/validate-terraform.sh

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -1933,58 +1933,50 @@ resource "aws_vpc_peering_connection" "test" {
   }
 }
 
+locals {
+  routes = [
+    {
+      destination_attr  = %[2]q
+      destination_value = %[3]q
+      target_attr       = %[4]q
+      target_value      = %[5]s.id
+    },
+    {
+      destination_attr  = %[6]q
+      destination_value = %[7]q
+      target_attr       = %[8]q
+      target_value      = %[9]s.id
+    },
+    {
+      destination_attr  = %[10]q
+      destination_value = %[11]q
+      target_attr       = %[12]q
+      target_value      = %[13]s.id
+    }
+  ]
+}
+
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
 
-  route {
-    # Destination.
-    cidr_block      = (%[2]q == "cidr_block") ? %[3]q : null
-    ipv6_cidr_block = (%[2]q == "ipv6_cidr_block") ? %[3]q : null
+  dynamic "route" {
+    for_each = local.routes
+    content {
+      # Destination.
+      cidr_block      = (route.value["destination_attr"] == "cidr_block") ? route.value["destination_value"] : null
+      ipv6_cidr_block = (route.value["destination_attr"] == "ipv6_cidr_block") ? route.value["destination_value"] : null
 
-    # Target
-    egress_only_gateway_id    = (%[4]q == "egress_only_gateway_id") ? %[5]s.id : null
-    gateway_id                = (%[4]q == "gateway_id") ? %[5]s.id : null
-    instance_id               = (%[4]q == "instance_id") ? %[5]s.id : null
-    local_gateway_id          = (%[4]q == "local_gateway_id") ? %[5]s.id : null
-    nat_gateway_id            = (%[4]q == "nat_gateway_id") ? %[5]s.id : null
-    network_interface_id      = (%[4]q == "network_interface_id") ? %[5]s.id : null
-    transit_gateway_id        = (%[4]q == "transit_gateway_id") ? %[5]s.id : null
-    vpc_endpoint_id           = (%[4]q == "vpc_endpoint_id") ? %[5]s.id : null
-    vpc_peering_connection_id = (%[4]q == "vpc_peering_connection_id") ? %[5]s.id : null
-  }
-
-  route {
-    # Destination.
-    cidr_block      = (%[6]q == "cidr_block") ? %[7]q : null
-    ipv6_cidr_block = (%[6]q == "ipv6_cidr_block") ? %[7]q : null
-
-    # Target
-    egress_only_gateway_id    = (%[8]q == "egress_only_gateway_id") ? %[9]s.id : null
-    gateway_id                = (%[8]q == "gateway_id") ? %[9]s.id : null
-    instance_id               = (%[8]q == "instance_id") ? %[9]s.id : null
-    local_gateway_id          = (%[8]q == "local_gateway_id") ? %[9]s.id : null
-    nat_gateway_id            = (%[8]q == "nat_gateway_id") ? %[9]s.id : null
-    network_interface_id      = (%[8]q == "network_interface_id") ? %[9]s.id : null
-    transit_gateway_id        = (%[8]q == "transit_gateway_id") ? %[9]s.id : null
-    vpc_endpoint_id           = (%[8]q == "vpc_endpoint_id") ? %[9]s.id : null
-    vpc_peering_connection_id = (%[8]q == "vpc_peering_connection_id") ? %[9]s.id : null
-  }
-
-  route {
-    # Destination.
-    cidr_block      = (%[10]q == "cidr_block") ? %[11]q : null
-    ipv6_cidr_block = (%[10]q == "ipv6_cidr_block") ? %[11]q : null
-
-    # Target
-    egress_only_gateway_id    = (%[12]q == "egress_only_gateway_id") ? %[13]s.id : null
-    gateway_id                = (%[12]q == "gateway_id") ? %[13]s.id : null
-    instance_id               = (%[12]q == "instance_id") ? %[13]s.id : null
-    local_gateway_id          = (%[12]q == "local_gateway_id") ? %[13]s.id : null
-    nat_gateway_id            = (%[12]q == "nat_gateway_id") ? %[13]s.id : null
-    network_interface_id      = (%[12]q == "network_interface_id") ? %[13]s.id : null
-    transit_gateway_id        = (%[12]q == "transit_gateway_id") ? %[13]s.id : null
-    vpc_endpoint_id           = (%[12]q == "vpc_endpoint_id") ? %[13]s.id : null
-    vpc_peering_connection_id = (%[12]q == "vpc_peering_connection_id") ? %[13]s.id : null
+      # Target.
+      egress_only_gateway_id    = (route.value["target_attr"] == "egress_only_gateway_id") ? route.value["target_value"] : null
+      gateway_id                = (route.value["target_attr"] == "gateway_id") ? route.value["target_value"] : null
+      instance_id               = (route.value["target_attr"] == "instance_id") ? route.value["target_value"] : null
+      local_gateway_id          = (route.value["target_attr"] == "local_gateway_id") ? route.value["target_value"] : null
+      nat_gateway_id            = (route.value["target_attr"] == "nat_gateway_id") ? route.value["target_value"] : null
+      network_interface_id      = (route.value["target_attr"] == "network_interface_id") ? route.value["target_value"] : null
+      transit_gateway_id        = (route.value["target_attr"] == "transit_gateway_id") ? route.value["target_value"] : null
+      vpc_endpoint_id           = (route.value["target_attr"] == "vpc_endpoint_id") ? route.value["target_value"] : null
+      vpc_peering_connection_id = (route.value["target_attr"] == "vpc_peering_connection_id") ? route.value["target_value"] : null
+    }
   }
 
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/pull/14013.

Addresses [this review comment](https://github.com/hashicorp/terraform-provider-aws/pull/14013/files#r535603513) by refactoring (and as a side effect simplifying) `testAccAWSRouteTableConfigMultipleRoutes()` so that `aws_route_table_test.go` no longer needs to be excluded from `terrafmt` linting.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSRouteTable_MultipleRoutes' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRouteTable_MultipleRoutes -timeout 120m
=== RUN   TestAccAWSRouteTable_MultipleRoutes
=== PAUSE TestAccAWSRouteTable_MultipleRoutes
=== CONT  TestAccAWSRouteTable_MultipleRoutes
--- PASS: TestAccAWSRouteTable_MultipleRoutes (145.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	145.183s
```
