### PR TITLE
tests/resource/fsx_lustre_file_system: Make GovCloud compatible

### DIFF
--- a/aws/resource_aws_fsx_lustre_file_system_test.go
+++ b/aws/resource_aws_fsx_lustre_file_system_test.go
@@ -767,7 +767,7 @@ resource "aws_subnet" "test1" {
 }
 
 func testAccAwsFsxLustreFileSystemConfigExportPath(rName, exportPrefix string) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   acl    = "private"
   bucket = %[1]q
@@ -782,11 +782,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   subnet_ids       = [aws_subnet.test1.id]
   deployment_type  = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
 }
-`, rName, exportPrefix)
+`, rName, exportPrefix))
 }
 
 func testAccAwsFsxLustreFileSystemConfigImportPath(rName, importPrefix string) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   acl    = "private"
   bucket = %[1]q
@@ -800,11 +800,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   subnet_ids       = [aws_subnet.test1.id]
   deployment_type  = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
 }
-`, rName, importPrefix)
+`, rName, importPrefix))
 }
 
 func testAccAwsFsxLustreFileSystemConfigImportedFileChunkSize(rName string, importedFileChunkSize int) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   acl    = "private"
   bucket = %[1]q
@@ -819,11 +819,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   subnet_ids               = [aws_subnet.test1.id]
   deployment_type          = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
 }
-`, rName, importedFileChunkSize)
+`, rName, importedFileChunkSize))
 }
 
 func testAccAwsFsxLustreFileSystemConfigSecurityGroupIds1() string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + `
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), `
 resource "aws_security_group" "test1" {
   description = "security group for FSx testing"
   vpc_id      = aws_vpc.test.id
@@ -851,11 +851,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   subnet_ids         = [aws_subnet.test1.id]
   deployment_type    = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
 }
-`
+`)
 }
 
 func testAccAwsFsxLustreFileSystemConfigSecurityGroupIds2() string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + `
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), `
 resource "aws_security_group" "test1" {
   description = "security group for FSx testing"
   vpc_id      = aws_vpc.test.id
@@ -902,11 +902,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   subnet_ids         = [aws_subnet.test1.id]
   deployment_type    = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
 }
-`
+`)
 }
 
 func testAccAwsFsxLustreFileSystemConfigStorageCapacity(storageCapacity int) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_fsx_lustre_file_system" "test" {
@@ -914,21 +914,21 @@ resource "aws_fsx_lustre_file_system" "test" {
   subnet_ids       = [aws_subnet.test1.id]
   deployment_type  = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
 }
-`, storageCapacity)
+`, storageCapacity))
 }
 
 func testAccAwsFsxLustreFileSystemConfigSubnetIds1() string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + `
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), `
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity = 1200
   subnet_ids       = [aws_subnet.test1.id]
   deployment_type  = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
 }
-`
+`)
 }
 
 func testAccAwsFsxLustreFileSystemConfigTags1(tagKey1, tagValue1 string) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_fsx_lustre_file_system" "test" {
@@ -940,11 +940,11 @@ resource "aws_fsx_lustre_file_system" "test" {
     %[1]q = %[2]q
   }
 }
-`, tagKey1, tagValue1)
+`, tagKey1, tagValue1))
 }
 
 func testAccAwsFsxLustreFileSystemConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_fsx_lustre_file_system" "test" {
@@ -957,11 +957,11 @@ resource "aws_fsx_lustre_file_system" "test" {
     %[3]q = %[4]q
   }
 }
-`, tagKey1, tagValue1, tagKey2, tagValue2)
+`, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccAwsFsxLustreFileSystemConfigWeeklyMaintenanceStartTime(weeklyMaintenanceStartTime string) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_fsx_lustre_file_system" "test" {
@@ -970,11 +970,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   weekly_maintenance_start_time = %[1]q
   deployment_type               = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
 }
-`, weeklyMaintenanceStartTime)
+`, weeklyMaintenanceStartTime))
 }
 
 func testAccAwsFsxLustreFileSystemConfigDailyAutomaticBackupStartTime(dailyAutomaticBackupStartTime string) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity                  = 1200
   subnet_ids                        = [aws_subnet.test1.id]
@@ -983,11 +983,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   daily_automatic_backup_start_time = %[1]q
   automatic_backup_retention_days   = 1
 }
-`, dailyAutomaticBackupStartTime)
+`, dailyAutomaticBackupStartTime))
 }
 
 func testAccAwsFsxLustreFileSystemConfigAutomaticBackupRetentionDays(retention int) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity                = 1200
   subnet_ids                      = ["${aws_subnet.test1.id}"]
@@ -995,32 +995,32 @@ resource "aws_fsx_lustre_file_system" "test" {
   per_unit_storage_throughput     = 50
   automatic_backup_retention_days = %[1]d
 }
