### PR TITLE
resource/opsworks: Fix hardcoded regions

### DIFF
--- a/aws/resource_aws_opsworks_instance_test.go
+++ b/aws/resource_aws_opsworks_instance_test.go
@@ -16,6 +16,7 @@ func TestAccAWSOpsworksInstance_basic(t *testing.T) {
 	stackName := fmt.Sprintf("tf-%d", acctest.RandInt())
 	var opsinst opsworks.Instance
 	resourceName := "aws_opsworks_instance.tf-acc"
+	dataSourceName := "data.aws_availability_zones.available"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(opsworks.EndpointsID, t) },
@@ -34,9 +35,9 @@ func TestAccAWSOpsworksInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "install_updates_on_boot", "true"),
 					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
 					resource.TestCheckResourceAttr(resourceName, "tenancy", "default"),
-					resource.TestCheckResourceAttr(resourceName, "os", "Amazon Linux 2016.09"),      // inherited from opsworks_stack_test
-					resource.TestCheckResourceAttr(resourceName, "root_device_type", "ebs"),         // inherited from opsworks_stack_test
-					resource.TestCheckResourceAttr(resourceName, "availability_zone", "us-west-2a"), // inherited from opsworks_stack_test
+					resource.TestCheckResourceAttr(resourceName, "os", "Amazon Linux 2016.09"),                       // inherited from opsworks_stack_test
+					resource.TestCheckResourceAttr(resourceName, "root_device_type", "ebs"),                          // inherited from opsworks_stack_test
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", dataSourceName, "names.0"), // inherited from opsworks_stack_test
 				),
 			},
 			{
@@ -145,9 +146,6 @@ func testAccCheckAWSOpsworksInstanceAttributes(
 		// Depending on the timing, the state could be requested or stopped
 		if *opsinst.Status != "stopped" && *opsinst.Status != "requested" {
 			return fmt.Errorf("Unexpected request status: %s", *opsinst.Status)
-		}
-		if *opsinst.AvailabilityZone != "us-west-2a" {
-			return fmt.Errorf("Unexpected availability zone: %s", *opsinst.AvailabilityZone)
 		}
 		if *opsinst.Architecture != "x86_64" {
 			return fmt.Errorf("Unexpected architecture: %s", *opsinst.Architecture)

--- a/aws/resource_aws_opsworks_stack.go
+++ b/aws/resource_aws_opsworks_stack.go
@@ -308,7 +308,7 @@ func resourceAwsOpsworksStackRead(d *schema.ResourceData, meta interface{}) erro
 						// If we haven't already, try us-east-1, legacy connection
 						notFound++
 						var connErr error
-						client, connErr = opsworksConnForRegion("us-east-1", meta)
+						client, connErr = opsworksConnForRegion("us-east-1", meta) //lintignore:AWSAT003
 						if connErr != nil {
 							return connErr
 						}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Acceptance Tests in GovCloud

```
--- SKIP: TestAccAWSOpsworksInstance_basic (1.23s)
--- SKIP: TestAccAWSOpsworksInstance_UpdateHostNameForceNew (1.23s)
```

### Acceptance Tests in `us-east-1`

These would not have worked previously:

```
--- PASS: TestAccAWSOpsworksInstance_UpdateHostNameForceNew (41.14s)
--- PASS: TestAccAWSOpsworksInstance_basic (41.43s)
```

### Acceptance Tests in `us-west-2`

```
--- PASS: TestAccAWSOpsworksInstance_UpdateHostNameForceNew (62.07s)
--- PASS: TestAccAWSOpsworksInstance_basic (62.80s)
```
