### PR TITLE
resource/aws_route53_resolver_dnssec_config - new resource

### DIFF
--- a/aws/internal/service/route53resolver/finder/finder.go
+++ b/aws/internal/service/route53resolver/finder/finder.go
@@ -42,3 +42,36 @@ func ResolverQueryLogConfigByID(conn *route53resolver.Route53Resolver, queryLogC
 
 	return output.ResolverQueryLogConfig, nil
 }
+
+// ResolverDnssecConfigByID returns the dnssec configuration corresponding to the specified ID.
+// Returns nil if no configuration is found.
+func ResolverDnssecConfigByID(conn *route53resolver.Route53Resolver, dnssecConfigID string) (*route53resolver.ResolverDnssecConfig, error) {
+	input := &route53resolver.ListResolverDnssecConfigsInput{}
+
+	var config *route53resolver.ResolverDnssecConfig
+	// GetResolverDnssecConfigs does not support query with id
+	err := conn.ListResolverDnssecConfigsPages(input, func(page *route53resolver.ListResolverDnssecConfigsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, c := range page.ResolverDnssecConfigs {
+			if aws.StringValue(c.Id) == dnssecConfigID {
+				config = c
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if config == nil {
+		return nil, nil
+	}
+
+	return config, nil
+}

--- a/aws/internal/service/route53resolver/waiter/status.go
+++ b/aws/internal/service/route53resolver/waiter/status.go
@@ -14,6 +14,9 @@ const (
 
 	resolverQueryLogConfigStatusNotFound = "NotFound"
 	resolverQueryLogConfigStatusUnknown  = "Unknown"
+
+	resolverDnssecConfigStatusNotFound = "NotFound"
+	resolverDnssecConfigStatusUnknown  = "Unknown"
 )
 
 // QueryLogConfigAssociationStatus fetches the QueryLogConfigAssociation and its Status
@@ -55,5 +58,22 @@ func QueryLogConfigStatus(conn *route53resolver.Route53Resolver, queryLogConfigI
 		}
 
 		return queryLogConfig, aws.StringValue(queryLogConfig.Status), nil
+	}
+}
+
+// DnssecConfigStatus fetches the DnssecConfig and its Status
+func DnssecConfigStatus(conn *route53resolver.Route53Resolver, dnssecConfigID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		dnssecConfig, err := finder.ResolverDnssecConfigByID(conn, dnssecConfigID)
+
+		if err != nil {
+			return nil, resolverDnssecConfigStatusUnknown, err
+		}
+
+		if dnssecConfig == nil {
+			return nil, resolverDnssecConfigStatusNotFound, nil
+		}
+
+		return dnssecConfig, aws.StringValue(dnssecConfig.ValidationStatus), nil
 	}
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -858,6 +858,7 @@ func Provider() *schema.Provider {
 			"aws_route53_vpc_association_authorization":               resourceAwsRoute53VPCAssociationAuthorization(),
 			"aws_route53_zone":                                        resourceAwsRoute53Zone(),
 			"aws_route53_health_check":                                resourceAwsRoute53HealthCheck(),
+			"aws_route53_resolver_dnssec_config":                      resourceAwsRoute53ResolverDnssecConfig(),
 			"aws_route53_resolver_endpoint":                           resourceAwsRoute53ResolverEndpoint(),
 			"aws_route53_resolver_query_log_config":                   resourceAwsRoute53ResolverQueryLogConfig(),
 			"aws_route53_resolver_query_log_config_association":       resourceAwsRoute53ResolverQueryLogConfigAssociation(),

--- a/aws/resource_aws_route53_resolver_dnssec_config.go
+++ b/aws/resource_aws_route53_resolver_dnssec_config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -25,6 +26,11 @@ func resourceAwsRoute53ResolverDnssecConfig() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -112,6 +118,15 @@ func resourceAwsRoute53ResolverDnssecConfigRead(d *schema.ResourceData, meta int
 	d.Set("owner_id", out.OwnerId)
 	d.Set("resource_id", out.ResourceId)
 	d.Set("validation_status", out.ValidationStatus)
+
+	configArn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "route53resolver",
+		Region:    meta.(*AWSClient).region,
+		AccountID: aws.StringValue(out.OwnerId),
+		Resource:  fmt.Sprintf("resolver-dnssec-config/%s", aws.StringValue(out.ResourceId)),
+	}.String()
+	d.Set("arn", configArn)
 
 	return nil
 }

--- a/aws/resource_aws_route53_resolver_dnssec_config.go
+++ b/aws/resource_aws_route53_resolver_dnssec_config.go
@@ -3,17 +3,13 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-)
-
-const (
-	route53ResolverDnssecConfigStatusNotFound = "NOT_FOUND"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/route53resolver/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/route53resolver/waiter"
 )
 
 func resourceAwsRoute53ResolverDnssecConfig() *schema.Resource {
@@ -52,11 +48,6 @@ func resourceAwsRoute53ResolverDnssecConfig() *schema.Resource {
 				Computed: true,
 			},
 		},
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
-		},
 	}
 }
 
