### PR TITLE
status argument for data.aws_db_cluster_snapshot and data.aws_db_snapshot

### DIFF
--- a/aws/data_source_aws_db_cluster_snapshot_test.go
+++ b/aws/data_source_aws_db_cluster_snapshot_test.go
@@ -342,7 +342,7 @@ resource "aws_db_cluster_snapshot" "test" {
 data "aws_db_cluster_snapshot" "test" {
   db_cluster_identifier = aws_db_cluster_snapshot.test.db_cluster_identifier
   most_recent           = true
-  status				= "%[2]s"
+  status                = "%[2]s"
 }
 `, rName, status)
 }

--- a/aws/data_source_aws_db_snapshot_test.go
+++ b/aws/data_source_aws_db_snapshot_test.go
@@ -128,8 +128,8 @@ resource "aws_db_snapshot" "incorrect" {
 }
 
 resource "aws_db_snapshot" "test" {
-	db_instance_identifier = aws_db_snapshot.incorrect.db_instance_identifier
-	db_snapshot_identifier = "testsnapshot%[1]d"
-  }
+  db_instance_identifier = aws_db_snapshot.incorrect.db_instance_identifier
+  db_snapshot_identifier = "testsnapshot%[1]d"
+}
 `, rInt, status)
 }

--- a/website/docs/d/db_cluster_snapshot.html.markdown
+++ b/website/docs/d/db_cluster_snapshot.html.markdown
@@ -61,6 +61,8 @@ The default is `false`.
 * `include_public` - (Optional) Set this value to true to include manual DB Cluster Snapshots that are public and can be
 copied or restored by any AWS account, otherwise set this value to false. The default is `false`.
 
+* `status` - (Optional) The status of DB Cluster Snapshot.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -77,7 +79,6 @@ In addition to all arguments above, the following attributes are exported:
 * `port` - Port that the DB cluster was listening on at the time of the snapshot.
 * `snapshot_create_time` - Time when the snapshot was taken, in Universal Coordinated Time (UTC).
 * `source_db_cluster_snapshot_identifier` - The DB Cluster Snapshot Arn that the DB Cluster Snapshot was copied from. It only has value in case of cross customer or cross region copy.
-* `status` - The status of this DB Cluster Snapshot.
 * `storage_encrypted` - Specifies whether the DB cluster snapshot is encrypted.
 * `vpc_id` - The VPC ID associated with the DB cluster snapshot.
 * `tags` - A map of tags for the resource.

--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -69,6 +69,7 @@ The default is `false`.
 * `include_public` - (Optional) Set this value to true to include manual DB snapshots that are public and can be
 copied or restored by any AWS account, otherwise set this value to false. The default is `false`.
 
+* `status` - (Optional) The status of this DB snapshot.
 
 ## Attributes Reference
 
@@ -87,7 +88,6 @@ In addition to all arguments above, the following attributes are exported:
 * `option_group_name` - Provides the option group name for the DB snapshot.
 * `source_db_snapshot_identifier` - The DB snapshot Arn that the DB snapshot was copied from. It only has value in case of cross customer or cross region copy.
 * `source_region` - The region that the DB snapshot was created in or copied from.
-* `status` - Specifies the status of this DB snapshot.
 * `storage_type` - Specifies the storage type associated with DB snapshot.
 * `vpc_id` - Specifies the ID of the VPC associated with the DB snapshot.
 * `snapshot_create_time` - Provides the time when the snapshot was taken, in Universal Coordinated Time (UTC).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16266

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_db_cluster_snapshot: Add `status` attribute (#16266)
data-source/aws_db_snapshot: Add `status` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDbSnapshotDataSource_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDbSnapshotDataSource_basic -timeout 120m
=== RUN   TestAccAWSDbSnapshotDataSource_basic
=== PAUSE TestAccAWSDbSnapshotDataSource_basic
=== CONT  TestAccAWSDbSnapshotDataSource_basic
2021/01/03 18:59:52 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 18:59:54 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 18:59:56 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 18:59:57 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 19:00:01 [INFO] Waiting for DB Instance (terraform-20210103175959357600000001) to be available
2021/01/03 19:06:32 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 19:06:35 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 19:06:39 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 19:06:42 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 19:06:44 [INFO] Waiting for DB Instance to be destroyed
--- PASS: TestAccAWSDbSnapshotDataSource_basic (643.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       647.092s
...

$ make testacc TESTARGS='-run=TestAccAWSDbSnapshotDataSource_withStatus'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDbSnapshotDataSource_withStatus -timeout 120m
=== RUN   TestAccAWSDbSnapshotDataSource_withStatus
=== PAUSE TestAccAWSDbSnapshotDataSource_withStatus
=== CONT  TestAccAWSDbSnapshotDataSource_withStatus
2021/01/03 20:20:44 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 20:20:48 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 20:20:50 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 20:20:52 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 20:20:54 [INFO] Waiting for DB Instance (terraform-20210103192053480600000001) to be available
2021/01/03 20:32:20 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 20:32:23 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 20:32:28 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 20:32:31 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 20:32:36 [WARN] Got error running Terraform: 
Error: Your query returned no results. Please change your search criteria and try again.


2021/01/03 20:32:36 [INFO] AWS Auth provider used: "EnvProvider"
2021/01/03 20:32:39 [INFO] Waiting for DB Instance to be destroyed
--- PASS: TestAccAWSDbSnapshotDataSource_withStatus (946.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       950.085s
```
