### PR TITLE
chore(docs): Remove quotes from tags

### DIFF
--- a/examples/cognito-user-pool/main.tf
+++ b/examples/cognito-user-pool/main.tf
@@ -151,7 +151,7 @@ resource "aws_cognito_user_pool" "pool" {
   }
 
   tags = {
-    "Name"    = "FooBar"
-    "Project" = "Terraform"
+    Name    = "FooBar"
+    Project = "Terraform"
   }
 }

--- a/website/docs/r/neptune_event_subscription.html.markdown
+++ b/website/docs/r/neptune_event_subscription.html.markdown
@@ -55,7 +55,7 @@ resource "aws_neptune_event_subscription" "default" {
   ]
 
   tags = {
-    "env" = "test"
+    env = "test"
   }
 }
 ```

--- a/website/docs/r/network_interface_sg_attachment.html.markdown
+++ b/website/docs/r/network_interface_sg_attachment.html.markdown
@@ -47,13 +47,13 @@ resource "aws_instance" "instance" {
   ami           = data.aws_ami.ami.id
 
   tags = {
-    "type" = "terraform-test-instance"
+    type = "terraform-test-instance"
   }
 }
 
 resource "aws_security_group" "sg" {
   tags = {
-    "type" = "terraform-test-security-group"
+    type = "terraform-test-security-group"
   }
 }
 
@@ -74,7 +74,7 @@ data "aws_instance" "instance" {
 
 resource "aws_security_group" "sg" {
   tags = {
-    "type" = "terraform-test-security-group"
+    type = "terraform-test-security-group"
   }
 }
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -117,8 +117,8 @@ resource "aws_s3_bucket" "bucket" {
     prefix = "log/"
 
     tags = {
-      "rule"      = "log"
-      "autoclean" = "true"
+      rule      = "log"
+      autoclean = "true"
     }
 
     transition {

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -275,8 +275,8 @@ resource "aws_wafv2_rule_group" "example" {
   }
 
   tags = {
-    "Name" = "example-and-statement"
-    "Code" = "123456"
+    Name = "example-and-statement"
+    Code = "123456"
   }
 }
 ```


### PR DESCRIPTION
In general tags key doesn't require quotation marks if they are single
words. This commit tries to uniform the practice throughout aws provider
document

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A (documentation)

