### PR TITLE
tests/workspaces - Add GovCloud related prechecks to workspaces directory datasource

### DIFF
--- a/aws/data_source_aws_workspaces_directory_test.go
+++ b/aws/data_source_aws_workspaces_directory_test.go
@@ -15,7 +15,12 @@ func TestAccDataSourceAwsWorkspacesDirectory_basic(t *testing.T) {
 	dataSourceName := "data.aws_workspaces_directory.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

These prechecks will make the test skip if SimpleAD is not present in the run partition.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16688

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsWorkspacesDirectory_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWorkspacesDirectory_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWorkspacesDirectory_basic
=== PAUSE TestAccDataSourceAwsWorkspacesDirectory_basic
=== CONT  TestAccDataSourceAwsWorkspacesDirectory_basic
    resource_aws_directory_service_directory_test.go:483: skipping acceptance testing: ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 7e9c8ec6-a978-4309-a272-d0f19f9acac1 : RequestId: 7e9c8ec6-a978-4309-a272-d0f19f9acac1
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "7e9c8ec6-a978-4309-a272-d0f19f9acac1"
          },
          Message_: "Simple AD directory creation is currently not supported in this region. : RequestId: 7e9c8ec6-a978-4309-a272-d0f19f9acac1 : RequestId: 7e9c8ec6-a978-4309-a272-d0f19f9acac1",
          RequestId: "7e9c8ec6-a978-4309-a272-d0f19f9acac1"
        }
--- SKIP: TestAccDataSourceAwsWorkspacesDirectory_basic (0.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.907s

```

### References:

 - #15129
