### PR TITLE
resource/aws_globalaccelerator_*: Timeouts for Global Accelerator resources

### DIFF
--- a/aws/resource_aws_globalaccelerator_accelerator.go
+++ b/aws/resource_aws_globalaccelerator_accelerator.go
@@ -29,6 +29,11 @@ func resourceAwsGlobalAcceleratorAccelerator() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -128,13 +133,13 @@ func resourceAwsGlobalAcceleratorAcceleratorCreate(d *schema.ResourceData, meta 
 
 	d.SetId(aws.StringValue(resp.Accelerator.AcceleratorArn))
 
-	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id())
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
 
 	if v := d.Get("attributes").([]interface{}); len(v) > 0 {
-		err = resourceAwsGlobalAcceleratorAcceleratorUpdateAttributes(conn, d.Id(), v[0].(map[string]interface{}))
+		err = resourceAwsGlobalAcceleratorAcceleratorUpdateAttributes(conn, d.Id(), d.Timeout(schema.TimeoutUpdate), v[0].(map[string]interface{}))
 		if err != nil {
 			return err
 		}
@@ -279,7 +284,7 @@ func resourceAwsGlobalAcceleratorAcceleratorUpdate(d *schema.ResourceData, meta 
 			return fmt.Errorf("Error updating Global Accelerator accelerator: %s", err)
 		}
 
-		err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id())
+		err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -287,7 +292,7 @@ func resourceAwsGlobalAcceleratorAcceleratorUpdate(d *schema.ResourceData, meta 
 
 	if d.HasChange("attributes") {
 		if v := d.Get("attributes").([]interface{}); len(v) > 0 {
-			err := resourceAwsGlobalAcceleratorAcceleratorUpdateAttributes(conn, d.Id(), v[0].(map[string]interface{}))
+			err := resourceAwsGlobalAcceleratorAcceleratorUpdateAttributes(conn, d.Id(), d.Timeout(schema.TimeoutUpdate), v[0].(map[string]interface{}))
 			if err != nil {
 				return err
 			}
@@ -305,12 +310,12 @@ func resourceAwsGlobalAcceleratorAcceleratorUpdate(d *schema.ResourceData, meta 
 	return resourceAwsGlobalAcceleratorAcceleratorRead(d, meta)
 }
 
-func resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn *globalaccelerator.GlobalAccelerator, acceleratorArn string) error {
+func resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn *globalaccelerator.GlobalAccelerator, acceleratorArn string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{globalaccelerator.AcceleratorStatusInProgress},
 		Target:  []string{globalaccelerator.AcceleratorStatusDeployed},
 		Refresh: resourceAwsGlobalAcceleratorAcceleratorStateRefreshFunc(conn, acceleratorArn),
-		Timeout: 10 * time.Minute,
+		Timeout: timeout,
 	}
 
 	log.Printf("[DEBUG] Waiting for Global Accelerator accelerator (%s) availability", acceleratorArn)
@@ -322,7 +327,7 @@ func resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn *globalacc
 	return nil
 }
 
-func resourceAwsGlobalAcceleratorAcceleratorUpdateAttributes(conn *globalaccelerator.GlobalAccelerator, acceleratorArn string, attributes map[string]interface{}) error {
+func resourceAwsGlobalAcceleratorAcceleratorUpdateAttributes(conn *globalaccelerator.GlobalAccelerator, acceleratorArn string, timeout time.Duration, attributes map[string]interface{}) error {
 	opts := &globalaccelerator.UpdateAcceleratorAttributesInput{
 		AcceleratorArn:  aws.String(acceleratorArn),
 		FlowLogsEnabled: aws.Bool(attributes["flow_logs_enabled"].(bool)),
@@ -341,6 +346,10 @@ func resourceAwsGlobalAcceleratorAcceleratorUpdateAttributes(conn *globalacceler
 	_, err := conn.UpdateAcceleratorAttributes(opts)
 	if err != nil {
 		return fmt.Errorf("Error updating Global Accelerator accelerator attributes: %s", err)
+	}
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn, timeout)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -362,7 +371,7 @@ func resourceAwsGlobalAcceleratorAcceleratorDelete(d *schema.ResourceData, meta 
 			return fmt.Errorf("Error disabling Global Accelerator accelerator: %s", err)
 		}
 
-		err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id())
+		err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}

--- a/aws/resource_aws_globalaccelerator_accelerator_test.go
+++ b/aws/resource_aws_globalaccelerator_accelerator_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/globalaccelerator"
@@ -71,7 +72,7 @@ func testSweepGlobalAcceleratorAccelerators(region string) error {
 
 			// Global Accelerator accelerators need to be in `DEPLOYED` state before they can be deleted.
 			// Removing listeners or disabling can both set the state to `IN_PROGRESS`.
-			if err := resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, arn); err != nil {
+			if err := resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, arn, 60*time.Minute); err != nil {
 				sweeperErr := fmt.Errorf("error waiting for Global Accelerator Accelerator (%s): %s", arn, err)
 				log.Printf("[ERROR] %s", sweeperErr)
 				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)

--- a/aws/resource_aws_globalaccelerator_endpoint_group.go
+++ b/aws/resource_aws_globalaccelerator_endpoint_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/globalaccelerator"
@@ -22,6 +23,12 @@ func resourceAwsGlobalAcceleratorEndpointGroup() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -199,7 +206,7 @@ func resourceAwsGlobalAcceleratorEndpointGroupCreate(d *schema.ResourceData, met
 		return err
 	}
 
-	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn)
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return err
@@ -311,7 +318,7 @@ func resourceAwsGlobalAcceleratorEndpointGroupUpdate(d *schema.ResourceData, met
 		return err
 	}
 
-	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn)
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn, d.Timeout(schema.TimeoutUpdate))
 
 	if err != nil {
 		return err
@@ -343,7 +350,7 @@ func resourceAwsGlobalAcceleratorEndpointGroupDelete(d *schema.ResourceData, met
 		return err
 	}
 
-	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn)
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn, d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
 		return err

