### PR TITLE
Add platform capability to Batch job definition

### DIFF
--- a/.changelog/16850.txt
+++ b/.changelog/16850.txt
@@ -1,0 +1,3 @@
+```release-notes:enhancement
+resource/aws_batch_job_definition: Add `platform_capabilities` attribute
+```

--- a/aws/internal/service/batch/consts.go
+++ b/aws/internal/service/batch/consts.go
@@ -1,0 +1,5 @@
+package batch
+
+const (
+	JobDefinitionStatusInactive = "INACTIVE"
+)

--- a/aws/internal/service/batch/finder/finder.go
+++ b/aws/internal/service/batch/finder/finder.go
@@ -1,0 +1,42 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfbatch "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch"
+)
+
+func JobDefinitionByARN(conn *batch.Batch, arn string) (*batch.JobDefinition, error) {
+	input := &batch.DescribeJobDefinitionsInput{
+		JobDefinitions: aws.StringSlice([]string{arn}),
+	}
+
+	return JobDefinition(conn, input)
+}
+
+func JobDefinition(conn *batch.Batch, input *batch.DescribeJobDefinitionsInput) (*batch.JobDefinition, error) {
+	output, err := conn.DescribeJobDefinitions(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.JobDefinitions) == 0 || output.JobDefinitions[0] == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	jobDefinition := output.JobDefinitions[0]
+
+	if status := aws.StringValue(jobDefinition.Status); status == tfbatch.JobDefinitionStatusInactive {
+		return nil, &resource.NotFoundError{
+			Message:     status,
+			LastRequest: input,
+		}
+	}
+
+	return jobDefinition, nil
+}

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -63,7 +63,7 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{batch.PlatformCapabilityEc2, batch.PlatformCapabilityFargate}, true),
+					ValidateFunc: validation.StringInSlice(batch.PlatformCapability_Values(), true),
 				},
 			},
 			"retry_strategy": {

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -83,8 +84,16 @@ func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 				Config: testAccBatchJobDefinitionConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "revision"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "platform_capability.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "container"),
 				),
 			},
 			{

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -119,9 +119,17 @@ func TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2(t *testing.T) {
 				Config: testAccBatchJobDefinitionConfigCapabilitiesEC2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "platform_capabilities.*", "EC2"),
+					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "revision"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "platform_capability.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "platform_capability.0", "EC2"),
+					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "container"),
 				),
 			},
 			{
@@ -147,9 +155,17 @@ func TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate(t *testing.T) {
 				Config: testAccBatchJobDefinitionConfigCapabilitiesFargate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "platform_capabilities.*", "FARGATE"),
+					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "revision"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "platform_capability.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "platform_capability.0", "FARGATE"),
+					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "container"),
 				),
 			},
 			{
@@ -496,7 +512,8 @@ func testAccBatchJobDefinitionConfigCapabilitiesEC2(rName string) string {
 resource "aws_batch_job_definition" "test" {
   name = %[1]q
   type = "container"
-  platform_capability = [
+
+  platform_capabilities = [
     "EC2",
   ]
 
@@ -515,7 +532,7 @@ func testAccBatchJobDefinitionConfigCapabilitiesFargate(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "ecs_task_execution_role" {
-  name               = "%[1]s-exec-role"
+  name               = %[1]q
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 
@@ -538,7 +555,8 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
 resource "aws_batch_job_definition" "test" {
   name = %[1]q
   type = "container"
-  platform_capability = [
+
+  platform_capabilities = [
     "FARGATE",
   ]
 

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -112,6 +112,7 @@ func TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		ErrorCheck:   testAccErrorCheck(t, batch.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
 		Steps: []resource.TestStep{
@@ -148,6 +149,7 @@ func TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		ErrorCheck:   testAccErrorCheck(t, batch.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -105,6 +105,29 @@ func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSBatchJobDefinition_disappears(t *testing.T) {
+	var jd batch.JobDefinition
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_batch_job_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		ErrorCheck:   testAccErrorCheck(t, batch.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchJobDefinitionConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsBatchJobDefinition(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2(t *testing.T) {
 	var jd batch.JobDefinition
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -84,6 +84,7 @@ func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "platform_capability.#", "0"),
 				),
 			},
 			{

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -53,28 +53,9 @@ CONTAINER_PROPERTIES
 }
 ```
 
-### EC2 Platform Capability
-
-```hcl
-resource "aws_batch_job_definition" "test" {
-  name = "tf_test_batch_job_definition"
-  type = "container"
-  platform_capability = [
-    "EC2",
-  ]
-
-  container_properties = jsonencode({
-    command = ["echo", "test"]
-    image   = "busybox"
-    memory  = 128
-    vcpus   = 1
-  })
-}
-```
-
 ### Fargate Platform Capability
 
-```hcl
+```terraform
 resource "aws_iam_role" "ecs_task_execution_role" {
   name               = "tf_test_batch_exec_role"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
@@ -99,7 +80,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
 resource "aws_batch_job_definition" "test" {
   name = "tf_test_batch_job_definition"
   type = "container"
-  platform_capability = [
+  platform_capabilities = [
     "FARGATE",
   ]
 
@@ -128,7 +109,7 @@ The following arguments are supported:
 * `container_properties` - (Optional) A valid [container properties](http://docs.aws.amazon.com/batch/latest/APIReference/API_RegisterJobDefinition.html)
     provided as a single valid JSON document. This parameter is required if the `type` parameter is `container`.
 * `parameters` - (Optional) Specifies the parameter substitution placeholders to set in the job definition.
-* `platform_capability` - (Optional) The platform capabilities required by the job definition. If no value is specified, it defaults to `EC2`. Jobs run on Fargate resources specify `FARGATE`.
+* `platform_capabilities` - (Optional) The platform capabilities required by the job definition. If no value is specified, it defaults to `EC2`. To run the job on Fargate resources, specify `FARGATE`.
 * `retry_strategy` - (Optional) Specifies the retry strategy to use for failed jobs that are submitted with this job definition.
     Maximum number of `retry_strategy` is `1`.  Defined below.
 * `tags` - (Optional) Key-value map of resource tags

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -53,6 +53,73 @@ CONTAINER_PROPERTIES
 }
 ```
 
+### EC2 Platform Capability
+
+```hcl
+resource "aws_batch_job_definition" "test" {
+  name = "tf_test_batch_job_definition"
+  type = "container"
+  platform_capability = [
+    "EC2",
+  ]
+
+  container_properties = jsonencode({
+    command = ["echo", "test"]
+    image   = "busybox"
+    memory  = 128
+    vcpus   = 1
+  })
+}
+```
+
+### Fargate Platform Capability
+
+```hcl
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "tf_test_batch_exec_role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_batch_job_definition" "test" {
+  name = "tf_test_batch_job_definition"
+  type = "container"
+  platform_capability = [
+    "FARGATE",
+  ]
+
+  container_properties = <<CONTAINER_PROPERTIES
+{
+  "command": ["echo", "test"],
+  "image": "busybox",
+  "fargatePlatformConfiguration": {
+    "platformVersion": "LATEST"
+  },
+  "resourceRequirements": [
+    {"type": "VCPU", "value": "0.25"},
+    {"type": "MEMORY", "value": "512"}
+  ],
+  "executionRoleArn": "${aws_iam_role.ecs_task_execution_role.arn}"
+}
+CONTAINER_PROPERTIES
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -61,6 +128,7 @@ The following arguments are supported:
 * `container_properties` - (Optional) A valid [container properties](http://docs.aws.amazon.com/batch/latest/APIReference/API_RegisterJobDefinition.html)
     provided as a single valid JSON document. This parameter is required if the `type` parameter is `container`.
 * `parameters` - (Optional) Specifies the parameter substitution placeholders to set in the job definition.
+* `platform_capability` - (Optional) The platform capabilities required by the job definition. If no value is specified, it defaults to `EC2`. Jobs run on Fargate resources specify `FARGATE`.
 * `retry_strategy` - (Optional) Specifies the retry strategy to use for failed jobs that are submitted with this job definition.
     Maximum number of `retry_strategy` is `1`.  Defined below.
 * `tags` - (Optional) Key-value map of resource tags


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16592

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_batch_job_definition: add platform capabilities support (#16850)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSBatchJobDefinition_' ACCTEST_PARALLELISM=4   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -run=TestAccAWSBatchJobDefinition_ -timeout 120m
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
--- PASS: TestAccAWSBatchJobDefinition_basic (43.89s)
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate (45.65s)
=== CONT  TestAccAWSBatchJobDefinition_Tags
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (47.09s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (70.40s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2 (40.08s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (86.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       134.167s
```
