### PR TITLE
tests/resource/codebuild_project: Fix hardcoded regions

### DIFF
--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -3467,7 +3467,7 @@ resource "aws_subnet" "test" {
   count = 2
 
   availability_zone = data.aws_availability_zones.available.names[count.index]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = aws_vpc.test.id
 
   tags = {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -3398,7 +3398,7 @@ resource "aws_codebuild_project" "test" {
 func testAccAWSCodeBuildProjectConfig_VpcConfig1(rName string) string {
 	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-  # InvalidInputException: CodeBuild currently doesn't support VPC in us-west-2d, please select subnets in other availability zones.
+  # InvalidInputException: CodeBuild currently doesn't support VPC in usw2-az4, please select subnets in other availability zones.
   exclude_zone_ids = ["usw2-az4"]
   state            = "available"
 
@@ -3459,7 +3459,7 @@ resource "aws_codebuild_project" "test" {
 func testAccAWSCodeBuildProjectConfig_VpcConfig2(rName string) string {
 	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-  # InvalidInputException: CodeBuild currently doesn't support VPC in us-west-2d, please select subnets in other availability zones.
+  # InvalidInputException: CodeBuild currently doesn't support VPC in usw2-az4, please select subnets in other availability zones.
   exclude_zone_ids = ["usw2-az4"]
   state            = "available"
 

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -2295,7 +2295,7 @@ POLICY
 }
 
 func testAccAWSCodeBuildProjectConfig_basic(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2315,11 +2315,11 @@ resource "aws_codebuild_project" "test" {
     type     = "GITHUB"
   }
 }
-`, rName, testAccAWSCodeBuildGitHubSourceLocationFromEnv())
+`, rName, testAccAWSCodeBuildGitHubSourceLocationFromEnv()))
 }
 
 func testAccAWSCodebuildProjectConfig_BadgeEnabled(rName string, badgeEnabled bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   badge_enabled = %t
   name          = "%s"
@@ -2340,11 +2340,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, badgeEnabled, rName)
+`, badgeEnabled, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_BuildTimeout(rName string, buildTimeout int) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   build_timeout = %d
   name          = "%s"
@@ -2365,11 +2365,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, buildTimeout, rName)
+`, buildTimeout, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_QueuedTimeout(rName string, queuedTimeout int) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   queued_timeout = %d
   name           = "%s"
@@ -2390,11 +2390,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, queuedTimeout, rName)
+`, queuedTimeout, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_Cache(rName, cacheLocation, cacheType string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2419,11 +2419,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, cacheLocation, cacheType)
+`, rName, cacheLocation, cacheType))
 }
 
 func testAccAWSCodeBuildProjectConfig_LocalCache(rName, modeType string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2448,11 +2448,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, modeType)
+`, rName, modeType))
 }
 
 func testAccAWSCodeBuildProjectConfig_Description(rName, description string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   description  = "%s"
   name         = "%s"
@@ -2473,11 +2473,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, description, rName)
+`, description, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_SourceVersion(rName, sourceVersion string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2499,11 +2499,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, sourceVersion)
+`, rName, sourceVersion))
 }
 
 func testAccAWSCodeBuildProjectConfig_EncryptionKey(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = "Terraform acc test"
   deletion_window_in_days = 7
@@ -2529,11 +2529,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_Environment_EnvironmentVariable_One(rName, key1, value1 string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -2558,11 +2558,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, key1, value1)
+`, rName, key1, value1))
 }
 
 func testAccAWSCodeBuildProjectConfig_Environment_EnvironmentVariable_Two(rName, key1, value1, key2, value2 string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -2592,11 +2592,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, key1, value1, key2, value2)
