### PR TITLE
resource/aws_eip_association: fix eventual consistency issue when associating EIP

### DIFF
--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -11,6 +11,9 @@ import (
 const (
 	// Maximum amount of time to wait for EC2 Instance attribute modifications to propagate
 	InstanceAttributePropagationTimeout = 2 * time.Minute
+
+	// General timeout for EC2 resource creations to propagate
+	PropagationTimeout = 2 * time.Minute
 )
 
 const (


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11617
Relates #12449

### Terraform Version
```
$ terraform -v
Terraform v0.12.16
+ provider.aws v2.39.0
```

### Affected Resource(s)

aws_eip_association

### Terraform Configuration
```
provider "aws" {
  version = "2.39.0"
  region = var.aws_region
}

resource "aws_instance" "this" {
  ami = "ami-06fb5332e8e3e577a"
  instance_type = "t2.nano"
  key_name = "default_key"
  vpc_security_group_ids = ["sg-923d3cf4"]
  subnet_id = "subnet-61a23e06"
  associate_public_ip_address = true

  root_block_device {
    volume_size = 20
    volume_type = "gp2"
    delete_on_termination = true
  }

  lifecycle {
    create_before_destroy = true
  }
}

resource "aws_eip" "this" {
  vpc = true
}

resource "aws_eip_association" "this" {
  instance_id   = aws_instance.this.id
  allocation_id = aws_eip.this.id
}
```

### Expected Behavior

`aws_eip_association` is created successfully in TF state and in EC2.

### Actual Behavior
Rarely, the EIP is associated, but in TF state the resource is not recorded due to eventual consistency issue when reading back the association

```
Error: Provider produced inconsistent result after apply
When applying changes to aws_eip_association.this, provider "aws" produced an unexpected new value for was present, but now absent. This is a bug in the provider, which should be reported in the provider's own issue tracker.
``` 

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIPAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEIPAssociation_ -timeout 120m
=== RUN   TestAccAWSEIPAssociation_instance
=== PAUSE TestAccAWSEIPAssociation_instance
=== RUN   TestAccAWSEIPAssociation_networkInterface
=== PAUSE TestAccAWSEIPAssociation_networkInterface
=== RUN   TestAccAWSEIPAssociation_basic
=== PAUSE TestAccAWSEIPAssociation_basic
=== RUN   TestAccAWSEIPAssociation_ec2Classic
=== PAUSE TestAccAWSEIPAssociation_ec2Classic
=== RUN   TestAccAWSEIPAssociation_spotInstance
=== PAUSE TestAccAWSEIPAssociation_spotInstance
=== RUN   TestAccAWSEIPAssociation_disappears
=== PAUSE TestAccAWSEIPAssociation_disappears
=== CONT  TestAccAWSEIPAssociation_instance
=== CONT  TestAccAWSEIPAssociation_spotInstance
=== CONT  TestAccAWSEIPAssociation_disappears
=== CONT  TestAccAWSEIPAssociation_ec2Classic
=== CONT  TestAccAWSEIPAssociation_networkInterface
=== CONT  TestAccAWSEIPAssociation_basic
=== CONT  TestAccAWSEIPAssociation_ec2Classic
    ec2_classic_test.go:54: this test can only run in EC2-Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccAWSEIPAssociation_ec2Classic (5.79s)
--- PASS: TestAccAWSEIPAssociation_networkInterface (75.35s)
--- PASS: TestAccAWSEIPAssociation_instance (108.61s)
--- PASS: TestAccAWSEIPAssociation_disappears (109.13s)
--- PASS: TestAccAWSEIPAssociation_basic (169.76s)
--- PASS: TestAccAWSEIPAssociation_spotInstance (310.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	310.577s
```
