### PR TITLE
feat: add http data source signing configuration

### DIFF
--- a/aws/resource_aws_appsync_datasource.go
+++ b/aws/resource_aws_appsync_datasource.go
@@ -108,18 +108,18 @@ func resourceAwsAppsyncDatasource() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"iamConfig": {
-							Type: schema.TypeList,
+						"iam_config": {
+							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"signingRegion": {
-										Type: schema.TypeString,
+									"region": {
+										Type:     schema.TypeString,
 										Required: true,
 									},
-									"signingServiceName": {
-										Type: schema.TypeString,
+									"service_name": {
+										Type:     schema.TypeString,
 										Required: true,
 									},
 								},
@@ -413,14 +413,14 @@ func expandAppsyncHTTPDataSourceConfig(l []interface{}) *appsync.HttpDataSourceC
 		Endpoint: aws.String(configured["endpoint"].(string)),
 	}
 
-	if(configured["iamConfig"] != nil) {
+	if configured["iam_config"] != nil {
 		iamConfig := configured["iamConfig"].(map[string]interface{})
 
 		result.SetAuthorizationConfig(&appsync.AuthorizationConfig{
 			AuthorizationType: aws.String("AWS_IAM"),
 			AwsIamConfig: &appsync.AwsIamConfig{
-				SigningRegion: aws.String(iamConfig["signingRegion"].(string)),
-				SigningServiceName: aws.String(iamConfig["signingServiceName"].(string)),
+				SigningRegion:      aws.String(iamConfig["region"].(string)),
+				SigningServiceName: aws.String(iamConfig["service_name"].(string)),
 			},
 		})
 	}

--- a/aws/resource_aws_appsync_datasource.go
+++ b/aws/resource_aws_appsync_datasource.go
@@ -414,7 +414,7 @@ func expandAppsyncHTTPDataSourceConfig(l []interface{}) *appsync.HttpDataSourceC
 	}
 
 	if configured["iam_config"] != nil {
-		iamConfig := configured["iamConfig"].(map[string]interface{})
+		iamConfig := configured["iam_config"].(map[string]interface{})
 
 		result.SetAuthorizationConfig(&appsync.AuthorizationConfig{
 			AuthorizationType: aws.String("AWS_IAM"),

--- a/aws/resource_aws_appsync_datasource.go
+++ b/aws/resource_aws_appsync_datasource.go
@@ -108,6 +108,23 @@ func resourceAwsAppsyncDatasource() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"iamConfig": {
+							Type: schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"signingRegion": {
+										Type: schema.TypeString,
+										Required: true,
+									},
+									"signingServiceName": {
+										Type: schema.TypeString,
+										Required: true,
+									}
+								}
+							}
+						}
 					},
 				},
 				ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "lambda_config"},
@@ -394,6 +411,18 @@ func expandAppsyncHTTPDataSourceConfig(l []interface{}) *appsync.HttpDataSourceC
 
 	result := &appsync.HttpDataSourceConfig{
 		Endpoint: aws.String(configured["endpoint"].(string)),
+	}
+
+	if(configured["iamConfig"] != nil) {
+		iamConfig := configured["iamConfig"].(map[string]interface{})
+
+		result.SetAuthorizationConfig(&appsync.AuthorizationConfig{
+			AuthorizationType: aws.String("AWS_IAM"),
+			AwsIamConfig: &appsync.AwsIamConfig{
+				SigningRegion: aws.String(iamConfig["signingRegion"].(string)),
+				SigningServiceName: aws.String(iamConfig["signingServiceName"].(string)),
+			}
+		})
 	}
 
 	return result

--- a/aws/resource_aws_appsync_datasource.go
+++ b/aws/resource_aws_appsync_datasource.go
@@ -121,10 +121,10 @@ func resourceAwsAppsyncDatasource() *schema.Resource {
 									"signingServiceName": {
 										Type: schema.TypeString,
 										Required: true,
-									}
-								}
-							}
-						}
+									},
+								},
+							},
+						},
 					},
 				},
 				ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "lambda_config"},
@@ -421,7 +421,7 @@ func expandAppsyncHTTPDataSourceConfig(l []interface{}) *appsync.HttpDataSourceC
 			AwsIamConfig: &appsync.AwsIamConfig{
 				SigningRegion: aws.String(iamConfig["signingRegion"].(string)),
 				SigningServiceName: aws.String(iamConfig["signingServiceName"].(string)),
-			}
+			},
 		})
 	}
 

