### PR TITLE
resource/aws_elasticache_parameter_group: acceptance test fixes

### DIFF
--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -338,3 +338,38 @@ func resourceAwsElasticacheParameterHash(v interface{}) int {
 
 	return hashcode.String(buf.String())
 }
+
+// Flattens an array of Parameters into a []map[string]interface{}
+func flattenElastiCacheParameters(list []*elasticache.Parameter) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, i := range list {
+		if i.ParameterValue != nil {
+			result = append(result, map[string]interface{}{
+				"name":  strings.ToLower(aws.StringValue(i.ParameterName)),
+				"value": aws.StringValue(i.ParameterValue),
+			})
+		}
+	}
+	return result
+}
+
+// Takes the result of flatmap.Expand for an array of parameters and
+// returns Parameter API compatible objects
+func expandElastiCacheParameters(configured []interface{}) []*elasticache.ParameterNameValue {
+	parameters := make([]*elasticache.ParameterNameValue, len(configured))
+
+	// Loop over our configured parameters and create
+	// an array of aws-sdk-go compatible objects
+	for i, pRaw := range configured {
+		parameters[i] = expandElastiCacheParameter(pRaw.(map[string]interface{}))
+	}
+
+	return parameters
+}
+
+func expandElastiCacheParameter(param map[string]interface{}) *elasticache.ParameterNameValue {
+	return &elasticache.ParameterNameValue{
+		ParameterName:  aws.String(param["name"].(string)),
+		ParameterValue: aws.String(param["value"].(string)),
+	}
+}

--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -74,14 +74,14 @@ func resourceAwsElasticacheParameterGroupCreate(d *schema.ResourceData, meta int
 		Description:               aws.String(d.Get("description").(string)),
 	}
 
-	log.Printf("[DEBUG] Create Cache Parameter Group: %#v", createOpts)
+	log.Printf("[DEBUG] Create ElastiCache Parameter Group: %#v", createOpts)
 	resp, err := conn.CreateCacheParameterGroup(&createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating Cache Parameter Group: %s", err)
+		return fmt.Errorf("error creating ElastiCache Parameter Group: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.CacheParameterGroup.CacheParameterGroupName))
-	log.Printf("[INFO] Cache Parameter Group ID: %s", d.Id())
+	log.Printf("[INFO] ElastiCache Parameter Group ID: %s", d.Id())
 
 	return resourceAwsElasticacheParameterGroupUpdate(d, meta)
 }
@@ -100,7 +100,7 @@ func resourceAwsElasticacheParameterGroupRead(d *schema.ResourceData, meta inter
 
 	if len(describeResp.CacheParameterGroups) != 1 ||
 		aws.StringValue(describeResp.CacheParameterGroups[0].CacheParameterGroupName) != d.Id() {
-		return fmt.Errorf("Unable to find Parameter Group: %#v", describeResp.CacheParameterGroups)
+		return fmt.Errorf("unable to find Parameter Group: %#v", describeResp.CacheParameterGroups)
 	}
 
 	d.Set("name", describeResp.CacheParameterGroups[0].CacheParameterGroupName)
@@ -162,7 +162,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 				ParameterNameValues:     paramsToModify,
 			}
 
-			log.Printf("[DEBUG] Reset Cache Parameter Group: %s", resetOpts)
+			log.Printf("[DEBUG] Reset ElastiCache Parameter Group: %s", resetOpts)
 			err := resource.Retry(30*time.Second, func() *resource.RetryError {
 				_, err := conn.ResetCacheParameterGroup(&resetOpts)
 				if err != nil {
@@ -201,7 +201,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 
 					allConfiguredParameters := expandElastiCacheParameters(d.Get("parameter").(*schema.Set).List())
 					if err != nil {
-						return fmt.Errorf("error expanding parameter configuration: %s", err)
+						return fmt.Errorf("error expanding parameter configuration: %w", err)
 					}
 
 					for _, configuredParameter := range allConfiguredParameters {
@@ -218,7 +218,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 					// The reserved-memory-percentage parameter does not exist in redis2.6 and redis2.8
 					family := d.Get("family").(string)
 					if family == "redis2.6" || family == "redis2.8" {
-						log.Printf("[WARN] Cannot reset Elasticache Parameter Group (%s) reserved-memory parameter with %s family", d.Id(), family)
+						log.Printf("[WARN] Cannot reset ElastiCache Parameter Group (%s) reserved-memory parameter with %s family", d.Id(), family)
 						break
 					}
 
@@ -269,7 +269,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 			}
 
 			if err != nil {
-				return fmt.Errorf("Error resetting Cache Parameter Group: %s", err)
+				return fmt.Errorf("error resetting ElastiCache Parameter Group: %w", err)
 			}
 		}
 
@@ -285,10 +285,10 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 				ParameterNameValues:     paramsToModify,
 			}
 
-			log.Printf("[DEBUG] Modify Cache Parameter Group: %s", modifyOpts)
+			log.Printf("[DEBUG] Modify ElastiCache Parameter Group: %s", modifyOpts)
 			_, err := conn.ModifyCacheParameterGroup(&modifyOpts)
 			if err != nil {
-				return fmt.Errorf("Error modifying Cache Parameter Group: %s", err)
+				return fmt.Errorf("error modifying ElastiCache Parameter Group: %w", err)
 			}
 		}
 	}
