### PR TITLE
tests/serverlessapplicationrespository_application: Fix hardcoded regions

### DIFF
--- a/aws/data_source_aws_serverlessapplicationrepository_application_test.go
+++ b/aws/data_source_aws_serverlessapplicationrepository_application_test.go
@@ -11,13 +11,14 @@ import (
 
 func TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Basic(t *testing.T) {
 	datasourceName := "data.aws_serverlessapplicationrepository_application.secrets_manager_postgres_single_user_rotator"
+	appARN := testAccAwsServerlessApplicationRepositoryCloudFormationApplicationID()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig(),
+				Config: testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig(appARN),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceID(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "name", "SecretsManagerRDSPostgreSQLRotationSingleUser"),
@@ -28,7 +29,7 @@ func TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Basic(t *tes
 				),
 			},
 			{
-				Config:      testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_NonExistent,
+				Config:      testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_NonExistent(),
 				ExpectError: regexp.MustCompile(`error getting Serverless Application Repository application`),
 			},
 		},
@@ -36,6 +37,7 @@ func TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Basic(t *tes
 }
 func TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Versioned(t *testing.T) {
 	datasourceName := "data.aws_serverlessapplicationrepository_application.secrets_manager_postgres_single_user_rotator"
+	appARN := testAccAwsServerlessApplicationRepositoryCloudFormationApplicationID()
 
 	const (
 		version1 = "1.0.13"
@@ -47,7 +49,7 @@ func TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Versioned(t 
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned(version1),
+				Config: testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned(appARN, version1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceID(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "name", "SecretsManagerRDSPostgreSQLRotationSingleUser"),
@@ -58,7 +60,7 @@ func TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Versioned(t 
 				),
 			},
 			{
-				Config: testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned(version2),
+				Config: testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned(appARN, version2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceID(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "name", "SecretsManagerRDSPostgreSQLRotationSingleUser"),
@@ -71,7 +73,7 @@ func TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Versioned(t 
 				),
 			},
 			{
-				Config:      testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned_NonExistent(),
+				Config:      testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned_NonExistent(appARN),
 				ExpectError: regexp.MustCompile(`error getting Serverless Application Repository application`),
 			},
 		},
@@ -92,44 +94,42 @@ func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceID(n str
 	}
 }
 
-func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig() string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		`
+func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig(appARN string) string {
+	return fmt.Sprintf(`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
-  application_id = local.postgres_single_user_rotator_arn
+  application_id = %[1]q
 }
-`)
+`, appARN)
 }
 
-const testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_NonExistent = `
+func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_NonExistent() string {
+	return `
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 data "aws_serverlessapplicationrepository_application" "no_such_function" {
   application_id = "arn:${data.aws_partition.current.partition}:serverlessrepo:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:applications/ThisFunctionDoesNotExist"
 }
-
-data "aws_caller_identity" "current" {}
-data "aws_partition" "current" {}
-data "aws_region" "current" {}
 `
-
-func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned(version string) string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
-data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
-  application_id   = local.postgres_single_user_rotator_arn
-  semantic_version = "%[1]s"
-}
-`, version))
 }
 
-func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned_NonExistent() string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		`
+func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned(appARN, version string) string {
+	return fmt.Sprintf(`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
-  application_id   = local.postgres_single_user_rotator_arn
+  application_id   = %[1]q
+  semantic_version = %[2]q
+}
+`, appARN, version)
+}
+
+func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned_NonExistent(appARN string) string {
+	return fmt.Sprintf(`
+data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
+  application_id   = %[1]q
   semantic_version = "42.13.7"
 }
-`)
+`, appARN)
 }

