### PR TITLE
resource/lb_target_group: Support deregistration connection termination

### DIFF
--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -58,6 +58,7 @@ resource "aws_lb_target_group" "lambda-example" {
 
 The following arguments are supported:
 
+* `deregistration_connection_termination` - (Optional) Boolean to enable / disable support for post-deregistration connection termination on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#deregistration-delay) for more information.
 * `deregistration_delay` - (Optional) Amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `health_check` - (Optional, Maximum of 1) Health Check configuration block. Detailed below.
 * `lambda_multi_value_headers_enabled` - (Optional) Whether the request and response headers exchanged between the load balancer and the Lambda function include arrays of values or strings. Only applies when `target_type` is `lambda`.


### PR DESCRIPTION
Add support for the "deregistration_delay.connection_termination.enabled" target group
attribute. Target groups attached to NLBs can use this attribute to specify whether or not connections to the load balancer will be terminated after the deregistration timeout.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
ENHANCEMENTS:
* resource/aws_lb_target_group: Support NLB `deregistration_delay.connection_termination.enabled` target group attribute
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLBTargetGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBTargetGroup_ -timeout 120m
=== RUN   TestAccAWSLBTargetGroup_basic
=== PAUSE TestAccAWSLBTargetGroup_basic
=== RUN   TestAccAWSLBTargetGroup_basicUdp
=== PAUSE TestAccAWSLBTargetGroup_basicUdp
=== RUN   TestAccAWSLBTargetGroup_withoutHealthcheck
=== PAUSE TestAccAWSLBTargetGroup_withoutHealthcheck
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== RUN   TestAccAWSLBTargetGroup_Protocol_Geneve
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Geneve
=== RUN   TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
=== RUN   TestAccAWSLBTargetGroup_Protocol_Tls
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Tls
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroupWithConnectionTermination
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroupWithConnectionTermination
=== RUN   TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== RUN   TestAccAWSLBTargetGroup_BackwardsCompatibility
=== PAUSE TestAccAWSLBTargetGroup_BackwardsCompatibility
=== RUN   TestAccAWSLBTargetGroup_namePrefix
=== PAUSE TestAccAWSLBTargetGroup_namePrefix
=== RUN   TestAccAWSLBTargetGroup_generatedName
=== PAUSE TestAccAWSLBTargetGroup_generatedName
=== RUN   TestAccAWSLBTargetGroup_changeNameForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeNameForceNew
=== RUN   TestAccAWSLBTargetGroup_changeProtocolForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeProtocolForceNew
=== RUN   TestAccAWSLBTargetGroup_changePortForceNew
=== PAUSE TestAccAWSLBTargetGroup_changePortForceNew
=== RUN   TestAccAWSLBTargetGroup_changeVpcForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeVpcForceNew
=== RUN   TestAccAWSLBTargetGroup_tags
=== PAUSE TestAccAWSLBTargetGroup_tags
=== RUN   TestAccAWSLBTargetGroup_enableHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_enableHealthCheck
=== RUN   TestAccAWSLBTargetGroup_updateHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_updateHealthCheck
=== RUN   TestAccAWSLBTargetGroup_updateSticknessEnabled
=== PAUSE TestAccAWSLBTargetGroup_updateSticknessEnabled
=== RUN   TestAccAWSLBTargetGroup_defaults_application
=== PAUSE TestAccAWSLBTargetGroup_defaults_application
=== RUN   TestAccAWSLBTargetGroup_defaults_network
=== PAUSE TestAccAWSLBTargetGroup_defaults_network
=== RUN   TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessDefaultALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessDefaultALB
=== RUN   TestAccAWSLBTargetGroup_stickinessValidNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessValidNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessValidALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessValidALB
=== RUN   TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessInvalidALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessInvalidALB
=== CONT  TestAccAWSLBTargetGroup_basic
=== CONT  TestAccAWSLBTargetGroup_changePortForceNew
=== CONT  TestAccAWSLBTargetGroup_changeNameForceNew
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroupWithConnectionTermination
=== CONT  TestAccAWSLBTargetGroup_namePrefix
=== CONT  TestAccAWSLBTargetGroup_BackwardsCompatibility
=== CONT  TestAccAWSLBTargetGroup_generatedName
=== CONT  TestAccAWSLBTargetGroup_changeProtocolForceNew
=== CONT  TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== CONT  TestAccAWSLBTargetGroup_withoutHealthcheck
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== CONT  TestAccAWSLBTargetGroup_Protocol_Geneve
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== CONT  TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
=== CONT  TestAccAWSLBTargetGroup_updateHealthCheck
=== CONT  TestAccAWSLBTargetGroup_defaults_network
=== CONT  TestAccAWSLBTargetGroup_defaults_application
=== CONT  TestAccAWSLBTargetGroup_basicUdp
=== CONT  TestAccAWSLBTargetGroup_Protocol_Tls
=== CONT  TestAccAWSLBTargetGroup_stickinessDefaultNLB
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (80.25s)
=== CONT  TestAccAWSLBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSLBTargetGroup_generatedName (99.12s)
=== CONT  TestAccAWSLBTargetGroup_stickinessInvalidNLB
--- PASS: TestAccAWSLBTargetGroup_namePrefix (100.52s)
=== CONT  TestAccAWSLBTargetGroup_enableHealthCheck
--- PASS: TestAccAWSLBTargetGroup_basicUdp (100.65s)
=== CONT  TestAccAWSLBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSLBTargetGroup_Protocol_Geneve (102.82s)
=== CONT  TestAccAWSLBTargetGroup_stickinessValidNLB
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (103.75s)
=== CONT  TestAccAWSLBTargetGroup_stickinessValidALB
--- PASS: TestAccAWSLBTargetGroup_basic (111.28s)
=== CONT  TestAccAWSLBTargetGroup_stickinessInvalidALB
--- PASS: TestAccAWSLBTargetGroup_defaults_application (115.84s)
=== CONT  TestAccAWSLBTargetGroup_tags
--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (119.27s)
=== CONT  TestAccAWSLBTargetGroup_stickinessDefaultALB
--- PASS: TestAccAWSLBTargetGroup_defaults_network (122.26s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (171.38s)
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (174.47s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (176.77s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (179.59s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (180.22s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithConnectionTermination (181.05s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (181.85s)
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (183.36s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (90.09s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (78.73s)
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (114.10s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (233.00s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (122.16s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (140.76s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (145.14s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (261.07s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (199.67s)
--- PASS: TestAccAWSLBTargetGroup_tags (189.67s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (309.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	414.293s
...
```
