### PR TITLE
.github/workflows: Increase goreleaser timeout from 1h to 2h

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -300,7 +300,7 @@ jobs:
       - name: goreleaser build
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: build --snapshot --timeout 1h
+          args: build --snapshot --timeout 2h
 
   semgrep:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

As part of submission checks, we run cross-compilation builds on all release ports to catch unexpected 32-bit architecture (e.g. integer overflows) and kernel specific code (e.g. upstream libraries missing kernel implementations).

In [failed builds](https://github.com/hashicorp/terraform-provider-aws/pull/16935/checks?check_run_id=1644053191), its hitting the timeout argument deadline without completing any builds:

```
2021-01-04T13:45:49.6869555Z [34m[1m   •[0m [1mbuilding binaries[0m[0m
2021-01-04T13:45:49.6871325Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_windows_amd64/terraform-provider-aws_v0.0.0-SNAPSHOT-9232ddf.exe
2021-01-04T13:45:49.6873982Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_linux_386/terraform-provider-aws_v0.0.0-SNAPSHOT-9232ddf
2021-01-04T13:45:49.6876550Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_darwin_amd64/terraform-provider-aws_v0.0.0-SNAPSHOT-9232ddf
2021-01-04T13:45:49.6879137Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_freebsd_386/terraform-provider-aws_v0.0.0-SNAPSHOT-9232ddf
2021-01-04T14:45:41.0926325Z [31m[1m      ⨯[0m [1mbuild failed after 3605.00s[0m[0m [31merror[0m=context deadline exceeded
2021-01-04T14:45:42.0956772Z ##[error]The process '/opt/hostedtoolcache/goreleaser-action/0.151.1/x64/goreleaser' failed with exit code 1
```

In [other successful builds](https://github.com/hashicorp/terraform-provider-aws/runs/1640560741?check_suite_focus=true), it finishes much more timely:

```
2021-01-03T19:42:34.6949476Z [34m[1m   •[0m [1mbuilding binaries[0m[0m
2021-01-03T19:42:34.6951506Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_windows_amd64/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48.exe
2021-01-03T19:42:34.6955124Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_linux_386/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48
2021-01-03T19:42:34.6958777Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_darwin_amd64/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48
2021-01-03T19:42:34.6962514Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_freebsd_386/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48
2021-01-03T20:00:50.5974306Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_freebsd_amd64/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48
2021-01-03T20:00:51.5547377Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_freebsd_arm_6/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48
2021-01-03T20:01:01.6084587Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_freebsd_arm64/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48
2021-01-03T20:02:16.4995804Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_linux_arm64/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48
2021-01-03T20:12:32.2856869Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_linux_amd64/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48
2021-01-03T20:14:57.1041524Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_linux_arm_6/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48
2021-01-03T20:15:36.7230782Z [34m[1m      •[0m building                 [0m [34mbinary[0m=/home/runner/work/terraform-provider-aws/terraform-provider-aws/dist/terraform-provider-aws_windows_386/terraform-provider-aws_v0.0.0-SNAPSHOT-9685f48.exe
2021-01-03T20:21:14.9668628Z [34m[1m   •[0m [1mbuild succeeded after 2339.43s[0m[0m
```

Assuming there is not a deadlock in `goreleaser` or `go build`, there could just be contention on GitHub Actions build hosts. For now, just increase the timeout unless other solutions are necessary.

Output from acceptance testing: N/A (CI testing)