--- a/aws/data_source_aws_serverlessapplicationrepository_application_test.go
+++ b/aws/data_source_aws_serverlessapplicationrepository_application_test.go
@@ -95,11 +95,11 @@ func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceID(n str
 func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig() string {
 	return composeConfig(
 		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
+		`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
   application_id = local.postgres_single_user_rotator_arn
 }
-`))
+`)
 }
 
 const testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_NonExistent = `
@@ -126,10 +126,10 @@ data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres
 func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned_NonExistent() string {
 	return composeConfig(
 		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
+		`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
   application_id   = local.postgres_single_user_rotator_arn
   semantic_version = "42.13.7"
 }
-`))
+`)
 }

--- a/aws/data_source_aws_serverlessapplicationrepository_application_test.go
+++ b/aws/data_source_aws_serverlessapplicationrepository_application_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Basic(t *tes
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig,
+				Config: testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceID(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "name", "SecretsManagerRDSPostgreSQLRotationSingleUser"),
@@ -71,7 +71,7 @@ func TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Versioned(t 
 				),
 			},
 			{
-				Config:      testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned_NonExistent,
+				Config:      testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned_NonExistent(),
 				ExpectError: regexp.MustCompile(`error getting Serverless Application Repository application`),
 			},
 		},
@@ -92,11 +92,15 @@ func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceID(n str
 	}
 }
 
-const testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig = testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication + `
+func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig() string {
+	return composeConfig(
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
+		fmt.Sprintf(`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
   application_id = local.postgres_single_user_rotator_arn
 }
-`
+`))
+}
 
 const testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_NonExistent = `
 data "aws_serverlessapplicationrepository_application" "no_such_function" {
@@ -110,7 +114,7 @@ data "aws_region" "current" {}
 
 func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned(version string) string {
 	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication,
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
 		fmt.Sprintf(`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
   application_id   = local.postgres_single_user_rotator_arn
@@ -119,9 +123,13 @@ data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres
 `, version))
 }
 
-const testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned_NonExistent = testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication + `
+func testAccCheckAwsServerlessApplicationRepositoryApplicationDataSourceConfig_Versioned_NonExistent() string {
+	return composeConfig(
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
+		fmt.Sprintf(`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
   application_id   = local.postgres_single_user_rotator_arn
   semantic_version = "42.13.7"
 }
-`
+`))
+}

