### PR TITLE
fix: added additional error detail to the graphql schema creation/update.

### DIFF
--- a/aws/resource_aws_appsync_graphql_api.go
+++ b/aws/resource_aws_appsync_graphql_api.go
@@ -598,6 +598,9 @@ func resourceAwsAppsyncSchemaPut(d *schema.ResourceData, meta interface{}) error
 				if err != nil {
 					return 0, "", err
 				}
+				if *result.Status == "FAILED" {
+					return result, *result.Status, fmt.Errorf("%s", *result.Details)
+				}
 				return result, *result.Status, nil
 			},
 			Timeout: d.Timeout(schema.TimeoutCreate),

--- a/aws/resource_aws_appsync_graphql_api_test.go
+++ b/aws/resource_aws_appsync_graphql_api_test.go
@@ -166,6 +166,22 @@ func TestAccAWSAppsyncGraphqlApi_Schema(t *testing.T) {
 	})
 }
 
+func TestAccAWSAppsyncGraphqlApi_Schema_Error(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appsync.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAppsyncGraphqlApiConfig_Schema_Invalid(rName),
+				ExpectError: regexp.MustCompile("The field type 'PostV2' is not present when resolving type 'Query'"),
+			},
+		},
+	})
+}
+
 func TestAccAWSAppsyncGraphqlApi_AuthenticationType(t *testing.T) {
 	var api1, api2 appsync.GraphqlApi
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1201,6 +1217,16 @@ resource "aws_appsync_graphql_api" "test" {
   authentication_type = "API_KEY"
   name                = %q
   schema              = "type Mutation {\n\tputPost(id: ID!, title: String!): Post\n}\n\ntype Post {\n\tid: ID!\n\ttitle: String!\n}\n\ntype Query {\n\tsinglePost(id: ID!): Post\n}\n\nschema {\n\tquery: Query\n\tmutation: Mutation\n\n}\n"
+}
+`, rName)
+}
+
+func testAccAppsyncGraphqlApiConfig_Schema_Invalid(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+  schema              = "type Mutation {\n\tputPost(id: ID!, title: String!): Post\n}\n\ntype Post {\n\tid: ID!\n\ttitle: String!\n}\n\ntype Query {\n\tsinglePost(id: ID!): PostV2\n}\n\nschema {\n\tquery: Query\n\tmutation: Mutation\n\n}\n"
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16814

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added additional error details for failed GraphQL creation/update operation

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAWSAppsyncGraphqlApi_Schema_Error'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAppsyncGraphqlApi_Schema_Error -timeout 120m
=== RUN   TestAccAWSAppsyncGraphqlApi_Schema_Error
=== PAUSE TestAccAWSAppsyncGraphqlApi_Schema_Error
=== CONT  TestAccAWSAppsyncGraphqlApi_Schema_Error
--- PASS: TestAccAWSAppsyncGraphqlApi_Schema_Error (12.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       14.492s
...
```
