### PR TITLE
r/aws_route: Correctly handle update of route target

### DIFF
--- a/.changelog/16930.txt
+++ b/.changelog/16930.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_route: Validate route destination and target attributes
+```
+
+```release-note:bug
+resource/aws_route: Correctly handle updates to the route target attributes (`egress_only_gateway_id`, `gateway_id`, `instance_id`,  `local_gateway_id`, `nat_gateway_id`, `network_interface_id`, `transit_gateway_id`, `vpc_peering_connection_id`)
+```

--- a/aws/data_source_aws_route.go
+++ b/aws/data_source_aws_route.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 )
 
 func dataSourceAwsRoute() *schema.Resource {
@@ -201,4 +203,17 @@ func getRoutes(table *ec2.RouteTable, d *schema.ResourceData) []*ec2.Route {
 		routes = append(routes, r)
 	}
 	return routes
+}
+
+// Helper: Create an ID for a route
+func resourceAwsRouteID(d *schema.ResourceData, r *ec2.Route) string {
+	routeTableID := d.Get("route_table_id").(string)
+
+	if destination := aws.StringValue(r.DestinationCidrBlock); destination != "" {
+		return tfec2.RouteCreateID(routeTableID, destination)
+	} else if destination := aws.StringValue(r.DestinationIpv6CidrBlock); destination != "" {
+		return tfec2.RouteCreateID(routeTableID, destination)
+	}
+
+	return ""
 }

--- a/aws/internal/net/cidr.go
+++ b/aws/internal/net/cidr.go
@@ -1,0 +1,23 @@
+package net
+
+import (
+	"net"
+)
+
+// CIDRBlocksEqual returns whether or not two CIDR blocks are equal:
+// - Both CIDR blocks parse to an IP address and network
+// - The string representation of the IP addresses are equal
+// - The string representation of the networks are equal
+// This function is especially useful for IPv6 CIDR blocks which have multiple valid representations.
+func CIDRBlocksEqual(cidr1, cidr2 string) bool {
+	ip1, ipnet1, err := net.ParseCIDR(cidr1)
+	if err != nil {
+		return false
+	}
+	ip2, ipnet2, err := net.ParseCIDR(cidr2)
+	if err != nil {
+		return false
+	}
+
+	return ip2.String() == ip1.String() && ipnet2.String() == ipnet1.String()
+}

--- a/aws/internal/net/cidr_test.go
+++ b/aws/internal/net/cidr_test.go
@@ -1,0 +1,26 @@
+package net
+
+import (
+	"testing"
+)
+
+func Test_CIDRBlocksEqual(t *testing.T) {
+	for _, ts := range []struct {
+		cidr1 string
+		cidr2 string
+		equal bool
+	}{
+		{"10.2.2.0/24", "10.2.2.0/24", true},
+		{"10.2.2.0/1234", "10.2.2.0/24", false},
+		{"10.2.2.0/24", "10.2.2.0/1234", false},
+		{"2001::/15", "2001::/15", true},
+		{"::/0", "2001::/15", false},
+		{"::/0", "::0/0", true},
+		{"", "", false},
+	} {
+		equal := CIDRBlocksEqual(ts.cidr1, ts.cidr2)
+		if ts.equal != equal {
+			t.Fatalf("CIDRBlocksEqual(%q, %q) should be: %t", ts.cidr1, ts.cidr2, ts.equal)
+		}
+	}
+}

--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	ErrCodeInvalidParameterValue = "InvalidParameterValue"
+	ErrCodeInvalidParameterException = "InvalidParameterException"
+	ErrCodeInvalidParameterValue     = "InvalidParameterValue"
 )
 
 const (
@@ -21,7 +22,12 @@ const (
 )
 
 const (
+	ErrCodeInvalidRouteNotFound        = "InvalidRoute.NotFound"
 	ErrCodeInvalidRouteTableIDNotFound = "InvalidRouteTableID.NotFound"
+)
+
+const (
+	ErrCodeInvalidTransitGatewayIDNotFound = "InvalidTransitGatewayID.NotFound"
 )
 
 const (

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -124,9 +124,8 @@ func RouteTable(conn *ec2.EC2, input *ec2.DescribeRouteTablesInput) (*ec2.RouteT
 
 	if output == nil || len(output.RouteTables) == 0 || output.RouteTables[0] == nil {
 		return nil, &resource.NotFoundError{
-			Message:      "Empty result",
-			LastRequest:  input,
-			LastResponse: output,
+			Message:     "Empty result",
+			LastRequest: input,
 		}
 	}
 

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -105,18 +105,10 @@ func RouteTableByID(conn *ec2.EC2, routeTableID string) (*ec2.RouteTable, error)
 		RouteTableIds: aws.StringSlice([]string{routeTableID}),
 	}
 
-	routeTables, err := RouteTables(conn, input)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return routeTables[0], nil
+	return RouteTable(conn, input)
 }
 
-// RouteTables returns the route tables corresponding to the specified input.
-// Returns NotFoundError if no route tables are found.
-func RouteTables(conn *ec2.EC2, input *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error) {
+func RouteTable(conn *ec2.EC2, input *ec2.DescribeRouteTablesInput) (*ec2.RouteTable, error) {
 	output, err := conn.DescribeRouteTables(input)
 
 	if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidRouteTableIDNotFound) {
@@ -138,7 +130,7 @@ func RouteTables(conn *ec2.EC2, input *ec2.DescribeRouteTablesInput) ([]*ec2.Rou
 		}
 	}
 
-	return output.RouteTables, nil
+	return output.RouteTables[0], nil
 }
 
 // RouteFinder returns the route corresponding to the specified destination.

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -105,10 +105,18 @@ func RouteTableByID(conn *ec2.EC2, routeTableID string) (*ec2.RouteTable, error)
 		RouteTableIds: aws.StringSlice([]string{routeTableID}),
 	}
 
-	return RouteTable(conn, input)
+	routeTables, err := RouteTables(conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return routeTables[0], nil
 }
 
-func RouteTable(conn *ec2.EC2, input *ec2.DescribeRouteTablesInput) (*ec2.RouteTable, error) {
+// RouteTables returns the route tables corresponding to the specified input.
+// Returns NotFoundError if no route tables are found.
+func RouteTables(conn *ec2.EC2, input *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error) {
 	output, err := conn.DescribeRouteTables(input)
 
 	if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidRouteTableIDNotFound) {
@@ -130,7 +138,7 @@ func RouteTable(conn *ec2.EC2, input *ec2.DescribeRouteTablesInput) (*ec2.RouteT
 		}
 	}
 
-	return output.RouteTables[0], nil
+	return output.RouteTables, nil
 }
 
 // RouteFinder returns the route corresponding to the specified destination.

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -109,18 +109,20 @@ func RouteTableByID(conn *ec2.EC2, routeTableID string) (*ec2.RouteTable, error)
 		return nil, err
 	}
 
-	if output == nil || len(output.RouteTables) == 0 || output.RouteTables[0] == nil {
+	if output == nil || len(output.RouteTables) == 0 {
 		return nil, nil
 	}
 
 	return output.RouteTables[0], nil
 }
 
+// RouteFinder returns the route corresponding to the specified destination.
+// Returns nil if no route is found.
 type RouteFinder func(*ec2.EC2, string, string) (*ec2.Route, error)
 
-// RouteByIpv4Destination returns the route corresponding to the specified IPv4 destination.
+// RouteByIPv4Destination returns the route corresponding to the specified IPv4 destination.
 // Returns nil if no route is found.
-func RouteByIpv4Destination(conn *ec2.EC2, routeTableID, destinationCidr string) (*ec2.Route, error) {
+func RouteByIPv4Destination(conn *ec2.EC2, routeTableID, destinationCidr string) (*ec2.Route, error) {
 	routeTable, err := RouteTableByID(conn, routeTableID)
 	if err != nil {
 		return nil, err
@@ -135,9 +137,9 @@ func RouteByIpv4Destination(conn *ec2.EC2, routeTableID, destinationCidr string)
 	return nil, nil
 }
 
-// RouteByIpv6Destination returns the route corresponding to the specified IPv6 destination.
+// RouteByIPv6Destination returns the route corresponding to the specified IPv6 destination.
 // Returns nil if no route is found.
-func RouteByIpv6Destination(conn *ec2.EC2, routeTableID, destinationIpv6Cidr string) (*ec2.Route, error) {
+func RouteByIPv6Destination(conn *ec2.EC2, routeTableID, destinationIpv6Cidr string) (*ec2.Route, error) {
 	routeTable, err := RouteTableByID(conn, routeTableID)
 	if err != nil {
 		return nil, err

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	tfnet "github.com/terraform-providers/terraform-provider-aws/aws/internal/net"
 	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 )
@@ -97,31 +99,46 @@ func InstanceByID(conn *ec2.EC2, id string) (*ec2.Instance, error) {
 }
 
 // RouteTableByID returns the route table corresponding to the specified identifier.
-// Returns nil if no route table is found.
+// Returns NotFoundError if no route table is found.
 func RouteTableByID(conn *ec2.EC2, routeTableID string) (*ec2.RouteTable, error) {
 	input := &ec2.DescribeRouteTablesInput{
 		RouteTableIds: aws.StringSlice([]string{routeTableID}),
 	}
 
+	return RouteTable(conn, input)
+}
+
+func RouteTable(conn *ec2.EC2, input *ec2.DescribeRouteTablesInput) (*ec2.RouteTable, error) {
 	output, err := conn.DescribeRouteTables(input)
+
+	if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidRouteTableIDNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	if output == nil || len(output.RouteTables) == 0 {
-		return nil, nil
+	if output == nil || len(output.RouteTables) == 0 || output.RouteTables[0] == nil {
+		return nil, &resource.NotFoundError{
+			Message:      "Empty result",
+			LastRequest:  input,
+			LastResponse: output,
+		}
 	}
 
 	return output.RouteTables[0], nil
 }
 
 // RouteFinder returns the route corresponding to the specified destination.
-// Returns nil if no route is found.
+// Returns NotFoundError if no route is found.
 type RouteFinder func(*ec2.EC2, string, string) (*ec2.Route, error)
 
 // RouteByIPv4Destination returns the route corresponding to the specified IPv4 destination.
-// Returns nil if no route is found.
+// Returns NotFoundError if no route is found.
 func RouteByIPv4Destination(conn *ec2.EC2, routeTableID, destinationCidr string) (*ec2.Route, error) {
 	routeTable, err := RouteTableByID(conn, routeTableID)
 	if err != nil {
@@ -134,11 +151,11 @@ func RouteByIPv4Destination(conn *ec2.EC2, routeTableID, destinationCidr string)
 		}
 	}
 
-	return nil, nil
+	return nil, &resource.NotFoundError{}
 }
 
 // RouteByIPv6Destination returns the route corresponding to the specified IPv6 destination.
-// Returns nil if no route is found.
+// Returns NotFoundError if no route is found.
 func RouteByIPv6Destination(conn *ec2.EC2, routeTableID, destinationIpv6Cidr string) (*ec2.Route, error) {
 	routeTable, err := RouteTableByID(conn, routeTableID)
 	if err != nil {
@@ -151,7 +168,7 @@ func RouteByIPv6Destination(conn *ec2.EC2, routeTableID, destinationIpv6Cidr str
 		}
 	}
 
-	return nil, nil
+	return nil, &resource.NotFoundError{}
 }
 
 // SecurityGroupByID looks up a security group by ID. When not found, returns nil and potentially an API error.

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	tfnet "github.com/terraform-providers/terraform-provider-aws/aws/internal/net"
 	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 )
 
@@ -93,6 +94,62 @@ func InstanceByID(conn *ec2.EC2, id string) (*ec2.Instance, error) {
 	}
 
 	return output.Reservations[0].Instances[0], nil
+}
+
+// RouteTableByID returns the route table corresponding to the specified identifier.
+// Returns nil if no route table is found.
+func RouteTableByID(conn *ec2.EC2, routeTableID string) (*ec2.RouteTable, error) {
+	input := &ec2.DescribeRouteTablesInput{
+		RouteTableIds: aws.StringSlice([]string{routeTableID}),
+	}
+
+	output, err := conn.DescribeRouteTables(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.RouteTables) == 0 || output.RouteTables[0] == nil {
+		return nil, nil
+	}
+
+	return output.RouteTables[0], nil
+}
+
+type RouteFinder func(*ec2.EC2, string, string) (*ec2.Route, error)
+
+// RouteByIpv4Destination returns the route corresponding to the specified IPv4 destination.
+// Returns nil if no route is found.
+func RouteByIpv4Destination(conn *ec2.EC2, routeTableID, destinationCidr string) (*ec2.Route, error) {
+	routeTable, err := RouteTableByID(conn, routeTableID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, route := range routeTable.Routes {
+		if tfnet.CIDRBlocksEqual(aws.StringValue(route.DestinationCidrBlock), destinationCidr) {
+			return route, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// RouteByIpv6Destination returns the route corresponding to the specified IPv6 destination.
+// Returns nil if no route is found.
+func RouteByIpv6Destination(conn *ec2.EC2, routeTableID, destinationIpv6Cidr string) (*ec2.Route, error) {
+	routeTable, err := RouteTableByID(conn, routeTableID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, route := range routeTable.Routes {
+		if tfnet.CIDRBlocksEqual(aws.StringValue(route.DestinationIpv6CidrBlock), destinationIpv6Cidr) {
+			return route, nil
+		}
+	}
+
+	return nil, nil
 }
 
 // SecurityGroupByID looks up a security group by ID. When not found, returns nil and potentially an API error.

--- a/aws/internal/service/ec2/id.go
+++ b/aws/internal/service/ec2/id.go
@@ -71,6 +71,11 @@ func ClientVpnRouteParseID(id string) (string, string, string, error) {
 			"target-subnet-id"+clientVpnRouteIDSeparator+"destination-cidr-block", id)
 }
 
+// RouteCreateID returns a route resource ID.
+func RouteCreateID(routeTableID, destination string) string {
+	return fmt.Sprintf("r-%s%d", routeTableID, hashcode.String(destination))
+}
+
 const transitGatewayPrefixListReferenceSeparator = "_"
 
 func TransitGatewayPrefixListReferenceCreateID(transitGatewayRouteTableID string, prefixListID string) string {

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func init() {
+	RegisterServiceErrorCheckFunc(elbv2.EndpointsID, testAccErrorCheckSkipELBv2)
+
 	resource.AddTestSweepers("aws_lb", &resource.Sweeper{
 		Name: "aws_lb",
 		F:    testSweepLBs,
@@ -23,6 +25,12 @@ func init() {
 			"aws_vpc_endpoint_service",
 		},
 	})
+}
+
+func testAccErrorCheckSkipELBv2(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"ValidationError: Type must be one of: 'application, network'",
+	)
 }
 
 func testSweepLBs(region string) error {

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -9,18 +8,32 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-// How long to sleep if a limit-exceeded event happens
-var routeTargetValidationError = errors.New("Error: more than 1 target specified. Only 1 of gateway_id, " +
-	"egress_only_gateway_id, nat_gateway_id, instance_id, network_interface_id, local_gateway_id, transit_gateway_id, " +
-	"vpc_endpoint_id, vpc_peering_connection_id is allowed.")
+var routeValidDestinations = []string{
+	"destination_cidr_block",
+	"destination_ipv6_cidr_block",
+}
 
-// AWS Route resource Schema declaration
+var routeValidTargets = []string{
+	"egress_only_gateway_id",
+	"gateway_id",
+	"instance_id",
+	"local_gateway_id",
+	"nat_gateway_id",
+	"network_interface_id",
+	"transit_gateway_id",
+	"vpc_endpoint_id",
+	"vpc_peering_connection_id",
+}
+
 func resourceAwsRoute() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsRouteCreate,
@@ -28,22 +41,7 @@ func resourceAwsRoute() *schema.Resource {
 		Update: resourceAwsRouteUpdate,
 		Delete: resourceAwsRouteDelete,
 		Importer: &schema.ResourceImporter{
-			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				idParts := strings.Split(d.Id(), "_")
-				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-					return nil, fmt.Errorf("unexpected format of ID (%q), expected ROUTETABLEID_DESTINATION", d.Id())
-				}
-				routeTableID := idParts[0]
-				destination := idParts[1]
-				d.Set("route_table_id", routeTableID)
-				if strings.Contains(destination, ":") {
-					d.Set("destination_ipv6_cidr_block", destination)
-				} else {
-					d.Set("destination_cidr_block", destination)
-				}
-				d.SetId(fmt.Sprintf("r-%s%d", routeTableID, hashcode.String(destination)))
-				return []*schema.ResourceData{d}, nil
-			},
+			State: resourceAwsRouteImport,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -52,6 +50,15 @@ func resourceAwsRoute() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			///
+			// Destinations.
+			///
 			"destination_cidr_block": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -73,49 +80,79 @@ func resourceAwsRoute() *schema.Resource {
 				DiffSuppressFunc: suppressEqualCIDRBlockDiffs,
 			},
 
+			// TODO This is a target once we have Managed Prefix List support.
 			"destination_prefix_list_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
+			//
+			// Targets.
+			//
 			"egress_only_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ExactlyOneOf:  routeValidTargets,
+				ConflictsWith: []string{"destination_cidr_block"}, // IPv6 destinations only.
 			},
 
-			"nat_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"local_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+			"gateway_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: routeValidTargets,
 			},
 
 			"instance_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: routeValidTargets,
 			},
 
-			"instance_owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+			"local_gateway_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: routeValidTargets,
+			},
+
+			"nat_gateway_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ExactlyOneOf:  routeValidTargets,
+				ConflictsWith: []string{"destination_ipv6_cidr_block"}, // IPv4 destinations only.
 			},
 
 			"network_interface_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: routeValidTargets,
+			},
+
+			"transit_gateway_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: routeValidTargets,
+			},
+
+			"vpc_endpoint_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ExactlyOneOf:  routeValidTargets,
+				ConflictsWith: []string{"destination_ipv6_cidr_block"}, // IPv4 destinations only.
+			},
+
+			"vpc_peering_connection_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: routeValidTargets,
+			},
+
+			//
+			// Computed attributes.
+			//
+			"instance_owner_id": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
@@ -128,180 +165,75 @@ func resourceAwsRoute() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"route_table_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"transit_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"vpc_endpoint_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"vpc_peering_connection_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 		},
 	}
 }
 
 func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	var numTargets int
-	var setTarget string
-	allowedTargets := []string{
-		"egress_only_gateway_id",
-		"gateway_id",
-		"nat_gateway_id",
-		"local_gateway_id",
-		"instance_id",
-		"network_interface_id",
-		"transit_gateway_id",
-		"vpc_peering_connection_id",
-		"vpc_endpoint_id",
+
+	destinationAttributeKey, destination, err := routeDestinationAttribute(d)
+
+	if err != nil {
+		return fmt.Errorf("error creating Route: %w", err)
 	}
 
-	// Check if more than 1 target is specified
-	for _, target := range allowedTargets {
-		if len(d.Get(target).(string)) > 0 {
-			numTargets++
-			setTarget = target
-		}
+	targetAttributeKey, target, err := routeTargetAttribute(d)
+
+	if err != nil {
+		return fmt.Errorf("error creating Route: %w", err)
 	}
 
-	if numTargets > 1 {
-		return routeTargetValidationError
+	routeTableID := d.Get("route_table_id").(string)
+	input := &ec2.CreateRouteInput{
+		RouteTableId: aws.String(routeTableID),
 	}
 
-	createOpts := &ec2.CreateRouteInput{}
-	// Formulate CreateRouteInput based on the target type
-	switch setTarget {
-	case "gateway_id":
-		createOpts = &ec2.CreateRouteInput{
-			RouteTableId: aws.String(d.Get("route_table_id").(string)),
-			GatewayId:    aws.String(d.Get("gateway_id").(string)),
-		}
+	var routeFinder finder.RouteFinder
 
-		if v, ok := d.GetOk("destination_cidr_block"); ok {
-			createOpts.DestinationCidrBlock = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
-		}
-
-	case "egress_only_gateway_id":
-		createOpts = &ec2.CreateRouteInput{
-			RouteTableId:                aws.String(d.Get("route_table_id").(string)),
-			DestinationIpv6CidrBlock:    aws.String(d.Get("destination_ipv6_cidr_block").(string)),
-			EgressOnlyInternetGatewayId: aws.String(d.Get("egress_only_gateway_id").(string)),
-		}
-	case "nat_gateway_id":
-		createOpts = &ec2.CreateRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			NatGatewayId:         aws.String(d.Get("nat_gateway_id").(string)),
-		}
-	case "local_gateway_id":
-		createOpts = &ec2.CreateRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			LocalGatewayId:       aws.String(d.Get("local_gateway_id").(string)),
-		}
-	case "instance_id":
-		createOpts = &ec2.CreateRouteInput{
-			RouteTableId: aws.String(d.Get("route_table_id").(string)),
-			InstanceId:   aws.String(d.Get("instance_id").(string)),
-		}
-
-		if v, ok := d.GetOk("destination_cidr_block"); ok {
-			createOpts.DestinationCidrBlock = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
-		}
-
-	case "network_interface_id":
-		createOpts = &ec2.CreateRouteInput{
-			RouteTableId:       aws.String(d.Get("route_table_id").(string)),
-			NetworkInterfaceId: aws.String(d.Get("network_interface_id").(string)),
-		}
-
-		if v, ok := d.GetOk("destination_cidr_block"); ok {
-			createOpts.DestinationCidrBlock = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
-		}
-
-	case "transit_gateway_id":
-		createOpts = &ec2.CreateRouteInput{
-			RouteTableId:     aws.String(d.Get("route_table_id").(string)),
-			TransitGatewayId: aws.String(d.Get("transit_gateway_id").(string)),
-		}
-
-		if v, ok := d.GetOk("destination_cidr_block"); ok {
-			createOpts.DestinationCidrBlock = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
-		}
-
-	case "vpc_endpoint_id":
-		createOpts = &ec2.CreateRouteInput{
-			RouteTableId:  aws.String(d.Get("route_table_id").(string)),
-			VpcEndpointId: aws.String(d.Get("vpc_endpoint_id").(string)),
-		}
-
-		if v, ok := d.GetOk("destination_cidr_block"); ok {
-			createOpts.DestinationCidrBlock = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
-		}
-
-	case "vpc_peering_connection_id":
-		createOpts = &ec2.CreateRouteInput{
-			RouteTableId:           aws.String(d.Get("route_table_id").(string)),
-			VpcPeeringConnectionId: aws.String(d.Get("vpc_peering_connection_id").(string)),
-		}
-
-		if v, ok := d.GetOk("destination_cidr_block"); ok {
-			createOpts.DestinationCidrBlock = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
-		}
-
+	switch destination := aws.String(destination); destinationAttributeKey {
+	case "destination_cidr_block":
+		input.DestinationCidrBlock = destination
+		routeFinder = finder.RouteByIpv4Destination
+	case "destination_ipv6_cidr_block":
+		input.DestinationIpv6CidrBlock = destination
+		routeFinder = finder.RouteByIpv6Destination
 	default:
-		return fmt.Errorf("A valid target type is missing. Specify one of the following attributes: %s", strings.Join(allowedTargets, ", "))
+		return fmt.Errorf("error creating Route: unexpected route destination attribute: %q", destinationAttributeKey)
 	}
-	log.Printf("[DEBUG] Route create config: %s", createOpts)
 
-	// Create the route
-	var err error
+	switch target := aws.String(target); targetAttributeKey {
+	case "egress_only_gateway_id":
+		input.EgressOnlyInternetGatewayId = target
+	case "gateway_id":
+		input.GatewayId = target
+	case "instance_id":
+		input.InstanceId = target
+	case "local_gateway_id":
+		input.LocalGatewayId = target
+	case "nat_gateway_id":
+		input.NatGatewayId = target
+	case "network_interface_id":
+		input.NetworkInterfaceId = target
+	case "transit_gateway_id":
+		input.TransitGatewayId = target
+	case "vpc_endpoint_id":
+		input.VpcEndpointId = target
+	case "vpc_peering_connection_id":
+		input.VpcPeeringConnectionId = target
+	default:
+		return fmt.Errorf("error creating Route: unexpected route target attribute: %q", targetAttributeKey)
+	}
 
+	log.Printf("[DEBUG] Creating Route: %s", input)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		_, err = conn.CreateRoute(createOpts)
+		_, err = conn.CreateRoute(input)
 
-		if isAWSErr(err, "InvalidParameterException", "") {
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidParameterException) {
 			return resource.RetryableError(err)
 		}
 
-		if isAWSErr(err, "InvalidTransitGatewayID.NotFound", "") {
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidTransitGatewayIDNotFound) {
 			return resource.RetryableError(err)
 		}
 
@@ -311,64 +243,44 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
-	if isResourceTimeoutError(err) {
-		_, err = conn.CreateRoute(createOpts)
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.CreateRoute(input)
 	}
+
 	if err != nil {
-		return fmt.Errorf("Error creating route: %s", err)
+		return fmt.Errorf("error creating Route for Route Table (%s) with destination (%s): %w", routeTableID, destination, err)
 	}
 
 	var route *ec2.Route
 
-	if v, ok := d.GetOk("destination_cidr_block"); ok {
-		err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), v.(string), "")
-			if err == nil {
-				if route != nil {
-					return nil
-				} else {
-					err = errors.New("Route not found")
-				}
-			}
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		route, err = routeFinder(conn, routeTableID, destination)
 
-			return resource.RetryableError(err)
-		})
-		if isResourceTimeoutError(err) {
-			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), v.(string), "")
-		}
 		if err != nil {
-			return fmt.Errorf("Error finding route after creating it: %s", err)
+			return resource.RetryableError(err)
 		}
+
 		if route == nil {
-			return fmt.Errorf("Unable to find matching route for Route Table (%s) and destination CIDR block (%s).", d.Get("route_table_id").(string), v)
+			return resource.RetryableError(fmt.Errorf("route not found"))
 		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		route, err = routeFinder(conn, routeTableID, destination)
 	}
 
-	if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-		err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), "", v.(string))
-			if err == nil {
-				if route != nil {
-					return nil
-				} else {
-					err = errors.New("Route not found")
-				}
-			}
-
-			return resource.RetryableError(err)
-		})
-		if isResourceTimeoutError(err) {
-			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), "", v.(string))
-		}
-		if err != nil {
-			return fmt.Errorf("Error finding route after creating it: %s", err)
-		}
-		if route == nil {
-			return fmt.Errorf("Unable to find matching route for Route Table (%s) and destination IPv6 CIDR block (%s).", d.Get("route_table_id").(string), v)
-		}
+	if err != nil {
+		return fmt.Errorf("error reading Route for Route Table (%s) with destination (%s): %w", routeTableID, destination, err)
 	}
 
-	d.SetId(resourceAwsRouteID(d, route))
+	if route == nil {
+		return fmt.Errorf("Route in Route Table (%s) with destination (%s) not found", routeTableID, destination)
+	}
+
+	d.SetId(tfec2.RouteCreateID(routeTableID, destination))
 
 	return resourceAwsRouteRead(d, meta)
 }
@@ -376,22 +288,39 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	routeTableId := d.Get("route_table_id").(string)
-	destinationCidrBlock := d.Get("destination_cidr_block").(string)
-	destinationIpv6CidrBlock := d.Get("destination_ipv6_cidr_block").(string)
+	destinationAttributeKey, destination, err := routeDestinationAttribute(d)
 
-	route, err := resourceAwsRouteFindRoute(conn, routeTableId, destinationCidrBlock, destinationIpv6CidrBlock)
-	if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
-		log.Printf("[WARN] Route Table (%s) not found, removing from state", routeTableId)
+	if err != nil {
+		return fmt.Errorf("error reading Route: %w", err)
+	}
+
+	var routeFinder finder.RouteFinder
+
+	switch destinationAttributeKey {
+	case "destination_cidr_block":
+		routeFinder = finder.RouteByIpv4Destination
+	case "destination_ipv6_cidr_block":
+		routeFinder = finder.RouteByIpv6Destination
+	default:
+		return fmt.Errorf("error reading Route: unexpected route destination attribute: %q", destinationAttributeKey)
+	}
+
+	routeTableID := d.Get("route_table_id").(string)
+
+	route, err := routeFinder(conn, routeTableID, destination)
+
+	if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidRouteTableIDNotFound) {
+		log.Printf("[WARN] Route Table (%s) not found, removing from state", routeTableID)
 		d.SetId("")
 		return nil
 	}
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading Route for Route Table (%s) with destination (%s): %w", routeTableID, destination, err)
 	}
 
 	if route == nil {
-		log.Printf("[WARN] Matching route not found, removing from state")
+		log.Printf("[WARN] Route in Route Table (%s) with destination (%s) not found, removing from state", routeTableID, destination)
 		d.SetId("")
 		return nil
 	}
@@ -401,9 +330,11 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("destination_prefix_list_id", route.DestinationPrefixListId)
 	// VPC Endpoint ID is returned in Gateway ID field
 	if strings.HasPrefix(aws.StringValue(route.GatewayId), "vpce-") {
+		d.Set("gateway_id", "")
 		d.Set("vpc_endpoint_id", route.GatewayId)
 	} else {
 		d.Set("gateway_id", route.GatewayId)
+		d.Set("vpc_endpoint_id", "")
 	}
 	d.Set("egress_only_gateway_id", route.EgressOnlyInternetGatewayId)
 	d.Set("nat_gateway_id", route.NatGatewayId)
@@ -421,200 +352,166 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	var numTargets int
-	var setTarget string
 
-	allowedTargets := []string{
-		"egress_only_gateway_id",
-		"gateway_id",
-		"nat_gateway_id",
-		"local_gateway_id",
-		"network_interface_id",
-		"instance_id",
-		"transit_gateway_id",
-		"vpc_endpoint_id",
-		"vpc_peering_connection_id",
-	}
-	// Check if more than 1 target is specified
-	for _, target := range allowedTargets {
-		if len(d.Get(target).(string)) > 0 {
-			numTargets++
-			setTarget = target
-		}
+	destinationAttributeKey, destination, err := routeDestinationAttribute(d)
+
+	if err != nil {
+		return fmt.Errorf("error updating Route: %w", err)
 	}
 
-	switch setTarget {
-	//instance_id is a special case due to the fact that AWS will "discover" the network_interface_id
-	//when it creates the route and return that data.  In the case of an update, we should ignore the
-	//existing network_interface_id
-	case "instance_id":
-		if numTargets > 2 || (numTargets == 2 && len(d.Get("network_interface_id").(string)) == 0) {
-			return routeTargetValidationError
-		}
+	targetAttributeKey, target, err := routeTargetAttribute(d)
+
+	if err != nil {
+		return fmt.Errorf("error updating Route: %w", err)
+	}
+
+	routeTableID := d.Get("route_table_id").(string)
+	input := &ec2.ReplaceRouteInput{
+		RouteTableId: aws.String(routeTableID),
+	}
+
+	switch destination := aws.String(destination); destinationAttributeKey {
+	case "destination_cidr_block":
+		input.DestinationCidrBlock = destination
+	case "destination_ipv6_cidr_block":
+		input.DestinationIpv6CidrBlock = destination
 	default:
-		if numTargets > 1 {
-			return routeTargetValidationError
-		}
+		return fmt.Errorf("error updating Route: unexpected route destination attribute: %q", destinationAttributeKey)
 	}
 
-	var replaceOpts *ec2.ReplaceRouteInput
-	// Formulate ReplaceRouteInput based on the target type
-	switch setTarget {
-	case "gateway_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			GatewayId:            aws.String(d.Get("gateway_id").(string)),
-		}
+	switch target := aws.String(target); targetAttributeKey {
 	case "egress_only_gateway_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:                aws.String(d.Get("route_table_id").(string)),
-			DestinationIpv6CidrBlock:    aws.String(d.Get("destination_ipv6_cidr_block").(string)),
-			EgressOnlyInternetGatewayId: aws.String(d.Get("egress_only_gateway_id").(string)),
-		}
-	case "nat_gateway_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			NatGatewayId:         aws.String(d.Get("nat_gateway_id").(string)),
-		}
-	case "local_gateway_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			LocalGatewayId:       aws.String(d.Get("local_gateway_id").(string)),
-		}
+		input.EgressOnlyInternetGatewayId = target
+	case "gateway_id":
+		input.GatewayId = target
 	case "instance_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			InstanceId:           aws.String(d.Get("instance_id").(string)),
-		}
+		input.InstanceId = target
+	case "local_gateway_id":
+		input.LocalGatewayId = target
+	case "nat_gateway_id":
+		input.NatGatewayId = target
 	case "network_interface_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			NetworkInterfaceId:   aws.String(d.Get("network_interface_id").(string)),
-		}
+		input.NetworkInterfaceId = target
 	case "transit_gateway_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			TransitGatewayId:     aws.String(d.Get("transit_gateway_id").(string)),
-		}
+		input.TransitGatewayId = target
 	case "vpc_endpoint_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			VpcEndpointId:        aws.String(d.Get("vpc_endpoint_id").(string)),
-		}
+		input.VpcEndpointId = target
 	case "vpc_peering_connection_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:           aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock:   aws.String(d.Get("destination_cidr_block").(string)),
-			VpcPeeringConnectionId: aws.String(d.Get("vpc_peering_connection_id").(string)),
-		}
+		input.VpcPeeringConnectionId = target
 	default:
-		return fmt.Errorf("An invalid target type specified: %s", setTarget)
+		return fmt.Errorf("error updating Route: unexpected route target attribute: %q", targetAttributeKey)
 	}
-	log.Printf("[DEBUG] Route replace config: %s", replaceOpts)
 
-	// Replace the route
-	_, err := conn.ReplaceRoute(replaceOpts)
-	return err
+	log.Printf("[DEBUG] Updating Route: %s", input)
+	_, err = conn.ReplaceRoute(input)
+
+	if err != nil {
+		return fmt.Errorf("error updating Route for Route Table (%s) with destination (%s): %w", routeTableID, destination, err)
+	}
+
+	return resourceAwsRouteRead(d, meta)
 }
 
 func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	deleteOpts := &ec2.DeleteRouteInput{
-		RouteTableId: aws.String(d.Get("route_table_id").(string)),
-	}
-	if v, ok := d.GetOk("destination_cidr_block"); ok {
-		deleteOpts.DestinationCidrBlock = aws.String(v.(string))
-	}
-	if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-		deleteOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
-	}
-	log.Printf("[DEBUG] Route delete opts: %s", deleteOpts)
+	destinationAttributeKey, destination, err := routeDestinationAttribute(d)
 
-	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		log.Printf("[DEBUG] Trying to delete route with opts %s", deleteOpts)
-		var err error
-		_, err = conn.DeleteRoute(deleteOpts)
+	if err != nil {
+		return fmt.Errorf("error deleting Route: %w", err)
+	}
+
+	routeTableID := d.Get("route_table_id").(string)
+	input := &ec2.DeleteRouteInput{
+		RouteTableId: aws.String(routeTableID),
+	}
+
+	switch destination := aws.String(destination); destinationAttributeKey {
+	case "destination_cidr_block":
+		input.DestinationCidrBlock = destination
+	case "destination_ipv6_cidr_block":
+		input.DestinationIpv6CidrBlock = destination
+	default:
+		return fmt.Errorf("error deleting Route: unexpected route destination attribute: %q", destinationAttributeKey)
+	}
+
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		log.Printf("[DEBUG] Deleting Route (%s)", d.Id())
+		_, err = conn.DeleteRoute(input)
 		if err == nil {
 			return nil
 		}
 
-		if isAWSErr(err, "InvalidRoute.NotFound", "") {
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidRouteNotFound) {
 			return nil
 		}
 
-		if isAWSErr(err, "InvalidParameterException", "") {
+		// Local routes (which may have been imported) cannot be deleted. Remove from state.
+		if tfawserr.ErrMessageContains(err, tfec2.ErrCodeInvalidParameterValue, "cannot remove local route") {
+			return nil
+		}
+
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidParameterException) {
 			return resource.RetryableError(err)
 		}
 
 		return resource.NonRetryableError(err)
 	})
-	if isResourceTimeoutError(err) {
-		_, err = conn.DeleteRoute(deleteOpts)
+
+	if tfresource.TimedOut(err) {
+		log.Printf("[DEBUG] Deleting Route (%s)", d.Id())
+		_, err = conn.DeleteRoute(input)
 	}
-	if isAWSErr(err, "InvalidRoute.NotFound", "") {
+
+	if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidRouteNotFound) {
 		return nil
 	}
+
 	if err != nil {
-		return fmt.Errorf("Error deleting route: %s", err)
+		return fmt.Errorf("error deleting Route for Route Table (%s) with destination (%s): %w", routeTableID, destination, err)
 	}
+
 	return nil
 }
 
-// Helper: Create an ID for a route
-func resourceAwsRouteID(d *schema.ResourceData, r *ec2.Route) string {
-
-	if r.DestinationIpv6CidrBlock != nil && *r.DestinationIpv6CidrBlock != "" {
-		return fmt.Sprintf("r-%s%d", d.Get("route_table_id").(string), hashcode.String(*r.DestinationIpv6CidrBlock))
+func resourceAwsRouteImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.Split(d.Id(), "_")
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected ROUTETABLEID_DESTINATION", d.Id())
 	}
 
-	return fmt.Sprintf("r-%s%d", d.Get("route_table_id").(string), hashcode.String(*r.DestinationCidrBlock))
+	routeTableID := idParts[0]
+	destination := idParts[1]
+	d.Set("route_table_id", routeTableID)
+	if strings.Contains(destination, ":") {
+		d.Set("destination_ipv6_cidr_block", destination)
+	} else {
+		d.Set("destination_cidr_block", destination)
+	}
+	d.SetId(tfec2.RouteCreateID(routeTableID, destination))
+
+	return []*schema.ResourceData{d}, nil
 }
 
-// resourceAwsRouteFindRoute returns any route whose destination is the specified IPv4 or IPv6 CIDR block.
-// Returns nil if the route table exists but no matching destination is found.
-func resourceAwsRouteFindRoute(conn *ec2.EC2, rtbid string, cidr string, ipv6cidr string) (*ec2.Route, error) {
-	routeTableID := rtbid
-
-	findOpts := &ec2.DescribeRouteTablesInput{
-		RouteTableIds: []*string{&routeTableID},
-	}
-
-	resp, err := conn.DescribeRouteTables(findOpts)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(resp.RouteTables) < 1 || resp.RouteTables[0] == nil {
-		return nil, nil
-	}
-
-	if cidr != "" {
-		for _, route := range (*resp.RouteTables[0]).Routes {
-			if route.DestinationCidrBlock != nil && *route.DestinationCidrBlock == cidr {
-				return route, nil
-			}
+// routeDestinationAttribute returns the attribute key and value of the route's destination.
+func routeDestinationAttribute(d *schema.ResourceData) (string, string, error) {
+	for _, key := range routeValidDestinations {
+		if v, ok := d.Get(key).(string); ok && v != "" {
+			return key, v, nil
 		}
-
-		return nil, nil
 	}
 
-	if ipv6cidr != "" {
-		for _, route := range (*resp.RouteTables[0]).Routes {
-			if cidrBlocksEqual(aws.StringValue(route.DestinationIpv6CidrBlock), ipv6cidr) {
-				return route, nil
-			}
+	return "", "", fmt.Errorf("route destination attribute not specified")
+}
+
+// routeTargetAttribute returns the attribute key and value of the route's target.
+func routeTargetAttribute(d *schema.ResourceData) (string, string, error) {
+	for _, key := range routeValidTargets {
+		// The HasChange check is necessary to handle Computed attributes that will be cleared once they are read back after update.
+		if v, ok := d.Get(key).(string); ok && v != "" && d.HasChange(key) {
+			return key, v, nil
 		}
-
-		return nil, nil
 	}
 
-	return nil, nil
+	return "", "", fmt.Errorf("route target attribute not specified")
 }

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -194,10 +194,10 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	switch destination := aws.String(destination); destinationAttributeKey {
 	case "destination_cidr_block":
 		input.DestinationCidrBlock = destination
-		routeFinder = finder.RouteByIpv4Destination
+		routeFinder = finder.RouteByIPv4Destination
 	case "destination_ipv6_cidr_block":
 		input.DestinationIpv6CidrBlock = destination
-		routeFinder = finder.RouteByIpv6Destination
+		routeFinder = finder.RouteByIPv6Destination
 	default:
 		return fmt.Errorf("error creating Route: unexpected route destination attribute: %q", destinationAttributeKey)
 	}
@@ -298,9 +298,9 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 
 	switch destinationAttributeKey {
 	case "destination_cidr_block":
-		routeFinder = finder.RouteByIpv4Destination
+		routeFinder = finder.RouteByIPv4Destination
 	case "destination_ipv6_cidr_block":
-		routeFinder = finder.RouteByIpv6Destination
+		routeFinder = finder.RouteByIPv6Destination
 	default:
 		return fmt.Errorf("error reading Route: unexpected route destination attribute: %q", destinationAttributeKey)
 	}

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -2727,11 +2727,11 @@ resource "aws_route_table" "test" {
 func testAccAWSRouteConfigIpv4LocalRoute(rName string) string {
 	return composeConfig(
 		testAccAWSRouteConfigIpv4NoRoute(rName),
-		fmt.Sprintf(`
+		`
 resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = aws_vpc.test.cidr_block
   gateway_id             = "local"
 }
-`))
+`)
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -408,7 +408,6 @@ func TestAccAWSRoute_IPv4_To_Instance(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -974,7 +974,7 @@ func TestAccAWSRoute_IPv4_Update_Target(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
-		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID, "elasticloadbalancing"),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1320,7 +1320,7 @@ func TestAccAWSRoute_IPv4_To_VpcEndpoint(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID, "elasticloadbalancing"),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -1337,9 +1337,9 @@ func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 		var route *ec2.Route
 		var err error
 		if v := rs.Primary.Attributes["destination_cidr_block"]; v != "" {
-			route, err = finder.RouteByIpv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = finder.RouteByIPv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
-			route, err = finder.RouteByIpv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = finder.RouteByIPv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		}
 
 		if route == nil && err == nil {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -433,6 +433,7 @@ func TestAccAWSRoute_IPv4_To_Instance(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -566,9 +567,8 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
 	destinationCidr := "10.3.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1171,6 +1171,7 @@ func TestAccAWSRoute_IPv6_Update_Target(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1319,6 +1320,7 @@ func TestAccAWSRoute_IPv4_To_VpcEndpoint(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1364,6 +1366,7 @@ func TestAccAWSRoute_LocalRoute(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
 // IPv4 to Internet Gateway.
@@ -43,7 +45,7 @@ func TestAccAWSRoute_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -129,7 +131,7 @@ func TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -176,7 +178,7 @@ func TestAccAWSRoute_IPv6_To_InternetGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -218,7 +220,7 @@ func TestAccAWSRoute_IPv6_To_Instance(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -260,7 +262,7 @@ func TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -302,7 +304,7 @@ func TestAccAWSRoute_IPv6_To_VpcPeeringConnection(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
 				),
 			},
@@ -344,7 +346,7 @@ func TestAccAWSRoute_IPv6_To_VpnGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -386,7 +388,7 @@ func TestAccAWSRoute_IPv4_To_VpnGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -427,7 +429,7 @@ func TestAccAWSRoute_IPv4_To_Instance(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -469,7 +471,7 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -512,7 +514,7 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_Attached(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -526,7 +528,6 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_Attached(t *testing.T) {
 	})
 }
 
-/*
 func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
 	resourceName := "aws_route.test"
 	eni1ResourceName := "aws_network_interface.test1"
@@ -552,11 +553,13 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
 					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eni1ResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -570,11 +573,13 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
 					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eni2ResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -587,7 +592,6 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
 		},
 	})
 }
-*/
 
 func TestAccAWSRoute_IPv4_To_VpcPeeringConnection(t *testing.T) {
 	resourceName := "aws_route.test"
@@ -617,7 +621,7 @@ func TestAccAWSRoute_IPv4_To_VpcPeeringConnection(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
 				),
 			},
@@ -659,7 +663,7 @@ func TestAccAWSRoute_IPv4_To_NatGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -730,7 +734,7 @@ func TestAccAWSRoute_IPv4_To_TransitGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", tgwResourceName, "id"),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -772,7 +776,7 @@ func TestAccAWSRoute_IPv6_To_TransitGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", tgwResourceName, "id"),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -814,7 +818,7 @@ func TestAccAWSRoute_IPv4_To_LocalGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -856,7 +860,7 @@ func TestAccAWSRoute_IPv6_To_LocalGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
@@ -906,6 +910,342 @@ func TestAccAWSRoute_ConditionalCidrBlock(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_IPv4_Update_Target(t *testing.T) {
+	resourceName := "aws_route.test"
+	vgwResourceName := "aws_vpn_gateway.test"
+	instanceResourceName := "aws_instance.test"
+	igwResourceName := "aws_internet_gateway.test"
+	eniResourceName := "aws_network_interface.test"
+	pcxResourceName := "aws_vpc_peering_connection.test"
+	ngwResourceName := "aws_nat_gateway.test"
+	tgwResourceName := "aws_ec2_transit_gateway.test"
+	vpcEndpointResourceName := "aws_vpc_endpoint.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.3.0.0/16"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "instance_id", instanceResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", igwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "nat_gateway_id", ngwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "nat_gateway_id", ngwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "network_interface_id", eniResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "transit_gateway_id", tgwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", tgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "vpc_endpoint_id", vpcEndpointResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_endpoint_id", vpcEndpointResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_IPv6_Update_Target(t *testing.T) {
+	resourceName := "aws_route.test"
+	vgwResourceName := "aws_vpn_gateway.test"
+	instanceResourceName := "aws_instance.test"
+	igwResourceName := "aws_internet_gateway.test"
+	eniResourceName := "aws_network_interface.test"
+	pcxResourceName := "aws_vpc_peering_connection.test"
+	eoigwResourceName := "aws_egress_only_internet_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "::/0"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "instance_id", instanceResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "gateway_id", igwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "egress_only_gateway_id", eoigwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "egress_only_gateway_id", eoigwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "network_interface_id", eniResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute_IPv4_To_VpcEndpoint(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route.test"
@@ -913,8 +1253,7 @@ func TestAccAWSRoute_IPv4_To_VpcEndpoint(t *testing.T) {
 	destinationCidr := "172.16.1.0/24"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
-		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -925,7 +1264,7 @@ func TestAccAWSRoute_IPv4_To_VpcEndpoint(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
-					// TODO resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
@@ -948,6 +1287,45 @@ func TestAccAWSRoute_IPv4_To_VpcEndpoint(t *testing.T) {
 	})
 }
 
+// https://github.com/terraform-providers/terraform-provider-aws/issues/11455.
+func TestAccAWSRoute_LocalRoute(t *testing.T) {
+	var routeTable ec2.RouteTable
+	var vpc ec2.Vpc
+	resourceName := "aws_route.test"
+	rtResourceName := "aws_route_table.test"
+	vpcResourceName := "aws_vpc.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4NoRoute(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcExists(vpcResourceName, &vpc),
+					testAccCheckRouteTableExists(rtResourceName, &routeTable),
+					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+				),
+			},
+			{
+				Config:       testAccAWSRouteConfigIpv4LocalRoute(rName),
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(rt *ec2.RouteTable, v *ec2.Vpc) resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						return fmt.Sprintf("%s_%s", aws.StringValue(rt.RouteTableId), aws.StringValue(v.CidrBlock)), nil
+					}
+				}(&routeTable, &vpc),
+				// Don't verify the state as the local route isn't actually in the pre-import state.
+				// Just running ImportState verifies that we can import a local route.
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route" {
@@ -955,12 +1333,14 @@ func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		route, err := resourceAwsRouteFindRoute(
-			conn,
-			rs.Primary.Attributes["route_table_id"],
-			rs.Primary.Attributes["destination_cidr_block"],
-			rs.Primary.Attributes["destination_ipv6_cidr_block"],
-		)
+
+		var route *ec2.Route
+		var err error
+		if v := rs.Primary.Attributes["destination_cidr_block"]; v != "" {
+			route, err = finder.RouteByIpv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
+			route, err = finder.RouteByIpv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+		}
 
 		if route == nil && err == nil {
 			return nil
@@ -1347,7 +1727,7 @@ resource "aws_route" "test" {
 
 func testAccAWSRouteConfigIpv6TransitGateway(rName, destinationCidr string) string {
 	return composeConfig(
-		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		testAccAvailableAZsNoOptInConfig(),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
@@ -1703,7 +2083,6 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-/*
 func testAccAWSRouteConfigIpv4NetworkInterfaceTwoAttachments(rName, destinationCidr, targetResourceName string) string {
 	return composeConfig(
 		testAccLatestAmazonNatInstanceAmiConfig(),
@@ -1781,7 +2160,6 @@ resource "aws_route" "test" {
 }
 `, rName, destinationCidr, targetResourceName))
 }
