### PR TITLE
r/ssoadmin_permission_set_inline_policy: new resource

### DIFF
--- a/aws/internal/service/ssoadmin/finder/finder.go
+++ b/aws/internal/service/ssoadmin/finder/finder.go
@@ -1,0 +1,24 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssoadmin"
+)
+
+func InlinePolicy(ssoadminconn *ssoadmin.SSOAdmin, instanceArn, permissionSetArn string) (*string, error) {
+	input := &ssoadmin.GetInlinePolicyForPermissionSetInput{
+		InstanceArn:      aws.String(instanceArn),
+		PermissionSetArn: aws.String(permissionSetArn),
+	}
+
+	output, err := ssoadminconn.GetInlinePolicyForPermissionSet(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output.InlinePolicy, nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -937,6 +937,7 @@ func Provider() *schema.Provider {
 			"aws_ssm_patch_group":                                     resourceAwsSsmPatchGroup(),
 			"aws_ssm_parameter":                                       resourceAwsSsmParameter(),
 			"aws_ssm_resource_data_sync":                              resourceAwsSsmResourceDataSync(),
+			"aws_ssoadmin_permission_set_inline_policy":               resourceAwsSsoAdminPermissionSetInlinePolicy(),
 			"aws_storagegateway_cache":                                resourceAwsStorageGatewayCache(),
 			"aws_storagegateway_cached_iscsi_volume":                  resourceAwsStorageGatewayCachedIscsiVolume(),
 			"aws_storagegateway_gateway":                              resourceAwsStorageGatewayGateway(),

--- a/aws/resource_aws_ssoadmin_permission_set_inline_policy.go
+++ b/aws/resource_aws_ssoadmin_permission_set_inline_policy.go
@@ -1,0 +1,131 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssoadmin"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ssoadmin/finder"
+)
+
+func resourceAwsSsoAdminPermissionSetInlinePolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSsoAdminPermissionSetInlinePolicyPut,
+		Read:   resourceAwsSsoAdminPermissionSetInlinePolicyRead,
+		Update: resourceAwsSsoAdminPermissionSetInlinePolicyPut,
+		Delete: resourceAwsSsoAdminPermissionSetInlinePolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"inline_policy": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validateIAMPolicyJson,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
+			},
+
+			"instance_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+
+			"permission_set_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+		},
+	}
+}
+
+func resourceAwsSsoAdminPermissionSetInlinePolicyPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ssoadminconn
+
+	instanceArn := d.Get("instance_arn").(string)
+	permissionSetArn := d.Get("permission_set_arn").(string)
+
+	input := &ssoadmin.PutInlinePolicyToPermissionSetInput{
+		InlinePolicy:     aws.String(d.Get("inline_policy").(string)),
+		InstanceArn:      aws.String(instanceArn),
+		PermissionSetArn: aws.String(permissionSetArn),
+	}
+
+	_, err := conn.PutInlinePolicyToPermissionSet(input)
+	if err != nil {
+		return fmt.Errorf("error putting Inline Policy for SSO Permission Set (%s): %w", permissionSetArn, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s,%s", permissionSetArn, instanceArn))
+
+	// (Re)provision ALL accounts after making the above changes
+	if err := provisionSsoAdminPermissionSet(conn, permissionSetArn, instanceArn); err != nil {
+		return err
+	}
+
+	return resourceAwsSsoAdminPermissionSetInlinePolicyRead(d, meta)
+}
+
+func resourceAwsSsoAdminPermissionSetInlinePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ssoadminconn
+
+	permissionSetArn, instanceArn, err := parseSsoAdminResourceID(d.Id())
+	if err != nil {
+		return fmt.Errorf("error parsing SSO Permission Set Inline Policy ID: %w", err)
+	}
+
+	policy, err := finder.InlinePolicy(conn, instanceArn, permissionSetArn)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Inline Policy for SSO Permission Set (%s) not found, removing from state", permissionSetArn)
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Inline Policy for SSO Permission Set (%s): %w", permissionSetArn, err)
+	}
+
+	if policy == nil {
+		log.Printf("[WARN] Inline Policy for SSO Permission Set (%s) not found, removing from state", permissionSetArn)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("inline_policy", policy)
+	d.Set("instance_arn", instanceArn)
+	d.Set("permission_set_arn", permissionSetArn)
+
+	return nil
+}
+
+func resourceAwsSsoAdminPermissionSetInlinePolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ssoadminconn
+
+	permissionSetArn, instanceArn, err := parseSsoAdminResourceID(d.Id())
+	if err != nil {
+		return fmt.Errorf("error parsing SSO Permission Set Inline Policy ID: %w", err)
+	}
+
+	input := &ssoadmin.DeleteInlinePolicyFromPermissionSetInput{
+		InstanceArn:      aws.String(instanceArn),
+		PermissionSetArn: aws.String(permissionSetArn),
+	}
+
+	_, err = conn.DeleteInlinePolicyFromPermissionSet(input)
+
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+			return nil
+		}
+		return fmt.Errorf("error detaching Inline Policy from SSO Permission Set (%s): %w", permissionSetArn, err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_ssoadmin_permission_set_inline_policy_test.go
+++ b/aws/resource_aws_ssoadmin_permission_set_inline_policy_test.go
@@ -208,14 +208,14 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_ssoadmin_permission_set" "test" {
-  name                = %q
-  instance_arn        = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  name         = %q
+  instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
 }
 
 resource "aws_ssoadmin_permission_set_inline_policy" "test" {
-  inline_policy        = data.aws_iam_policy_document.test.json
-  instance_arn         = aws_ssoadmin_permission_set.test.instance_arn
-  permission_set_arn   = aws_ssoadmin_permission_set.test.arn
+  inline_policy      = data.aws_iam_policy_document.test.json
+  instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.test.arn
 }
 `, rName)
 }
@@ -239,14 +239,14 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_ssoadmin_permission_set" "test" {
-  name                = %q
-  instance_arn        = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  name         = %q
+  instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
 }
 
 resource "aws_ssoadmin_permission_set_inline_policy" "test" {
-  inline_policy        = data.aws_iam_policy_document.test.json
-  instance_arn         = aws_ssoadmin_permission_set.test.instance_arn
-  permission_set_arn   = aws_ssoadmin_permission_set.test.arn
+  inline_policy      = data.aws_iam_policy_document.test.json
+  instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.test.arn
 }
 `, rName)
 }

