### PR TITLE
resource: aws_imagebuilder_image_recipe - Relax kms_key_id contstraint

### DIFF
--- a/aws/resource_aws_imagebuilder_image_recipe.go
+++ b/aws/resource_aws_imagebuilder_image_recipe.go
@@ -80,7 +80,7 @@ func resourceAwsImageBuilderImageRecipe() *schema.Resource {
 										Type:         schema.TypeString,
 										Optional:     true,
 										ForceNew:     true,
-										ValidateFunc: validateArn,
+										ValidateFunc: validation.StringLenBetween(1, 1024),
 									},
 									"snapshot_id": {
 										Type:     schema.TypeString,


### PR DESCRIPTION
The validate length between 1 and 1024 follows:

- The AWS API documentation
- The validation for kms_key_id on resource_aws_imagebuilder_component

And will allow users to supply values such as Key ID and Key Alias

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16757

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Fixes #17075; Relax kms_key_id constraint, so that it matches AWS API Documentation and validation used for aws_imagebuilder_image_component
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
