### PR TITLE
adds an event bus policy resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -549,6 +549,7 @@ func Provider() *schema.Provider {
 			"aws_cloudfront_realtime_log_config":                      resourceAwsCloudFrontRealtimeLogConfig(),
 			"aws_cloudtrail":                                          resourceAwsCloudTrail(),
 			"aws_cloudwatch_event_bus":                                resourceAwsCloudWatchEventBus(),
+			"aws_cloudwatch_event_bus_policy":                         resourceAwsCloudWatchEventBusPolicy(),
 			"aws_cloudwatch_event_permission":                         resourceAwsCloudWatchEventPermission(),
 			"aws_cloudwatch_event_rule":                               resourceAwsCloudWatchEventRule(),
 			"aws_cloudwatch_event_target":                             resourceAwsCloudWatchEventTarget(),

--- a/aws/resource_aws_cloudwatch_event_bus_policy.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 
@@ -9,6 +8,7 @@ import (
 	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	tfevents "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudwatchevents"
 	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
@@ -35,8 +35,10 @@ func resourceAwsCloudWatchEventBusPolicy() *schema.Resource {
 				Default:      tfevents.DefaultEventBusName,
 			},
 			"policy": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 		},
 	}

--- a/aws/resource_aws_cloudwatch_event_bus_policy.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy.go
@@ -114,16 +114,7 @@ func resourceAwsCloudWatchEventBusPolicyRead(d *schema.ResourceData, meta interf
 	}
 	d.Set("event_bus_name", busName)
 
-	log.Printf("[WARN] about to unmarshal json")
-	policyBytes := []byte(*policy)
-	log.Printf("[WARN] converted policy into byte array")
-	var policyObject interface{}
-	if err := json.Unmarshal(policyBytes, &policyObject); err != nil {
-		return fmt.Errorf("error parsing json from policy for CloudWatch EventBus (%s): %w", d.Id(), err)
-	}
-	marshalled, _ := json.Marshal(policyObject)
-	log.Printf("[WARN] finished unmarshalling json")
-	d.Set("policy", string(marshalled))
+	d.Set("policy", policy)
 
 	return nil
 }

