### PR TITLE
tech-debt/networkfirewall_resource_policy: update policy configs and examples in documentation

### DIFF
--- a/aws/resource_aws_networkfirewall_resource_policy_test.go
+++ b/aws/resource_aws_networkfirewall_resource_policy_test.go
@@ -28,14 +28,15 @@ func TestAccAwsNetworkFirewallResourcePolicy_firewallPolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsNetworkFirewallResourcePolicyExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", "aws_networkfirewall_firewall_policy.test", "arn"),
-					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":"network-firewall:ListFirewallPolicies"`)),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:CreateFirewall","network-firewall:UpdateFirewall","network-firewall:AssociateFirewallPolicy","network-firewall:ListFirewallPolicies"\]`)),
 				),
 			},
 			{
+				// Update the policy's Actions
 				Config: testAccNetworkFirewallResourcePolicy_firewallPolicy_updatePolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsNetworkFirewallResourcePolicyExists(resourceName),
-					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:ListFirewallPolicies","network-firewall:AssociateFirewallPolicy"\]`)),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:UpdateFirewall","network-firewall:AssociateFirewallPolicy","network-firewall:ListFirewallPolicies","network-firewall:CreateFirewall"\]`)),
 				),
 			},
 			{
@@ -61,14 +62,15 @@ func TestAccAwsNetworkFirewallResourcePolicy_ruleGroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsNetworkFirewallResourcePolicyExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", "aws_networkfirewall_rule_group.test", "arn"),
-					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":"network-firewall:ListRuleGroups"`)),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:CreateFirewallPolicy","network-firewall:UpdateFirewallPolicy","network-firewall:ListRuleGroups"\]`)),
 				),
 			},
 			{
+				// Update the policy's Actions
 				Config: testAccNetworkFirewallResourcePolicy_ruleGroup_updatePolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsNetworkFirewallResourcePolicyExists(resourceName),
-					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:ListRuleGroups","network-firewall:CreateFirewallPolicy"\]`)),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:UpdateFirewallPolicy","network-firewall:ListRuleGroups","network-firewall:CreateFirewallPolicy"\]`)),
 				),
 			},
 			{
@@ -212,9 +214,15 @@ func testAccNetworkFirewallResourcePolicy_firewallPolicy(rName string) string {
 		testAccNetworkFirewallResourcePolicyFirewallPolicyBaseConfig(rName), `
 resource "aws_networkfirewall_resource_policy" "test" {
   resource_arn = aws_networkfirewall_firewall_policy.test.arn
+  # policy's Action element must include all of the following operations
   policy = jsonencode({
     Statement = [{
-      Action   = "network-firewall:ListFirewallPolicies"
+      Action = [
+        "network-firewall:CreateFirewall",
+        "network-firewall:UpdateFirewall",
+        "network-firewall:AssociateFirewallPolicy",
+        "network-firewall:ListFirewallPolicies"
+      ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_firewall_policy.test.arn
       Principal = {
@@ -232,9 +240,15 @@ func testAccNetworkFirewallResourcePolicy_firewallPolicy_updatePolicy(rName stri
 		testAccNetworkFirewallResourcePolicyFirewallPolicyBaseConfig(rName), `
 resource "aws_networkfirewall_resource_policy" "test" {
   resource_arn = aws_networkfirewall_firewall_policy.test.arn
+  # policy's Action element must include all of the following operations
   policy = jsonencode({
     Statement = [{
-      Action   = ["network-firewall:ListFirewallPolicies", "network-firewall:AssociateFirewallPolicy"]
+      Action = [
+        "network-firewall:UpdateFirewall",
+        "network-firewall:AssociateFirewallPolicy",
+        "network-firewall:ListFirewallPolicies",
+        "network-firewall:CreateFirewall"
+      ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_firewall_policy.test.arn
       Principal = {
@@ -275,9 +289,14 @@ func testAccNetworkFirewallResourcePolicy_ruleGroup(rName string) string {
 		testAccNetworkFirewallResourcePolicyRuleGroupBaseConfig(rName), `
 resource "aws_networkfirewall_resource_policy" "test" {
   resource_arn = aws_networkfirewall_rule_group.test.arn
+  # policy's Action element must include all of the following operations
   policy = jsonencode({
     Statement = [{
-      Action   = "network-firewall:ListRuleGroups"
+      Action = [
+        "network-firewall:CreateFirewallPolicy",
+        "network-firewall:UpdateFirewallPolicy",
+        "network-firewall:ListRuleGroups"
+      ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_rule_group.test.arn
       Principal = {
@@ -295,9 +314,14 @@ func testAccNetworkFirewallResourcePolicy_ruleGroup_updatePolicy(rName string) s
 		testAccNetworkFirewallResourcePolicyRuleGroupBaseConfig(rName), `
 resource "aws_networkfirewall_resource_policy" "test" {
   resource_arn = aws_networkfirewall_rule_group.test.arn
+  # policy's Action element must include all of the following operations
   policy = jsonencode({
     Statement = [{
-      Action   = ["network-firewall:ListRuleGroups", "network-firewall:CreateFirewallPolicy"]
+      Action = [
+        "network-firewall:UpdateFirewallPolicy",
+        "network-firewall:ListRuleGroups",
+        "network-firewall:CreateFirewallPolicy"
+      ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_rule_group.test.arn
       Principal = {

--- a/website/docs/r/networkfirewall_resource_policy.html.markdown
+++ b/website/docs/r/networkfirewall_resource_policy.html.markdown
@@ -17,9 +17,15 @@ Provides an AWS Network Firewall Resource Policy Resource for a rule group or fi
 ```hcl
 resource "aws_networkfirewall_resource_policy" "example" {
   resource_arn = aws_networkfirewall_firewall_policy.example.arn
+  # policy's Action element must include all of the following operations
   policy = jsonencode({
     Statement = [{
-      Action   = "network-firewall:ListFirewallPolicies"
+      Action = [
+        "network-firewall:ListFirewallPolicies",
+        "network-firewall:CreateFirewall",
+        "network-firewall:UpdateFirewall",
+        "network-firewall:AssociateFirewallPolicy"
+      ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_firewall_policy.example.arn
       Principal = {
@@ -36,9 +42,14 @@ resource "aws_networkfirewall_resource_policy" "example" {
 ```hcl
 resource "aws_networkfirewall_resource_policy" "example" {
   resource_arn = aws_networkfirewall_rule_group.example.arn
+  # policy's Action element must include all of the following operations
   policy = jsonencode({
     Statement = [{
-      Action   = "network-firewall:ListRuleGroups"
+      Action = [
+        "network-firewall:ListRuleGroups",
+        "network-firewall:CreateFirewallPolicy",
+        "network-firewall:UpdateFirewallPolicy"
+      ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_rule_group.example.arn
       Principal = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16774 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsNetworkFirewallResourcePolicy_disappears (128.79s)
--- PASS: TestAccAwsNetworkFirewallResourcePolicy_firewallPolicy (132.03s)
--- PASS: TestAccAwsNetworkFirewallResourcePolicy_ruleGroup (132.63s)
--- PASS: TestAccAwsNetworkFirewallResourcePolicy_disappears_FirewallPolicy (137.81s)
--- PASS: TestAccAwsNetworkFirewallResourcePolicy_disappears_RuleGroup (139.15s)
```
