### PR TITLE
Add aws_codestarconnections_host resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -529,6 +529,7 @@ func Provider() *schema.Provider {
 			"aws_codepipeline":                                        resourceAwsCodePipeline(),
 			"aws_codepipeline_webhook":                                resourceAwsCodePipelineWebhook(),
 			"aws_codestarconnections_connection":                      resourceAwsCodeStarConnectionsConnection(),
+			"aws_codestarconnections_host":                            resourceAwsCodeStarConnectionsHost(),
 			"aws_codestarnotifications_notification_rule":             resourceAwsCodeStarNotificationsNotificationRule(),
 			"aws_cur_report_definition":                               resourceAwsCurReportDefinition(),
 			"aws_customer_gateway":                                    resourceAwsCustomerGateway(),

--- a/aws/resource_aws_codestarconnections_host.go
+++ b/aws/resource_aws_codestarconnections_host.go
@@ -1,0 +1,242 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codestarconnections"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsCodeStarConnectionsHost() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCodeStarConnectionsHostCreate,
+		Read:   resourceAwsCodeStarConnectionsHostRead,
+		Update: resourceAwsCodeStarConnectionsHostUpdate,
+		Delete: resourceAwsCodeStarConnectionsHostDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"provider_endpoint": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"provider_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					codestarconnections.ProviderTypeGitHubEnterpriseServer,
+				}, false),
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"security_group_ids": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"subnet_ids": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"tls_certificate": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsCodeStarConnectionsHostCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codestarconnectionsconn
+
+	params := &codestarconnections.CreateHostInput{
+		Name:             aws.String(d.Get("name").(string)),
+		ProviderEndpoint: aws.String(d.Get("provider_endpoint").(string)),
+		ProviderType:     aws.String(d.Get("provider_type").(string)),
+		VpcConfiguration: expandCodeStarConnectionsHostVpcConfiguration(d.Get("vpc_configuration").([]interface{})),
+	}
+
+	resp, err := conn.CreateHost(params)
+	if err != nil {
+		return fmt.Errorf("error creating CodeStar host: %w", err)
+	}
+
+	d.SetId(aws.StringValue(resp.HostArn))
+	d.Set("arn", aws.StringValue(resp.HostArn))
+
+	if err := waitForCodeStarConnectionsHost(conn, d.Id()); err != nil {
+		return err
+	}
+
+	return resourceAwsCodeStarConnectionsHostRead(d, meta)
+}
+
+func resourceAwsCodeStarConnectionsHostRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codestarconnectionsconn
+
+	resp, err := conn.GetHost(&codestarconnections.GetHostInput{
+		HostArn: aws.String(d.Id()),
+	})
+	if tfawserr.ErrCodeEquals(err, codestarconnections.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] CodeStar host (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading CodeStar host: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("error reading CodeStar host (%s): empty response", d.Id())
+	}
+
+	d.Set("arn", d.Id())
+	d.Set("name", resp.Name)
+	d.Set("provider_endpoint", resp.ProviderEndpoint)
+	d.Set("provider_type", resp.ProviderType)
+	d.Set("status", resp.Status)
+	d.Set("vpc_configuration", flattenCodeStarConnectionsHostVpcConfiguration(resp.VpcConfiguration))
+
+	return nil
+}
+
+func resourceAwsCodeStarConnectionsHostUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codestarconnectionsconn
+
+	if d.HasChange("provider_endpoint") || d.HasChange("vpc_configuration") {
+		input := codestarconnections.UpdateHostInput{
+			HostArn:          aws.String(d.Get("name").(string)),
+			ProviderEndpoint: aws.String(d.Get("provider_endpoint").(string)),
+			VpcConfiguration: expandCodeStarConnectionsHostVpcConfiguration(d.Get("vpc_configuration").([]interface{})),
+		}
+
+		_, err := conn.UpdateHost(&input)
+		if err != nil {
+			return fmt.Errorf("error updating CodeStar host: %w", err)
+		}
+
+		if err := waitForCodeStarConnectionsHost(conn, d.Id()); err != nil {
+			return err
+		}
+	}
+
+	return resourceAwsCodeStarConnectionsHostRead(d, meta)
+}
+
+func resourceAwsCodeStarConnectionsHostDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codestarconnectionsconn
+
+	_, err := conn.DeleteHost(&codestarconnections.DeleteHostInput{
+		HostArn: aws.String(d.Id()),
+	})
+	if tfawserr.ErrCodeEquals(err, codestarconnections.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error deleting CodeStar host: %w", err)
+	}
+
+	return nil
+}
+
+func expandCodeStarConnectionsHostVpcConfiguration(l []interface{}) *codestarconnections.VpcConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	vc := &codestarconnections.VpcConfiguration{
+		SecurityGroupIds: expandStringSet(m["security_group_ids"].(*schema.Set)),
+		SubnetIds:        expandStringSet(m["subnet_ids"].(*schema.Set)),
+		VpcId:            aws.String(m["vpc_id"].(string)),
+	}
+
+	if v := m["tls_certificate"].(string); len(v) != 0 {
+		vc.TlsCertificate = aws.String(v)
+	}
+
+	return vc
+}
+
+func flattenCodeStarConnectionsHostVpcConfiguration(vpcConfig *codestarconnections.VpcConfiguration) []interface{} {
+	if vpcConfig == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"security_group_ids": flattenStringSet(vpcConfig.SecurityGroupIds),
+		"subnet_ids":         flattenStringSet(vpcConfig.SubnetIds),
+		"vpc_id":             aws.StringValue(vpcConfig.VpcId),
+	}
+
+	if vpcConfig.TlsCertificate != nil {
+		m["tls_certificate"] = aws.StringValue(vpcConfig.TlsCertificate)
+	}
+
+	return []interface{}{m}
+}
+
+func waitForCodeStarConnectionsHost(conn *codestarconnections.CodeStarConnections, arn string) error {
+	stateConf := resource.StateChangeConf{
+		Pending: []string{
+			"VPC_CONFIG_INITIALIZING",
+			"VPC_CONFIG_DELETING",
+		},
+		Target: []string{
+			"VPC_CONFIG_FAILED_INITIALIZATION",
+			"PENDING",
+			"AVAILABLE",
+		},
+		Timeout: 30 * time.Minute,
+		Delay:   1 * time.Minute,
+		Refresh: func() (interface{}, string, error) {
+			out, err := conn.GetHost(&codestarconnections.GetHostInput{
+				HostArn: aws.String(arn),
+			})
+
+			if err != nil {
+				return nil, "", err
+			}
+
+			return out, *out.Status, nil
+		},
+	}
+	_, err := stateConf.WaitForState()
+	return err
+}