@@ -74,11 +65,9 @@ func resourceAwsRoute53ResolverDnssecConfigCreate(d *schema.ResourceData, meta i
 		return fmt.Errorf("error creating Route53 Resolver DNSSEC config: %w", err)
 	}
 
-	d.SetId(aws.StringValue(resp.ResolverDNSSECConfig.ResourceId))
+	d.SetId(aws.StringValue(resp.ResolverDNSSECConfig.Id))
 
-	err = route53ResolverDnssecConfigWait(conn, d.Id(), d.Timeout(schema.TimeoutCreate),
-		[]string{route53resolver.ResolverDNSSECValidationStatusEnabling},
-		[]string{route53resolver.ResolverDNSSECValidationStatusEnabled})
+	_, err = waiter.DnssecConfigCreated(conn, d.Id())
 	if err != nil {
 		return err
 	}
@@ -88,43 +77,30 @@ func resourceAwsRoute53ResolverDnssecConfigCreate(d *schema.ResourceData, meta i
 
 func resourceAwsRoute53ResolverDnssecConfigRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).route53resolverconn
-	ec2Conn := meta.(*AWSClient).ec2conn
 
-	vpc, err := vpcDescribe(ec2Conn, d.Id())
-	if err != nil {
-		return fmt.Errorf("error getting VPC associated with Route53 Resolver DNSSEC config (%s): %w", d.Id(), err)
-	}
+	config, err := finder.ResolverDnssecConfigByID(conn, d.Id())
 
