### PR TITLE
resource/networkfirewall_rule_group: remove ForceNew attribute from stateful_rule field and its children

### DIFF
--- a/aws/resource_aws_networkfirewall_rule_group.go
+++ b/aws/resource_aws_networkfirewall_rule_group.go
@@ -170,26 +170,22 @@ func resourceAwsNetworkFirewallRuleGroup() *schema.Resource {
 									"stateful_rule": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										ForceNew: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"action": {
 													Type:         schema.TypeString,
 													Required:     true,
-													ForceNew:     true,
 													ValidateFunc: validation.StringInSlice(networkfirewall.StatefulAction_Values(), false),
 												},
 												"header": {
 													Type:     schema.TypeList,
 													Required: true,
 													MaxItems: 1,
-													ForceNew: true,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"destination": {
 																Type:     schema.TypeString,
 																Required: true,
-																ForceNew: true,
 																ValidateFunc: validation.Any(
 																	validateIpv4CIDRNetworkAddress,
 																	validation.StringInSlice([]string{networkfirewall.StatefulRuleDirectionAny}, false),
@@ -198,24 +194,20 @@ func resourceAwsNetworkFirewallRuleGroup() *schema.Resource {
 															"destination_port": {
 																Type:     schema.TypeString,
 																Required: true,
-																ForceNew: true,
 															},
 															"direction": {
 																Type:         schema.TypeString,
 																Required:     true,
-																ForceNew:     true,
 																ValidateFunc: validation.StringInSlice(networkfirewall.StatefulRuleDirection_Values(), false),
 															},
 															"protocol": {
 																Type:         schema.TypeString,
 																Required:     true,
-																ForceNew:     true,
 																ValidateFunc: validation.StringInSlice(networkfirewall.StatefulRuleProtocol_Values(), false),
 															},
 															"source": {
 																Type:     schema.TypeString,
 																Required: true,
-																ForceNew: true,
 																ValidateFunc: validation.Any(
 																	validateIpv4CIDRNetworkAddress,
 																	validation.StringInSlice([]string{networkfirewall.StatefulRuleDirectionAny}, false),
@@ -224,7 +216,6 @@ func resourceAwsNetworkFirewallRuleGroup() *schema.Resource {
 															"source_port": {
 																Type:     schema.TypeString,
 																Required: true,
-																ForceNew: true,
 															},
 														},
 													},
@@ -498,19 +489,20 @@ func resourceAwsNetworkFirewallRuleGroupUpdate(ctx context.Context, d *schema.Re
 	log.Printf("[DEBUG] Updating NetworkFirewall Rule Group %s", arn)
 
 	if d.HasChanges("description", "rule_group", "rules", "type") {
+		// Provide updated object with the currently configured fields
 		input := &networkfirewall.UpdateRuleGroupInput{
 			RuleGroupArn: aws.String(arn),
 			Type:         aws.String(d.Get("type").(string)),
 			UpdateToken:  aws.String(d.Get("update_token").(string)),
 		}
-		if d.HasChange("description") {
-			input.Description = aws.String(d.Get("description").(string))
+		if v, ok := d.GetOk("description"); ok {
+			input.Description = aws.String(v.(string))
 		}
-		if d.HasChange("rule_group") {
-			input.RuleGroup = expandNetworkFirewallRuleGroup(d.Get("rule_group").([]interface{}))
+		if v, ok := d.GetOk("rule_group"); ok {
+			input.RuleGroup = expandNetworkFirewallRuleGroup(v.([]interface{}))
 		}
-		if d.HasChange("rules") {
-			input.Rules = aws.String(d.Get("rules").(string))
+		if v, ok := d.GetOk("rules"); ok {
+			input.Rules = aws.String(v.(string))
 		}
 
 		_, err := conn.UpdateRuleGroupWithContext(ctx, input)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16868 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/networkfirewall_rule_group: remove ForceNew attribute from stateful_rule configuration block
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statelessRuleWithCustomAction (137.23s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_statelessRule (138.48s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_statefulRule (138.70s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_disappears (143.01s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_rules (143.92s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_rulesSourceList (148.03s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateRulesSourceList (176.74s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statefulRule_header (177.97s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateStatefulRule (178.11s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateStatelessRule (178.50s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_rulesSourceAndRuleVariables (186.76s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statefulRule_action (190.40s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_tags (198.29s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateMultipleStatefulRules (198.92s)
```
