### PR TITLE
.github/workflows: Reduce goreleaser parallelism to match GitHub Actions hosted runners

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,7 +27,7 @@ jobs:
       - name: goreleaser release
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: release --rm-dist --skip-sign --snapshot --timeout 2h
+          args: release --parallelism 2 --rm-dist --skip-sign --snapshot --timeout 2h
       - name: artifact naming
         id: naming
         run: |

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -300,7 +300,7 @@ jobs:
       - name: goreleaser build
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: build --snapshot --timeout 2h
+          args: build --parallelism 2 --snapshot --timeout 2h
 
   semgrep:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Most of the GitHub Actions logging is either missing or cutoff without explanation, but finally found one with a `signal: killed` entry. We may be triggering oom-killer or another abuse protection mechanism, so this attempts to reduce the footprint on the runner. I did not immediately see a way to dynamically fetch the processor count via workflow information.
