### PR TITLE
name_regex argument for aws_wafv2_web_acl data source

### DIFF
--- a/aws/data_source_aws_wafv2_web_acl.go
+++ b/aws/data_source_aws_wafv2_web_acl.go
@@ -46,11 +46,11 @@ func dataSourceAwsWafv2WebACL() *schema.Resource {
 
 func dataSourceAwsWafv2WebACLRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafv2conn
-	name := d.Get("name").(string)
-	name_regex := d.Get("name_regex").(string)
+	name, nameOk := d.GetOk("name")
+	nameRegex, nameRegexOk := d.GetOk("name_regex")
 
-	if name == "" && name_regex == "" {
-		return fmt.Errorf("Either name or name_regex must be configured")
+	if !nameOk && !nameRegexOk {
+		return fmt.Errorf("One of name or name_regex must be assigned")
 	}
 
 	var foundWebACL *wafv2.WebACLSummary
@@ -69,8 +69,8 @@ func dataSourceAwsWafv2WebACLRead(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("Error reading WAFv2 WebACLs")
 		}
 
-		if name_regex != "" {
-			r := regexp.MustCompile(name_regex)
+		if nameRegexOk {
+			r := regexp.MustCompile(nameRegex.(string))
 			for _, webACL := range resp.WebACLs {
 				if r.MatchString(aws.StringValue(webACL.Name)) {
 					foundWebACL = webACL
@@ -79,7 +79,7 @@ func dataSourceAwsWafv2WebACLRead(d *schema.ResourceData, meta interface{}) erro
 			}
 		} else {
 			for _, webACL := range resp.WebACLs {
-				if aws.StringValue(webACL.Name) == name {
+				if aws.StringValue(webACL.Name) == name.(string) {
 					foundWebACL = webACL
 					break
 				}

--- a/aws/data_source_aws_wafv2_web_acl_test.go
+++ b/aws/data_source_aws_wafv2_web_acl_test.go
@@ -66,9 +66,9 @@ resource "aws_wafv2_web_acl" "test" {
 }
 
 data "aws_wafv2_web_acl" "test" {
-  name  = aws_wafv2_web_acl.test.name
-  scope = "REGIONAL"
-  depends_on  = [aws_wafv2_web_acl.test]
+  name       = aws_wafv2_web_acl.test.name
+  scope      = "REGIONAL"
+  depends_on = [aws_wafv2_web_acl.test]
 }
 `, name)
 }
@@ -91,9 +91,9 @@ resource "aws_wafv2_web_acl" "test" {
 }
 
 data "aws_wafv2_web_acl" "test" {
-  name_regex  = "^tf-acc-test-[0-9]+$"
-  scope       = "REGIONAL"
-  depends_on  = [aws_wafv2_web_acl.test]
+  name_regex = "^tf-acc-test-[0-9]+$"
+  scope      = "REGIONAL"
+  depends_on = [aws_wafv2_web_acl.test]
 }
 `, name)
 }

--- a/website/docs/d/wafv2_web_acl.html.markdown
+++ b/website/docs/d/wafv2_web_acl.html.markdown
@@ -23,13 +23,18 @@ data "aws_wafv2_web_acl" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the WAFv2 Web ACL.
+* `name` - (Optional) The name of the WAFv2 Web ACL.
+* `name_regex` - (Optional) A regex string to apply to the WAFv2 Web ACL list returned by AWS.
+
+~> **NOTE:** Either `name` or `name_regex` must be configured.
+
 * `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `name` - The name of the WAFv2 Web ACL.
 * `arn` - The Amazon Resource Name (ARN) of the entity.
 * `description` - The description of the WebACL that helps with identification.
 * `id` - The unique identifier of the WebACL.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
 Closes #16828

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_wafv2_web_acl: Add `name_regex` attribute (#16828)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsWafv2WebACL_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2WebACL_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2WebACL_basic
=== PAUSE TestAccDataSourceAwsWafv2WebACL_basic
=== CONT  TestAccDataSourceAwsWafv2WebACL_basic
2021/01/02 03:17:14 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:17 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:19 [WARN] Got error running Terraform: 
Error: WAFv2 WebACL not found for name: tf-acc-test-does-not-exist


2021/01/02 03:17:19 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:21 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:22 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:26 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:28 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:31 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:33 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:36 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:38 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:40 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:42 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:45 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:48 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/02 03:17:49 [INFO] Deleting WAFv2 WebACL f3cd0849-6991-4b4c-9082-5bb377a9d3ae
--- PASS: TestAccDataSourceAwsWafv2WebACL_basic (36.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       38.936s
```
