### PR TITLE
resource/gamelift: Fix hardcoded regions

### DIFF
--- a/aws/resource_aws_gamelift_alias_test.go
+++ b/aws/resource_aws_gamelift_alias_test.go
@@ -92,7 +92,11 @@ func TestAccAWSGameliftAlias_basic(t *testing.T) {
 	uMessage := fmt.Sprintf("tf test updated message %s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftAliasDestroy,
 		Steps: []resource.TestStep{
@@ -138,7 +142,11 @@ func TestAccAWSGameliftAlias_tags(t *testing.T) {
 	aliasName := acctest.RandomWithPrefix("tf-acc-alias")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftAliasDestroy,
 		Steps: []resource.TestStep{
@@ -207,7 +215,11 @@ func TestAccAWSGameliftAlias_fleetRouting(t *testing.T) {
 	resourceName := "aws_gamelift_alias.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftAliasDestroy,
 		Steps: []resource.TestStep{
@@ -244,7 +256,11 @@ func TestAccAWSGameliftAlias_disappears(t *testing.T) {
 	message := fmt.Sprintf("tf test message %s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftAliasDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_gamelift_build_test.go
+++ b/aws/resource_aws_gamelift_build_test.go
@@ -85,7 +85,11 @@ func TestAccAWSGameliftBuild_basic(t *testing.T) {
 	key := *loc.Key
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftBuildDestroy,
 		Steps: []resource.TestStep{
@@ -145,7 +149,11 @@ func TestAccAWSGameliftBuild_tags(t *testing.T) {
 	key := *loc.Key
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftBuildDestroy,
 		Steps: []resource.TestStep{
@@ -203,7 +211,11 @@ func TestAccAWSGameliftBuild_disappears(t *testing.T) {
 	key := *loc.Key
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftBuildDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_gamelift_fleet_test.go
+++ b/aws/resource_aws_gamelift_fleet_test.go
@@ -261,7 +261,11 @@ func TestAccAWSGameliftFleet_basic(t *testing.T) {
 	resourceName := "aws_gamelift_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftFleetDestroy,
 		Steps: []resource.TestStep{
@@ -338,7 +342,11 @@ func TestAccAWSGameliftFleet_tags(t *testing.T) {
 	resourceName := "aws_gamelift_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftFleetDestroy,
 		Steps: []resource.TestStep{
@@ -403,7 +411,11 @@ func TestAccAWSGameliftFleet_allFields(t *testing.T) {
 	resourceName := "aws_gamelift_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftFleetDestroy,
 		Steps: []resource.TestStep{
@@ -516,7 +528,11 @@ func TestAccAWSGameliftFleet_disappears(t *testing.T) {
 	resourceName := "aws_gamelift_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftFleetDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_gamelift_game_session_queue_test.go
+++ b/aws/resource_aws_gamelift_game_session_queue_test.go
@@ -93,7 +93,11 @@ func TestAccAWSGameliftGameSessionQueue_basic(t *testing.T) {
 	uTimeoutInSeconds := int64(600)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftGameSessionQueueDestroy,
 		Steps: []resource.TestStep{
@@ -152,7 +156,11 @@ func TestAccAWSGameliftGameSessionQueue_tags(t *testing.T) {
 	queueName := testAccGameliftGameSessionQueuePrefix + acctest.RandString(8)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftGameSessionQueueDestroy,
 		Steps: []resource.TestStep{
@@ -208,7 +216,11 @@ func TestAccAWSGameliftGameSessionQueue_disappears(t *testing.T) {
 	timeoutInSeconds := int64(124)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(gamelift.EndpointsID, t)
+			testAccPreCheckAWSGamelift(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftGameSessionQueueDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_gamelift_test.go
+++ b/aws/resource_aws_gamelift_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -45,20 +46,20 @@ func testAccAWSGameliftSampleGame(region string) (*testAccGameliftGame, error) {
 // Account ID found from CloudTrail event (role ARN) after finishing tutorial in given region
 func testAccGameliftAccountIdByRegion(region string) (string, error) {
 	m := map[string]string{
-		"ap-northeast-1": "120069834884",
-		"ap-northeast-2": "805673136642",
-		"ap-south-1":     "134975661615",
-		"ap-southeast-1": "077577004113",
-		"ap-southeast-2": "112188327105",
-		"ca-central-1":   "800535022691",
-		"eu-central-1":   "797584052317",
-		"eu-west-1":      "319803218673",
-		"eu-west-2":      "937342764187",
-		"sa-east-1":      "028872612690",
-		"us-east-1":      "783764748367",
-		"us-east-2":      "415729564621",
-		"us-west-1":      "715879310420",
-		"us-west-2":      "741061592171",
+		endpoints.ApNortheast1RegionID: "120069834884",
+		endpoints.ApNortheast2RegionID: "805673136642",
+		endpoints.ApSouth1RegionID:     "134975661615",
+		endpoints.ApSoutheast1RegionID: "077577004113",
+		endpoints.ApSoutheast2RegionID: "112188327105",
+		endpoints.CaCentral1RegionID:   "800535022691",
+		endpoints.EuCentral1RegionID:   "797584052317",
+		endpoints.EuWest1RegionID:      "319803218673",
+		endpoints.EuWest2RegionID:      "937342764187",
+		endpoints.SaEast1RegionID:      "028872612690",
+		endpoints.UsEast1RegionID:      "783764748367",
+		endpoints.UsEast2RegionID:      "415729564621",
+		endpoints.UsWest1RegionID:      "715879310420",
+		endpoints.UsWest2RegionID:      "741061592171",
 	}
 
 	if accId, ok := m[region]; ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Acceptance Tests in GovCloud

```
--- SKIP: TestAccAWSGameliftAlias_fleetRouting (0.00s)
--- SKIP: TestAccAWSGameliftBuild_basic (0.00s)
--- SKIP: TestAccAWSGameliftBuild_tags (0.00s)
--- SKIP: TestAccAWSGameliftBuild_disappears (0.00s)
--- SKIP: TestAccAWSGameliftFleet_basic (0.00s)
--- SKIP: TestAccAWSGameliftFleet_tags (0.00s)
--- SKIP: TestAccAWSGameliftFleet_allFields (0.00s)
--- SKIP: TestAccAWSGameliftFleet_disappears (0.00s)
--- SKIP: TestAccAWSGameliftGameSessionQueue_basic (1.28s)
--- SKIP: TestAccAWSGameliftGameSessionQueue_tags (0.00s)
--- SKIP: TestAccAWSGameliftGameSessionQueue_disappears (0.00s)
--- SKIP: TestAccAWSGameliftAlias_basic (0.00s)
--- SKIP: TestAccAWSGameliftAlias_disappears (0.00s)
--- SKIP: TestAccAWSGameliftAlias_tags (0.00s)
```

### Acceptance Tests in `us-west-2`

```
--- PASS: TestAccAWSGameliftGameSessionQueue_basic (22.91s)
--- PASS: TestAccAWSGameliftGameSessionQueue_tags (31.81s)
--- PASS: TestAccAWSGameliftGameSessionQueue_disappears (8.84s)
--- PASS: TestAccAWSGameliftAlias_disappears (10.24s)
--- PASS: TestAccAWSGameliftBuild_disappears (10.63s)
--- PASS: TestAccAWSGameliftBuild_basic (25.04s)
--- PASS: TestAccAWSGameliftAlias_tags (32.88s)
--- PASS: TestAccAWSGameliftAlias_basic (32.89s)
--- PASS: TestAccAWSGameliftBuild_tags (34.45s)
--- PASS: TestAccAWSGameliftFleet_disappears (1723.46s)
--- PASS: TestAccAWSGameliftFleet_allFields (1725.07s)
--- PASS: TestAccAWSGameliftFleet_basic (1838.65s)
--- PASS: TestAccAWSGameliftFleet_tags (1870.37s)
--- PASS: TestAccAWSGameliftAlias_fleetRouting (1926.44s)
```

### Acceptance Tests in `us-east-1`

```
--- PASS: TestAccAWSGameliftGameSessionQueue_basic (22.35s)
--- PASS: TestAccAWSGameliftGameSessionQueue_tags (18.98s)
--- PASS: TestAccAWSGameliftGameSessionQueue_disappears (5.46s)
--- PASS: TestAccAWSGameliftAlias_disappears (7.04s)
--- PASS: TestAccAWSGameliftBuild_disappears (7.35s)
--- PASS: TestAccAWSGameliftBuild_basic (15.71s)
--- PASS: TestAccAWSGameliftAlias_basic (24.10s)
--- PASS: TestAccAWSGameliftBuild_tags (35.27s)
--- PASS: TestAccAWSGameliftAlias_tags (41.65s)
--- PASS: TestAccAWSGameliftFleet_tags (1633.98s)
--- PASS: TestAccAWSGameliftFleet_disappears (1705.76s)
--- PASS: TestAccAWSGameliftFleet_allFields (1721.55s)
--- PASS: TestAccAWSGameliftFleet_basic (1728.27s)
--- PASS: TestAccAWSGameliftAlias_fleetRouting (1735.22s)
```