### PR TITLE
Update AWS Lightsail Create Instance with option to Create from Snapshot

### DIFF
--- a/aws/resource_aws_lightsail_instance.go
+++ b/aws/resource_aws_lightsail_instance.go
@@ -41,11 +41,6 @@ func resourceAwsLightsailInstance() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"blueprint_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"bundle_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -53,6 +48,16 @@ func resourceAwsLightsailInstance() *schema.Resource {
 			},
 
 			// Optional attributes
+			"blueprint_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"instance_snapshot_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"key_pair_name": {
 				// Not compatible with aws_key_pair (yet)
 				// We'll need a new aws_lightsail_key_pair resource
@@ -121,11 +126,113 @@ func resourceAwsLightsailInstanceCreate(d *schema.ResourceData, meta interface{}
 
 	iName := d.Get("name").(string)
 
-	req := lightsail.CreateInstancesInput{
-		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
-		BlueprintId:      aws.String(d.Get("blueprint_id").(string)),
-		BundleId:         aws.String(d.Get("bundle_id").(string)),
-		InstanceNames:    aws.StringSlice([]string{iName}),
+	if _, ok := d.GetOk("blueprint_id"); ok {
+		req := lightsail.CreateInstancesInput{
+			AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
+			BlueprintId:      aws.String(d.Get("blueprint_id").(string)),
+			BundleId:         aws.String(d.Get("bundle_id").(string)),
+			InstanceNames:    aws.StringSlice([]string{iName}),
+		}
+
+		if v, ok := d.GetOk("key_pair_name"); ok {
+			req.KeyPairName = aws.String(v.(string))
+		}
+		if v, ok := d.GetOk("user_data"); ok {
+			req.UserData = aws.String(v.(string))
+		}
+
+		if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+			req.Tags = keyvaluetags.New(v).IgnoreAws().LightsailTags()
+		}
+
+		resp, err := conn.CreateInstances(&req)
+		if err != nil {
+			return err
+		}
+
+		if len(resp.Operations) == 0 {
+			return fmt.Errorf("No operations found for CreateInstance request")
+		}
+
+		op := resp.Operations[0]
+		d.SetId(d.Get("name").(string))
+
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"Started"},
+			Target:     []string{"Completed", "Succeeded"},
+			Refresh:    resourceAwsLightsailOperationRefreshFunc(op.Id, meta),
+			Timeout:    10 * time.Minute,
+			Delay:      5 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			// We don't return an error here because the Create call succeeded
+			log.Printf("[ERR] Error waiting for instance (%s) to become ready: %s", d.Id(), err)
+		}
+	}
+
+	if _, ok := d.GetOk("instance_snapshot_name"); ok {
+		req := lightsail.CreateInstancesFromSnapshotInput{
+			AvailabilityZone:     aws.String(d.Get("availability_zone").(string)),
+			InstanceSnapshotName: aws.String(d.Get("instance_snapshot_name").(string)),
+			BundleId:             aws.String(d.Get("bundle_id").(string)),
+			InstanceNames:        aws.StringSlice([]string{iName}),
+		}
+
+		if v, ok := d.GetOk("key_pair_name"); ok {
+			req.KeyPairName = aws.String(v.(string))
+		}
+		if v, ok := d.GetOk("user_data"); ok {
+			req.UserData = aws.String(v.(string))
+		}
+
+		if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+			req.Tags = keyvaluetags.New(v).IgnoreAws().LightsailTags()
+		}
+
+		resp, err := conn.CreateInstancesFromSnapshot(&req)
+		if err != nil {
+			return err
+		}
+
+		if len(resp.Operations) == 0 {
+			return fmt.Errorf("No operations found for CreateInstance request")
+		}
+
+		op := resp.Operations[0]
+		d.SetId(d.Get("name").(string))
+
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"Started"},
+			Target:     []string{"Completed", "Succeeded"},
+			Refresh:    resourceAwsLightsailOperationRefreshFunc(op.Id, meta),
+			Timeout:    10 * time.Minute,
+			Delay:      5 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			// We don't return an error here because the Create call succeeded
+			log.Printf("[ERR] Error waiting for instance (%s) to become ready: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsLightsailInstanceRead(d, meta)
+}
+
+func resourceAwsLightsailInstanceCreateFromSnapshot(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	iName := d.Get("name").(string)
+
+	req := lightsail.CreateInstancesFromSnapshotInput{
+		AvailabilityZone:     aws.String(d.Get("availability_zone").(string)),
+		InstanceSnapshotName: aws.String(d.Get("instance_snapshot_name").(string)),
+		BundleId:             aws.String(d.Get("bundle_id").(string)),
+		InstanceNames:        aws.StringSlice([]string{iName}),
 	}
 
 	if v, ok := d.GetOk("key_pair_name"); ok {
@@ -139,7 +246,7 @@ func resourceAwsLightsailInstanceCreate(d *schema.ResourceData, meta interface{}
 		req.Tags = keyvaluetags.New(v).IgnoreAws().LightsailTags()
 	}
 
-	resp, err := conn.CreateInstances(&req)
+	resp, err := conn.CreateInstancesFromSnapshot(&req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

First time submitter, go easy on me. ;-)

Updating to allow creation of Lightsail instance from either blueprint_id or instance_snapshot_name.  Updated the code and tested functionality -- it works.  I am not experienced in Go, so not sure I implemented the change in the best way.

```
resource "aws_lightsail_instance" "centos_instance" {
  availability_zone = "us-west-2b"
  blueprint_id      = "centos_7_1901_01"
  bundle_id         = "small_2_0"
  name              = "cntipa04-uw2"
}

or

resource "aws_lightsail_instance" "centos_instance" {
  availability_zone      = "us-west-2b"
  instance_snapshot_name = "cntipa02-uw2-1607819969"
  bundle_id              = "small_2_0"
  name                   = "cntipa04-uw2"
}
```

Need some help with updating tests.  I am not sure how to update the tests for an either/or on the blueprint_id or instance_snapshot_name.  The `make test` continues to function with the implemented changes.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
~~Relates OR Closes #0000~~

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
ENHANCEMENTS

- resource/aws_lightsail_instance:  Add `instance_snapshot_name` to enable creation of Lightsail instance from a snapshot.

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLightsailInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLightsailInstance -timeout 120m
=== RUN   TestAccAWSLightsailInstance_basic
=== PAUSE TestAccAWSLightsailInstance_basic
=== RUN   TestAccAWSLightsailInstance_Name
=== PAUSE TestAccAWSLightsailInstance_Name
=== RUN   TestAccAWSLightsailInstance_Tags
=== PAUSE TestAccAWSLightsailInstance_Tags
=== RUN   TestAccAWSLightsailInstance_disapear
=== PAUSE TestAccAWSLightsailInstance_disapear
=== CONT  TestAccAWSLightsailInstance_basic
=== CONT  TestAccAWSLightsailInstance_disapear
=== CONT  TestAccAWSLightsailInstance_Name
=== CONT  TestAccAWSLightsailInstance_Tags
--- PASS: TestAccAWSLightsailInstance_disapear (51.08s)
--- PASS: TestAccAWSLightsailInstance_basic (53.04s)
--- PASS: TestAccAWSLightsailInstance_Tags (67.39s)
--- PASS: TestAccAWSLightsailInstance_Name (102.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       104.224s
```
