### PR TITLE
data-source/aws_route53_zone: Perform NS record lookup for private Hosted Zones

### DIFF
--- a/.changelog/17002.txt
+++ b/.changelog/17002.txt
@@ -1,0 +1,7 @@
+```release-note:note
+data-source/aws_route53_zone: The Route 53 `ListResourceRecordSets` API call has been implemented to support the `name_servers` attribute for private Hosted Zones similar to the resource implementation. Environments using restrictive IAM permissions may require updates.
+```
+
+```release-note:bug
+data-source/aws_route53_zone: Ensure `name_servers` is populated for private Hosted Zones
+```

--- a/aws/data_source_aws_route53_zone.go
+++ b/aws/data_source_aws_route53_zone.go
@@ -170,10 +170,12 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("linked_service_description", hostedZoneFound.LinkedService.Description)
 	}
 
-	nameServers, err := hostedZoneNameServers(idHostedZone, conn)
+	nameServers, err := hostedZoneNameServers(conn, idHostedZone, aws.StringValue(hostedZoneFound.Name))
+
 	if err != nil {
-		return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", err)
+		return fmt.Errorf("error getting Route 53 Hosted Zone (%s) name servers: %w", idHostedZone, err)
 	}
+
 	if err := d.Set("name_servers", nameServers); err != nil {
 		return fmt.Errorf("error setting name_servers: %w", err)
 	}
@@ -181,35 +183,45 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 	tags, err = keyvaluetags.Route53ListTags(conn, idHostedZone, route53.TagResourceTypeHostedzone)
 
 	if err != nil {
-		return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", err)
+		return fmt.Errorf("error listing Route 53 Hosted Zone (%s) tags: %w", idHostedZone, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil
 }
 
 // used to retrieve name servers
-func hostedZoneNameServers(id string, conn *route53.Route53) ([]string, error) {
-	req := &route53.GetHostedZoneInput{}
-	req.Id = aws.String(id)
+func hostedZoneNameServers(conn *route53.Route53, id string, name string) ([]string, error) {
+	input := &route53.GetHostedZoneInput{
+		Id: aws.String(id),
+	}
 
-	resp, err := conn.GetHostedZone(req)
+	output, err := conn.GetHostedZone(input)
+
 	if err != nil {
-		return []string{}, err
+		return nil, fmt.Errorf("error getting Route 53 Hosted Zone (%s): %w", id, err)
 	}
 
-	if resp.DelegationSet == nil {
-		return []string{}, nil
+	if output == nil {
+		return nil, fmt.Errorf("error getting Route 53 Hosted Zone (%s): empty response", id)
 	}
 
-	servers := []string{}
-	for _, server := range resp.DelegationSet.NameServers {
-		if server != nil {
-			servers = append(servers, aws.StringValue(server))
+	if output.DelegationSet != nil {
+		return aws.StringValueSlice(output.DelegationSet.NameServers), nil
+	}
+
+	if output.HostedZone != nil && output.HostedZone.Config != nil && aws.BoolValue(output.HostedZone.Config.PrivateZone) {
+		nameServers, err := getNameServers(id, name, conn)
+
+		if err != nil {
+			return nil, fmt.Errorf("error listing Route 53 Hosted Zone (%s) NS records: %w", id, err)
 		}
+
+		return nameServers, nil
 	}
-	return servers, nil
+
+	return nil, nil
 }

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -25,7 +25,7 @@ func TestAccAWSRoute53ZoneDataSource_id(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
-					resource.TestCheckResourceAttrPair(resourceName, "name_servers", dataSourceName, "name_servers"),
+					resource.TestCheckResourceAttrPair(resourceName, "name_servers.#", dataSourceName, "name_servers.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
 				),
 			},
@@ -49,7 +49,7 @@ func TestAccAWSRoute53ZoneDataSource_name(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
-					resource.TestCheckResourceAttrPair(resourceName, "name_servers", dataSourceName, "name_servers"),
+					resource.TestCheckResourceAttrPair(resourceName, "name_servers.#", dataSourceName, "name_servers.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
 				),
 			},
@@ -73,7 +73,7 @@ func TestAccAWSRoute53ZoneDataSource_tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
-					resource.TestCheckResourceAttrPair(resourceName, "name_servers", dataSourceName, "name_servers"),
+					resource.TestCheckResourceAttrPair(resourceName, "name_servers.#", dataSourceName, "name_servers.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
 				),
 			},
@@ -97,7 +97,7 @@ func TestAccAWSRoute53ZoneDataSource_vpc(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
-					resource.TestCheckResourceAttrPair(resourceName, "name_servers", dataSourceName, "name_servers"),
+					resource.TestCheckResourceAttrPair(resourceName, "name_servers.#", dataSourceName, "name_servers.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #10391
Closes #16862

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES

* data-source/aws_route53_zone: The Route 53 `ListResourceRecordSets` API call has been implemented to support the `name_servers` attribute for private Hosted Zones similar to the resource implementation. Environments using restrictive IAM permissions may require updates.

BUG FIXES

* data-source/aws_route53_zone: Ensure `name_servers` is populated for private Hosted Zones
```

Previously after testing updates:

```
=== CONT  TestAccAWSRoute53ZoneDataSource_vpc
    data_source_aws_route53_zone_test.go:89: Step 1/1 error: Check failed: Check 3/4 error: aws_route53_zone.test: Attribute "name_servers.#" is "4", but "name_servers.#" is not set in data.aws_route53_zone.test
--- FAIL: TestAccAWSRoute53ZoneDataSource_vpc (83.04s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53ZoneDataSource_id (46.24s)
--- PASS: TestAccAWSRoute53ZoneDataSource_name (47.24s)
--- PASS: TestAccAWSRoute53ZoneDataSource_tags (94.61s)
--- PASS: TestAccAWSRoute53ZoneDataSource_vpc (94.63s)
--- PASS: TestAccAWSRoute53ZoneDataSource_serviceDiscovery (110.28s)
```
