### PR TITLE
resource/aws_s3_bucket_inventory: Prevent crashes with empty destination, filter, and schedule configuration blocks

### DIFF
--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -200,7 +200,7 @@ func resourceAwsS3BucketInventoryPut(d *schema.ResourceData, meta interface{}) e
 		inventoryConfiguration.OptionalFields = expandStringList(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("schedule"); ok {
+	if v, ok := d.GetOk("schedule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		scheduleList := v.([]interface{})
 		scheduleMap := scheduleList[0].(map[string]interface{})
 		inventoryConfiguration.Schedule = &s3.InventorySchedule{
@@ -208,13 +208,13 @@ func resourceAwsS3BucketInventoryPut(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if v, ok := d.GetOk("filter"); ok {
+	if v, ok := d.GetOk("filter"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		filterList := v.([]interface{})
 		filterMap := filterList[0].(map[string]interface{})
 		inventoryConfiguration.Filter = expandS3InventoryFilter(filterMap)
 	}
 
-	if v, ok := d.GetOk("destination"); ok {
+	if v, ok := d.GetOk("destination"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		destinationList := v.([]interface{})
 		destinationMap := destinationList[0].(map[string]interface{})
 		bucketList := destinationMap["bucket"].([]interface{})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16952
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16953
Reference: https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/contributing/data-handling-and-conversion.md#root-typelist-of-resource-and-aws-structure


Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_s3_bucket_inventory: Prevent crashes with empty destination, filter, and schedule configuration blocks
```

Output from acceptance testing:

```
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (26.70s)
--- PASS: TestAccAWSS3BucketInventory_basic (26.73s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (27.01s)
```
