### PR TITLE
New Resource: aws_ecrpublic_registry_catalog_data

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -620,6 +620,7 @@ func Provider() *schema.Provider {
 			"aws_ec2_transit_gateway_route_table_propagation":         resourceAwsEc2TransitGatewayRouteTablePropagation(),
 			"aws_ec2_transit_gateway_vpc_attachment":                  resourceAwsEc2TransitGatewayVpcAttachment(),
 			"aws_ec2_transit_gateway_vpc_attachment_accepter":         resourceAwsEc2TransitGatewayVpcAttachmentAccepter(),
+			"aws_ecrpublic_registry_catalog_data":                     resourceAwsEcrPublicRegistryCatalogData(),
 			"aws_ecr_lifecycle_policy":                                resourceAwsEcrLifecyclePolicy(),
 			"aws_ecr_repository":                                      resourceAwsEcrRepository(),
 			"aws_ecr_repository_policy":                               resourceAwsEcrRepositoryPolicy(),

--- a/aws/resource_aws_ecrpublic_registry_catalog_data.go
+++ b/aws/resource_aws_ecrpublic_registry_catalog_data.go
@@ -40,7 +40,7 @@ func resourceAwsEcrPublicRegistryCatalogDataCreate(d *schema.ResourceData, meta 
 		return fmt.Errorf("error changing ECR Public Registry catalog data: %s", err)
 	}
 
-	return resourceAwsEcrRepositoryRead(d, meta)
+	return resourceAwsEcrPublicRegistryCatalogDataRead(d, meta)
 }
 
 func resourceAwsEcrPublicRegistryCatalogDataRead(d *schema.ResourceData, meta interface{}) error {
@@ -67,7 +67,7 @@ func resourceAwsEcrPublicRegistryCatalogDataUpdate(d *schema.ResourceData, meta 
 
 	if d.HasChange("display_name") {
 		input := &ecrpublic.PutRegistryCatalogDataInput{
-			DisplayName: aws.String(d.Get("setting").(string)),
+			DisplayName: aws.String(d.Get("display_name").(string)),
 		}
 
 		_, err := conn.PutRegistryCatalogData(input)
@@ -77,7 +77,7 @@ func resourceAwsEcrPublicRegistryCatalogDataUpdate(d *schema.ResourceData, meta 
 		}
 	}
 
-	return resourceAwsEcrRepositoryRead(d, meta)
+	return resourceAwsEcrPublicRegistryCatalogDataRead(d, meta)
 }
 
 func resourceAwsEcrPublicRegistryCatalogDataDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_ecrpublic_registry_catalog_data.go
+++ b/aws/resource_aws_ecrpublic_registry_catalog_data.go
@@ -1,0 +1,63 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecrpublic"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsEcrPublicRegistryCatalogData() *schema.Resource {
+	return &schema.Resource{
+		Read:   resourceAwsEcrPublicRegistryCatalogDataRead,
+		Update: resourceAwsEcrPublicRegistryCatalogDataUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceAwsEcrRegistryCatalogDataRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrpublicconn
+
+	var out *ecrpublic.GetRegistryCatalogDataOutput
+	input := &ecrpublic.GetRegistryCatalogDataInput{}
+
+	out, err := conn.GetRegistryCatalogData(input)
+
+	if err != nil {
+		return fmt.Errorf("error reading ECR Public Registry catalog data", err)
+	}
+
+	registryCatalogData := out.RegistryCatalogData
+
+	d.Set("display_name", registryCatalogData.DisplayName)
+
+	return nil
+}
+
+func resourceAwsEcrRegistryCatalogDataUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrpublicconn
+
+	if d.HasChange("display_name") {
+		input := &ecrpublic.PutRegistryCatalogDataInput{
+			DisplayName: aws.String(d.Get("setting").(string)),
+		}
+
+		_, err := conn.PutRegistryCatalogData(input)
+
+		if err != nil {
+			return fmt.Errorf("error changing ECR Public Registry catalog data", err)
+		}
+	}
+
+	return resourceAwsEcrRepositoryRead(d, meta)
+}

