### PR TITLE
Add custom sender support to lambda_config in aws_cognito_user_pool

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -192,12 +192,57 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validateArn,
 						},
+						"custom_email_sender": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"lambda_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"lambda_version": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      cognitoidentityprovider.CustomEmailSenderLambdaVersionTypeV10,
+										ValidateFunc: validation.StringInSlice(cognitoidentityprovider.CustomEmailSenderLambdaVersionType_Values(), false),
+									},
+								},
+							},
+						},
 						"custom_message": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validateArn,
 						},
+						"custom_sms_sender": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"lambda_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"lambda_version": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      cognitoidentityprovider.CustomSMSSenderLambdaVersionTypeV10,
+										ValidateFunc: validation.StringInSlice(cognitoidentityprovider.CustomSMSSenderLambdaVersionType_Values(), false),
+									},
+								},
+							},
+						},
 						"define_auth_challenge": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
+						},
+						"kms_key_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validateArn,

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -193,9 +193,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							ValidateFunc: validateArn,
 						},
 						"custom_email_sender": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:         schema.TypeList,
+							Optional:     true,
+							MaxItems:     1,
+							Computed:     true,
+							RequiredWith: []string{"lambda_config.0.kms_key_id"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"lambda_arn": {
@@ -218,9 +220,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							ValidateFunc: validateArn,
 						},
 						"custom_sms_sender": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:         schema.TypeList,
+							Optional:     true,
+							MaxItems:     1,
+							Computed:     true,
+							RequiredWith: []string{"lambda_config.0.kms_key_id"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"lambda_arn": {

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -1782,7 +1782,7 @@ resource "aws_cognito_user_pool" "test" {
       lambda_arn     = aws_lambda_function.test.arn
       lambda_version = "V1_0"
     }
-	}
+  }
 }
 `, name)
 }

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -932,8 +932,15 @@ func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.create_auth_challenge"),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.0.custom_email_sender.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_email_sender.0.lambda_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_email_sender.0.lambda_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_message"),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.0.custom_sms_sender.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_sms_sender.0.lambda_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_sms_sender.0.lambda_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.define_auth_challenge"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.kms_key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.post_authentication"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.post_confirmation"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.pre_authentication"),
@@ -953,8 +960,15 @@ func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.create_auth_challenge"),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.0.custom_email_sender.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_email_sender.0.lambda_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_email_sender.0.lambda_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_message"),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.0.custom_sms_sender.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_sms_sender.0.lambda_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_sms_sender.0.lambda_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.define_auth_challenge"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.kms_key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.post_authentication"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.post_confirmation"),
 					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.pre_authentication"),
@@ -1739,6 +1753,10 @@ resource "aws_lambda_function" "test" {
   runtime       = "nodejs12.x"
 }
 
+resource "aws_kms_key" "test" {
+  description = %[1]q
+}
+
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
@@ -1746,6 +1764,7 @@ resource "aws_cognito_user_pool" "test" {
     create_auth_challenge          = aws_lambda_function.test.arn
     custom_message                 = aws_lambda_function.test.arn
     define_auth_challenge          = aws_lambda_function.test.arn
+    kms_key_id                     = aws_kms_key.test.arn
     post_authentication            = aws_lambda_function.test.arn
     post_confirmation              = aws_lambda_function.test.arn
     pre_authentication             = aws_lambda_function.test.arn
@@ -1753,7 +1772,17 @@ resource "aws_cognito_user_pool" "test" {
     pre_token_generation           = aws_lambda_function.test.arn
     user_migration                 = aws_lambda_function.test.arn
     verify_auth_challenge_response = aws_lambda_function.test.arn
-  }
+
+    custom_email_sender {
+      lambda_arn     = aws_lambda_function.test.arn
+      lambda_version = "V1_0"
+    }
+
+    custom_sms_sender {
+      lambda_arn     = aws_lambda_function.test.arn
+      lambda_version = "V1_0"
+    }
+	}
 }
 `, name)
 }
@@ -1796,6 +1825,14 @@ resource "aws_lambda_function" "second" {
   runtime       = "nodejs12.x"
 }
 
