### PR TITLE
resource/aws_route53_zone_association: Prevent deletion errors for missing Hosted Zone or VPC association

### DIFF
--- a/aws/resource_aws_route53_zone_association.go
+++ b/aws/resource_aws_route53_zone_association.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -171,6 +172,14 @@ func resourceAwsRoute53ZoneAssociationDelete(d *schema.ResourceData, meta interf
 	}
 
 	_, err = conn.DisassociateVPCFromHostedZone(input)
+
+	if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchHostedZone) {
+		return nil
+	}
+
+	if tfawserr.ErrCodeEquals(err, route53.ErrCodeVPCAssociationNotFound) {
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error disassociating Route 53 Hosted Zone (%s) from EC2 VPC (%s): %w", zoneID, vpcID, err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://docs.aws.amazon.com/Route53/latest/APIReference/API_DisassociateVPCFromHostedZone.html#API_DisassociateVPCFromHostedZone_Errors
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15945
Closes #17016

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_route53_zone_association: Prevent deletion errors for missing Hosted Zone or VPC association
```

This is a best effort fix for the errors returned by the Route 53 `DisassociateVPCFromHostedZone` API, which are unrelated to the potential errors during the `Read` function that uses the `ListHostedZonesByVPC` API. The acceptance testing framework does not lend itself well to testing this situation and this highlights a case where #15945 would need special handling.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_Zone (146.44s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears (147.22s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_VPC (147.31s)
--- PASS: TestAccAWSRoute53ZoneAssociation_CrossRegion (149.84s)
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (150.01s)
--- PASS: TestAccAWSRoute53ZoneAssociation_CrossAccount (507.91s)
```
