### PR TITLE
resource/config_aggregate_authorization: Fix hardcoded regions

### DIFF
--- a/aws/resource_aws_config_aggregate_authorization.go
+++ b/aws/resource_aws_config_aggregate_authorization.go
@@ -168,7 +168,7 @@ func describeConfigAggregateAuthorizations(conn *configservice.ConfigService) ([
 func resourceAwsConfigAggregateAuthorizationParseID(id string) (string, string, error) {
 	idParts := strings.Split(id, ":")
 	if len(idParts) != 2 {
-		return "", "", fmt.Errorf("Please make sure the ID is in the form account_id:region (i.e. 123456789012:us-east-1")
+		return "", "", fmt.Errorf("Please make sure the ID is in the form account_id:region (i.e. 123456789012:us-east-1") // lintignore:AWSAT003
 	}
 	accountId := idParts[0]
 	region := idParts[1]

--- a/aws/resource_aws_config_aggregate_authorization_test.go
+++ b/aws/resource_aws_config_aggregate_authorization_test.go
@@ -61,19 +61,17 @@ func TestAccAWSConfigAggregateAuthorization_basic(t *testing.T) {
 	rString := acctest.RandStringFromCharSet(12, "0123456789")
 	resourceName := "aws_config_aggregate_authorization.example"
 
-	region := "eu-west-1"
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSConfigAggregateAuthorizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSConfigAggregateAuthorizationConfig_basic(rString),
+				Config: testAccAWSConfigAggregateAuthorizationConfig_basic(rString, testAccGetAlternateRegion()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "account_id", rString),
-					resource.TestCheckResourceAttr(resourceName, "region", region),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "config", regexp.MustCompile(fmt.Sprintf(`aggregation-authorization/%s/%s$`, rString, region))),
+					resource.TestCheckResourceAttr(resourceName, "region", testAccGetAlternateRegion()),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "config", regexp.MustCompile(fmt.Sprintf(`aggregation-authorization/%s/%s$`, rString, testAccGetAlternateRegion()))),
 				),
 			},
 			{
@@ -95,7 +93,7 @@ func TestAccAWSConfigAggregateAuthorization_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSConfigAggregateAuthorizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSConfigAggregateAuthorizationConfig_tags(rString, "foo", "bar", "fizz", "buzz"),
+				Config: testAccAWSConfigAggregateAuthorizationConfig_tags(rString, "foo", "bar", "fizz", "buzz", testAccGetAlternateRegion()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rString),
@@ -104,7 +102,7 @@ func TestAccAWSConfigAggregateAuthorization_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSConfigAggregateAuthorizationConfig_tags(rString, "foo", "bar2", "fizz2", "buzz2"),
+				Config: testAccAWSConfigAggregateAuthorizationConfig_tags(rString, "foo", "bar2", "fizz2", "buzz2", testAccGetAlternateRegion()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rString),
@@ -118,7 +116,7 @@ func TestAccAWSConfigAggregateAuthorization_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSConfigAggregateAuthorizationConfig_basic(rString),
+				Config: testAccAWSConfigAggregateAuthorizationConfig_basic(rString, testAccGetAlternateRegion()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
@@ -156,20 +154,20 @@ func testAccCheckAWSConfigAggregateAuthorizationDestroy(s *terraform.State) erro
 	return nil
 }
 
-func testAccAWSConfigAggregateAuthorizationConfig_basic(rString string) string {
+func testAccAWSConfigAggregateAuthorizationConfig_basic(rString, region string) string {
 	return fmt.Sprintf(`
 resource "aws_config_aggregate_authorization" "example" {
   account_id = %[1]q
-  region     = "eu-west-1"
+  region     = %[2]q
 }
-`, rString)
+`, rString, region)
 }
 
-func testAccAWSConfigAggregateAuthorizationConfig_tags(rString, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAWSConfigAggregateAuthorizationConfig_tags(rString, tagKey1, tagValue1, tagKey2, tagValue2, region string) string {
 	return fmt.Sprintf(`
 resource "aws_config_aggregate_authorization" "example" {
   account_id = %[1]q
-  region     = "eu-west-1"
+  region     = %[6]q
 
   tags = {
     Name = %[1]q
@@ -178,5 +176,5 @@ resource "aws_config_aggregate_authorization" "example" {
     %[4]s = %[5]q
   }
 }
-`, rString, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rString, tagKey1, tagValue1, tagKey2, tagValue2, region)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Acceptance Tests in GovCloud

```
--- PASS: TestAccAWSConfigAggregateAuthorization_basic (16.42s)
--- PASS: TestAccAWSConfigAggregateAuthorization_tags (39.17s)
```

### Acceptance Tests in `us-west-2`

```
--- PASS: TestAccAWSConfigAggregateAuthorization_basic (13.36s)
--- PASS: TestAccAWSConfigAggregateAuthorization_tags (30.24s)
```
