### PR TITLE
resource/aws_emr_cluster: fix error on missing cluster

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -978,6 +978,11 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := emrconn.DescribeCluster(req)
 	if err != nil {
+		if isAWSErr(err, emr.ErrCodeInvalidRequestException, "is not valid") {
+			log.Printf("[DEBUG] EMR Cluster (%s) not found", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error reading EMR cluster: %s", err)
 	}
 

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -978,6 +978,13 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := emrconn.DescribeCluster(req)
 	if err != nil {
+		// After a Cluster has been terminated for an indeterminate period of time,
+		// the EMR API will return this type of error:
+		//   InvalidRequestException: Cluster id 'j-XXX' is not valid.
+		// If this causes issues with masking other legitimate request errors, the
+		// handling should be updated for deeper inspection of the special error type
+		// which includes an accurate error code:
+		//   ErrorCode: "NoSuchCluster",
 		if isAWSErr(err, emr.ErrCodeInvalidRequestException, "is not valid") {
 			log.Printf("[DEBUG] EMR Cluster (%s) not found", d.Id())
 			d.SetId("")


### PR DESCRIPTION
After a certain amount of time, destroyed EMR clusters completely disappear from AWS API output. They don't just display some deleted state, they're just gone. `DescribeClusters` that specifically target their ID return status `400` with `ErrorCode: "NoSuchCluster"`.

Currently, if you have one of these clusters in a statefile and you never update it in between the time when it was deleted and when it is purged from the API, terraform crashes the next time you try to run it, with an error such as this one:

```log
-----------------------------------------------------: timestamp=2020-12-29T15:33:16.926-0500
2020-12-29T15:33:16.926-0500 [INFO]  plugin.terraform-provider-aws: 2020/12/29 15:33:16 [DEBUG] [aws-sdk-go] {"__type":"InvalidRequestException","ErrorCode":"NoSuchCluster","Message":"Cluster id 'j-38DWY37V6BEMY' is not valid."}: timestamp=2020-12-29T15:33:16.926-0500
2020-12-29T15:33:16.926-0500 [INFO]  plugin.terraform-provider-aws: 2020/12/29 15:33:16 [DEBUG] [aws-sdk-go] DEBUG: Validate Response elasticmapreduce/DescribeCluster failed, attempt 0/25, error InvalidReques

tException: Cluster id 'j-38DWY37V6BEMY' is not valid.
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "981d28dd-c27d-48cc-b351-b68edaaae134"
  },
  ErrorCode: "NoSuchCluster",
  Message_: "Cluster id 'j-38DWY37V6BEMY' is not valid."
}: timestamp=2020-12-29T15:33:16.926-0500
2020/12/29 15:33:16 [TRACE] vertex "aws_emr_cluster.cluster": visit complete
2020/12/29 15:33:16 [TRACE] vertex "aws_emr_cluster.cluster": dynamic subgraph encountered errors
2020/12/29 15:33:16 [TRACE] vertex "aws_emr_cluster.cluster": visit complete
2020/12/29 15:33:16 [TRACE] vertex "aws_emr_cluster.cluster (expand)": dynamic subgraph encountered errors
2020/12/29 15:33:16 [TRACE] vertex "aws_emr_cluster.cluster (expand)": visit complete
2020/12/29 15:33:16 [TRACE] dag/walk: upstream of "meta.count-boundary (EachMode fixup)" errored, so skipping
2020/12/29 15:33:16 [TRACE] dag/walk: upstream of "provider[\"registry.terraform.io/hashicorp/aws\"] (close)" errored, so skipping
2020/12/29 15:33:16 [TRACE] dag/walk: upstream of "root" errored, so skipping
2020/12/29 15:33:16 [INFO] backend/local: plan operation completed
```
This has been reported in, e.g, #7783.

This patch fixes that.

- [x] Tested manually.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7783.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixes a crash when planning with a statefile that includes a very old deleted cluster
```