-	// GetResolverDnssecConfig returns AccessDeniedException if sending a request with non-existing VPC id
-	if vpc == nil {
-		log.Printf("[WARN] VPC associated with Resolver DNSSEC config (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
-	raw, state, err := route53ResolverDnssecConfigRefresh(conn, d.Id())()
 	if err != nil {
 		return fmt.Errorf("error getting Route53 Resolver DNSSEC config (%s): %w", d.Id(), err)
 	}
 
-	if state == route53ResolverDnssecConfigStatusNotFound || state == route53resolver.ResolverDNSSECValidationStatusDisabled {
+	if config == nil || aws.StringValue(config.ValidationStatus) == route53resolver.ResolverDNSSECValidationStatusDisabled {
 		log.Printf("[WARN] Route53 Resolver DNSSEC config (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	out := raw.(*route53resolver.ResolverDnssecConfig)
-	d.Set("id", out.Id)
-	d.Set("owner_id", out.OwnerId)
-	d.Set("resource_id", out.ResourceId)
-	d.Set("validation_status", out.ValidationStatus)
+	d.Set("id", config.Id)
+	d.Set("owner_id", config.OwnerId)
+	d.Set("resource_id", config.ResourceId)
+	d.Set("validation_status", config.ValidationStatus)
 
 	configArn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Service:   "route53resolver",
 		Region:    meta.(*AWSClient).region,
-		AccountID: aws.StringValue(out.OwnerId),
-		Resource:  fmt.Sprintf("resolver-dnssec-config/%s", aws.StringValue(out.ResourceId)),
+		AccountID: aws.StringValue(config.OwnerId),
+		Resource:  fmt.Sprintf("resolver-dnssec-config/%s", aws.StringValue(config.ResourceId)),
 	}.String()
 	d.Set("arn", configArn)
 
@@ -136,7 +112,7 @@ func resourceAwsRoute53ResolverDnssecConfigDelete(d *schema.ResourceData, meta i
 
 	log.Printf("[DEBUG] Deleting Route53 Resolver DNSSEC config: %s", d.Id())
 	_, err := conn.UpdateResolverDnssecConfig(&route53resolver.UpdateResolverDnssecConfigInput{
-		ResourceId: aws.String(d.Id()),
+		ResourceId: aws.String(d.Get("resource_id").(string)),
 		Validation: aws.String(route53resolver.ValidationDisable),
 	})
 	if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
@@ -146,46 +122,10 @@ func resourceAwsRoute53ResolverDnssecConfigDelete(d *schema.ResourceData, meta i
 		return fmt.Errorf("error deleting Route53 Resolver DNSSEC config (%s): %w", d.Id(), err)
 	}
 
-	err = route53ResolverDnssecConfigWait(conn, d.Id(), d.Timeout(schema.TimeoutDelete),
-		[]string{route53resolver.ResolverDNSSECValidationStatusDisabling},
-		[]string{route53resolver.ResolverDNSSECValidationStatusDisabled})
+	_, err = waiter.DnssecConfigDeleted(conn, d.Id())
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func route53ResolverDnssecConfigWait(conn *route53resolver.Route53Resolver, id string, timeout time.Duration, pending, target []string) error {
-	stateConf := &resource.StateChangeConf{
-		Pending:    pending,
-		Target:     target,
-		Refresh:    route53ResolverDnssecConfigRefresh(conn, id),
-		Timeout:    timeout,
-		Delay:      10 * time.Second,
-		MinTimeout: 5 * time.Second,
-	}
-	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("error waiting for Route53 Resolver DNSSEC config (%s) to reach target state: %w", id, err)
-	}
-
-	return nil
-}
-
-func route53ResolverDnssecConfigRefresh(conn *route53resolver.Route53Resolver, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.GetResolverDnssecConfig(&route53resolver.GetResolverDnssecConfigInput{
-			ResourceId: aws.String(id),
-		})
-
-		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-			return &route53resolver.ResolverDnssecConfig{}, route53ResolverDnssecConfigStatusNotFound, nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return resp.ResolverDNSSECConfig, aws.StringValue(resp.ResolverDNSSECConfig.ValidationStatus), nil
-	}
 }

--- a/aws/resource_aws_route53_resolver_dnssec_config.go
+++ b/aws/resource_aws_route53_resolver_dnssec_config.go
@@ -65,7 +65,7 @@ func resourceAwsRoute53ResolverDnssecConfigCreate(d *schema.ResourceData, meta i
 	log.Printf("[DEBUG] Creating Route53 Resolver DNSSEC config: %#v", req)
 	resp, err := conn.UpdateResolverDnssecConfig(req)
 	if err != nil {
-		return fmt.Errorf("error creating Route53 Resolver DNSSEC config: %s", err)
+		return fmt.Errorf("error creating Route53 Resolver DNSSEC config: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.ResolverDNSSECConfig.ResourceId))
@@ -86,7 +86,7 @@ func resourceAwsRoute53ResolverDnssecConfigRead(d *schema.ResourceData, meta int
 
 	vpc, err := vpcDescribe(ec2Conn, d.Id())
 	if err != nil {
-		return fmt.Errorf("error getting VPC associated with Route53 Resolver DNSSEC config (%s): %s", d.Id(), err)
+		return fmt.Errorf("error getting VPC associated with Route53 Resolver DNSSEC config (%s): %w", d.Id(), err)
 	}
 
 	// GetResolverDnssecConfig returns AccessDeniedException if sending a request with non-existing VPC id
@@ -98,7 +98,7 @@ func resourceAwsRoute53ResolverDnssecConfigRead(d *schema.ResourceData, meta int
 
 	raw, state, err := route53ResolverDnssecConfigRefresh(conn, d.Id())()
 	if err != nil {
-		return fmt.Errorf("error getting Route53 Resolver DNSSEC config (%s): %s", d.Id(), err)
+		return fmt.Errorf("error getting Route53 Resolver DNSSEC config (%s): %w", d.Id(), err)
 	}
 
 	if state == route53ResolverDnssecConfigStatusNotFound || state == route53resolver.ResolverDNSSECValidationStatusDisabled {
@@ -128,7 +128,7 @@ func resourceAwsRoute53ResolverDnssecConfigDelete(d *schema.ResourceData, meta i
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("error deleting Route53 Resolver DNSSEC config (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting Route53 Resolver DNSSEC config (%s): %w", d.Id(), err)
 	}
 
 	err = route53ResolverDnssecConfigWait(conn, d.Id(), d.Timeout(schema.TimeoutDelete),
@@ -151,7 +151,7 @@ func route53ResolverDnssecConfigWait(conn *route53resolver.Route53Resolver, id s
 		MinTimeout: 5 * time.Second,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("error waiting for Route53 Resolver DNSSEC config (%s) to reach target state: %s", id, err)
+		return fmt.Errorf("error waiting for Route53 Resolver DNSSEC config (%s) to reach target state: %w", id, err)
 	}
 
 	return nil

--- a/aws/resource_aws_route53_resolver_dnssec_config.go
+++ b/aws/resource_aws_route53_resolver_dnssec_config.go
@@ -1,0 +1,176 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	route53ResolverDnssecConfigStatusNotFound = "NOT_FOUND"
+)
+
+func resourceAwsRoute53ResolverDnssecConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53ResolverDnssecConfigCreate,
+		Read:   resourceAwsRoute53ResolverDnssecConfigRead,
+		Delete: resourceAwsRoute53ResolverDnssecConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"resource_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"validation_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+	}
+}
+
+func resourceAwsRoute53ResolverDnssecConfigCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	req := &route53resolver.UpdateResolverDnssecConfigInput{
+		ResourceId: aws.String(d.Get("resource_id").(string)),
+		Validation: aws.String(route53resolver.ValidationEnable),
+	}
+
+	log.Printf("[DEBUG] Creating Route53 Resolver DNSSEC config: %#v", req)
+	resp, err := conn.UpdateResolverDnssecConfig(req)
+	if err != nil {
+		return fmt.Errorf("error creating Route53 Resolver DNSSEC config: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.ResolverDNSSECConfig.ResourceId))
+
+	err = route53ResolverDnssecConfigWait(conn, d.Id(), d.Timeout(schema.TimeoutCreate),
+		[]string{route53resolver.ResolverDNSSECValidationStatusEnabling},
+		[]string{route53resolver.ResolverDNSSECValidationStatusEnabled})
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsRoute53ResolverDnssecConfigRead(d, meta)
+}
+
+func resourceAwsRoute53ResolverDnssecConfigRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+	ec2Conn := meta.(*AWSClient).ec2conn
+
+	vpc, err := vpcDescribe(ec2Conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error getting VPC associated with Route53 Resolver DNSSEC config (%s): %s", d.Id(), err)
+	}
+
+	// GetResolverDnssecConfig returns AccessDeniedException if sending a request with non-existing VPC id
+	if vpc == nil {
+		log.Printf("[WARN] VPC associated with Resolver DNSSEC config (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	raw, state, err := route53ResolverDnssecConfigRefresh(conn, d.Id())()
+	if err != nil {
+		return fmt.Errorf("error getting Route53 Resolver DNSSEC config (%s): %s", d.Id(), err)
+	}
+
+	if state == route53ResolverDnssecConfigStatusNotFound || state == route53resolver.ResolverDNSSECValidationStatusDisabled {
+		log.Printf("[WARN] Route53 Resolver DNSSEC config (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	out := raw.(*route53resolver.ResolverDnssecConfig)
+	d.Set("id", out.Id)
+	d.Set("owner_id", out.OwnerId)
+	d.Set("resource_id", out.ResourceId)
+	d.Set("validation_status", out.ValidationStatus)
+
+	return nil
+}
+
+func resourceAwsRoute53ResolverDnssecConfigDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	log.Printf("[DEBUG] Deleting Route53 Resolver DNSSEC config: %s", d.Id())
+	_, err := conn.UpdateResolverDnssecConfig(&route53resolver.UpdateResolverDnssecConfigInput{
+		ResourceId: aws.String(d.Id()),
+		Validation: aws.String(route53resolver.ValidationDisable),
+	})
+	if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error deleting Route53 Resolver DNSSEC config (%s): %s", d.Id(), err)
+	}
+
+	err = route53ResolverDnssecConfigWait(conn, d.Id(), d.Timeout(schema.TimeoutDelete),
+		[]string{route53resolver.ResolverDNSSECValidationStatusDisabling},
+		[]string{route53resolver.ResolverDNSSECValidationStatusDisabled})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func route53ResolverDnssecConfigWait(conn *route53resolver.Route53Resolver, id string, timeout time.Duration, pending, target []string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    pending,
+		Target:     target,
+		Refresh:    route53ResolverDnssecConfigRefresh(conn, id),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("error waiting for Route53 Resolver DNSSEC config (%s) to reach target state: %s", id, err)
+	}
+
+	return nil
+}
+
+func route53ResolverDnssecConfigRefresh(conn *route53resolver.Route53Resolver, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.GetResolverDnssecConfig(&route53resolver.GetResolverDnssecConfigInput{
+			ResourceId: aws.String(id),
+		})
+
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			return &route53resolver.ResolverDnssecConfig{}, route53ResolverDnssecConfigStatusNotFound, nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return resp.ResolverDNSSECConfig, aws.StringValue(resp.ResolverDNSSECConfig.ValidationStatus), nil
+	}
+}

--- a/aws/resource_aws_route53_resolver_dnssec_config_test.go
+++ b/aws/resource_aws_route53_resolver_dnssec_config_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 	"time"
 
@@ -87,6 +88,7 @@ func TestAccAWSRoute53ResolverDnssecConfig_basic(t *testing.T) {
 				Config: testAccRoute53ResolverDnssecConfigConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverDnssecConfigExists(resourceName, &config),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "route53resolver", regexp.MustCompile(`resolver-dnssec-config/.+$`)),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "resource_id"),

--- a/aws/resource_aws_route53_resolver_dnssec_config_test.go
+++ b/aws/resource_aws_route53_resolver_dnssec_config_test.go
@@ -1,0 +1,237 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_route53_resolver_dnssec_config", &resource.Sweeper{
+		Name: "aws_route53_resolver_dnssec_config",
+		F:    testSweepRoute53ResolverDnssecConfig,
+	})
+}
+
+func testSweepRoute53ResolverDnssecConfig(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).route53resolverconn
+
+	var errors error
+	err = conn.ListResolverDnssecConfigsPages(&route53resolver.ListResolverDnssecConfigsInput{}, func(page *route53resolver.ListResolverDnssecConfigsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, resolverDnssecConfig := range page.ResolverDnssecConfigs {
+			id := aws.StringValue(resolverDnssecConfig.ResourceId)
+
+			log.Printf("[INFO] Deleting Route53 Resolver Dnssec config: %s", id)
+			_, err := conn.UpdateResolverDnssecConfig(&route53resolver.UpdateResolverDnssecConfigInput{
+				ResourceId: aws.String(id),
+				Validation: aws.String(route53resolver.ResolverDNSSECValidationStatusDisabled),
+			})
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				continue
+			}
+			if err != nil {
+				errors = multierror.Append(errors, fmt.Errorf("error deleting Route53 Resolver Resolver Dnssec config (%s): %w", id, err))
+				continue
+			}
+
+			err = route53ResolverEndpointWaitUntilTargetState(conn, id, 10*time.Minute,
+				[]string{route53resolver.ResolverDNSSECValidationStatusDisabling},
+				[]string{route53resolver.ResolverDNSSECValidationStatusDisabled})
+			if err != nil {
+				errors = multierror.Append(errors, err)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Route53 Resolver Resolver Dnssec config sweep for %s: %s", region, err)
+			return nil
+		}
+		errors = multierror.Append(errors, fmt.Errorf("error retrieving Route53 Resolver Resolver Dnssec config: %w", err))
+	}
+
+	return errors
+}
+
+func TestAccAWSRoute53ResolverDnssecConfig_basic(t *testing.T) {
+	var config route53resolver.ResolverDnssecConfig
+	resourceName := "aws_route53_resolver_dnssec_config.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverDnssecConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverDnssecConfigConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverDnssecConfigExists(resourceName, &config),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "resource_id"),
+					resource.TestCheckResourceAttr(resourceName, "validation_status", "ENABLED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ResolverDnssecConfig_disappear(t *testing.T) {
+	var config route53resolver.ResolverDnssecConfig
+	resourceName := "aws_route53_resolver_dnssec_config.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverDnssecConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverDnssecConfigConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverDnssecConfigExists(resourceName, &config),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53ResolverDnssecConfig(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ResolverDnssecConfig_disappear_VPC(t *testing.T) {
+	var config route53resolver.ResolverDnssecConfig
+	resourceName := "aws_route53_resolver_dnssec_config.test"
+	vpcResourceName := "aws_vpc.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverDnssecConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverDnssecConfigConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverDnssecConfigExists(resourceName, &config),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsVpc(), vpcResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRoute53ResolverDnssecConfigDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
+	ec2Conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_resolver_dnssec_config" {
+			continue
+		}
+
+		vpc, err := vpcDescribe(ec2Conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		// The VPC has been deleted
+		if vpc == nil {
+			continue
+		}
+
+		// Try to find the resource
+		out, err := conn.GetResolverDnssecConfig(&route53resolver.GetResolverDnssecConfigInput{
+			ResourceId: aws.String(rs.Primary.ID),
+		})
+		// Verify the error is what we want
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if aws.StringValue(out.ResolverDNSSECConfig.ValidationStatus) == route53resolver.ResolverDNSSECValidationStatusDisabled {
+			continue
+		}
+
+		return fmt.Errorf("Route 53 Resolver Dnssec config still exists: %s", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckRoute53ResolverDnssecConfigExists(n string, c *route53resolver.ResolverDnssecConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Route 53 Resolver Dnssec config ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
+		resp, err := conn.GetResolverDnssecConfig(&route53resolver.GetResolverDnssecConfigInput{
+			ResourceId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		*c = *resp.ResolverDNSSECConfig
+
+		return nil
+	}
+}
+
+func testAccRoute53ResolverDnssecConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = %q
+  }
+}
+`, rName)
+}
+
+func testAccRoute53ResolverDnssecConfigConfigBasic(rName string) string {
+	return testAccRoute53ResolverDnssecConfigBase(rName) + `
+resource "aws_route53_resolver_dnssec_config" "test" {
+  resource_id = aws_vpc.test.id
+}
+`
+}

--- a/website/docs/r/route53_resolver_dnssec_config.html.markdown
+++ b/website/docs/r/route53_resolver_dnssec_config.html.markdown
@@ -39,18 +39,10 @@ In addition to all arguments above, the following attributes are exported:
 * `owner_id` - The owner account ID of the virtual private cloud (VPC) for a configuration for DNSSEC validation.
 * `validation_status` - The validation status for a DNSSEC configuration. The status can be one of the following: `ENABLING`, `ENABLED`, `DISABLING` and `DISABLED`.
 
-## Timeouts
-
-`aws_route53_resolver_dnssec_config` provides the following
-[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
-
-- `create` - (Default `10 minutes`) Used for creating Route 53 Resolver DNSSEC config
-- `delete` - (Default `10 minutes`) Used for destroying Route 53 Resolver DNSSEC config
-
 ## Import
 
- Route 53 Resolver DNSSEC configs can be imported using the VPC ID, e.g.
+ Route 53 Resolver DNSSEC configs can be imported using the Route 53 Resolver DNSSEC config ID, e.g.
 
 ```
-$ terraform import aws_route53_resolver_dnssec_config.example vpc-7a190fdssf3
+$ terraform import aws_route53_resolver_dnssec_config.example rdsc-be1866ecc1683e95
 ```

--- a/website/docs/r/route53_resolver_dnssec_config.html.markdown
+++ b/website/docs/r/route53_resolver_dnssec_config.html.markdown
@@ -34,6 +34,7 @@ The following argument is supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN for a configuration for DNSSEC validation.
 * `id` - The ID for a configuration for DNSSEC validation.
 * `owner_id` - The owner account ID of the virtual private cloud (VPC) for a configuration for DNSSEC validation.
 * `validation_status` - The validation status for a DNSSEC configuration. The status can be one of the following: `ENABLING`, `ENABLED`, `DISABLING` and `DISABLED`.

--- a/website/docs/r/route53_resolver_dnssec_config.html.markdown
+++ b/website/docs/r/route53_resolver_dnssec_config.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Route53 Resolver"
+layout: "aws"
+page_title: "AWS: aws_route53_resolver_dnssec_config"
+description: |-
+  Provides a Route 53 Resolver DNSSEC config resource.
+---
+
+# Resource: aws_route53_resolver_dnssec_config
+
+Provides a Route 53 Resolver DNSSEC config resource.
+
+## Example Usage
+
+```hcl
+resource "aws_vpc" "example" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+resource "aws_route53_resolver_dnssec_config" "example" {
+  resource_id = aws_vpc.example.id
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `resource_id` - (Required) The ID of the virtual private cloud (VPC) that you're updating the DNSSEC validation status for.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID for a configuration for DNSSEC validation.
+* `owner_id` - The owner account ID of the virtual private cloud (VPC) for a configuration for DNSSEC validation.
+* `validation_status` - The validation status for a DNSSEC configuration. The status can be one of the following: `ENABLING`, `ENABLED`, `DISABLING` and `DISABLED`.
+
+## Timeouts
+
+`aws_route53_resolver_dnssec_config` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for creating Route 53 Resolver DNSSEC config
+- `delete` - (Default `10 minutes`) Used for destroying Route 53 Resolver DNSSEC config
+
+## Import
+
+ Route 53 Resolver DNSSEC configs can be imported using the VPC ID, e.g.
+
+```
+$ terraform import aws_route53_resolver_dnssec_config.example vpc-7a190fdssf3
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/16837

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_route53_resolver_dnssec_config`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53ResolverDnssecConfig_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRoute53ResolverDnssecConfig_* -timeout 120m
=== RUN   TestAccAWSRoute53ResolverDnssecConfig_basic
=== PAUSE TestAccAWSRoute53ResolverDnssecConfig_basic
=== RUN   TestAccAWSRoute53ResolverDnssecConfig_disappear
=== PAUSE TestAccAWSRoute53ResolverDnssecConfig_disappear
=== RUN   TestAccAWSRoute53ResolverDnssecConfig_disappear_VPC
=== PAUSE TestAccAWSRoute53ResolverDnssecConfig_disappear_VPC
=== CONT  TestAccAWSRoute53ResolverDnssecConfig_basic
=== CONT  TestAccAWSRoute53ResolverDnssecConfig_disappear_VPC
=== CONT  TestAccAWSRoute53ResolverDnssecConfig_disappear
--- PASS: TestAccAWSRoute53ResolverDnssecConfig_disappear_VPC (159.43s)
--- PASS: TestAccAWSRoute53ResolverDnssecConfig_basic (287.57s)
--- PASS: TestAccAWSRoute53ResolverDnssecConfig_disappear (289.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	291.487s
```

Thank you for your review! 👍 