### PR TITLE
resource/eks_fargate_profile: Fix hardcoded regions

### DIFF
--- a/aws/resource_aws_eks_fargate_profile_test.go
+++ b/aws/resource_aws_eks_fargate_profile_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/eks"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -338,14 +339,24 @@ func testAccPreCheckAWSEksFargateProfile(t *testing.T) {
 	// create and destroy an EKS Cluster just to find the real error, instead
 	// we take the least desirable approach of hardcoding allowed regions.
 	allowedRegions := []string{
-		"ap-northeast-1",
-		"ap-southeast-1",
-		"ap-southeast-2",
-		"eu-central-1",
-		"eu-west-1",
-		"us-east-1",
-		"us-east-2",
-		"us-west-2",
+		endpoints.ApEast1RegionID,
+		endpoints.ApNortheast1RegionID,
+		endpoints.ApNortheast2RegionID,
+		endpoints.ApSouth1RegionID,
+		endpoints.ApSoutheast1RegionID,
+		endpoints.ApSoutheast2RegionID,
+		endpoints.CaCentral1RegionID,
+		endpoints.EuCentral1RegionID,
+		endpoints.EuNorth1RegionID,
+		endpoints.EuWest1RegionID,
+		endpoints.EuWest2RegionID,
+		endpoints.EuWest3RegionID,
+		endpoints.MeSouth1RegionID,
+		endpoints.SaEast1RegionID,
+		endpoints.UsEast1RegionID,
+		endpoints.UsEast2RegionID,
+		endpoints.UsWest1RegionID,
+		endpoints.UsWest2RegionID,
 	}
 	region := testAccProvider.Meta().(*AWSClient).region
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Acceptance Tests in GovCloud

```
--- SKIP: TestAccAWSEksFargateProfile_basic (1.75s)
--- SKIP: TestAccAWSEksFargateProfile_disappears (1.74s)
--- SKIP: TestAccAWSEksFargateProfile_Multi_Profile (1.74s)
--- SKIP: TestAccAWSEksFargateProfile_Selector_Labels (1.73s)
--- SKIP: TestAccAWSEksFargateProfile_Tags (1.72s)
```

### Acceptance Tests in `us-west-2`

Unrelated, flaky failures.

```
--- PASS: TestAccAWSEksFargateProfile_basic (1173.06s)
--- PASS: TestAccAWSEksFargateProfile_disappears (1285.90s)
--- FAIL: TestAccAWSEksFargateProfile_Multi_Profile (1300.08s)
--- PASS: TestAccAWSEksFargateProfile_Selector_Labels (1319.37s)
--- FAIL: TestAccAWSEksFargateProfile_Tags (1434.58s)
```

### Acceptance Tests in `us-east-1`

Unrelated, flaky failures.

```
--- FAIL: TestAccAWSEksFargateProfile_Selector_Labels (945.68s)
--- PASS: TestAccAWSEksFargateProfile_disappears (1121.45s)
--- PASS: TestAccAWSEksFargateProfile_Tags (1297.30s)
--- PASS: TestAccAWSEksFargateProfile_Multi_Profile (1335.34s)
--- PASS: TestAccAWSEksFargateProfile_basic (1337.71s)
```