### PR TITLE
resource/msk_scram_secret_association: update secret handling on read/update

### DIFF
--- a/website/docs/r/msk_scram_secret_association.html.markdown
+++ b/website/docs/r/msk_scram_secret_association.html.markdown
@@ -78,13 +78,14 @@ POLICY
 The following arguments are supported:
 
 * `cluster_arn` - (Required, Forces new resource) Amazon Resource Name (ARN) of the MSK cluster.
-* `secret_arn_list` - (Required) List of AWS Secrets Manager secret ARNs.
+* `secret_arn_list` - (Required) Set of AWS Secrets Manager secret ARNs.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Amazon Resource Name (ARN) of the MSK cluster.
+* `scram_secrets` - Set of AWS Secrets Manager secret ARNs associated with the MSK cluster including secrets configured in `secret_arn_list` and those managed outside of Terraform, if any.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16791 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/msk_scram_secret_association: update secret handling on read/update
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsMskScramSecretAssociation_update (1696.19s)
--- PASS: TestAccAwsMskScramSecretAssociation_disappears (1714.16s)
--- PASS: TestAccAwsMskScramSecretAssociation_distributedKeyManagement (1719.34s)
--- PASS: TestAccAwsMskScramSecretAssociation_basic (1751.14s)
--- PASS: TestAccAwsMskScramSecretAssociation_disappears_Cluster (1796.78s)
```
