### PR TITLE
Allows EventBus Rule/Target event_bus_name to accept ARN

### DIFF
--- a/aws/internal/service/cloudwatchevents/id.go
+++ b/aws/internal/service/cloudwatchevents/id.go
@@ -37,6 +37,9 @@ func RuleCreateID(eventBusName, ruleName string) string {
 	return eventBusName + ruleIDSeparator + ruleName
 }
 
+const arnPrefix = "arn:"
+const resourceSeparator = "/"
+
 func RuleParseID(id string) (string, string, error) {
 	parts := strings.Split(id, ruleIDSeparator)
 	if len(parts) == 1 && parts[0] != "" {
@@ -44,6 +47,9 @@ func RuleParseID(id string) (string, string, error) {
 	}
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil
+	}
+	if len(parts) == 3 && strings.HasPrefix(parts[0], arnPrefix) {
+		return parts[0] + resourceSeparator + parts[1], parts[2], nil
 	}
 
 	return "", "", fmt.Errorf("unexpected format for ID (%q), expected <event-bus-name>"+ruleIDSeparator+"<rule-name> or <rule-name>", id)

--- a/aws/resource_aws_cloudwatch_event_rule.go
+++ b/aws/resource_aws_cloudwatch_event_rule.go
@@ -59,7 +59,7 @@ func resourceAwsCloudWatchEventRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateCloudWatchEventBusName,
+				ValidateFunc: validateCloudWatchEventBusNameOrARN,
 				Default:      tfevents.DefaultEventBusName,
 			},
 			"event_pattern": {

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -41,7 +41,7 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateCloudWatchEventBusName,
+				ValidateFunc: validateCloudWatchEventBusNameOrARN,
 				Default:      tfevents.DefaultEventBusName,
 			},
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2482,6 +2482,11 @@ var validateCloudWatchEventBusName = validation.All(
 	validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`), ""),
 )
 
+var validateCloudWatchEventBusNameOrARN = validation.All(
+	validation.StringLenBetween(1, 1600),
+	validation.StringMatch(regexp.MustCompile(`^(arn:aws[\w-]*:events:[a-z]{2}-[a-z]+-[\w-]+:[0-9]{12}:event-bus\/)?[/\.\-_A-Za-z0-9]+$`), ""),
+)
+
 var validateServiceDiscoveryNamespaceName = validation.All(
 	validation.StringLenBetween(1, 1024),
 	validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z._-]+$`), ""),

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3206,6 +3206,46 @@ func TestCloudWatchEventCustomEventBusName(t *testing.T) {
 	}
 }
 
+func TestCloudWatchEventCustomEventBusNameOrARN(t *testing.T) {
+	cases := []struct {
+		Value   string
+		IsValid bool
+	}{
+		{
+			Value:   "",
+			IsValid: false,
+		},
+		{
+			Value:   acctest.RandStringFromCharSet(1600, acctest.CharSetAlpha),
+			IsValid: true,
+		},
+		{
+			Value:   acctest.RandStringFromCharSet(1601, acctest.CharSetAlpha),
+			IsValid: false,
+		},
+		{
+			Value:   "test0._1-",
+			IsValid: true,
+		},
+		{
+			Value:   "arn:aws:events:us-east-1:123456789012:event-bus/default", //lintignore:AWSAT003,AWSAT005
+			IsValid: true,
+		},
+		{
+			Value:   "arn:aws:events:us-east-1:123456789012:eventbus/default", //lintignore:AWSAT003,AWSAT005
+			IsValid: false,
+		},
+	}
+	for _, tc := range cases {
+		_, errors := validateCloudWatchEventBusNameOrARN(tc.Value, "aws_cloudwatch_event_bus")
+		isValid := len(errors) == 0
+		if tc.IsValid && !isValid {
+			t.Errorf("expected %q to return valid, but did not", tc.Value)
+		} else if !tc.IsValid && isValid {
+			t.Errorf("expected %q to not return valid, but did", tc.Value)
+		}
+	}
+}
 func TestValidateServiceDiscoveryNamespaceName(t *testing.T) {
 	validNames := []string{
 		"ValidName",


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16973

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_cloudwatch_event_rule and aws_cloudwatch_event_target will now accept an ARN in the event_bus_name argument 
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestCloudWatchEventCustomEventBusNameOrARN'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestCloudWatchEventCustomEventBusNameOrARN -timeout 120m
=== RUN   TestCloudWatchEventCustomEventBusNameOrARN
--- PASS: TestCloudWatchEventCustomEventBusNameOrARN (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1.913s
...
```