### PR TITLE
resource/aws_ram: Fix eventual consistency problems

### DIFF
--- a/.changelog/17032.txt
+++ b/.changelog/17032.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ram_resource_share_accepter: Improve handling of eventual consistency
+```
+
+```release-note:bug
+resource/aws_ram_resource_share: Improve handling of eventual consistency
+```

--- a/.changelog/17032.txt
+++ b/.changelog/17032.txt
@@ -5,3 +5,7 @@ resource/aws_ram_resource_share_accepter: Improve handling of eventual consisten
 ```release-note:bug
 resource/aws_ram_resource_share: Improve handling of eventual consistency
 ```
+
+```release-note:bug
+resource/aws_ram_principal_association: Improve handling of eventual consistency
+```

--- a/aws/internal/service/ram/finder/finder.go
+++ b/aws/internal/service/ram/finder/finder.go
@@ -1,0 +1,186 @@
+package finder
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ram"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+// ResourceShareOwnerOtherAccountsByArn returns the resource share owned by other accounts corresponding to the specified ARN.
+// Returns nil if no configuration is found.
+func ResourceShareOwnerOtherAccountsByArn(conn *ram.RAM, arn string) (*ram.ResourceShare, error) {
+	listResourceSharesInput := &ram.GetResourceSharesInput{
+		ResourceOwner:     aws.String(ram.ResourceOwnerOtherAccounts),
+		ResourceShareArns: aws.StringSlice([]string{arn}),
+	}
+
+	return resourceShare(conn, listResourceSharesInput)
+}
+
+// ResourceShareOwnerSelfByArn returns the resource share owned by own account corresponding to the specified ARN.
+// Returns nil if no configuration is found.
+func ResourceShareOwnerSelfByArn(conn *ram.RAM, arn string) (*ram.ResourceShare, error) {
+	listResourceSharesInput := &ram.GetResourceSharesInput{
+		ResourceOwner:     aws.String(ram.ResourceOwnerSelf),
+		ResourceShareArns: aws.StringSlice([]string{arn}),
+	}
+
+	return resourceShare(conn, listResourceSharesInput)
+}
+
+// ResourceShareInvitationByResourceShareArnAndStatus returns the resource share invitation corresponding to the specified resource share ARN.
+// Returns nil if no configuration is found.
+func ResourceShareInvitationByResourceShareArnAndStatus(conn *ram.RAM, resourceShareArn, status string) (*ram.ResourceShareInvitation, error) {
+	var invitation *ram.ResourceShareInvitation
+
+	// Retry for Ram resource share invitation eventual consistency
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		i, err := resourceShareInvitationByResourceShareArnAndStatus(conn, resourceShareArn, status)
+		invitation = i
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if invitation == nil {
+			return resource.RetryableError(&resource.NotFoundError{})
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		invitation, err = resourceShareInvitationByResourceShareArnAndStatus(conn, resourceShareArn, status)
+	}
+
+	if invitation == nil {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return invitation, nil
+}
+
+// ResourceShareInvitationByArn returns the resource share invitation corresponding to the specified ARN.
+// Returns nil if no configuration is found.
+func ResourceShareInvitationByArn(conn *ram.RAM, arn string) (*ram.ResourceShareInvitation, error) {
+	var invitation *ram.ResourceShareInvitation
+
+	// Retry for Ram resource share invitation eventual consistency
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		i, err := resourceShareInvitationByArn(conn, arn)
+		invitation = i
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if invitation == nil {
+			resource.RetryableError(&resource.NotFoundError{})
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		invitation, err = resourceShareInvitationByArn(conn, arn)
+	}
+
+	if invitation == nil {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return invitation, nil
+}
+
+func resourceShare(conn *ram.RAM, input *ram.GetResourceSharesInput) (*ram.ResourceShare, error) {
+	var shares *ram.GetResourceSharesOutput
+
+	// Retry for Ram resource share eventual consistency
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		ss, err := conn.GetResourceShares(input)
+		shares = ss
+
+		if tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if len(shares.ResourceShares) == 0 {
+			return resource.RetryableError(&resource.NotFoundError{})
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		shares, err = conn.GetResourceShares(input)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if shares == nil || len(shares.ResourceShares) == 0 {
+		return nil, nil
+	}
+
+	return shares.ResourceShares[0], nil
+}
+
+func resourceShareInvitationByResourceShareArnAndStatus(conn *ram.RAM, resourceShareArn, status string) (*ram.ResourceShareInvitation, error) {
+	var invitation *ram.ResourceShareInvitation
+
+	input := &ram.GetResourceShareInvitationsInput{
+		ResourceShareArns: []*string{aws.String(resourceShareArn)},
+	}
+
+	err := conn.GetResourceShareInvitationsPages(input, func(page *ram.GetResourceShareInvitationsOutput, lastPage bool) bool {
+		for _, rsi := range page.ResourceShareInvitations {
+			if aws.StringValue(rsi.Status) == status {
+				invitation = rsi
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return invitation, nil
+}
+
+func resourceShareInvitationByArn(conn *ram.RAM, arn string) (*ram.ResourceShareInvitation, error) {
+	input := &ram.GetResourceShareInvitationsInput{
+		ResourceShareInvitationArns: []*string{aws.String(arn)},
+	}
+
+	output, err := conn.GetResourceShareInvitations(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.ResourceShareInvitations) == 0 {
+		return nil, nil
+	}
+
+	return output.ResourceShareInvitations[0], nil
+}

--- a/aws/internal/service/ram/waiter/status.go
+++ b/aws/internal/service/ram/waiter/status.go
@@ -1,0 +1,55 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ram"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ram/finder"
+)
+
+const (
+	resourceShareInvitationStatusNotFound = "NotFound"
+	resourceShareInvitationStatusUnknown  = "Unknown"
+
+	resourceShareStatusNotFound = "NotFound"
+	resourceShareStatusUnknown  = "Unknown"
+)
+
+// ResourceShareInvitationStatus fetches the ResourceShareInvitation and its Status
+func ResourceShareInvitationStatus(conn *ram.RAM, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		invitation, err := finder.ResourceShareInvitationByArn(conn, arn)
+
+		if err != nil {
+			return nil, resourceShareInvitationStatusUnknown, err
+		}
+
+		if invitation == nil {
+			return nil, resourceShareInvitationStatusNotFound, nil
+		}
+
+		return invitation, aws.StringValue(invitation.Status), nil
+	}
+}
+
+// ResourceShareOwnerSelfStatus fetches the ResourceShare and its Status
+func ResourceShareOwnerSelfStatus(conn *ram.RAM, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		share, err := finder.ResourceShareOwnerSelfByArn(conn, arn)
+
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, ram.ErrCodeUnknownResourceException) {
+				return nil, resourceShareStatusNotFound, nil
+			}
+
+			return nil, resourceShareStatusUnknown, err
+		}
+
+		if share == nil {
+			return nil, resourceShareStatusNotFound, nil
+		}
+
+		return share, aws.StringValue(share.Status), nil
+	}
+}

--- a/aws/internal/service/ram/waiter/waiter.go
+++ b/aws/internal/service/ram/waiter/waiter.go
@@ -1,0 +1,80 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ram"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// ResourceShareInvitationAccepted waits for a ResourceShareInvitation to return ACCEPTED
+func ResourceShareInvitationAccepted(conn *ram.RAM, arn string, timeout time.Duration) (*ram.ResourceShareInvitation, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ram.ResourceShareInvitationStatusPending},
+		Target:  []string{ram.ResourceShareInvitationStatusAccepted},
+		Refresh: ResourceShareInvitationStatus(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*ram.ResourceShareInvitation); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+// ResourceShareOwnedBySelfDisassociated waits for a ResourceShare owned by own account to be disassociated
+func ResourceShareOwnedBySelfDisassociated(conn *ram.RAM, arn string, timeout time.Duration) (*ram.ResourceShare, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ram.ResourceShareAssociationStatusAssociated},
+		Target:  []string{},
+		Refresh: ResourceShareOwnerSelfStatus(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*ram.ResourceShare); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+// ResourceShareOwnedBySelfActive waits for a ResourceShare owned by own account to return ACTIVE
+func ResourceShareOwnedBySelfActive(conn *ram.RAM, arn string, timeout time.Duration) (*ram.ResourceShare, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ram.ResourceShareStatusPending},
+		Target:  []string{ram.ResourceShareStatusActive},
+		Refresh: ResourceShareOwnerSelfStatus(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*ram.ResourceShare); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+// ResourceShareOwnedBySelfDeleted waits for a ResourceShare owned by own account to return DELETED
+func ResourceShareOwnedBySelfDeleted(conn *ram.RAM, arn string, timeout time.Duration) (*ram.ResourceShare, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ram.ResourceShareStatusDeleting},
+		Target:  []string{ram.ResourceShareStatusDeleted},
+		Refresh: ResourceShareOwnerSelfStatus(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*ram.ResourceShare); ok {
+		return v, err
+	}
+
+	return nil, err
+}

--- a/aws/resource_aws_ram_resource_share_accepter.go
+++ b/aws/resource_aws_ram_resource_share_accepter.go
@@ -10,6 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ram"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ram/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ram/waiter"
 )
 
 func resourceAwsRamResourceShareAccepter() *schema.Resource {
@@ -81,7 +83,7 @@ func resourceAwsRamResourceShareAccepterCreate(d *schema.ResourceData, meta inte
 
 	shareARN := d.Get("share_arn").(string)
 
-	invitation, err := resourceAwsRamResourceShareGetInvitation(conn, shareARN, ram.ResourceShareInvitationStatusPending)
+	invitation, err := finder.ResourceShareInvitationByResourceShareArnAndStatus(conn, shareARN, ram.ResourceShareInvitationStatusPending)
 
 	if err != nil {
 		return err
@@ -108,16 +110,11 @@ func resourceAwsRamResourceShareAccepterCreate(d *schema.ResourceData, meta inte
 
 	d.SetId(shareARN)
 
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{ram.ResourceShareInvitationStatusPending},
-		Target:  []string{ram.ResourceShareInvitationStatusAccepted},
-		Refresh: resourceAwsRamResourceShareAccepterStateRefreshFunc(
-			conn,
-			aws.StringValue(output.ResourceShareInvitation.ResourceShareInvitationArn)),
-		Timeout: d.Timeout(schema.TimeoutCreate),
-	}
-
-	_, err = stateConf.WaitForState()
+	_, err = waiter.ResourceShareInvitationAccepted(
+		conn,
+		aws.StringValue(output.ResourceShareInvitation.ResourceShareInvitationArn),
+		d.Timeout(schema.TimeoutCreate),
+	)
 
 	if err != nil {
 		return fmt.Errorf("Error waiting for RAM resource share (%s) state: %s", d.Id(), err)
@@ -130,7 +127,7 @@ func resourceAwsRamResourceShareAccepterRead(d *schema.ResourceData, meta interf
 	accountID := meta.(*AWSClient).accountid
 	conn := meta.(*AWSClient).ramconn
 
-	invitation, err := resourceAwsRamResourceShareGetInvitation(conn, d.Id(), ram.ResourceShareInvitationStatusAccepted)
+	invitation, err := finder.ResourceShareInvitationByResourceShareArnAndStatus(conn, d.Id(), ram.ResourceShareInvitationStatusAccepted)
 
 	if err != nil {
 		return fmt.Errorf("Error retrieving invitation for resource share %s: %s", d.Id(), err)
@@ -143,23 +140,17 @@ func resourceAwsRamResourceShareAccepterRead(d *schema.ResourceData, meta interf
 		d.Set("receiver_account_id", accountID)
 	}
 
-	listResourceSharesInput := &ram.GetResourceSharesInput{
-		ResourceOwner:     aws.String(ram.ResourceOwnerOtherAccounts),
-		ResourceShareArns: aws.StringSlice([]string{d.Id()}),
-	}
+	resourceShare, err := finder.ResourceShareOwnerOtherAccountsByArn(conn, d.Id())
 
-	shares, err := conn.GetResourceShares(listResourceSharesInput)
 	if err != nil {
-		return fmt.Errorf("error retrieving resource shares: %w", err)
+		return fmt.Errorf("error retrieving resource share: %w", err)
 	}
 
-	if len(shares.ResourceShares) != 1 {
+	if resourceShare == nil {
 		log.Printf("[WARN] No RAM resource share with ARN (%s) found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
-
-	resourceShare := shares.ResourceShares[0]
 
 	d.Set("status", resourceShare.Status)
 	d.Set("sender_account_id", resourceShare.OwningAccountId)
@@ -215,72 +206,12 @@ func resourceAwsRamResourceShareAccepterDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error leaving RAM resource share: %s", err)
 	}
 
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{ram.ResourceShareAssociationStatusAssociated},
-		Target:  []string{ram.ResourceShareAssociationStatusDisassociated},
-		Refresh: resourceAwsRamResourceShareStateRefreshFunc(conn, d.Id()),
-		Timeout: d.Timeout(schema.TimeoutDelete),
-	}
-
-	if _, err := stateConf.WaitForState(); err != nil {
-		if isAWSErr(err, ram.ErrCodeUnknownResourceException, "") {
-			// what we want
-			return nil
-		}
+	_, err = waiter.ResourceShareOwnedBySelfDisassociated(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+	if err != nil {
 		return fmt.Errorf("Error waiting for RAM resource share (%s) state: %s", d.Id(), err)
 	}
 
 	return nil
-}
-
-func resourceAwsRamResourceShareGetInvitation(conn *ram.RAM, resourceShareARN, status string) (*ram.ResourceShareInvitation, error) {
-	input := &ram.GetResourceShareInvitationsInput{
-		ResourceShareArns: []*string{aws.String(resourceShareARN)},
-	}
-
-	var invitation *ram.ResourceShareInvitation
-	err := conn.GetResourceShareInvitationsPages(input, func(page *ram.GetResourceShareInvitationsOutput, lastPage bool) bool {
-		for _, rsi := range page.ResourceShareInvitations {
-			if aws.StringValue(rsi.Status) == status {
-				invitation = rsi
-				return false
-			}
-		}
-
-		return !lastPage
-	})
-
-	if invitation == nil {
-		return nil, nil
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("Error reading RAM resource share invitation %s: %s", resourceShareARN, err)
-	}
-
-	return invitation, nil
-}
-
-func resourceAwsRamResourceShareAccepterStateRefreshFunc(conn *ram.RAM, invitationArn string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		request := &ram.GetResourceShareInvitationsInput{
-			ResourceShareInvitationArns: []*string{aws.String(invitationArn)},
-		}
-
-		output, err := conn.GetResourceShareInvitations(request)
-
-		if err != nil {
-			return nil, "Unable to get resource share invitations", err
-		}
-
-		if len(output.ResourceShareInvitations) == 0 {
-			return nil, "Resource share invitation not found", nil
-		}
-
-		invitation := output.ResourceShareInvitations[0]
-
-		return invitation, aws.StringValue(invitation.Status), nil
-	}
 }
 
 func resourceAwsRamResourceShareGetIDFromARN(arn string) string {

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -17,8 +17,7 @@ func TestAccAwsRamResourceShareAccepter_basic(t *testing.T) {
 	var providers []*schema.Provider
 	resourceName := "aws_ram_resource_share_accepter.test"
 	principalAssociationResourceName := "aws_ram_principal_association.test"
-
-	shareName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -30,7 +29,7 @@ func TestAccAwsRamResourceShareAccepter_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAwsRamResourceShareAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsRamResourceShareAccepterBasic(shareName),
+				Config: testAccAwsRamResourceShareAccepterBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareAccepterExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "share_arn", principalAssociationResourceName, "resource_share_arn"),
@@ -39,12 +38,12 @@ func TestAccAwsRamResourceShareAccepter_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", ram.ResourceShareStatusActive),
 					testAccCheckResourceAttrAccountID(resourceName, "receiver_account_id"),
 					resource.TestMatchResourceAttr(resourceName, "sender_account_id", regexp.MustCompile(`\d{12}`)),
-					resource.TestCheckResourceAttr(resourceName, "share_name", shareName),
+					resource.TestCheckResourceAttr(resourceName, "share_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "resources.%", "0"),
 				),
 			},
 			{
-				Config:            testAccAwsRamResourceShareAccepterBasic(shareName),
+				Config:            testAccAwsRamResourceShareAccepterBasic(rName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -132,7 +131,7 @@ func testAccCheckAwsRamResourceShareAccepterExists(name string) resource.TestChe
 	}
 }
 
-func testAccAwsRamResourceShareAccepterBasic(shareName string) string {
+func testAccAwsRamResourceShareAccepterBasic(rName string) string {
 	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
 resource "aws_ram_resource_share_accepter" "test" {
   share_arn = aws_ram_principal_association.test.resource_share_arn
@@ -157,5 +156,5 @@ resource "aws_ram_principal_association" "test" {
 }
 
 data "aws_caller_identity" "receiver" {}
-`, shareName)
+`, rName)
 }

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -53,6 +53,32 @@ func TestAccAwsRamResourceShareAccepter_basic(t *testing.T) {
 	})
 }
 
+func TestAccAwsRamResourceShareAccepter_disappears(t *testing.T) {
+	var providers []*schema.Provider
+	resourceName := "aws_ram_resource_share_accepter.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ErrorCheck:        testAccErrorCheck(t, ram.EndpointsID),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
+		CheckDestroy:      testAccCheckAwsRamResourceShareAccepterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRamResourceShareAccepterBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRamResourceShareAccepterExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRamResourceShareAccepter(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsRamResourceShareAccepterDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ramconn
 

--- a/aws/resource_aws_ram_resource_share_test.go
+++ b/aws/resource_aws_ram_resource_share_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestAccAwsRamResourceShare_basic(t *testing.T) {
 	var resourceShare ram.ResourceShare
-	resourceName := "aws_ram_resource_share.example"
-	shareName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	resourceName := "aws_ram_resource_share.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,12 +24,12 @@ func TestAccAwsRamResourceShare_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsRamResourceShareDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsRamResourceShareConfigName(shareName),
+				Config: testAccAwsRamResourceShareConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareExists(resourceName, &resourceShare),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ram", regexp.MustCompile(`resource-share/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "allow_external_principals", "false"),
-					resource.TestCheckResourceAttr(resourceName, "name", shareName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -44,8 +44,8 @@ func TestAccAwsRamResourceShare_basic(t *testing.T) {
 
 func TestAccAwsRamResourceShare_AllowExternalPrincipals(t *testing.T) {
 	var resourceShare1, resourceShare2 ram.ResourceShare
-	resourceName := "aws_ram_resource_share.example"
-	shareName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	resourceName := "aws_ram_resource_share.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -54,7 +54,7 @@ func TestAccAwsRamResourceShare_AllowExternalPrincipals(t *testing.T) {
 		CheckDestroy: testAccCheckAwsRamResourceShareDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsRamResourceShareConfigAllowExternalPrincipals(shareName, false),
+				Config: testAccAwsRamResourceShareConfigAllowExternalPrincipals(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareExists(resourceName, &resourceShare1),
 					resource.TestCheckResourceAttr(resourceName, "allow_external_principals", "false"),
@@ -66,7 +66,7 @@ func TestAccAwsRamResourceShare_AllowExternalPrincipals(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAwsRamResourceShareConfigAllowExternalPrincipals(shareName, true),
+				Config: testAccAwsRamResourceShareConfigAllowExternalPrincipals(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareExists(resourceName, &resourceShare2),
 					resource.TestCheckResourceAttr(resourceName, "allow_external_principals", "true"),
@@ -78,9 +78,9 @@ func TestAccAwsRamResourceShare_AllowExternalPrincipals(t *testing.T) {
 
 func TestAccAwsRamResourceShare_Name(t *testing.T) {
 	var resourceShare1, resourceShare2 ram.ResourceShare
-	resourceName := "aws_ram_resource_share.example"
-	shareName1 := fmt.Sprintf("tf-%s", acctest.RandString(10))
-	shareName2 := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	resourceName := "aws_ram_resource_share.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -89,10 +89,10 @@ func TestAccAwsRamResourceShare_Name(t *testing.T) {
 		CheckDestroy: testAccCheckAwsRamResourceShareDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsRamResourceShareConfigName(shareName1),
+				Config: testAccAwsRamResourceShareConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareExists(resourceName, &resourceShare1),
-					resource.TestCheckResourceAttr(resourceName, "name", shareName1),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 			{
@@ -101,10 +101,10 @@ func TestAccAwsRamResourceShare_Name(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAwsRamResourceShareConfigName(shareName2),
+				Config: testAccAwsRamResourceShareConfigName(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareExists(resourceName, &resourceShare2),
-					resource.TestCheckResourceAttr(resourceName, "name", shareName2),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 				),
 			},
 		},
@@ -113,8 +113,8 @@ func TestAccAwsRamResourceShare_Name(t *testing.T) {
 
 func TestAccAwsRamResourceShare_Tags(t *testing.T) {
 	var resourceShare1, resourceShare2, resourceShare3 ram.ResourceShare
-	resourceName := "aws_ram_resource_share.example"
-	shareName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	resourceName := "aws_ram_resource_share.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -123,7 +123,7 @@ func TestAccAwsRamResourceShare_Tags(t *testing.T) {
 		CheckDestroy: testAccCheckAwsRamResourceShareDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsRamResourceShareConfigTags1(shareName, "key1", "value1"),
+				Config: testAccAwsRamResourceShareConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareExists(resourceName, &resourceShare1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -136,7 +136,7 @@ func TestAccAwsRamResourceShare_Tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAwsRamResourceShareConfigTags2(shareName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAwsRamResourceShareConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareExists(resourceName, &resourceShare2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -145,7 +145,7 @@ func TestAccAwsRamResourceShare_Tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsRamResourceShareConfigTags1(shareName, "key2", "value2"),
+				Config: testAccAwsRamResourceShareConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareExists(resourceName, &resourceShare3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -222,44 +222,44 @@ func testAccCheckAwsRamResourceShareDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAwsRamResourceShareConfigAllowExternalPrincipals(shareName string, allowExternalPrincipals bool) string {
+func testAccAwsRamResourceShareConfigAllowExternalPrincipals(rName string, allowExternalPrincipals bool) string {
 	return fmt.Sprintf(`
-resource "aws_ram_resource_share" "example" {
-  allow_external_principals = %t
-  name                      = %q
+resource "aws_ram_resource_share" "test" {
+  allow_external_principals = %[1]t
+  name                      = %[2]q
 }
-`, allowExternalPrincipals, shareName)
+`, allowExternalPrincipals, rName)
 }
 
-func testAccAwsRamResourceShareConfigName(shareName string) string {
+func testAccAwsRamResourceShareConfigName(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ram_resource_share" "example" {
-  name = %q
+resource "aws_ram_resource_share" "test" {
+  name = %[1]q
 }
-`, shareName)
+`, rName)
 }
 
-func testAccAwsRamResourceShareConfigTags1(shareName, tagKey1, tagValue1 string) string {
+func testAccAwsRamResourceShareConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_ram_resource_share" "example" {
-  name = %q
+resource "aws_ram_resource_share" "test" {
+  name = %[1]q
 
   tags = {
-    %q = %q
+    %[2]q = %[3]q
   }
 }
-`, shareName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1)
 }
 
-func testAccAwsRamResourceShareConfigTags2(shareName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAwsRamResourceShareConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_ram_resource_share" "example" {
-  name = %q
+resource "aws_ram_resource_share" "test" {
+  name = %[1]q
 
   tags = {
-    %q = %q
-    %q = %q
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, shareName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13494
Closes #15187
Closes #16578
Closes #17658
Closes #18332

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_ram_resource_share_accepter: Fix eventual consistency problems
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsRamResourceShareAccepter_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsRamResourceShareAccepter_* -timeout 120m
=== RUN   TestAccAwsRamResourceShareAccepter_basic
=== PAUSE TestAccAwsRamResourceShareAccepter_basic
=== CONT  TestAccAwsRamResourceShareAccepter_basic
--- PASS: TestAccAwsRamResourceShareAccepter_basic (79.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	81.162s

$ make testacc TESTARGS='-run=TestAccAwsRamResourceShare_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsRamResourceShare_* -timeout 120m
=== RUN   TestAccAwsRamResourceShareAccepter_basic
=== PAUSE TestAccAwsRamResourceShareAccepter_basic
=== RUN   TestAccAwsRamResourceShare_basic
=== PAUSE TestAccAwsRamResourceShare_basic
=== RUN   TestAccAwsRamResourceShare_AllowExternalPrincipals
=== PAUSE TestAccAwsRamResourceShare_AllowExternalPrincipals
=== RUN   TestAccAwsRamResourceShare_Name
=== PAUSE TestAccAwsRamResourceShare_Name
=== RUN   TestAccAwsRamResourceShare_Tags
=== PAUSE TestAccAwsRamResourceShare_Tags
=== CONT  TestAccAwsRamResourceShareAccepter_basic
=== CONT  TestAccAwsRamResourceShare_Name
=== CONT  TestAccAwsRamResourceShare_AllowExternalPrincipals
=== CONT  TestAccAwsRamResourceShare_Tags
=== CONT  TestAccAwsRamResourceShare_basic
--- PASS: TestAccAwsRamResourceShare_basic (42.74s)
--- PASS: TestAccAwsRamResourceShare_Name (69.01s)
--- PASS: TestAccAwsRamResourceShare_AllowExternalPrincipals (69.10s)
--- PASS: TestAccAwsRamResourceShareAccepter_basic (90.10s)
--- PASS: TestAccAwsRamResourceShare_Tags (92.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	94.688s
```

Thank you for your review! 👍 