### PR TITLE
resource/aws_ecs_capacity_provider: Add support for instance warmup period

### DIFF
--- a/aws/resource_aws_ecs_capacity_provider.go
+++ b/aws/resource_aws_ecs_capacity_provider.go
@@ -68,7 +68,7 @@ func resourceAwsEcsCapacityProvider() *schema.Resource {
 										Optional:     true,
 										Computed:     true,
 										ForceNew:     true,
-										ValidateFunc: validation.IntAtLeast(1),
+										ValidateFunc: validation.IntBetween(1, 10000),
 									},
 									"maximum_scaling_step_size": {
 										Type:         schema.TypeInt,

--- a/aws/resource_aws_ecs_capacity_provider.go
+++ b/aws/resource_aws_ecs_capacity_provider.go
@@ -63,6 +63,13 @@ func resourceAwsEcsCapacityProvider() *schema.Resource {
 							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"instance_warmup_period": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Computed:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.IntAtLeast(1),
+									},
 									"maximum_scaling_step_size": {
 										Type:         schema.TypeInt,
 										Optional:     true,
@@ -248,6 +255,9 @@ func expandAutoScalingGroupProvider(configured interface{}) *ecs.AutoScalingGrou
 		ms := v[0].(map[string]interface{})
 		managedScaling := ecs.ManagedScaling{}
 
+		if val, ok := ms["instance_warmup_period"].(int); ok && val != 0 {
+			managedScaling.InstanceWarmupPeriod = aws.Int64(int64(val))
+		}
 		if val, ok := ms["maximum_scaling_step_size"].(int); ok && val != 0 {
 			managedScaling.MaximumScalingStepSize = aws.Int64(int64(val))
 		}
@@ -279,6 +289,7 @@ func flattenAutoScalingGroupProvider(provider *ecs.AutoScalingGroupProvider) []m
 
 	if provider.ManagedScaling != nil {
 		m := map[string]interface{}{
+			"instance_warmup_period":    aws.Int64Value(provider.ManagedScaling.InstanceWarmupPeriod),
 			"maximum_scaling_step_size": aws.Int64Value(provider.ManagedScaling.MaximumScalingStepSize),
 			"minimum_scaling_step_size": aws.Int64Value(provider.ManagedScaling.MinimumScalingStepSize),
 			"status":                    aws.StringValue(provider.ManagedScaling.Status),

--- a/aws/resource_aws_ecs_capacity_provider_test.go
+++ b/aws/resource_aws_ecs_capacity_provider_test.go
@@ -117,6 +117,7 @@ func TestAccAWSEcsCapacityProvider_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "auto_scaling_group_provider.0.auto_scaling_group_arn", "aws_autoscaling_group.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_termination_protection", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.instance_warmup_period", "300"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.minimum_scaling_step_size", "1"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.maximum_scaling_step_size", "10000"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.status", "DISABLED"),
@@ -172,6 +173,7 @@ func TestAccAWSEcsCapacityProvider_ManagedScaling(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "auto_scaling_group_provider.0.auto_scaling_group_arn", "aws_autoscaling_group.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_termination_protection", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.instance_warmup_period", "400"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.minimum_scaling_step_size", "2"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.maximum_scaling_step_size", "10"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.status", "ENABLED"),
@@ -205,6 +207,7 @@ func TestAccAWSEcsCapacityProvider_ManagedScalingPartial(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "auto_scaling_group_provider.0.auto_scaling_group_arn", "aws_autoscaling_group.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_termination_protection", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.instance_warmup_period", "300"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.minimum_scaling_step_size", "2"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.maximum_scaling_step_size", "10000"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.status", "ENABLED"),
@@ -397,6 +400,7 @@ resource "aws_ecs_capacity_provider" "test" {
     auto_scaling_group_arn = aws_autoscaling_group.test.arn
 
     managed_scaling {
+      instance_warmup_period    = 400
       maximum_scaling_step_size = 10
       minimum_scaling_step_size = 2
       status                    = "ENABLED"

--- a/website/docs/r/ecs_capacity_provider.html.markdown
+++ b/website/docs/r/ecs_capacity_provider.html.markdown
@@ -62,6 +62,7 @@ The `auto_scaling_group_provider` block supports the following:
 
 The `managed_scaling` block supports the following:
 
+* `instance_warmup_period` - (Optional) The period of time, in seconds, after a newly launched Amazon EC2 instance can contribute to CloudWatch metrics for Auto Scaling group. If this parameter is omitted, the default value of 300 seconds is used.
 * `maximum_scaling_step_size` - (Optional) The maximum step adjustment size. A number between 1 and 10,000.
 * `minimum_scaling_step_size` - (Optional) The minimum step adjustment size. A number between 1 and 10,000.
 * `status` - (Optional) Whether auto scaling is managed by ECS. Valid values are `ENABLED` and `DISABLED`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/16673

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ecs_capacity_provider: Add support for instance warmup period
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccAWSEcsCapacityProvider_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEcsCapacityProvider_* -timeout 120m
=== RUN   TestAccAWSEcsCapacityProvider_basic
=== PAUSE TestAccAWSEcsCapacityProvider_basic
=== RUN   TestAccAWSEcsCapacityProvider_disappears
=== PAUSE TestAccAWSEcsCapacityProvider_disappears
=== RUN   TestAccAWSEcsCapacityProvider_ManagedScaling
=== PAUSE TestAccAWSEcsCapacityProvider_ManagedScaling
=== RUN   TestAccAWSEcsCapacityProvider_ManagedScalingPartial
=== PAUSE TestAccAWSEcsCapacityProvider_ManagedScalingPartial
=== RUN   TestAccAWSEcsCapacityProvider_Tags
=== PAUSE TestAccAWSEcsCapacityProvider_Tags
=== CONT  TestAccAWSEcsCapacityProvider_basic
=== CONT  TestAccAWSEcsCapacityProvider_ManagedScalingPartial
=== CONT  TestAccAWSEcsCapacityProvider_ManagedScaling
=== CONT  TestAccAWSEcsCapacityProvider_disappears
=== CONT  TestAccAWSEcsCapacityProvider_Tags
--- PASS: TestAccAWSEcsCapacityProvider_ManagedScalingPartial (66.75s)
--- PASS: TestAccAWSEcsCapacityProvider_ManagedScaling (66.82s)
--- PASS: TestAccAWSEcsCapacityProvider_disappears (68.01s)
--- PASS: TestAccAWSEcsCapacityProvider_basic (85.37s)
--- PASS: TestAccAWSEcsCapacityProvider_Tags (137.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	139.787s
```

Thank you for your review! 👍 