### PR TITLE
r/aws_route_table: AWS Wavelength support and 'arn' attribute

### DIFF
--- a/.changelog/16979.txt
+++ b/.changelog/16979.txt
@@ -1,0 +1,11 @@
+```release-notes:enhancement
+resource/aws_default_route_table: Add `arn` attribute
+```
+
+```release-notes:enhancement
+resource/aws_route_table: Add `arn` attribute
+```
+
+```release-notes:enhancement
+resource/aws_route_table: Add `carrier_gateway_id` attribute to `route` configuration block
+```

--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -114,6 +114,11 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 
 			"tags": tagsSchema(),
 
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -50,6 +50,9 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 				Optional:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						///
+						// Destinations.
+						///
 						"cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -66,6 +69,14 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 								validation.StringIsEmpty,
 								validateIpv6CIDRNetworkAddress,
 							),
+						},
+
+						//
+						// Targets.
+						//
+						"carrier_gateway_id": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 
 						"egress_only_gateway_id": {
@@ -88,6 +99,11 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 							Optional: true,
 						},
 
+						"network_interface_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"transit_gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -99,11 +115,6 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 						},
 
 						"vpc_peering_connection_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"network_interface_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},

--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -50,9 +50,6 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 				Optional:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						///
-						// Destinations.
-						///
 						"cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -69,14 +66,6 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 								validation.StringIsEmpty,
 								validateIpv6CIDRNetworkAddress,
 							),
-						},
-
-						//
-						// Targets.
-						//
-						"carrier_gateway_id": {
-							Type:     schema.TypeString,
-							Optional: true,
 						},
 
 						"egress_only_gateway_id": {
@@ -99,11 +88,6 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 							Optional: true,
 						},
 
-						"network_interface_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
 						"transit_gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -118,17 +102,17 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+
+						"network_interface_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 				Set: resourceAwsRouteTableHash,
 			},
 
 			"tags": tagsSchema(),
-
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 
 			"owner_id": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -50,6 +50,9 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 				Optional:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						///
+						// Destinations.
+						///
 						"cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -66,6 +69,14 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 								validation.StringIsEmpty,
 								validateIpv6CIDRNetworkAddress,
 							),
+						},
+
+						//
+						// Targets.
+						//
+						"carrier_gateway_id": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 
 						"egress_only_gateway_id": {
@@ -88,6 +99,11 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 							Optional: true,
 						},
 
