### PR TITLE
resource/aws_instance: add support for Capacity Reservations

### DIFF
--- a/.changelog/16908.txt
+++ b/.changelog/16908.txt
@@ -1,0 +1,3 @@
+```release-notes:enhancement
+resource/aws_instance: Add `capacity_reservation_specification` argument
+```

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -562,23 +562,21 @@ func resourceAwsInstance() *schema.Resource {
 
 			"capacity_reservation_specification": {
 				Type:     schema.TypeList,
-				Optional: true,
 				MaxItems: 1,
+				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"capacity_reservation_preference": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								ec2.CapacityReservationPreferenceOpen,
-								ec2.CapacityReservationPreferenceNone,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(ec2.CapacityReservationPreference_Values(), false),
+							ExactlyOneOf: []string{"capacity_reservation_specification.0.capacity_reservation_preference", "capacity_reservation_specification.0.capacity_reservation_target"},
 						},
 						"capacity_reservation_target": {
 							Type:     schema.TypeList,
-							Optional: true,
 							MaxItems: 1,
+							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"capacity_reservation_id": {
@@ -587,6 +585,7 @@ func resourceAwsInstance() *schema.Resource {
 									},
 								},
 							},
+							ExactlyOneOf: []string{"capacity_reservation_specification.0.capacity_reservation_preference", "capacity_reservation_specification.0.capacity_reservation_target"},
 						},
 					},
 				},

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -569,6 +569,10 @@ func resourceAwsInstance() *schema.Resource {
 						"capacity_reservation_preference": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ec2.CapacityReservationPreferenceOpen,
+								ec2.CapacityReservationPreferenceNone,
+							}, false),
 						},
 						"capacity_reservation_target": {
 							Type:     schema.TypeList,

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1585,6 +1585,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("capacity_reservation_specification"); ok {
 			capacityReservationSpecification := expandCapacityReservationSpecification(v.([]interface{}))
 			if *capacityReservationSpecification != (ec2.CapacityReservationSpecification{}) && capacityReservationSpecification != nil {
+				log.Printf("[DEBUG] Modifying capacity reservation for instance %s", d.Id())
 				_, err := conn.ModifyInstanceCapacityReservationAttributes(&ec2.ModifyInstanceCapacityReservationAttributesInput{
 					CapacityReservationSpecification: capacityReservationSpecification,
 					InstanceId:                       aws.String(d.Id()),

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -585,11 +585,6 @@ func resourceAwsInstance() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
-									"capacity_reservation_resource_group_arn": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validateArn,
-									},
 								},
 							},
 						},
@@ -2800,10 +2795,6 @@ func expandCapacityReservationTarget(crt []interface{}) *ec2.CapacityReservation
 		capacityReservationTarget.CapacityReservationId = aws.String(v.(string))
 	}
 
-	if v, ok := m["capacity_reservation_resource_group_arn"]; ok && v != "" {
-		capacityReservationTarget.CapacityReservationResourceGroupArn = aws.String(v.(string))
-	}
-
 	return capacityReservationTarget
 }
 
@@ -2852,8 +2843,7 @@ func flattenCapacityReservationTarget(crt *ec2.CapacityReservationTargetResponse
 	}
 
 	m := map[string]interface{}{
-		"capacity_reservation_id":                 aws.StringValue(crt.CapacityReservationId),
-		"capacity_reservation_resource_group_arn": aws.StringValue(crt.CapacityReservationResourceGroupArn),
+		"capacity_reservation_id": aws.StringValue(crt.CapacityReservationId),
 	}
 
 	return []interface{}{m}

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1615,7 +1615,7 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 				Config: testAccInstanceConfigUpdateInstanceType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
-					testAccCheckInstanceNotRecreated(t, &before, &after),
+					testAccCheckInstanceNotRecreated(&before, &after),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.large"),
 				),
 			},
