### PR TITLE
d/aws_prefix_list: fixes

### DIFF
--- a/aws/data_source_aws_prefix_list.go
+++ b/aws/data_source_aws_prefix_list.go
@@ -45,11 +45,12 @@ func dataSourceAwsPrefixListRead(d *schema.ResourceData, meta interface{}) error
 	if prefixListID := d.Get("prefix_list_id"); prefixListID != "" {
 		req.PrefixListIds = aws.StringSlice([]string{prefixListID.(string)})
 	}
-	req.Filters = buildEC2AttributeFilterList(
-		map[string]string{
-			"prefix-list-name": d.Get("name").(string),
-		},
-	)
+	if prefixListName := d.Get("name"); prefixListName.(string) != "" {
+		req.Filters = append(req.Filters, &ec2.Filter{
+			Name:   aws.String("prefix-list-name"),
+			Values: aws.StringSlice([]string{prefixListName.(string)}),
+		})
+	}
 
 	log.Printf("[DEBUG] Reading Prefix List: %s", req)
 	resp, err := conn.DescribePrefixLists(req)

--- a/aws/data_source_aws_prefix_list_test.go
+++ b/aws/data_source_aws_prefix_list_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -38,6 +39,19 @@ func TestAccDataSourceAwsPrefixList_filter(t *testing.T) {
 					testAccDataSourceAwsPrefixListCheck("data.aws_prefix_list.s3_by_id"),
 					testAccDataSourceAwsPrefixListCheck("data.aws_prefix_list.s3_by_name"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsPrefixList_nameDoesNotOverrideFilter(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsPrefixListConfig_nameDoesNotOverrideFilter,
+				ExpectError: regexp.MustCompile(`no matching prefix list found`),
 			},
 		},
 	})
@@ -126,6 +140,19 @@ data "aws_prefix_list" "s3_by_id" {
   filter {
     name   = "prefix-list-id"
     values = [data.aws_prefix_list.s3_by_name.id]
+  }
+}
+`
+
+const testAccDataSourceAwsPrefixListConfig_nameDoesNotOverrideFilter = `
+data "aws_region" "current" {}
+
+data "aws_prefix_list" "test" {
+  name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+
+  filter {
+    name   = "prefix-list-name"
+    values = ["com.amazonaws.${data.aws_region.current.name}.s3"]
   }
 }
 `

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "VPC"
 layout: "aws"
-page_title: "AWS: aws_prefix-list"
+page_title: "AWS: aws_prefix_list"
 description: |-
     Provides details about a specific prefix list
 ---


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13986

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
- data-source/aws_prefix_list: Specifying the `name` attribute no longer overwrites all filters
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS=-run=TestAccDataSourceAwsPrefixList
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsPrefixList -timeout 120m
--- PASS: TestAccDataSourceAwsPrefixList_nameDoesNotOverrideFilter (3.90s)
--- PASS: TestAccDataSourceAwsPrefixList_basic (15.76s)
--- PASS: TestAccDataSourceAwsPrefixList_filter (15.85s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       17.375s
```