--- a/aws/resource_aws_ecrpublic_registry_catalog_data.go
+++ b/aws/resource_aws_ecrpublic_registry_catalog_data.go
@@ -10,8 +10,10 @@ import (
 
 func resourceAwsEcrPublicRegistryCatalogData() *schema.Resource {
 	return &schema.Resource{
+		Create: resourceAwsEcrPublicRegistryCatalogDataCreate,
 		Read:   resourceAwsEcrPublicRegistryCatalogDataRead,
 		Update: resourceAwsEcrPublicRegistryCatalogDataUpdate,
+		Delete: resourceAwsEcrPublicRegistryCatalogDataDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -23,6 +25,22 @@ func resourceAwsEcrPublicRegistryCatalogData() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceAwsEcrPublicRegistryCatalogDataCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrpublicconn
+
+	input := &ecrpublic.PutRegistryCatalogDataInput{
+		DisplayName: aws.String(d.Get("display_name").(string)),
+	}
+
+	_, err := conn.PutRegistryCatalogData(input)
+
+	if err != nil {
+		return fmt.Errorf("error changing ECR Public Registry catalog data: %s", err)
+	}
+
+	return resourceAwsEcrRepositoryRead(d, meta)
 }
 
 func resourceAwsEcrPublicRegistryCatalogDataRead(d *schema.ResourceData, meta interface{}) error {
@@ -60,4 +78,8 @@ func resourceAwsEcrPublicRegistryCatalogDataUpdate(d *schema.ResourceData, meta 
 	}
 
 	return resourceAwsEcrRepositoryRead(d, meta)
+}
+
+func resourceAwsEcrPublicRegistryCatalogDataDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
 }

--- a/aws/resource_aws_ecrpublic_registry_catalog_data.go
+++ b/aws/resource_aws_ecrpublic_registry_catalog_data.go
@@ -25,7 +25,7 @@ func resourceAwsEcrPublicRegistryCatalogData() *schema.Resource {
 	}
 }
 
-func resourceAwsEcrRegistryCatalogDataRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEcrPublicRegistryCatalogDataRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecrpublicconn
 
 	var out *ecrpublic.GetRegistryCatalogDataOutput
@@ -34,7 +34,7 @@ func resourceAwsEcrRegistryCatalogDataRead(d *schema.ResourceData, meta interfac
 	out, err := conn.GetRegistryCatalogData(input)
 
 	if err != nil {
-		return fmt.Errorf("error reading ECR Public Registry catalog data", err)
+		return fmt.Errorf("error reading ECR Public Registry catalog data: %s", err)
 	}
 
 	registryCatalogData := out.RegistryCatalogData
@@ -44,7 +44,7 @@ func resourceAwsEcrRegistryCatalogDataRead(d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func resourceAwsEcrRegistryCatalogDataUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEcrPublicRegistryCatalogDataUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecrpublicconn
 
 	if d.HasChange("display_name") {
@@ -55,7 +55,7 @@ func resourceAwsEcrRegistryCatalogDataUpdate(d *schema.ResourceData, meta interf
 		_, err := conn.PutRegistryCatalogData(input)
 
 		if err != nil {
-			return fmt.Errorf("error changing ECR Public Registry catalog data", err)
+			return fmt.Errorf("error changing ECR Public Registry catalog data: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_ecrpublic_registry_catalog_data_test.go
+++ b/aws/resource_aws_ecrpublic_registry_catalog_data_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSEcrPublicRegistryCatalogData_update(t *testing.T) {
+func TestAccAWSEcrPublicRegistryCatalogData_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ecrpublic_registry_catalog_data.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEcrPublicRegistryCatalogDataConfig(rName),

--- a/aws/resource_aws_ecrpublic_registry_catalog_data_test.go
+++ b/aws/resource_aws_ecrpublic_registry_catalog_data_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSEcrPublicRegistryCatalogData_update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecrpublic_registry_catalog_data.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcrPublicRegistryCatalogDataConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "display_name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAWSEcrPublicRegistryCatalogDataConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecrpublic_registry_catalog_data" "test" {
+  display_name = %q
+}
+`, rName)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16538

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_ecrpublic_registry_catalog_data` 
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
