### PR TITLE
fix #16917 - changed aws transfer username validation to support 100 chars

### DIFF
--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -134,19 +134,24 @@ func TestAccAWSTransferUser_UserName_Validation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSTransferUserName_validation("!@#$%^"),
-				ExpectError: regexp.MustCompile(`Invalid "user_name": must be between 3 and 32 alphanumeric or special characters hyphen and underscore. However, "user_name" cannot begin with a hyphen`),
+				ExpectError: regexp.MustCompile(`Invalid "user_name": must be between 3 and 100 alphanumeric or special characters hyphen and underscore. However, "user_name" cannot begin with a hyphen`),
 			},
 			{
 				Config:      testAccAWSTransferUserName_validation(acctest.RandString(2)),
-				ExpectError: regexp.MustCompile(`Invalid "user_name": must be between 3 and 32 alphanumeric or special characters hyphen and underscore. However, "user_name" cannot begin with a hyphen`),
+				ExpectError: regexp.MustCompile(`Invalid "user_name": must be between 3 and 100 alphanumeric or special characters hyphen and underscore. However, "user_name" cannot begin with a hyphen`),
 			},
 			{
-				Config:      testAccAWSTransferUserName_validation(acctest.RandString(33)),
-				ExpectError: regexp.MustCompile(`Invalid "user_name": must be between 3 and 32 alphanumeric or special characters hyphen and underscore. However, "user_name" cannot begin with a hyphen`),
+				Config:             testAccAWSTransferUserName_validation(acctest.RandString(33)),
+				ExpectNonEmptyPlan: true,
+				PlanOnly:           true,
+			},
+			{
+				Config:      testAccAWSTransferUserName_validation(acctest.RandString(101)),
+				ExpectError: regexp.MustCompile(`Invalid "user_name": must be between 3 and 100 alphanumeric or special characters hyphen and underscore. However, "user_name" cannot begin with a hyphen`),
 			},
 			{
 				Config:      testAccAWSTransferUserName_validation("-abcdef"),
-				ExpectError: regexp.MustCompile(`Invalid "user_name": must be between 3 and 32 alphanumeric or special characters hyphen and underscore. However, "user_name" cannot begin with a hyphen`),
+				ExpectError: regexp.MustCompile(`Invalid "user_name": must be between 3 and 100 alphanumeric or special characters hyphen and underscore. However, "user_name" cannot begin with a hyphen`),
 			},
 			{
 				Config:             testAccAWSTransferUserName_validation("valid_username"),

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -97,8 +97,8 @@ func validateTransferServerID(v interface{}, k string) (ws []string, errors []er
 func validateTransferUserName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	// https://docs.aws.amazon.com/transfer/latest/userguide/API_CreateUser.html
-	if !regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]{2,31}$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("Invalid %q: must be between 3 and 32 alphanumeric or special characters hyphen and underscore. However, %q cannot begin with a hyphen", k, k))
+	if !regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]{2,99}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("Invalid %q: must be between 3 and 100 alphanumeric or special characters hyphen and underscore. However, %q cannot begin with a hyphen", k, k))
 	}
 	return
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #16917

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

BUG FIXES

* resource/aws_transfer_user: Ensure that user is created with more than 32 characters ([#16669](https://github.com/hashicorp/terraform-provider-aws/issues/16669))
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSTransferUser_UserName_Validation'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSTransferUser_UserName_Validation -timeout 120m
=== RUN   TestAccAWSTransferUser_UserName_Validation
=== PAUSE TestAccAWSTransferUser_UserName_Validation
=== CONT  TestAccAWSTransferUser_UserName_Validation
--- PASS: TestAccAWSTransferUser_UserName_Validation (34.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	37.024s
```