@@ -324,7 +324,7 @@ func resourceAwsElasticacheParameterGroupDelete(d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Elasticache Parameter Group (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting ElastiCache Parameter Group (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -103,6 +103,14 @@ func TestAccAWSElasticacheParameterGroup_removeAllParameters(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "appendonly",
+						"value": "yes",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "appendfsync",
+						"value": "always",
+					}),
 				),
 			},
 			{
@@ -133,6 +141,10 @@ func TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter(t *testin
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "reserved-memory",
+						"value": "0",
+					}),
 				),
 			},
 			{
@@ -168,6 +180,10 @@ func TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter(t *testin
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "reserved-memory",
+						"value": "0",
+					}),
 				),
 			},
 			{
@@ -175,6 +191,10 @@ func TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter(t *testin
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "reserved-memory-percent",
+						"value": "25",
+					}),
 				),
 			},
 			{
@@ -203,6 +223,10 @@ func TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter(t *testin
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "reserved-memory",
+						"value": "0",
+					}),
 				),
 			},
 			{
@@ -210,6 +234,10 @@ func TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter(t *testin
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "reserved-memory",
+						"value": "1",
+					}),
 				),
 			},
 			{

--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccAWSElasticacheParameterGroup_basic(t *testing.T) {
 	var v elasticache.CacheParameterGroup
-	resourceName := "aws_elasticache_parameter_group.bar"
+	resourceName := "aws_elasticache_parameter_group.test"
 	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,6 +43,7 @@ func TestAccAWSElasticacheParameterGroup_basic(t *testing.T) {
 
 func TestAccAWSElasticacheParameterGroup_addParameter(t *testing.T) {
 	var v elasticache.CacheParameterGroup
+	resourceName := "aws_elasticache_parameter_group.test"
 	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -53,29 +54,29 @@ func TestAccAWSElasticacheParameterGroup_addParameter(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheParameterGroupConfigParameter1(rName, "redis2.8", "appendonly", "yes"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
-					resource.TestCheckResourceAttr("aws_elasticache_parameter_group.bar", "parameter.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_elasticache_parameter_group.bar", "parameter.*", map[string]string{
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "appendonly",
 						"value": "yes",
 					}),
 				),
 			},
 			{
-				ResourceName:      "aws_elasticache_parameter_group.bar",
+				ResourceName:      "aws_elasticache_parameter_group.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSElasticacheParameterGroupConfigParameter2(rName, "redis2.8", "appendonly", "yes", "appendfsync", "always"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
-					resource.TestCheckResourceAttr("aws_elasticache_parameter_group.bar", "parameter.#", "2"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_elasticache_parameter_group.bar", "parameter.*", map[string]string{
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "appendonly",
 						"value": "yes",
 					}),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_elasticache_parameter_group.bar", "parameter.*", map[string]string{
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "appendfsync",
 						"value": "always",
 					}),
@@ -88,6 +89,7 @@ func TestAccAWSElasticacheParameterGroup_addParameter(t *testing.T) {
 // Regression for https://github.com/hashicorp/terraform-provider-aws/issues/116
 func TestAccAWSElasticacheParameterGroup_removeAllParameters(t *testing.T) {
 	var v elasticache.CacheParameterGroup
+	resourceName := "aws_elasticache_parameter_group.test"
 	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -98,15 +100,15 @@ func TestAccAWSElasticacheParameterGroup_removeAllParameters(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheParameterGroupConfigParameter2(rName, "redis2.8", "appendonly", "yes", "appendfsync", "always"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
-					resource.TestCheckResourceAttr("aws_elasticache_parameter_group.bar", "parameter.#", "2"),
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
 				),
 			},
 			{
 				Config: testAccAWSElasticacheParameterGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
-					resource.TestCheckResourceAttr("aws_elasticache_parameter_group.bar", "parameter.#", "0"),
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "0"),
 				),
 			},
 		},
@@ -117,7 +119,7 @@ func TestAccAWSElasticacheParameterGroup_removeAllParameters(t *testing.T) {
 // This covers our custom logic handling for this situation.
 func TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter(t *testing.T) {
 	var cacheParameterGroup1 elasticache.CacheParameterGroup
-	resourceName := "aws_elasticache_parameter_group.bar"
+	resourceName := "aws_elasticache_parameter_group.test"
 	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -152,7 +154,7 @@ func TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter(t *testin
 // This covers our custom logic handling for this situation.
 func TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter(t *testing.T) {
 	var cacheParameterGroup1 elasticache.CacheParameterGroup
-	resourceName := "aws_elasticache_parameter_group.bar"
+	resourceName := "aws_elasticache_parameter_group.test"
 	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -187,7 +189,7 @@ func TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter(t *testin
 // This covers our custom logic handling for this situation.
 func TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter(t *testing.T) {
 	var cacheParameterGroup1 elasticache.CacheParameterGroup
-	resourceName := "aws_elasticache_parameter_group.bar"
+	resourceName := "aws_elasticache_parameter_group.test"
 	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -220,6 +222,7 @@ func TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter(t *testin
 
 func TestAccAWSElasticacheParameterGroup_UppercaseName(t *testing.T) {
 	var v elasticache.CacheParameterGroup
+	resourceName := "aws_elasticache_parameter_group.test"
 	rInt := acctest.RandInt()
 	rName := fmt.Sprintf("TF-ELASTIPG-%d", rInt)
 
@@ -231,13 +234,12 @@ func TestAccAWSElasticacheParameterGroup_UppercaseName(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheParameterGroupConfigParameter1(rName, "redis2.8", "appendonly", "yes"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_parameter_group.bar", "name", fmt.Sprintf("tf-elastipg-%d", rInt)),
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr("aws_elasticache_parameter_group.test", "name", fmt.Sprintf("tf-elastipg-%d", rInt)),
 				),
 			},
 			{
-				ResourceName:      "aws_elasticache_parameter_group.bar",
+				ResourceName:      "aws_elasticache_parameter_group.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -247,7 +249,7 @@ func TestAccAWSElasticacheParameterGroup_UppercaseName(t *testing.T) {
 
 func TestAccAWSElasticacheParameterGroup_Description(t *testing.T) {
 	var v elasticache.CacheParameterGroup
-	resourceName := "aws_elasticache_parameter_group.bar"
+	resourceName := "aws_elasticache_parameter_group.test"
 	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -356,7 +358,7 @@ func testAccCheckAWSElasticacheParameterGroupExists(n string, v *elasticache.Cac
 
 func testAccAWSElasticacheParameterGroupConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_elasticache_parameter_group" "bar" {
+resource "aws_elasticache_parameter_group" "test" {
   family = "redis2.8"
   name   = %q
 }
@@ -365,7 +367,7 @@ resource "aws_elasticache_parameter_group" "bar" {
 
 func testAccAWSElasticacheParameterGroupConfigDescription(rName, description string) string {
 	return fmt.Sprintf(`
-resource "aws_elasticache_parameter_group" "bar" {
+resource "aws_elasticache_parameter_group" "test" {
   description = %q
   family      = "redis2.8"
   name        = %q
@@ -375,7 +377,7 @@ resource "aws_elasticache_parameter_group" "bar" {
 
 func testAccAWSElasticacheParameterGroupConfigParameter1(rName, family, parameterName1, parameterValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_elasticache_parameter_group" "bar" {
+resource "aws_elasticache_parameter_group" "test" {
   family = %q
   name   = %q
 
@@ -389,7 +391,7 @@ resource "aws_elasticache_parameter_group" "bar" {
 
 func testAccAWSElasticacheParameterGroupConfigParameter2(rName, family, parameterName1, parameterValue1, parameterName2, parameterValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_elasticache_parameter_group" "bar" {
+resource "aws_elasticache_parameter_group" "test" {
   family = %q
   name   = %q
 

--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -312,7 +312,7 @@ func TestAccAWSElasticacheParameterGroup_UppercaseName(t *testing.T) {
 				Config: testAccAWSElasticacheParameterGroupConfigParameter1(rName, "redis2.8", "appendonly", "yes"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &v),
-					resource.TestCheckResourceAttr("aws_elasticache_parameter_group.test", "name", fmt.Sprintf("tf-elastipg-%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-elastipg-%d", rInt)),
 				),
 			},
 			{

--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -65,7 +65,7 @@ func TestAccAWSElasticacheParameterGroup_addParameter(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_elasticache_parameter_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -316,7 +316,7 @@ func TestAccAWSElasticacheParameterGroup_UppercaseName(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_elasticache_parameter_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -125,9 +125,9 @@ func TestAccAWSElasticacheParameterGroup_removeAllParameters(t *testing.T) {
 	})
 }
 
-// The API throws 500 errors when attempting to reset the reserved-memory parameter.
+// The API returns errors when attempting to reset the reserved-memory parameter.
 // This covers our custom logic handling for this situation.
-func TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter(t *testing.T) {
+func TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_AllParameters(t *testing.T) {
 	var cacheParameterGroup1 elasticache.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
 	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
@@ -164,7 +164,54 @@ func TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter(t *testin
 	})
 }
 
-// The API throws 500 errors when attempting to reset the reserved-memory parameter.
+// The API returns errors when attempting to reset the reserved-memory parameter.
+// This covers our custom logic handling for this situation.
+func TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_RemainingParameters(t *testing.T) {
+	var cacheParameterGroup1 elasticache.CacheParameterGroup
+	resourceName := "aws_elasticache_parameter_group.test"
+	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheParameterGroupConfigParameter2(rName, "redis3.2", "reserved-memory", "0", "tcp-keepalive", "360"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "reserved-memory",
+						"value": "0",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "tcp-keepalive",
+						"value": "360",
+					}),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheParameterGroupConfigParameter1(rName, "redis3.2", "tcp-keepalive", "360"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":  "tcp-keepalive",
+						"value": "360",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// The API returns errors when attempting to reset the reserved-memory parameter.
 // This covers our custom logic handling for this situation.
 func TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter(t *testing.T) {
 	var cacheParameterGroup1 elasticache.CacheParameterGroup
@@ -207,7 +254,7 @@ func TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter(t *testin
 	})
 }
 
-// The API throws 500 errors when attempting to reset the reserved-memory parameter.
+// The API returns errors when attempting to reset the reserved-memory parameter.
 // This covers our custom logic handling for this situation.
 func TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter(t *testing.T) {
 	var cacheParameterGroup1 elasticache.CacheParameterGroup

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -474,27 +474,6 @@ func expandOptionSetting(list []interface{}) []*rds.OptionSetting {
 
 // Takes the result of flatmap.Expand for an array of parameters and
 // returns Parameter API compatible objects
-func expandElastiCacheParameters(configured []interface{}) []*elasticache.ParameterNameValue {
-	parameters := make([]*elasticache.ParameterNameValue, 0, len(configured))
-
-	// Loop over our configured parameters and create
-	// an array of aws-sdk-go compatible objects
-	for _, pRaw := range configured {
-		data := pRaw.(map[string]interface{})
-
-		p := &elasticache.ParameterNameValue{
-			ParameterName:  aws.String(data["name"].(string)),
-			ParameterValue: aws.String(data["value"].(string)),
-		}
-
-		parameters = append(parameters, p)
-	}
-
-	return parameters
-}
-
-// Takes the result of flatmap.Expand for an array of parameters and
-// returns Parameter API compatible objects
 func expandNeptuneParameters(configured []interface{}) []*neptune.Parameter {
 	parameters := make([]*neptune.Parameter, 0, len(configured))
 
@@ -957,20 +936,6 @@ func flattenRedshiftParameters(list []*redshift.Parameter) []map[string]interfac
 			"name":  strings.ToLower(*i.ParameterName),
 			"value": strings.ToLower(*i.ParameterValue),
 		})
-	}
-	return result
-}
-
-// Flattens an array of Parameters into a []map[string]interface{}
-func flattenElastiCacheParameters(list []*elasticache.Parameter) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(list))
-	for _, i := range list {
-		if i.ParameterValue != nil {
-			result = append(result, map[string]interface{}{
-				"name":  strings.ToLower(*i.ParameterName),
-				"value": *i.ParameterValue,
-			})
-		}
 	}
 	return result
 }

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/organizations"
@@ -618,29 +617,6 @@ func TestExpandRedshiftParameters(t *testing.T) {
 	}
 }
 
-func TestExpandElasticacheParameters(t *testing.T) {
-	expanded := []interface{}{
-		map[string]interface{}{
-			"name":         "activerehashing",
-			"value":        "yes",
-			"apply_method": "immediate",
-		},
-	}
-	parameters := expandElastiCacheParameters(expanded)
-
-	expected := &elasticache.ParameterNameValue{
-		ParameterName:  aws.String("activerehashing"),
-		ParameterValue: aws.String("yes"),
-	}
-
-	if !reflect.DeepEqual(parameters[0], expected) {
-		t.Fatalf(
-			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			parameters[0],
-			expected)
-	}
-}
-
 func TestExpandStepAdjustments(t *testing.T) {
 	expanded := []interface{}{
 		map[string]interface{}{
@@ -720,35 +696,6 @@ func TestFlattenRedshiftParameters(t *testing.T) {
 
 	for _, tc := range cases {
 		output := flattenRedshiftParameters(tc.Input)
-		if !reflect.DeepEqual(output, tc.Output) {
-			t.Fatalf("Got:\n\n%#v\n\nExpected:\n\n%#v", output, tc.Output)
-		}
-	}
-}
-
-func TestFlattenElasticacheParameters(t *testing.T) {
-	cases := []struct {
-		Input  []*elasticache.Parameter
-		Output []map[string]interface{}
-	}{
-		{
-			Input: []*elasticache.Parameter{
-				{
-					ParameterName:  aws.String("activerehashing"),
-					ParameterValue: aws.String("yes"),
-				},
-			},
-			Output: []map[string]interface{}{
-				{
-					"name":  "activerehashing",
-					"value": "yes",
-				},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		output := flattenElastiCacheParameters(tc.Input)
 		if !reflect.DeepEqual(output, tc.Output) {
 			t.Fatalf("Got:\n\n%#v\n\nExpected:\n\n%#v", output, tc.Output)
 		}


### PR DESCRIPTION
In the Commercial partition, the AWS API has started returning a different error message when resetting the parameter `reserved-memory`. Previously, it returned a 500: `InternalFailure: An internal error has occurred. Please try your query again at a later time.`. It now returns a 400: `InvalidParameterValue: Parameter reserved-memory doesn't exist`. Note that the GovCloud partition still returns the 500 error.

This was causing both `TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter` and `TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter` to fail in the Commercial partition.

In addition, in both partitions, the parameter used as a potential workaround was incorrectly coded as `reserved-memory-percentage` instead of `reserved-memory-percent`, causing `TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter` to fail in the GovCloud partition.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Commercial partition
```console
$ make testacc TESTARGS='-run=TestAccAWSElasticacheParameterGroup_'

--- PASS: TestAccAWSElasticacheParameterGroup_Description (129.63s)
--- PASS: TestAccAWSElasticacheParameterGroup_basic (129.67s)
--- PASS: TestAccAWSElasticacheParameterGroup_UppercaseName (131.69s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeAllParameters (162.59s)
--- PASS: TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter (173.74s)
--- PASS: TestAccAWSElasticacheParameterGroup_addParameter (175.76s)
--- PASS: TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter (175.79s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_RemainingParameters (177.27s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_AllParameters (177.39s)
```

GovCloud partition
```console
$ make testacc TESTARGS='-run=TestAccAWSElasticacheParameterGroup_'

--- PASS: TestAccAWSElasticacheParameterGroup_basic (116.18s)
--- PASS: TestAccAWSElasticacheParameterGroup_Description (118.78s)
--- PASS: TestAccAWSElasticacheParameterGroup_UppercaseName (119.86s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeAllParameters (150.83s)
--- PASS: TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter (163.45s)
--- PASS: TestAccAWSElasticacheParameterGroup_addParameter (165.37s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_AllParameters (165.66s)
--- PASS: TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter (165.93s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_RemainingParameters (166.56s)
```