-*/
 
 func testAccAWSRouteConfigIpv4VpcPeeringConnection(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
@@ -2028,4 +2406,332 @@ resource "aws_route" "test" {
   vpc_endpoint_id        = aws_vpc_endpoint.test.id
 }
 `, rName, destinationCidr))
+}
+
+func testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+locals {
+  target_attr  = %[3]q
+  target_value = %[4]s.id
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
+  subnet_ids         = [aws_subnet.test.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "target" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id      = aws_vpc.test.id
+  peer_vpc_id = aws_vpc.target.id
+  auto_accept = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_eip" "test" {
+  vpc = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_nat_gateway" "test" {
+  allocation_id = aws_eip.test.id
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+
+  depends_on = [aws_internet_gateway.test]
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_lb" "test" {
+  load_balancer_type = "gateway"
+  name               = %[1]q
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  allowed_principals         = [data.aws_caller_identity.current.arn]
+  gateway_load_balancer_arns = [aws_lb.test.arn]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_endpoint" "test" {
+  service_name      = aws_vpc_endpoint_service.test.service_name
+  subnet_ids        = [aws_subnet.test.id]
+  vpc_endpoint_type = aws_vpc_endpoint_service.test.service_type
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = %[2]q
+
+  egress_only_gateway_id    = (local.target_attr == "egress_only_gateway_id") ? local.target_value : null
+  gateway_id                = (local.target_attr == "gateway_id") ? local.target_value : null
+  instance_id               = (local.target_attr == "instance_id") ? local.target_value : null
+  local_gateway_id          = (local.target_attr == "local_gateway_id") ? local.target_value : null
+  nat_gateway_id            = (local.target_attr == "nat_gateway_id") ? local.target_value : null
+  network_interface_id      = (local.target_attr == "network_interface_id") ? local.target_value : null
+  transit_gateway_id        = (local.target_attr == "transit_gateway_id") ? local.target_value : null
+  vpc_endpoint_id           = (local.target_attr == "vpc_endpoint_id") ? local.target_value : null
+  vpc_peering_connection_id = (local.target_attr == "vpc_peering_connection_id") ? local.target_value : null
+}
+`, rName, destinationCidr, targetAttribute, targetValue))
+}
+
+func testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableAZsNoOptInConfig(),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+locals {
+  target_attr  = %[3]q
+  target_value = %[4]s.id
+}
+
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  ipv6_address_count = 1
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_egress_only_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "target" {
+  cidr_block                       = "10.0.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id      = aws_vpc.test.id
+  peer_vpc_id = aws_vpc.target.id
+  auto_accept = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id              = aws_route_table.test.id
+  destination_ipv6_cidr_block = %[2]q
+
+  egress_only_gateway_id    = (local.target_attr == "egress_only_gateway_id") ? local.target_value : null
+  gateway_id                = (local.target_attr == "gateway_id") ? local.target_value : null
+  instance_id               = (local.target_attr == "instance_id") ? local.target_value : null
+  local_gateway_id          = (local.target_attr == "local_gateway_id") ? local.target_value : null
+  nat_gateway_id            = (local.target_attr == "nat_gateway_id") ? local.target_value : null
+  network_interface_id      = (local.target_attr == "network_interface_id") ? local.target_value : null
+  transit_gateway_id        = (local.target_attr == "transit_gateway_id") ? local.target_value : null
+  vpc_endpoint_id           = (local.target_attr == "vpc_endpoint_id") ? local.target_value : null
+  vpc_peering_connection_id = (local.target_attr == "vpc_peering_connection_id") ? local.target_value : null
+}
+`, rName, destinationCidr, targetAttribute, targetValue))
+}
+
+func testAccAWSRouteConfigIpv4NoRoute(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccAWSRouteConfigIpv4LocalRoute(rName string) string {
+	return composeConfig(
+		testAccAWSRouteConfigIpv4NoRoute(rName),
+		fmt.Sprintf(`
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = aws_vpc.test.cidr_block
+  gateway_id             = "local"
+}
+`))
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -840,6 +840,7 @@ func validateIpv6CIDRBlock(cidr string) error {
 	return nil
 }
 
+// TODO Replace with tfnet.CIDRBlocksEqual.
 // cidrBlocksEqual returns whether or not two CIDR blocks are equal:
 // - Both CIDR blocks parse to an IP address and network
 // - The string representation of the IP addresses are equal

--- a/scripts/validate-terraform.sh
+++ b/scripts/validate-terraform.sh
@@ -25,8 +25,6 @@ rules=(
     "--only=aws_instance_previous_type"
     "--only=aws_db_instance_previous_type"
     "--only=aws_elasticache_cluster_previous_type"
-    # Prevent some configuration errors
-    "--only=aws_route_specified_multiple_targets"
 )
 while read -r filename ; do
     block_number=0

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -16,6 +16,8 @@ defined in-line. At this time you cannot use a Route Table with in-line routes
 in conjunction with any Route resources. Doing so will cause
 a conflict of rule settings and will overwrite rules.
 
+~> **NOTE on `gateway_id` attribute:** The AWS API is very forgiving with the resource ID passed in the `gateway_id` attribute. For example an `aws_route` resource can be created with an [`aws_nat_gateway`](nat_gateway.html) or [`aws_egress_only_internet_gateway`](egress_only_internet_gateway.html) ID specified for the `gateway_id` attribute. Specifying anything other than an [`aws_internet_gateway`](internet_gateway.html) or [`aws_vpn_gateway`](vpn_gateway.html) ID will lead to Terraform reporting a permanent diff between your configuration and recorded state, as the AWS API returns the more-specific attribute. If you are experiencing constant diffs with an `aws_route` resource, the first thing to check is that the correct attribute is being specified.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Builds on: #14014 
Dependents: #16961, #17291, #17295

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/684.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/2270.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11455.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/12073.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/12631.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13302.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13079.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14995.

Replaces https://github.com/terraform-providers/terraform-provider-aws/pull/14050, https://github.com/terraform-providers/terraform-provider-aws/pull/14531, https://github.com/terraform-providers/terraform-provider-aws/pull/14796, https://github.com/terraform-providers/terraform-provider-aws/pull/15049, https://github.com/hashicorp/terraform-provider-aws/pull/15723, #16219.

Uses additional tests cases from https://github.com/terraform-providers/terraform-provider-aws/pull/14014.

Includes functionality from https://github.com/terraform-providers/terraform-provider-aws/pull/12062.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSRoute_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSRoute_ -timeout 120m
=== RUN   TestAccAWSRoute_basic
=== PAUSE TestAccAWSRoute_basic
=== RUN   TestAccAWSRoute_disappears
=== PAUSE TestAccAWSRoute_disappears
=== RUN   TestAccAWSRoute_disappears_RouteTable
=== PAUSE TestAccAWSRoute_disappears_RouteTable
=== RUN   TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway
=== PAUSE TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway
=== RUN   TestAccAWSRoute_IPv6_To_InternetGateway
=== PAUSE TestAccAWSRoute_IPv6_To_InternetGateway
=== RUN   TestAccAWSRoute_IPv6_To_Instance
=== PAUSE TestAccAWSRoute_IPv6_To_Instance
=== RUN   TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached
=== PAUSE TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached
=== RUN   TestAccAWSRoute_IPv6_To_VpcPeeringConnection
=== PAUSE TestAccAWSRoute_IPv6_To_VpcPeeringConnection
=== RUN   TestAccAWSRoute_IPv6_To_VpnGateway
=== PAUSE TestAccAWSRoute_IPv6_To_VpnGateway
=== RUN   TestAccAWSRoute_IPv4_To_VpnGateway
=== PAUSE TestAccAWSRoute_IPv4_To_VpnGateway
=== RUN   TestAccAWSRoute_IPv4_To_Instance
=== PAUSE TestAccAWSRoute_IPv4_To_Instance
=== RUN   TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached
=== PAUSE TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached
=== RUN   TestAccAWSRoute_IPv4_To_NetworkInterface_Attached
=== PAUSE TestAccAWSRoute_IPv4_To_NetworkInterface_Attached
=== RUN   TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments
=== PAUSE TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments
=== RUN   TestAccAWSRoute_IPv4_To_VpcPeeringConnection
=== PAUSE TestAccAWSRoute_IPv4_To_VpcPeeringConnection
=== RUN   TestAccAWSRoute_IPv4_To_NatGateway
=== PAUSE TestAccAWSRoute_IPv4_To_NatGateway
=== RUN   TestAccAWSRoute_DoesNotCrashWithVpcEndpoint
=== PAUSE TestAccAWSRoute_DoesNotCrashWithVpcEndpoint
=== RUN   TestAccAWSRoute_IPv4_To_TransitGateway
=== PAUSE TestAccAWSRoute_IPv4_To_TransitGateway
=== RUN   TestAccAWSRoute_IPv6_To_TransitGateway
=== PAUSE TestAccAWSRoute_IPv6_To_TransitGateway
=== RUN   TestAccAWSRoute_IPv4_To_LocalGateway
=== PAUSE TestAccAWSRoute_IPv4_To_LocalGateway
=== RUN   TestAccAWSRoute_IPv6_To_LocalGateway
=== PAUSE TestAccAWSRoute_IPv6_To_LocalGateway
=== RUN   TestAccAWSRoute_ConditionalCidrBlock
=== PAUSE TestAccAWSRoute_ConditionalCidrBlock
=== RUN   TestAccAWSRoute_IPv4_Update_Target
=== PAUSE TestAccAWSRoute_IPv4_Update_Target
=== RUN   TestAccAWSRoute_IPv6_Update_Target
=== PAUSE TestAccAWSRoute_IPv6_Update_Target
=== RUN   TestAccAWSRoute_IPv4_To_VpcEndpoint
=== PAUSE TestAccAWSRoute_IPv4_To_VpcEndpoint
=== RUN   TestAccAWSRoute_LocalRoute
=== PAUSE TestAccAWSRoute_LocalRoute
=== CONT  TestAccAWSRoute_basic
=== CONT  TestAccAWSRoute_IPv4_To_VpcPeeringConnection
--- PASS: TestAccAWSRoute_IPv4_To_VpcPeeringConnection (27.43s)
=== CONT  TestAccAWSRoute_LocalRoute
--- PASS: TestAccAWSRoute_basic (36.72s)
=== CONT  TestAccAWSRoute_IPv4_To_VpcEndpoint
--- PASS: TestAccAWSRoute_LocalRoute (21.98s)
=== CONT  TestAccAWSRoute_IPv6_Update_Target
--- PASS: TestAccAWSRoute_IPv6_Update_Target (226.03s)
=== CONT  TestAccAWSRoute_IPv4_Update_Target
--- PASS: TestAccAWSRoute_IPv4_To_VpcEndpoint (273.71s)
=== CONT  TestAccAWSRoute_ConditionalCidrBlock
=== CONT  TestAccAWSRoute_IPv6_To_LocalGateway
--- PASS: TestAccAWSRoute_ConditionalCidrBlock (51.91s)
=== CONT  TestAccAWSRoute_IPv6_To_LocalGateway
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSRoute_IPv6_To_LocalGateway (1.28s)
=== CONT  TestAccAWSRoute_IPv4_To_LocalGateway
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSRoute_IPv4_To_LocalGateway (1.10s)
=== CONT  TestAccAWSRoute_IPv6_To_TransitGateway
--- PASS: TestAccAWSRoute_IPv6_To_TransitGateway (357.84s)
=== CONT  TestAccAWSRoute_IPv4_To_TransitGateway
--- PASS: TestAccAWSRoute_IPv4_Update_Target (626.78s)
=== CONT  TestAccAWSRoute_DoesNotCrashWithVpcEndpoint
--- PASS: TestAccAWSRoute_DoesNotCrashWithVpcEndpoint (43.28s)
=== CONT  TestAccAWSRoute_IPv4_To_NatGateway
--- PASS: TestAccAWSRoute_IPv4_To_TransitGateway (399.08s)
=== CONT  TestAccAWSRoute_IPv6_To_VpcPeeringConnection
--- PASS: TestAccAWSRoute_IPv6_To_VpcPeeringConnection (25.57s)
=== CONT  TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments
--- PASS: TestAccAWSRoute_IPv4_To_NatGateway (228.62s)
=== CONT  TestAccAWSRoute_IPv4_To_NetworkInterface_Attached
--- PASS: TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments (190.46s)
=== CONT  TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached
--- PASS: TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached (57.67s)
=== CONT  TestAccAWSRoute_IPv4_To_Instance
--- PASS: TestAccAWSRoute_IPv4_To_NetworkInterface_Attached (340.04s)
=== CONT  TestAccAWSRoute_IPv4_To_VpnGateway
--- PASS: TestAccAWSRoute_IPv4_To_VpnGateway (35.60s)
=== CONT  TestAccAWSRoute_IPv6_To_VpnGateway
--- PASS: TestAccAWSRoute_IPv6_To_VpnGateway (41.86s)
=== CONT  TestAccAWSRoute_IPv6_To_InternetGateway
--- PASS: TestAccAWSRoute_IPv6_To_InternetGateway (34.47s)
=== CONT  TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached
--- PASS: TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached (58.80s)
=== CONT  TestAccAWSRoute_IPv6_To_Instance
--- PASS: TestAccAWSRoute_IPv4_To_Instance (326.97s)
=== CONT  TestAccAWSRoute_disappears_RouteTable
--- PASS: TestAccAWSRoute_disappears_RouteTable (33.05s)
=== CONT  TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway
--- PASS: TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway (37.46s)
=== CONT  TestAccAWSRoute_disappears
--- PASS: TestAccAWSRoute_disappears (31.77s)
--- PASS: TestAccAWSRoute_IPv6_To_Instance (327.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2012.898s
```