+						"network_interface_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"transit_gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -102,17 +118,17 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-
-						"network_interface_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
 					},
 				},
 				Set: resourceAwsRouteTableHash,
 			},
 
 			"tags": tagsSchema(),
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 
 			"owner_id": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -38,6 +38,7 @@ func TestAccAWSDefaultRouteTable_basic(t *testing.T) {
 				Config: testAccDefaultRouteTableConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -100,6 +101,7 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -119,6 +121,7 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					// The route block from the previous step should still be
@@ -134,6 +137,7 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					// This config uses attribute syntax to set zero routes
@@ -168,6 +172,7 @@ func TestAccAWSDefaultRouteTable_swap(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -38,7 +38,6 @@ func TestAccAWSDefaultRouteTable_basic(t *testing.T) {
 				Config: testAccDefaultRouteTableConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -101,7 +100,6 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -121,7 +119,6 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					// The route block from the previous step should still be
@@ -137,7 +134,6 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					// This config uses attribute syntax to set zero routes
@@ -172,7 +168,6 @@ func TestAccAWSDefaultRouteTable_swap(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -398,41 +393,6 @@ func TestAccAWSDefaultRouteTable_ConditionalCidrBlock(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateIdFunc: testAccAWSDefaultRouteTableImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSDefaultRouteTable_IPv4_To_CarrierGateway(t *testing.T) {
-	var routeTable ec2.RouteTable
-	resourceName := "aws_default_route_table.test"
-	cgwResourceName := "aws_ec2_carrier_gateway.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	destinationCidr := "0.0.0.0/0"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRouteTableDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDefaultRouteTableConfigIpv4CarrierGateway(rName, destinationCidr),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(resourceName, &routeTable),
-					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
-					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
-					testAccCheckDefaultRouteTableRoute(resourceName, "cidr_block", destinationCidr, "carrier_gateway_id", cgwResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
 				ImportStateVerify: true,
 			},
 		},
@@ -988,39 +948,6 @@ resource "aws_default_route_table" "test" {
   }
 }
 `, rName, destinationCidr, destinationIpv6Cidr, ipv6Route)
-}
-
-func testAccDefaultRouteTableConfigIpv4CarrierGateway(rName, destinationCidr string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_ec2_carrier_gateway" "test" {
-  vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_default_route_table" "test" {
-  default_route_table_id = aws_vpc.test.default_route_table_id
-
-  route {
-    cidr_block         = %[2]q
-    carrier_gateway_id = aws_ec2_carrier_gateway.test.id
-  }
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName, destinationCidr)
 }
 
 func testAccAWSDefaultRouteTableImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -38,6 +38,7 @@ func TestAccAWSDefaultRouteTable_basic(t *testing.T) {
 				Config: testAccDefaultRouteTableConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -100,6 +101,7 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -119,6 +121,7 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					// The route block from the previous step should still be
@@ -134,6 +137,7 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					// This config uses attribute syntax to set zero routes
@@ -168,6 +172,7 @@ func TestAccAWSDefaultRouteTable_swap(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -393,6 +398,41 @@ func TestAccAWSDefaultRouteTable_ConditionalCidrBlock(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateIdFunc: testAccAWSDefaultRouteTableImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDefaultRouteTable_IPv4_To_CarrierGateway(t *testing.T) {
+	var routeTable ec2.RouteTable
+	resourceName := "aws_default_route_table.test"
+	cgwResourceName := "aws_ec2_carrier_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "0.0.0.0/0"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDefaultRouteTableConfigIpv4CarrierGateway(rName, destinationCidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists(resourceName, &routeTable),
+					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+					testAccCheckDefaultRouteTableRoute(resourceName, "cidr_block", destinationCidr, "carrier_gateway_id", cgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
 				ImportStateVerify: true,
 			},
 		},
@@ -948,6 +988,39 @@ resource "aws_default_route_table" "test" {
   }
 }
 `, rName, destinationCidr, destinationIpv6Cidr, ipv6Route)
+}
+
+func testAccDefaultRouteTableConfigIpv4CarrierGateway(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_carrier_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_default_route_table" "test" {
+  default_route_table_id = aws_vpc.test.default_route_table_id
+
+  route {
+    cidr_block         = %[2]q
+    carrier_gateway_id = aws_ec2_carrier_gateway.test.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, destinationCidr)
 }
 
 func testAccAWSDefaultRouteTableImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -261,7 +261,7 @@ func TestAccAWSDefaultRouteTable_IPv4_To_VpcEndpoint(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID, "elasticloadbalancing"),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -293,7 +293,7 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	ownerID := aws.StringValue(rt.OwnerId)
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: ownerID,
 		Resource:  fmt.Sprintf("route-table/%s", d.Id()),

--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -22,6 +23,7 @@ var routeTableValidDestinations = []string{
 }
 
 var routeTableValidTargets = []string{
+	"carrier_gateway_id",
 	"egress_only_gateway_id",
 	"gateway_id",
 	"instance_id",
@@ -67,6 +69,9 @@ func resourceAwsRouteTable() *schema.Resource {
 				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						///
+						// Destinations.
+						///
 						"cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -85,6 +90,14 @@ func resourceAwsRouteTable() *schema.Resource {
 							),
 						},
 
+						//
+						// Targets.
+						//
+						"carrier_gateway_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"egress_only_gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -100,12 +113,17 @@ func resourceAwsRouteTable() *schema.Resource {
 							Optional: true,
 						},
 
+						"local_gateway_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"nat_gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"local_gateway_id": {
+						"network_interface_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -124,14 +142,14 @@ func resourceAwsRouteTable() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-
-						"network_interface_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
 					},
 				},
 				Set: resourceAwsRouteTableHash,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"owner_id": {
@@ -231,6 +249,9 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 		if r.DestinationIpv6CidrBlock != nil {
 			m["ipv6_cidr_block"] = aws.StringValue(r.DestinationIpv6CidrBlock)
 		}
+		if r.CarrierGatewayId != nil {
+			m["carrier_gateway_id"] = aws.StringValue(r.CarrierGatewayId)
+		}
 		if r.EgressOnlyInternetGatewayId != nil {
 			m["egress_only_gateway_id"] = aws.StringValue(r.EgressOnlyInternetGatewayId)
 		}
@@ -269,7 +290,16 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
 
-	d.Set("owner_id", rt.OwnerId)
+	ownerID := aws.StringValue(rt.OwnerId)
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ec2",
+		Region:    meta.(*AWSClient).region,
+		AccountID: ownerID,
+		Resource:  fmt.Sprintf("route-table/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+	d.Set("owner_id", ownerID)
 
 	return nil
 }
@@ -422,6 +452,10 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 				opts.GatewayId = aws.String(s)
 			}
 
+			if s, ok := m["carrier_gateway_id"].(string); ok && s != "" {
+				opts.CarrierGatewayId = aws.String(s)
+			}
+
 			if s, ok := m["egress_only_gateway_id"].(string); ok && s != "" {
 				opts.EgressOnlyInternetGatewayId = aws.String(s)
 			}
@@ -556,6 +590,10 @@ func resourceAwsRouteTableHash(v interface{}) int {
 	}
 
 	if v, ok := m["gateway_id"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["carrier_gateway_id"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -595,6 +595,7 @@ func TestAccAWSRouteTable_IPv4_To_CarrierGateway(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -158,6 +158,7 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -240,6 +241,7 @@ func TestAccAWSRouteTable_IPv4_To_InternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "2"),
@@ -254,6 +256,7 @@ func TestAccAWSRouteTable_IPv4_To_InternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "2"),
@@ -291,6 +294,7 @@ func TestAccAWSRouteTable_IPv4_To_Instance(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -327,6 +331,7 @@ func TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -427,7 +432,7 @@ func TestAccAWSRouteTable_RequireRouteTarget(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRouteTableConfigNoTarget(rName),
-				ExpectError: regexp.MustCompile("error creating route: one of `egress_only_gateway_id"),
+				ExpectError: regexp.MustCompile(`error creating route: one of .*\begress_only_gateway_id\b`),
 			},
 		},
 	})