--- a/aws/resource_aws_ssoadmin_permission_set_inline_policy_test.go
+++ b/aws/resource_aws_ssoadmin_permission_set_inline_policy_test.go
@@ -1,0 +1,252 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssoadmin"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ssoadmin/finder"
+)
+
+func TestAccAWSSSOAdminPermissionSetInlinePolicy_basic(t *testing.T) {
+	resourceName := "aws_ssoadmin_permission_set_inline_policy.test"
+	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSSOAdminInstances(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSOAdminPermissionSetInlinePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSSOAdminPermissionSetInlinePolicyBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSOAdminPermissionSetInlinePolicyExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
+					resource.TestMatchResourceAttr(resourceName, "inline_policy", regexp.MustCompile("s3:ListAllMyBuckets")),
+					resource.TestMatchResourceAttr(resourceName, "inline_policy", regexp.MustCompile("s3:GetBucketLocation")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSOAdminPermissionSetInlinePolicy_update(t *testing.T) {
+	resourceName := "aws_ssoadmin_permission_set_inline_policy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSSOAdminInstances(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSOAdminPermissionSetInlinePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSSOAdminPermissionSetInlinePolicyBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSOAdminPermissionSetInlinePolicyExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSSOAdminPermissionSetInlinePolicyUpdateConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSOAdminPermissionSetInlinePolicyExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "inline_policy", regexp.MustCompile("s3:ListAllMyBuckets")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSOAdminPermissionSetInlinePolicy_disappears(t *testing.T) {
+	resourceName := "aws_ssoadmin_permission_set_inline_policy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSSOAdminInstances(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSOAdminPermissionSetInlinePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSSOAdminPermissionSetInlinePolicyBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSOAdminPermissionSetInlinePolicyExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSsoAdminPermissionSetInlinePolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSOInlinePolicy_disappears_permissionSet(t *testing.T) {
+	resourceName := "aws_ssoadmin_permission_set_inline_policy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSSOAdminInstances(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSOAdminPermissionSetInlinePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSSOAdminPermissionSetInlinePolicyBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSOAdminPermissionSetInlinePolicyExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSsoAdminPermissionSet(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSSOAdminPermissionSetInlinePolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ssoadminconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ssoadmin_permission_set_inline_policy" {
+			continue
+		}
+
+		permissionSetArn, instanceArn, err := parseSsoAdminResourceID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("error parsing SSO Permission Set Inline Policy ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		policy, err := finder.InlinePolicy(conn, instanceArn, permissionSetArn)
+
+		if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if aws.StringValue(policy) == "" {
+			continue
+		}
+
+		return fmt.Errorf("Inline Policy for SSO PermissionSet (%s) still exists", permissionSetArn)
+	}
+
+	return nil
+}
+
+func testAccCheckAWSSSOAdminPermissionSetInlinePolicyExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+		}
+
+		permissionSetArn, instanceArn, err := parseSsoAdminResourceID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("error parsing SSO Permission Set Inline Policy ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ssoadminconn
+
+		policy, err := finder.InlinePolicy(conn, instanceArn, permissionSetArn)
+
+		if err != nil {
+			return err
+		}
+
+		if policy == nil {
+			return fmt.Errorf("Inline Policy for SSO Permission Set (%s) not found", permissionSetArn)
+		}
+
+		return nil
+	}
+}
+
+func testAccSSOAdminPermissionSetInlinePolicyBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    sid = "1"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+}
+
+resource "aws_ssoadmin_permission_set" "test" {
+  name                = %q
+  instance_arn        = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "test" {
+  inline_policy        = data.aws_iam_policy_document.test.json
+  instance_arn         = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn   = aws_ssoadmin_permission_set.test.arn
+}
+`, rName)
+}
+
+func testAccSSOAdminPermissionSetInlinePolicyUpdateConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_ssoadmin_instances" "test" {}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    sid = "1"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+}
+
+resource "aws_ssoadmin_permission_set" "test" {
+  name                = %q
+  instance_arn        = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "test" {
+  inline_policy        = data.aws_iam_policy_document.test.json
+  instance_arn         = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn   = aws_ssoadmin_permission_set.test.arn
+}
+`, rName)
+}