--- a/aws/resource_aws_codestarconnections_host.go
+++ b/aws/resource_aws_codestarconnections_host.go
@@ -2,13 +2,13 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codestarconnections"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -138,7 +138,7 @@ func resourceAwsCodeStarConnectionsHostRead(d *schema.ResourceData, meta interfa
 func resourceAwsCodeStarConnectionsHostUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codestarconnectionsconn
 
-	if d.HasChange("provider_endpoint") || d.HasChange("vpc_configuration") {
+	if d.HasChanges("provider_endpoint", "vpc_configuration") {
 		input := codestarconnections.UpdateHostInput{
 			HostArn:          aws.String(d.Get("name").(string)),
 			ProviderEndpoint: aws.String(d.Get("provider_endpoint").(string)),

--- a/aws/resource_aws_codestarconnections_host_test.go
+++ b/aws/resource_aws_codestarconnections_host_test.go
@@ -1,0 +1,222 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codestarconnections"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSCodeStarConnectionsHost_basic(t *testing.T) {
+	var v codestarconnections.GetHostOutput
+	resourceName := "aws_codestarconnections_host.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(codestarconnections.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeStarConnectionsHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeStarConnectionsHostConfigBasic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCodeStarConnectionsHostExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "id", "codestar-connections", regexp.MustCompile("host/.+")),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codestar-connections", regexp.MustCompile("host/.+")),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "provider_endpoint", "https://test.com"),
+					resource.TestCheckResourceAttr(resourceName, "provider_type", codestarconnections.ProviderTypeGitHubEnterpriseServer),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeStarConnectionsHost_disappears(t *testing.T) {
+	var v codestarconnections.GetHostOutput
+	resourceName := "aws_codestarconnections_host.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(codestarconnections.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeStarConnectionsHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeStarConnectionsHostConfigBasic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCodeStarConnectionsHostExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCodeStarConnectionsHost(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeStarConnectionsHost_vpcConfig(t *testing.T) {
+	var v codestarconnections.GetHostOutput
+	resourceName := "aws_codestarconnections_host.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(codestarconnections.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeStarConnectionsHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeStarConnectionsHostConfigVpcConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCodeStarConnectionsHostExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "id", "codestar-connections", regexp.MustCompile("host/.+")),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codestar-connections", regexp.MustCompile("host/.+")),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "provider_endpoint", "https://test.com"),
+					resource.TestCheckResourceAttr(resourceName, "provider_type", codestarconnections.ProviderTypeGitHubEnterpriseServer),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.tls_certificate", "-----BEGIN CERTIFICATE-----\nMIID2jCCAsKgAwIBAgIJAJ58TJVjU7G1MA0GCSqGSIb3DQEBBQUAMFExCzAJBgNV\nBAYTAlVTMREwDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYD\nVQQKEwdDaGFydGVyMQwwCgYDVQQLEwNDU0UwHhcNMTcwMTMwMTkyMDA4WhcNMjYx\nMjA5MTkyMDA4WjBRMQswCQYDVQQGEwJVUzERMA8GA1UECBMIQ29sb3JhZG8xDzAN\nBgNVBAcTBkRlbnZlcjEQMA4GA1UEChMHQ2hhcnRlcjEMMAoGA1UECxMDQ1NFMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv6dq6VLIImlAaTrckb5w3X6J\nWP7EGz2ChGAXlkEYto6dPCba0v5+f+8UlMOpeB25XGoai7gdItqNWVFpYsgmndx3\nvTad3ukO1zeElKtw5oHPH2plOaiv/gVJaDa9NTeINj0EtGZs74fCOclAzGFX5vBc\nb08ESWBceRgGjGv3nlij4JzHfqTkCKQz6P6pBivQBfk62rcOkkH5rKoaGltRHROS\nMbkwOhu2hN0KmSYTXRvts0LXnZU4N0l2ms39gmr7UNNNlKYINL2JoTs9dNBc7APD\ndZvlEHd+/FjcLCI8hC3t4g4AbfW0okIBCNG0+oVjqGb2DeONSJKsThahXt89MQID\nAQABo4G0MIGxMB0GA1UdDgQWBBQKq8JxjY1GmeZXJjfOMfW0kBIzPDCBgQYDVR0j\nBHoweIAUCqvCcY2NRpnmVyY3zjH1tJASMzyhVaRTMFExCzAJBgNVBAYTAlVTMREw\nDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYDVQQKEwdDaGFy\ndGVyMQwwCgYDVQQLEwNDU0WCCQCefEyVY1OxtTAMBgNVHRMEBTADAQH/MA0GCSqG\nSIb3DQEBBQUAA4IBAQAWifoMk5kbv+yuWXvFwHiB4dWUUmMlUlPU/E300yVTRl58\np6DfOgJs7MMftd1KeWqTO+uW134QlTt7+jwI8Jq0uyKCu/O2kJhVtH/Ryog14tGl\n+wLcuIPLbwJI9CwZX4WMBrq4DnYss+6F47i8NCc+Z3MAiG4vtq9ytBmaod0dj2bI\ng4/Lac0e00dql9RnqENh1+dF0V+QgTJCoPkMqDNAlSB8vOodBW81UAb2z12t+IFi\n3X9J3WtCK2+T5brXL6itzewWJ2ALvX3QpmZx7fMHJ3tE+SjjyivE1BbOlzYHx83t\nTeYnm7pS9un7A/UzTDHbs7hPUezLek+H3xTPAnnq\n-----END CERTIFICATE-----\n"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_configuration.0.vpc_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCodeStarConnectionsHostExists(n string, v *codestarconnections.GetHostOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No CodeStar host ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).codestarconnectionsconn
+
+		resp, err := conn.GetHost(&codestarconnections.GetHostInput{
+			HostArn: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAWSCodeStarConnectionsHostDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).codestarconnectionsconn
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "aws_codestarconnections_host":
+			_, err := conn.DeleteHost(&codestarconnections.DeleteHostInput{
+				HostArn: aws.String(rs.Primary.ID),
+			})
+
+			if err != nil && !isAWSErr(err, codestarconnections.ErrCodeResourceNotFoundException, "") {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSCodeStarConnectionsHostVpcConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index + 2)
+  vpc_id            = aws_vpc.test.id
+  tags = {
+    Name = "%[1]s-${count.index}"
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccAWSCodeStarConnectionsHostConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codestarconnections_host" "test" {
+  name              = %[1]q
+  provider_endpoint = "https://test.com"
+  provider_type     = "GitHubEnterpriseServer"
+}
+`, rName)
+}
+
+func testAccAWSCodeStarConnectionsHostConfigVpcConfig(rName string) string {
+	return testAccAWSCodeStarConnectionsHostVpcConfig(rName) + fmt.Sprintf(`
+resource "aws_codestarconnections_host" "test" {
+  name              = %[1]q
+  provider_endpoint = "https://test.com"
+  provider_type     = "GitHubEnterpriseServer"
+  vpc_configuration {
+    security_group_ids = [aws_security_group.test.id]
+    subnet_ids         = aws_subnet.test[*].id
+    tls_certificate    = "-----BEGIN CERTIFICATE-----\nMIID2jCCAsKgAwIBAgIJAJ58TJVjU7G1MA0GCSqGSIb3DQEBBQUAMFExCzAJBgNV\nBAYTAlVTMREwDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYD\nVQQKEwdDaGFydGVyMQwwCgYDVQQLEwNDU0UwHhcNMTcwMTMwMTkyMDA4WhcNMjYx\nMjA5MTkyMDA4WjBRMQswCQYDVQQGEwJVUzERMA8GA1UECBMIQ29sb3JhZG8xDzAN\nBgNVBAcTBkRlbnZlcjEQMA4GA1UEChMHQ2hhcnRlcjEMMAoGA1UECxMDQ1NFMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv6dq6VLIImlAaTrckb5w3X6J\nWP7EGz2ChGAXlkEYto6dPCba0v5+f+8UlMOpeB25XGoai7gdItqNWVFpYsgmndx3\nvTad3ukO1zeElKtw5oHPH2plOaiv/gVJaDa9NTeINj0EtGZs74fCOclAzGFX5vBc\nb08ESWBceRgGjGv3nlij4JzHfqTkCKQz6P6pBivQBfk62rcOkkH5rKoaGltRHROS\nMbkwOhu2hN0KmSYTXRvts0LXnZU4N0l2ms39gmr7UNNNlKYINL2JoTs9dNBc7APD\ndZvlEHd+/FjcLCI8hC3t4g4AbfW0okIBCNG0+oVjqGb2DeONSJKsThahXt89MQID\nAQABo4G0MIGxMB0GA1UdDgQWBBQKq8JxjY1GmeZXJjfOMfW0kBIzPDCBgQYDVR0j\nBHoweIAUCqvCcY2NRpnmVyY3zjH1tJASMzyhVaRTMFExCzAJBgNVBAYTAlVTMREw\nDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYDVQQKEwdDaGFy\ndGVyMQwwCgYDVQQLEwNDU0WCCQCefEyVY1OxtTAMBgNVHRMEBTADAQH/MA0GCSqG\nSIb3DQEBBQUAA4IBAQAWifoMk5kbv+yuWXvFwHiB4dWUUmMlUlPU/E300yVTRl58\np6DfOgJs7MMftd1KeWqTO+uW134QlTt7+jwI8Jq0uyKCu/O2kJhVtH/Ryog14tGl\n+wLcuIPLbwJI9CwZX4WMBrq4DnYss+6F47i8NCc+Z3MAiG4vtq9ytBmaod0dj2bI\ng4/Lac0e00dql9RnqENh1+dF0V+QgTJCoPkMqDNAlSB8vOodBW81UAb2z12t+IFi\n3X9J3WtCK2+T5brXL6itzewWJ2ALvX3QpmZx7fMHJ3tE+SjjyivE1BbOlzYHx83t\nTeYnm7pS9un7A/UzTDHbs7hPUezLek+H3xTPAnnq\n-----END CERTIFICATE-----\n"
+    vpc_id             = aws_vpc.test.id
+  }
+}
+`, rName)
+}

--- a/aws/resource_aws_codestarconnections_host_test.go
+++ b/aws/resource_aws_codestarconnections_host_test.go
@@ -165,7 +165,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  count = 2
+  count             = 2
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index + 2)
   vpc_id            = aws_vpc.test.id

--- a/website/docs/r/codestarconnections_host.markdown
+++ b/website/docs/r/codestarconnections_host.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "CodeStar Connections"
+layout: "aws"
+page_title: "AWS: aws_codestarconnections_host"
+description: |-
+  Provides a CodeStar Host
+---
+
+# Resource: aws_codestarconnections_host
+
+Provides a CodeStar Host.
+
+~> **NOTE:** The `aws_codestarconnections_host` resource is created in the state `PENDING`. Authentication with the host provider must be completed in the AWS Console. For more information visit [Set up a pending host](https://docs.aws.amazon.com/dtconsole/latest/userguide/connections-host-setup.html).
+
+## Example Usage
+
+```hcl
+resource "aws_codestarconnections_host" "example" {
+  name              = "example-host"
+  provider_endpoint = "https://example.com"
+  provider_type     = "GitHubEnterpriseServer"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the host to be created. The name must be unique in the calling AWS account.
+* `provider_endpoint` - (Required) The endpoint of the infrastructure to be represented by the host after it is created.
+* `provider_type` - (Required) The name of the external provider where your third-party code repository is configured.
+* `vpc_configuration` - (Optional) The VPC configuration to be provisioned for the host. A VPC must be configured, and the infrastructure to be represented by the host must already be connected to the VPC.
+
+A `vpc_configuration` block supports the following arguments:
+
+* `security_group_ids` - (Required) he ID of the security group or security groups associated with the Amazon VPC connected to the infrastructure where your provider type is installed.
+* `subnet_ids` - (Required) The ID of the subnet or subnets associated with the Amazon VPC connected to the infrastructure where your provider type is installed.
+* `tls_certificate` - (Optional) The value of the Transport Layer Security (TLS) certificate associated with the infrastructure where your provider type is installed.
+* `vpc_id` - (Required) The ID of the Amazon VPC connected to the infrastructure where your provider type is installed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The CodeStar Host ARN.
+* `arn` - The CodeStar Host ARN.
+* `status` - The CodeStar Host status. Possible values are `PENDING`, `AVAILABLE`, `VPC_CONFIG_DELETING`, `VPC_CONFIG_INITIALIZING`, and `VPC_CONFIG_FAILED_INITIALIZATION`.
+
+## Import
+
+CodeStar Host can be imported using the ARN, e.g.
+
+```
+$ terraform import aws_codestarconnections_host.example-host arn:aws:codestar-connections:us-west-1:0123456789:host/79d4d357-a2ee-41e4-b350-2fe39ae59448
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/15453

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_codestarconnections_host`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeStarConnectionsHost_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeStarConnectionsHost_* -timeout 120m
=== RUN   TestAccAWSCodeStarConnectionsHost_basic
=== PAUSE TestAccAWSCodeStarConnectionsHost_basic
=== RUN   TestAccAWSCodeStarConnectionsHost_disappears
=== PAUSE TestAccAWSCodeStarConnectionsHost_disappears
=== RUN   TestAccAWSCodeStarConnectionsHost_vpcConfig
=== PAUSE TestAccAWSCodeStarConnectionsHost_vpcConfig
=== CONT  TestAccAWSCodeStarConnectionsHost_basic
=== CONT  TestAccAWSCodeStarConnectionsHost_vpcConfig
=== CONT  TestAccAWSCodeStarConnectionsHost_disappears
--- PASS: TestAccAWSCodeStarConnectionsHost_disappears (87.31s)
--- PASS: TestAccAWSCodeStarConnectionsHost_basic (96.56s)
--- PASS: TestAccAWSCodeStarConnectionsHost_vpcConfig (483.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	485.633s
```

Thank you for your review! 👍 
