### PR TITLE
d/aws_route: AWS Wavelength support

### DIFF
--- a/.changelog/16963.txt
+++ b/.changelog/16963.txt
@@ -1,0 +1,3 @@
+```release-notes:enhancement
+data-source/aws_route: Add `carrier_gateway_id` attribute
+```

--- a/aws/data_source_aws_route.go
+++ b/aws/data_source_aws_route.go
@@ -2,12 +2,12 @@ package aws
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
 func dataSourceAwsRoute() *schema.Resource {
@@ -19,52 +19,74 @@ func dataSourceAwsRoute() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
+			///
+			// Destinations.
+			///
 			"destination_cidr_block": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
+
 			"destination_ipv6_cidr_block": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
+
+			//
+			// Targets.
+			//
+			"carrier_gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"egress_only_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
+
 			"gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
+
 			"instance_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"nat_gateway_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+
 			"local_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
+
+			"nat_gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"network_interface_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"transit_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
+
 			"vpc_peering_connection_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"network_interface_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -75,63 +97,19 @@ func dataSourceAwsRoute() *schema.Resource {
 
 func dataSourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	req := &ec2.DescribeRouteTablesInput{}
-	rtbId := d.Get("route_table_id")
-	cidr := d.Get("destination_cidr_block")
-	ipv6Cidr := d.Get("destination_ipv6_cidr_block")
 
-	req.Filters = buildEC2AttributeFilterList(
-		map[string]string{
-			"route-table-id":                    rtbId.(string),
-			"route.destination-cidr-block":      cidr.(string),
-			"route.destination-ipv6-cidr-block": ipv6Cidr.(string),
-		},
-	)
+	routeTableID := d.Get("route_table_id").(string)
 
-	log.Printf("[DEBUG] Reading Route Table: %s", req)
-	resp, err := conn.DescribeRouteTables(req)
+	routeTable, err := finder.RouteTableByID(conn, routeTableID)
+
 	if err != nil {
-		return err
-	}
-	if resp == nil || len(resp.RouteTables) == 0 {
-		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
-	}
-	if len(resp.RouteTables) > 1 {
-		return fmt.Errorf("Your query returned more than one route table. Please change your search criteria and try again.")
+		return fmt.Errorf("error reading Route Table (%s): %w", routeTableID, err)
 	}
 
-	results := getRoutes(resp.RouteTables[0], d)
+	routes := []*ec2.Route{}
 
-	if len(results) == 0 {
-		return fmt.Errorf("No routes matching supplied arguments found in table(s)")
-	}
-	if len(results) > 1 {
-		return fmt.Errorf("Multiple routes matched; use additional constraints to reduce matches to a single route")
-	}
-	route := results[0]
-
-	d.SetId(resourceAwsRouteID(d, route)) // using function from "resource_aws_route.go"
-	d.Set("destination_cidr_block", route.DestinationCidrBlock)
-	d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)
-	d.Set("egress_only_gateway_id", route.EgressOnlyInternetGatewayId)
-	d.Set("gateway_id", route.GatewayId)
-	d.Set("instance_id", route.InstanceId)
-	d.Set("nat_gateway_id", route.NatGatewayId)
-	d.Set("local_gateway_id", route.LocalGatewayId)
-	d.Set("transit_gateway_id", route.TransitGatewayId)
-	d.Set("vpc_peering_connection_id", route.VpcPeeringConnectionId)
-	d.Set("network_interface_id", route.NetworkInterfaceId)
-
-	return nil
-}
-
-func getRoutes(table *ec2.RouteTable, d *schema.ResourceData) []*ec2.Route {
-	ec2Routes := table.Routes
-	routes := make([]*ec2.Route, 0, len(ec2Routes))
-	// Loop through the routes and add them to the set
-	for _, r := range ec2Routes {
-
-		if r.Origin != nil && *r.Origin == "EnableVgwRoutePropagation" {
+	for _, r := range routeTable.Routes {
+		if aws.StringValue(r.Origin) == ec2.RouteOriginEnableVgwRoutePropagation {
 			continue
 		}
 
@@ -141,79 +119,79 @@ func getRoutes(table *ec2.RouteTable, d *schema.ResourceData) []*ec2.Route {
 			continue
 		}
 
-		if v, ok := d.GetOk("destination_cidr_block"); ok {
-			if r.DestinationCidrBlock == nil || *r.DestinationCidrBlock != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("destination_cidr_block"); ok && aws.StringValue(r.DestinationCidrBlock) != v.(string) {
+			continue
 		}
 
-		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-			if r.DestinationIpv6CidrBlock == nil || *r.DestinationIpv6CidrBlock != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok && aws.StringValue(r.DestinationIpv6CidrBlock) != v.(string) {
+			continue
 		}
 
-		if v, ok := d.GetOk("egress_only_gateway_id"); ok {
-			if r.EgressOnlyInternetGatewayId == nil || *r.EgressOnlyInternetGatewayId != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("carrier_gateway_id"); ok && aws.StringValue(r.CarrierGatewayId) != v.(string) {
+			continue
 		}
 
-		if v, ok := d.GetOk("gateway_id"); ok {
-			if r.GatewayId == nil || *r.GatewayId != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("egress_only_gateway_id"); ok && aws.StringValue(r.EgressOnlyInternetGatewayId) != v.(string) {
+			continue
 		}
 
-		if v, ok := d.GetOk("instance_id"); ok {
-			if r.InstanceId == nil || *r.InstanceId != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("gateway_id"); ok && aws.StringValue(r.GatewayId) != v.(string) {
+			continue
 		}
 
-		if v, ok := d.GetOk("nat_gateway_id"); ok {
-			if r.NatGatewayId == nil || *r.NatGatewayId != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("instance_id"); ok && aws.StringValue(r.InstanceId) != v.(string) {
+			continue
 		}
 
-		if v, ok := d.GetOk("local_gateway_id"); ok {
-			if r.LocalGatewayId == nil || *r.LocalGatewayId != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("local_gateway_id"); ok && aws.StringValue(r.LocalGatewayId) != v.(string) {
+			continue
 		}
 
-		if v, ok := d.GetOk("transit_gateway_id"); ok {
-			if r.TransitGatewayId == nil || *r.TransitGatewayId != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("nat_gateway_id"); ok && aws.StringValue(r.NatGatewayId) != v.(string) {
+			continue
 		}
 
-		if v, ok := d.GetOk("vpc_peering_connection_id"); ok {
-			if r.VpcPeeringConnectionId == nil || *r.VpcPeeringConnectionId != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("network_interface_id"); ok && aws.StringValue(r.NetworkInterfaceId) != v.(string) {
+			continue
 		}
 
-		if v, ok := d.GetOk("network_interface_id"); ok {
-			if r.NetworkInterfaceId == nil || *r.NetworkInterfaceId != v.(string) {
-				continue
-			}
+		if v, ok := d.GetOk("transit_gateway_id"); ok && aws.StringValue(r.TransitGatewayId) != v.(string) {
+			continue
 		}
+
+		if v, ok := d.GetOk("vpc_peering_connection_id"); ok && aws.StringValue(r.VpcPeeringConnectionId) != v.(string) {
+			continue
+		}
+
 		routes = append(routes, r)
 	}
-	return routes
-}
 
-// Helper: Create an ID for a route
-func resourceAwsRouteID(d *schema.ResourceData, r *ec2.Route) string {
-	routeTableID := d.Get("route_table_id").(string)
-
-	if destination := aws.StringValue(r.DestinationCidrBlock); destination != "" {
-		return tfec2.RouteCreateID(routeTableID, destination)
-	} else if destination := aws.StringValue(r.DestinationIpv6CidrBlock); destination != "" {
-		return tfec2.RouteCreateID(routeTableID, destination)
+	if len(routes) == 0 {
+		return fmt.Errorf("No routes matching supplied arguments found in Route Table (%s)", routeTableID)
 	}
 
-	return ""
+	if len(routes) > 1 {
+		return fmt.Errorf("%d routes matched in Route Table (%s); use additional constraints to reduce matches to a single route", len(routes), routeTableID)
+	}
+
+	route := routes[0]
+
+	if destination := aws.StringValue(route.DestinationCidrBlock); destination != "" {
+		d.SetId(tfec2.RouteCreateID(routeTableID, destination))
+	} else if destination := aws.StringValue(route.DestinationIpv6CidrBlock); destination != "" {
+		d.SetId(tfec2.RouteCreateID(routeTableID, destination))
+	}
+	d.Set("carrier_gateway_id", route.CarrierGatewayId)
+	d.Set("destination_cidr_block", route.DestinationCidrBlock)
+	d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)
+	d.Set("egress_only_gateway_id", route.EgressOnlyInternetGatewayId)
+	d.Set("gateway_id", route.GatewayId)
+	d.Set("instance_id", route.InstanceId)
+	d.Set("local_gateway_id", route.LocalGatewayId)
+	d.Set("nat_gateway_id", route.NatGatewayId)
+	d.Set("network_interface_id", route.NetworkInterfaceId)
+	d.Set("transit_gateway_id", route.TransitGatewayId)
+	d.Set("vpc_peering_connection_id", route.VpcPeeringConnectionId)
+
+	return nil
 }

--- a/aws/data_source_aws_route.go
+++ b/aws/data_source_aws_route.go
@@ -28,7 +28,6 @@ func dataSourceAwsRoute() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
 			"destination_ipv6_cidr_block": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -43,49 +42,41 @@ func dataSourceAwsRoute() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
 			"egress_only_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"instance_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"local_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"nat_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"network_interface_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"transit_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"vpc_peering_connection_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -181,6 +172,7 @@ func dataSourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	} else if destination := aws.StringValue(route.DestinationIpv6CidrBlock); destination != "" {
 		d.SetId(tfec2.RouteCreateID(routeTableID, destination))
 	}
+
 	d.Set("carrier_gateway_id", route.CarrierGatewayId)
 	d.Set("destination_cidr_block", route.DestinationCidrBlock)
 	d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)

--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -122,6 +122,7 @@ func TestAccAWSRouteDataSource_CarrierGatewayID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{

--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -115,6 +115,28 @@ func TestAccAWSRouteDataSource_LocalGatewayID(t *testing.T) {
 	})
 }
 
+func TestAccAWSRouteDataSource_CarrierGatewayID(t *testing.T) {
+	dataSourceName := "data.aws_route.test"
+	resourceName := "aws_route.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteDataSourceConfigIpv4CarrierGateway(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "destination_cidr_block", dataSourceName, "destination_cidr_block"),
+					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", dataSourceName, "route_table_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "carrier_gateway_id", dataSourceName, "carrier_gateway_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsRouteConfigBasic(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
@@ -349,6 +371,45 @@ data "aws_route" "by_local_gateway_id" {
   route_table_id   = aws_route_table.test.id
   local_gateway_id = data.aws_ec2_local_gateway.first.id
   depends_on       = [aws_route.test]
+}
+`, rName)
+}
+
+func testAccAWSRouteDataSourceConfigIpv4CarrierGateway(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_carrier_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  destination_cidr_block = "0.0.0.0/0"
+  route_table_id         = aws_route_table.test.id
+  carrier_gateway_id     = aws_ec2_carrier_gateway.test.id
+}
+
+data "aws_route" "test" {
+  route_table_id     = aws_route.test.route_table_id
+  carrier_gateway_id = aws_route.test.carrier_gateway_id
 }
 `, rName)
 }

--- a/website/docs/d/route.html.markdown
+++ b/website/docs/d/route.html.markdown
@@ -10,14 +10,11 @@ description: |-
 
 `aws_route` provides details about a specific Route.
 
-This resource can prove useful when finding the resource
-associated with a CIDR. For example, finding the peering
-connection associated with a CIDR value.
+This resource can prove useful when finding the resource associated with a CIDR. For example, finding the peering connection associated with a CIDR value.
 
 ## Example Usage
 
-The following example shows how one might use a CIDR value to find a network interface id
-and use this to create a data source of that network interface.
+The following example shows how one might use a CIDR value to find a network interface id and use this to create a data source of that network interface.
 
 ```terraform
 variable "subnet_id" {}
@@ -38,35 +35,26 @@ data "aws_network_interface" "interface" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available
-Route in the current region. The given filters must match exactly one
-Route whose data will be exported as attributes.
+The arguments of this data source act as filters for querying the available Route in the current region. The given filters must match exactly oneRoute whose data will be exported as attributes.
 
-* `route_table_id` - (Required) The id of the specific Route Table containing the Route entry.
+The following arguments are required:
 
-* `destination_cidr_block` - (Optional) The CIDR block of the Route belonging to the Route Table.
+* `route_table_id` - (Required) The ID of the specific Route Table containing the Route entry.
 
-* `destination_ipv6_cidr_block` - (Optional) The IPv6 CIDR block of the Route belonging to the Route Table.
+The following arguments are optional:
 
-* `egress_only_gateway_id` - (Optional) The Egress Only Gateway ID of the Route belonging to the Route Table.
-
-* `gateway_id` - (Optional) The Gateway ID of the Route belonging to the Route Table.
-
-* `instance_id` - (Optional) The Instance ID of the Route belonging to the Route Table.
-
-* `nat_gateway_id` - (Optional) The NAT Gateway ID of the Route belonging to the Route Table.
-
-* `local_gateway_id` - (Optional) The Local Gateway ID of the Route belonging to the Route Table.
-
-* `transit_gateway_id` - (Optional) The EC2 Transit Gateway ID of the Route belonging to the Route Table.
-
-* `vpc_peering_connection_id` - (Optional) The VPC Peering Connection ID of the Route belonging to the Route Table.
-
-* `network_interface_id` - (Optional) The Network Interface ID of the Route belonging to the Route Table.
-
-* `carrier_gateway_id` - (Optional) The EC2 Carrier Gateway ID of the Route belonging to the Route Table.
+* `carrier_gateway_id` - (Optional) EC2 Carrier Gateway ID of the Route belonging to the Route Table.
+* `destination_cidr_block` - (Optional) CIDR block of the Route belonging to the Route Table.
+* `destination_ipv6_cidr_block` - (Optional) IPv6 CIDR block of the Route belonging to the Route Table.
+* `egress_only_gateway_id` - (Optional) Egress Only Gateway ID of the Route belonging to the Route Table.
+* `gateway_id` - (Optional) Gateway ID of the Route belonging to the Route Table.
+* `instance_id` - (Optional) Instance ID of the Route belonging to the Route Table.
+* `local_gateway_id` - (Optional) Local Gateway ID of the Route belonging to the Route Table.
+* `nat_gateway_id` - (Optional) NAT Gateway ID of the Route belonging to the Route Table.
+* `network_interface_id` - (Optional) Network Interface ID of the Route belonging to the Route Table.
+* `transit_gateway_id` - (Optional) EC2 Transit Gateway ID of the Route belonging to the Route Table.
+* `vpc_peering_connection_id` - (Optional) VPC Peering Connection ID of the Route belonging to the Route Table.
 
 ## Attributes Reference
 
-All of the argument attributes are also exported as
-result attributes when there is data available. For example, the `vpc_peering_connection_id` field will be empty when the route is attached to a Network Interface.
+All of the argument attributes are also exported as result attributes when there is data available. For example, the `vpc_peering_connection_id` field will be empty when the route is attached to a Network Interface.

--- a/website/docs/d/route.html.markdown
+++ b/website/docs/d/route.html.markdown
@@ -64,6 +64,8 @@ Route whose data will be exported as attributes.
 
 * `network_interface_id` - (Optional) The Network Interface ID of the Route belonging to the Route Table.
 
+* `carrier_gateway_id` - (Optional) The EC2 Carrier Gateway ID of the Route belonging to the Route Table.
+
 ## Attributes Reference
 
 All of the argument attributes are also exported as


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14518.

Builds on #14014, #16930, #16961 and #14018.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_route: Add `carrier_gateway_id` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSRouteDataSource_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSRouteDataSource_ -timeout 180m
go: downloading github.com/aws/aws-sdk-go v1.38.6
=== RUN   TestAccAWSRouteDataSource_basic
=== PAUSE TestAccAWSRouteDataSource_basic
=== RUN   TestAccAWSRouteDataSource_TransitGatewayID
=== PAUSE TestAccAWSRouteDataSource_TransitGatewayID
=== RUN   TestAccAWSRouteDataSource_IPv6DestinationCidr
=== PAUSE TestAccAWSRouteDataSource_IPv6DestinationCidr
=== RUN   TestAccAWSRouteDataSource_LocalGatewayID
=== PAUSE TestAccAWSRouteDataSource_LocalGatewayID
=== RUN   TestAccAWSRouteDataSource_CarrierGatewayID
=== PAUSE TestAccAWSRouteDataSource_CarrierGatewayID
=== CONT  TestAccAWSRouteDataSource_basic
=== CONT  TestAccAWSRouteDataSource_LocalGatewayID
    data_source_aws_outposts_outposts_test.go:67: skipping since no Outposts found
--- SKIP: TestAccAWSRouteDataSource_LocalGatewayID (1.32s)
=== CONT  TestAccAWSRouteDataSource_CarrierGatewayID
--- PASS: TestAccAWSRouteDataSource_CarrierGatewayID (25.47s)
=== CONT  TestAccAWSRouteDataSource_IPv6DestinationCidr
--- PASS: TestAccAWSRouteDataSource_IPv6DestinationCidr (24.72s)
=== CONT  TestAccAWSRouteDataSource_TransitGatewayID
--- PASS: TestAccAWSRouteDataSource_basic (75.27s)
--- PASS: TestAccAWSRouteDataSource_TransitGatewayID (389.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	441.029s
```