### PR TITLE
r/aws_db_instance Bugfix: Pass db_subnet_group_name in restore_to_point_in_time (Issue #16821)

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1149,7 +1149,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 				input.StorageType = aws.String(v.(string))
 			}
 
-			if v, ok := d.GetOk("subnet_group_name"); ok {
+			if v, ok := d.GetOk("db_subnet_group_name"); ok {
 				input.DBSubnetGroupName = aws.String(v.(string))
 			}
 


### PR DESCRIPTION
Resolves a misspelling in https://github.com/hashicorp/terraform-provider-aws/pull/15969

Resolves https://github.com/hashicorp/terraform-provider-aws/issues/16821

Release note for CHANGELOG:

BUG FIXES:
- resource/aws_db_instance: db_subnet_group_name passed correctly now