### PR TITLE
resource/aws_cloudfront_public_key: Add import support

### DIFF
--- a/aws/resource_aws_cloudfront_public_key.go
+++ b/aws/resource_aws_cloudfront_public_key.go
@@ -16,6 +16,9 @@ func resourceAwsCloudFrontPublicKey() *schema.Resource {
 		Read:   resourceAwsCloudFrontPublicKeyRead,
 		Update: resourceAwsCloudFrontPublicKeyUpdate,
 		Delete: resourceAwsCloudFrontPublicKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"caller_reference": {

--- a/aws/resource_aws_cloudfront_public_key_test.go
+++ b/aws/resource_aws_cloudfront_public_key_test.go
@@ -39,6 +39,27 @@ func TestAccAWSCloudFrontPublicKey_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudFrontPublicKey_disappears(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_cloudfront_public_key.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontPublicKeyConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontPublicKeyExistence(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudFrontPublicKey(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudFrontPublicKey_namePrefix(t *testing.T) {
 	startsWithPrefix := regexp.MustCompile("^tf-acc-test-")
 	resourceName := "aws_cloudfront_public_key.example"

--- a/aws/resource_aws_cloudfront_public_key_test.go
+++ b/aws/resource_aws_cloudfront_public_key_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestAccAWSCloudFrontPublicKey_basic(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudfront_public_key.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
@@ -23,11 +24,16 @@ func TestAccAWSCloudFrontPublicKey_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontPublicKeyConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFrontPublicKeyExistence("aws_cloudfront_public_key.example"),
+					testAccCheckCloudFrontPublicKeyExistence(resourceName),
 					resource.TestCheckResourceAttr("aws_cloudfront_public_key.example", "comment", "test key"),
 					resource.TestMatchResourceAttr("aws_cloudfront_public_key.example", "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
 					resource.TestCheckResourceAttr("aws_cloudfront_public_key.example", "name", fmt.Sprintf("tf-acc-test-%d", rInt)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -35,6 +41,7 @@ func TestAccAWSCloudFrontPublicKey_basic(t *testing.T) {
 
 func TestAccAWSCloudFrontPublicKey_namePrefix(t *testing.T) {
 	startsWithPrefix := regexp.MustCompile("^tf-acc-test-")
+	resourceName := "aws_cloudfront_public_key.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
@@ -44,9 +51,17 @@ func TestAccAWSCloudFrontPublicKey_namePrefix(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontPublicKeyConfig_namePrefix(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFrontPublicKeyExistence("aws_cloudfront_public_key.example"),
+					testAccCheckCloudFrontPublicKeyExistence(resourceName),
 					resource.TestMatchResourceAttr("aws_cloudfront_public_key.example", "name", startsWithPrefix),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
 			},
 		},
 	})
@@ -54,6 +69,7 @@ func TestAccAWSCloudFrontPublicKey_namePrefix(t *testing.T) {
 
 func TestAccAWSCloudFrontPublicKey_update(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudfront_public_key.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
@@ -63,14 +79,19 @@ func TestAccAWSCloudFrontPublicKey_update(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontPublicKeyConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFrontPublicKeyExistence("aws_cloudfront_public_key.example"),
+					testAccCheckCloudFrontPublicKeyExistence(resourceName),
 					resource.TestCheckResourceAttr("aws_cloudfront_public_key.example", "comment", "test key"),
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCloudFrontPublicKeyConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFrontPublicKeyExistence("aws_cloudfront_public_key.example"),
+					testAccCheckCloudFrontPublicKeyExistence(resourceName),
 					resource.TestCheckResourceAttr("aws_cloudfront_public_key.example", "comment", "test key1"),
 				),
 			},

--- a/website/docs/r/cloudfront_public_key.html.markdown
+++ b/website/docs/r/cloudfront_public_key.html.markdown
@@ -36,3 +36,11 @@ In addition to all arguments above, the following attributes are exported:
 * `caller_reference` - Internal value used by CloudFront to allow future updates to the public key configuration.
 * `etag` - The current version of the public key. For example: `E2QWRUHAPOMQZL`.
 * `id` - The identifier for the public key. For example: `K3D5EWEUDCCXON`.
+
+## Import
+
+CloudFront Public Key can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_cloudfront_public_key.example K3D5EWEUDCCXON
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cloudfront_public_key: Add import support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudFrontPublicKey_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontPublicKey_* -timeout 120m
=== RUN   TestAccAWSCloudFrontPublicKey_basic
=== PAUSE TestAccAWSCloudFrontPublicKey_basic
=== RUN   TestAccAWSCloudFrontPublicKey_disappears
=== PAUSE TestAccAWSCloudFrontPublicKey_disappears
=== RUN   TestAccAWSCloudFrontPublicKey_namePrefix
=== PAUSE TestAccAWSCloudFrontPublicKey_namePrefix
=== RUN   TestAccAWSCloudFrontPublicKey_update
=== PAUSE TestAccAWSCloudFrontPublicKey_update
=== CONT  TestAccAWSCloudFrontPublicKey_basic
=== CONT  TestAccAWSCloudFrontPublicKey_update
=== CONT  TestAccAWSCloudFrontPublicKey_disappears
=== CONT  TestAccAWSCloudFrontPublicKey_namePrefix
--- PASS: TestAccAWSCloudFrontPublicKey_disappears (33.45s)
--- PASS: TestAccAWSCloudFrontPublicKey_basic (45.46s)
--- PASS: TestAccAWSCloudFrontPublicKey_namePrefix (45.55s)
--- PASS: TestAccAWSCloudFrontPublicKey_update (69.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	71.962s
```

Thank you for your review! 👍 