@@ -452,6 +457,7 @@ func TestAccAWSRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "2"),
@@ -471,6 +477,7 @@ func TestAccAWSRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "2"),
@@ -490,6 +497,7 @@ func TestAccAWSRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -524,6 +532,7 @@ func TestAccAWSRouteTable_IPv4_To_TransitGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -559,10 +568,46 @@ func TestAccAWSRouteTable_IPv4_To_VpcEndpoint(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
 					testAccCheckAWSRouteTableRoute(resourceName, "cidr_block", destinationCidr, "vpc_endpoint_id", vpceResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRouteTable_IPv4_To_CarrierGateway(t *testing.T) {
+	var routeTable ec2.RouteTable
+	resourceName := "aws_route_table.test"
+	cgwResourceName := "aws_ec2_carrier_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "0.0.0.0/0"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteTableConfigIpv4CarrierGateway(rName, destinationCidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists(resourceName, &routeTable),
+					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+					testAccCheckAWSRouteTableRoute(resourceName, "cidr_block", destinationCidr, "carrier_gateway_id", cgwResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
@@ -594,6 +639,7 @@ func TestAccAWSRouteTable_IPv4_To_LocalGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -629,6 +675,7 @@ func TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -664,6 +711,7 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "propagating_vgws.*", vgwResourceName1, "id"),
@@ -677,6 +725,7 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "propagating_vgws.*", vgwResourceName2, "id"),
@@ -750,6 +799,7 @@ func TestAccAWSRouteTable_IPv4_To_NatGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -786,6 +836,7 @@ func TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -819,6 +870,7 @@ func TestAccAWSRouteTable_VpcMultipleCidrs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -851,6 +903,7 @@ func TestAccAWSRouteTable_VpcClassicLink(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -889,6 +942,7 @@ func TestAccAWSRouteTable_GatewayVpcEndpoint(t *testing.T) {
 					// Refresh the route table once the VPC endpoint route is present.
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -933,6 +987,7 @@ func TestAccAWSRouteTable_MultipleRoutes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 5),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "3"),
@@ -951,6 +1006,7 @@ func TestAccAWSRouteTable_MultipleRoutes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 5),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "3"),
@@ -969,6 +1025,7 @@ func TestAccAWSRouteTable_MultipleRoutes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 5),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "3"),
@@ -1664,6 +1721,39 @@ resource "aws_route_table" "test" {
 `, rName, destinationCidr))
 }
 
+func testAccAWSRouteTableConfigIpv4CarrierGateway(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_carrier_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block         = %[2]q
+    carrier_gateway_id = aws_ec2_carrier_gateway.test.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, destinationCidr)
+}
+
 func testAccAWSRouteTableConfigRouteIpv4LocalGateway(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "all" {}
@@ -2050,6 +2140,7 @@ resource "aws_route_table" "test" {
       ipv6_cidr_block = (route.value["destination_attr"] == "ipv6_cidr_block") ? route.value["destination_value"] : null
 
       # Target.
+      carrier_gateway_id        = (route.value["target_attr"] == "carrier_gateway_id") ? route.value["target_value"] : null
       egress_only_gateway_id    = (route.value["target_attr"] == "egress_only_gateway_id") ? route.value["target_value"] : null
       gateway_id                = (route.value["target_attr"] == "gateway_id") ? route.value["target_value"] : null
       instance_id               = (route.value["target_attr"] == "instance_id") ? route.value["target_value"] : null

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -18,16 +18,36 @@ For more information, see the Amazon VPC User Guide on [Route Tables](https://do
 
 ## Example Usage
 
-```terraform
-resource "aws_default_route_table" "r" {
-  default_route_table_id = aws_vpc.foo.default_route_table_id
+```hcl
+resource "aws_default_route_table" "example" {
+  default_route_table_id = aws_vpc.example.default_route_table_id
 
   route {
-    # ...
+    cidr_block = "10.0.1.0/24"
+    gateway_id = aws_internet_gateway.example.id
+  }
+
+  route {
+    ipv6_cidr_block        = "::/0"
+    egress_only_gateway_id = aws_egress_only_internet_gateway.example.id
   }
 
   tags = {
-    Name = "default table"
+    Name = "example"
+  }
+}
+```
+
+To subsequently remove all managed routes:
+
+```hcl
+resource "aws_default_route_table" "example" {
+  default_route_table_id = aws_vpc.example.default_route_table_id
+
+  route = []
+
+  tags = {
+    Name = "example"
   }
 }
 ```
@@ -41,12 +61,10 @@ The following arguments are required:
 The following arguments are optional:
 
 * `propagating_vgws` - (Optional) List of virtual gateways for propagation.
-* `route` - (Optional) Configuration block of routes. Detailed below.
+* `route` - (Optional) Configuration block of routes. Detailed below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html). This means that omitting this argument is interpreted as ignoring any existing routes. To remove all managed routes an empty list should be specified. See the example above.
 * `tags` - (Optional) Map of tags to assign to the resource.
 
 ### route
-
-This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
 
 One of the following destination arguments must be supplied:
 

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -75,7 +75,6 @@ One of the following destination arguments must be supplied:
 
 One of the following target arguments must be supplied:
 
-* `carrier_gateway_id` - (Optional) Identifier of a carrier gateway. This attribute can only be used when the VPC contains a subnet which is associated with a Wavelength Zone.
 * `egress_only_gateway_id` - (Optional) Identifier of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional) Identifier of an EC2 instance.

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -55,7 +55,6 @@ One of the following destination arguments must be supplied:
 
 One of the following target arguments must be supplied:
 