--- a/aws/resource_aws_cloudwatch_event_bus_policy.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy.go
@@ -1,0 +1,172 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfevents "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudwatchevents"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+)
+
+func resourceAwsCloudWatchEventBusPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudWatchEventBusPolicyCreate,
+		Read:   resourceAwsCloudWatchEventBusPolicyRead,
+		Update: resourceAwsCloudWatchEventBusPolicyUpdate,
+		Delete: resourceAwsCloudWatchEventBusPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"event_bus_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCloudWatchEventBusName,
+				Default:      tfevents.DefaultEventBusName,
+			},
+			"policy": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsCloudWatchEventBusPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+
+	eventBusName := d.Get("event_bus_name").(string)
+	policy := d.Get("policy").(string)
+
+	input := events.PutPermissionInput{
+		EventBusName: aws.String(eventBusName),
+		Policy:       aws.String(policy),
+	}
+
+	log.Printf("[DEBUG] Creating CloudWatch Events policy: %s", input)
+	_, err := conn.PutPermission(&input)
+	if err != nil {
+		return fmt.Errorf("Creating CloudWatch Events policy failed: %w", err)
+	}
+
+	d.SetId(eventBusName)
+
+	return resourceAwsCloudWatchEventBusPolicyRead(d, meta)
+}
+
+// See also: https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DescribeEventBus.html
+func resourceAwsCloudWatchEventBusPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+
+	eventBusName := d.Id()
+
+	input := events.DescribeEventBusInput{
+		Name: aws.String(eventBusName),
+	}
+	var output *events.DescribeEventBusOutput
+	var policy *string
+
+	// Especially with concurrent PutPermission calls there can be a slight delay
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		log.Printf("[DEBUG] Reading CloudWatch Events bus: %s", input)
+		output, err := conn.DescribeEventBus(&input)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("reading CloudWatch Events permission (%s) failed: %w", d.Id(), err))
+		}
+
+		policy, err = getEventBusPolicy(output)
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		output, err = conn.DescribeEventBus(&input)
+		if output != nil {
+			policy, err = getEventBusPolicy(output)
+		}
+	}
+
+	if isResourceNotFoundError(err) {
+		log.Printf("[WARN] Policy on {%s} EventBus not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading policy from CloudWatch EventBus (%s): %w", d.Id(), err)
+	}
+
+	busName := aws.StringValue(output.Name)
+	if busName == "" {
+		busName = tfevents.DefaultEventBusName
+	}
+	d.Set("event_bus_name", busName)
+
+	d.Set("policy", policy)
+
+	return nil
+}
+
+func getEventBusPolicy(output *events.DescribeEventBusOutput) (*string, error) {
+	if output == nil || output.Policy == nil {
+		return nil, &resource.NotFoundError{
+			Message:      fmt.Sprintf("Policy for CloudWatch EventBus %s not found", *output.Name),
+			LastResponse: output,
+		}
+	}
+
+	return output.Policy, nil
+}
+
+func resourceAwsCloudWatchEventBusPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+
+	eventBusName := d.Id()
+
+	input := events.PutPermissionInput{
+		EventBusName: aws.String(eventBusName),
+		Policy:       aws.String(d.Get("policy").(string)),
+	}
+
+	log.Printf("[DEBUG] Update CloudWatch EventBus policy: %s", input)
+	_, err := conn.PutPermission(&input)
+	if isAWSErr(err, events.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] CloudWatch EventBus %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error updating policy for CloudWatch EventBus (%s): %w", d.Id(), err)
+	}
+
+	return resourceAwsCloudWatchEventBusPolicyRead(d, meta)
+}
+
+func resourceAwsCloudWatchEventBusPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+
+	eventBusName := d.Id()
+	removeAllPermissions := true
+
+	input := events.RemovePermissionInput{
+		EventBusName:         aws.String(eventBusName),
+		RemoveAllPermissions: &removeAllPermissions,
+	}
+
+	log.Printf("[DEBUG] Delete CloudWatch EventBus Policy: %s", input)
+	_, err := conn.RemovePermission(&input)
+	if isAWSErr(err, events.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error deleting policy for CloudWatch EventBus (%s): %w", d.Id(), err)
+	}
+	return nil
+}

