### PR TITLE
ElastiCache documentation fixes and bringing some validations in line with documentation

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -382,11 +382,10 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 		req.NotificationTopicArn = aws.String(v.(string))
 	}
 
-	snaps := d.Get("snapshot_arns").(*schema.Set)
-	if snaps.Len() > 0 {
-		s := expandStringSet(snaps)
-		req.SnapshotArns = s
-		log.Printf("[DEBUG] Restoring Redis cluster from S3 snapshot: %#v", s)
+	snaps := d.Get("snapshot_arns").([]interface{})
+	if len(snaps) > 0 {
+		req.SnapshotArns = expandStringList(snaps)
+		log.Printf("[DEBUG] Restoring Redis cluster from S3 snapshot: %#v", snaps)
 	}
 
 	if v, ok := d.GetOk("snapshot_name"); ok {

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -204,18 +204,19 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			// A single-element string list containing an Amazon Resource Name (ARN) that
-			// uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot
-			// file will be used to populate the node group.
-			//
-			// See also:
-			// https://github.com/aws/aws-sdk-go/blob/4862a174f7fc92fb523fc39e68f00b87d91d2c3d/service/elasticache/api.go#L2079
 			"snapshot_arns": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				MaxItems: 1,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.All(
+						validateArn,
+						validation.StringDoesNotContainAny(","),
+					),
+				},
+				Set: schema.HashString,
 			},
 			"snapshot_retention_limit": {
 				Type:         schema.TypeInt,
@@ -293,7 +294,7 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 				// Engine memcached does not currently support vertical scaling
 				// InvalidParameterCombination: Scaling is not supported for engine memcached
-				// https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Scaling.Memcached.html#Scaling.Memcached.Vertically
+				// https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/Scaling.html#Scaling.Memcached.Vertically
 				if diff.Id() == "" || !diff.HasChange("node_type") {
 					return nil
 				}

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -204,19 +204,17 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			// A single-element string list containing an Amazon Resource Name (ARN) that
-			// uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot
-			// file will be used to populate the node group.
-			//
-			// See also:
-			// https://github.com/aws/aws-sdk-go/blob/4862a174f7fc92fb523fc39e68f00b87d91d2c3d/service/elasticache/api.go#L2079
 			"snapshot_arns": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				// Note: Unlike aws_elasticache_cluster, this does not have a limit of 1 item.
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validateArn,
+					Type: schema.TypeString,
+					ValidateFunc: validation.All(
+						validateArn,
+						validation.StringDoesNotContainAny(","),
+					),
 				},
 				Set: schema.HashString,
 			},

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -155,8 +155,8 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// Suppress default memcached/redis ports when not defined
-					if !d.IsNewResource() && new == "0" && (old == "6379" || old == "11211") {
+					// Suppress default Redis ports when not defined
+					if !d.IsNewResource() && new == "0" && old == elasticacheDefaultRedisPort {
 						return true
 					}
 					return false

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 * `replication_group_id` - (Optional) The ID of the replication group to which this cluster should belong. If this parameter is specified, the cluster is added to the specified replication group as a read replica; otherwise, the cluster is a standalone primary that is not part of any replication group.
 
-* `engine` – (Required unless `replication_group_id` is provided) Name of the cache engine to be used for this cache cluster. Valid values are `memcached` or `redis`. 
+* `engine` – (Required unless `replication_group_id` is provided) Name of the cache engine to be used for this cache cluster. Valid values are `memcached` or `redis`.
 
 * `engine_version` – (Optional) Version number of the cache engine to be used.
 See [Describe Cache Engine Versions](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-engine-versions.html)

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -16,7 +16,7 @@ Provides an ElastiCache Cluster resource, which manages either a
 For working with Redis (Cluster Mode Enabled) replication groups, see the
 [`aws_elasticache_replication_group` resource](/docs/providers/aws/r/elasticache_replication_group.html).
 
-~> **Note:** When you change an attribute, such as `node_type`, by default
+~> **Note:** When you change an attribute, such as `num_cache_nodes`, by default
 it is applied in the next maintenance window. Because of this, Terraform may report
 a difference in its planning phase because the actual modification has not yet taken
 place. You can use the `apply_immediately` flag to instruct the service to apply the
@@ -25,6 +25,8 @@ See the AWS Documentation on Modifying an ElastiCache Cache Cluster for
 [ElastiCache for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/Clusters.Modify.html) or
 [ElastiCache for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.Modify.html)
 for more information.
+
+~> **Note:** Any attribute changes that re-create the resource will be applied immediately, regardless of the value of `apply_immediately`.
 
 ## Example Usage
 
@@ -71,12 +73,11 @@ resource "aws_elasticache_cluster" "replica" {
 The following arguments are supported:
 
 * `cluster_id` – (Required) Group identifier. ElastiCache converts
-  this name to lowercase
+  this name to lowercase. Changing this value will re-create the resource.
 
 * `replication_group_id` - (Optional) The ID of the replication group to which this cluster should belong. If this parameter is specified, the cluster is added to the specified replication group as a read replica; otherwise, the cluster is a standalone primary that is not part of any replication group.
 
-* `engine` – (Required unless `replication_group_id` is provided) Name of the cache engine to be used for this cache cluster.
- Valid values for this parameter are `memcached` or `redis`
+* `engine` – (Required unless `replication_group_id` is provided) Name of the cache engine to be used for this cache cluster. Valid values are `memcached` or `redis`. 
 
 * `engine_version` – (Optional) Version number of the cache engine to be used.
 See [Describe Cache Engine Versions](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-engine-versions.html)
@@ -98,11 +99,11 @@ the highest numbered nodes will be removed.
 * `parameter_group_name` – (Required unless `replication_group_id` is provided) Name of the parameter group to associate
 with this cache cluster
 
-* `port` – (Optional) The port number on which each of the cache nodes will accept connections. For Memcached the default is 11211, and for Redis the default port is 6379. Cannot be provided with `replication_group_id`.
+* `port` – (Optional) The port number on which each of the cache nodes will accept connections. For Memcached the default is 11211, and for Redis the default port is 6379. Cannot be provided with `replication_group_id`. Changing this value will re-create the resource.
 
-* `subnet_group_name` – (Optional, VPC only) Name of the subnet group to be used for the cache cluster.
+* `subnet_group_name` – (Optional, VPC only) Name of the subnet group to be used for the cache cluster. Changing this value will re-create the resource.
 
-* `security_group_names` – (Optional, EC2 Classic only) List of security group names to associate with this cache cluster
+* `security_group_names` – (Optional, EC2 Classic only) List of security group names to associate with this cache cluster. Changing this value will re-create the resource.
 
 * `security_group_ids` – (Optional, VPC only) One or more VPC security groups associated with the cache cluster
 
@@ -129,7 +130,7 @@ SNS topic to send ElastiCache notifications to. Example:
 
 * `az_mode` - (Optional, Memcached only) Specifies whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region. Valid values for this parameter are `single-az` or `cross-az`, default is `single-az`. If you want to choose `cross-az`, `num_cache_nodes` must be greater than `1`
 
-* `availability_zone` - (Optional) The Availability Zone for the cache cluster. If you want to create cache nodes in multi-az, use `preferred_availability_zones` instead. Default: System chosen Availability Zone.
+* `availability_zone` - (Optional) The Availability Zone for the cache cluster. If you want to create cache nodes in multi-az, use `preferred_availability_zones` instead. Default: System chosen Availability Zone. Changing this value will re-create the resource.
 
 * `preferred_availability_zones` - (Optional, Memcached only) A list of the Availability Zones in which cache nodes are created. If you are creating your cluster in an Amazon VPC you can only locate nodes in Availability Zones that are associated with the subnets in the selected subnet group. The number of Availability Zones listed must equal the value of `num_cache_nodes`. If you want all the nodes in the same Availability Zone, use `availability_zone` instead, or repeat the Availability Zone multiple times in the list. Default: System chosen Availability Zones. Detecting drift of existing node availability zone is not currently supported. Updating this argument by itself to migrate existing node availability zones is not currently supported and will show a perpetual difference.
 

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -8,7 +8,11 @@ description: |-
 
 # Resource: aws_elasticache_cluster
 
-Provides an ElastiCache Cluster resource, which manages a Memcached cluster or Redis instance.
+Provides an ElastiCache Cluster resource, which manages either a
+[Memcached cluster](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/WhatIs.html), a
+[single-node Redis instance](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html), or a
+[read replica in a Redis (Cluster Mode Enabled) replication group].
+
 For working with Redis (Cluster Mode Enabled) replication groups, see the
 [`aws_elasticache_replication_group` resource](/docs/providers/aws/r/elasticache_replication_group.html).
 
@@ -17,7 +21,10 @@ it is applied in the next maintenance window. Because of this, Terraform may rep
 a difference in its planning phase because the actual modification has not yet taken
 place. You can use the `apply_immediately` flag to instruct the service to apply the
 change immediately. Using `apply_immediately` can result in a brief downtime as the server reboots.
-See the AWS Docs on [Modifying an ElastiCache Cache Cluster][2] for more information.
+See the AWS Documentation on Modifying an ElastiCache Cache Cluster for
+[ElastiCache for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/Clusters.Modify.html) or
+[ElastiCache for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.Modify.html)
+for more information.
 
 ## Example Usage
 
@@ -80,38 +87,32 @@ on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H 
 The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`
 
 * `node_type` – (Required unless `replication_group_id` is provided) The compute and memory capacity of the nodes. See
-[Available Cache Node Types](https://aws.amazon.com/elasticache/details#Available_Cache_Node_Types) for
-supported node types
+[Available Cache Node Types](https://aws.amazon.com/elasticache/pricing/#Available_node_types) for
+supported node types. For Memcached, changing this value will re-create the resource.
 
 * `num_cache_nodes` – (Required unless `replication_group_id` is provided) The initial number of cache nodes that the
-cache cluster will have. For Redis, this value must be 1. For Memcache, this
+cache cluster will have. For Redis, this value must be 1. For Memcached, this
 value must be between 1 and 20. If this number is reduced on subsequent runs,
 the highest numbered nodes will be removed.
 
 * `parameter_group_name` – (Required unless `replication_group_id` is provided) Name of the parameter group to associate
 with this cache cluster
 
-* `port` – (Optional) The port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379. Cannot be provided with `replication_group_id`.
+* `port` – (Optional) The port number on which each of the cache nodes will accept connections. For Memcached the default is 11211, and for Redis the default port is 6379. Cannot be provided with `replication_group_id`.
 
-* `subnet_group_name` – (Optional, VPC only) Name of the subnet group to be used
-for the cache cluster.
+* `subnet_group_name` – (Optional, VPC only) Name of the subnet group to be used for the cache cluster.
 
-* `security_group_names` – (Optional, EC2 Classic only) List of security group
-names to associate with this cache cluster
+* `security_group_names` – (Optional, EC2 Classic only) List of security group names to associate with this cache cluster
 
-* `security_group_ids` – (Optional, VPC only) One or more VPC security groups associated
- with the cache cluster
+* `security_group_ids` – (Optional, VPC only) One or more VPC security groups associated with the cache cluster
 
 * `apply_immediately` - (Optional) Specifies whether any database modifications
      are applied immediately, or during the next maintenance window. Default is
-     `false`. See [Amazon ElastiCache Documentation for more information.][1]
-     (Available since v0.6.0)
+     `false`. See [Amazon ElastiCache Documentation for more information.](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheCluster.html)
 
-* `snapshot_arns` – (Optional) A single-element string list containing an
-Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3.
-Example: `arn:aws:s3:::my_bucket/snapshot1.rdb`
+* `snapshot_arns` – (Optional, Redis only) A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. The object name cannot contain any commas. Changing `snapshot_arns` forces a new resource.
 
-* `snapshot_name` - (Optional) The name of a snapshot from which to restore data into the new node group.  Changing the `snapshot_name` forces a new resource.
+* `snapshot_name` - (Optional, Redis only) The name of a snapshot from which to restore data into the new node group. Changing `snapshot_name` forces a new resource.
 
 * `snapshot_window` - (Optional, Redis only) The daily time range (in UTC) during which ElastiCache will
 begin taking a daily snapshot of your cache cluster. Example: 05:00-09:00
@@ -142,13 +143,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the created ElastiCache Cluster.
 * `cache_nodes` - List of node objects including `id`, `address`, `port` and `availability_zone`.
-   Referenceable e.g. as `${aws_elasticache_cluster.bar.cache_nodes.0.address}`
 * `configuration_endpoint` - (Memcached only) The configuration endpoint to allow host discovery.
 * `cluster_address` - (Memcached only) The DNS name of the cache cluster without the port appended.
-
-[1]: https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheCluster.html
-[2]: https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Modify.html
-
 
 ## Import
 

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -9,8 +9,10 @@ description: |-
 # Resource: aws_elasticache_replication_group
 
 Provides an ElastiCache Replication Group resource.
-For working with Memcached or single primary Redis instances (Cluster Mode Disabled), see the
-[`aws_elasticache_cluster` resource](/docs/providers/aws/r/elasticache_cluster.html).
+
+For working with a [Memcached cluster](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/WhatIs.html) or a
+[single-node Redis instance (Cluster Mode Disabled)](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html),
+see the [`aws_elasticache_cluster` resource](/docs/providers/aws/r/elasticache_cluster.html).
 
 ~> **Note:** When you change an attribute, such as `engine_version`, by
 default the ElastiCache API applies it in the next maintenance window. Because
@@ -19,6 +21,9 @@ actual modification has not yet taken place. You can use the
 `apply_immediately` flag to instruct the service to apply the change
 immediately. Using `apply_immediately` can result in a brief downtime as
 servers reboots.
+See the AWS Documentation on
+[Modifying an ElastiCache Cache Cluster](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.Modify.html)
+for more information.
 
 ~> **Note:** Be aware of the terminology collision around "cluster" for `aws_elasticache_replication_group`. For example, it is possible to create a ["Cluster Mode Disabled [Redis] Cluster"](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.Create.CON.Redis.html). With "Cluster Mode Enabled", the data will be stored in shards (called "node groups"). See [Redis Cluster Configuration](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/cluster-create-determine-requirements.html#redis-cluster-configuration) for a diagram of the differences. To enable cluster mode, use a parameter group that has cluster mode enabled. The default parameter groups provided by AWS end with ".cluster.on", for example `default.redis6.x.cluster.on`.
 
@@ -118,9 +123,8 @@ The following arguments are supported:
 * `subnet_group_name` - (Optional) The name of the cache subnet group to be used for the replication group.
 * `security_group_names` - (Optional) A list of cache security group names to associate with this replication group.
 * `security_group_ids` - (Optional) One or more Amazon VPC security groups associated with this replication group. Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud
-* `snapshot_arns` – (Optional) A single-element string list containing an
-Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3.
-Example: `arn:aws:s3:::my_bucket/snapshot1.rdb`
+* `snapshot_arns` – (Optional) A list of
+Amazon Resource Names (ARNs) that identify Redis RDB snapshot files stored in Amazon S3. The names object names cannot contain any commas.
 * `snapshot_name` - (Optional) The name of a snapshot from which to restore data into the new node group. Changing the `snapshot_name` forces a new resource.
 * `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance
 on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC).

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -25,6 +25,8 @@ See the AWS Documentation on
 [Modifying an ElastiCache Cache Cluster](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.Modify.html)
 for more information.
 
+~> **Note:** Any attribute changes that re-create the resource will be applied immediately, regardless of the value of `apply_immediately`.
+
 ~> **Note:** Be aware of the terminology collision around "cluster" for `aws_elasticache_replication_group`. For example, it is possible to create a ["Cluster Mode Disabled [Redis] Cluster"](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.Create.CON.Redis.html). With "Cluster Mode Enabled", the data will be stored in shards (called "node groups"). See [Redis Cluster Configuration](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/cluster-create-determine-requirements.html#redis-cluster-configuration) for a diagram of the differences. To enable cluster mode, use a parameter group that has cluster mode enabled. The default parameter groups provided by AWS end with ".cluster.on", for example `default.redis6.x.cluster.on`.
 
 ## Example Usage


### PR DESCRIPTION
Clarifies documentation around `aws_elasticache_cluster` forcing new resource when `node_type` is changed.

Also updates links to AWS documentation for the split between Redis and Memcached.

Additional cleanup.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_\|TestAccAWSElasticacheCluster_'

--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (92.91s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached (736.74s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NonClusteredParameterGroup (797.02s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (756.47s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (987.34s)
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (990.40s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (993.80s)
--- PASS: TestAccAWSElasticacheReplicationGroup_useCmkKmsKeyId (1275.23s)
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (1402.40s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis (13.79s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1544.07s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (874.66s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (1732.90s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis (692.47s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (2078.44s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached (676.45s)
--- PASS: TestAccAWSElasticacheReplicationGroup_tags (2185.35s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (2355.82s)
--- PASS: TestAccAWSElasticacheCluster_vpc (660.46s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (2403.54s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis (1435.40s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (755.23s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (2488.60s)
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (2584.51s)
--- PASS: TestAccAWSElasticacheCluster_Port_Redis_Default (557.94s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (2658.04s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (599.39s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1701.32s)
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic (551.43s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica (1947.42s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone (1776.81s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached (1511.04s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (929.59s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica (2177.41s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached (1375.49s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis (663.86s)
--- PASS: TestAccAWSElasticacheCluster_Port (710.43s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1155.18s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1285.29s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups (3796.91s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (3832.58s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis (1367.72s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (898.99s)
```