--- a/aws/resource_aws_appsync_datasource_test.go
+++ b/aws/resource_aws_appsync_datasource_test.go
@@ -769,11 +769,11 @@ resource "aws_appsync_datasource" "test" {
   type   = "HTTP"
 
   http_config {
-		endpoint = %q
-		iamConfig {
-			signingRegion      = %q
-			signingServiceName = %q
-		}
+    endpoint = %q
+    iamConfig {
+      signingRegion      = %q
+      signingServiceName = %q
+    }
   }
 }
 `, rName, rName, endpoint, region, service)

--- a/aws/resource_aws_appsync_datasource_test.go
+++ b/aws/resource_aws_appsync_datasource_test.go
@@ -771,7 +771,7 @@ resource "aws_appsync_datasource" "test" {
   http_config {
     endpoint = %q
     iam_config {
-      region      = %q
+      region       = %q
       service_name = %q
     }
   }

--- a/aws/resource_aws_appsync_datasource_test.go
+++ b/aws/resource_aws_appsync_datasource_test.go
@@ -226,15 +226,15 @@ func TestAccAwsAppsyncDatasource_HTTPConfig_AuthorizationConfig(t *testing.T) {
 			{
 				Config: testAccAppsyncDatasourceConfig_HTTPConfig_Endpoint_Signing(rName, "http://example.com", "us-east-1", "cognito-idp"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "http_config.0.iamConfig.signingRegion", "us-east-1"),
-					resource.TestCheckResourceAttr(resourceName, "http_config.0.iamConfig.signingServiceName", "cognito-idp"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.iam_config.region", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.iam_config.service_name", "cognito-idp"),
 				),
 			},
 			{
 				Config: testAccAppsyncDatasourceConfig_HTTPConfig_Endpoint_Signing(rName, "http://example.org", "us-east-2", "states"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "http_config.0.iamConfig.signingRegion", "us-east-2"),
-					resource.TestCheckResourceAttr(resourceName, "http_config.0.iamConfig.signingServiceName", "states"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.iam_config.region", "us-east-2"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.iam_config.service_name", "states"),
 				),
 			},
 			{
@@ -770,9 +770,9 @@ resource "aws_appsync_datasource" "test" {
 
   http_config {
     endpoint = %q
-    iamConfig {
-      signingRegion      = %q
-      signingServiceName = %q
+    iam_config {
+      region      = %q
+      service_name = %q
     }
   }
 }

--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -118,8 +118,8 @@ The following arguments are supported:
 
 * `endpoint` - (Required) HTTP URL.
 * `iamConfig` - (Optional) Configuration for signing requests to AWS services.
-  * `signingRegion` (Required) AWS region that requests will be sent to.
-  * `signingServiceName` (Required) AWS service that requests will be sent to.
+    * `signingRegion` (Required) AWS region that requests will be sent to.
+    * `signingServiceName` (Required) AWS service that requests will be sent to.
 
 ### lambda_config
 

--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -117,9 +117,9 @@ The following arguments are supported:
 The following arguments are supported:
 
 * `endpoint` - (Required) HTTP URL.
-* `iamConfig` - (Optional) Configuration for signing requests to AWS services.
-    * `signingRegion` (Required) AWS region that requests will be sent to.
-    * `signingServiceName` (Required) AWS service that requests will be sent to.
+* `iam_config` - (Optional) Configuration for signing requests to AWS services.
+    * `region` (Required) AWS region that requests will be sent to.
+    * `service_name` (Required) AWS service that requests will be sent to.
 
 ### lambda_config
 

--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -117,6 +117,9 @@ The following arguments are supported:
 The following arguments are supported:
 
 * `endpoint` - (Required) HTTP URL.
+* `iamConfig` - (Optional) Configuration for signing requests to AWS services.
+  * `signingRegion` (Required) AWS region that requests will be sent to.
+  * `signingServiceName` (Required) AWS service that requests will be sent to.
 
 ### lambda_config
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds request signing support to appsync http datasources. This allows you to send calls to AWS services that aren't directly supported.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsAppsyncDatasource_HTTPConfig_AuthorizationConfig'

...
```
