### PR TITLE
Prefer expandStringSet() – Resources I-W

### DIFF
--- a/aws/resource_aws_iam_group_membership.go
+++ b/aws/resource_aws_iam_group_membership.go
@@ -43,7 +43,7 @@ func resourceAwsIamGroupMembershipCreate(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).iamconn
 
 	group := d.Get("group").(string)
-	userList := expandStringList(d.Get("users").(*schema.Set).List())
+	userList := expandStringSet(d.Get("users").(*schema.Set))
 
 	if err := addUsersToGroup(conn, userList, group); err != nil {
 		return err
@@ -110,8 +110,8 @@ func resourceAwsIamGroupMembershipUpdate(d *schema.ResourceData, meta interface{
 
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
-		remove := expandStringList(os.Difference(ns).List())
-		add := expandStringList(ns.Difference(os).List())
+		remove := expandStringSet(os.Difference(ns))
+		add := expandStringSet(ns.Difference(os))
 
 		if err := removeUsersFromGroup(conn, remove, group); err != nil {
 			return err
@@ -127,7 +127,7 @@ func resourceAwsIamGroupMembershipUpdate(d *schema.ResourceData, meta interface{
 
 func resourceAwsIamGroupMembershipDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).iamconn
-	userList := expandStringList(d.Get("users").(*schema.Set).List())
+	userList := expandStringSet(d.Get("users").(*schema.Set))
 	group := d.Get("group").(string)
 
 	err := removeUsersFromGroup(conn, userList, group)

--- a/aws/resource_aws_iam_policy_attachment.go
+++ b/aws/resource_aws_iam_policy_attachment.go
@@ -57,9 +57,9 @@ func resourceAwsIamPolicyAttachmentCreate(d *schema.ResourceData, meta interface
 
 	name := d.Get("name").(string)
 	arn := d.Get("policy_arn").(string)
-	users := expandStringList(d.Get("users").(*schema.Set).List())
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
-	groups := expandStringList(d.Get("groups").(*schema.Set).List())
+	users := expandStringSet(d.Get("users").(*schema.Set))
+	roles := expandStringSet(d.Get("roles").(*schema.Set))
+	groups := expandStringSet(d.Get("groups").(*schema.Set))
 
 	if len(users) == 0 && len(roles) == 0 && len(groups) == 0 {
 		return fmt.Errorf("No Users, Roles, or Groups specified for IAM Policy Attachment %s", name)
@@ -161,9 +161,9 @@ func resourceAwsIamPolicyAttachmentDelete(d *schema.ResourceData, meta interface
 	conn := meta.(*AWSClient).iamconn
 	name := d.Get("name").(string)
 	arn := d.Get("policy_arn").(string)
-	users := expandStringList(d.Get("users").(*schema.Set).List())
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
-	groups := expandStringList(d.Get("groups").(*schema.Set).List())
+	users := expandStringSet(d.Get("users").(*schema.Set))
+	roles := expandStringSet(d.Get("roles").(*schema.Set))
+	groups := expandStringSet(d.Get("groups").(*schema.Set))
 
 	var userErr, roleErr, groupErr error
 	if len(users) != 0 {
@@ -239,8 +239,8 @@ func updateUsers(conn *iam.IAM, d *schema.ResourceData) error {
 	}
 	os := o.(*schema.Set)
 	ns := n.(*schema.Set)
-	remove := expandStringList(os.Difference(ns).List())
-	add := expandStringList(ns.Difference(os).List())
+	remove := expandStringSet(os.Difference(ns))
+	add := expandStringSet(ns.Difference(os))
 
 	if rErr := detachPolicyFromUsers(conn, remove, arn); rErr != nil {
 		return rErr
@@ -261,8 +261,8 @@ func updateRoles(conn *iam.IAM, d *schema.ResourceData) error {
 	}
 	os := o.(*schema.Set)
 	ns := n.(*schema.Set)
-	remove := expandStringList(os.Difference(ns).List())
-	add := expandStringList(ns.Difference(os).List())
+	remove := expandStringSet(os.Difference(ns))
+	add := expandStringSet(ns.Difference(os))
 
 	if rErr := detachPolicyFromRoles(conn, remove, arn); rErr != nil {
 		return rErr
@@ -283,8 +283,8 @@ func updateGroups(conn *iam.IAM, d *schema.ResourceData) error {
 	}
 	os := o.(*schema.Set)
 	ns := n.(*schema.Set)
-	remove := expandStringList(os.Difference(ns).List())
-	add := expandStringList(ns.Difference(os).List())
+	remove := expandStringSet(os.Difference(ns))
+	add := expandStringSet(ns.Difference(os))
 
 	if rErr := detachPolicyFromGroups(conn, remove, arn); rErr != nil {
 		return rErr

--- a/aws/resource_aws_iam_user_group_membership.go
+++ b/aws/resource_aws_iam_user_group_membership.go
@@ -40,7 +40,7 @@ func resourceAwsIamUserGroupMembershipCreate(d *schema.ResourceData, meta interf
 	conn := meta.(*AWSClient).iamconn
 
 	user := d.Get("user").(string)
-	groupList := expandStringList(d.Get("groups").(*schema.Set).List())
+	groupList := expandStringSet(d.Get("groups").(*schema.Set))
 
 	if err := addUserToGroups(conn, user, groupList); err != nil {
 		return err
@@ -112,8 +112,8 @@ func resourceAwsIamUserGroupMembershipUpdate(d *schema.ResourceData, meta interf
 
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
-		remove := expandStringList(os.Difference(ns).List())
-		add := expandStringList(ns.Difference(os).List())
+		remove := expandStringSet(os.Difference(ns))
+		add := expandStringSet(ns.Difference(os))
 
 		if err := removeUserFromGroups(conn, user, remove); err != nil {
 			return err
@@ -130,7 +130,7 @@ func resourceAwsIamUserGroupMembershipUpdate(d *schema.ResourceData, meta interf
 func resourceAwsIamUserGroupMembershipDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).iamconn
 	user := d.Get("user").(string)
-	groups := expandStringList(d.Get("groups").(*schema.Set).List())
+	groups := expandStringSet(d.Get("groups").(*schema.Set))
 
 	err := removeUserFromGroups(conn, user, groups)
 	return err

--- a/aws/resource_aws_kinesis_stream.go
+++ b/aws/resource_aws_kinesis_stream.go
@@ -399,12 +399,9 @@ func updateKinesisShardLevelMetrics(conn *kinesis.Kinesis, d *schema.ResourceDat
 
 	disableMetrics := os.Difference(ns)
 	if disableMetrics.Len() != 0 {
-		metrics := disableMetrics.List()
-		log.Printf("[DEBUG] Disabling shard level metrics %v for stream %s", metrics, sn)
-
 		props := &kinesis.DisableEnhancedMonitoringInput{
 			StreamName:        aws.String(sn),
-			ShardLevelMetrics: expandStringList(metrics),
+			ShardLevelMetrics: expandStringSet(disableMetrics),
 		}
 
 		_, err := conn.DisableEnhancedMonitoring(props)
@@ -418,12 +415,9 @@ func updateKinesisShardLevelMetrics(conn *kinesis.Kinesis, d *schema.ResourceDat
 
 	enabledMetrics := ns.Difference(os)
 	if enabledMetrics.Len() != 0 {
-		metrics := enabledMetrics.List()
-		log.Printf("[DEBUG] Enabling shard level metrics %v for stream %s", metrics, sn)
-
 		props := &kinesis.EnableEnhancedMonitoringInput{
 			StreamName:        aws.String(sn),
-			ShardLevelMetrics: expandStringList(metrics),
+			ShardLevelMetrics: expandStringSet(enabledMetrics),
 		}
 
 		_, err := conn.EnableEnhancedMonitoring(props)

--- a/aws/resource_aws_lambda_layer_version.go
+++ b/aws/resource_aws_lambda_layer_version.go
@@ -162,7 +162,7 @@ func resourceAwsLambdaLayerVersionPublish(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("compatible_runtimes"); ok && v.(*schema.Set).Len() > 0 {
-		params.CompatibleRuntimes = expandStringList(v.(*schema.Set).List())
+		params.CompatibleRuntimes = expandStringSet(v.(*schema.Set))
 	}
 
 	log.Printf("[DEBUG] Publishing Lambda layer: %s", params)

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -373,9 +373,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("security_groups"); ok {
-		createLaunchConfigurationOpts.SecurityGroups = expandStringList(
-			v.(*schema.Set).List(),
-		)
+		createLaunchConfigurationOpts.SecurityGroups = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("vpc_classic_link_id"); ok {
@@ -387,9 +385,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("vpc_classic_link_security_groups"); ok {
-		createLaunchConfigurationOpts.ClassicLinkVPCSecurityGroups = expandStringList(
-			v.(*schema.Set).List(),
-		)
+		createLaunchConfigurationOpts.ClassicLinkVPCSecurityGroups = expandStringSet(v.(*schema.Set))
 	}
 
 	var blockDevices []*autoscaling.BlockDeviceMapping

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -1323,11 +1323,11 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 	}
 
 	if v, ok := d.GetOk("security_group_names"); ok {
-		opts.SecurityGroups = expandStringList(v.(*schema.Set).List())
+		opts.SecurityGroups = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("vpc_security_group_ids"); ok {
-		opts.SecurityGroupIds = expandStringList(v.(*schema.Set).List())
+		opts.SecurityGroupIds = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("block_device_mappings"); ok {

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -274,11 +274,11 @@ func resourceAwsLbCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("security_groups"); ok {
-		elbOpts.SecurityGroups = expandStringList(v.(*schema.Set).List())
+		elbOpts.SecurityGroups = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("subnets"); ok {
-		elbOpts.Subnets = expandStringList(v.(*schema.Set).List())
+		elbOpts.Subnets = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("subnet_mapping"); ok {
@@ -455,7 +455,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("security_groups") {
-		sgs := expandStringList(d.Get("security_groups").(*schema.Set).List())
+		sgs := expandStringSet(d.Get("security_groups").(*schema.Set))
 
 		params := &elbv2.SetSecurityGroupsInput{
 			LoadBalancerArn: aws.String(d.Id()),
@@ -473,7 +473,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 	// resource is just created, so we don't attempt if it is a newly created
 	// resource.
 	if d.HasChange("subnets") && !d.IsNewResource() {
-		subnets := expandStringList(d.Get("subnets").(*schema.Set).List())
+		subnets := expandStringSet(d.Get("subnets").(*schema.Set))
 
 		params := &elbv2.SetSubnetsInput{
 			LoadBalancerArn: aws.String(d.Id()),

--- a/aws/resource_aws_lex_intent.go
+++ b/aws/resource_aws_lex_intent.go
@@ -289,7 +289,7 @@ func resourceAwsLexIntentCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if v, ok := d.GetOk("sample_utterances"); ok {
-		input.SampleUtterances = expandStringList(v.(*schema.Set).List())
+		input.SampleUtterances = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("slot"); ok {
@@ -440,7 +440,7 @@ func resourceAwsLexIntentUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if v, ok := d.GetOk("sample_utterances"); ok {
-		input.SampleUtterances = expandStringList(v.(*schema.Set).List())
+		input.SampleUtterances = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("slot"); ok {

--- a/aws/resource_aws_load_balancer_backend_server_policy.go
+++ b/aws/resource_aws_load_balancer_backend_server_policy.go
@@ -46,7 +46,7 @@ func resourceAwsLoadBalancerBackendServerPoliciesCreate(d *schema.ResourceData, 
 
 	policyNames := []*string{}
 	if v, ok := d.GetOk("policy_names"); ok {
-		policyNames = expandStringList(v.(*schema.Set).List())
+		policyNames = expandStringSet(v.(*schema.Set))
 	}
 
 	setOpts := &elb.SetLoadBalancerPoliciesForBackendServerInput{

--- a/aws/resource_aws_load_balancer_listener_policy.go
+++ b/aws/resource_aws_load_balancer_listener_policy.go
@@ -46,7 +46,7 @@ func resourceAwsLoadBalancerListenerPoliciesCreate(d *schema.ResourceData, meta 
 
 	policyNames := []*string{}
 	if v, ok := d.GetOk("policy_names"); ok {
-		policyNames = expandStringList(v.(*schema.Set).List())
+		policyNames = expandStringSet(v.(*schema.Set))
 	}
 
 	setOpts := &elb.SetLoadBalancerPoliciesOfListenerInput{

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -286,7 +286,7 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 		input.MaintenanceWindowStartTime = expandMqWeeklyStartTime(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("subnet_ids"); ok {
-		input.SubnetIds = expandStringList(v.(*schema.Set).List())
+		input.SubnetIds = expandStringSet(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk("tags"); ok {
 		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().MqTags()

--- a/aws/resource_aws_neptune_cluster.go
+++ b/aws/resource_aws_neptune_cluster.go
@@ -304,8 +304,8 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-		createDbClusterInput.AvailabilityZones = expandStringList(attr.List())
-		restoreDBClusterFromSnapshotInput.AvailabilityZones = expandStringList(attr.List())
+		createDbClusterInput.AvailabilityZones = expandStringSet(attr)
+		restoreDBClusterFromSnapshotInput.AvailabilityZones = expandStringSet(attr)
 	}
 
 	if attr, ok := d.GetOk("backup_retention_period"); ok {
@@ -316,8 +316,8 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if attr := d.Get("enable_cloudwatch_logs_exports").(*schema.Set); attr.Len() > 0 {
-		createDbClusterInput.EnableCloudwatchLogsExports = expandStringList(attr.List())
-		restoreDBClusterFromSnapshotInput.EnableCloudwatchLogsExports = expandStringList(attr.List())
+		createDbClusterInput.EnableCloudwatchLogsExports = expandStringSet(attr)
+		restoreDBClusterFromSnapshotInput.EnableCloudwatchLogsExports = expandStringSet(attr)
 	}
 
 	if attr, ok := d.GetOk("engine_version"); ok {
@@ -359,11 +359,11 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-		createDbClusterInput.VpcSecurityGroupIds = expandStringList(attr.List())
+		createDbClusterInput.VpcSecurityGroupIds = expandStringSet(attr)
 		if restoreDBClusterFromSnapshot {
 			clusterUpdate = true
 		}
-		restoreDBClusterFromSnapshotInput.VpcSecurityGroupIds = expandStringList(attr.List())
+		restoreDBClusterFromSnapshotInput.VpcSecurityGroupIds = expandStringSet(attr)
 	}
 
 	if restoreDBClusterFromSnapshot {
@@ -552,7 +552,7 @@ func resourceAwsNeptuneClusterUpdate(d *schema.ResourceData, meta interface{}) e
 
 	if d.HasChange("vpc_security_group_ids") {
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			req.VpcSecurityGroupIds = expandStringList(attr.List())
+			req.VpcSecurityGroupIds = expandStringSet(attr)
 		} else {
 			req.VpcSecurityGroupIds = []*string{}
 		}
@@ -567,13 +567,13 @@ func resourceAwsNeptuneClusterUpdate(d *schema.ResourceData, meta interface{}) e
 		disableLogTypes := old.(*schema.Set).Difference(new.(*schema.Set))
 
 		if disableLogTypes.Len() > 0 {
-			logs.SetDisableLogTypes(expandStringList(disableLogTypes.List()))
+			logs.SetDisableLogTypes(expandStringSet(disableLogTypes))
 		}
 
 		enableLogTypes := new.(*schema.Set).Difference(old.(*schema.Set))
 
 		if enableLogTypes.Len() > 0 {
-			logs.SetEnableLogTypes(expandStringList(enableLogTypes.List()))
+			logs.SetEnableLogTypes(expandStringSet(enableLogTypes))
 		}
 
 		req.CloudwatchLogsExportConfiguration = logs

--- a/aws/resource_aws_neptune_event_subscription.go
+++ b/aws/resource_aws_neptune_event_subscription.go
@@ -283,8 +283,8 @@ func resourceAwsNeptuneEventSubscriptionUpdate(d *schema.ResourceData, meta inte
 
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
-		remove := expandStringList(os.Difference(ns).List())
-		add := expandStringList(ns.Difference(os).List())
+		remove := expandStringSet(os.Difference(ns))
+		add := expandStringSet(ns.Difference(os))
 
 		if len(remove) > 0 {
 			for _, removing := range remove {

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -505,7 +505,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-			opts.AvailabilityZones = expandStringList(attr.List())
+			opts.AvailabilityZones = expandStringSet(attr)
 		}
 
 		if v, ok := d.GetOk("backtrack_window"); ok {
@@ -565,7 +565,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			opts.VpcSecurityGroupIds = expandStringList(attr.List())
+			opts.VpcSecurityGroupIds = expandStringSet(attr)
 		}
 
 		log.Printf("[DEBUG] RDS Cluster restore from snapshot configuration: %s", opts)
@@ -633,11 +633,11 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
+			createOpts.VpcSecurityGroupIds = expandStringSet(attr)
 		}
 
 		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-			createOpts.AvailabilityZones = expandStringList(attr.List())
+			createOpts.AvailabilityZones = expandStringSet(attr)
 		}
 
 		if v, ok := d.GetOk("backup_retention_period"); ok {
@@ -743,7 +743,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
+			createOpts.VpcSecurityGroupIds = expandStringSet(attr)
 		}
 
 		if attr, ok := d.GetOk("kms_key_id"); ok {
@@ -854,11 +854,11 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
+			createOpts.VpcSecurityGroupIds = expandStringSet(attr)
 		}
 
 		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-			createOpts.AvailabilityZones = expandStringList(attr.List())
+			createOpts.AvailabilityZones = expandStringSet(attr)
 		}
 
 		if v, ok := d.GetOk("backup_retention_period"); ok {
@@ -1146,7 +1146,7 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("vpc_security_group_ids") {
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			req.VpcSecurityGroupIds = expandStringList(attr.List())
+			req.VpcSecurityGroupIds = expandStringSet(attr)
 		} else {
 			req.VpcSecurityGroupIds = []*string{}
 		}

--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -192,13 +192,13 @@ func resourceAwsRDSClusterEndpointUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if attr := d.Get("excluded_members").(*schema.Set); attr.Len() > 0 {
-		input.ExcludedMembers = expandStringList(attr.List())
+		input.ExcludedMembers = expandStringSet(attr)
 	} else {
 		input.ExcludedMembers = make([]*string, 0)
 	}
 
 	if attr := d.Get("static_members").(*schema.Set); attr.Len() > 0 {
-		input.StaticMembers = expandStringList(attr.List())
+		input.StaticMembers = expandStringSet(attr)
 	} else {
 		input.StaticMembers = make([]*string, 0)
 	}

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -370,11 +370,11 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if v := d.Get("cluster_security_groups").(*schema.Set); v.Len() > 0 {
-			restoreOpts.ClusterSecurityGroups = expandStringList(v.List())
+			restoreOpts.ClusterSecurityGroups = expandStringSet(v)
 		}
 
 		if v := d.Get("vpc_security_group_ids").(*schema.Set); v.Len() > 0 {
-			restoreOpts.VpcSecurityGroupIds = expandStringList(v.List())
+			restoreOpts.VpcSecurityGroupIds = expandStringSet(v)
 		}
 
 		if v, ok := d.GetOk("preferred_maintenance_window"); ok {
@@ -394,7 +394,7 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if v, ok := d.GetOk("iam_roles"); ok {
-			restoreOpts.IamRoles = expandStringList(v.(*schema.Set).List())
+			restoreOpts.IamRoles = expandStringSet(v.(*schema.Set))
 		}
 
 		log.Printf("[DEBUG] Redshift Cluster restore cluster options: %s", restoreOpts)
@@ -438,11 +438,11 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if v := d.Get("cluster_security_groups").(*schema.Set); v.Len() > 0 {
-			createOpts.ClusterSecurityGroups = expandStringList(v.List())
+			createOpts.ClusterSecurityGroups = expandStringSet(v)
 		}
 
 		if v := d.Get("vpc_security_group_ids").(*schema.Set); v.Len() > 0 {
-			createOpts.VpcSecurityGroupIds = expandStringList(v.List())
+			createOpts.VpcSecurityGroupIds = expandStringSet(v)
 		}
 
 		if v, ok := d.GetOk("cluster_subnet_group_name"); ok {
@@ -478,7 +478,7 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if v, ok := d.GetOk("iam_roles"); ok {
-			createOpts.IamRoles = expandStringList(v.(*schema.Set).List())
+			createOpts.IamRoles = expandStringSet(v.(*schema.Set))
 		}
 
 		log.Printf("[DEBUG] Redshift Cluster create options: %s", createOpts)
@@ -675,12 +675,12 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if d.HasChange("cluster_security_groups") {
-		req.ClusterSecurityGroups = expandStringList(d.Get("cluster_security_groups").(*schema.Set).List())
+		req.ClusterSecurityGroups = expandStringSet(d.Get("cluster_security_groups").(*schema.Set))
 		requestUpdate = true
 	}
 
 	if d.HasChange("vpc_security_group_ids") {
-		req.VpcSecurityGroupIds = expandStringList(d.Get("vpc_security_group_ids").(*schema.Set).List())
+		req.VpcSecurityGroupIds = expandStringSet(d.Get("vpc_security_group_ids").(*schema.Set))
 		requestUpdate = true
 	}
 
@@ -755,14 +755,14 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		removeIams := os.Difference(ns).List()
-		addIams := ns.Difference(os).List()
+		removeIams := os.Difference(ns)
+		addIams := ns.Difference(os)
 
 		log.Printf("[INFO] Building Redshift Modify Cluster IAM Role Options")
 		req := &redshift.ModifyClusterIamRolesInput{
 			ClusterIdentifier: aws.String(d.Id()),
-			AddIamRoles:       expandStringList(addIams),
-			RemoveIamRoles:    expandStringList(removeIams),
+			AddIamRoles:       expandStringSet(addIams),
+			RemoveIamRoles:    expandStringSet(removeIams),
 		}
 
 		log.Printf("[INFO] Modifying Redshift Cluster IAM Roles: %s", d.Id())

--- a/aws/resource_aws_redshift_snapshot_schedule.go
+++ b/aws/resource_aws_redshift_snapshot_schedule.go
@@ -152,7 +152,7 @@ func resourceAwsRedshiftSnapshotScheduleUpdate(d *schema.ResourceData, meta inte
 	if d.HasChange("definitions") {
 		modifyOpts := &redshift.ModifySnapshotScheduleInput{
 			ScheduleIdentifier:  aws.String(d.Id()),
-			ScheduleDefinitions: expandStringList(d.Get("definitions").(*schema.Set).List()),
+			ScheduleDefinitions: expandStringSet(d.Get("definitions").(*schema.Set)),
 		}
 		_, err := conn.ModifySnapshotSchedule(modifyOpts)
 		if isAWSErr(err, redshift.ErrCodeSnapshotScheduleNotFoundFault, "") {

--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -186,7 +186,7 @@ func resourceAwsRoute53HealthCheckUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if d.HasChange("child_healthchecks") {
-		updateHealthCheck.ChildHealthChecks = expandStringList(d.Get("child_healthchecks").(*schema.Set).List())
+		updateHealthCheck.ChildHealthChecks = expandStringSet(d.Get("child_healthchecks").(*schema.Set))
 
 	}
 	if d.HasChange("child_health_threshold") {
@@ -215,7 +215,7 @@ func resourceAwsRoute53HealthCheckUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if d.HasChange("regions") {
-		updateHealthCheck.Regions = expandStringList(d.Get("regions").(*schema.Set).List())
+		updateHealthCheck.Regions = expandStringSet(d.Get("regions").(*schema.Set))
 	}
 
 	if d.HasChange("disabled") {
@@ -289,7 +289,7 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 
 	if *healthConfig.Type == route53.HealthCheckTypeCalculated {
 		if v, ok := d.GetOk("child_healthchecks"); ok {
-			healthConfig.ChildHealthChecks = expandStringList(v.(*schema.Set).List())
+			healthConfig.ChildHealthChecks = expandStringSet(v.(*schema.Set))
 		}
 
 		if v, ok := d.GetOk("child_health_threshold"); ok {
@@ -316,7 +316,7 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 	}
 
 	if v, ok := d.GetOk("regions"); ok {
-		healthConfig.Regions = expandStringList(v.(*schema.Set).List())
+		healthConfig.Regions = expandStringSet(v.(*schema.Set))
 	}
 
 	callerRef := resource.UniqueId()

--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -197,7 +197,7 @@ func resourceAwsS3BucketInventoryPut(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if v, ok := d.GetOk("optional_fields"); ok {
-		inventoryConfiguration.OptionalFields = expandStringList(v.(*schema.Set).List())
+		inventoryConfiguration.OptionalFields = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("schedule"); ok {

--- a/aws/resource_aws_secretsmanager_secret_version.go
+++ b/aws/resource_aws_secretsmanager_secret_version.go
@@ -87,7 +87,7 @@ func resourceAwsSecretsManagerSecretVersionCreate(d *schema.ResourceData, meta i
 	}
 
 	if v, ok := d.GetOk("version_stages"); ok {
-		input.VersionStages = expandStringList(v.(*schema.Set).List())
+		input.VersionStages = expandStringSet(v.(*schema.Set))
 	}
 
 	log.Printf("[DEBUG] Putting Secrets Manager Secret %q value", secretID)

--- a/aws/resource_aws_ses_event_destination.go
+++ b/aws/resource_aws_ses_event_destination.go
@@ -136,14 +136,14 @@ func resourceAwsSesEventDestinationCreate(d *schema.ResourceData, meta interface
 	configurationSetName := d.Get("configuration_set_name").(string)
 	eventDestinationName := d.Get("name").(string)
 	enabled := d.Get("enabled").(bool)
-	matchingEventTypes := d.Get("matching_types").(*schema.Set).List()
+	matchingEventTypes := d.Get("matching_types").(*schema.Set)
 
 	createOpts := &ses.CreateConfigurationSetEventDestinationInput{
 		ConfigurationSetName: aws.String(configurationSetName),
 		EventDestination: &ses.EventDestination{
 			Name:               aws.String(eventDestinationName),
 			Enabled:            aws.Bool(enabled),
-			MatchingEventTypes: expandStringList(matchingEventTypes),
+			MatchingEventTypes: expandStringSet(matchingEventTypes),
 		},
 	}
 

--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -626,7 +626,7 @@ func buildReceiptRule(d *schema.ResourceData) *ses.ReceiptRule {
 	}
 
 	if v, ok := d.GetOk("recipients"); ok {
-		receiptRule.Recipients = expandStringList(v.(*schema.Set).List())
+		receiptRule.Recipients = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("scan_enabled"); ok {

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -147,11 +147,11 @@ func resourceAwsSsmPatchBaselineCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("approved_patches"); ok && v.(*schema.Set).Len() > 0 {
-		params.ApprovedPatches = expandStringList(v.(*schema.Set).List())
+		params.ApprovedPatches = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("rejected_patches"); ok && v.(*schema.Set).Len() > 0 {
-		params.RejectedPatches = expandStringList(v.(*schema.Set).List())
+		params.RejectedPatches = expandStringSet(v.(*schema.Set))
 	}
 
 	if _, ok := d.GetOk("global_filter"); ok {
@@ -187,11 +187,11 @@ func resourceAwsSsmPatchBaselineUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("approved_patches") {
-		params.ApprovedPatches = expandStringList(d.Get("approved_patches").(*schema.Set).List())
+		params.ApprovedPatches = expandStringSet(d.Get("approved_patches").(*schema.Set))
 	}
 
 	if d.HasChange("rejected_patches") {
-		params.RejectedPatches = expandStringList(d.Get("rejected_patches").(*schema.Set).List())
+		params.RejectedPatches = expandStringSet(d.Get("rejected_patches").(*schema.Set))
 	}
 
 	if d.HasChange("approved_patches_compliance_level") {

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -470,11 +470,11 @@ func vpcEndpointWaitUntilAvailable(conn *ec2.EC2, vpceId string, timeout time.Du
 	return err
 }
 
-func vpcEndpointWaitUntilDeleted(conn *ec2.EC2, vpceId string, timeout time.Duration) error {
+func vpcEndpointWaitUntilDeleted(conn *ec2.EC2, vpceID string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"available", "pending", "deleting"},
 		Target:     []string{"deleted"},
-		Refresh:    vpcEndpointStateRefresh(conn, vpceId),
+		Refresh:    vpcEndpointStateRefresh(conn, vpceID),
 		Timeout:    timeout,
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
@@ -487,9 +487,9 @@ func vpcEndpointWaitUntilDeleted(conn *ec2.EC2, vpceId string, timeout time.Dura
 
 func setVpcEndpointCreateList(d *schema.ResourceData, key string, c *[]*string) {
 	if v, ok := d.GetOk(key); ok {
-		list := v.(*schema.Set).List()
-		if len(list) > 0 {
-			*c = expandStringList(list)
+		list := v.(*schema.Set)
+		if list.Len() > 0 {
+			*c = expandStringSet(list)
 		}
 	}
 }
@@ -500,12 +500,12 @@ func setVpcEndpointUpdateLists(d *schema.ResourceData, key string, a, r *[]*stri
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		add := expandStringList(ns.Difference(os).List())
+		add := expandStringSet(ns.Difference(os))
 		if len(add) > 0 {
 			*a = add
 		}
 
-		remove := expandStringList(os.Difference(ns).List())
+		remove := expandStringSet(os.Difference(ns))
 		if len(remove) > 0 {
 			*r = remove
 		}

--- a/aws/resource_aws_vpc_endpoint_service.go
+++ b/aws/resource_aws_vpc_endpoint_service.go
@@ -420,12 +420,12 @@ func setVpcEndpointServiceUpdateLists(d *schema.ResourceData, key string, a, r *
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		add := expandStringList(ns.Difference(os).List())
+		add := expandStringSet(ns.Difference(os))
 		if len(add) > 0 {
 			*a = add
 		}
 
-		remove := expandStringList(os.Difference(ns).List())
+		remove := expandStringSet(os.Difference(ns))
 		if len(remove) > 0 {
 			*r = remove
 		}

--- a/aws/resource_aws_wafv2_web_acl_logging_configuration.go
+++ b/aws/resource_aws_wafv2_web_acl_logging_configuration.go
@@ -56,7 +56,7 @@ func resourceAwsWafv2WebACLLoggingConfigurationPut(d *schema.ResourceData, meta 
 
 	resourceArn := d.Get("resource_arn").(string)
 	config := &wafv2.LoggingConfiguration{
-		LogDestinationConfigs: expandStringList(d.Get("log_destination_configs").(*schema.Set).List()),
+		LogDestinationConfigs: expandStringSet(d.Get("log_destination_configs").(*schema.Set)),
 		ResourceArn:           aws.String(resourceArn),
 	}
 


### PR DESCRIPTION
Replaces `expandStringList(x.List())` with `expandStringSet(x)`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17052

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGroupMembership\|TestAccAWSIAMPolicyAttachment\|TestAccAWSKinesisStream\|TestAccAWSLambdaLayerVersion\|TestAccAWSLaunchConfiguration\|TestAccAWSLaunchTemplate\|TestAccAWSLB\|TestAccAwsLexIntent\|TestAccAWSLoadBalancerBackendServerPolicy\|TestAccAWSLoadBalancerListenerPolicy\|TestAccAWSMqBroker\|TestAccAWSNeptuneCluster\|TestAccAWSNeptuneEventSubscription\|TestAccAWSRDSCluster\|TestAccAWSRDSClusterEndpoint\|TestAccAWSRedshiftCluster\|TestAccAWSRedshiftSnapshotSchedule\|TestAccAWSRoute53HealthCheck\|TestAccAWSS3BucketInventory\|TestAccAwsSecretsManagerSecretVersion\|TestAccAWSSESEventDestination\|TestAccAWSSESReceiptRule\|TestAccAWSSSMPatchBaseline\|TestAccAWSUserGroupMembership\|TestAccAWSVpcEndpoint\|TestAccAWSVpcEndpointService\|TestAccAwsWafv2WebACLLoggingConfiguration'

--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (10.81s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_basic (50.95s)
--- PASS: TestAccAWSLaunchTemplateDataSource_enclaveOptions (51.19s)
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (53.07s)
--- PASS: TestAccAWSLaunchTemplateDataSource_id_basic (53.18s)
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (53.55s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_tags (54.67s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (60.76s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (61.31s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_ebsNoDevice (63.55s)
--- PASS: TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup (84.41s)
--- PASS: TestAccAWSIAMPolicyAttachment_Roles_RenamedRole (86.77s)
--- PASS: TestAccAWSIAMPolicyAttachment_Users_RenamedUser (80.50s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (95.03s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associateCarrierIPAddress (94.90s)
--- PASS: TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination (95.92s)
--- PASS: TestAccAWSGroupMembership_basic (100.89s)
--- PASS: TestAccAWSLambdaLayerVersion_basic (23.25s)
--- PASS: TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError (67.09s)
--- PASS: TestAccAWSLambdaLayerVersion_compatibleRuntimes (25.63s)
--- PASS: TestAccAWSKinesisStream_basic (72.07s)
--- PASS: TestAccAWSLambdaLayerVersion_s3 (31.00s)
--- PASS: TestAccAWSLambdaLayerVersion_description (32.59s)
--- PASS: TestAccAWSKinesisStreamDataSource_basic (147.24s)
--- PASS: TestAccAWSLambdaLayerVersion_update (57.02s)
--- PASS: TestAccAWSKinesisStream_enforceConsumerDeletion (90.50s)
--- PASS: TestAccAWSLambdaLayerVersion_licenseInfo (40.44s)
--- SKIP: TestAccAWSLaunchConfiguration_withVpcClassicLink (1.78s)
--- PASS: TestAccAWSLaunchConfiguration_withInstanceStoreAMI (39.87s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (42.98s)
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (38.85s)
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (43.33s)
--- PASS: TestAccAWSLaunchConfiguration_basic (73.23s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (41.84s)
--- PASS: TestAccAWSKinesisStream_retentionPeriod (140.31s)
--- PASS: TestAccAWSKinesisStream_createMultipleConcurrentStreams (152.57s)
--- PASS: TestAccAWSLaunchConfiguration_metadataOptions (48.68s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_VolumeSize (80.40s)
--- PASS: TestAccAWSKinesisStream_shardCount (164.43s)
--- PASS: TestAccAWSKinesisStream_UpdateKmsKeyId (136.65s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (68.78s)
--- PASS: TestAccAWSLaunchTemplate_disappears (34.23s)
--- PASS: TestAccAWSKinesisStream_shardLevelMetrics (175.23s)
--- PASS: TestAccAWSLaunchTemplate_basic (43.61s)
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (55.72s)
--- PASS: TestAccAWSKinesisStream_encryption (194.43s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (95.24s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (66.94s)
--- PASS: TestAccAWSLaunchTemplate_data (52.69s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_Gp3 (65.45s)
--- PASS: TestAccAWSKinesisStream_Tags (197.40s)
--- PASS: TestAccAWSLaunchConfiguration_userData (104.49s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (58.24s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (63.78s)
--- PASS: TestAccAWSLaunchTemplate_cpuOptions (56.11s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (96.81s)
--- PASS: TestAccAWSIAMPolicyAttachment_basic (326.49s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (61.80s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (128.13s)
--- PASS: TestAccAWSLaunchTemplate_description (101.22s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (53.59s)
--- PASS: TestAccAWSLaunchTemplate_tags (97.36s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (58.32s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (61.62s)
--- PASS: TestAccAWSLaunchTemplate_update (129.84s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (51.45s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (46.17s)
--- PASS: TestAccAWSLaunchTemplate_metadataOptions (49.90s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (52.64s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (92.12s)
--- PASS: TestAccAWSLaunchTemplate_networkInterfaceAddresses (87.77s)
--- PASS: TestAccAWSLaunchTemplate_NetworkInterfaces_DeleteOnTermination (171.53s)
--- PASS: TestAccAWSLaunchTemplate_placement_partitionNum (88.01s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (207.16s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_disappears (45.34s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_disappears_ELB (44.30s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (109.91s)
--- PASS: TestAccAWSLaunchTemplate_enclaveOptions (110.60s)
--- PASS: TestAccAWSLaunchTemplate_hibernation (109.21s)
--- PASS: TestAccAWSLaunchTemplate_defaultVersion (106.94s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_basic (74.24s)
--- PASS: TestAccAWSLaunchTemplate_associateCarrierIPAddress (145.13s)
--- PASS: TestAccAWSLaunchTemplate_associatePublicIPAddress (149.84s)
--- PASS: TestAccAWSUserGroupMembership_basic (422.33s)
--- PASS: TestAccAWSLaunchTemplate_updateDefaultVersion (107.66s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader_invalid (1.99s)
--- PASS: TestAccAWSLBListenerRule_conditionAttributesCount (24.20s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears (361.84s)
--- PASS: TestAccAWSIAMPolicyAttachment_paginatedEntities (540.67s)
--- PASS: TestAccAWSGroupMembership_paginatedUserList (548.68s)
--- PASS: TestAccAWSLBListenerRule_basic (168.29s)
--- PASS: TestAccAWSLBListenerRule_redirect (165.42s)
--- FAIL: TestAccAWSLBListenerRule_fixedResponse (164.15s)
--- PASS: TestAccAWSLBListenerRule_BackwardsCompatibility (188.55s)
--- PASS: TestAccAWSLBListenerRule_forwardWeighted (199.85s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (179.92s)
--- PASS: TestAccAWSLBListenerRule_Action_Order (156.73s)
--- PASS: TestAccAWSLBListenerRule_updateFixedResponse (186.24s)
--- PASS: TestAccAWSLBListenerRule_oidc (171.91s)
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (170.20s)
--- PASS: TestAccAWSLBListenerRule_cognito (175.95s)
--- PASS: TestAccAWSLBListenerRule_conditionHostHeader (168.98s)
--- PASS: TestAccAWSLBListenerRule_conditionQueryString (156.28s)
--- PASS: TestAccAWSLBListenerRule_conditionPathPattern (165.45s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader (185.23s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (237.84s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpRequestMethod (196.32s)
--- PASS: TestAccAWSLBListenerRule_priority (252.97s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_disappears (27.86s)
--- PASS: TestAccAWSLBListenerRule_conditionMultiple (158.22s)
--- PASS: TestAccAWSLBListener_LoadBalancerArn_GatewayLoadBalancer (110.92s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_basic (66.43s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMixed (188.54s)
--- PASS: TestAccAWSLBListener_basic (168.80s)
--- PASS: TestAccAWSLBListenerRule_conditionSourceIp (203.94s)
--- PASS: TestAccAWSLBTargetGroup_basic (23.55s)
--- PASS: TestAccAWSLBTargetGroup_basicUdp (24.86s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMultiple (209.66s)
--- PASS: TestAccAWSLBListener_https (174.61s)
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (22.12s)
--- PASS: TestAccAWSLBListener_redirect (166.56s)
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (92.17s)
--- PASS: TestAccAWSLBTargetGroupAttachment_disappears (88.55s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Geneve (36.30s)
--- PASS: TestAccAWSLBTargetGroupAttachment_lambda (72.12s)
--- PASS: TestAccAWSLBTargetGroupAttachment_Port (89.78s)
--- PASS: TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility (102.06s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (37.39s)
--- PASS: TestAccAWSLBListener_oidc (183.01s)
--- PASS: TestAccAWSLBTargetGroupAttachment_ipAddress (92.00s)
--- PASS: TestAccAWSLBListener_BackwardsCompatibility (224.31s)
--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (51.10s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order_Recreates (185.73s)
--- PASS: TestAccAWSLBListener_forwardWeighted (273.03s)
--- PASS: TestAccAWSLBListener_fixedResponse (234.68s)
--- PASS: TestAccAWSLBTargetGroup_generatedName (53.70s)
--- PASS: TestAccAWSLBTargetGroup_namePrefix (56.12s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (86.85s)
--- PASS: TestAccAWSLBListener_cognito (235.92s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order (221.89s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (100.28s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (101.68s)
--- PASS: TestLBCloudwatchSuffixFromARN (0.00s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (137.26s)
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (103.99s)
--- PASS: TestAccAWSLBTargetGroup_defaults_application (59.89s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (57.70s)
--- SKIP: TestAccAWSLB_ALB_outpost (1.81s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (108.08s)
--- PASS: TestAccAWSLBListener_basicUdp (338.20s)
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (106.20s)
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (102.75s)
--- PASS: TestAccAWSLBTargetGroup_defaults_network (74.61s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (109.48s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (64.71s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (102.58s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (89.74s)
--- PASS: TestAccAWSLBTargetGroup_tags (133.74s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (72.07s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (122.00s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (109.97s)
--- PASS: TestAccAWSLBListener_Protocol_Tls (355.49s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (128.78s)
--- PASS: TestAccAWSLB_ALB_basic (179.29s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (171.63s)
--- PASS: TestAccAWSLB_generatedName (180.60s)
--- PASS: TestAccAWSLB_namePrefix (178.96s)
--- PASS: TestAccAWSLB_BackwardsCompatibility (191.31s)
--- PASS: TestAccAwsLexIntent_basic (11.74s)
--- PASS: TestAccAWSLB_NLB_basic (228.23s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway (238.27s)
--- PASS: TestAccAwsLexIntent_createVersion (38.61s)
--- PASS: TestAccAwsLexIntent_conclusionStatement (38.80s)
--- PASS: TestAccAwsLexIntent_confirmationPromptAndRejectionStatement (32.88s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing (269.37s)
--- PASS: TestAccAWSLB_NLB_privateipv4address (263.56s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (264.98s)
--- PASS: TestAccAWSLB_noSecurityGroup (220.77s)
--- PASS: TestAccAWSLB_tags (278.08s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (271.39s)
--- PASS: TestAccAWSLB_updatedSubnets (260.84s)
--- PASS: TestAccAwsLexIntent_dialogCodeHook (59.11s)
--- PASS: TestResourceAWSMqBrokerPasswordValidation (0.00s)
--- PASS: TestAccAwsLexIntent_disappears (32.71s)
--- PASS: TestDiffAwsMqBrokerUsers (0.00s)
--- PASS: TestAccAwsLexIntent_followUpPrompt (55.71s)
--- PASS: TestAccAwsLexIntent_slotsCustom (45.96s)
--- PASS: TestAccAwsLexIntent_fulfillmentActivity (65.87s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (294.22s)
--- PASS: TestAccAwsLexIntent_sampleUtterances (73.70s)
--- PASS: TestAccAwsLexIntent_slots (72.89s)
--- PASS: TestAccAWSLB_updatedIpAddressType (289.83s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields (315.16s)
--- PASS: TestAccAwsLexIntent_updateWithExternalChange (58.70s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (320.81s)
--- PASS: TestAccAWSLoadBalancerListenerPolicy_basic (71.59s)
--- PASS: TestAccAWSLoadBalancerBackendServerPolicy_basic (88.24s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (373.71s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (235.87s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (279.72s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_basic (12.28s)
--- PASS: TestAccAWSLB_ALB_AccessLogs (374.65s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_namePrefix (13.18s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_generatedName (14.14s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Description (14.25s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Parameter (23.07s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Tags (30.86s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (321.75s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (359.94s)
--- PASS: TestAccAWSNeptuneCluster_basic (123.89s)
--- PASS: TestAccAWSNeptuneCluster_namePrefix (133.28s)
--- PASS: TestAccAWSNeptuneClusterSnapshot_basic (198.99s)
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (143.96s)
--- PASS: TestAccAWSNeptuneCluster_tags (150.85s)
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (167.39s)
--- PASS: TestAccAWSNeptuneCluster_encrypted (125.67s)
--- PASS: TestAccAWSNeptuneCluster_kmsKey (126.49s)
--- PASS: TestAccAWSNeptuneCluster_backupsUpdate (142.68s)
--- PASS: TestAccAWSNeptuneCluster_iamAuth (135.50s)
--- PASS: TestAccAWSNeptuneCluster_updateCloudwatchLogsExports (174.23s)
--- PASS: TestAccAWSNeptuneCluster_deleteProtection (174.66s)
--- PASS: TestAccAWSNeptuneEventSubscription_withPrefix (72.95s)
--- PASS: TestAccAWSNeptuneEventSubscription_basic (111.45s)
--- PASS: TestAccAWSNeptuneClusterInstance_generatedName (662.51s)
--- PASS: TestAccAWSNeptuneEventSubscription_withSourceIds (83.09s)
--- PASS: TestAccAWSNeptuneClusterInstance_namePrefix (714.82s)
--- PASS: TestAccAWSNeptuneClusterInstance_withSubnetGroup (713.65s)
--- PASS: TestAccAWSNeptuneEventSubscription_withCategories (112.93s)
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (805.44s)
--- PASS: TestAccAWSNeptuneClusterInstance_kmsKey (811.68s)
--- PASS: TestAccAWSNeptuneClusterInstance_basic (895.54s)
--- PASS: TestAccAWSMqBroker_disappears (1089.15s)
--- PASS: TestAccAWSMqBroker_basic (1158.60s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_KmsKeyId (1156.26s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Disabled (1163.67s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Enabled (1168.24s)
--- PASS: TestAccAWSMqBroker_updateTags (1184.24s)
--- PASS: TestAccAWSRDSClusterInstance_generatedName (495.60s)
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (607.93s)
--- PASS: TestAccAWSMqBroker_updateSecurityGroup (1424.01s)
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (602.06s)
--- PASS: TestAccAWSRDSClusterInstance_isAlreadyBeingDeleted (768.24s)
--- PASS: TestAccAWSRDSClusterInstance_az (774.99s)
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (682.99s)
--- PASS: TestAccAWSMqBroker_updateUsers (1598.51s)
--- PASS: TestAccAWSRDSClusterInstance_disappears (716.61s)
--- PASS: TestAccAWSRDSClusterInstance_CopyTagsToSnapshot (641.22s)
--- PASS: TestAccAWSRDSClusterEndpoint_tags (1081.52s)
--- PASS: TestAccAWSMqBroker_allFieldsDefaultVpc (1842.72s)
--- PASS: TestAccAWSRDSClusterEndpoint_basic (1145.43s)
--- PASS: TestAccAWSRDSCluster_basic (124.20s)
--- PASS: TestAccAWSMqBroker_allFieldsCustomVpc (1901.20s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_RemovedToEnabled (751.14s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (124.85s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2 (681.90s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1 (762.34s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (152.43s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (129.13s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (5.47s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToRemoved (863.09s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (156.21s)
--- PASS: TestAccAWSRDSCluster_generatedName (134.25s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToDisabled (955.82s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql (752.54s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql_DefaultKeyToCustomKey (544.79s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (164.89s)
--- PASS: TestAccAWSRDSCluster_Tags (141.19s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1_DefaultKeyToCustomKey (717.56s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_Postgresql (124.17s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1 (722.96s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_MySQL (193.01s)
--- PASS: TestAccAWSRDSCluster_kmsKey (124.42s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (149.76s)
--- PASS: TestAccAWSRDSCluster_PointInTimeRestore_EnabledCloudwatchLogsExports (310.37s)
--- PASS: TestAccAWSRDSCluster_encrypted (134.06s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2_DefaultKeyToCustomKey (727.56s)
--- PASS: TestAccAWSRDSClusterInstance_CACertificateIdentifier (641.77s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2 (762.68s)
--- PASS: TestAccAWSRDSCluster_PointInTimeRestore (333.21s)
--- PASS: TestAccAWSRDSCluster_iamAuth (127.17s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql (701.65s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1584.00s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (165.88s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (118.59s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (186.59s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (192.47s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (144.88s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (143.76s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned (119.95s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global (140.20s)
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add (142.49s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringInterval (1292.83s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove (176.60s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update (173.05s)
--- PASS: TestAccAWSRDSCluster_Port (255.11s)
--- PASS: TestAccAWSRDSCluster_EngineMode (440.85s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity (308.31s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (336.34s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (427.71s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (393.70s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (346.78s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (347.12s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_KmsKeyId (343.29s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (342.36s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (383.27s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (347.45s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (432.30s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (496.81s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (384.53s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (384.10s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (377.68s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (345.52s)
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (245.03s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (394.23s)
--- PASS: TestAccAWSRDSCluster_AllowMajorVersionUpgrade (1298.26s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (353.87s)
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (446.92s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1003.27s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_basic (19.21s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withMultipleDefinition (19.23s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withIdentifierPrefix (11.52s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withDescription (11.73s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withTags (19.13s)
--- PASS: TestAccAWSRedshiftCluster_kmsKey (596.98s)
--- PASS: TestAccAWSRedshiftCluster_basic (636.63s)
--- PASS: TestAccAWSRoute53HealthCheck_basic (29.85s)
--- PASS: TestAccAWSRoute53HealthCheck_tags (42.97s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (1512.41s)
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (29.38s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (17.93s)
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (15.45s)
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (16.50s)
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (17.31s)
--- PASS: TestAccAWSRoute53HealthCheck_Ipv6Config (24.43s)
--- PASS: TestAccAWSRoute53HealthCheck_disappears (11.01s)
--- PASS: TestAccAWSS3BucketInventory_basic (17.34s)
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (44.82s)
--- PASS: TestAccAWSRoute53HealthCheck_Disabled (37.70s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (15.02s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_BasicString (13.05s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (14.81s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_Base64Binary (13.32s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_VersionStages (28.63s)
--- PASS: TestAccAWSSESReceiptRuleSet_basic (10.93s)
--- PASS: TestAccAWSSESReceiptRuleSet_disappears (8.61s)
--- PASS: TestAccAWSRDSCluster_ReplicationSourceIdentifier_KmsKeyId (1424.59s)
--- PASS: TestAccAWSSESReceiptRule_basic (12.47s)
--- PASS: TestAccAWSSESReceiptRule_s3Action (14.72s)
--- PASS: TestAccAWSSESReceiptRule_order (13.88s)
--- PASS: TestAccAWSSESEventDestination_basic (76.25s)
--- PASS: TestAccAWSSESReceiptRule_actions (14.23s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withForceDestroy (261.83s)
--- PASS: TestAccAWSSESReceiptRule_disappears (21.70s)
--- PASS: TestAccAWSSSMPatchBaseline_disappears (11.40s)
--- PASS: TestAccAWSSSMPatchBaseline_basic (25.12s)
--- PASS: TestAccAWSSESEventDestination_disappears (100.19s)
--- PASS: TestAccAWSSSMPatchBaseline_tags (34.91s)
--- PASS: TestAccAWSSSMPatchBaseline_OperatingSystem (25.70s)
--- PASS: TestAccAWSVpcEndpointRouteTableAssociation_basic (29.41s)
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (870.06s)
--- PASS: TestAccAWSRedshiftSnapshotScheduleAssociation_basic (490.61s)
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (971.05s)
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (974.94s)
--- PASS: TestAccAWSVpcEndpointConnectionNotification_basic (239.37s)
--- PASS: TestAccAWSVpcEndpointService_GatewayLoadBalancerArns (178.23s)
--- PASS: TestAccAWSVpcEndpoint_gatewayBasic (24.59s)
--- PASS: TestAccAWSVpcEndpointService_disappears (248.61s)
--- PASS: TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy (46.28s)
--- PASS: TestAccAWSVpcEndpoint_gatewayPolicy (41.04s)
--- PASS: TestAccAWSVpcEndpointService_tags (261.39s)
--- PASS: TestAccAWSVpcEndpointService_private_dns_name (247.07s)
--- PASS: TestAccAWSVpcEndpoint_interfaceBasic (74.75s)
--- PASS: TestAccAWSVpcEndpoint_disappears (22.13s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_ReplicationSourceIdentifier (1741.23s)
--- PASS: TestAccAWSVpcEndpointSubnetAssociation_basic (285.07s)
--- PASS: TestAccAWSVpcEndpoint_tags (48.90s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_PrimarySecondaryClusters (1814.01s)
--- PASS: TestAccAWSVpcEndpointServiceAllowedPrincipal_basic (511.05s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_basic (99.27s)
--- PASS: TestAccAWSVpcEndpointService_AllowedPrincipals (526.94s)
--- PASS: TestAccAWSVpcEndpointService_basic (531.07s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate (233.46s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_update (129.96s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_disappears (83.29s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_disappears_WebAcl (74.22s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate (285.49s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_changeResourceARNForceNew (177.02s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_changeLogDestinationConfigsForceNew (165.47s)
--- PASS: TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup (411.06s)
--- PASS: TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer (308.03s)
--- FAIL: TestAccAWSRedshiftCluster_publiclyAccessible (1399.86s)
--- FAIL: TestAccAWSRedshiftCluster_iamRoles (1547.00s)
--- PASS: TestAccAWSVpcEndpointSubnetAssociation_multiple (663.19s)
--- PASS: TestAccAWSRedshiftCluster_tags (1938.53s)
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (2379.58s)
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (2743.49s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption2 (3263.87s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (3565.19s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption1 (4701.65s)
--- FAIL: TestAccAWSRedshiftCluster_updateNodeCount (6903.27s)
```

Test `TestAccAWSRDSCluster_s3Restore` is pre-existing. Other errors are intermittent.