+resource "aws_kms_key" "test" {
+  description = "test description"
+}
+
+resource "aws_kms_key" "second" {
+  description = "second description"
+}
+
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
@@ -1803,6 +1840,7 @@ resource "aws_cognito_user_pool" "test" {
     create_auth_challenge          = aws_lambda_function.second.arn
     custom_message                 = aws_lambda_function.second.arn
     define_auth_challenge          = aws_lambda_function.second.arn
+    kms_key_id                     = aws_kms_key.second.arn
     post_authentication            = aws_lambda_function.second.arn
     post_confirmation              = aws_lambda_function.second.arn
     pre_authentication             = aws_lambda_function.second.arn
@@ -1810,6 +1848,16 @@ resource "aws_cognito_user_pool" "test" {
     pre_token_generation           = aws_lambda_function.second.arn
     user_migration                 = aws_lambda_function.second.arn
     verify_auth_challenge_response = aws_lambda_function.second.arn
+
+    custom_email_sender {
+      lambda_arn     = aws_lambda_function.second.arn
+      lambda_version = "V1_0"
+    }
+
+    custom_sms_sender {
+      lambda_arn     = aws_lambda_function.second.arn
+      lambda_version = "V1_0"
+    }
   }
 }
 `, name)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2627,7 +2627,19 @@ func flattenCognitoUserPoolLambdaConfig(s *cognitoidentityprovider.LambdaConfigT
 	}
 
 	if s.CustomEmailSender != nil {
-		m["custom_email_sender"] = *s.CustomEmailSender
+		d := map[string]interface{}{}
+
+		if s.CustomEmailSender.LambdaArn != nil {
+			d["lambda_arn"] = *s.CustomEmailSender.LambdaArn
+		}
+
+		if s.CustomEmailSender.LambdaVersion != nil {
+			d["lambda_version"] = *s.CustomEmailSender.LambdaVersion
+		}
+
+		if len(d) > 0 {
+			m["custom_email_sender"] = []map[string]interface{}{d}
+		}
 	}
 
 	if s.CustomMessage != nil {
@@ -2635,7 +2647,19 @@ func flattenCognitoUserPoolLambdaConfig(s *cognitoidentityprovider.LambdaConfigT
 	}
 
 	if s.CustomSMSSender != nil {
-		m["custom_sms_sender"] = *s.CustomSMSSender
+		d := map[string]interface{}{}
+
+		if s.CustomSMSSender.LambdaArn != nil {
+			d["lambda_arn"] = *s.CustomSMSSender.LambdaArn
+		}
+
+		if s.CustomSMSSender.LambdaVersion != nil {
+			d["lambda_version"] = *s.CustomSMSSender.LambdaVersion
+		}
+
+		if len(d) > 0 {
+			m["custom_sms_sender"] = []map[string]interface{}{d}
+		}
 	}
 
 	if s.DefineAuthChallenge != nil {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2530,12 +2530,58 @@ func expandCognitoUserPoolLambdaConfig(config map[string]interface{}) *cognitoid
 		configs.CreateAuthChallenge = aws.String(v.(string))
 	}
 
+	if v, ok := config["custom_email_sender"]; ok {
+		data := v.([]interface{})
+
+		if len(data) > 0 {
+			m, ok := data[0].(map[string]interface{})
+			if ok {
+				customEmailLambdaVersionConfigType := &cognitoidentityprovider.CustomEmailLambdaVersionConfigType{}
+
+				if v, ok := m["lambda_arn"]; ok && v.(string) != "" {
+					customEmailLambdaVersionConfigType.LambdaArn = aws.String(v.(string))
+				}
+
+				if v, ok := m["lambda_version"]; ok && v.(string) != "" {
+					customEmailLambdaVersionConfigType.LambdaVersion = aws.String(v.(string))
+				}
+
+				configs.CustomEmailSender = customEmailLambdaVersionConfigType
+			}
+		}
+	}
+
 	if v, ok := config["custom_message"]; ok && v.(string) != "" {
 		configs.CustomMessage = aws.String(v.(string))
 	}
 
+	if v, ok := config["custom_sms_sender"]; ok {
+		data := v.([]interface{})
+
+		if len(data) > 0 {
+			m, ok := data[0].(map[string]interface{})
+			if ok {
+				customSMSLambdaVersionConfigType := &cognitoidentityprovider.CustomSMSLambdaVersionConfigType{}
+
+				if v, ok := m["lambda_arn"]; ok && v.(string) != "" {
+					customSMSLambdaVersionConfigType.LambdaArn = aws.String(v.(string))
+				}
+
+				if v, ok := m["lambda_version"]; ok && v.(string) != "" {
+					customSMSLambdaVersionConfigType.LambdaVersion = aws.String(v.(string))
+				}
+
+				configs.CustomSMSSender = customSMSLambdaVersionConfigType
+			}
+		}
+	}
+
 	if v, ok := config["define_auth_challenge"]; ok && v.(string) != "" {
 		configs.DefineAuthChallenge = aws.String(v.(string))
+	}
+
+	if v, ok := config["kms_key_id"]; ok && v.(string) != "" {
+		configs.KMSKeyID = aws.String(v.(string))
 	}
 
 	if v, ok := config["post_authentication"]; ok && v.(string) != "" {
@@ -2580,12 +2626,24 @@ func flattenCognitoUserPoolLambdaConfig(s *cognitoidentityprovider.LambdaConfigT
 		m["create_auth_challenge"] = *s.CreateAuthChallenge
 	}
 
+	if s.CustomEmailSender != nil {
+		m["custom_email_sender"] = *s.CustomEmailSender
+	}
+
 	if s.CustomMessage != nil {
 		m["custom_message"] = *s.CustomMessage
 	}
 
+	if s.CustomSMSSender != nil {
+		m["custom_sms_sender"] = *s.CustomSMSSender
+	}
+
 	if s.DefineAuthChallenge != nil {
 		m["define_auth_challenge"] = *s.DefineAuthChallenge
+	}
+
+	if s.KMSKeyID != nil {
+		m["kms_key_id"] = *s.KMSKeyID
 	}
 
 	if s.PostAuthentication != nil {

--- a/examples/cognito-user-pool/main.tf
+++ b/examples/cognito-user-pool/main.tf
@@ -124,12 +124,12 @@ resource "aws_cognito_user_pool" "pool" {
     verify_auth_challenge_response = aws_lambda_function.main.arn
 
     custom_email_sender {
-      lambda_arn     = aws_lambda_function.test.arn
+      lambda_arn     = aws_lambda_function.main.arn
       lambda_version = "V1_0"
     }
 
     custom_sms_sender {
-      lambda_arn     = aws_lambda_function.test.arn
+      lambda_arn     = aws_lambda_function.main.arn
       lambda_version = "V1_0"
     }
   }

--- a/examples/cognito-user-pool/main.tf
+++ b/examples/cognito-user-pool/main.tf
@@ -82,6 +82,10 @@ resource "aws_iam_role_policy" "main" {
 EOF
 }
 
+resource "aws_kms_key" "main" {
+  description = "key"
+}
+
 resource "aws_cognito_user_pool" "pool" {
   name                       = "terraform-example"
   email_verification_subject = "Device Verification Code"
@@ -110,6 +114,7 @@ resource "aws_cognito_user_pool" "pool" {
     create_auth_challenge          = aws_lambda_function.main.arn
     custom_message                 = aws_lambda_function.main.arn
     define_auth_challenge          = aws_lambda_function.main.arn
+    kms_key_id                     = aws_kms_key.main.arn
     post_authentication            = aws_lambda_function.main.arn
     post_confirmation              = aws_lambda_function.main.arn
     pre_authentication             = aws_lambda_function.main.arn
@@ -117,6 +122,16 @@ resource "aws_cognito_user_pool" "pool" {
     pre_token_generation           = aws_lambda_function.main.arn
     user_migration                 = aws_lambda_function.main.arn
     verify_auth_challenge_response = aws_lambda_function.main.arn
+
+    custom_email_sender {
+      lambda_arn     = aws_lambda_function.test.arn
+      lambda_version = "V1_0"
+    }
+
+    custom_sms_sender {
+      lambda_arn     = aws_lambda_function.test.arn
+      lambda_version = "V1_0"
+    }
   }
 
   schema {

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -116,8 +116,11 @@ The following arguments are supported:
 #### Lambda Configuration
 
 * `create_auth_challenge` (Optional) - The ARN of the lambda creating an authentication challenge.
+* `custom_email_sender` (Optional) - Specifies the [constraints for a custom email sender](#custom-sender-constraints) AWS Lambda trigger.
 * `custom_message` (Optional) - A custom Message AWS Lambda trigger.
+* `custom_sms_sender` (Optional) - Specifies the [constraints for a custom SMS sender](#custom-sender-constraints) AWS Lambda trigger..
 * `define_auth_challenge` (Optional) - Defines the authentication challenge.
+* `kms_key_id` (Optional) - Defines the key to encrypt codes and temporary passwords sent to CustomEmailSender and CustomSMSSender Lambda triggers.
 * `post_authentication` (Optional) - A post-authentication AWS Lambda trigger.
 * `post_confirmation` (Optional) - A post-confirmation AWS Lambda trigger.
 * `pre_authentication` (Optional) - A pre-authentication AWS Lambda trigger.
@@ -125,6 +128,11 @@ The following arguments are supported:
 * `pre_token_generation` (Optional) - Allow to customize identity token claims before token generation.
 * `user_migration` (Optional) - The user migration Lambda config type.
 * `verify_auth_challenge_response` (Optional) - Verifies the authentication challenge response.
+
+##### Custom Sender Constraints
+
+* `lambda_arn` (Required) - The ARN of the custom sender Lambda.
+* `lambda_version` (Optional) - The Lambda version represents the signature of the "request" attribute in the "event" information Amazon Cognito passes to your custom sender Lambda function. The only supported value is V1_0.
 
 #### Password Policy
 

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -132,7 +132,7 @@ The following arguments are supported:
 ##### Custom Sender Constraints
 
 * `lambda_arn` (Required) - The ARN of the custom sender Lambda.
-* `lambda_version` (Optional) - The Lambda version represents the signature of the "request" attribute in the "event" information Amazon Cognito passes to your custom sender Lambda function. The only supported value is V1_0.
+* `lambda_version` (Optional) - The Lambda version represents the signature of the "request" attribute in the "event" information Amazon Cognito passes to your custom sender Lambda function. Default value is "V1_0".
 
 #### Password Policy
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #16760

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cognito_user_pool: Add `custom_email_sender`, `custom_sms_sender`, and `kms_key_id` support to `lambda_config`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPool_withLambdaConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserPool_withLambdaConfig -v -timeout 120m
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig
=== PAUSE TestAccAWSCognitoUserPool_withLambdaConfig
=== CONT  TestAccAWSCognitoUserPool_withLambdaConfig
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (62.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	64.099s
```
