### PR TITLE
Allow additional resource types

### DIFF
--- a/aws/resource_aws_fms_policy.go
+++ b/aws/resource_aws_fms_policy.go
@@ -97,7 +97,7 @@ func resourceAwsFmsPolicy() *schema.Resource {
 				Required: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{"AWS::ApiGateway::Stage", "AWS::ElasticLoadBalancingV2::LoadBalancer", "AWS::CloudFront::Distribution"}, false),
+					ValidateFunc: validation.StringInSlice([]string{"AWS::ApiGateway::Stage", "AWS::ElasticLoadBalancingV2::LoadBalancer", "AWS::CloudFront::Distribution", "AWS::EC2::NetworkInterface", "AWS::EC2::Instance", "AWS::EC2::SecurityGroup"}, false),
 				},
 				Set: schema.HashString,
 			},


### PR DESCRIPTION
```release-note
Allow additional resource types so that any `SecurityServicePolicyData` can be used.

```

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSFmsPolicy -timeout 120m
=== RUN   TestAccAWSFmsPolicy_basic
=== PAUSE TestAccAWSFmsPolicy_basic
=== RUN   TestAccAWSFmsPolicy_includeMap
=== PAUSE TestAccAWSFmsPolicy_includeMap
=== RUN   TestAccAWSFmsPolicy_update
=== PAUSE TestAccAWSFmsPolicy_update
=== RUN   TestAccAWSFmsPolicy_tags
=== PAUSE TestAccAWSFmsPolicy_tags
=== CONT  TestAccAWSFmsPolicy_basic
=== CONT  TestAccAWSFmsPolicy_tags
=== CONT  TestAccAWSFmsPolicy_includeMap
=== CONT  TestAccAWSFmsPolicy_update
--- PASS: TestAccAWSFmsPolicy_tags (24.08s)
--- PASS: TestAccAWSFmsPolicy_includeMap (25.15s)
--- PASS: TestAccAWSFmsPolicy_basic (26.70s)
--- PASS: TestAccAWSFmsPolicy_update (43.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	43.846s
```