+`, rName, key1, value1, key2, value2))
 }
 
 func testAccAWSCodeBuildProjectConfig_Environment_EnvironmentVariable_Zero(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -2616,11 +2616,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_Environment_EnvironmentVariable_Type(rName, environmentVariableType string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2651,11 +2651,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, environmentVariableType)
+`, rName, environmentVariableType))
 }
 
 func testAccAWSCodeBuildProjectConfig_Environment_Certificate(rName string, bName string, oName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket_object" "test" {
   bucket  = aws_s3_bucket.test.bucket
   key     = "%s"
@@ -2682,11 +2685,11 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, oName, rName)
+`, oName, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_Environment_RegistryCredential1(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -2722,11 +2725,11 @@ resource "aws_secretsmanager_secret_version" "test" {
   secret_id     = aws_secretsmanager_secret.test.id
   secret_string = jsonencode(map("username", "user", "password", "pass"))
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_Environment_RegistryCredential2(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -2762,11 +2765,11 @@ resource "aws_secretsmanager_secret_version" "test" {
   secret_id     = aws_secretsmanager_secret.test.id
   secret_string = jsonencode(map("username", "user", "password", "pass"))
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_LogsConfig_CloudWatchLogs(rName, status, gName, sName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2794,11 +2797,14 @@ resource "aws_codebuild_project" "test" {
     }
   }
 }
-`, rName, status, gName, sName)
+`, rName, status, gName, sName))
 }
 
 func testAccAWSCodeBuildProjectConfig_LogsConfig_S3Logs(rName, bName, status, location string, encryptionDisabled bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2826,11 +2832,11 @@ resource "aws_codebuild_project" "test" {
     }
   }
 }
-`, rName, status, location, encryptionDisabled)
+`, rName, status, location, encryptionDisabled))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Auth(rName, authResource, authType string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2855,11 +2861,11 @@ resource "aws_codebuild_project" "test" {
     }
   }
 }
-`, rName, authResource, authType)
+`, rName, authResource, authType))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_GitCloneDepth(rName string, gitCloneDepth int) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2880,11 +2886,11 @@ resource "aws_codebuild_project" "test" {
     type            = "GITHUB"
   }
 }
-`, rName, gitCloneDepth)
+`, rName, gitCloneDepth))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_GitSubmodulesConfig_CodeCommit(rName string, fetchSubmodules bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2908,11 +2914,11 @@ resource "aws_codebuild_project" "test" {
     }
   }
 }
-`, rName, fetchSubmodules)
+`, rName, fetchSubmodules))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_GitSubmodulesConfig_GitHub(rName string, fetchSubmodules bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2936,11 +2942,11 @@ resource "aws_codebuild_project" "test" {
     }
   }
 }
-`, rName, fetchSubmodules)
+`, rName, fetchSubmodules))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_GitSubmodulesConfig_GitHubEnterprise(rName string, fetchSubmodules bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -2964,11 +2970,11 @@ resource "aws_codebuild_project" "test" {
     }
   }
 }
-`, rName, fetchSubmodules)
+`, rName, fetchSubmodules))
 }
 
 func testAccAWSCodeBuildProjectConfig_SecondarySources_GitSubmodulesConfig_CodeCommit(rName string, fetchSubmodules bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%[1]s"
   service_role = aws_iam_role.test.arn
@@ -3012,11 +3018,11 @@ resource "aws_codebuild_project" "test" {
     }
   }
 }
-`, rName, fetchSubmodules)
+`, rName, fetchSubmodules))
 }
 
 func testAccAWSCodeBuildProjectConfig_SecondarySources_GitSubmodulesConfig_GitHub(rName string, fetchSubmodules bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%[1]s"
   service_role = aws_iam_role.test.arn
@@ -3060,11 +3066,11 @@ resource "aws_codebuild_project" "test" {
     }
   }
 }
-`, rName, fetchSubmodules)
+`, rName, fetchSubmodules))
 }
 
 func testAccAWSCodeBuildProjectConfig_SecondarySources_GitSubmodulesConfig_GitHubEnterprise(rName string, fetchSubmodules bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%[1]s"
   service_role = aws_iam_role.test.arn
@@ -3108,11 +3114,11 @@ resource "aws_codebuild_project" "test" {
     }
   }
 }
-`, rName, fetchSubmodules)
+`, rName, fetchSubmodules))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_InsecureSSL(rName string, insecureSSL bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -3133,11 +3139,11 @@ resource "aws_codebuild_project" "test" {
     type         = "GITHUB"
   }
 }
-`, rName, insecureSSL)
+`, rName, insecureSSL))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_Bitbucket(rName string, reportBuildStatus bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
   service_role = aws_iam_role.test.arn
@@ -3158,11 +3164,11 @@ resource "aws_codebuild_project" "test" {
     type                = "BITBUCKET"
   }
 }
-`, rName, reportBuildStatus)
+`, rName, reportBuildStatus))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHub(rName string, reportBuildStatus bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
   service_role = aws_iam_role.test.arn
@@ -3183,11 +3189,11 @@ resource "aws_codebuild_project" "test" {
     type                = "GITHUB"
   }
 }
-`, rName, reportBuildStatus)
+`, rName, reportBuildStatus))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHubEnterprise(rName string, reportBuildStatus bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
   service_role = aws_iam_role.test.arn
@@ -3208,11 +3214,11 @@ resource "aws_codebuild_project" "test" {
     type                = "GITHUB_ENTERPRISE"
   }
 }
-`, rName, reportBuildStatus)
+`, rName, reportBuildStatus))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Type_Bitbucket(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
   service_role = aws_iam_role.test.arn
@@ -3232,11 +3238,11 @@ resource "aws_codebuild_project" "test" {
     type     = "BITBUCKET"
   }
 }
-`, rName, testAccAWSCodeBuildBitbucketSourceLocationFromEnv())
+`, rName, testAccAWSCodeBuildBitbucketSourceLocationFromEnv()))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Type_CodeCommit(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
   service_role = aws_iam_role.test.arn
@@ -3256,11 +3262,11 @@ resource "aws_codebuild_project" "test" {
     type     = "CODECOMMIT"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Type_CodePipeline(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
   service_role = aws_iam_role.test.arn
@@ -3279,11 +3285,11 @@ resource "aws_codebuild_project" "test" {
     type = "CODEPIPELINE"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Type_GitHubEnterprise(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
   service_role = aws_iam_role.test.arn
@@ -3303,11 +3309,11 @@ resource "aws_codebuild_project" "test" {
     type     = "GITHUB_ENTERPRISE"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Type_S3(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
@@ -3337,11 +3343,11 @@ resource "aws_codebuild_project" "test" {
     type     = "S3"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Type_NoSource(rName string, rLocation string, rBuildspec string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
   service_role = aws_iam_role.test.arn
@@ -3362,11 +3368,11 @@ resource "aws_codebuild_project" "test" {
     buildspec = %q
   }
 }
-`, rName, rLocation, rBuildspec)
+`, rName, rLocation, rBuildspec))
 }
 
 func testAccAWSCodeBuildProjectConfig_Tags(rName, tagKey, tagValue string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -3392,11 +3398,14 @@ resource "aws_codebuild_project" "test" {
     %s = "%s"
   }
 }
-`, rName, tagKey, tagValue)
+`, rName, tagKey, tagValue))
 }
 
 func testAccAWSCodeBuildProjectConfig_VpcConfig1(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   # InvalidInputException: CodeBuild currently doesn't support VPC in usw2-az4, please select subnets in other availability zones.
   exclude_zone_ids = ["usw2-az4"]
@@ -3453,22 +3462,14 @@ resource "aws_codebuild_project" "test" {
     vpc_id             = aws_vpc.test.id
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_VpcConfig2(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # InvalidInputException: CodeBuild currently doesn't support VPC in usw2-az4, please select subnets in other availability zones.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -3477,7 +3478,7 @@ resource "aws_subnet" "test" {
   count = 2
 
   availability_zone = data.aws_availability_zones.available.names[count.index]
-  cidr_block        = "10.0.${count.index}.0/24"
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
   vpc_id            = aws_vpc.test.id
 
   tags = {
@@ -3514,11 +3515,11 @@ resource "aws_codebuild_project" "test" {
     vpc_id             = aws_vpc.test.id
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodeBuildProjectConfig_WindowsServer2019Container(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -3538,11 +3539,11 @@ resource "aws_codebuild_project" "test" {
     type     = "GITHUB"
   }
 }
-`, rName, testAccAWSCodeBuildGitHubSourceLocationFromEnv())
+`, rName, testAccAWSCodeBuildGitHubSourceLocationFromEnv()))
 }
 
 func testAccAWSCodeBuildProjectConfig_ARMContainer(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -3562,11 +3563,14 @@ resource "aws_codebuild_project" "test" {
     type     = "GITHUB"
   }
 }
-`, rName, testAccAWSCodeBuildGitHubSourceLocationFromEnv())
+`, rName, testAccAWSCodeBuildGitHubSourceLocationFromEnv()))
 }
 
 func testAccAWSCodebuildProjectConfig_Artifacts_ArtifactIdentifier(rName string, bName string, artifactIdentifier string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3588,11 +3592,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, artifactIdentifier)
+`, rName, artifactIdentifier))
 }
 
 func testAccAWSCodebuildProjectConfig_Artifacts_EncryptionDisabled(rName string, bName string, encryptionDisabled bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -3614,11 +3621,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, encryptionDisabled)
