### PR TITLE
website: Show using jsonencode to generate IAM policy documents

### DIFF
--- a/website/docs/r/iam_group_policy.html.markdown
+++ b/website/docs/r/iam_group_policy.html.markdown
@@ -17,20 +17,20 @@ resource "aws_iam_group_policy" "my_developer_policy" {
   name  = "my_developer_policy"
   group = aws_iam_group.my_developers.name
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:Describe*"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 resource "aws_iam_group" "my_developers" {

--- a/website/docs/r/iam_policy.html.markdown
+++ b/website/docs/r/iam_policy.html.markdown
@@ -18,20 +18,20 @@ resource "aws_iam_policy" "policy" {
   path        = "/"
   description = "My test policy"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:Describe*"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
 }
 ```
 

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -18,21 +18,21 @@ Provides an IAM role.
 resource "aws_iam_role" "test_role" {
   name = "test_role"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
       },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+    ]
+  })
 
   tags = {
     tag-key = "tag-value"

--- a/website/docs/r/iam_role_policy.html.markdown
+++ b/website/docs/r/iam_role_policy.html.markdown
@@ -17,40 +17,38 @@ resource "aws_iam_role_policy" "test_policy" {
   name = "test_policy"
   role = aws_iam_role.test_role.id
 
-  policy = <<-EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
       {
-        "Action": [
-          "ec2:Describe*"
-        ],
-        "Effect": "Allow",
-        "Resource": "*"
-      }
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
     ]
-  }
-  EOF
+  })
 }
 
 resource "aws_iam_role" "test_role" {
   name = "test_role"
 
-  assume_role_policy = <<-EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
       {
-        "Action": "sts:AssumeRole",
-        "Principal": {
-          "Service": "ec2.amazonaws.com"
-        },
-        "Effect": "Allow",
-        "Sid": ""
-      }
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
     ]
-  }
-  EOF
+  })
 }
 ```
 

--- a/website/docs/r/iam_user_policy.html.markdown
+++ b/website/docs/r/iam_user_policy.html.markdown
@@ -17,20 +17,20 @@ resource "aws_iam_user_policy" "lb_ro" {
   name = "test"
   user = aws_iam_user.lb.name
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:Describe*"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
 }
 
 resource "aws_iam_user" "lb" {

--- a/website/docs/r/iot_policy.html.markdown
+++ b/website/docs/r/iot_policy.html.markdown
@@ -16,20 +16,20 @@ Provides an IoT policy.
 resource "aws_iot_policy" "pubsub" {
   name = "PubSubToAnyTopic"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "iot:*"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "iot:*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
 }
 ```
 

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -40,21 +40,21 @@ resource "aws_lambda_function" "test_lambda" {
 resource "aws_iam_role" "iam_for_lambda" {
   name = "iam_for_lambda"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
       },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+    ]
+  })
 }
 ```
 
@@ -90,21 +90,21 @@ resource "aws_lambda_function" "func" {
 resource "aws_iam_role" "default" {
   name = "iam_for_lambda_with_sns"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
       },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+    ]
+  })
 }
 ```
 

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -22,24 +22,29 @@ resource "aws_s3_bucket" "b" {
 resource "aws_s3_bucket_policy" "b" {
   bucket = aws_s3_bucket.b.id
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "MYBUCKETPOLICY",
-  "Statement": [
-    {
-      "Sid": "IPAllow",
-      "Effect": "Deny",
-      "Principal": "*",
-      "Action": "s3:*",
-      "Resource": "arn:aws:s3:::my-tf-test-bucket/*",
-      "Condition": {
-         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
-      }
-    }
-  ]
-}
-POLICY
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression's result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "MYBUCKETPOLICY"
+    Statement = [
+      {
+        Sid       = "IPAllow"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.b.arn,
+          "${aws_s3_bucket.b.arn}/*",
+        ]
+        Condition = {
+          IPAddress = {
+            "aws:SourceIp" = "8.8.8.8/32"
+          }
+        }
+      },
+    ]
+  })
 }
 ```
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This is a documentation-only change which does not affect the behavior of the provider.

---

The existing examples of inline IAM policy documents tend to show them as "heredoc" strings, which was the required style in Terraform v0.11 and earlier.

However, users seem to frequently start from these simple examples and then later need to insert dynamic elements such as ARNs or lists of ARNs from other resources, and because they started with a multi-line string template they then understandably start experimenting with string templating to produce the dynamic JSON, and run into various issues with incorrect quoting and generation of commas.

When helping users in that case (e.g. in the community forum) we typically suggest that they switch to using [the `jsonencode` function](https://www.terraform.io/docs/configuration/functions/jsonencode.html) for generating that dynamic JSON, because then they can just use normal Terraform language expression features and let Terraform itself worry about making the result valid JSON syntax.

In an attempt to help users discover that solution themselves, rather than fighting with string templates first, I've changed the examples for the resource types I've most commonly seen questions about in order to show generating the JSON string 
programmatically using the `jsonencode` function. Not everyone will necessarily realize right away that they can also use dynamic expressions in there, I hope that this will at least set folks on a better path when they start evaluating possible solutions by making it less likely that string templates will be seen as a viable option.

There are many more heredoc-based IAM policy examples in other resource types -- particularly in various examples that include `aws_iam_role` helper resources with `assume_role_policy` arguments -- but I wanted to keep this confined to a frequently-seen subset to start just to avoid this being a huge diff that could be disruptive to merge. Hopefully over time we can update more of these (though there's no particular urgency here), and also maybe write any new examples in this `jsonencode` style.

The `jsonencode` style is also typically how Terraform CLI will present the value in the plan diff, in order to potentially produce a structural diff _within_ the JSON data structure, so hopefully this will also help set users up to be less surprised when they encounter that for the first time.

