### PR TITLE
d/aws_route_table: AWS Wavelength support

### DIFF
--- a/.changelog/17001.txt
+++ b/.changelog/17001.txt
@@ -1,0 +1,7 @@
+```release-notes:enhancement
+data-source/aws_route_table: Add `arn` attribute
+```
+
+```release-notes:enhancement
+data-source/aws_route_table: Add `carrier_gateway_id` attribute to `routes` list
+```

--- a/aws/data_source_aws_route_table.go
+++ b/aws/data_source_aws_route_table.go
@@ -172,7 +172,7 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	filter, filterOk := d.GetOk("filter")
 
 	if !rtbOk && !vpcIdOk && !subnetIdOk && !gatewayIdOk && !filterOk && !tagsOk {
-		return fmt.Errorf("One of route_table_id, vpc_id, subnet_id, gateway_id, filters, or tags must be assigned")
+		return fmt.Errorf("one of route_table_id, vpc_id, subnet_id, gateway_id, filters, or tags must be assigned")
 	}
 	req.Filters = buildEC2AttributeFilterList(
 		map[string]string{
@@ -195,10 +195,10 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 	if resp == nil || len(resp.RouteTables) == 0 {
-		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again")
+		return fmt.Errorf("query returned no results. Please change your search criteria and try again")
 	}
 	if len(resp.RouteTables) > 1 {
-		return fmt.Errorf("Multiple Route Table matched; use additional constraints to reduce matches to a single Route Table")
+		return fmt.Errorf("multiple Route Tables matched; use additional constraints to reduce matches to a single Route Table")
 	}
 
 	rt := resp.RouteTables[0]
@@ -208,7 +208,7 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	ownerID := aws.StringValue(rt.OwnerId)
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
+		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
 		AccountID: ownerID,
 		Resource:  fmt.Sprintf("route-table/%s", d.Id()),

--- a/aws/data_source_aws_route_table_test.go
+++ b/aws/data_source_aws_route_table_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -28,6 +29,7 @@ func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 				Config: testAccDataSourceAwsRouteTableConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					// By tags.
+					testAccMatchResourceAttrRegionalARN(datasource1Name, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					resource.TestCheckResourceAttrPair(datasource1Name, "id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource1Name, "route_table_id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource1Name, "owner_id", rtResourceName, "owner_id"),
@@ -39,6 +41,7 @@ func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 					testAccCheckListHasSomeElementAttrPair(datasource1Name, "associations", "gateway_id", igwResourceName, "id"),
 					resource.TestCheckResourceAttr(datasource1Name, "tags.Name", rName),
 					// By filter.
+					testAccMatchResourceAttrRegionalARN(datasource2Name, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					resource.TestCheckResourceAttrPair(datasource2Name, "id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource2Name, "route_table_id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource2Name, "owner_id", rtResourceName, "owner_id"),
@@ -50,6 +53,7 @@ func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 					testAccCheckListHasSomeElementAttrPair(datasource2Name, "associations", "gateway_id", igwResourceName, "id"),
 					resource.TestCheckResourceAttr(datasource2Name, "tags.Name", rName),
 					// By subnet ID.
+					testAccMatchResourceAttrRegionalARN(datasource3Name, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					resource.TestCheckResourceAttrPair(datasource3Name, "id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource3Name, "route_table_id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource3Name, "owner_id", rtResourceName, "owner_id"),
@@ -61,6 +65,7 @@ func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 					testAccCheckListHasSomeElementAttrPair(datasource3Name, "associations", "gateway_id", igwResourceName, "id"),
 					resource.TestCheckResourceAttr(datasource3Name, "tags.Name", rName),
 					// By route table ID.
+					testAccMatchResourceAttrRegionalARN(datasource4Name, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					resource.TestCheckResourceAttrPair(datasource4Name, "id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource4Name, "route_table_id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource4Name, "owner_id", rtResourceName, "owner_id"),
@@ -72,6 +77,7 @@ func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 					testAccCheckListHasSomeElementAttrPair(datasource4Name, "associations", "gateway_id", igwResourceName, "id"),
 					resource.TestCheckResourceAttr(datasource4Name, "tags.Name", rName),
 					// By gateway ID.
+					testAccMatchResourceAttrRegionalARN(datasource5Name, "arn", "ec2", regexp.MustCompile(`route-table/.+$`)),
 					resource.TestCheckResourceAttrPair(datasource5Name, "id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource5Name, "route_table_id", rtResourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasource5Name, "owner_id", rtResourceName, "owner_id"),

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -10,14 +10,11 @@ description: |-
 
 `aws_route_table` provides details about a specific Route Table.
 
-This resource can prove useful when a module accepts a Subnet id as
-an input variable and needs to, for example, add a route in
-the Route Table.
+This resource can prove useful when a module accepts a Subnet ID as an input variable and needs to, for example, add a route in the Route Table.
 
 ## Example Usage
 
-The following example shows how one might accept a Route Table id as a variable
-and use this data source to obtain the data necessary to create a route.
+The following example shows how one might accept a Route Table ID as a variable and use this data source to obtain the data necessary to create a route.
 
 ```hcl
 variable "subnet_id" {}
@@ -35,62 +32,63 @@ resource "aws_route" "route" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available
-Route Table in the current region. The given filters must match exactly one
-Route Table whose data will be exported as attributes.
+The arguments of this data source act as filters for querying the available Route Table in the current region. The given filters must match exactly one Route Table whose data will be exported as attributes.
 
-* `filter` - (Optional) Custom filter block as described below.
+The following arguments are optional:
 
-* `route_table_id` - (Optional) The id of the specific Route Table to retrieve.
+* `filter` - (Optional) Configuration block. Detailed below.
+* `gateway_id` - (Optional) ID of an Internet Gateway or Virtual Private Gateway which is connected to the Route Table (not exported if not passed as a parameter).
+* `route_table_id` - (Optional) ID of the specific Route Table to retrieve.
+* `subnet_id` - (Optional) ID of a Subnet which is connected to the Route Table (not exported if not passed as a parameter).
+* `tags` - (Optional) Map of tags, each pair of which must exactly match a pair on the desired Route Table.
+* `vpc_id` - (Optional) ID of the VPC that the desired Route Table belongs to.
 
-* `tags` - (Optional) A map of tags, each pair of which must exactly match
-  a pair on the desired Route Table.
+### filter 
 
-* `vpc_id` - (Optional) The id of the VPC that the desired Route Table belongs to.
+Complex filters can be expressed using one or more `filter` blocks.
 
-* `subnet_id` - (Optional) The id of a Subnet which is connected to the Route Table (not exported if not passed as a parameter).
+The following arguments are required:
 
-* `gateway_id` - (Optional) The id of an Internet Gateway or Virtual Private Gateway which is connected to the Route Table (not exported if not passed as a parameter).
-
-More complex filters can be expressed using one or more `filter` sub-blocks,
-which take the following arguments:
-
-* `name` - (Required) The name of the field to filter by, as defined by
-  [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRouteTables.html).
-
-* `values` - (Required) Set of values that are accepted for the given field.
-  A Route Table will be selected if any one of the given values matches.
+* `name` - (Required) Name of the field to filter by, as defined by [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRouteTables.html).
+* `values` - (Required) Set of values that are accepted for the given field. A Route Table will be selected if any one of the given values matches.
 
 ## Attributes Reference
 
-All of the argument attributes except the `filter` block are also exported as
-result attributes. This data source will complete the data by populating
-any fields that are not included in the configuration with the data for
-the selected Route Table. In addition the following attributes are exported:
+In addition to the arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the route table.
-* `owner_id` - The ID of the AWS account that owns the route table
+* `arn` - ARN of the route table.
+* `associations` - List of associations with attributes detailed below.
+* `owner_id` - ID of the AWS account that owns the route table.
+* `routes` - List of routes with attributes detailed below.
 
-`routes` are also exported with the following attributes, when there are relevants:
-Each route supports the following:
+### routes
 
-* `cidr_block` - The CIDR block of the route.
-* `ipv6_cidr_block` - The IPv6 CIDR block of the route.
-* `carrier_gateway_id` - The ID of the Carrier Gateway.
-* `egress_only_gateway_id` - The ID of the Egress Only Internet Gateway.
-* `gateway_id` - The Internet Gateway ID.
-* `nat_gateway_id` - The NAT Gateway ID.
-* `local_gateway_id` - The Local Gateway ID.
-* `instance_id` - The EC2 instance ID.
-* `transit_gateway_id` - The EC2 Transit Gateway ID.
-* `vpc_endpoint_id` - The VPC Endpoint ID.
-* `vpc_peering_connection_id` - The VPC Peering ID.
-* `network_interface_id` - The ID of the elastic network interface (eni) to use.
+When relevant, routes are also exported with the following attributes:
 
-`associations` are also exported with the following attributes:
+For destinations:
 
-* `route_table_association_id` - The Association ID.
-* `route_table_id` - The Route Table ID.
-* `subnet_id` - The Subnet ID. Only set when associated with a Subnet.
-* `gateway_id` - The Gateway ID. Only set when associated with an Internet Gateway or Virtual Private Gateway.
-* `main` - If the Association due to the Main Route Table.
+* `cidr_block` - CIDR block of the route.
+* `ipv6_cidr_block` - IPv6 CIDR block of the route.
+
+For targets:
+
+* `carrier_gateway_id` - ID of the Carrier Gateway.
+* `egress_only_gateway_id` - ID of the Egress Only Internet Gateway.
+* `gateway_id` - Internet Gateway ID.
+* `instance_id` - EC2 instance ID.
+* `local_gateway_id` - Local Gateway ID.
+* `nat_gateway_id` - NAT Gateway ID.
+* `network_interface_id` - ID of the elastic network interface (eni) to use.
+* `transit_gateway_id` - EC2 Transit Gateway ID.
+* `vpc_endpoint_id` - VPC Endpoint ID.
+* `vpc_peering_connection_id` - VPC Peering ID.
+
+### associations
+
+Associations are also exported with the following attributes:
+
+* `gateway_id` - Gateway ID. Only set when associated with an Internet Gateway or Virtual Private Gateway.
+* `main` - Whether the association is due to the main route table.
+* `route_table_association_id` - Association ID.
+* `route_table_id` - Route Table ID.
+* `subnet_id` - Subnet ID. Only set when associated with a subnet.

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -68,6 +68,7 @@ result attributes. This data source will complete the data by populating
 any fields that are not included in the configuration with the data for
 the selected Route Table. In addition the following attributes are exported:
 
+* `arn` - The ARN of the route table.
 * `owner_id` - The ID of the AWS account that owns the route table
 
 `routes` are also exported with the following attributes, when there are relevants:
@@ -75,6 +76,7 @@ Each route supports the following:
 
 * `cidr_block` - The CIDR block of the route.
 * `ipv6_cidr_block` - The IPv6 CIDR block of the route.
+* `carrier_gateway_id` - The ID of the Carrier Gateway.
 * `egress_only_gateway_id` - The ID of the Egress Only Internet Gateway.
 * `gateway_id` - The Internet Gateway ID.
 * `nat_gateway_id` - The NAT Gateway ID.

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -43,7 +43,7 @@ The following arguments are optional:
 * `tags` - (Optional) Map of tags, each pair of which must exactly match a pair on the desired Route Table.
 * `vpc_id` - (Optional) ID of the VPC that the desired Route Table belongs to.
 
-### filter 
+### filter
 
 Complex filters can be expressed using one or more `filter` blocks.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14518.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/13624.

Builds on #14016.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsRouteTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsRouteTable_ -timeout 120m
=== RUN   TestAccDataSourceAwsRouteTable_basic
=== PAUSE TestAccDataSourceAwsRouteTable_basic
=== RUN   TestAccDataSourceAwsRouteTable_main
=== PAUSE TestAccDataSourceAwsRouteTable_main
=== CONT  TestAccDataSourceAwsRouteTable_basic
=== CONT  TestAccDataSourceAwsRouteTable_main
--- PASS: TestAccDataSourceAwsRouteTable_main (19.21s)
--- PASS: TestAccDataSourceAwsRouteTable_basic (33.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	33.695s
```