--- a/website/docs/r/ssoadmin_permission_set_inline_policy.html.markdown
+++ b/website/docs/r/ssoadmin_permission_set_inline_policy.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_permission_set_inline_policy"
+description: |-
+  Manages an IAM inline policy for a Single Sign-On (SSO) Permission Set
+---
+
+# Resource: aws_ssoadmin_permission_set_inline_policy
+
+Provides an IAM inline policy for a Single Sign-On (SSO) Permission Set resource
+
+~> **NOTE:** Creating or updating this resource will automatically [Provision the Permission Set](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_ProvisionPermissionSet.html) to apply the corresponding updates to all assigned accounts.
+
+## Example Usage
+
+```hcl
+data "aws_ssoadmin_instances" "example" {}
+
+resource "aws_ssoadmin_permission_set" "example" {
+  name         = "Example"
+  instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    sid = "1"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "example" {
+  inline_policy      = data.aws_iam_policy_document.test.json
+  instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `inline_policy` - (Required) The IAM inline policy to attach to a Permission Set.
+* `instance_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed.
+* `permission_set_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the Permission Set.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Permission Set Amazon Resource Name (ARN) and SSO Instance Amazon Resource Name (ARN), separated by a comma (`,`).
+
+## Import
+
+SSO Permission Set Inline Policies can be imported using the `permission_set_arn` and `instance_arn` separated by a comma (`,`) e.g.
+
+```
+$ terraform import aws_ssoadmin_permission_set_inline_policy.example arn:aws:sso:::permissionSet/ssoins-2938j0x8920sbj72/ps-80383020jr9302rk,arn:aws:sso:::instance/ssoins-2938j0x8920sbj72
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Preceded by #15808
Relates #15108
Relates #15540

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/ssoadmin_permission_set_inline_policy: new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSSSOAdminPermissionSetInlinePolicy_disappears (21.74s)
--- PASS: TestAccAWSSSOAdminPermissionSetInlinePolicy_basic (22.01s)
--- PASS: TestAccAWSSSOAdminPermissionSetInlinePolicy_update (41.44s)
```