-`, retention)
+`, retention))
 }
 
 func testAccAwsFsxLustreFileSystemDeploymentType(deploymentType string) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity = 1200
   subnet_ids       = [aws_subnet.test1.id]
   deployment_type  = %[1]q
 }
-`, deploymentType)
+`, deploymentType))
 }
 
 func testAccAwsFsxLustreFileSystemPersistentDeploymentType(perUnitStorageThroughput int) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity            = 1200
   subnet_ids                  = [aws_subnet.test1.id]
   deployment_type             = "PERSISTENT_1"
   per_unit_storage_throughput = %[1]d
 }
-`, perUnitStorageThroughput)
+`, perUnitStorageThroughput))
 }
 
 func testAccAwsFsxLustreFileSystemConfigKmsKeyId1() string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + `
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), `
 resource "aws_kms_key" "test1" {
   description             = "FSx KMS Testing key"
   deletion_window_in_days = 7
@@ -1033,11 +1033,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   per_unit_storage_throughput = 50
   kms_key_id                  = aws_kms_key.test1.arn
 }
-`
+`)
 }
 
 func testAccAwsFsxLustreFileSystemConfigKmsKeyId2() string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + `
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), `
 resource "aws_kms_key" "test2" {
   description             = "FSx KMS Testing key"
   deletion_window_in_days = 7
@@ -1050,11 +1050,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   per_unit_storage_throughput = 50
   kms_key_id                  = aws_kms_key.test2.arn
 }
-`
+`)
 }
 
 func testAccAwsFsxLustreFileSystemHddStorageType(drive_cache_type string) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity            = 6000
   subnet_ids                  = [aws_subnet.test1.id]
@@ -1063,11 +1063,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   storage_type                = "HDD"
   drive_cache_type            = %[1]q
 }
-`, drive_cache_type)
+`, drive_cache_type))
 }
 
 func testAccAwsFsxLustreFileSystemAutoImportPolicyConfig(rName, exportPrefix, policy string) string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   acl    = "private"
   bucket = %[1]q
@@ -1083,11 +1083,11 @@ resource "aws_fsx_lustre_file_system" "test" {
   subnet_ids         = [aws_subnet.test1.id]
   deployment_type    = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
 }
-`, rName, exportPrefix, policy)
+`, rName, exportPrefix, policy))
 }
 
 func testAccAwsFsxLustreFileSystemCopyTagsToBackups() string {
-	return testAccAwsFsxLustreFileSystemConfigBase() + `
+	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), `
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity            = 1200
   deployment_type             = "PERSISTENT_1"
@@ -1095,5 +1095,5 @@ resource "aws_fsx_lustre_file_system" "test" {
   per_unit_storage_throughput = 50
   copy_tags_to_backups        = true
 }
-`
+`)
 }

--- a/aws/resource_aws_fsx_lustre_file_system_test.go
+++ b/aws/resource_aws_fsx_lustre_file_system_test.go
@@ -754,6 +754,8 @@ func testAccCheckFsxLustreFileSystemRecreated(i, j *fsx.FileSystem) resource.Tes
 
 func testAccAwsFsxLustreFileSystemConfigBase() string {
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), `
+data "aws_partition" "current" {}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -773,8 +775,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-data "aws_partition" "current" {}
-
 resource "aws_fsx_lustre_file_system" "test" {
   export_path      = "s3://${aws_s3_bucket.test.bucket}%[2]s"
   import_path      = "s3://${aws_s3_bucket.test.bucket}"
@@ -792,8 +792,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-data "aws_partition" "current" {}
-
 resource "aws_fsx_lustre_file_system" "test" {
   import_path      = "s3://${aws_s3_bucket.test.bucket}%[2]s"
   storage_capacity = 1200
@@ -809,8 +807,6 @@ resource "aws_s3_bucket" "test" {
   acl    = "private"
   bucket = %[1]q
 }
-
-data "aws_partition" "current" {}
 
 resource "aws_fsx_lustre_file_system" "test" {
   import_path              = "s3://${aws_s3_bucket.test.bucket}"
@@ -842,8 +838,6 @@ resource "aws_security_group" "test1" {
     to_port     = 0
   }
 }
-
-data "aws_partition" "current" {}
 
 resource "aws_fsx_lustre_file_system" "test" {
   security_group_ids = [aws_security_group.test1.id]
@@ -894,8 +888,6 @@ resource "aws_security_group" "test2" {
   }
 }
 
-data "aws_partition" "current" {}
-
 resource "aws_fsx_lustre_file_system" "test" {
   security_group_ids = [aws_security_group.test1.id, aws_security_group.test2.id]
   storage_capacity   = 1200
@@ -907,8 +899,6 @@ resource "aws_fsx_lustre_file_system" "test" {
 
 func testAccAwsFsxLustreFileSystemConfigStorageCapacity(storageCapacity int) string {
 	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
-data "aws_partition" "current" {}
-
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity = %[1]d
   subnet_ids       = [aws_subnet.test1.id]
@@ -929,8 +919,6 @@ resource "aws_fsx_lustre_file_system" "test" {
 
 func testAccAwsFsxLustreFileSystemConfigTags1(tagKey1, tagValue1 string) string {
 	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
-data "aws_partition" "current" {}
-
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity = 1200
   subnet_ids       = [aws_subnet.test1.id]
@@ -945,8 +933,6 @@ resource "aws_fsx_lustre_file_system" "test" {
 
 func testAccAwsFsxLustreFileSystemConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
-data "aws_partition" "current" {}
-
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity = 1200
   subnet_ids       = [aws_subnet.test1.id]
@@ -962,8 +948,6 @@ resource "aws_fsx_lustre_file_system" "test" {
 
 func testAccAwsFsxLustreFileSystemConfigWeeklyMaintenanceStartTime(weeklyMaintenanceStartTime string) string {
 	return composeConfig(testAccAwsFsxLustreFileSystemConfigBase(), fmt.Sprintf(`
