### PR TITLE
resource/aws_rds_cluster: Add db_instance_parameter_group_name argument

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -115,7 +115,10 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
+			"db_instance_parameter_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"deletion_protection": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -1122,6 +1125,11 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("allow_major_version_upgrade"); ok {
 		req.AllowMajorVersionUpgrade = aws.Bool(v.(bool))
+	}
+
+	if d.HasChange("db_instance_parameter_group_name") {
+		req.DBInstanceParameterGroupName = aws.String(d.Get("db_instance_parameter_group_name").(string))
+		requestUpdate = true
 	}
 
 	if d.HasChange("backtrack_window") {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

This PR adds the `db_instance_parameter_group_name` argument for `aws_rds_cluster` (see [ModifyDBCluster documentation](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBCluster.html#DBInstanceParameterGroupName)).  This parameter is required to perform major version upgrades. Not having this parameter set results in this error:

```
Error: Failed to modify RDS Cluster (my-cluster): InvalidParameterCombination: The current DB instance parameter group my-cluster-instance-pg is custom. You must explicitly specify a new DB instance parameter group, either default or custom, for the engine version upgrade.
        status code: 400, request id: xxxxx-xxxxxx-xxxxx-xxxxx
```