+`, rName, encryptionDisabled))
 }
 
 func testAccAWSCodebuildProjectConfig_Artifacts_Location(rName, bName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3639,11 +3649,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodebuildProjectConfig_Artifacts_Name(rName string, bName string, name string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3665,11 +3678,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, name)
+`, rName, name))
 }
 
 func testAccAWSCodebuildProjectConfig_Artifacts_NamespaceType(rName, namespaceType string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(rName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3691,11 +3707,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, namespaceType)
+`, rName, namespaceType))
 }
 
 func testAccAWSCodebuildProjectConfig_Artifacts_OverrideArtifactName(rName string, bName string, overrideArtifactName bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -3717,11 +3736,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, overrideArtifactName)
+`, rName, overrideArtifactName))
 }
 
 func testAccAWSCodebuildProjectConfig_Artifacts_Packaging(rName, packaging string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(rName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3743,11 +3765,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, packaging)
+`, rName, packaging))
 }
 
 func testAccAWSCodebuildProjectConfig_Artifacts_Path(rName, path string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(rName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3769,11 +3794,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, path)
+`, rName, path))
 }
 
 func testAccAWSCodebuildProjectConfig_Artifacts_Type(rName string, bName string, artifactType string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3794,11 +3822,14 @@ resource "aws_codebuild_project" "test" {
     location = "${aws_s3_bucket.test.bucket}/"
   }
 }
