### PR TITLE
Remove preview note for S3 object ownership as it's now GA

### DIFF
--- a/website/docs/r/s3_bucket_ownership_controls.html.markdown
+++ b/website/docs/r/s3_bucket_ownership_controls.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Provides a resource to manage S3 Bucket Ownership Controls. For more information, see the [S3 Developer Guide](https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html).
 
-~> **NOTE:** This AWS functionality is in Preview and may change before General Availability release. Backwards compatibility is not guaranteed between Terraform AWS Provider releases.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

Remove note from s3_bucket_ownership_controls docs as the feature is GA as of November, see changes to their docs: https://github.com/awsdocs/amazon-s3-developer-guide/commit/8917363385b30433ae04579171c561fea9588878#diff-98faa8a34f83a2cc670f4463b159cdea2c9ced436cea1f652bd7afdcff7e14c5R4

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update s3_bucket_ownership_controls docs to reflect GA of AWS feature.
```