--- a/aws/resource_aws_serverlessapplicationrepository_cloudformation_stack_test.go
+++ b/aws/resource_aws_serverlessapplicationrepository_cloudformation_stack_test.go
@@ -494,12 +494,13 @@ locals {
   application_account = local.security_manager_accounts[data.aws_partition.current.partition]
 
   security_manager_regions = {
-    %[1]q = %[3]q,
-    %[2]q = %[4]q,
+    %[1]q = %[3]q
+    %[2]q = %[4]q
   }
+
   security_manager_accounts = {
-    %[1]q = "297356227824",
-    %[2]q = "023102451235",
+    %[1]q = "297356227824"
+    %[2]q = "023102451235"
   }
 }
 `, endpoints.AwsPartitionID, endpoints.AwsUsGovPartitionID, endpoints.UsEast1RegionID, endpoints.UsGovWest1RegionID)

--- a/aws/resource_aws_serverlessapplicationrepository_cloudformation_stack_test.go
+++ b/aws/resource_aws_serverlessapplicationrepository_cloudformation_stack_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	serverlessrepository "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -18,7 +20,7 @@ import (
 func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_basic(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
-
+	appARN := testAccAwsServerlessApplicationRepositoryCloudFormationApplicationID()
 	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -27,7 +29,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_basic(t *testi
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfig(stackName),
+				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfig(stackName, appARN),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "name", stackName),
@@ -68,7 +70,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_basic(t *testi
 func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_disappears(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
-
+	appARN := testAccAwsServerlessApplicationRepositoryCloudFormationApplicationID()
 	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -77,7 +79,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_disappears(t *
 		CheckDestroy: testAccCheckAmiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfig(stackName),
+				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfig(stackName, appARN),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsServerlessApplicationRepositoryCloudFormationStack(), resourceName),
@@ -91,13 +93,13 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_disappears(t *
 func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_versioned(t *testing.T) {
 	var stack1, stack2, stack3 cloudformation.Stack
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	appARN := testAccAwsServerlessApplicationRepositoryCloudFormationApplicationID()
+	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
 	const (
 		version1 = "1.0.13"
 		version2 = "1.1.36"
 	)
-
-	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -105,7 +107,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_versioned(t *t
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned(stackName, version1),
+				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned(stackName, appARN, version1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack1),
 					resource.TestCheckResourceAttr(resourceName, "semantic_version", version1),
@@ -119,7 +121,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_versioned(t *t
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned2(stackName, version2),
+				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned2(stackName, appARN, version2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack2),
 					testAccCheckCloudFormationStackNotRecreated(&stack1, &stack2),
@@ -131,7 +133,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_versioned(t *t
 			},
 			{
 				// Confirm removal of "CAPABILITY_RESOURCE_POLICY" is handled properly
-				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned(stackName, version1),
+				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned(stackName, appARN, version1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack3),
 					testAccCheckCloudFormationStackNotRecreated(&stack2, &stack3),
@@ -147,10 +149,10 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_versioned(t *t
 func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_paired(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	appARN := testAccAwsServerlessApplicationRepositoryCloudFormationApplicationID()
+	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
 	const version = "1.1.36"
-
-	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -158,7 +160,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_paired(t *test
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versionedPaired(stackName, version),
+				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versionedPaired(stackName, appARN, version),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "semantic_version", version),
@@ -174,7 +176,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_paired(t *test
 func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_Tags(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
-
+	appARN := testAccAwsServerlessApplicationRepositoryCloudFormationApplicationID()
 	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -183,7 +185,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_Tags(t *testin
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags1(stackName, "key1", "value1"),
+				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags1(stackName, appARN, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -196,7 +198,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_Tags(t *testin
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags2(stackName, appARN, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -204,7 +206,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_Tags(t *testin
 				),
 			},
 			{
-				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags1(stackName, "key2", "value2"),
+				Config: testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags1(stackName, appARN, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -220,7 +222,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_update(t *test
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	initialName := acctest.RandomWithPrefix("FuncName1")
 	updatedName := acctest.RandomWithPrefix("FuncName2")
-
+	appARN := testAccAwsServerlessApplicationRepositoryCloudFormationApplicationID()
 	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -229,7 +231,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_update(t *test
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateInitial(stackName, initialName),
+				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateInitial(stackName, appARN, initialName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack),
 					testAccCheckResourceAttrRegionalARNIgnoreRegionAndAccount(resourceName, "application_id", "serverlessrepo", "applications/SecretsManagerRDSPostgreSQLRotationSingleUser"),
@@ -239,7 +241,7 @@ func TestAccAwsServerlessApplicationRepositoryCloudFormationStack_update(t *test
 				),
 			},
 			{
-				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateUpdated(stackName, updatedName),
+				Config: testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateUpdated(stackName, appARN, updatedName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessApplicationRepositoryCloudFormationStackExists(resourceName, &stack),
 					resource.TestCheckResourceAttr(resourceName, "parameters.functionName", updatedName),
@@ -298,127 +300,160 @@ func testAccAwsServerlessApplicationRepositoryCloudFormationStackNameNoPrefixImp
 	}
 }
 
-func testAccAwsServerlessApplicationRepositoryCloudFormationStackConfig(stackName string) string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
+func testAccAwsServerlessApplicationRepositoryCloudFormationApplicationID() string {
+	arnRegion := endpoints.UsEast1RegionID
+	arnAccountID := "297356227824"
+	if testAccGetPartition() == endpoints.AwsUsGovPartitionID {
+		arnRegion = endpoints.UsGovWest1RegionID
+		arnAccountID = "023102451235"
+	}
+
+	return arn.ARN{
+		Partition: testAccGetPartition(),
+		Service:   serverlessrepository.ServiceName,
+		Region:    arnRegion,
+		AccountID: arnAccountID,
+		Resource:  "applications/SecretsManagerRDSPostgreSQLRotationSingleUser",
+	}.String()
+}
+
+func testAccAwsServerlessApplicationRepositoryCloudFormationStackConfig(stackName, appARN string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
-  name           = "%[1]s"
-  application_id = local.postgres_single_user_rotator_arn
+  name           = %[1]q
+  application_id = %[2]q
+
   capabilities = [
     "CAPABILITY_IAM",
     "CAPABILITY_RESOURCE_POLICY",
   ]
+
   parameters = {
     functionName = "func-%[1]s"
     endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
   }
 }
-
-data "aws_region" "current" {}
-`, stackName))
+`, stackName, appARN)
 }
 
-func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateInitial(stackName, functionName string) string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
+func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateInitial(stackName, appARN, functionName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
-  name           = "%[1]s"
-  application_id = local.postgres_single_user_rotator_arn
+  name           = %[1]q
+  application_id = %[2]q
+
   capabilities = [
     "CAPABILITY_IAM",
     "CAPABILITY_RESOURCE_POLICY",
   ]
+
   parameters = {
-    functionName = "%[2]s"
+    functionName = %[3]q
     endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
   }
+
   tags = {
     key = "value"
   }
 }
-
-data "aws_region" "current" {}
-`, stackName, functionName))
+`, stackName, appARN, functionName)
 }
 
-func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateUpdated(stackName, functionName string) string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
+func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateUpdated(stackName, appARN, functionName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
-  name           = "%[1]s"
-  application_id = local.postgres_single_user_rotator_arn
+  name           = %[1]q
+  application_id = %[2]q
+
   capabilities = [
     "CAPABILITY_IAM",
     "CAPABILITY_RESOURCE_POLICY",
   ]
+
   parameters = {
-    functionName = "%[2]s"
+    functionName = %[3]q
     endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
   }
+
   tags = {
     key = "value"
   }
 }
-
-data "aws_region" "current" {}
-`, stackName, functionName))
+`, stackName, appARN, functionName)
 }
 
-func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned(stackName, version string) string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
+func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned(stackName, appARN, version string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
-  name             = "%[1]s"
-  application_id   = local.postgres_single_user_rotator_arn
-  semantic_version = "%[2]s"
+  name             = %[1]q
+  application_id   = %[2]q
+  semantic_version = %[3]q
+
   capabilities = [
     "CAPABILITY_IAM",
   ]
+
   parameters = {
     functionName = "func-%[1]s"
     endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
   }
 }
-
-data "aws_region" "current" {}
-`, stackName, version))
+`, stackName, appARN, version)
 }
 
-func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned2(stackName, version string) string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
+func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned2(stackName, appARN, version string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
-  name           = "%[1]s"
-  application_id = local.postgres_single_user_rotator_arn
+  name           = %[1]q
+  application_id = %[2]q
+
   capabilities = [
     "CAPABILITY_IAM",
     "CAPABILITY_RESOURCE_POLICY",
   ]
-  semantic_version = "%[2]s"
+
+  semantic_version = %[3]q
+
   parameters = {
     functionName = "func-%[1]s"
     endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
   }
 }
-
-data "aws_region" "current" {}
-`, stackName, version))
+`, stackName, appARN, version)
 }
 
-func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versionedPaired(stackName, version string) string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
+func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versionedPaired(stackName, appARN, version string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
-  name             = "%[1]s"
+  name             = %[1]q
   application_id   = data.aws_serverlessapplicationrepository_application.secrets_manager_postgres_single_user_rotator.application_id
   semantic_version = data.aws_serverlessapplicationrepository_application.secrets_manager_postgres_single_user_rotator.semantic_version
   capabilities     = data.aws_serverlessapplicationrepository_application.secrets_manager_postgres_single_user_rotator.required_capabilities
+
   parameters = {
     functionName = "func-%[1]s"
     endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
@@ -426,82 +461,63 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 }
 
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
-  application_id   = local.postgres_single_user_rotator_arn
-  semantic_version = "%[2]s"
+  application_id   = %[2]q
+  semantic_version = %[3]q
+}
+`, stackName, appARN, version)
 }
 
