### PR TITLE
resource/devicefarm_project: Fix hardcoded regions

### DIFF
--- a/aws/resource_aws_devicefarm_project.go
+++ b/aws/resource_aws_devicefarm_project.go
@@ -35,13 +35,6 @@ func resourceAwsDevicefarmProject() *schema.Resource {
 
 func resourceAwsDevicefarmProjectCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).devicefarmconn
-	region := meta.(*AWSClient).region
-
-	//	We need to ensure that DeviceFarm is only being run against us-west-2
-	//	As this is the only place that AWS currently supports it
-	if region != "us-west-2" {
-		return fmt.Errorf("DeviceFarm can only be used with us-west-2. You are trying to use it on %s", region)
-	}
 
 	input := &devicefarm.CreateProjectInput{
 		Name: aws.String(d.Get("name").(string)),

--- a/aws/resource_aws_devicefarm_project_test.go
+++ b/aws/resource_aws_devicefarm_project_test.go
@@ -46,26 +46,6 @@ func TestAccAWSDeviceFarmProject_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSDeviceFarmProject_otherRegion(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	if testAccGetRegion() == endpoints.UsWest2RegionID {
-		t.Skipf("skipping test; test does not run in current region (%s)", testAccGetRegion())
-	}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(devicefarm.EndpointsID, t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDeviceFarmProjectDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDeviceFarmProjectConfig(rName),
-				ExpectError: regexp.MustCompile(`no such host`),
-			},
-		},
-	})
-}
-
 func TestAccAWSDeviceFarmProject_disappears(t *testing.T) {
 	var proj devicefarm.Project
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/aws/resource_aws_devicefarm_project_test.go
+++ b/aws/resource_aws_devicefarm_project_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,7 +19,13 @@ func TestAccAWSDeviceFarmProject_basic(t *testing.T) {
 	resourceName := "aws_devicefarm_project.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(devicefarm.EndpointsID, t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			testAccRegionPreCheck(t, endpoints.UsWest2RegionID)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDeviceFarmProjectDestroy,
 		Steps: []resource.TestStep{
@@ -39,13 +46,39 @@ func TestAccAWSDeviceFarmProject_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDeviceFarmProject_otherRegion(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	if testAccGetRegion() == endpoints.UsWest2RegionID {
+		t.Skipf("skipping test; test does not run in current region (%s)", testAccGetRegion())
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(devicefarm.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDeviceFarmProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDeviceFarmProjectConfig(rName),
+				ExpectError: regexp.MustCompile(`no such host`),
+			},
+		},
+	})
+}
+
 func TestAccAWSDeviceFarmProject_disappears(t *testing.T) {
 	var proj devicefarm.Project
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_devicefarm_project.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(devicefarm.EndpointsID, t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			testAccRegionPreCheck(t, endpoints.UsWest2RegionID)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDeviceFarmProjectDestroy,
 		Steps: []resource.TestStep{

--- a/website/docs/r/devicefarm_project.html.markdown
+++ b/website/docs/r/devicefarm_project.html.markdown
@@ -9,11 +9,11 @@ description: |-
 # Resource: aws_devicefarm_project
 
 Provides a resource to manage AWS Device Farm Projects.
-Please keep in mind that this feature is only supported on the "us-west-2" region.
-This resource will error if you try to create a project in another region.
 
 For more information about Device Farm Projects, see the AWS Documentation on
 [Device Farm Projects][aws-get-project].
+
+~> **NOTE:** AWS currently has limited regional support for Device Farm (e.g. `us-west-2`). See [AWS Device Farm endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/devicefarm.html) for information on supported regions.
 
 ## Basic Example Usage
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/devicefarm_project: Allow resource to work in any region when AWS adds support [GH-16977]
```

### Acceptance Tests in GovCloud

```
--- SKIP: TestAccAWSDeviceFarmProject_basic (1.23s)
--- SKIP: TestAccAWSDeviceFarmProject_otherRegion (1.23s)
--- SKIP: TestAccAWSDeviceFarmProject_disappears (1.23s)
```

### Acceptance Tests in `us-west-2`

```
    resource_aws_devicefarm_project_test.go:53: skipping test; test does not run in current region (us-west-2)
--- SKIP: TestAccAWSDeviceFarmProject_otherRegion (0.00s)
--- PASS: TestAccAWSDeviceFarmProject_disappears (8.75s)
--- PASS: TestAccAWSDeviceFarmProject_basic (11.77s)
```

### Acceptance Tests in `us-east-1`

```
    provider_test.go:716: skipping tests; AWS_DEFAULT_REGION (us-east-1) does not equal us-west-2
--- SKIP: TestAccAWSDeviceFarmProject_basic (0.53s)
    provider_test.go:716: skipping tests; AWS_DEFAULT_REGION (us-east-1) does not equal us-west-2
--- SKIP: TestAccAWSDeviceFarmProject_disappears (0.53s)
--- PASS: TestAccAWSDeviceFarmProject_otherRegion (28.76s)
```