@@ -1681,7 +1681,7 @@ func TestAccAWSInstance_EbsRootDevice_ModifySize(t *testing.T) {
 				Config: testAccAwsEc2InstanceRootBlockDevice(updatedSize, deleteOnTermination, volumeType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
-					testAccCheckInstanceNotRecreated(t, &original, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", updatedSize),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.delete_on_termination", deleteOnTermination),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", volumeType),
@@ -1721,7 +1721,7 @@ func TestAccAWSInstance_EbsRootDevice_ModifyType(t *testing.T) {
 				Config: testAccAwsEc2InstanceRootBlockDevice(volumeSize, deleteOnTermination, updatedType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
-					testAccCheckInstanceNotRecreated(t, &original, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.delete_on_termination", deleteOnTermination),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", updatedType),
@@ -1763,7 +1763,7 @@ func TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1(t *testing.T) {
 				Config: testAccAwsEc2InstanceRootBlockDeviceWithIOPS(volumeSize, deleteOnTermination, volumeType, updatedIOPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
-					testAccCheckInstanceNotRecreated(t, &original, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.delete_on_termination", deleteOnTermination),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", volumeType),
@@ -1806,7 +1806,7 @@ func TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2(t *testing.T) {
 				Config: testAccAwsEc2InstanceRootBlockDeviceWithIOPS(volumeSize, deleteOnTermination, volumeType, updatedIOPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
-					testAccCheckInstanceNotRecreated(t, &original, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.delete_on_termination", deleteOnTermination),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", volumeType),
@@ -1849,7 +1849,7 @@ func TestAccAWSInstance_EbsRootDevice_ModifyThroughput_Gp3(t *testing.T) {
 				Config: testAccAwsEc2InstanceRootBlockDeviceWithThroughput(volumeSize, deleteOnTermination, volumeType, updatedThroughput),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
-					testAccCheckInstanceNotRecreated(t, &original, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.delete_on_termination", deleteOnTermination),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", volumeType),
@@ -1890,7 +1890,7 @@ func TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination(t *testing.T) {
 				Config: testAccAwsEc2InstanceRootBlockDevice(volumeSize, updatedDeleteOnTermination, volumeType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
-					testAccCheckInstanceNotRecreated(t, &original, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", volumeSize),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.delete_on_termination", updatedDeleteOnTermination),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", volumeType),
@@ -1935,7 +1935,7 @@ func TestAccAWSInstance_EbsRootDevice_ModifyAll(t *testing.T) {
 				Config: testAccAwsEc2InstanceRootBlockDeviceWithIOPS(updatedSize, updatedDeleteOnTermination, updatedType, updatedIOPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
-					testAccCheckInstanceNotRecreated(t, &original, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", updatedSize),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.delete_on_termination", updatedDeleteOnTermination),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", updatedType),
@@ -1982,7 +1982,7 @@ func TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize(t *testing
 				Config: testAccAwsEc2InstanceConfigBlockDevicesWithDeleteOnTerminate(updatedRootVolumeSize, deleteOnTermination),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
-					testAccCheckInstanceNotRecreated(t, &before, &after),
+					testAccCheckInstanceNotRecreated(&before, &after),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", updatedRootVolumeSize),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
 						"volume_size": "9",
@@ -2036,7 +2036,7 @@ func TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermina
 				Config: testAccAwsEc2InstanceConfigBlockDevicesWithDeleteOnTerminate(rootVolumeSize, updatedDeleteOnTermination),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
-					testAccCheckInstanceNotRecreated(t, &before, &after),
+					testAccCheckInstanceNotRecreated(&before, &after),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", rootVolumeSize),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.delete_on_termination", updatedDeleteOnTermination),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
@@ -2643,7 +2643,7 @@ func TestAccAWSInstance_getPasswordData_falseToTrue(t *testing.T) {
 				Config: testAccInstanceConfig_getPasswordData(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
-					testAccCheckInstanceNotRecreated(t, &before, &after),
+					testAccCheckInstanceNotRecreated(&before, &after),
 					resource.TestCheckResourceAttr(resourceName, "get_password_data", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "password_data"),
 				),
@@ -2681,7 +2681,7 @@ func TestAccAWSInstance_getPasswordData_trueToFalse(t *testing.T) {
 				Config: testAccInstanceConfig_getPasswordData(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
-					testAccCheckInstanceNotRecreated(t, &before, &after),
+					testAccCheckInstanceNotRecreated(&before, &after),
 					resource.TestCheckResourceAttr(resourceName, "get_password_data", "false"),
 					resource.TestCheckResourceAttr(resourceName, "password_data", ""),
 				),
@@ -3395,6 +3395,7 @@ func TestAccAWSInstance_enclaveOptions(t *testing.T) {
 func TestAccAWSInstance_CapacityReservation_unspecifiedDefaultsToOpen(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -3403,7 +3404,7 @@ func TestAccAWSInstance_CapacityReservation_unspecifiedDefaultsToOpen(t *testing
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_unspecified(),
+				Config: testAccInstanceConfigCapacityReservationSpecification_unspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -3417,7 +3418,7 @@ func TestAccAWSInstance_CapacityReservation_unspecifiedDefaultsToOpen(t *testing
 			},
 			// Adding 'open' preference should show no difference
 			{
-				Config:             testAccInstanceConfigCapacityReservationSpecification_preference("open"),
+				Config:             testAccInstanceConfigCapacityReservationSpecification_preference(rName, "open"),
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
 			},
@@ -3428,6 +3429,7 @@ func TestAccAWSInstance_CapacityReservation_unspecifiedDefaultsToOpen(t *testing
 func TestAccAWSInstance_CapacityReservation_Preference_open(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -3436,7 +3438,7 @@ func TestAccAWSInstance_CapacityReservation_Preference_open(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference("open"),
+				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "open"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -3455,6 +3457,7 @@ func TestAccAWSInstance_CapacityReservation_Preference_open(t *testing.T) {
 func TestAccAWSInstance_CapacityReservation_Preference_none(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -3463,7 +3466,7 @@ func TestAccAWSInstance_CapacityReservation_Preference_none(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference("none"),
+				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "none"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
@@ -3482,6 +3485,7 @@ func TestAccAWSInstance_CapacityReservation_Preference_none(t *testing.T) {
 func TestAccAWSInstance_CapacityReservation_TargetId(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -3490,7 +3494,7 @@ func TestAccAWSInstance_CapacityReservation_TargetId(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_targetId(),
+				Config: testAccInstanceConfigCapacityReservationSpecification_targetId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.0.capacity_reservation_target.#", "1"),
@@ -3510,6 +3514,7 @@ func TestAccAWSInstance_CapacityReservation_modifyPreference(t *testing.T) {
 	var original ec2.Instance
 	var updated ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -3518,23 +3523,23 @@ func TestAccAWSInstance_CapacityReservation_modifyPreference(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference("open"),
+				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "open"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.0.capacity_reservation_preference", "open"),
 				),
 			},
-			{Config: testAccInstanceConfigCapacityReservationSpecification_preference("open"),
+			{Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "open"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStopInstance(&original), // Stop instance to modify capacity reservation
 				),
 			},
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference("none"),
+				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "none"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
-					testAccCheckInstanceNotRecreated(t, &original, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.0.capacity_reservation_preference", "none"),
 				),
@@ -3547,6 +3552,7 @@ func TestAccAWSInstance_CapacityReservation_modifyTarget(t *testing.T) {
 	var original ec2.Instance
 	var updated ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -3555,23 +3561,23 @@ func TestAccAWSInstance_CapacityReservation_modifyTarget(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_preference("none"),
+				Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "none"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.0.capacity_reservation_preference", "none"),
 				),
 			},
-			{Config: testAccInstanceConfigCapacityReservationSpecification_preference("none"),
+			{Config: testAccInstanceConfigCapacityReservationSpecification_preference(rName, "none"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStopInstance(&original), // Stop instance to modify capacity reservation
 				),
 			},
 			{
-				Config: testAccInstanceConfigCapacityReservationSpecification_targetId(),
+				Config: testAccInstanceConfigCapacityReservationSpecification_targetId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &updated),
-					testAccCheckInstanceNotRecreated(t, &original, &updated),
+					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "capacity_reservation_specification.0.capacity_reservation_target.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "capacity_reservation_specification.0.capacity_reservation_target.0.capacity_reservation_id"),
 				),
@@ -3580,20 +3586,20 @@ func TestAccAWSInstance_CapacityReservation_modifyTarget(t *testing.T) {
 	})
 }
 
-func testAccCheckInstanceNotRecreated(t *testing.T,
-	before, after *ec2.Instance) resource.TestCheckFunc {
+func testAccCheckInstanceNotRecreated(before, after *ec2.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *before.InstanceId != *after.InstanceId {
-			t.Fatalf("AWS Instance IDs have changed. Before %s. After %s", *before.InstanceId, *after.InstanceId)
+		if before, after := aws.StringValue(before.InstanceId), aws.StringValue(after.InstanceId); before != after {
+			return fmt.Errorf("EC2 Instance (%s/%s) recreated", before, after)
 		}
+
 		return nil
 	}
 }
 
 func testAccCheckInstanceRecreated(before, after *ec2.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.StringValue(before.InstanceId) == aws.StringValue(after.InstanceId) {
-			return fmt.Errorf("EC2 Instance (%s) not recreated", aws.StringValue(before.InstanceId))
+		if before, after := aws.StringValue(before.InstanceId), aws.StringValue(after.InstanceId); before == after {
+			return fmt.Errorf("EC2 Instance (%s) not recreated", before)
 		}
 
 		return nil
@@ -6174,19 +6180,23 @@ data "aws_ec2_instance_type_offering" "available" {
 `, availabilityZoneName, strings.Join(preferredInstanceTypes, "\", \""))
 }
 
-func testAccInstanceConfigCapacityReservationSpecification_unspecified() string {
+func testAccInstanceConfigCapacityReservationSpecification_unspecified(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t2.micro"),
-		`
+		fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+
+  tags = {
+    Name = %[1]q
+  }
 }
-`)
+`, rName))
 }
 
-func testAccInstanceConfigCapacityReservationSpecification_preference(crPreference string) string {
+func testAccInstanceConfigCapacityReservationSpecification_preference(rName, crPreference string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t2.micro"),
@@ -6196,13 +6206,17 @@ resource "aws_instance" "test" {
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
 
   capacity_reservation_specification {
-    capacity_reservation_preference = "%[1]s"
+    capacity_reservation_preference = %[2]q
+  }
+
+  tags = {
+    Name = %[1]q
   }
 }
-`, crPreference))
+`, rName, crPreference))
 }
 
-func testAccInstanceConfigCapacityReservationSpecification_targetId() string {
+func testAccInstanceConfigCapacityReservationSpecification_targetId(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t2.micro"),
@@ -6215,6 +6229,10 @@ resource "aws_instance" "test" {
     capacity_reservation_target {
       capacity_reservation_id = aws_ec2_capacity_reservation.test.id
     }
+  }
+
+  tags = {
+    Name = %[1]q
   }
 }
 
@@ -6229,9 +6247,13 @@ data "aws_availability_zones" "available" {
 
 resource "aws_ec2_capacity_reservation" "test" {
   instance_type     = data.aws_ec2_instance_type_offering.available.instance_type
-  instance_platform = "%[1]s"
+  instance_platform = %[2]q
   availability_zone = data.aws_availability_zones.available.names[0]
   instance_count    = 10
+
+  tags = {
+    Name = %[1]q
+  }
 }
-`, ec2.CapacityReservationInstancePlatformLinuxUnix))
+`, rName, ec2.CapacityReservationInstancePlatformLinuxUnix))
 }

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -3398,6 +3398,7 @@ func TestAccAWSInstance_CapacityReservation_unspecifiedDefaultsToOpen(t *testing
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -3430,6 +3431,7 @@ func TestAccAWSInstance_CapacityReservation_Preference_open(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -3456,6 +3458,7 @@ func TestAccAWSInstance_CapacityReservation_Preference_none(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -3482,6 +3485,7 @@ func TestAccAWSInstance_CapacityReservation_TargetId(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -3509,6 +3513,7 @@ func TestAccAWSInstance_CapacityReservation_modifyPreference(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -3545,6 +3550,7 @@ func TestAccAWSInstance_CapacityReservation_modifyTarget(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -93,6 +93,7 @@ The following arguments are supported:
 * `ami` - (Required) AMI to use for the instance.
 * `associate_public_ip_address` - (Optional) Whether to associate a public IP address with an instance in a VPC.
 * `availability_zone` - (Optional) AZ to start the instance in.
+* `capacity_reservation_specification` - (Optional) Describes an instance's Capacity Reservation targeting option. See [Capacity Reservation Specification](#capacity-reservation-specification) below for more details.
 
 -> **NOTE:** Changing `cpu_core_count` and/or `cpu_threads_per_core` will cause the resource to be destroyed and re-created.
 
@@ -143,6 +144,29 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 * `create` - (Defaults to 10 mins) Used when launching the instance (until it reaches the initial `running` state)
 * `update` - (Defaults to 10 mins) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type
 * `delete` - (Defaults to 20 mins) Used when terminating the instance
+
+### Capacity Reservation Specification
+
+~> **NOTE:** You can specify only one argument at a time. If you specify both `capacity_reservation_preference` and `capacity_reservation_target`, the request fails. Modifying `capacity_reservation_preference` or `capacity_reservation_target` in this block requires the instance to be in `stopped` state.
+
+Capacity reservation specification can be applied/modified to the EC2 Instance at creation time or when the instance is `stopped`.
+
+The `capacity_reservation_specification` block supports the following:
+
+* `capacity_reservation_preference` - (Optional) Indicates the instance's Capacity Reservation preferences. Can be `"open"` or `"none"`. (Default: `"open"`).
+* `capacity_reservation_target` - (Optional) Information about the target Capacity Reservation. See [Capacity Reservation Target](#capacity-reservation-target) below for more details.
+
+For more information, see the documentation on [Capacity Reservations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-reservations-using.html).
+
+### Capacity Reservation Target
+
+~> **NOTE:** Modifying `capacity_reservation_id` in this block requires the instance to be in `stopped` state.
+
+Describes a target Capacity Reservation.
+
+This `capacity_reservation_target` block supports the following:
+
+* `capacity_reservation_id` - (Optional) The ID of the Capacity Reservation in which to run the instance.
 
 ### Credit Specification
 
@@ -231,6 +255,7 @@ Each `network_interface` block supports the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the instance.
+* `capacity_reservation_specification` - Capacity reservation specification of the instance.
 * `instance_state` - The state of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped`. See [Instance Lifecycle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html) for more information.
 * `outpost_arn` - The ARN of the Outpost the instance is assigned to.
 * `password_data` - Base-64 encoded encrypted password data for the instance. Useful for getting the administrator password for instances running Microsoft Windows. This attribute is only exported if `get_password_data` is true. Note that this encrypted value will be stored in the state file, as with all exported attributes. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
### Description
This enhancement will add support for launching EC2 instances with Capacity Reservations. When you launch an instance, you can specify whether to launch the instance into any open Capacity Reservation, into a target Capacity Reservation, or avoid running in a Capacity Reservation. You can also modify the Capacity Reservation settings for a stopped instance at any time.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8189

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENT:

- resource/aws_instance: add support for `capacity_reservation_specification`, `capacity_reservation_preference`, `capacity_reservation_target` and `capacity_reservation_id` arguments

```

### Affected Resource(s)
- resource: aws_instance

### Terraform Configuration
```HCL
resource "aws_instance" "foo" {
  ami           = "ami-1234567890"
  instance_type = "t3.micro"

  capacity_reservation_specification {
    capacity_reservation_preference = "open"
    capacity_reservation_target {
      capacity_reservation_id = "cr-123456789"
    }
  }
}

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSInstance_CapacityReservation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSInstance_CapacityReservation -timeout 120m
=== RUN   TestAccAWSInstance_CapacityReservation_unspecifiedDefaultsToOpen
=== PAUSE TestAccAWSInstance_CapacityReservation_unspecifiedDefaultsToOpen
=== RUN   TestAccAWSInstance_CapacityReservation_Preference_open
=== PAUSE TestAccAWSInstance_CapacityReservation_Preference_open
=== RUN   TestAccAWSInstance_CapacityReservation_Preference_none
=== PAUSE TestAccAWSInstance_CapacityReservation_Preference_none
=== RUN   TestAccAWSInstance_CapacityReservation_TargetId
=== PAUSE TestAccAWSInstance_CapacityReservation_TargetId
=== RUN   TestAccAWSInstance_CapacityReservation_modifyPreference
=== PAUSE TestAccAWSInstance_CapacityReservation_modifyPreference
=== RUN   TestAccAWSInstance_CapacityReservation_modifyTarget
=== PAUSE TestAccAWSInstance_CapacityReservation_modifyTarget
=== CONT  TestAccAWSInstance_CapacityReservation_unspecifiedDefaultsToOpen
=== CONT  TestAccAWSInstance_CapacityReservation_modifyPreference
=== CONT  TestAccAWSInstance_CapacityReservation_modifyTarget
=== CONT  TestAccAWSInstance_CapacityReservation_TargetId
=== CONT  TestAccAWSInstance_CapacityReservation_Preference_none
=== CONT  TestAccAWSInstance_CapacityReservation_Preference_open
--- PASS: TestAccAWSInstance_CapacityReservation_Preference_none (132.54s)
--- PASS: TestAccAWSInstance_CapacityReservation_TargetId (134.15s)
--- PASS: TestAccAWSInstance_CapacityReservation_Preference_open (143.59s)
--- PASS: TestAccAWSInstance_CapacityReservation_unspecifiedDefaultsToOpen (156.67s)
--- PASS: TestAccAWSInstance_CapacityReservation_modifyTarget (233.60s)
--- PASS: TestAccAWSInstance_CapacityReservation_modifyPreference (240.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       241.999s

```