-data "aws_region" "current" {}
-`, stackName, version))
-}
-
-func testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags1(rName, tagKey1, tagValue1 string) string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
-resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
-  name           = "%[1]s"
-  application_id = local.postgres_single_user_rotator_arn
-  capabilities = [
-    "CAPABILITY_IAM",
-    "CAPABILITY_RESOURCE_POLICY",
-  ]
-  parameters = {
-    functionName = "func-%[1]s"
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
-  }
-  tags = {
-    %[2]q = %[3]q
-  }
-}
-
-data "aws_region" "current" {}
-`, rName, tagKey1, tagValue1))
-}
-
-func testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
-		fmt.Sprintf(`
-resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
-  name           = "%[1]s"
-  application_id = local.postgres_single_user_rotator_arn
-  capabilities = [
-    "CAPABILITY_IAM",
-    "CAPABILITY_RESOURCE_POLICY",
-  ]
-  parameters = {
-    functionName = "func-%[1]s"
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
-  }
-  tags = {
-    %[2]q = %[3]q
-    %[4]q = %[5]q
-  }
-}
-
-data "aws_region" "current" {}
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
-}
-
-func testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication() string {
+func testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags1(rName, appARN, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-locals {
-  postgres_single_user_rotator_arn = "arn:${data.aws_partition.current.partition}:serverlessrepo:${local.application_region}:${local.application_account}:applications/SecretsManagerRDSPostgreSQLRotationSingleUser"
+data "aws_region" "current" {}
 
-  application_region  = local.security_manager_regions[data.aws_partition.current.partition]
-  application_account = local.security_manager_accounts[data.aws_partition.current.partition]
+resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
+  name           = %[1]q
+  application_id = %[2]q
 
-  security_manager_regions = {
-    %[1]q = %[3]q
-    %[2]q = %[4]q
+  capabilities = [
+    "CAPABILITY_IAM",
+    "CAPABILITY_RESOURCE_POLICY",
+  ]
+
+  parameters = {
+    functionName = "func-%[1]s"
+    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
   }
 
-  security_manager_accounts = {
-    %[1]q = "297356227824"
-    %[2]q = "023102451235"
+  tags = {
+    %[3]q = %[4]q
   }
 }
-`, endpoints.AwsPartitionID, endpoints.AwsUsGovPartitionID, endpoints.UsEast1RegionID, endpoints.UsGovWest1RegionID)
+`, rName, appARN, tagKey1, tagValue1)
+}
+
+func testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags2(rName, appARN, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
+  name           = %[1]q
+  application_id = %[2]q
+
+  capabilities = [
+    "CAPABILITY_IAM",
+    "CAPABILITY_RESOURCE_POLICY",
+  ]
+
+  parameters = {
+    functionName = "func-%[1]s"
+    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+  }
+
+  tags = {
+    %[3]q = %[4]q
+    %[5]q = %[6]q
+  }
+}
+`, rName, appARN, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_serverlessapplicationrepository_cloudformation_stack_test.go
+++ b/aws/resource_aws_serverlessapplicationrepository_cloudformation_stack_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -299,7 +300,7 @@ func testAccAwsServerlessApplicationRepositoryCloudFormationStackNameNoPrefixImp
 
 func testAccAwsServerlessApplicationRepositoryCloudFormationStackConfig(stackName string) string {
 	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication,
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
 		fmt.Sprintf(`
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
   name           = "%[1]s"
@@ -320,7 +321,7 @@ data "aws_region" "current" {}
 
 func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateInitial(stackName, functionName string) string {
 	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication,
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
 		fmt.Sprintf(`
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
   name           = "%[1]s"
@@ -344,7 +345,7 @@ data "aws_region" "current" {}
 
 func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_updateUpdated(stackName, functionName string) string {
 	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication,
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
 		fmt.Sprintf(`
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
   name           = "%[1]s"
@@ -368,7 +369,7 @@ data "aws_region" "current" {}
 
 func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned(stackName, version string) string {
 	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication,
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
 		fmt.Sprintf(`
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
   name             = "%[1]s"
@@ -389,7 +390,7 @@ data "aws_region" "current" {}
 
 func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versioned2(stackName, version string) string {
 	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication,
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
 		fmt.Sprintf(`
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
   name           = "%[1]s"
@@ -411,7 +412,7 @@ data "aws_region" "current" {}
 
 func testAccAWSServerlessApplicationRepositoryCloudFormationStackConfig_versionedPaired(stackName, version string) string {
 	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication,
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
 		fmt.Sprintf(`
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
   name             = "%[1]s"
@@ -435,7 +436,7 @@ data "aws_region" "current" {}
 
 func testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication,
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
 		fmt.Sprintf(`
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
   name           = "%[1]s"
@@ -459,7 +460,7 @@ data "aws_region" "current" {}
 
 func testAccAwsServerlessApplicationRepositoryCloudFormationStackConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return composeConfig(
-		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication,
+		testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication(),
 		fmt.Sprintf(`
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-rotator" {
   name           = "%[1]s"
@@ -482,7 +483,8 @@ data "aws_region" "current" {}
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-const testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication = `
+func testAccCheckAwsServerlessApplicationRepositoryPostgresSingleUserRotatorApplication() string {
+	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 locals {
@@ -492,12 +494,13 @@ locals {
   application_account = local.security_manager_accounts[data.aws_partition.current.partition]
 
   security_manager_regions = {
-    "aws"        = "us-east-1",
-    "aws-us-gov" = "us-gov-west-1",
+    %[1]q = %[3]q,
+    %[2]q = %[4]q,
   }
   security_manager_accounts = {
-    "aws"        = "297356227824",
-    "aws-us-gov" = "023102451235",
+    %[1]q = "297356227824",
+    %[2]q = "023102451235",
   }
 }
-`
+`, endpoints.AwsPartitionID, endpoints.AwsUsGovPartitionID, endpoints.UsEast1RegionID, endpoints.UsGovWest1RegionID)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 [Phase 2](https://github.com/hashicorp/terraform-provider-aws/issues/12995#issuecomment-730680494)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Acceptance Tests in GovCloud

```
--- PASS: TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Basic (17.40s)
--- PASS: TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Versioned (29.28s)

--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_basic (94.14s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_disappears (95.13s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_paired (98.15s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_versioned (172.80s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_update (176.26s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_Tags (202.27s)
```

### Acceptance Tests in `us-west-2`

```
--- PASS: TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Basic (12.51s)
--- PASS: TestAccDataSourceAwsServerlessApplicationRepositoryApplication_Versioned (20.12s)

--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_disappears (91.86s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_basic (103.04s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_paired (111.42s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_update (172.95s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_Tags (191.24s)
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_versioned (215.53s)
```
