### PR TITLE
Prefer expandStringSet() – Resources A-F

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -508,7 +508,7 @@ func flattenCookieNames(cn *cloudfront.CookieNames) []interface{} {
 func expandAllowedMethods(s *schema.Set) *cloudfront.AllowedMethods {
 	return &cloudfront.AllowedMethods{
 		Quantity: aws.Int64(int64(s.Len())),
-		Items:    expandStringList(s.List()),
+		Items:    expandStringSet(s),
 	}
 }
 
@@ -522,7 +522,7 @@ func flattenAllowedMethods(am *cloudfront.AllowedMethods) *schema.Set {
 func expandCachedMethods(s *schema.Set) *cloudfront.CachedMethods {
 	return &cloudfront.CachedMethods{
 		Quantity: aws.Int64(int64(s.Len())),
-		Items:    expandStringList(s.List()),
+		Items:    expandStringSet(s),
 	}
 }
 
@@ -1000,14 +1000,12 @@ func flattenLoggingConfig(lc *cloudfront.LoggingConfig) []interface{} {
 	return []interface{}{m}
 }
 
-func expandAliases(as *schema.Set) *cloudfront.Aliases {
-	s := as.List()
-	var aliases cloudfront.Aliases
-	if len(s) > 0 {
-		aliases.Quantity = aws.Int64(int64(len(s)))
-		aliases.Items = expandStringList(s)
-	} else {
-		aliases.Quantity = aws.Int64(0)
+func expandAliases(s *schema.Set) *cloudfront.Aliases {
+	aliases := cloudfront.Aliases{
+		Quantity: aws.Int64(int64(s.Len())),
+	}
+	if s.Len() > 0 {
+		aliases.Items = expandStringSet(s)
 	}
 	return &aliases
 }

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -301,10 +301,10 @@ func TestCloudFrontStructure_expandCloudFrontDefaultCacheBehavior(t *testing.T) 
 	if *dcb.LambdaFunctionAssociations.Quantity != 2 {
 		t.Fatalf("Expected LambdaFunctionAssociations to be 2, got %v", *dcb.LambdaFunctionAssociations.Quantity)
 	}
-	if !reflect.DeepEqual(dcb.AllowedMethods.Items, expandStringList(allowedMethodsConf().List())) {
+	if !reflect.DeepEqual(dcb.AllowedMethods.Items, expandStringSet(allowedMethodsConf())) {
 		t.Fatalf("Expected AllowedMethods.Items to be %v, got %v", allowedMethodsConf().List(), dcb.AllowedMethods.Items)
 	}
-	if !reflect.DeepEqual(dcb.AllowedMethods.CachedMethods.Items, expandStringList(cachedMethodsConf().List())) {
+	if !reflect.DeepEqual(dcb.AllowedMethods.CachedMethods.Items, expandStringSet(cachedMethodsConf())) {
 		t.Fatalf("Expected AllowedMethods.CachedMethods.Items to be %v, got %v", cachedMethodsConf().List(), dcb.AllowedMethods.CachedMethods.Items)
 	}
 }
@@ -502,7 +502,7 @@ func TestCloudFrontStructure_expandAllowedMethods(t *testing.T) {
 	if *am.Quantity != 7 {
 		t.Fatalf("Expected Quantity to be 7, got %v", *am.Quantity)
 	}
-	if !reflect.DeepEqual(am.Items, expandStringList(data.List())) {
+	if !reflect.DeepEqual(am.Items, expandStringSet(data)) {
 		t.Fatalf("Expected Items to be %v, got %v", data, am.Items)
 	}
 }
@@ -523,7 +523,7 @@ func TestCloudFrontStructure_expandCachedMethods(t *testing.T) {
 	if *cm.Quantity != 3 {
 		t.Fatalf("Expected Quantity to be 3, got %v", *cm.Quantity)
 	}
-	if !reflect.DeepEqual(cm.Items, expandStringList(data.List())) {
+	if !reflect.DeepEqual(cm.Items, expandStringSet(data)) {
 		t.Fatalf("Expected Items to be %v, got %v", data, cm.Items)
 	}
 }
@@ -870,7 +870,7 @@ func TestCloudFrontStructure_expandAliases(t *testing.T) {
 	if *a.Quantity != 2 {
 		t.Fatalf("Expected Quantity to be 2, got %v", *a.Quantity)
 	}
-	if !reflect.DeepEqual(a.Items, expandStringList(data.List())) {
+	if !reflect.DeepEqual(a.Items, expandStringSet(data)) {
 		t.Fatalf("Expected Items to be [example.com www.example.com], got %v", a.Items)
 	}
 }

--- a/aws/data_source_aws_autoscaling_groups.go
+++ b/aws/data_source_aws_autoscaling_groups.go
@@ -122,7 +122,7 @@ func expandAsgTagFilters(in []interface{}) []*autoscaling.Filter {
 	out := make([]*autoscaling.Filter, len(in))
 	for i, filter := range in {
 		m := filter.(map[string]interface{})
-		values := expandStringList(m["values"].(*schema.Set).List())
+		values := expandStringSet(m["values"].(*schema.Set))
 
 		out[i] = &autoscaling.Filter{
 			Name:   aws.String(m["name"].(string)),

--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -207,7 +207,7 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 
 	var cacheKeyParameters []*string
 	if v, ok := d.GetOk("cache_key_parameters"); ok {
-		cacheKeyParameters = expandStringList(v.(*schema.Set).List())
+		cacheKeyParameters = expandStringSet(v.(*schema.Set))
 	}
 
 	var cacheNamespace *string

--- a/aws/resource_aws_api_gateway_method.go
+++ b/aws/resource_aws_api_gateway_method.go
@@ -133,7 +133,7 @@ func resourceAwsApiGatewayMethodCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("authorization_scopes"); ok {
-		input.AuthorizationScopes = expandStringList(v.(*schema.Set).List())
+		input.AuthorizationScopes = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("request_validator_id"); ok {

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -650,7 +650,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 
 	// Availability Zones are optional if VPC Zone Identifier(s) are specified
 	if v, ok := d.GetOk("availability_zones"); ok && v.(*schema.Set).Len() > 0 {
-		createOpts.AvailabilityZones = expandStringList(v.(*schema.Set).List())
+		createOpts.AvailabilityZones = expandStringSet(v.(*schema.Set))
 	}
 
 	resourceID := d.Get("name").(string)
@@ -684,8 +684,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("load_balancers"); ok && v.(*schema.Set).Len() > 0 {
-		createOpts.LoadBalancerNames = expandStringList(
-			v.(*schema.Set).List())
+		createOpts.LoadBalancerNames = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("vpc_zone_identifier"); ok && v.(*schema.Set).Len() > 0 {
@@ -697,7 +696,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("target_group_arns"); ok && len(v.(*schema.Set).List()) > 0 {
-		createOpts.TargetGroupARNs = expandStringList(v.(*schema.Set).List())
+		createOpts.TargetGroupARNs = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("service_linked_role_arn"); ok {
@@ -1034,7 +1033,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("availability_zones") {
 		if v, ok := d.GetOk("availability_zones"); ok && v.(*schema.Set).Len() > 0 {
-			opts.AvailabilityZones = expandStringList(v.(*schema.Set).List())
+			opts.AvailabilityZones = expandStringSet(v.(*schema.Set))
 		}
 	}
 
@@ -1092,8 +1091,8 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
-		remove := expandStringList(os.Difference(ns).List())
-		add := expandStringList(ns.Difference(os).List())
+		remove := expandStringSet(os.Difference(ns))
+		add := expandStringSet(ns.Difference(os))
 
 		if len(remove) > 0 {
 			// API only supports removing 10 at a time
@@ -1162,8 +1161,8 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
-		remove := expandStringList(os.Difference(ns).List())
-		add := expandStringList(ns.Difference(os).List())
+		remove := expandStringSet(os.Difference(ns))
+		add := expandStringSet(ns.Difference(os))
 
 		if len(remove) > 0 {
 			// AWS API only supports adding/removing 10 at a time
@@ -1431,7 +1430,7 @@ func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) 
 func enableASGSuspendedProcesses(d *schema.ResourceData, conn *autoscaling.AutoScaling) error {
 	props := &autoscaling.ScalingProcessQuery{
 		AutoScalingGroupName: aws.String(d.Id()),
-		ScalingProcesses:     expandStringList(d.Get("suspended_processes").(*schema.Set).List()),
+		ScalingProcesses:     expandStringSet(d.Get("suspended_processes").(*schema.Set)),
 	}
 
 	_, err := conn.SuspendProcesses(props)
@@ -1442,7 +1441,7 @@ func enableASGMetricsCollection(d *schema.ResourceData, conn *autoscaling.AutoSc
 	props := &autoscaling.EnableMetricsCollectionInput{
 		AutoScalingGroupName: aws.String(d.Id()),
 		Granularity:          aws.String(d.Get("metrics_granularity").(string)),
-		Metrics:              expandStringList(d.Get("enabled_metrics").(*schema.Set).List()),
+		Metrics:              expandStringSet(d.Get("enabled_metrics").(*schema.Set)),
 	}
 
 	log.Printf("[INFO] Enabling metrics collection for the Auto Scaling Group: %s", d.Id())
@@ -1467,7 +1466,7 @@ func updateASGSuspendedProcesses(d *schema.ResourceData, conn *autoscaling.AutoS
 	if resumeProcesses.Len() != 0 {
 		props := &autoscaling.ScalingProcessQuery{
 			AutoScalingGroupName: aws.String(d.Id()),
-			ScalingProcesses:     expandStringList(resumeProcesses.List()),
+			ScalingProcesses:     expandStringSet(resumeProcesses),
 		}
 
 		_, err := conn.ResumeProcesses(props)
@@ -1480,7 +1479,7 @@ func updateASGSuspendedProcesses(d *schema.ResourceData, conn *autoscaling.AutoS
 	if suspendedProcesses.Len() != 0 {
 		props := &autoscaling.ScalingProcessQuery{
 			AutoScalingGroupName: aws.String(d.Id()),
-			ScalingProcesses:     expandStringList(suspendedProcesses.List()),
+			ScalingProcesses:     expandStringSet(suspendedProcesses),
 		}
 
 		_, err := conn.SuspendProcesses(props)
@@ -1510,7 +1509,7 @@ func updateASGMetricsCollection(d *schema.ResourceData, conn *autoscaling.AutoSc
 	if disableMetrics.Len() != 0 {
 		props := &autoscaling.DisableMetricsCollectionInput{
 			AutoScalingGroupName: aws.String(d.Id()),
-			Metrics:              expandStringList(disableMetrics.List()),
+			Metrics:              expandStringSet(disableMetrics),
 		}
 
 		_, err := conn.DisableMetricsCollection(props)
@@ -1523,7 +1522,7 @@ func updateASGMetricsCollection(d *schema.ResourceData, conn *autoscaling.AutoSc
 	if enabledMetrics.Len() != 0 {
 		props := &autoscaling.EnableMetricsCollectionInput{
 			AutoScalingGroupName: aws.String(d.Id()),
-			Metrics:              expandStringList(enabledMetrics.List()),
+			Metrics:              expandStringSet(enabledMetrics),
 			Granularity:          aws.String(d.Get("metrics_granularity").(string)),
 		}
 

--- a/aws/resource_aws_autoscaling_notification.go
+++ b/aws/resource_aws_autoscaling_notification.go
@@ -43,8 +43,8 @@ func resourceAwsAutoscalingNotification() *schema.Resource {
 
 func resourceAwsAutoscalingNotificationCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).autoscalingconn
-	gl := expandStringList(d.Get("group_names").(*schema.Set).List())
-	nl := expandStringList(d.Get("notifications").(*schema.Set).List())
+	gl := expandStringSet(d.Get("group_names").(*schema.Set))
+	nl := expandStringSet(d.Get("notifications").(*schema.Set))
 
 	topic := d.Get("topic_arn").(string)
 	if err := addNotificationConfigToGroupsWithTopic(conn, gl, nl, topic); err != nil {
@@ -59,7 +59,7 @@ func resourceAwsAutoscalingNotificationCreate(d *schema.ResourceData, meta inter
 
 func resourceAwsAutoscalingNotificationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).autoscalingconn
-	gl := expandStringList(d.Get("group_names").(*schema.Set).List())
+	gl := expandStringSet(d.Get("group_names").(*schema.Set))
 
 	opts := &autoscaling.DescribeNotificationConfigurationsInput{
 		AutoScalingGroupNames: gl,
@@ -121,7 +121,7 @@ func resourceAwsAutoscalingNotificationUpdate(d *schema.ResourceData, meta inter
 
 	// Notifications API call is a PUT, so we don't need to diff the list, just
 	// push whatever it is and AWS sorts it out
-	nl := expandStringList(d.Get("notifications").(*schema.Set).List())
+	nl := expandStringSet(d.Get("notifications").(*schema.Set))
 
 	o, n := d.GetChange("group_names")
 	if o == nil {
@@ -131,8 +131,8 @@ func resourceAwsAutoscalingNotificationUpdate(d *schema.ResourceData, meta inter
 		n = new(schema.Set)
 	}
 
-	remove := expandStringList(o.(*schema.Set).List())
-	add := expandStringList(n.(*schema.Set).List())
+	remove := expandStringSet(o.(*schema.Set))
+	add := expandStringSet(n.(*schema.Set))
 
 	topic := d.Get("topic_arn").(string)
 
@@ -142,7 +142,7 @@ func resourceAwsAutoscalingNotificationUpdate(d *schema.ResourceData, meta inter
 
 	var update []*string
 	if d.HasChange("notifications") {
-		update = expandStringList(d.Get("group_names").(*schema.Set).List())
+		update = expandStringSet(d.Get("group_names").(*schema.Set))
 	} else {
 		update = add
 	}
@@ -191,7 +191,7 @@ func removeNotificationConfigToGroupsWithTopic(conn *autoscaling.AutoScaling, gr
 func resourceAwsAutoscalingNotificationDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).autoscalingconn
 
-	gl := expandStringList(d.Get("group_names").(*schema.Set).List())
+	gl := expandStringSet(d.Get("group_names").(*schema.Set))
 
 	topic := d.Get("topic_arn").(string)
 	err := removeNotificationConfigToGroupsWithTopic(conn, gl, topic)

--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -136,13 +136,13 @@ func resourceAwsCloudFormationStackCreate(d *schema.ResourceData, meta interface
 		input.TemplateURL = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("capabilities"); ok {
-		input.Capabilities = expandStringList(v.(*schema.Set).List())
+		input.Capabilities = expandStringSet(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk("disable_rollback"); ok {
 		input.DisableRollback = aws.Bool(v.(bool))
 	}
 	if v, ok := d.GetOk("notification_arns"); ok {
-		input.NotificationARNs = expandStringList(v.(*schema.Set).List())
+		input.NotificationARNs = expandStringSet(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk("on_failure"); ok {
 		input.OnFailure = aws.String(v.(string))
@@ -311,11 +311,11 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 
 	// Capabilities must be present whether they are changed or not
 	if v, ok := d.GetOk("capabilities"); ok {
-		input.Capabilities = expandStringList(v.(*schema.Set).List())
+		input.Capabilities = expandStringSet(v.(*schema.Set))
 	}
 
 	if d.HasChange("notification_arns") {
-		input.NotificationARNs = expandStringList(d.Get("notification_arns").(*schema.Set).List())
+		input.NotificationARNs = expandStringSet(d.Get("notification_arns").(*schema.Set))
 	}
 
 	// Parameters must be present whether they are changed or not

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -981,8 +981,8 @@ func expandCodeBuildVpcConfig(rawVpcConfig []interface{}) *codebuild.VpcConfig {
 
 	data := rawVpcConfig[0].(map[string]interface{})
 	vpcConfig.VpcId = aws.String(data["vpc_id"].(string))
-	vpcConfig.Subnets = expandStringList(data["subnets"].(*schema.Set).List())
-	vpcConfig.SecurityGroupIds = expandStringList(data["security_group_ids"].(*schema.Set).List())
+	vpcConfig.Subnets = expandStringSet(data["subnets"].(*schema.Set))
+	vpcConfig.SecurityGroupIds = expandStringSet(data["security_group_ids"].(*schema.Set))
 
 	return &vpcConfig
 }

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -504,7 +504,7 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 	}
 
 	if attr, ok := d.GetOk("autoscaling_groups"); ok {
-		input.AutoScalingGroups = expandStringList(attr.(*schema.Set).List())
+		input.AutoScalingGroups = expandStringSet(attr.(*schema.Set))
 	}
 
 	if attr, ok := d.GetOk("on_premises_instance_tag_filter"); ok {
@@ -687,7 +687,7 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 	// include (original or new) autoscaling groups when blue_green_deployment_config changes except for ECS
 	if _, isEcs := d.GetOk("ecs_service"); d.HasChange("autoscaling_groups") || (d.HasChange("blue_green_deployment_config") && !isEcs) {
 		_, n := d.GetChange("autoscaling_groups")
-		input.AutoScalingGroups = expandStringList(n.(*schema.Set).List())
+		input.AutoScalingGroups = expandStringSet(n.(*schema.Set))
 	}
 
 	// TagFilters aren't like tags. They don't append. They simply replace.

--- a/aws/resource_aws_codestarnotifications_notification_rule.go
+++ b/aws/resource_aws_codestarnotifications_notification_rule.go
@@ -125,7 +125,7 @@ func resourceAwsCodeStarNotificationsNotificationRuleCreate(d *schema.ResourceDa
 
 	params := &codestarnotifications.CreateNotificationRuleInput{
 		DetailType:   aws.String(d.Get("detail_type").(string)),
-		EventTypeIds: expandStringList(d.Get("event_type_ids").(*schema.Set).List()),
+		EventTypeIds: expandStringSet(d.Get("event_type_ids").(*schema.Set)),
 		Name:         aws.String(d.Get("name").(string)),
 		Resource:     aws.String(d.Get("resource").(string)),
 		Status:       aws.String(d.Get("status").(string)),
@@ -252,7 +252,7 @@ func resourceAwsCodeStarNotificationsNotificationRuleUpdate(d *schema.ResourceDa
 	params := &codestarnotifications.UpdateNotificationRuleInput{
 		Arn:          aws.String(d.Id()),
 		DetailType:   aws.String(d.Get("detail_type").(string)),
-		EventTypeIds: expandStringList(d.Get("event_type_ids").(*schema.Set).List()),
+		EventTypeIds: expandStringSet(d.Get("event_type_ids").(*schema.Set)),
 		Name:         aws.String(d.Get("name").(string)),
 		Status:       aws.String(d.Get("status").(string)),
 		Targets:      expandCodeStarNotificationsNotificationRuleTargets(d.Get("target").(*schema.Set).List()),

--- a/aws/resource_aws_dax_cluster.go
+++ b/aws/resource_aws_dax_cluster.go
@@ -181,7 +181,7 @@ func resourceAwsDaxClusterCreate(d *schema.ResourceData, meta interface{}) error
 	subnetGroupName := d.Get("subnet_group_name").(string)
 	securityIdSet := d.Get("security_group_ids").(*schema.Set)
 
-	securityIds := expandStringList(securityIdSet.List())
+	securityIds := expandStringSet(securityIdSet)
 	tags := keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().DaxTags()
 
 	req := &dax.CreateClusterInput{
@@ -211,10 +211,9 @@ func resourceAwsDaxClusterCreate(d *schema.ResourceData, meta interface{}) error
 		req.NotificationTopicArn = aws.String(v.(string))
 	}
 
-	preferred_azs := d.Get("availability_zones").(*schema.Set).List()
-	if len(preferred_azs) > 0 {
-		azs := expandStringList(preferred_azs)
-		req.AvailabilityZones = azs
+	preferredAZs := d.Get("availability_zones").(*schema.Set)
+	if preferredAZs.Len() > 0 {
+		req.AvailabilityZones = expandStringSet(preferredAZs)
 	}
 
 	if v, ok := d.GetOk("server_side_encryption"); ok && len(v.([]interface{})) > 0 {
@@ -368,7 +367,7 @@ func resourceAwsDaxClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("security_group_ids") {
 		if attr := d.Get("security_group_ids").(*schema.Set); attr.Len() > 0 {
-			req.SecurityGroupIds = expandStringList(attr.List())
+			req.SecurityGroupIds = expandStringSet(attr)
 			requestUpdate = true
 		}
 	}

--- a/aws/resource_aws_db_event_subscription.go
+++ b/aws/resource_aws_db_event_subscription.go
@@ -317,8 +317,8 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
-		remove := expandStringList(os.Difference(ns).List())
-		add := expandStringList(ns.Difference(os).List())
+		remove := expandStringSet(os.Difference(ns))
+		add := expandStringSet(ns.Difference(os))
 
 		if len(remove) > 0 {
 			for _, removing := range remove {

--- a/aws/resource_aws_dms_event_subscription.go
+++ b/aws/resource_aws_dms_event_subscription.go
@@ -91,11 +91,11 @@ func resourceAwsDmsEventSubscriptionCreate(d *schema.ResourceData, meta interfac
 	}
 
 	if v, ok := d.GetOk("event_categories"); ok {
-		request.EventCategories = expandStringList(v.(*schema.Set).List())
+		request.EventCategories = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("source_ids"); ok {
-		request.SourceIds = expandStringList(v.(*schema.Set).List())
+		request.SourceIds = expandStringSet(v.(*schema.Set))
 	}
 
 	_, err := conn.CreateEventSubscription(request)
@@ -135,7 +135,7 @@ func resourceAwsDmsEventSubscriptionUpdate(d *schema.ResourceData, meta interfac
 		}
 
 		if v, ok := d.GetOk("event_categories"); ok {
-			request.EventCategories = expandStringList(v.(*schema.Set).List())
+			request.EventCategories = expandStringSet(v.(*schema.Set))
 		}
 
 		_, err := conn.ModifyEventSubscription(request)

--- a/aws/resource_aws_dms_replication_instance.go
+++ b/aws/resource_aws_dms_replication_instance.go
@@ -164,7 +164,7 @@ func resourceAwsDmsReplicationInstanceCreate(d *schema.ResourceData, meta interf
 		request.ReplicationSubnetGroupIdentifier = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("vpc_security_group_ids"); ok {
-		request.VpcSecurityGroupIds = expandStringList(v.(*schema.Set).List())
+		request.VpcSecurityGroupIds = expandStringSet(v.(*schema.Set))
 	}
 
 	log.Println("[DEBUG] DMS create replication instance:", request)
@@ -322,7 +322,7 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 
 	if d.HasChange("vpc_security_group_ids") {
 		if v, ok := d.GetOk("vpc_security_group_ids"); ok {
-			request.VpcSecurityGroupIds = expandStringList(v.(*schema.Set).List())
+			request.VpcSecurityGroupIds = expandStringSet(v.(*schema.Set))
 			hasChanges = true
 		}
 	}

--- a/aws/resource_aws_dms_replication_subnet_group.go
+++ b/aws/resource_aws_dms_replication_subnet_group.go
@@ -58,7 +58,7 @@ func resourceAwsDmsReplicationSubnetGroupCreate(d *schema.ResourceData, meta int
 	request := &dms.CreateReplicationSubnetGroupInput{
 		ReplicationSubnetGroupIdentifier:  aws.String(d.Get("replication_subnet_group_id").(string)),
 		ReplicationSubnetGroupDescription: aws.String(d.Get("replication_subnet_group_description").(string)),
-		SubnetIds:                         expandStringList(d.Get("subnet_ids").(*schema.Set).List()),
+		SubnetIds:                         expandStringSet(d.Get("subnet_ids").(*schema.Set)),
 		Tags:                              keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().DatabasemigrationserviceTags(),
 	}
 
@@ -129,7 +129,7 @@ func resourceAwsDmsReplicationSubnetGroupUpdate(d *schema.ResourceData, meta int
 	// changes to SubnetIds.
 	request := &dms.ModifyReplicationSubnetGroupInput{
 		ReplicationSubnetGroupIdentifier: aws.String(d.Get("replication_subnet_group_id").(string)),
-		SubnetIds:                        expandStringList(d.Get("subnet_ids").(*schema.Set).List()),
+		SubnetIds:                        expandStringSet(d.Get("subnet_ids").(*schema.Set)),
 	}
 
 	if d.HasChange("replication_subnet_group_description") {

--- a/aws/resource_aws_docdb_cluster.go
+++ b/aws/resource_aws_docdb_cluster.go
@@ -288,7 +288,7 @@ func resourceAwsDocDBClusterCreate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-			opts.AvailabilityZones = expandStringList(attr.List())
+			opts.AvailabilityZones = expandStringSet(attr)
 		}
 
 		if attr, ok := d.GetOk("backup_retention_period"); ok {
@@ -332,7 +332,7 @@ func resourceAwsDocDBClusterCreate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			opts.VpcSecurityGroupIds = expandStringList(attr.List())
+			opts.VpcSecurityGroupIds = expandStringSet(attr)
 		}
 
 		log.Printf("[DEBUG] DocDB Cluster restore from snapshot configuration: %s", opts)
@@ -387,11 +387,11 @@ func resourceAwsDocDBClusterCreate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
+			createOpts.VpcSecurityGroupIds = expandStringSet(attr)
 		}
 
 		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-			createOpts.AvailabilityZones = expandStringList(attr.List())
+			createOpts.AvailabilityZones = expandStringSet(attr)
 		}
 
 		if v, ok := d.GetOk("backup_retention_period"); ok {
@@ -602,7 +602,7 @@ func resourceAwsDocDBClusterUpdate(d *schema.ResourceData, meta interface{}) err
 
 	if d.HasChange("vpc_security_group_ids") {
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			req.VpcSecurityGroupIds = expandStringList(attr.List())
+			req.VpcSecurityGroupIds = expandStringSet(attr)
 		} else {
 			req.VpcSecurityGroupIds = []*string{}
 		}

--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -150,7 +150,7 @@ func resourceAwsEc2ClientVpnEndpointCreate(d *schema.ResourceData, meta interfac
 	}
 
 	if v, ok := d.GetOk("dns_servers"); ok {
-		req.DnsServers = expandStringList(v.(*schema.Set).List())
+		req.DnsServers = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("authentication_options"); ok {
@@ -288,7 +288,7 @@ func resourceAwsEc2ClientVpnEndpointUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	if d.HasChange("dns_servers") {
-		dnsValue := expandStringList(d.Get("dns_servers").(*schema.Set).List())
+		dnsValue := expandStringSet(d.Get("dns_servers").(*schema.Set))
 		var enabledValue *bool
 
 		if len(dnsValue) > 0 {

--- a/aws/resource_aws_ec2_traffic_mirror_filter.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter.go
@@ -86,14 +86,14 @@ func resourceAwsEc2TrafficMirrorFilterUpdate(d *schema.ResourceData, meta interf
 		}
 
 		o, n := d.GetChange("network_services")
-		newServices := n.(*schema.Set).Difference(o.(*schema.Set)).List()
-		if len(newServices) > 0 {
-			input.AddNetworkServices = expandStringList(newServices)
+		newServices := n.(*schema.Set).Difference(o.(*schema.Set))
+		if newServices.Len() > 0 {
+			input.AddNetworkServices = expandStringSet(newServices)
 		}
 
-		removeServices := o.(*schema.Set).Difference(n.(*schema.Set)).List()
-		if len(removeServices) > 0 {
-			input.RemoveNetworkServices = expandStringList(removeServices)
+		removeServices := o.(*schema.Set).Difference(n.(*schema.Set))
+		if removeServices.Len() > 0 {
+			input.RemoveNetworkServices = expandStringSet(removeServices)
 		}
 
 		_, err := conn.ModifyTrafficMirrorFilterNetworkServices(input)

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -442,7 +442,7 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	if v, ok := d.GetOk("requires_compatibilities"); ok && v.(*schema.Set).Len() > 0 {
-		input.RequiresCompatibilities = expandStringList(v.(*schema.Set).List())
+		input.RequiresCompatibilities = expandStringSet(v.(*schema.Set))
 	}
 
 	proxyConfigs := d.Get("proxy_configuration").([]interface{})

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -312,8 +312,8 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 	} else {
 		securityNameSet := d.Get("security_group_names").(*schema.Set)
 		securityIdSet := d.Get("security_group_ids").(*schema.Set)
-		securityNames := expandStringList(securityNameSet.List())
-		securityIds := expandStringList(securityIdSet.List())
+		securityNames := expandStringSet(securityNameSet)
+		securityIds := expandStringSet(securityIdSet)
 		tags := keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().ElasticacheTags()
 
 		req.CacheSecurityGroupNames = securityNames
@@ -370,9 +370,9 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 		req.NotificationTopicArn = aws.String(v.(string))
 	}
 
-	snaps := d.Get("snapshot_arns").(*schema.Set).List()
-	if len(snaps) > 0 {
-		s := expandStringList(snaps)
+	snaps := d.Get("snapshot_arns").(*schema.Set)
+	if snaps.Len() > 0 {
+		s := expandStringSet(snaps)
 		req.SnapshotArns = s
 		log.Printf("[DEBUG] Restoring Redis cluster from S3 snapshot: %#v", s)
 	}
@@ -515,7 +515,7 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 	requestUpdate := false
 	if d.HasChange("security_group_ids") {
 		if attr := d.Get("security_group_ids").(*schema.Set); attr.Len() > 0 {
-			req.SecurityGroupIds = expandStringList(attr.List())
+			req.SecurityGroupIds = expandStringSet(attr)
 			requestUpdate = true
 		}
 	}

--- a/aws/resource_aws_elasticache_subnet_group.go
+++ b/aws/resource_aws_elasticache_subnet_group.go
@@ -60,7 +60,7 @@ func resourceAwsElasticacheSubnetGroupCreate(d *schema.ResourceData, meta interf
 
 	log.Printf("[DEBUG] Cache subnet group create: name: %s, description: %s", name, desc)
 
-	subnetIds := expandStringList(subnetIdsSet.List())
+	subnetIds := expandStringSet(subnetIdsSet)
 
 	req := &elasticache.CreateCacheSubnetGroupInput{
 		CacheSubnetGroupDescription: aws.String(desc),

--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -290,15 +290,15 @@ func resourceAwsElbCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("availability_zones"); ok {
-		elbOpts.AvailabilityZones = expandStringList(v.(*schema.Set).List())
+		elbOpts.AvailabilityZones = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("security_groups"); ok {
-		elbOpts.SecurityGroups = expandStringList(v.(*schema.Set).List())
+		elbOpts.SecurityGroups = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("subnets"); ok {
-		elbOpts.Subnets = expandStringList(v.(*schema.Set).List())
+		elbOpts.Subnets = expandStringSet(v.(*schema.Set))
 	}
 
 	log.Printf("[DEBUG] ELB create configuration: %#v", elbOpts)
@@ -669,11 +669,9 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("security_groups") {
-		groups := d.Get("security_groups").(*schema.Set).List()
-
 		applySecurityGroupsOpts := elb.ApplySecurityGroupsToLoadBalancerInput{
 			LoadBalancerName: aws.String(d.Id()),
-			SecurityGroups:   expandStringList(groups),
+			SecurityGroups:   expandStringSet(d.Get("security_groups").(*schema.Set)),
 		}
 
 		_, err := elbconn.ApplySecurityGroupsToLoadBalancer(&applySecurityGroupsOpts)
@@ -687,8 +685,8 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		removed := expandStringList(os.Difference(ns).List())
-		added := expandStringList(ns.Difference(os).List())
+		removed := expandStringSet(os.Difference(ns))
+		added := expandStringSet(ns.Difference(os))
 
 		if len(added) > 0 {
 			enableOpts := &elb.EnableAvailabilityZonesForLoadBalancerInput{
@@ -722,8 +720,8 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		removed := expandStringList(os.Difference(ns).List())
-		added := expandStringList(ns.Difference(os).List())
+		removed := expandStringSet(os.Difference(ns))
+		added := expandStringSet(ns.Difference(os))
 
 		if len(removed) > 0 {
 			detachOpts := &elb.DetachLoadBalancerFromSubnetsInput{

--- a/aws/resource_aws_fms_policy.go
+++ b/aws/resource_aws_fms_policy.go
@@ -142,7 +142,7 @@ func resourceAwsFmsPolicyCreate(d *schema.ResourceData, meta interface{}) error 
 		PolicyName:          aws.String(d.Get("name").(string)),
 		RemediationEnabled:  aws.Bool(d.Get("remediation_enabled").(bool)),
 		ResourceType:        aws.String("ResourceTypeList"),
-		ResourceTypeList:    expandStringList(d.Get("resource_type_list").(*schema.Set).List()),
+		ResourceTypeList:    expandStringSet(d.Get("resource_type_list").(*schema.Set)),
 		ExcludeResourceTags: aws.Bool(d.Get("exclude_resource_tags").(bool)),
 	}
 
@@ -240,7 +240,7 @@ func resourceAwsFmsPolicyUpdate(d *schema.ResourceData, meta interface{}) error 
 		PolicyUpdateToken:   aws.String(d.Get("policy_update_token").(string)),
 		RemediationEnabled:  aws.Bool(d.Get("remediation_enabled").(bool)),
 		ResourceType:        aws.String("ResourceTypeList"),
-		ResourceTypeList:    expandStringList(d.Get("resource_type_list").(*schema.Set).List()),
+		ResourceTypeList:    expandStringSet(d.Get("resource_type_list").(*schema.Set)),
 		ExcludeResourceTags: aws.Bool(d.Get("exclude_resource_tags").(bool)),
 	}
 


### PR DESCRIPTION
Replaces `expandStringList(x.List())` with `expandStringSet(x)`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17052

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayIntegration\|TestAccAWSAPIGatewayMethod\|TestAccAWSASGNotification\|TestAccAWSAutoScalingGroup\|TestAccAWSAutoscalingGroups\|TestAccAWSCloudFormationStack\|TestAccAWSCodeBuildProject\|TestAccAWSCodeDeployDeploymentGroup\|TestAccAWSCodeStarNotificationsNotificationRule\|TestAccAWSDAXCluster\|TestAccAWSDBEventSubscription\|TestAccAWSDmsEventSubscription\|TestAccAWSDmsReplicationInstance\|TestAccAWSDmsReplicationSubnetGroup\|TestAccAWSDocDBCluster\|TestAccAwsEc2ClientVpn\|TestAccAWSEc2TrafficMirrorFilter\|TestAccAWSEcsTaskDefinition\|TestAccAWSElasticacheCluster\|TestAccAWSElasticacheSubnetGroup\|TestAccAWSELB\|TestAccAWSELBUpdate\|TestAccAWSFmsPolicy'

--- PASS: TestCloudFrontStructure_expandTrustedSigners_empty (0.00s)
--- PASS: TestCloudFrontStructure_expandCloudFrontDefaultCacheBehavior (0.00s)
--- PASS: TestCloudFrontStructure_expandTrustedSigners (0.00s)
--- PASS: TestCloudFrontStructure_flattenAllowedMethods (0.00s)
--- PASS: TestCloudFrontStructure_expandHeaders (0.00s)
--- PASS: TestCloudFrontStructure_expandlambdaFunctionAssociations_empty (0.00s)
--- PASS: TestCloudFrontStructure_expandQueryStringCacheKeys (0.00s)
--- PASS: TestCloudFrontStructure_expandAllowedMethods (0.00s)
--- PASS: TestCloudFrontStructure_flattenTrustedSigners (0.00s)
--- PASS: TestCloudFrontStructure_expandCachedMethods (0.00s)
--- PASS: TestCloudFrontStructure_expandForwardedValues (0.01s)
--- PASS: TestCloudFrontStructure_flattenlambdaFunctionAssociations (0.00s)
--- PASS: TestCloudFrontStructure_flattenCookieNames (0.00s)
--- PASS: TestCloudFrontStructure_flattenHeaders (0.00s)
--- PASS: TestCloudFrontStructure_flattenForwardedValues (0.00s)
--- PASS: TestCloudFrontStructure_expandLambdaFunctionAssociations (0.01s)
--- PASS: TestCloudFrontStructure_expandCookieNames (0.00s)
--- PASS: TestCloudFrontStructure_flattenCookiePreference (0.00s)
--- PASS: TestCloudFrontStructure_flattenQueryStringCacheKeys (0.00s)
--- PASS: TestCloudFrontStructure_expandCookiePreference (0.00s)
--- PASS: TestCloudFrontStructure_flattenOrigins (0.00s)
--- PASS: TestCloudFrontStructure_flattenCachedMethods (0.00s)
--- PASS: TestCloudFrontStructure_expandOriginGroups (0.00s)
--- PASS: TestCloudFrontStructure_expandOrigins (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomHeaders (0.00s)
--- PASS: TestCloudFrontStructure_flattenOriginGroups (0.00s)
--- PASS: TestCloudFrontStructure_expandOrigin (0.00s)
--- PASS: TestCloudFrontStructure_flattenOrigin (0.00s)
--- PASS: TestCloudFrontStructure_expandOriginCustomHeader (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomOriginConfig (0.00s)
--- PASS: TestCloudFrontStructure_flattenOriginCustomHeader (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomHeaders (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfigSSL (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfig (0.00s)
--- PASS: TestCloudFrontStructure_expandS3OriginConfig (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomOriginConfigSSL (0.00s)
--- PASS: TestCloudFrontStructure_flattenS3OriginConfig (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponses (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponses (0.01s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponse (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode (0.00s)
--- PASS: TestCloudFrontStructure_expandLoggingConfig_nilValue (0.00s)
--- PASS: TestCloudFrontStructure_expandLoggingConfig (0.00s)
--- PASS: TestCloudFrontStructure_expandGeoRestriction_whitelist (0.00s)
--- PASS: TestCloudFrontStructure_expandRestrictions (0.00s)
--- PASS: TestCloudFrontStructure_flattenAliases (0.00s)
--- PASS: TestCloudFrontStructure_expandAliases (0.00s)
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_whitelist (0.00s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate (0.00s)
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_no_items (0.00s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id (0.00s)
--- PASS: TestCloudFrontStructure_expandGeoRestriction_no_items (0.00s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn (0.00s)
--- PASS: TestAccAWSAPIGatewayIntegration_disappears (38.73s)
--- PASS: TestAccAWSAPIGatewayIntegration_cache_key_parameters (112.20s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (159.73s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (168.80s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_basic (188.98s)
--- PASS: TestAccAWSAPIGatewayMethodResponse_disappears (217.53s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_Multiple (250.32s)
--- PASS: TestAccAWSAutoscalingGroups_basic (253.27s)
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_basic (282.11s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit (167.05s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds (339.25s)
--- PASS: TestAccAWSAPIGatewayMethod_customrequestvalidator (31.69s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy (182.33s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled (431.73s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel (461.34s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (61.16s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_disappears (242.59s)
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_disappears (524.92s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (92.89s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled (556.12s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted (573.10s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl (581.80s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (103.79s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled (640.72s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (161.47s)
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (397.83s)
--- PASS: TestAccAWSAutoScalingGroup_basic (283.89s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (34.62s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (51.76s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimitDisabledByDefault (554.45s)
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (69.30s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (141.35s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (193.87s)
--- PASS: TestAccAWSAutoScalingGroup_tags (285.48s)
--- PASS: TestAccAWSAPIGatewayMethod_disappears (431.86s)
--- PASS: TestAccAWSAPIGatewayIntegration_integrationType (804.21s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (192.40s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (271.22s)
--- PASS: TestAccAWSAPIGatewayMethod_cognitoauthorizer (627.64s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (248.45s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimitDisabledByDefault (753.29s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit (772.47s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (202.79s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (353.00s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (242.66s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (239.00s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (122.14s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (380.86s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_CapacityRebalance (134.62s)
--- PASS: TestAccAWSAPIGatewayIntegration_contentHandling (1079.35s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity (108.02s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (193.26s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (162.69s)
--- PASS: TestCreateAutoScalingGroupInstanceRefreshInput (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/empty_list (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/nil (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/defaults (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/instance_warmup_only (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/instance_warmup_zero (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/instance_warmup_empty_string (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/min_healthy_percentage_only (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/preferences (0.00s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (40.85s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (68.68s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (575.14s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (428.61s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (84.74s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (109.10s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (82.00s)
--- PASS: TestAccAWSAPIGatewayMethod_basic (906.10s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (83.00s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Triggers (396.44s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Basic (418.35s)
--- PASS: TestAccAWSAutoScalingGroup_launchTempPartitionNum (60.88s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (98.46s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (365.82s)
--- PASS: TestAccAWSCloudFormationStackSet_basic (29.37s)
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_Default (0.00s)
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_NoEcho (0.00s)
--- PASS: TestAccAWSCloudFormationStackSet_disappears (29.65s)
--- PASS: TestAccAWSAPIGatewayIntegration_basic (1216.83s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (162.81s)
--- PASS: TestAccAWSASGNotification_basic (158.42s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Start (516.42s)
--- PASS: TestAccAWSASGNotification_Pagination (163.63s)
--- PASS: TestAccAWSAPIGatewayMethodResponse_basic (1365.49s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_basic (275.11s)
--- PASS: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (254.90s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears (280.69s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (280.55s)
--- PASS: TestAccAWSCloudFormationStackSet_ExecutionRoleName (262.81s)
--- PASS: TestAccAWSCloudFormationStackSet_Description (263.79s)
--- PASS: TestAccAWSCloudFormationStack_CreationFailure_Delete (148.39s)
--- PASS: TestAccAWSCloudFormationStackSet_Name (272.13s)
--- PASS: TestAccAWSCloudFormationStack_CreationFailure_DoNothing (168.87s)
--- PASS: TestAccAWSCloudFormationStack_CreationFailure_Rollback (163.47s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateBody (266.35s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateUrl (254.76s)
--- PASS: TestAccAWSCloudFormationStack_basic (221.11s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (656.76s)
--- PASS: TestAccAWSCloudFormationStack_disappears (94.48s)
--- PASS: TestAccAWSCloudFormationStack_yaml (89.49s)
--- PASS: TestAccAWSCodeBuildProject_basic (62.32s)
--- PASS: TestAccAWSCloudFormationStackSet_Parameters (341.04s)
--- PASS: TestAccAWSASGNotification_update (401.12s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (60.91s)
--- PASS: TestAccAWSCloudFormationStack_UpdateFailure (149.71s)
--- PASS: TestAccAWSCloudFormationStack_defaultParams (96.52s)
--- PASS: TestAccAWSCloudFormationStackSet_Tags (340.45s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (102.73s)
--- PASS: TestAccAWSCloudFormationStack_withTransform (89.40s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_RetainStack (391.41s)
--- FAIL: TestAccAWSCodeBuildProject_Source_Auth (17.89s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (88.16s)
--- PASS: TestAccAWSCloudFormationStack_allAttributes (130.82s)
--- PASS: TestAccAWSCodeBuildProject_SourceVersion (54.74s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (67.51s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (93.34s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (137.98s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (78.12s)
--- PASS: TestAccAWSCloudFormationStack_withParams (187.76s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (479.07s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (210.06s)
--- PASS: TestAccAWSCodeBuildProject_Description (210.69s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (297.66s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit (306.72s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (223.64s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (214.40s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (342.75s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub (313.02s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise (309.28s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub (304.77s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit (310.11s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (348.90s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (364.15s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise (300.67s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (349.99s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (301.13s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value (361.69s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (158.79s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (306.28s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (295.65s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (280.00s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (50.02s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (77.07s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (74.94s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (77.05s)
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
--- PASS: TestAccAWSCodeBuildProject_WindowsServer2019Container (81.76s)
--- PASS: TestAccAWSCodeBuildProject_ARMContainer (83.13s)
--- PASS: TestAccAWSCodeBuildProject_Cache (469.68s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (88.48s)
--- PASS: TestAccAWSCodeBuildProject_Tags (148.24s)
--- PASS: TestAWSCodeBuildProject_nameValidation (0.00s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (240.04s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (272.70s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (288.34s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (294.72s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (296.09s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (306.18s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (306.49s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (309.54s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (309.84s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (302.20s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (251.50s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (306.45s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (352.70s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (307.23s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (234.87s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (302.75s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (299.65s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (287.75s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (288.92s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (83.43s)
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (246.06s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (81.66s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (106.13s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (63.88s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (84.88s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (118.44s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (71.12s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (109.26s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (164.62s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (207.67s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (108.00s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (132.13s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (109.35s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap (0.00s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (123.80s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (112.88s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildAutoRollbackConfig (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandDeploymentStyle (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_autoRollbackConfigToMap (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenDeploymentStyle (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandLoadBalancerInfo (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandBlueGreenDeploymentConfig (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenBlueGreenDeploymentConfig (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenLoadBalancerInfo (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildAlarmConfig (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_alarmConfigToMap (0.00s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (136.72s)
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_basic (1.13s)
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_Targets (1.14s)
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_Status (0.84s)
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_Tags (1.05s)
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_EventTypeIds (1.13s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (79.80s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (158.16s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (114.90s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (121.86s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (106.69s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (106.22s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (67.58s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (108.07s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (111.62s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (118.09s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (128.82s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (188.19s)
--- PASS: TestAccAWSDBEventSubscription_withPrefix (166.05s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (206.09s)
--- PASS: TestAccAWSDBEventSubscription_disappears (182.23s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (269.81s)
--- PASS: TestAccAWSDBEventSubscription_basicUpdate (291.49s)
--- PASS: TestAccAWSDBEventSubscription_withSourceIds (272.07s)
--- PASS: TestAccAWSDBEventSubscription_categoryUpdate (276.24s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (340.36s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (400.81s)
--- PASS: TestAccAWSDmsReplicationInstance_basic (382.45s)
--- PASS: TestAccAWSDmsEventSubscription_basic (493.83s)
--- PASS: TestAccAWSDmsReplicationInstance_KmsKeyArn (304.68s)
--- PASS: TestAccAWSDmsEventSubscription_disappears (518.86s)
--- PASS: TestAccAWSDmsEventSubscription_Enabled (576.15s)
--- PASS: TestAccAWSDmsEventSubscription_EventCategories (561.94s)
--- PASS: TestAccAWSDmsReplicationSubnetGroup_basic (124.47s)
--- PASS: TestAccAWSDmsReplicationInstance_AvailabilityZone (488.75s)
--- PASS: TestAccAWSDmsEventSubscription_Tags (607.36s)
--- PASS: TestAccAWSDAXCluster_encryption_disabled (728.20s)
--- PASS: TestAccAWSDAXCluster_basic (732.74s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_basic (15.37s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_namePrefix (15.04s)
--- PASS: TestAccAWSDmsReplicationInstance_PreferredMaintenanceWindow (458.10s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_generatedName (15.69s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Description (17.37s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_disappears (12.52s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Parameter (29.00s)
--- PASS: TestAccAWSDmsReplicationInstance_AutoMinorVersionUpgrade (610.35s)
--- PASS: TestAccAWSDmsReplicationInstance_PubliclyAccessible (493.05s)
--- PASS: TestAccAWSDAXCluster_encryption_enabled (796.33s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Tags (40.10s)
--- PASS: TestAccAWSDocDBCluster_missingUserNameCausesError (8.04s)
--- PASS: TestAccAWSDmsReplicationInstance_EngineVersion (702.10s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationSubnetGroupId (510.82s)
--- PASS: TestAccAWSDmsReplicationInstance_Tags (466.24s)
--- PASS: TestAccAWSDmsReplicationInstance_VpcSecurityGroupIds (473.99s)
--- PASS: TestAccAWSDocDBCluster_basic (255.59s)
--- PASS: TestAccAWSDocDBCluster_namePrefix (259.21s)
--- PASS: TestAccAWSDocDBCluster_generatedName (270.55s)
--- PASS: TestAccAWSDocDBCluster_takeFinalSnapshot (289.09s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationInstanceClass (779.80s)
--- PASS: TestAccAWSDocDBClusterSnapshot_basic (367.05s)
--- PASS: TestAccAWSEc2TrafficMirrorFilterRule_basic (56.71s)
--- PASS: TestAccAWSDocDBCluster_kmsKey (249.41s)
--- PASS: TestAccAWSEc2TrafficMirrorFilter_basic (57.22s)
--- PASS: TestAccAWSEc2TrafficMirrorFilter_disappears (16.61s)
--- PASS: TestAccAWSDocDBCluster_encrypted (208.95s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (21.51s)
--- PASS: TestAccAWSDocDBCluster_updateTags (367.12s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (24.58s)
--- PASS: TestAccAWSEcsTaskDefinition_basic (40.33s)
--- PASS: TestAccAWSEc2TrafficMirrorFilter_tags (60.77s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (26.74s)
--- PASS: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (299.86s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal (34.49s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolume (32.38s)
--- PASS: TestAccAWSEcsTaskDefinition_withTransitEncryptionEFSVolume (34.54s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume (26.07s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (28.67s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSAccessPoint (40.10s)
--- PASS: TestAccAWSDocDBCluster_backupsUpdate (241.55s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (47.98s)
--- PASS: TestAccAWSEcsTaskDefinition_withIPCMode (52.11s)
--- PASS: TestAccAWSEcsTaskDefinition_withPidMode (81.47s)
--- PASS: TestAccAWSDmsReplicationInstance_AllocatedStorage (1129.96s)
--- PASS: TestAccAWSEcsTaskDefinition_constraint (104.76s)
--- PASS: TestAccAWSDocDBClusterInstance_generatedName (670.62s)
--- PASS: TestValidateAwsEcsTaskDefinitionContainerDefinitions (0.17s)
--- PASS: TestAccAWSDocDBClusterInstance_az (726.65s)
--- PASS: TestAccAWSDocDBClusterInstance_kmsKey (701.65s)
--- PASS: TestAccAWSDocDBClusterInstance_basic (826.68s)
--- PASS: TestAccAWSDocDBClusterInstance_namePrefix (755.72s)
--- PASS: TestAccAWSDAXCluster_resize (1414.63s)
--- SKIP: TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic (8.15s)
--- PASS: TestAccAWSDocDBCluster_Port (407.06s)
--- PASS: TestAccAWSEcsTaskDefinition_arrays (239.75s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (278.25s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (233.28s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (257.71s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (271.41s)
--- PASS: TestAccAWSEcsTaskDefinition_ProxyConfiguration (194.67s)
--- PASS: TestAccAWSEcsTaskDefinition_inferenceAccelerator (173.21s)
--- PASS: TestAccAWSEcsTaskDefinition_disappears (244.16s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (225.49s)
--- PASS: TestAccAWSDocDBClusterInstance_disappears (843.71s)
--- PASS: TestAccAWSDocDBCluster_deleteProtection (501.26s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis (3.00s)
--- PASS: TestAccAWSElasticacheCluster_Port_Redis_Default (644.83s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached (821.92s)
--- PASS: TestAccAWSElasticacheCluster_Port (788.40s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (798.48s)
--- PASS: TestAccAWSElasticacheCluster_vpc (705.12s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis (832.16s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis (705.54s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached (710.13s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (816.14s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (762.65s)
--- PASS: TestAccAWSElasticacheSubnetGroup_basic (136.80s)
--- PASS: TestAccAWSELB_disappears (115.32s)
--- PASS: TestAccAWSELB_basic (122.19s)
--- PASS: TestAccAWSELB_fullCharacterRange (89.45s)
--- PASS: TestAccAWSElasticacheSubnetGroup_update (157.10s)
--- PASS: TestAccAWSELB_namePrefix (26.14s)
--- PASS: TestAccAWSELB_generatedName (23.52s)
--- PASS: TestAccAWSELB_generatesNameForZeroValue (24.44s)
--- PASS: TestAccAWSELB_AccessLogs_enabled (116.54s)
--- PASS: TestAccAWSELB_availabilityZones (41.17s)
--- PASS: TestAccAWSELB_AccessLogs_disabled (67.44s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (930.90s)
--- PASS: TestAccAWSELBAttachment_drift (194.91s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (43.87s)
--- PASS: TestAccAWSELB_HealthCheck (28.17s)
--- PASS: TestAccAWSELB_tags (67.11s)
--- PASS: TestAccAWSELB_swap_subnets (65.39s)
--- PASS: TestAccAWSELBUpdate_HealthCheck (44.70s)
--- PASS: TestResourceAwsElbListenerHash (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCannotBeginWithHyphen (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCanBeAnEmptyString (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCannotBeLongerThan32Characters (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCannotHaveSpecialCharacters (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCannotEndWithHyphen (0.00s)
--- PASS: TestResourceAWSELB_validateAccessLogsInterval (0.00s)
--- PASS: TestResourceAWSELB_validateHealthCheckTarget (0.00s)
--- FAIL: TestAccAWSFmsPolicy_basic (2.98s)
--- FAIL: TestAccAWSFmsPolicy_includeMap (3.50s)
--- PASS: TestAccAWSELB_ConnectionDraining (25.57s)
--- FAIL: TestAccAWSFmsPolicy_update (3.23s)
--- PASS: TestAccAWSELBUpdate_Timeout (53.21s)
--- FAIL: TestAccAWSFmsPolicy_tags (9.59s)
--- PASS: TestAccAWSDmsReplicationInstance_MultiAz (2176.93s)
--- PASS: TestAccAWSELB_Timeout (74.63s)
--- PASS: TestAccAWSELBAttachment_basic (272.76s)
--- PASS: TestAccAWSELB_SecurityGroups (47.37s)
--- PASS: TestAccAWSELB_listener (98.45s)
--- PASS: TestAccAWSELBUpdate_ConnectionDraining (63.49s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1217.02s)
--- PASS: TestAccAWSELB_InstanceAttaching (342.55s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1259.19s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached (1359.55s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis (1388.86s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis (1447.08s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone (1451.61s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached (1519.00s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica (1388.29s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica (1402.96s)
--- PASS: TestAccAwsEc2ClientVpn_serial (25.72s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Endpoint_disappears (25.61s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Endpoint_withLogGroup (51.61s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Endpoint_federated (29.93s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Endpoint_splitTunnel (51.95s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Endpoint_withDNSServers (65.12s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/AuthorizationRule_basic (255.07s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Route_basic (706.98s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_securityGroups (866.79s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Endpoint_basic (28.50s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_disappears (868.18s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Endpoint_msAD (1877.20s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/AuthorizationRule_Subnets (131.24s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_basic (756.46s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Endpoint_mutualAuthAndMsAD (2089.16s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/AuthorizationRule_disappears (35.97s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/AuthorizationRule_groups (75.89s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Endpoint_tags (42.44s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Route_disappears (738.91s)
    --- PASS: TestAccAwsEc2ClientVpn_serial/Route_description (726.90s)
```

Test failures are pre-existing