### PR TITLE
resource/aws_batch_job_definition: Add support for evaluate on exit to job retry strategy

### DIFF
--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -216,6 +217,10 @@ func TestAccAWSBatchJobDefinition_ContainerProperties_Advanced(t *testing.T) {
 		},
 		RetryStrategy: &batch.RetryStrategy{
 			Attempts: aws.Int64(int64(1)),
+			EvaluateOnExit: []*batch.EvaluateOnExit{
+				{Action: aws.String(strings.ToLower(batch.RetryActionRetry)), OnStatusReason: aws.String("Host EC2*")},
+				{Action: aws.String(strings.ToLower(batch.RetryActionExit)), OnReason: aws.String("*")},
+			},
 		},
 		Timeout: &batch.JobTimeout{
 			AttemptDurationSeconds: aws.Int64(int64(60)),
@@ -421,6 +426,9 @@ func testAccCheckBatchJobDefinitionAttributes(jd *batch.JobDefinition, compare *
 				if compare.RetryStrategy != nil && aws.Int64Value(compare.RetryStrategy.Attempts) != aws.Int64Value(jd.RetryStrategy.Attempts) {
 					return fmt.Errorf("Bad Job Definition Retry Strategy\n\t expected: %d\n\tgot: %d\n", aws.Int64Value(compare.RetryStrategy.Attempts), aws.Int64Value(jd.RetryStrategy.Attempts))
 				}
+				if compare.RetryStrategy != nil && !reflect.DeepEqual(compare.RetryStrategy.EvaluateOnExit, jd.RetryStrategy.EvaluateOnExit) {
+					return fmt.Errorf("Bad Job Definition Retry Strategy\n\t expected: %v\n\tgot: %v\n", compare.RetryStrategy.EvaluateOnExit, jd.RetryStrategy.EvaluateOnExit)
+				}
 				if compare.ContainerProperties != nil && compare.ContainerProperties.Command != nil && !reflect.DeepEqual(compare.ContainerProperties, jd.ContainerProperties) {
 					return fmt.Errorf("Bad Job Definition Container Properties\n\t expected: %s\n\tgot: %s\n", compare.ContainerProperties, jd.ContainerProperties)
 				}
@@ -473,6 +481,14 @@ resource "aws_batch_job_definition" "test" {
   }
   retry_strategy {
     attempts = 1
+    evaluate_on_exit {
+      action           = "retry"
+      on_status_reason = "Host EC2*"
+    }
+    evaluate_on_exit {
+      action    = "exit"
+      on_reason = "*"
+    }
   }
   timeout {
     attempt_duration_seconds = 60

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -482,7 +482,7 @@ resource "aws_batch_job_definition" "test" {
   retry_strategy {
     attempts = 1
     evaluate_on_exit {
-      action           = "retry"
+      action           = "RETRY"
       on_status_reason = "Host EC2*"
     }
     evaluate_on_exit {

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -122,8 +122,7 @@ The following arguments are supported:
 `retry_strategy` supports the following:
 
 * `attempts` - (Optional) The number of times to move a job to the `RUNNABLE` status. You may specify between `1` and `10` attempts.
-
-* `evaluate_on_exit` - (Optional) The [evaluate on exit](#evaluate_on_exit) conditions under which the job should be retried or failed. If this parameter is specified, then the `attempts` parameter must also be specified. You may specify up to `5`.
+* `evaluate_on_exit` - (Optional) The [evaluate on exit](#evaluate_on_exit) conditions under which the job should be retried or failed. If this parameter is specified, then the `attempts` parameter must also be specified. You may specify up to 5 configuration blocks.
 
 ## timeout
 
@@ -134,11 +133,8 @@ The following arguments are supported:
 ### evaluate_on_exit
 
 * `action` - (Required) Specifies the action to take if all of the specified conditions are met. The values are not case sensitive. Valid values: `RETRY`, `EXIT`.
-
 * `on_exit_code` - (Optional) A glob pattern to match against the decimal representation of the exit code returned for a job.
-
 * `on_reason` - (Optional) A glob pattern to match against the reason returned for a job.
-
 * `on_status_reason` - (Optional) A glob pattern to match against the status reason returned for a job.
 
 ## Attributes Reference

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -123,11 +123,23 @@ The following arguments are supported:
 
 * `attempts` - (Optional) The number of times to move a job to the `RUNNABLE` status. You may specify between `1` and `10` attempts.
 
+* `evaluate_on_exit` - (Optional) The [evaluate on exit](#evaluate_on_exit) conditions under which the job should be retried or failed. If this parameter is specified, then the `attempts` parameter must also be specified. You may specify up to `5`.
+
 ## timeout
 
 `timeout` supports the following:
 
 * `attempt_duration_seconds` - (Optional) The time duration in seconds after which AWS Batch terminates your jobs if they have not finished. The minimum value for the timeout is `60` seconds.
+
+### evaluate_on_exit
+
+* `action` - (Required) Specifies the action to take if all of the specified conditions are met. The values are not case sensitive. Valid values: `RETRY`, `EXIT`.
+
+* `on_exit_code` - (Optional) A glob pattern to match against the decimal representation of the exit code returned for a job.
+
+* `on_reason` - (Optional) A glob pattern to match against the reason returned for a job.
+
+* `on_status_reason` - (Optional) A glob pattern to match against the status reason returned for a job.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Extend the existing support for AWS Batch job definition `RetryStrategy` by adding support for `EvaluateOnExit` configurations. This allows for custom retry functionality based on job failure types (e.g., container image pull failure, underlying EC2 host failure, etc.).

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/16574

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_batch_job_definition: Add `evaluate_on_exit` support to `retry_strategy`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSBatchJobDefinition'                             
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchJobDefinition -timeout 120m
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (11.73s)
--- PASS: TestAccAWSBatchJobDefinition_basic (11.82s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (23.73s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (26.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	26.265s
```