--- a/website/docs/r/globalaccelerator_accelerator.markdown
+++ b/website/docs/r/globalaccelerator_accelerator.markdown
@@ -60,6 +60,14 @@ In addition to all arguments above, the following attributes are exported:
 
 [1]: https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html
 
+## Timeouts
+
+`aws_globalaccelerator_accelerator` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Default `30 minutes`) How long to wait for the Global Accelerator Accelerator to be created.
+* `update` - (Default `30 minutes`) How long to wait for the Global Accelerator Accelerator to be updated.
+
 ## Import
 
 Global Accelerator accelerators can be imported using the `id`, e.g.

--- a/website/docs/r/globalaccelerator_endpoint_group.html.markdown
+++ b/website/docs/r/globalaccelerator_endpoint_group.html.markdown
@@ -58,6 +58,13 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The Amazon Resource Name (ARN) of the endpoint group.
 * `arn` - The Amazon Resource Name (ARN) of the endpoint group.
 
+`aws_globalaccelerator_endpoint_group` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Default `30 minutes`) How long to wait for the Global Accelerator Endpoint Group to be created.
+* `update` - (Default `30 minutes`) How long to wait for the Global Accelerator Endpoint Group to be updated.
+* `delete` - (Default `30 minutes`) How long to wait for the Global Accelerator Endpoint Group to be deleted.
+
 ## Import
 
 Global Accelerator endpoint groups can be imported using the `id`, e.g.

--- a/website/docs/r/globalaccelerator_listener.markdown
+++ b/website/docs/r/globalaccelerator_listener.markdown
@@ -57,6 +57,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Amazon Resource Name (ARN) of the listener.
 
+`aws_globalaccelerator_listener` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Default `30 minutes`) How long to wait for the Global Accelerator Listener to be created.
+* `update` - (Default `30 minutes`) How long to wait for the Global Accelerator Listener to be updated.
+* `delete` - (Default `30 minutes`) How long to wait for the Global Accelerator Listener to be deleted.
+
 ## Import
 
 Global Accelerator listeners can be imported using the `id`, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17048 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add Timeouts to AWS Global Accelerator resources
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsGlobalAccelerator'           
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsGlobalAccelerator -timeout 120m
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_basic
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_basic
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_update
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_update
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_attributes
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_attributes
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_tags
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_tags
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_basic
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_basic
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_disappears
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_disappears
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_Update
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_Update
=== RUN   TestAccAwsGlobalAcceleratorListener_basic
=== PAUSE TestAccAwsGlobalAcceleratorListener_basic
=== RUN   TestAccAwsGlobalAcceleratorListener_update
=== PAUSE TestAccAwsGlobalAcceleratorListener_update
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_basic
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_basic
=== CONT  TestAccAwsGlobalAcceleratorListener_update
=== CONT  TestAccAwsGlobalAcceleratorListener_basic
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_attributes
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_update
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_Update
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_tags
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_disappears
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_basic (81.60s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_attributes (95.73s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_tags (115.54s)
--- PASS: TestAccAwsGlobalAcceleratorListener_basic (130.25s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_update (131.40s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion (152.70s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol (160.97s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_disappears (167.98s)
--- PASS: TestAccAwsGlobalAcceleratorListener_update (170.39s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_basic (181.54s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_Update (192.80s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides (221.51s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint (566.37s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP (726.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       726.201s

...
```

This PR adds user customisable timeouts to the AWS Global Accelerator resources. Currently the timeout is set to `30 minutes` for all operations in response to feedback on #17048.

Please note that a delete timeout has not been added to `aws_globalaccelerator_accelerator` as the deletion process involves disabling it first (covered by update timeout), after which deletion is rapid.