-data "aws_partition" "current" {}
-
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity              = 1200
   subnet_ids                    = [aws_subnet.test1.id]
@@ -1072,8 +1056,6 @@ resource "aws_s3_bucket" "test" {
   acl    = "private"
   bucket = %[1]q
 }
-
-data "aws_partition" "current" {}
 
 resource "aws_fsx_lustre_file_system" "test" {
   export_path        = "s3://${aws_s3_bucket.test.bucket}%[2]s"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17109

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### Output from acceptance testing (GovCloud):

```
    provider_test.go:742: skipping tests; current partition (aws-us-gov) does not equal aws
--- SKIP: TestAccAWSFsxLustreFileSystem_DeploymentTypeScratch1 (0.61s)
--- PASS: TestAccAWSFsxLustreFileSystem_dailyAutomaticBackupStartTime (493.89s)
--- PASS: TestAccAWSFsxLustreFileSystem_Tags (513.35s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageTypeHddDriveCacheNone (536.14s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageTypeHddDriveCacheRead (577.49s)
--- PASS: TestAccAWSFsxLustreFileSystem_basic (598.12s)
--- PASS: TestAccAWSFsxLustreFileSystem_disappears (616.66s)
--- PASS: TestAccAWSFsxLustreFileSystem_copyTagsToBackups (618.16s)
--- PASS: TestAccAWSFsxLustreFileSystem_WeeklyMaintenanceStartTime (637.07s)
--- PASS: TestAccAWSFsxLustreFileSystem_DeploymentTypePersistent1 (639.15s)
--- PASS: TestAccAWSFsxLustreFileSystem_automaticBackupRetentionDays (698.23s)
--- PASS: TestAccAWSFsxLustreFileSystem_KmsKeyId (851.27s)
--- PASS: TestAccAWSFsxLustreFileSystem_SecurityGroupIds (912.17s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportPath (989.44s)
--- PASS: TestAccAWSFsxLustreFileSystem_autoImportPolicy (1037.38s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageCapacity (1192.47s)
--- PASS: TestAccAWSFsxLustreFileSystem_ExportPath (1385.80s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportedFileChunkSize (1387.35s)
```

### Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSFsxLustreFileSystem_autoImportPolicy (1167.42s)
--- PASS: TestAccAWSFsxLustreFileSystem_automaticBackupRetentionDays (576.12s)
--- PASS: TestAccAWSFsxLustreFileSystem_basic (554.61s)
--- PASS: TestAccAWSFsxLustreFileSystem_copyTagsToBackups (617.93s)
--- PASS: TestAccAWSFsxLustreFileSystem_dailyAutomaticBackupStartTime (582.08s)
--- PASS: TestAccAWSFsxLustreFileSystem_DeploymentTypePersistent1 (575.19s)
--- PASS: TestAccAWSFsxLustreFileSystem_DeploymentTypeScratch1 (658.44s)
--- PASS: TestAccAWSFsxLustreFileSystem_disappears (585.33s)
--- PASS: TestAccAWSFsxLustreFileSystem_ExportPath (1146.08s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportedFileChunkSize (1357.11s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportPath (1356.10s)
--- PASS: TestAccAWSFsxLustreFileSystem_KmsKeyId (915.03s)
--- PASS: TestAccAWSFsxLustreFileSystem_SecurityGroupIds (947.36s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageCapacity (1358.53s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageTypeHddDriveCacheNone (596.69s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageTypeHddDriveCacheRead (671.54s)
--- PASS: TestAccAWSFsxLustreFileSystem_Tags (515.98s)
--- PASS: TestAccAWSFsxLustreFileSystem_WeeklyMaintenanceStartTime (672.14s)
```
