### PR TITLE
[WIP] Support wildcard in Lambda permission

### DIFF
--- a/aws/iam_policy_model.go
+++ b/aws/iam_policy_model.go
@@ -124,6 +124,40 @@ func (ps IAMPolicyStatementPrincipalSet) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&raw)
 }
 
+func (ps *IAMPolicyStatementPrincipal) UnmarshalJSON(b []byte) error {
+	var out IAMPolicyStatementPrincipal
+
+	var data interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	switch t := data.(type) {
+	case string:
+		out = IAMPolicyStatementPrincipal{Type: "AWS", Identifiers: []string{"*"}}
+	case map[string]interface{}:
+		for key, value := range data.(map[string]interface{}) {
+			switch vt := value.(type) {
+			case string:
+				out = IAMPolicyStatementPrincipal{Type: key, Identifiers: value.(string)}
+			case []interface{}:
+				values := []string{}
+				for _, v := range value.([]interface{}) {
+					values = append(values, v.(string))
+				}
+				out = IAMPolicyStatementPrincipal{Type: key, Identifiers: values}
+			default:
+				return fmt.Errorf("Unsupported data type %T for IAMPolicyStatementPrincipal", vt)
+			}
+		}
+	default:
+		return fmt.Errorf("Unsupported data type %T for IAMPolicyStatementPrincipal", t)
+	}
+
+	*ps = out
+	return nil
+}
+
 func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
 	var out IAMPolicyStatementPrincipalSet
 

--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -285,12 +285,8 @@ func resourceAwsLambdaPermissionRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("action", statement.Action)
-	// Check if the principal is a cross-account IAM role
-	if _, ok := statement.Principal["AWS"]; ok {
-		d.Set("principal", statement.Principal["AWS"])
-	} else {
-		d.Set("principal", statement.Principal["Service"])
-	}
+
+	d.Set("principal", statement.Principal.Identifiers.(string))
 
 	if stringEquals, ok := statement.Condition["StringEquals"]; ok {
 		d.Set("source_account", stringEquals["AWS:SourceAccount"])
@@ -466,6 +462,6 @@ type LambdaPolicyStatement struct {
 	Action    string
 	Resource  string
 	Effect    string
-	Principal map[string]string
+	Principal IAMPolicyStatementPrincipal
 	Sid       string
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2776

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
BUG FIXES
* resource/aws_lambda_permission: Support a Principal of "*" (that is not JSON)
```