-* `carrier_gateway_id` - (Optional) Identifier of a carrier gateway. This attribute can only be used when the VPC contains a subnet which is associated with a Wavelength Zone.
 * `egress_only_gateway_id` - (Optional) Identifier of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional) Identifier of an EC2 instance.

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -55,6 +55,7 @@ One of the following destination arguments must be supplied:
 
 One of the following target arguments must be supplied:
 
+* `carrier_gateway_id` - (Optional) Identifier of a carrier gateway. This attribute can only be used when the VPC contains a subnet which is associated with a Wavelength Zone.
 * `egress_only_gateway_id` - (Optional) Identifier of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional) Identifier of an EC2 instance.
@@ -71,6 +72,7 @@ Note that the default route, mapping the VPC's CIDR block to "local", is created
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the route table.
+* `arn` - The ARN of the route table.
 * `owner_id` - ID of the AWS account that owns the route table.
 * `vpc_id` - ID of the VPC.
 

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -75,6 +75,7 @@ One of the following destination arguments must be supplied:
 
 One of the following target arguments must be supplied:
 
+* `carrier_gateway_id` - (Optional) Identifier of a carrier gateway. This attribute can only be used when the VPC contains a subnet which is associated with a Wavelength Zone.
 * `egress_only_gateway_id` - (Optional) Identifier of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional) Identifier of an EC2 instance.

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -18,7 +18,7 @@ For more information, see the Amazon VPC User Guide on [Route Tables](https://do
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "aws_default_route_table" "example" {
   default_route_table_id = aws_vpc.example.default_route_table_id
 
@@ -40,7 +40,7 @@ resource "aws_default_route_table" "example" {
 
 To subsequently remove all managed routes:
 
-```hcl
+```terraform
 resource "aws_default_route_table" "example" {
   default_route_table_id = aws_vpc.example.default_route_table_id
 

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -66,6 +66,8 @@ The following arguments are optional:
 
 ### route
 
+This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+
 One of the following destination arguments must be supplied:
 
 * `cidr_block` - (Required) The CIDR block of the route.

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -31,22 +31,36 @@ the separate resource.
 
 ## Example Usage
 
-```terraform
-resource "aws_route_table" "r" {
-  vpc_id = aws_vpc.default.id
+```hcl
+resource "aws_route_table" "example" {
+  vpc_id = aws_vpc.example.id
 
   route {
     cidr_block = "10.0.1.0/24"
-    gateway_id = aws_internet_gateway.main.id
+    gateway_id = aws_internet_gateway.example.id
   }
 
   route {
     ipv6_cidr_block        = "::/0"
-    egress_only_gateway_id = aws_egress_only_internet_gateway.foo.id
+    egress_only_gateway_id = aws_egress_only_internet_gateway.example.id
   }
 
   tags = {
-    Name = "main"
+    Name = "example"
+  }
+}
+```
+
+To subsequently remove all managed routes:
+
+```hcl
+resource "aws_route_table" "example" {
+  vpc_id = aws_vpc.example.id
+
+  route = []
+
+  tags = {
+    Name = "example"
   }
 }
 ```
@@ -57,6 +71,7 @@ The following arguments are supported:
 
 * `vpc_id` - (Required) The VPC ID.
 * `route` - (Optional) A list of route objects. Their keys are documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+This means that omitting this argument is interpreted as ignoring any existing routes. To remove all managed routes an empty list should be specified. See the example above.
 * `tags` - (Optional) A map of tags to assign to the resource.
 * `propagating_vgws` - (Optional) A list of virtual gateways for propagation.
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -31,7 +31,7 @@ the separate resource.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "aws_route_table" "example" {
   vpc_id = aws_vpc.example.id
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -69,11 +69,12 @@ One of the following destination arguments must be supplied:
 
 One of the following target arguments must be supplied:
 
+* `carrier_gateway_id` - (Optional) Identifier of a carrier gateway. This attribute can only be used when the VPC contains a subnet which is associated with a Wavelength Zone.
 * `egress_only_gateway_id` - (Optional) Identifier of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional) Identifier of an EC2 instance.
-* `nat_gateway_id` - (Optional) Identifier of a VPC NAT gateway.
 * `local_gateway_id` - (Optional) Identifier of a Outpost local gateway.
+* `nat_gateway_id` - (Optional) Identifier of a VPC NAT gateway.
 * `network_interface_id` - (Optional) Identifier of an EC2 network interface.
 * `transit_gateway_id` - (Optional) Identifier of an EC2 Transit Gateway.
 * `vpc_endpoint_id` - (Optional) Identifier of a VPC Endpoint.
@@ -89,6 +90,7 @@ In addition to all arguments above, the following attributes are exported:
 attribute once the route resource is created.
 
 * `id` - The ID of the routing table.
+* `arn` - The ARN of the route table.
 * `owner_id` - The ID of the AWS account that owns the route table.
 
 ## Import

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -53,7 +53,7 @@ resource "aws_route_table" "example" {
 
 To subsequently remove all managed routes:
 
-```hcl
+```terraform
 resource "aws_route_table" "example" {
   vpc_id = aws_vpc.example.id
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14518.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/13624.

Closes: https://github.com/hashicorp/terraform-provider-aws/issues/199 (Documentation).

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSRouteTable_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSRouteTable_ -timeout 120m
=== RUN   TestAccAWSRouteTable_basic
=== PAUSE TestAccAWSRouteTable_basic
=== RUN   TestAccAWSRouteTable_disappears
=== PAUSE TestAccAWSRouteTable_disappears
=== RUN   TestAccAWSRouteTable_disappears_SubnetAssociation
=== PAUSE TestAccAWSRouteTable_disappears_SubnetAssociation
=== RUN   TestAccAWSRouteTable_IPv4_To_InternetGateway
=== PAUSE TestAccAWSRouteTable_IPv4_To_InternetGateway
=== RUN   TestAccAWSRouteTable_IPv4_To_Instance
=== PAUSE TestAccAWSRouteTable_IPv4_To_Instance
=== RUN   TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway
=== PAUSE TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway
=== RUN   TestAccAWSRouteTable_tags
=== PAUSE TestAccAWSRouteTable_tags
=== RUN   TestAccAWSRouteTable_RequireRouteDestination
=== PAUSE TestAccAWSRouteTable_RequireRouteDestination
=== RUN   TestAccAWSRouteTable_RequireRouteTarget
=== PAUSE TestAccAWSRouteTable_RequireRouteTarget
=== RUN   TestAccAWSRouteTable_Route_ConfigMode
=== PAUSE TestAccAWSRouteTable_Route_ConfigMode
=== RUN   TestAccAWSRouteTable_IPv4_To_TransitGateway
=== PAUSE TestAccAWSRouteTable_IPv4_To_TransitGateway
=== RUN   TestAccAWSRouteTable_IPv4_To_VpcEndpoint
=== PAUSE TestAccAWSRouteTable_IPv4_To_VpcEndpoint
=== RUN   TestAccAWSRouteTable_IPv4_To_CarrierGateway
=== PAUSE TestAccAWSRouteTable_IPv4_To_CarrierGateway
=== RUN   TestAccAWSRouteTable_IPv4_To_LocalGateway
=== PAUSE TestAccAWSRouteTable_IPv4_To_LocalGateway
=== RUN   TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection
=== PAUSE TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
=== PAUSE TestAccAWSRouteTable_vgwRoutePropagation
=== RUN   TestAccAWSRouteTable_ConditionalCidrBlock
=== PAUSE TestAccAWSRouteTable_ConditionalCidrBlock
=== RUN   TestAccAWSRouteTable_IPv4_To_NatGateway
=== PAUSE TestAccAWSRouteTable_IPv4_To_NatGateway
=== RUN   TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached
=== PAUSE TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached
=== RUN   TestAccAWSRouteTable_VpcMultipleCidrs
=== PAUSE TestAccAWSRouteTable_VpcMultipleCidrs
=== RUN   TestAccAWSRouteTable_VpcClassicLink
=== PAUSE TestAccAWSRouteTable_VpcClassicLink
=== RUN   TestAccAWSRouteTable_GatewayVpcEndpoint
=== PAUSE TestAccAWSRouteTable_GatewayVpcEndpoint
=== RUN   TestAccAWSRouteTable_MultipleRoutes
=== PAUSE TestAccAWSRouteTable_MultipleRoutes
=== CONT  TestAccAWSRouteTable_basic
=== CONT  TestAccAWSRouteTable_IPv4_To_CarrierGateway
--- PASS: TestAccAWSRouteTable_basic (22.53s)
=== CONT  TestAccAWSRouteTable_MultipleRoutes
--- PASS: TestAccAWSRouteTable_IPv4_To_CarrierGateway (27.08s)
=== CONT  TestAccAWSRouteTable_GatewayVpcEndpoint
--- PASS: TestAccAWSRouteTable_GatewayVpcEndpoint (38.31s)
=== CONT  TestAccAWSRouteTable_VpcClassicLink
--- PASS: TestAccAWSRouteTable_VpcClassicLink (22.43s)
=== CONT  TestAccAWSRouteTable_VpcMultipleCidrs
--- PASS: TestAccAWSRouteTable_VpcMultipleCidrs (44.06s)
=== CONT  TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached
--- PASS: TestAccAWSRouteTable_MultipleRoutes (167.25s)
=== CONT  TestAccAWSRouteTable_IPv4_To_NatGateway
--- PASS: TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached (64.25s)
=== CONT  TestAccAWSRouteTable_ConditionalCidrBlock
--- PASS: TestAccAWSRouteTable_ConditionalCidrBlock (52.89s)
=== CONT  TestAccAWSRouteTable_vgwRoutePropagation
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (65.65s)
=== CONT  TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection
--- PASS: TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection (26.92s)
=== CONT  TestAccAWSRouteTable_IPv4_To_LocalGateway
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSRouteTable_IPv4_To_LocalGateway (1.76s)
=== CONT  TestAccAWSRouteTable_tags
--- PASS: TestAccAWSRouteTable_IPv4_To_NatGateway (216.05s)
=== CONT  TestAccAWSRouteTable_IPv4_To_VpcEndpoint
--- PASS: TestAccAWSRouteTable_tags (69.02s)
=== CONT  TestAccAWSRouteTable_IPv4_To_TransitGateway
--- PASS: TestAccAWSRouteTable_IPv4_To_VpcEndpoint (297.37s)
=== CONT  TestAccAWSRouteTable_Route_ConfigMode
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (70.12s)
=== CONT  TestAccAWSRouteTable_RequireRouteTarget
--- PASS: TestAccAWSRouteTable_RequireRouteTarget (11.79s)
=== CONT  TestAccAWSRouteTable_RequireRouteDestination
=== CONT  TestAccAWSRouteTable_IPv4_To_InternetGateway
--- PASS: TestAccAWSRouteTable_IPv4_To_TransitGateway (411.37s)
--- PASS: TestAccAWSRouteTable_IPv4_To_InternetGateway (64.50s)
=== CONT  TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway
--- PASS: TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway (47.10s)
=== CONT  TestAccAWSRouteTable_IPv4_To_Instance
--- PASS: TestAccAWSRouteTable_RequireRouteDestination (314.49s)
=== CONT  TestAccAWSRouteTable_disappears_SubnetAssociation
--- PASS: TestAccAWSRouteTable_disappears_SubnetAssociation (24.60s)
=== CONT  TestAccAWSRouteTable_disappears
--- PASS: TestAccAWSRouteTable_disappears (19.61s)
--- PASS: TestAccAWSRouteTable_IPv4_To_Instance (324.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1259.709s
r/aws_default_route_table: Add 'arn' attribute.

Acceptance test output:

$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDefaultRouteTable_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSDefaultRouteTable_ -timeout 120m
=== RUN   TestAccAWSDefaultRouteTable_basic
=== PAUSE TestAccAWSDefaultRouteTable_basic
=== RUN   TestAccAWSDefaultRouteTable_disappears_Vpc
=== PAUSE TestAccAWSDefaultRouteTable_disappears_Vpc
=== RUN   TestAccAWSDefaultRouteTable_Route_ConfigMode
=== PAUSE TestAccAWSDefaultRouteTable_Route_ConfigMode
=== RUN   TestAccAWSDefaultRouteTable_swap
=== PAUSE TestAccAWSDefaultRouteTable_swap
=== RUN   TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway
=== PAUSE TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway
=== RUN   TestAccAWSDefaultRouteTable_IPv4_To_VpcEndpoint
=== PAUSE TestAccAWSDefaultRouteTable_IPv4_To_VpcEndpoint
=== RUN   TestAccAWSDefaultRouteTable_VpcEndpointAssociation
=== PAUSE TestAccAWSDefaultRouteTable_VpcEndpointAssociation
=== RUN   TestAccAWSDefaultRouteTable_tags
=== PAUSE TestAccAWSDefaultRouteTable_tags
=== RUN   TestAccAWSDefaultRouteTable_ConditionalCidrBlock
=== PAUSE TestAccAWSDefaultRouteTable_ConditionalCidrBlock
=== CONT  TestAccAWSDefaultRouteTable_basic
=== CONT  TestAccAWSDefaultRouteTable_IPv4_To_VpcEndpoint
--- PASS: TestAccAWSDefaultRouteTable_basic (29.97s)
=== CONT  TestAccAWSDefaultRouteTable_ConditionalCidrBlock
--- PASS: TestAccAWSDefaultRouteTable_ConditionalCidrBlock (54.15s)
=== CONT  TestAccAWSDefaultRouteTable_tags
--- PASS: TestAccAWSDefaultRouteTable_tags (52.24s)
=== CONT  TestAccAWSDefaultRouteTable_VpcEndpointAssociation
--- PASS: TestAccAWSDefaultRouteTable_VpcEndpointAssociation (44.51s)
=== CONT  TestAccAWSDefaultRouteTable_swap
--- PASS: TestAccAWSDefaultRouteTable_swap (91.07s)
=== CONT  TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway
=== CONT  TestAccAWSDefaultRouteTable_Route_ConfigMode
--- PASS: TestAccAWSDefaultRouteTable_IPv4_To_VpcEndpoint (323.68s)
--- PASS: TestAccAWSDefaultRouteTable_Route_ConfigMode (84.01s)
=== CONT  TestAccAWSDefaultRouteTable_disappears_Vpc
--- PASS: TestAccAWSDefaultRouteTable_disappears_Vpc (14.13s)
--- PASS: TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway (400.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	672.134s
```
