### PR TITLE
tests/resource/budgets_budget: Fix hardcoded regions

### DIFF
--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -409,7 +409,7 @@ func testAccAWSBudgetsBudgetConfigUpdate(name string) budgets.Budget {
 		},
 		CostFilters: map[string][]*string{
 			"AZ": {
-				aws.String("us-east-2"),
+				aws.String(testAccGetAlternateRegion()),
 			},
 		},
 		CostTypes: &budgets.CostTypes{
@@ -444,7 +444,7 @@ func testAccAWSBudgetsBudgetConfigDefaults(name string) budgets.Budget {
 		},
 		CostFilters: map[string][]*string{
 			"AZ": {
-				aws.String("us-east-1"),
+				aws.String(testAccGetRegion()),
 			},
 		},
 		CostTypes: &budgets.CostTypes{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Acceptance Tests in GovCloud

```
--- SKIP: TestAccAWSBudgetsBudget_basic (1.24s)
--- SKIP: TestAccAWSBudgetsBudget_notification (1.24s)
--- SKIP: TestAccAWSBudgetsBudget_prefix (1.24s)
```

### Acceptance Tests in `us-west-2`

```
--- PASS: TestAccAWSBudgetsBudget_prefix (20.32s)
--- PASS: TestAccAWSBudgetsBudget_basic (22.82s)
--- PASS: TestAccAWSBudgetsBudget_notification (68.24s)
```

### Acceptance Tests in `us-east-1`

```
--- PASS: TestAccAWSBudgetsBudget_prefix (16.25s)
--- PASS: TestAccAWSBudgetsBudget_basic (17.68s)
--- PASS: TestAccAWSBudgetsBudget_notification (51.99s)
```