### PR TITLE
Properly handle response from Lambda API for Image type Lambda Functions

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -1302,15 +1302,13 @@ func expandLambdaFileSystemConfigs(fscMaps []interface{}) []*lambda.FileSystemCo
 func flattenLambdaImageConfig(response *lambda.ImageConfigResponse) []map[string]interface{} {
 	settings := make(map[string]interface{})
 
-	imageConfig := response.ImageConfig
-
-	if response == nil || response.Error != nil || imageConfig == nil {
+	if response == nil || response.Error != nil || response.ImageConfig == nil {
 		return nil
 	}
 
-	settings["command"] = imageConfig.Command
-	settings["entry_point"] = imageConfig.EntryPoint
-	settings["working_directory"] = imageConfig.WorkingDirectory
+	settings["command"] = response.ImageConfig.Command
+	settings["entry_point"] = response.ImageConfig.EntryPoint
+	settings["working_directory"] = response.ImageConfig.WorkingDirectory
 
 	return []map[string]interface{}{settings}
 }

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -1302,13 +1302,15 @@ func expandLambdaFileSystemConfigs(fscMaps []interface{}) []*lambda.FileSystemCo
 func flattenLambdaImageConfig(response *lambda.ImageConfigResponse) []map[string]interface{} {
 	settings := make(map[string]interface{})
 
-	if response == nil || response.Error != nil {
+	imageConfig := response.ImageConfig
+
+	if response == nil || response.Error != nil || imageConfig == nil {
 		return nil
 	}
 
-	settings["command"] = response.ImageConfig.Command
-	settings["entry_point"] = response.ImageConfig.EntryPoint
-	settings["working_directory"] = response.ImageConfig.WorkingDirectory
+	settings["command"] = imageConfig.Command
+	settings["entry_point"] = imageConfig.EntryPoint
+	settings["working_directory"] = imageConfig.WorkingDirectory
 
 	return []map[string]interface{}{settings}
 }


### PR DESCRIPTION
The `ImageConfigResponse` returned from a lambda function of type `IMAGE` can return all null keys values in the response from the Lambda service. While this is an odd behavior of the service, the provider should not crash due to the empty key representation of the Lambda resource.

Example Response:

```
{
    ...
    "Configuration": {
        ...
        "ImageConfigResponse": {
            "Error": null,
            "ImageConfig": null
        },
    },
}
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17081 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixes crash when using `Image` package type for `aws_lambda_function` resources
```
