### PR TITLE
r/aws_apigatewayv2_integration: Data mapping in HTTP APIs

### DIFF
--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -40,6 +40,7 @@ func TestAccAWSAPIGatewayV2Integration_basicWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
@@ -82,9 +83,12 @@ func TestAccAWSAPIGatewayV2Integration_basicHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "integration_uri", "https://example.com"),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
 				),
 			},
 			{
@@ -115,6 +119,96 @@ func TestAccAWSAPIGatewayV2Integration_disappears(t *testing.T) {
 					testAccCheckAWSAPIGatewayV2IntegrationDisappears(&apiId, &v),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Integration_DataMappingHttp(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetIntegrationOutput
+	resourceName := "aws_apigatewayv2_integration.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2IntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_dataMappingHttp(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "connection_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
+					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_method", "ANY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_subtype", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_type", "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_uri", "http://www.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
+					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.append:header.header1", "$context.requestId"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.remove:querystring.qs1", "''"),
+					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "response_parameters.*", map[string]string{
+						"status_code":                    "500",
+						"mappings.%":                     "2",
+						"mappings.append:header.header1": "$context.requestId",
+						"mappings.overwrite:statuscode":  "403",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "response_parameters.*", map[string]string{
+						"status_code":                  "404",
+						"mappings.%":                   "1",
+						"mappings.append:header.error": "$stageVariables.environmentId",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_dataMappingHttpUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "connection_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
+					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_method", "ANY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_subtype", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_type", "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_uri", "http://www.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
+					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.append:header.header1", "$context.accountId"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.overwrite:header.header2", "$stageVariables.environmentId"),
+					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "response_parameters.*", map[string]string{
+						"status_code":                    "500",
+						"mappings.%":                     "2",
+						"mappings.append:header.header1": "$context.requestId",
+						"mappings.overwrite:statuscode":  "403",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2IntegrationImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -151,6 +245,7 @@ func TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.stage", "'value1'"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.application/json", ""),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", "$request.body.name"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "28999"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
@@ -178,6 +273,7 @@ func TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.application/json", "#set($number=42)"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.application/xml", "#set($percent=$number/100)"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", "$request.body.id"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "51"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
@@ -222,6 +318,7 @@ func TestAccAWSAPIGatewayV2Integration_LambdaWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
@@ -266,6 +363,7 @@ func TestAccAWSAPIGatewayV2Integration_LambdaHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "2.0"),
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
@@ -311,6 +409,7 @@ func TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "12345"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
@@ -355,7 +454,9 @@ func TestAccAWSAPIGatewayV2Integration_VpcLinkHttp(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "integration_uri", lbListenerResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29001"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
@@ -384,7 +485,9 @@ func TestAccAWSAPIGatewayV2Integration_VpcLinkHttp(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "integration_uri", lbListenerResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29001"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
@@ -435,6 +538,7 @@ func TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.MessageGroupId", "$request.body.authentication_key"),
 					resource.TestCheckResourceAttrPair(resourceName, "request_parameters.QueueUrl", sqsQueue1ResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
@@ -460,6 +564,7 @@ func TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.MessageGroupId", "$request.body.authentication_key"),
 					resource.TestCheckResourceAttrPair(resourceName, "request_parameters.QueueUrl", sqsQueue2ResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "response_parameters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "30000"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
@@ -677,6 +782,66 @@ func testAccAWSAPIGatewayV2IntegrationConfig_basic(rName string) string {
 resource "aws_apigatewayv2_integration" "test" {
   api_id           = aws_apigatewayv2_api.test.id
   integration_type = "MOCK"
+}
+`
+}
+
+func testAccAWSAPIGatewayV2IntegrationConfig_dataMappingHttp(rName string) string {
+	return testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName) + `
+resource "aws_apigatewayv2_integration" "test" {
+  api_id = aws_apigatewayv2_api.test.id
+
+  integration_type   = "HTTP_PROXY"
+  integration_method = "ANY"
+  integration_uri    = "http://www.example.com"
+
+  request_parameters = {
+    "append:header.header1"  = "$context.requestId"
+    "remove:querystring.qs1" = "''"
+  }
+
+  response_parameters {
+    status_code = "500"
+
+    mappings = {
+      "append:header.header1" = "$context.requestId"
+      "overwrite:statuscode"  = "403"
+    }
+  }
+
+  response_parameters {
+    status_code = "404"
+
+    mappings = {
+      "append:header.error" = "$stageVariables.environmentId"
+    }
+  }
+}
+`
+}
+
+func testAccAWSAPIGatewayV2IntegrationConfig_dataMappingHttpUpdated(rName string) string {
+	return testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName) + `
+resource "aws_apigatewayv2_integration" "test" {
+  api_id = aws_apigatewayv2_api.test.id
+
+  integration_type   = "HTTP_PROXY"
+  integration_method = "ANY"
+  integration_uri    = "http://www.example.com"
+
+  request_parameters = {
+    "append:header.header1"    = "$context.accountId"
+    "overwrite:header.header2" = "$stageVariables.environmentId"
+  }
+
+  response_parameters {
+    status_code = "500"
+
+    mappings = {
+      "append:header.header1" = "$context.requestId"
+      "overwrite:statuscode"  = "403"
+    }
+  }
 }
 `
 }

--- a/website/docs/r/apigatewayv2_integration.html.markdown
+++ b/website/docs/r/apigatewayv2_integration.html.markdown
@@ -82,14 +82,23 @@ For an `HTTP` integration, specify a fully-qualified URL. For an HTTP API privat
 * `passthrough_behavior` - (Optional) The pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the `request_templates` attribute.
 Valid values: `WHEN_NO_MATCH`, `WHEN_NO_TEMPLATES`, `NEVER`. Default is `WHEN_NO_MATCH`. Supported only for WebSocket APIs.
 * `payload_format_version` - (Optional) The [format of the payload](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) sent to an integration. Valid values: `1.0`, `2.0`. Default is `1.0`.
-* `request_parameters` - (Optional) A key-value map specifying request parameters that are passed from the method request to the backend.
-Supported only for WebSocket APIs.
-* `request_templates` - (Optional) A map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. Supported only for WebSocket APIs.
+* `request_parameters` - (Optional) For WebSocket APIs, a key-value map specifying request parameters that are passed from the method request to the backend.
+For HTTP APIs with a specified `integration_subtype`, a key-value map specifying parameters that are passed to `AWS_PROXY` integrations.
+For HTTP APIs without a specified `integration_subtype`, a key-value map specifying how to transform HTTP requests before sending them to the backend.
+See the [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html) for details.
+* `request_templates` - (Optional) A map of [Velocity](https://velocity.apache.org/) templates that are applied on the request payload based on the value of the Content-Type header sent by the client. Supported only for WebSocket APIs.
+* `response_parameters` - (Optional) Mappings to transform the HTTP response from a backend integration before returning the response to clients. Supported only for HTTP APIs.
 * `template_selection_expression` - (Optional) The [template selection expression](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-template-selection-expressions) for the integration.
 * `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs.
 The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.
 Terraform will only perform drift detection of its value when present in a configuration.
 * `tls_config` - (Optional) The TLS configuration for a private integration. Supported only for HTTP APIs.
+
+The `response_parameters` object supports the following:
+
+* `status_code` - (Required) The HTTP status code in the range 200-599.
+* `mappings` - (Required) A key-value map. The key of ths map identifies the location of the request parameter to change, and how to change it. The corresponding value specifies the new data for the parameter.
+See the [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html) for details.
 
 The `tls_config` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/17021.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_integration: Add `response_parameters` attribute.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Integration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Integration_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Integration_basicWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_basicWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_basicHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_basicHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_disappears
=== PAUSE TestAccAWSAPIGatewayV2Integration_disappears
=== RUN   TestAccAWSAPIGatewayV2Integration_DataMappingHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_DataMappingHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_LambdaWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_LambdaWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_LambdaHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_LambdaHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration
=== PAUSE TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration
=== CONT  TestAccAWSAPIGatewayV2Integration_basicWebSocket
=== CONT  TestAccAWSAPIGatewayV2Integration_LambdaHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== CONT  TestAccAWSAPIGatewayV2Integration_DataMappingHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_LambdaWebSocket
=== CONT  TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_disappears
=== CONT  TestAccAWSAPIGatewayV2Integration_basicHttp
--- PASS: TestAccAWSAPIGatewayV2Integration_disappears (29.08s)
--- PASS: TestAccAWSAPIGatewayV2Integration_basicWebSocket (30.68s)
--- PASS: TestAccAWSAPIGatewayV2Integration_basicHttp (32.61s)
--- PASS: TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp (46.05s)
--- PASS: TestAccAWSAPIGatewayV2Integration_DataMappingHttp (48.71s)
--- PASS: TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration (48.96s)
--- PASS: TestAccAWSAPIGatewayV2Integration_LambdaWebSocket (49.47s)
--- PASS: TestAccAWSAPIGatewayV2Integration_LambdaHttp (53.71s)
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLinkHttp (412.36s)
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket (718.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	719.017s
```