--- a/aws/resource_aws_cloudwatch_event_bus_policy.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy.go
@@ -31,7 +31,7 @@ func resourceAwsCloudWatchEventBusPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateCloudWatchEventBusName,
+				ValidateFunc: validateCloudWatchEventBusNameOrARN,
 				Default:      tfevents.DefaultEventBusName,
 			},
 			"policy": {

--- a/aws/resource_aws_cloudwatch_event_bus_policy_test.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy_test.go
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_event_bus" "test" {
 
 data "aws_iam_policy_document" "access" {
   statement {
-    sid = "test-resource-policy"
+    sid    = "test-resource-policy"
     effect = "Allow"
     principals {
       identifiers = ["ecs.amazonaws.com"]

--- a/aws/resource_aws_cloudwatch_event_bus_policy_test.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy_test.go
@@ -58,7 +58,7 @@ func testAccCheckAWSCloudwatchEventBusPolicyExists(pr string) resource.TestCheck
 		if err != nil {
 			return fmt.Errorf("Reading CloudWatch Events bus policy for '%s' failed: %w", pr, err)
 		}
-		if describedEventBus.Policy == nil {
+		if describedEventBus.Policy == nil || len(*describedEventBus.Policy) == 0 {
 			return fmt.Errorf("Not found: %s", pr)
 		}
 

--- a/aws/resource_aws_cloudwatch_event_bus_policy_test.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy_test.go
@@ -1,0 +1,102 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSCloudwatchEventBusPolicy_basic(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_bus_policy.test"
+	rstring := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventBusDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudwatchEventBusPolicyConfig(rstring),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloudwatchEventBusPolicyExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCloudwatchEventBusPolicyExists(pr string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		eventBusResource, ok := state.RootModule().Resources[pr]
+		if !ok {
+			return fmt.Errorf("Not found: %s", pr)
+		}
+
+		if eventBusResource.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		eventBusName := eventBusResource.Primary.ID
+
+		input := &events.DescribeEventBusInput{
+			Name: aws.String(eventBusName),
+		}
+
+		cloudWatchEventsConnection := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn
+		describedEventBus, err := cloudWatchEventsConnection.DescribeEventBus(input)
+
+		if err != nil {
+			return fmt.Errorf("Reading CloudWatch Events bus policy for '%s' failed: %w", pr, err)
+		}
+		if describedEventBus.Policy == nil {
+			return fmt.Errorf("Not found: %s", pr)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSCloudwatchEventBusPolicyConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_bus" "test" {
+  name = %[1]q
+}
+
+data "aws_iam_policy_document" "access" {
+  statement {
+	sid = "test-resource-policy"
+
+    effect = "Allow"
+
+    principals {
+      identifiers = ["ecs.amazonaws.com"]
+      type        = "Service"
+    }
+
+    actions = [
+      "events:PutEvents",
+      "events:PutRule"
+    ]
+
+    resources = [
+      aws_cloudwatch_event_bus.test.arn,
+    ]
+  }
+}
+
+resource "aws_cloudwatch_event_bus_policy" "test" {
+  policy    = data.aws_iam_policy_document.access.json
+  event_bus_name = aws_cloudwatch_event_bus.test.name
+}
+`, name)
+}

--- a/aws/resource_aws_cloudwatch_event_bus_policy_test.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy_test.go
@@ -74,20 +74,16 @@ resource "aws_cloudwatch_event_bus" "test" {
 
 data "aws_iam_policy_document" "access" {
   statement {
-	sid = "test-resource-policy"
-
+    sid = "test-resource-policy"
     effect = "Allow"
-
     principals {
       identifiers = ["ecs.amazonaws.com"]
       type        = "Service"
     }
-
     actions = [
       "events:PutEvents",
       "events:PutRule"
     ]
-
     resources = [
       aws_cloudwatch_event_bus.test.arn,
     ]
@@ -95,7 +91,7 @@ data "aws_iam_policy_document" "access" {
 }
 
 resource "aws_cloudwatch_event_bus_policy" "test" {
-  policy    = data.aws_iam_policy_document.access.json
+  policy         = data.aws_iam_policy_document.access.json
   event_bus_name = aws_cloudwatch_event_bus.test.name
 }
 `, name)

--- a/website/docs/r/cloudwatch_event_bus_policy.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus_policy.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "EventBridge (CloudWatch Events)"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_event_bus_policy"
+description: |-
+  Provides a resource to create an EventBridge policy to support cross-account events.
+---
+
+# Resource: aws_cloudwatch_event_permission
+
+Provides a resource to create an EventBridge resource policy to support cross-account events.
+
+~> **Note:** EventBridge was formerly known as CloudWatch Events. The functionality is identical.
+
+~> **Note:** The cloudwatch eventbus policy resource is incompatible with the cloudwatch event permissions resource and will overwrite them.
+
+## Example Usage
+
+### Account Access
+
+```hcl
+resource "aws_cloudwatch_event_bus_policy" "test" {
+  policy         = data.aws_iam_policy_document.access.json
+  event_bus_name = aws_cloudwatch_event_bus.test.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy` - (Required) The text of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
+* `event_bus_name` - (Optional) The event bus to set the permissions on. If you omit this, the permissions are set on the `default` event bus.
+
+## Import
+
+EventBridge permissions can be imported using the `event_bus_name`, e.g.
+
+```shell
+$ terraform import aws_cloudwatch_event_bus_policy.DevAccountAccess example-event-bus
+```


### PR DESCRIPTION

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #16838

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```
Adds support for resource policies on cloudwatch eventbridge

```

Output from acceptance testing:

```

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=CloudwatchEventBusPolicy -timeout 120m
=== RUN   TestAccAWSCloudwatchEventBusPolicy_basic
=== PAUSE TestAccAWSCloudwatchEventBusPolicy_basic
=== CONT  TestAccAWSCloudwatchEventBusPolicy_basic
--- PASS: TestAccAWSCloudwatchEventBusPolicy_basic (19.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.990s

```
