### PR TITLE
[doc] Add a warning on loggroup naming convention with EKS

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -81,8 +81,6 @@ resource "aws_iam_role_policy_attachment" "example-AmazonEKSVPCResourceControlle
 
 -> The below configuration uses [`depends_on`](/docs/configuration/resources.html#depends_on-explicit-resource-dependencies) to prevent ordering issues with EKS automatically creating the log group first and a variable for naming consistency. Other ordering and naming methodologies may be more appropriate for your environment.
 
--> Be carreful the logroup name's /aws/eks/${var.cluster_name}/cluster is mandatory until EKS API accept loggroup name's as parameter.
-
 ```hcl
 variable "cluster_name" {
   default = "example"
@@ -99,6 +97,8 @@ resource "aws_eks_cluster" "example" {
 }
 
 resource "aws_cloudwatch_log_group" "example" {
+  # The log group name format is /aws/eks/<cluster-name>/cluster
+  # Reference: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
   name              = "/aws/eks/${var.cluster_name}/cluster"
   retention_in_days = 7
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -81,6 +81,8 @@ resource "aws_iam_role_policy_attachment" "example-AmazonEKSVPCResourceControlle
 
 -> The below configuration uses [`depends_on`](/docs/configuration/resources.html#depends_on-explicit-resource-dependencies) to prevent ordering issues with EKS automatically creating the log group first and a variable for naming consistency. Other ordering and naming methodologies may be more appropriate for your environment.
 
+-> Be carreful the logroup name's /aws/eks/${var.cluster_name}/cluster is mandatory until EKS API accept loggroup name's as parameter.
+
 ```hcl
 variable "cluster_name" {
   default = "example"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
 Add a warning on loggroup naming convention with EKS
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
