### PR TITLE
Implement dynamodb kinesis streaming destination

### DIFF
--- a/.changelog/16743.txt
+++ b/.changelog/16743.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_dynamodb_kinesis_streaming_destination
+```

--- a/aws/internal/service/dynamodb/finder/finder.go
+++ b/aws/internal/service/dynamodb/finder/finder.go
@@ -7,6 +7,37 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
+func DynamoDBKinesisDataStreamDestination(ctx context.Context, conn *dynamodb.DynamoDB, streamArn, tableName string) (*dynamodb.KinesisDataStreamDestination, error) {
+	input := &dynamodb.DescribeKinesisStreamingDestinationInput{
+		TableName: aws.String(tableName),
+	}
+
+	output, err := conn.DescribeKinesisStreamingDestinationWithContext(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	var result *dynamodb.KinesisDataStreamDestination
+
+	for _, destination := range output.KinesisDataStreamDestinations {
+		if destination == nil {
+			continue
+		}
+
+		if aws.StringValue(destination.StreamArn) == streamArn {
+			result = destination
+			break
+		}
+	}
+
+	return result, nil
+}
+
 func DynamoDBTableByName(conn *dynamodb.DynamoDB, tableName string) (*dynamodb.TableDescription, error) {
 	input := &dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),
@@ -87,35 +118,4 @@ func DynamoDBTTLRDescriptionByTableName(conn *dynamodb.DynamoDB, tableName strin
 	}
 
 	return output.TimeToLiveDescription, nil
-}
-
-func KinesisDataStreamDestination(ctx context.Context, conn *dynamodb.DynamoDB, streamArn, tableName string) (*dynamodb.KinesisDataStreamDestination, error) {
-	input := &dynamodb.DescribeKinesisStreamingDestinationInput{
-		TableName: aws.String(tableName),
-	}
-
-	output, err := conn.DescribeKinesisStreamingDestinationWithContext(ctx, input)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if output == nil {
-		return nil, nil
-	}
-
-	var result *dynamodb.KinesisDataStreamDestination
-
-	for _, destination := range output.KinesisDataStreamDestinations {
-		if destination == nil {
-			continue
-		}
-
-		if aws.StringValue(destination.StreamArn) == streamArn {
-			result = destination
-			break
-		}
-	}
-
-	return result, nil
 }

--- a/aws/internal/service/dynamodb/waiter/status.go
+++ b/aws/internal/service/dynamodb/waiter/status.go
@@ -1,6 +1,7 @@
 package waiter
 
 import (
+	"context"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -166,5 +167,21 @@ func DynamoDBTableSESStatus(conn *dynamodb.DynamoDB, tableName string) resource.
 		}
 
 		return table, aws.StringValue(table.SSEDescription.Status), nil
+	}
+}
+
+func KinesisStreamingDestinationStatus(ctx context.Context, conn *dynamodb.DynamoDB, streamArn, tableName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		result, err := finder.KinesisDataStreamDestination(ctx, conn, streamArn, tableName)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if result == nil {
+			return nil, "", nil
+		}
+
+		return result, aws.StringValue(result.DestinationStatus), nil
 	}
 }

--- a/aws/internal/service/dynamodb/waiter/status.go
+++ b/aws/internal/service/dynamodb/waiter/status.go
@@ -11,6 +11,22 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/dynamodb/finder"
 )
 
+func DynamoDBKinesisStreamingDestinationStatus(ctx context.Context, conn *dynamodb.DynamoDB, streamArn, tableName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		result, err := finder.DynamoDBKinesisDataStreamDestination(ctx, conn, streamArn, tableName)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if result == nil {
+			return nil, "", nil
+		}
+
+		return result, aws.StringValue(result.DestinationStatus), nil
+	}
+}
+
 func DynamoDBTableStatus(conn *dynamodb.DynamoDB, tableName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		table, err := finder.DynamoDBTableByName(conn, tableName)
@@ -167,21 +183,5 @@ func DynamoDBTableSESStatus(conn *dynamodb.DynamoDB, tableName string) resource.
 		}
 
 		return table, aws.StringValue(table.SSEDescription.Status), nil
-	}
-}
-
-func KinesisStreamingDestinationStatus(ctx context.Context, conn *dynamodb.DynamoDB, streamArn, tableName string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		result, err := finder.KinesisDataStreamDestination(ctx, conn, streamArn, tableName)
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		if result == nil {
-			return nil, "", nil
-		}
-
-		return result, aws.StringValue(result.DestinationStatus), nil
 	}
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -643,6 +643,7 @@ func Provider() *schema.Provider {
 			"aws_dynamodb_table":                                      resourceAwsDynamoDbTable(),
 			"aws_dynamodb_table_item":                                 resourceAwsDynamoDbTableItem(),
 			"aws_dynamodb_global_table":                               resourceAwsDynamoDbGlobalTable(),
+			"aws_dynamodb_kinesis_streaming_destination":              resourceAwsDynamodbKinesisStreamingDestination(),
 			"aws_ebs_default_kms_key":                                 resourceAwsEbsDefaultKmsKey(),
 			"aws_ebs_encryption_by_default":                           resourceAwsEbsEncryptionByDefault(),
 			"aws_ebs_snapshot":                                        resourceAwsEbsSnapshot(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -643,7 +643,7 @@ func Provider() *schema.Provider {
 			"aws_dynamodb_table":                                      resourceAwsDynamoDbTable(),
 			"aws_dynamodb_table_item":                                 resourceAwsDynamoDbTableItem(),
 			"aws_dynamodb_global_table":                               resourceAwsDynamoDbGlobalTable(),
-			"aws_dynamodb_kinesis_streaming_destination":              resourceAwsDynamodbKinesisStreamingDestination(),
+			"aws_dynamodb_kinesis_streaming_destination":              resourceAwsDynamoDbKinesisStreamingDestination(),
 			"aws_ebs_default_kms_key":                                 resourceAwsEbsDefaultKmsKey(),
 			"aws_ebs_encryption_by_default":                           resourceAwsEbsEncryptionByDefault(),
 			"aws_ebs_snapshot":                                        resourceAwsEbsSnapshot(),

--- a/aws/resource_aws_dynamodb_kinesis_streaming_destination.go
+++ b/aws/resource_aws_dynamodb_kinesis_streaming_destination.go
@@ -118,7 +118,7 @@ func resourceAwsDynamodbKinesisStreamingDestinationDelete(ctx context.Context, d
 	return nil
 }
 
-func createDynamodbKinesisStreamingDestinationResourceId(tableName  string, streamArn string) string {
+func createDynamodbKinesisStreamingDestinationResourceId(tableName string, streamArn string) string {
 	return fmt.Sprintf("%s_%s", tableName, streamArn)
 }
 

--- a/aws/resource_aws_dynamodb_kinesis_streaming_destination.go
+++ b/aws/resource_aws_dynamodb_kinesis_streaming_destination.go
@@ -1,0 +1,169 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsDynamodbKinesisStreamingDestination() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAwsDynamodbKinesisStreamingDestinationCreate,
+		ReadContext:   resourceAwsDynamodbKinesisStreamingDestinationRead,
+		DeleteContext: resourceAwsDynamodbKinesisStreamingDestinationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"table_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"stream_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDynamodbKinesisStreamingDestinationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).dynamodbconn
+
+	tableName := d.Get("table_name").(string)
+	streamArn := d.Get("stream_arn").(string)
+
+	_, err := conn.EnableKinesisStreamingDestination(&dynamodb.EnableKinesisStreamingDestinationInput{
+		TableName: aws.String(tableName),
+		StreamArn: aws.String(streamArn),
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error enabling Dynamodb Kinesis streaming destination: %s", err))
+	}
+
+	if err := waitForDynamodbKinesisStreamingDestinationToBeActive(ctx, tableName, streamArn, d.Timeout(schema.TimeoutCreate), conn); err != nil {
+		return diag.FromErr(fmt.Errorf("failed waiting for Kinesis streaming destination to become active: %s", err))
+	}
+
+	return resourceAwsDynamodbKinesisStreamingDestinationRead(ctx, d, meta)
+}
+
+func resourceAwsDynamodbKinesisStreamingDestinationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).dynamodbconn
+
+	tableName := d.Get("table_name").(string)
+	streamArn := d.Get("stream_arn").(string)
+
+	result, err := conn.DescribeKinesisStreamingDestination(&dynamodb.DescribeKinesisStreamingDestinationInput{
+		TableName: aws.String(tableName),
+	})
+
+	if err != nil {
+		if isAWSErr(err, dynamodb.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] Dynamodb Table (%s) not found, error code (404)", tableName)
+			d.SetId("")
+			return nil
+		}
+
+		return diag.FromErr(fmt.Errorf("error retrieving DynamoDB table item: %s", err))
+	}
+
+	for _, destination := range result.KinesisDataStreamDestinations {
+		if *destination.StreamArn == streamArn {
+			if *destination.DestinationStatus == dynamodb.DestinationStatusActive ||
+				*destination.DestinationStatus == dynamodb.DestinationStatusEnabling {
+				d.SetId(fmt.Sprintf("%s_%s", tableName, streamArn))
+			} else {
+				log.Printf("[WARN] Dynamodb Kinesis streaming destination (%s, %s) not active: %s", tableName, streamArn, *destination.DestinationStatus)
+				d.SetId("")
+			}
+			return nil
+		}
+	}
+
+	log.Printf("[WARN] Dynamodb Kinesis streaming destination (%s, %s) not found", tableName, streamArn)
+	d.SetId("")
+	return nil
+}
+
+func resourceAwsDynamodbKinesisStreamingDestinationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).dynamodbconn
+
+	tableName := d.Get("table_name").(string)
+	streamArn := d.Get("stream_arn").(string)
+
+	_, err := conn.DisableKinesisStreamingDestination(&dynamodb.DisableKinesisStreamingDestinationInput{
+		TableName: aws.String(tableName),
+		StreamArn: aws.String(streamArn),
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error disabling Dynamodb Kinesis streaming destination: %s", err))
+	}
+
+	if err := waitForDynamodbKinesisStreamingDestinationToBeDisabled(ctx, tableName, streamArn, d.Timeout(schema.TimeoutDelete), conn); err != nil {
+		return diag.FromErr(fmt.Errorf("failed waiting for Kinesis streaming destination to be disabled: %s", err))
+	}
+
+	return nil
+}
+
+func waitForDynamodbKinesisStreamingDestinationToBeActive(ctx context.Context, tableName string, streamArn string, timeout time.Duration, conn *dynamodb.DynamoDB) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{dynamodb.DestinationStatusDisabled, dynamodb.DestinationStatusEnabling},
+		Target:  []string{dynamodb.DestinationStatusActive},
+		Timeout: timeout,
+		Refresh: func() (interface{}, string, error) {
+			result, err := conn.DescribeKinesisStreamingDestination(&dynamodb.DescribeKinesisStreamingDestinationInput{
+				TableName: aws.String(tableName),
+			})
+			if err != nil {
+				return 42, "", err
+			}
+
+			for _, destination := range result.KinesisDataStreamDestinations {
+				if *destination.StreamArn == streamArn {
+					return destination, *destination.DestinationStatus, nil
+				}
+			}
+			return 42, "", fmt.Errorf("Kinesis streaming destination %s not found for table %s", streamArn, tableName)
+		},
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
+}
+
+func waitForDynamodbKinesisStreamingDestinationToBeDisabled(ctx context.Context, tableName string, streamArn string, timeout time.Duration, conn *dynamodb.DynamoDB) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{dynamodb.DestinationStatusActive, dynamodb.DestinationStatusDisabling},
+		Target:  []string{dynamodb.DestinationStatusDisabled},
+		Timeout: timeout,
+		Refresh: func() (interface{}, string, error) {
+			result, err := conn.DescribeKinesisStreamingDestination(&dynamodb.DescribeKinesisStreamingDestinationInput{
+				TableName: aws.String(tableName),
+			})
+			if err != nil {
+				return 42, "", err
+			}
+
+			for _, destination := range result.KinesisDataStreamDestinations {
+				if *destination.StreamArn == streamArn {
+					return destination, *destination.DestinationStatus, nil
+				}
+			}
+			return 42, "", fmt.Errorf("Kinesis streaming destination %s not found for table %s", streamArn, tableName)
+		},
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
+}

--- a/aws/resource_aws_dynamodb_kinesis_streaming_destination.go
+++ b/aws/resource_aws_dynamodb_kinesis_streaming_destination.go
@@ -53,6 +53,8 @@ func resourceAwsDynamodbKinesisStreamingDestinationCreate(ctx context.Context, d
 		return diag.FromErr(fmt.Errorf("failed waiting for Kinesis streaming destination to become active: %s", err))
 	}
 
+	d.SetId(createDynamodbKinesisStreamingDestinationResourceId(tableName, streamArn))
+
 	return resourceAwsDynamodbKinesisStreamingDestinationRead(ctx, d, meta)
 }
 
@@ -80,7 +82,7 @@ func resourceAwsDynamodbKinesisStreamingDestinationRead(ctx context.Context, d *
 		if *destination.StreamArn == streamArn {
 			if *destination.DestinationStatus == dynamodb.DestinationStatusActive ||
 				*destination.DestinationStatus == dynamodb.DestinationStatusEnabling {
-				d.SetId(fmt.Sprintf("%s_%s", tableName, streamArn))
+				d.SetId(createDynamodbKinesisStreamingDestinationResourceId(tableName, streamArn))
 			} else {
 				log.Printf("[WARN] Dynamodb Kinesis streaming destination (%s, %s) not active: %s", tableName, streamArn, *destination.DestinationStatus)
 				d.SetId("")
@@ -114,6 +116,10 @@ func resourceAwsDynamodbKinesisStreamingDestinationDelete(ctx context.Context, d
 	}
 
 	return nil
+}
+
+func createDynamodbKinesisStreamingDestinationResourceId(tableName  string, streamArn string) string {
+	return fmt.Sprintf("%s_%s", tableName, streamArn)
 }
 
 func waitForDynamodbKinesisStreamingDestinationToBeActive(ctx context.Context, tableName string, streamArn string, timeout time.Duration, conn *dynamodb.DynamoDB) error {

--- a/aws/resource_aws_dynamodb_kinesis_streaming_destination.go
+++ b/aws/resource_aws_dynamodb_kinesis_streaming_destination.go
@@ -3,13 +3,13 @@ package aws
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/aws/resource_aws_dynamodb_kinesis_streaming_destination_test.go
+++ b/aws/resource_aws_dynamodb_kinesis_streaming_destination_test.go
@@ -1,0 +1,209 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAwsDynamodbKinesisStreamingDestination_basic(t *testing.T) {
+	var conf dynamodb.DescribeKinesisStreamingDestinationOutput
+
+	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	streamName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	resourceName := "aws_dynamodb_kinesis_streaming_destination.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSDynamodbKinesisStreamingDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDynamodbKinesisStreamingDestinationConfigBasic(tableName, streamName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynamodbKinesisStreamingDestinationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "table_name", tableName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "stream_arn", "kinesis", regexp.MustCompile(fmt.Sprintf("stream/%s", streamName))),
+				),
+			},
+			{
+				Config: testAccAwsDynamodbKinesisStreamingDestinationConfigBase(tableName, streamName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDynamodbKinesisStreamingDestinationNotExist,
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsDynamodbKinesisStreamingDestination_disappears(t *testing.T) {
+	var conf dynamodb.DescribeKinesisStreamingDestinationOutput
+
+	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	streamName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	resourceName := "aws_dynamodb_kinesis_streaming_destination.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSDynamodbKinesisStreamingDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDynamodbKinesisStreamingDestinationConfigBasic(tableName, streamName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynamodbKinesisStreamingDestinationExists(resourceName, &conf),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsDynamodbKinesisStreamingDestination(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsDynamodbKinesisStreamingDestination_disappears_DynamoTable(t *testing.T) {
+	var conf dynamodb.DescribeKinesisStreamingDestinationOutput
+
+	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	streamName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	resourceName := "aws_dynamodb_kinesis_streaming_destination.test"
+	parentResourceName := "aws_dynamodb_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSDynamodbKinesisStreamingDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDynamodbKinesisStreamingDestinationConfigBasic(tableName, streamName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynamodbKinesisStreamingDestinationExists(resourceName, &conf),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsDynamoDbTable(), parentResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccAwsDynamodbKinesisStreamingDestinationConfigBase(tableName string, streamName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name           = "%s"
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = "hk"
+
+  attribute {
+    name = "hk"
+    type = "S"
+  }
+}
+
+resource "aws_kinesis_stream" "test" {
+  name        = "%s"
+  shard_count = 2
+}
+`, tableName, streamName)
+}
+
+func testAccAwsDynamodbKinesisStreamingDestinationConfigBasic(tableName string, streamName string) string {
+	return composeConfig(testAccAwsDynamodbKinesisStreamingDestinationConfigBase(tableName, streamName),
+		`
+resource "aws_dynamodb_kinesis_streaming_destination" "test" {
+	table_name = aws_dynamodb_table.test.name
+	stream_arn = aws_kinesis_stream.test.arn
+}
+`)
+}
+
+func testAccCheckDynamodbKinesisStreamingDestinationExists(n string, conf *dynamodb.DescribeKinesisStreamingDestinationOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+		describeOpts := &dynamodb.DescribeKinesisStreamingDestinationInput{
+			TableName: aws.String(rs.Primary.Attributes["table_name"]),
+		}
+		resp, err := conn.DescribeKinesisStreamingDestination(describeOpts)
+		if err != nil {
+			return err
+		}
+
+		*conf = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAWSDynamodbKinesisStreamingDestinationNotExist(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dynamodb_kinesis_streaming_destination" {
+			continue
+		}
+
+		log.Printf("[DEBUG] Checking if DynamoDB kinesis streaming destination %s exists", rs.Primary.ID)
+		describeOpts := &dynamodb.DescribeKinesisStreamingDestinationInput{
+			TableName: aws.String(rs.Primary.Attributes["table_name"]),
+		}
+
+		resp, err := conn.DescribeKinesisStreamingDestination(describeOpts)
+		if err != nil {
+			return err
+		}
+
+		if len(resp.KinesisDataStreamDestinations) > 0 {
+			return fmt.Errorf("Error: DynamoDB kinesis streaming destination still exists %s", rs.Primary.ID)
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDynamodbKinesisStreamingDestinationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dynamodb_table" {
+			continue
+		}
+
+		log.Printf("[DEBUG] Checking if DynamoDB table %s exists", rs.Primary.ID)
+		// Check if queue exists by checking for its attributes
+		params := &dynamodb.DescribeTableInput{
+			TableName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeTable(params)
+		if err == nil {
+			return fmt.Errorf("DynamoDB table %s still exists. Failing!", rs.Primary.ID)
+		}
+
+		// Verify the error is what we want
+		if dbErr, ok := err.(awserr.Error); ok && dbErr.Code() == "ResourceNotFoundException" {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_dynamodb_kinesis_streaming_destination_test.go
+++ b/aws/resource_aws_dynamodb_kinesis_streaming_destination_test.go
@@ -118,8 +118,8 @@ func testAccAwsDynamodbKinesisStreamingDestinationConfigBasic(tableName string, 
 	return composeConfig(testAccAwsDynamodbKinesisStreamingDestinationConfigBase(tableName, streamName),
 		`
 resource "aws_dynamodb_kinesis_streaming_destination" "test" {
-	table_name = aws_dynamodb_table.test.name
-	stream_arn = aws_kinesis_stream.test.arn
+  table_name = aws_dynamodb_table.test.name
+  stream_arn = aws_kinesis_stream.test.arn
 }
 `)
 }

--- a/aws/resource_aws_dynamodb_kinesis_streaming_destination_test.go
+++ b/aws/resource_aws_dynamodb_kinesis_streaming_destination_test.go
@@ -20,6 +20,7 @@ func TestAccAwsDynamoDbKinesisStreamingDestination_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, dynamodb.EndpointsID),
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSDynamoDbKinesisStreamingDestinationDestroy,
 		Steps: []resource.TestStep{
@@ -46,6 +47,7 @@ func TestAccAwsDynamoDbKinesisStreamingDestination_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, dynamodb.EndpointsID),
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSDynamoDbKinesisStreamingDestinationDestroy,
 		Steps: []resource.TestStep{
@@ -69,6 +71,7 @@ func TestAccAwsDynamoDbKinesisStreamingDestination_disappears_DynamoDbTable(t *t
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, dynamodb.EndpointsID),
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSDynamoDbKinesisStreamingDestinationDestroy,
 		Steps: []resource.TestStep{
@@ -129,7 +132,7 @@ func testAccCheckDynamoDbKinesisStreamingDestinationExists(resourceName string) 
 
 		conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
 
-		output, err := finder.KinesisDataStreamDestination(context.Background(), conn, streamArn, tableName)
+		output, err := finder.DynamoDBKinesisDataStreamDestination(context.Background(), conn, streamArn, tableName)
 
 		if err != nil {
 			return err
@@ -157,7 +160,7 @@ func testAccCheckAWSDynamoDbKinesisStreamingDestinationDestroy(s *terraform.Stat
 			return err
 		}
 
-		output, err := finder.KinesisDataStreamDestination(context.Background(), conn, streamArn, tableName)
+		output, err := finder.DynamoDBKinesisDataStreamDestination(context.Background(), conn, streamArn, tableName)
 
 		if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {
 			continue

--- a/aws/resource_aws_dynamodb_kinesis_streaming_destination_test.go
+++ b/aws/resource_aws_dynamodb_kinesis_streaming_destination_test.go
@@ -2,16 +2,16 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"log"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAwsDynamodbKinesisStreamingDestination_basic(t *testing.T) {

--- a/website/docs/r/dynamodb_kinesis_streaming_destination.html.markdown
+++ b/website/docs/r/dynamodb_kinesis_streaming_destination.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "DynamoDB"
+layout: "aws"
+page_title: "AWS: aws_dynamodb_kinesis_streaming_destination"
+description: |-
+  Configures a Kinesis streaming destination for item level changes to a DynamoDB table
+---
+
+# Resource: aws_dynamodb_kinesis_streaming_destination
+
+Configures a [Kinesis streaming destination](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/kds.html) for item level changes to a DynamoDB table.
+
+## Example Usage
+
+```hcl
+resource "aws_dynamodb_table" "orders" {
+  name           = "orders"
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}
+
+resource "aws_kinesis_stream" "order_item_changes" {
+  name        = "order_item_changes"
+  shard_count = 1
+}
+
+resource "aws_dynamodb_kinesis_streaming_destination" "order_changes" {
+  table_name = aws_dynamodb_table.orders.name
+  stream_arn = aws_kinesis_stream.order_item_changes.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `table_name` - (Required) The name of the DynamoDB table to capture changes from. There 
+  can only be one Kinesis streaming destination for a given DynamoDB table.
+* `stream_arn` - (Required) The arn of the Kinesis stream to capture changes into. This 
+must exist in the same account and region as the DynamoDB table.

--- a/website/docs/r/dynamodb_kinesis_streaming_destination.html.markdown
+++ b/website/docs/r/dynamodb_kinesis_streaming_destination.html.markdown
@@ -14,8 +14,8 @@ Configures a [Kinesis streaming destination](https://docs.aws.amazon.com/amazond
 
 ```hcl
 resource "aws_dynamodb_table" "orders" {
-  name           = "orders"
-  hash_key       = "id"
+  name     = "orders"
+  hash_key = "id"
 
   attribute {
     name = "id"
@@ -38,7 +38,7 @@ resource "aws_dynamodb_kinesis_streaming_destination" "order_changes" {
 
 The following arguments are supported:
 
-* `table_name` - (Required) The name of the DynamoDB table to capture changes from. There 
+* `table_name` - (Required) The name of the DynamoDB table to capture changes from. There
   can only be one Kinesis streaming destination for a given DynamoDB table.
-* `stream_arn` - (Required) The arn of the Kinesis stream to capture changes into. This 
+* `stream_arn` - (Required) The arn of the Kinesis stream to capture changes into. This
 must exist in the same account and region as the DynamoDB table.

--- a/website/docs/r/dynamodb_kinesis_streaming_destination.html.markdown
+++ b/website/docs/r/dynamodb_kinesis_streaming_destination.html.markdown
@@ -3,17 +3,17 @@ subcategory: "DynamoDB"
 layout: "aws"
 page_title: "AWS: aws_dynamodb_kinesis_streaming_destination"
 description: |-
-  Configures a Kinesis streaming destination for item level changes to a DynamoDB table
+  Enables a Kinesis streaming destination for a DynamoDB table
 ---
 
 # Resource: aws_dynamodb_kinesis_streaming_destination
 
-Configures a [Kinesis streaming destination](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/kds.html) for item level changes to a DynamoDB table.
+Enables a [Kinesis streaming destination](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/kds.html) for data replication of a DynamoDB table.
 
 ## Example Usage
 
-```hcl
-resource "aws_dynamodb_table" "orders" {
+```terraform
+resource "aws_dynamodb_table" "example" {
   name     = "orders"
   hash_key = "id"
 
@@ -23,14 +23,14 @@ resource "aws_dynamodb_table" "orders" {
   }
 }
 
-resource "aws_kinesis_stream" "order_item_changes" {
+resource "aws_kinesis_stream" "example" {
   name        = "order_item_changes"
   shard_count = 1
 }
 
-resource "aws_dynamodb_kinesis_streaming_destination" "order_changes" {
-  table_name = aws_dynamodb_table.orders.name
-  stream_arn = aws_kinesis_stream.order_item_changes.arn
+resource "aws_dynamodb_kinesis_streaming_destination" "example" {
+  stream_arn = aws_kinesis_stream.example.arn
+  table_name = aws_dynamodb_table.example.name
 }
 ```
 
@@ -38,7 +38,21 @@ resource "aws_dynamodb_kinesis_streaming_destination" "order_changes" {
 
 The following arguments are supported:
 
-* `table_name` - (Required) The name of the DynamoDB table to capture changes from. There
+* `stream_arn` - (Required) The ARN for a Kinesis data stream. This must exist in the same account and region as the DynamoDB table.
+  
+* `table_name` - (Required) The name of the DynamoDB table. There
   can only be one Kinesis streaming destination for a given DynamoDB table.
-* `stream_arn` - (Required) The arn of the Kinesis stream to capture changes into. This
-must exist in the same account and region as the DynamoDB table.
+  
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The `table_name` and `stream_arn` separated by a comma (`,`).
+
+## Import
+
+DynamoDB Kinesis Streaming Destinations can be imported using the `table_name` and `stream_arn` separated by `,`, e.g.
+
+```
+$ terraform import aws_dynamodb_kinesis_streaming_destination.example example,arn:aws:kinesis:us-east-1:111122223333:exampleStreamName
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16406

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added resource for DynamoDB Kinesis streaming destination.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsDynamodbKinesisStreamingDestination'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsDynamodbKinesisStreamingDestination -timeout 120m
=== RUN   TestAccAwsDynamodbKinesisStreamingDestination_basic
=== PAUSE TestAccAwsDynamodbKinesisStreamingDestination_basic
=== RUN   TestAccAwsDynamodbKinesisStreamingDestination_disappears
=== PAUSE TestAccAwsDynamodbKinesisStreamingDestination_disappears
=== RUN   TestAccAwsDynamodbKinesisStreamingDestination_disappears_DynamoTable
=== PAUSE TestAccAwsDynamodbKinesisStreamingDestination_disappears_DynamoTable
=== CONT  TestAccAwsDynamodbKinesisStreamingDestination_basic
=== CONT  TestAccAwsDynamodbKinesisStreamingDestination_disappears_DynamoTable
=== CONT  TestAccAwsDynamodbKinesisStreamingDestination_disappears
--- PASS: TestAccAwsDynamodbKinesisStreamingDestination_disappears_DynamoTable (99.76s)
--- PASS: TestAccAwsDynamodbKinesisStreamingDestination_disappears (100.39s)
--- PASS: TestAccAwsDynamodbKinesisStreamingDestination_basic (134.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	136.461s
```