-`, rName, artifactType)
+`, rName, artifactType))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts(rName string, bName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -3831,11 +3862,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts_ArtifactIdentifier(rName string, bName string, artifactIdentifier string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3862,11 +3896,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, artifactIdentifier)
+`, rName, artifactIdentifier))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts_EncryptionDisabled(rName string, bName string, encryptionDisabled bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -3894,11 +3931,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, encryptionDisabled)
+`, rName, encryptionDisabled))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts_Location(rName, bName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3925,11 +3965,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts_Name(rName string, bName string, name string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3957,11 +4000,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, name)
+`, rName, name))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts_NamespaceType(rName, namespaceType string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(rName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -3989,11 +4035,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, namespaceType)
+`, rName, namespaceType))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts_OverrideArtifactName(rName string, bName string, overrideArtifactName bool) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
   service_role = aws_iam_role.test.arn
@@ -4021,11 +4070,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, overrideArtifactName)
+`, rName, overrideArtifactName))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts_Packaging(rName, packaging string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(rName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -4053,11 +4105,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, packaging)
+`, rName, packaging))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts_Path(rName, path string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(rName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -4085,11 +4140,14 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, rName, path)
+`, rName, path))
 }
 
 func testAccAWSCodebuildProjectConfig_SecondaryArtifacts_Type(rName string, bName string, artifactType string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
+		testAccAWSCodeBuildProjectConfig_Base_Bucket(bName),
+		fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -4116,11 +4174,11 @@ resource "aws_codebuild_project" "test" {
     type     = "CODECOMMIT"
   }
 }
-`, rName, artifactType)
+`, rName, artifactType))
 }
 
 func testAccAWSCodeBuildProjectConfig_SecondarySources_CodeCommit(rName string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
   service_role = aws_iam_role.test.arn
@@ -4152,5 +4210,5 @@ resource "aws_codebuild_project" "test" {
     source_identifier = "secondarySource2"
   }
 }
-`, rName)
+`, rName))
 }

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -3406,17 +3406,6 @@ func testAccAWSCodeBuildProjectConfig_VpcConfig1(rName string) string {
 		testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName),
 		testAccAvailableAZsNoOptInConfig(),
 		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # InvalidInputException: CodeBuild currently doesn't support VPC in usw2-az4, please select subnets in other availability zones.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Acceptance Tests `GovCloud`

Failures are unrelated and tracked elsewhere.

```
--- FAIL: TestAccAWSCodeBuildProject_ARMContainer (8.89s)
--- FAIL: TestAccAWSCodeBuildProject_Cache (57.36s)
--- FAIL: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (77.34s)
--- FAIL: TestAccAWSCodeBuildProject_WindowsServer2019Container (14.79s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (52.72s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (99.01s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (66.58s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (118.00s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (56.88s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (58.34s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (62.62s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (73.76s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (47.02s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (36.15s)
--- PASS: TestAccAWSCodeBuildProject_basic (186.35s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (55.79s)
--- PASS: TestAccAWSCodeBuildProject_Description (54.35s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (219.16s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (78.88s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (95.95s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value (137.60s)
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (57.70s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (79.96s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (104.39s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (243.59s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (241.21s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (85.26s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (99.29s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (165.44s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (64.72s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (65.23s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (137.84s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (73.27s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (47.31s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (45.27s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit (207.66s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub (84.59s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise (67.38s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (89.64s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit (70.93s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub (45.70s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise (84.62s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (51.78s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (44.89s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (44.91s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (50.30s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (29.99s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (36.72s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (39.71s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (43.35s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (54.46s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (14.45s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (49.23s)
--- PASS: TestAccAWSCodeBuildProject_SourceVersion (57.87s)
--- PASS: TestAccAWSCodeBuildProject_Tags (87.58s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (79.45s)
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
```

### Acceptance Tests `us-west-2`

```
--- PASS: TestAccAWSCodeBuildProject_ARMContainer (31.25s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (72.25s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (104.87s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (279.63s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (461.44s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (67.05s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (60.95s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (88.27s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (227.05s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (69.57s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (34.95s)
--- PASS: TestAccAWSCodeBuildProject_basic (65.17s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (53.39s)
--- PASS: TestAccAWSCodeBuildProject_Cache (85.79s)
--- PASS: TestAccAWSCodeBuildProject_Description (54.45s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (29.38s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (32.13s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (84.64s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (83.74s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value (74.38s)
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (256.96s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (69.46s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (87.65s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (50.55s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (38.85s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (83.41s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (78.55s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (93.74s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (89.79s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (100.99s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (70.52s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (86.68s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (92.74s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (42.04s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit (52.78s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub (235.51s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise (46.58s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (131.25s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit (91.12s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub (68.39s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise (96.73s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (67.58s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (99.47s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (144.73s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (52.05s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (38.06s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (90.02s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (88.85s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (36.98s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (38.68s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (11.83s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (43.15s)
--- PASS: TestAccAWSCodeBuildProject_SourceVersion (30.70s)
--- PASS: TestAccAWSCodeBuildProject_Tags (39.73s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (89.46s)
--- PASS: TestAccAWSCodeBuildProject_WindowsServer2019Container (155.55s)
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
```