### PR TITLE
feature: Add working_directory to ImageBuilder

### DIFF
--- a/aws/data_source_aws_imagebuilder_image_recipe.go
+++ b/aws/data_source_aws_imagebuilder_image_recipe.go
@@ -116,6 +116,10 @@ func dataSourceAwsImageBuilderImageRecipe() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"working_directory": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -154,6 +158,7 @@ func dataSourceAwsImageBuilderImageRecipeRead(d *schema.ResourceData, meta inter
 	d.Set("platform", imageRecipe.Platform)
 	d.Set("tags", keyvaluetags.ImagebuilderKeyValueTags(imageRecipe.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map())
 	d.Set("version", imageRecipe.Version)
+	d.Set("working_directory", imageRecipe.WorkingDirectory)
 
 	return nil
 }

--- a/aws/data_source_aws_imagebuilder_image_recipe_test.go
+++ b/aws/data_source_aws_imagebuilder_image_recipe_test.go
@@ -59,6 +59,7 @@ resource "aws_imagebuilder_component" "test" {
     }]
     schemaVersion = 1.0
   })
+  working_directory = "/tmp"
   name     = %[1]q
   platform = "Linux"
   version  = "1.0.0"

--- a/aws/resource_aws_imagebuilder_image_recipe.go
+++ b/aws/resource_aws_imagebuilder_image_recipe.go
@@ -174,7 +174,7 @@ func resourceAwsImageBuilderImageRecipe() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
+				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 		},
 	}

--- a/aws/resource_aws_imagebuilder_image_recipe.go
+++ b/aws/resource_aws_imagebuilder_image_recipe.go
@@ -170,6 +170,12 @@ func resourceAwsImageBuilderImageRecipe() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 128),
 			},
+			"working_directory": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 128),
+			},
 		},
 	}
 }
@@ -207,6 +213,9 @@ func resourceAwsImageBuilderImageRecipeCreate(d *schema.ResourceData, meta inter
 
 	if v, ok := d.GetOk("version"); ok {
 		input.SemanticVersion = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("working_directory"); ok {
+		input.WorkingDirectory = aws.String(v.(string))
 	}
 
 	output, err := conn.CreateImageRecipe(input)
@@ -261,6 +270,7 @@ func resourceAwsImageBuilderImageRecipeRead(d *schema.ResourceData, meta interfa
 	d.Set("platform", imageRecipe.Platform)
 	d.Set("tags", keyvaluetags.ImagebuilderKeyValueTags(imageRecipe.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map())
 	d.Set("version", imageRecipe.Version)
+	d.Set("working_directory", imageRecipe.WorkingDirectory)
 
 	return nil
 }

--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -48,6 +48,7 @@ The following attributes are optional:
 * `block_device_mapping` - (Optional) Configuration block(s) with block device mappings for the the image recipe. Detailed below.
 * `description` - (Optional) Description of the image recipe.
 * `tags` - (Optional) Key-value map of resource tags for the image recipe.
+* `working_directory` - (Optional) The working directory to be used during build and test workflows.
 
 ### block_device_mapping
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16946

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Additional Property "working_directory"
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
