### PR TITLE
Add configuration set support for Cognito user pools

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -155,6 +155,10 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 								cognitoidentityprovider.EmailSendingAccountTypeDeveloper,
 							}, false),
 						},
+						"configuration_set": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -622,6 +626,10 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 				emailConfigurationType.EmailSendingAccount = aws.String(v.(string))
 			}
 
+			if v, ok := config["configuration_set"]; ok && v.(string) != "" {
+				emailConfigurationType.ConfigurationSet = aws.String(v.(string))
+			}
+
 			params.EmailConfiguration = emailConfigurationType
 		}
 	}
@@ -1074,6 +1082,10 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 
 				if v, ok := config["from_email_address"]; ok && v.(string) != "" {
 					emailConfigurationType.From = aws.String(v.(string))
+				}
+
+				if v, ok := config["configuration_set"]; ok && v.(string) != "" {
+					emailConfigurationType.ConfigurationSet = aws.String(v.(string))
 				}
 
 				params.EmailConfiguration = emailConfigurationType

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2406,6 +2406,10 @@ func flattenCognitoUserPoolEmailConfiguration(s *cognitoidentityprovider.EmailCo
 		m["email_sending_account"] = *s.EmailSendingAccount
 	}
 
+	if s.ConfigurationSet != nil {
+		m["configuration_set"] = *s.ConfigurationSet
+	}
+
 	if len(m) > 0 {
 		return []map[string]interface{}{m}
 	}

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -112,6 +112,7 @@ The following arguments are supported:
 * `source_arn` (Optional) - The ARN of the SES verified email identity to to use. Required if `email_sending_account` is set to `DEVELOPER`.
 * `from_email_address` (Optional) - Sender’s email address or sender’s display name with their email address (e.g. `john@example.com`, `John Smith <john@example.com>` or `\"John Smith Ph.D.\" <john@example.com>`). Escaped double quotes are required around display names that contain certain characters as specified in [RFC 5322](https://tools.ietf.org/html/rfc5322).
 * `email_sending_account` (Optional) - The email delivery method to use. `COGNITO_DEFAULT` for the default email functionality built into Cognito or `DEVELOPER` to use your Amazon SES configuration.
+* `configuration_set` (Optional) - The email configuration set name from SES.
 
 #### Lambda Configuration
 


### PR DESCRIPTION
Adds configuration set support for Cognito user pools.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* resource/aws_cognito_user_pool: Add `configuration_set`
```

Output from acceptance testing:

```bash
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPool_withEmailConfiguration'                                                                                                  

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserPool_withEmailConfiguration -timeout 120m
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withEmailConfiguration
=== CONT  TestAccAWSCognitoUserPool_withEmailConfiguration
--- PASS: TestAccAWSCognitoUserPool_withEmailConfiguration (49.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       52.910s
```
