### PR TITLE
tests/service/ec2: Add PreCheck for Managed Prefix Lists

### DIFF
--- a/aws/data_source_aws_ec2_managed_prefix_list_test.go
+++ b/aws/data_source_aws_ec2_managed_prefix_list_test.go
@@ -44,7 +44,7 @@ func TestAccDataSourceAwsEc2ManagedPrefixList_basic(t *testing.T) {
 	prefixListResourceName := "data.aws_prefix_list.s3_by_id"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -98,7 +98,7 @@ func TestAccDataSourceAwsEc2ManagedPrefixList_filter(t *testing.T) {
 	resourceById := "data.aws_ec2_managed_prefix_list.s3_by_id"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -149,7 +149,7 @@ data "aws_ec2_managed_prefix_list" "s3_by_id" {
 
 func TestAccDataSourceAwsEc2ManagedPrefixList_matchesTooMany(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1014,6 +1014,9 @@ func testAccPreCheckSkipError(err error) bool {
 	if isAWSErr(err, "InvalidInputException", "Unknown operation") {
 		return true
 	}
+	if isAWSErr(err, "InvalidAction", "is not valid") {
+		return true
+	}
 	if isAWSErr(err, "InvalidAction", "Unavailable Operation") {
 		return true
 	}

--- a/aws/resource_aws_ec2_managed_prefix_list_test.go
+++ b/aws/resource_aws_ec2_managed_prefix_list_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,7 +19,7 @@ func TestAccAwsEc2ManagedPrefixList_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEc2ManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
@@ -51,7 +52,7 @@ func TestAccAwsEc2ManagedPrefixList_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEc2ManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
@@ -72,7 +73,7 @@ func TestAccAwsEc2ManagedPrefixList_AddressFamily_IPv6(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEc2ManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
@@ -98,7 +99,7 @@ func TestAccAwsEc2ManagedPrefixList_Entry(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEc2ManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
@@ -156,7 +157,7 @@ func TestAccAwsEc2ManagedPrefixList_Name(t *testing.T) {
 	rName2 := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEc2ManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
@@ -192,7 +193,7 @@ func TestAccAwsEc2ManagedPrefixList_Tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsEc2ManagedPrefixListDestroy,
 		Steps: []resource.TestStep{
@@ -284,6 +285,22 @@ func testAccAwsEc2ManagedPrefixListExists(resourceName string) resource.TestChec
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckEc2ManagedPrefixList(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	input := &ec2.DescribeManagedPrefixListsInput{}
+
+	_, err := conn.DescribeManagedPrefixLists(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16804

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccDataSourceAwsEc2ManagedPrefixList_matchesTooMany (3.65s)
--- PASS: TestAccDataSourceAwsEc2ManagedPrefixList_basic (20.74s)
--- PASS: TestAccDataSourceAwsEc2ManagedPrefixList_filter (20.86s)

--- PASS: TestAccAwsEc2ManagedPrefixList_disappears (21.32s)
--- PASS: TestAccAwsEc2ManagedPrefixList_basic (22.83s)
--- PASS: TestAccAwsEc2ManagedPrefixList_AddressFamily_IPv6 (23.06s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Name (35.60s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Entry (40.87s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Tags (47.58s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccDataSourceAwsEc2ManagedPrefixList_basic (1.74s)
--- SKIP: TestAccDataSourceAwsEc2ManagedPrefixList_filter (1.72s)
--- SKIP: TestAccDataSourceAwsEc2ManagedPrefixList_matchesTooMany (1.73s)

--- SKIP: TestAccAwsEc2ManagedPrefixList_AddressFamily_IPv6 (1.75s)
--- SKIP: TestAccAwsEc2ManagedPrefixList_basic (1.73s)
--- SKIP: TestAccAwsEc2ManagedPrefixList_disappears (1.73s)
--- SKIP: TestAccAwsEc2ManagedPrefixList_Entry (1.73s)
--- SKIP: TestAccAwsEc2ManagedPrefixList_Name (1.75s)
--- SKIP: TestAccAwsEc2ManagedPrefixList_Tags (1.74s)
```
