### PR TITLE
r/sagemaker_user_profile - new resource

### DIFF
--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -80,3 +80,23 @@ func FeatureGroupByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Desc
 
 	return output, nil
 }
+
+// UserProfileByName returns the domain corresponding to the specified domain id.
+// Returns nil if no domain is found.
+func UserProfileByName(conn *sagemaker.SageMaker, domainID, userProfileName string) (*sagemaker.DescribeUserProfileOutput, error) {
+	input := &sagemaker.DescribeUserProfileInput{
+		DomainId:        aws.String(domainID),
+		UserProfileName: aws.String(userProfileName),
+	}
+
+	output, err := conn.DescribeUserProfile(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output, nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -884,6 +884,7 @@ func Provider() *schema.Provider {
 			"aws_sagemaker_model":                                     resourceAwsSagemakerModel(),
 			"aws_sagemaker_notebook_instance_lifecycle_configuration": resourceAwsSagemakerNotebookInstanceLifeCycleConfiguration(),
 			"aws_sagemaker_notebook_instance":                         resourceAwsSagemakerNotebookInstance(),
+			"aws_sagemaker_user_profile":                              resourceAwsSagemakerUserProfile(),
 			"aws_secretsmanager_secret":                               resourceAwsSecretsManagerSecret(),
 			"aws_secretsmanager_secret_policy":                        resourceAwsSecretsManagerSecretPolicy(),
 			"aws_secretsmanager_secret_version":                       resourceAwsSecretsManagerSecretVersion(),

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -360,6 +360,9 @@ func resourceAwsSagemakerDomainDelete(d *schema.ResourceData, meta interface{}) 
 
 	input := &sagemaker.DeleteDomainInput{
 		DomainId: aws.String(d.Id()),
+		RetentionPolicy: &sagemaker.RetentionPolicy{
+			HomeEfsFileSystem: aws.String(sagemaker.RetentionTypeDelete),
+		},
 	}
 
 	if _, err := conn.DeleteDomain(input); err != nil {

--- a/aws/resource_aws_sagemaker_user_profile.go
+++ b/aws/resource_aws_sagemaker_user_profile.go
@@ -45,13 +45,15 @@ func resourceAwsSagemakerUserProfile() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"single_sign_on_user_indentifier": {
+			"single_sign_on_user_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"single_sign_on_user_value": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"user_settings": {
 				Type:     schema.TypeList,
@@ -227,7 +229,7 @@ func resourceAwsSagemakerUserProfileCreate(d *schema.ResourceData, meta interfac
 		input.UserSettings = expandSagemakerDomainDefaultUserSettings(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("single_sign_on_user_indentifier"); ok {
+	if v, ok := d.GetOk("single_sign_on_user_identifier"); ok {
 		input.SingleSignOnUserIdentifier = aws.String(v.(string))
 	}
 
@@ -273,28 +275,28 @@ func resourceAwsSagemakerUserProfileRead(d *schema.ResourceData, meta interface{
 	if err != nil {
 		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
 			d.SetId("")
-			log.Printf("[WARN] Unable to find SageMaker UserProfile (%s), removing from state", d.Id())
+			log.Printf("[WARN] Unable to find SageMaker User Profile (%s), removing from state", d.Id())
 			return nil
 		}
-		return fmt.Errorf("error reading SageMaker UserProfile (%s): %w", d.Id(), err)
+		return fmt.Errorf("error reading SageMaker User Profile (%s): %w", d.Id(), err)
 	}
 
 	arn := aws.StringValue(UserProfile.UserProfileArn)
 	d.Set("user_profile_name", UserProfile.UserProfileName)
 	d.Set("domain_id", UserProfile.DomainId)
-	d.Set("single_sign_on_user_indentifier", UserProfile.SingleSignOnUserIdentifier)
+	d.Set("single_sign_on_user_identifier", UserProfile.SingleSignOnUserIdentifier)
 	d.Set("single_sign_on_user_value", UserProfile.SingleSignOnUserValue)
 	d.Set("arn", arn)
 	d.Set("home_efs_file_system_uid", UserProfile.HomeEfsFileSystemUid)
 
 	if err := d.Set("user_settings", flattenSagemakerDomainDefaultUserSettings(UserProfile.UserSettings)); err != nil {
-		return fmt.Errorf("error setting user_settings for SageMaker UserProfile (%s): %w", d.Id(), err)
+		return fmt.Errorf("error setting user_settings for SageMaker User Profile (%s): %w", d.Id(), err)
 	}
 
 	tags, err := keyvaluetags.SagemakerListTags(conn, arn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for SageMaker UserProfile (%s): %w", d.Id(), err)
+		return fmt.Errorf("error listing tags for SageMaker User Profile (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
@@ -317,7 +319,7 @@ func resourceAwsSagemakerUserProfileUpdate(d *schema.ResourceData, meta interfac
 		log.Printf("[DEBUG] SageMaker User Profile update config: %#v", *input)
 		_, err := conn.UpdateUserProfile(input)
 		if err != nil {
-			return fmt.Errorf("error updating SageMaker UserProfile: %w", err)
+			return fmt.Errorf("error updating SageMaker User Profile: %w", err)
 		}
 	}
 
@@ -345,13 +347,13 @@ func resourceAwsSagemakerUserProfileDelete(d *schema.ResourceData, meta interfac
 
 	if _, err := conn.DeleteUserProfile(input); err != nil {
 		if !isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
-			return fmt.Errorf("error deleting SageMaker UserProfile (%s): %w", d.Id(), err)
+			return fmt.Errorf("error deleting SageMaker User Profile (%s): %w", d.Id(), err)
 		}
 	}
 
 	if _, err := waiter.UserProfileDeleted(conn, domainID, userProfileName); err != nil {
 		if !isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
-			return fmt.Errorf("error waiting for SageMaker UserProfile (%s) to delete: %w", d.Id(), err)
+			return fmt.Errorf("error waiting for SageMaker User Profile (%s) to delete: %w", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_sagemaker_user_profile.go
+++ b/aws/resource_aws_sagemaker_user_profile.go
@@ -1,0 +1,378 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/waiter"
+)
+
+func resourceAwsSagemakerUserProfile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerUserProfileCreate,
+		Read:   resourceAwsSagemakerUserProfileRead,
+		Update: resourceAwsSagemakerUserProfileUpdate,
+		Delete: resourceAwsSagemakerUserProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_profile_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 63),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,62}`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
+				),
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"single_sign_on_user_indentifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"single_sign_on_user_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_settings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"security_groups": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 5,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"execution_role": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"sharing_settings": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"notebook_output_option": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      sagemaker.NotebookOutputOptionDisabled,
+										ValidateFunc: validation.StringInSlice(sagemaker.NotebookOutputOption_Values(), false),
+									},
+									"s3_kms_key_id": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateArn,
+									},
+									"s3_output_path": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"tensor_board_app_settings": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"jupyter_server_app_settings": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"kernel_gateway_app_settings": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+												},
+											},
+										},
+									},
+									"custom_image": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 30,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"app_image_config_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"image_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"image_version_number": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"tags": tagsSchema(),
+			"home_efs_file_system_uid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSagemakerUserProfileCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	input := &sagemaker.CreateUserProfileInput{
+		UserProfileName: aws.String(d.Get("user_profile_name").(string)),
+		DomainId:        aws.String(d.Get("domain_id").(string)),
+	}
+
+	if v, ok := d.GetOk("user_settings"); ok {
+		input.UserSettings = expandSagemakerDomainDefaultUserSettings(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("single_sign_on_user_indentifier"); ok {
+		input.SingleSignOnUserIdentifier = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("single_sign_on_user_value"); ok {
+		input.SingleSignOnUserValue = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SagemakerTags()
+	}
+
+	log.Printf("[DEBUG] SageMaker User Profile create config: %#v", *input)
+	output, err := conn.CreateUserProfile(input)
+	if err != nil {
+		return fmt.Errorf("error creating SageMaker User Profile: %w", err)
+	}
+
+	userProfileArn := aws.StringValue(output.UserProfileArn)
+	domainID, userProfileName, err := decodeSagemakerUserProfileName(userProfileArn)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(userProfileArn)
+
+	if _, err := waiter.UserProfileInService(conn, domainID, userProfileName); err != nil {
+		return fmt.Errorf("error waiting for SageMaker User Profile (%s) to create: %w", d.Id(), err)
+	}
+
+	return resourceAwsSagemakerUserProfileRead(d, meta)
+}
+
+func resourceAwsSagemakerUserProfileRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	domainID, userProfileName, err := decodeSagemakerUserProfileName(d.Id())
+	if err != nil {
+		return err
+	}
+
+	UserProfile, err := finder.UserProfileByName(conn, domainID, userProfileName)
+	if err != nil {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
+			d.SetId("")
+			log.Printf("[WARN] Unable to find SageMaker UserProfile (%s), removing from state", d.Id())
+			return nil
+		}
+		return fmt.Errorf("error reading SageMaker UserProfile (%s): %w", d.Id(), err)
+	}
+
+	arn := aws.StringValue(UserProfile.UserProfileArn)
+	d.Set("user_profile_name", UserProfile.UserProfileName)
+	d.Set("domain_id", UserProfile.DomainId)
+	d.Set("single_sign_on_user_indentifier", UserProfile.SingleSignOnUserIdentifier)
+	d.Set("single_sign_on_user_value", UserProfile.SingleSignOnUserValue)
+	d.Set("arn", arn)
+	d.Set("home_efs_file_system_uid", UserProfile.HomeEfsFileSystemUid)
+
+	if err := d.Set("user_settings", flattenSagemakerDomainDefaultUserSettings(UserProfile.UserSettings)); err != nil {
+		return fmt.Errorf("error setting user_settings for SageMaker UserProfile (%s): %w", d.Id(), err)
+	}
+
+	tags, err := keyvaluetags.SagemakerListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for SageMaker UserProfile (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsSagemakerUserProfileUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	if d.HasChange("user_settings") {
+		input := &sagemaker.UpdateUserProfileInput{
+			UserProfileName: aws.String(d.Get("user_profile_name").(string)),
+			DomainId:        aws.String(d.Get("domain_id").(string)),
+			UserSettings:    expandSagemakerDomainDefaultUserSettings(d.Get("user_settings").([]interface{})),
+		}
+
+		log.Printf("[DEBUG] SageMaker User Profile update config: %#v", *input)
+		_, err := conn.UpdateUserProfile(input)
+		if err != nil {
+			return fmt.Errorf("error updating SageMaker UserProfile: %w", err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.SagemakerUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating SageMaker UserProfile (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsSagemakerUserProfileRead(d, meta)
+}
+
+func resourceAwsSagemakerUserProfileDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	userProfileName := d.Get("user_profile_name").(string)
+	domainID := d.Get("domain_id").(string)
+
+	input := &sagemaker.DeleteUserProfileInput{
+		UserProfileName: aws.String(userProfileName),
+		DomainId:        aws.String(domainID),
+	}
+
+	if _, err := conn.DeleteUserProfile(input); err != nil {
+		if !isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
+			return fmt.Errorf("error deleting SageMaker UserProfile (%s): %w", d.Id(), err)
+		}
+	}
+
+	if _, err := waiter.UserProfileDeleted(conn, domainID, userProfileName); err != nil {
+		if !isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
+			return fmt.Errorf("error waiting for SageMaker UserProfile (%s) to delete: %w", d.Id(), err)
+		}
+	}
+
+	return nil
+}
+
+func decodeSagemakerUserProfileName(id string) (string, string, error) {
+	userProfileARN, err := arn.Parse(id)
+	if err != nil {
+		return "", "", err
+	}
+
+	userProfileResourceNameName := strings.TrimPrefix(userProfileARN.Resource, "user-profile/")
+	parts := strings.Split(userProfileResourceNameName, "/")
+
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Unexpected format of ID (%q), expected DOMAIN-ID/USER-PROFILE-NAME", userProfileResourceNameName)
+	}
+
+	domainID := parts[0]
+	userProfileName := parts[1]
+
+	return domainID, userProfileName, nil
+}

--- a/aws/resource_aws_sagemaker_user_profile_test.go
+++ b/aws/resource_aws_sagemaker_user_profile_test.go
@@ -369,7 +369,7 @@ resource "aws_sagemaker_domain" "test" {
   auth_mode   = "IAM"
   vpc_id      = aws_vpc.test.id
   subnet_ids  = [aws_subnet.test.id]
-  
+
   default_user_settings {
     execution_role = aws_iam_role.test.arn
   }
@@ -482,7 +482,7 @@ resource "aws_sagemaker_user_profile" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = %[1]q
 
- user_settings {
+  user_settings {
     execution_role = aws_iam_role.test.arn
 
     kernel_gateway_app_settings {

--- a/aws/resource_aws_sagemaker_user_profile_test.go
+++ b/aws/resource_aws_sagemaker_user_profile_test.go
@@ -1,0 +1,496 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_sagemaker_user_profile", &resource.Sweeper{
+		Name: "aws_sagemaker_user_profile",
+		F:    testSweepSagemakerUserProfiles,
+		Dependencies: []string{
+			"aws_efs_mount_target",
+			"aws_efs_file_system",
+		},
+	})
+}
+
+func testSweepSagemakerUserProfiles(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sagemakerconn
+
+	err = conn.ListUserProfilesPages(&sagemaker.ListUserProfilesInput{}, func(page *sagemaker.ListUserProfilesOutput, lastPage bool) bool {
+		for _, instance := range page.UserProfiles {
+			input := &sagemaker.DeleteUserProfileInput{
+				UserProfileName: instance.UserProfileName,
+				DomainId:        instance.DomainId,
+			}
+
+			userProfile := aws.StringValue(instance.UserProfileName)
+			log.Printf("[INFO] Deleting SageMaker User Profile: %s", userProfile)
+			if _, err := conn.DeleteUserProfile(input); err != nil {
+				log.Printf("[ERROR] Error deleting SageMaker User Profile (%s): %s", userProfile, err)
+				continue
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping SageMaker domain sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving SageMaker domains: %w", err)
+	}
+
+	return nil
+}
+
+func TestAccAWSSagemakerUserProfile_basic(t *testing.T) {
+	var domain sagemaker.DescribeUserProfileOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_user_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerUserProfileBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerUserProfileExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "user_profile_name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_id", "aws_sagemaker_domain.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "0"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "sagemaker", regexp.MustCompile(`user-profile/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "home_efs_file_system_uid"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerUserProfile_tags(t *testing.T) {
+	var domain sagemaker.DescribeUserProfileOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_user_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerUserProfileConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerUserProfileExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSagemakerUserProfileConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerUserProfileExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSagemakerUserProfileConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerUserProfileExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerUserProfile_tensorboardAppSettings(t *testing.T) {
+	var domain sagemaker.DescribeUserProfileOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_user_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerUserProfileConfigTensorBoardAppSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerUserProfileExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.tensor_board_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.tensor_board_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.tensor_board_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerUserProfile_tensorboardAppSettingsWithImage(t *testing.T) {
+	var domain sagemaker.DescribeUserProfileOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_user_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerUserProfileConfigTensorBoardAppSettingsWithImage(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerUserProfileExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.tensor_board_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.tensor_board_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.tensor_board_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_settings.0.tensor_board_app_settings.0.default_resource_spec.0.sagemaker_image_arn", "aws_sagemaker_image.test", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerUserProfile_kernelGatewayAppSettings(t *testing.T) {
+	var domain sagemaker.DescribeUserProfileOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_user_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerUserProfileConfigKernelGatewayAppSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerUserProfileExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.kernel_gateway_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerUserProfile_jupyterServerAppSettings(t *testing.T) {
+	var domain sagemaker.DescribeUserProfileOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_user_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerUserProfileConfigJupyterServerAppSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerUserProfileExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerUserProfile_disappears(t *testing.T) {
+	var domain sagemaker.DescribeUserProfileOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_user_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerUserProfileBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerUserProfileExists(resourceName, &domain),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerUserProfile(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSagemakerUserProfileDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_user_settings" {
+			continue
+		}
+
+		domainID := rs.Primary.Attributes["domain_id"]
+		userProfileName := rs.Primary.Attributes["user_profile_name"]
+
+		userProfile, err := finder.UserProfileByName(conn, domainID, userProfileName)
+		if err != nil {
+			return nil
+		}
+
+		userProfileArn := aws.StringValue(userProfile.UserProfileArn)
+		if userProfileArn == rs.Primary.ID {
+			return fmt.Errorf("SageMaker User Profile %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSSagemakerUserProfileExists(n string, userProfile *sagemaker.DescribeUserProfileOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No sagmaker domain ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+		domainID := rs.Primary.Attributes["domain_id"]
+		userProfileName := rs.Primary.Attributes["user_profile_name"]
+
+		resp, err := finder.UserProfileByName(conn, domainID, userProfileName)
+		if err != nil {
+			return err
+		}
+
+		*userProfile = *resp
+
+		return nil
+	}
+}
+
+func testAccAWSSagemakerUserProfileConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.1.0/24"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = [aws_subnet.test.id]
+  
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+  }
+}
+`, rName)
+}
+
+func testAccAWSSagemakerUserProfileBasicConfig(rName string) string {
+	return testAccAWSSagemakerUserProfileConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_user_profile" "test" {
+  domain_id         = aws_sagemaker_domain.test.id
+  user_profile_name = %[1]q
+}
+`, rName)
+}
+
+func testAccAWSSagemakerUserProfileConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccAWSSagemakerUserProfileConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_user_profile" "test" {
+  domain_id         = aws_sagemaker_domain.test.id
+  user_profile_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSSagemakerUserProfileConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSSagemakerUserProfileConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_user_profile" "test" {
+  domain_id         = aws_sagemaker_domain.test.id
+  user_profile_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAWSSagemakerUserProfileConfigTensorBoardAppSettings(rName string) string {
+	return testAccAWSSagemakerUserProfileConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_user_profile" "test" {
+  domain_id         = aws_sagemaker_domain.test.id
+  user_profile_name = %[1]q
+
+  user_settings {
+    execution_role = aws_iam_role.test.arn
+
+    tensor_board_app_settings {
+      default_resource_spec {
+        instance_type = "ml.t3.micro"
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSSagemakerUserProfileConfigTensorBoardAppSettingsWithImage(rName string) string {
+	return testAccAWSSagemakerUserProfileConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_image" "test" {
+  image_name = %[1]q
+  role_arn   = aws_iam_role.test.arn
+}
+
+resource "aws_sagemaker_user_profile" "test" {
+  domain_id         = aws_sagemaker_domain.test.id
+  user_profile_name = %[1]q
+
+  user_settings {
+    execution_role = aws_iam_role.test.arn
+
+    tensor_board_app_settings {
+      default_resource_spec {
+        instance_type       = "ml.t3.micro"
+        sagemaker_image_arn = aws_sagemaker_image.test.arn
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSSagemakerUserProfileConfigJupyterServerAppSettings(rName string) string {
+	return testAccAWSSagemakerUserProfileConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_user_profile" "test" {
+  domain_id         = aws_sagemaker_domain.test.id
+  user_profile_name = %[1]q
+
+  user_settings {
+    execution_role = aws_iam_role.test.arn
+
+    jupyter_server_app_settings {
+      default_resource_spec {
+        instance_type = "ml.t3.micro"
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSSagemakerUserProfileConfigKernelGatewayAppSettings(rName string) string {
+	return testAccAWSSagemakerUserProfileConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_user_profile" "test" {
+  domain_id         = aws_sagemaker_domain.test.id
+  user_profile_name = %[1]q
+
+ user_settings {
+    execution_role = aws_iam_role.test.arn
+
+    kernel_gateway_app_settings {
+      default_resource_spec {
+        instance_type = "ml.t3.micro"
+      }
+    }
+  }
+}
+`, rName)
+}

--- a/website/docs/r/sagemaker_user_profile.html.markdown
+++ b/website/docs/r/sagemaker_user_profile.html.markdown
@@ -19,23 +19,6 @@ resource "aws_sagemaker_user_profile" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = %[1]q
 }
-
-resource "aws_iam_role" "example" {
-  name               = "example"
-  path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.example.json
-}
-
-data "aws_iam_policy_document" "example" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["sagemaker.amazonaws.com"]
-    }
-  }
-}
 ```
 
 ## Argument Reference

--- a/website/docs/r/sagemaker_user_profile.html.markdown
+++ b/website/docs/r/sagemaker_user_profile.html.markdown
@@ -15,9 +15,9 @@ Provides a Sagemaker User Profile resource.
 ### Basic usage
 
 ```hcl
-resource "aws_sagemaker_user_profile" "test" {
+resource "aws_sagemaker_user_profile" "example" {
   domain_id         = aws_sagemaker_domain.test.id
-  user_profile_name = %[1]q
+  user_profile_name = "example"
 }
 ```
 

--- a/website/docs/r/sagemaker_user_profile.html.markdown
+++ b/website/docs/r/sagemaker_user_profile.html.markdown
@@ -1,0 +1,106 @@
+---
+subcategory: "Sagemaker"
+layout: "aws"
+page_title: "AWS: aws_sagemaker_user_profile"
+description: |-
+  Provides a Sagemaker User Profile resource.
+---
+
+# Resource: aws_sagemaker_user_profile
+
+Provides a Sagemaker User Profile resource.
+
+## Example Usage
+
+### Basic usage
+
+```hcl
+resource "aws_sagemaker_user_profile" "test" {
+  domain_id         = aws_sagemaker_domain.test.id
+  user_profile_name = %[1]q
+}
+
+resource "aws_iam_role" "example" {
+  name               = "example"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.example.json
+}
+
+data "aws_iam_policy_document" "example" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.amazonaws.com"]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `user_profile_name` - (Required) The name for the User Profile.
+* `domain_id` - (Required) The ID of the associated Domain.
+* `single_sign_on_user_indentifier` - (Optional) A specifier for the type of value specified in `single_sign_on_user_value`. Currently, the only supported value is `UserName`. If the Domain's AuthMode is SSO, this field is required. If the Domain's AuthMode is not SSO, this field cannot be specified.
+* `single_sign_on_user_value` - (Required) The username of the associated AWS Single Sign-On User for this UserProfile. If the Domain's AuthMode is SSO, this field is required, and must match a valid username of a user in your directory. If the Domain's AuthMode is not SSO, this field cannot be specified.
+* `user_settings` - (Required) The user settings. See [User Settings](#user-settings) below.
+* `tags` - (Optional) A map of tags to assign to the resource.
+
+### User Settings
+
+* `execution_role` - (Required) The execution role ARN for the user.
+* `security_groups` - (Optional) The security groups.
+* `sharing_settings` - (Optional) The sharing settings. See [Sharing Settings](#sharing-settings) below.
+* `tensor_board_app_settings` - (Optional) The TensorBoard app settings. See [TensorBoard App Settings](#tensorboard-app-settings) below.
+* `jupyter_server_app_settings` - (Optional) The Jupyter server's app settings. See [Jupyter Server App Settings](#jupyter-server-app-settings) below.
+* `kernel_gateway_app_settings` - (Optional) The kernel gateway app settings. See [Kernel Gateway App Settings](#kernal-gateway-app-settings) below.
+
+#### Sharing Settings
+
+* `notebook_output_option` - (Optional) Whether to include the notebook cell output when sharing the notebook. The default is `Disabled`. Valid values are `Allowed` and `Disabled`.
+* `s3_kms_key_id` - (Optional) When `notebook_output_option` is Allowed, the AWS Key Management Service (KMS) encryption key ID used to encrypt the notebook cell output in the Amazon S3 bucket.
+* `s3_output_path` - (Optional) When `notebook_output_option` is Allowed, the Amazon S3 bucket used to save the notebook cell output.
+
+#### TensorBoard App Settings
+
+* `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
+
+#### Kernel Gateway App Settings
+
+* `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
+* `custom_image` - (Optional) A list of custom SageMaker images that are configured to run as a KernelGateway app. see [Custom Image](#custom-image) below.
+
+#### Jupyter Server App Settings
+
+* `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
+
+##### Default Resource Spec
+
+* `instance_type` - (Optional) The instance type.
+* `sagemaker_image_arn` - (Optional) The Amazon Resource Name (ARN) of the SageMaker image created on the instance.
+
+##### Custom Image
+
+* `app_image_config_name` - (Required) The name of the App Image Config.
+* `image_name` - (Required) The name of the Custom Image.
+* `image_version_number` - (Optional) The version number of the Custom Image.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The user profile Amazon Resource Name (ARN).
+* `arn` - The user profile Amazon Resource Name (ARN).
+* `home_efs_file_system_uid` - The ID of the user's profile in the Amazon Elastic File System (EFS) volume.
+
+
+## Import
+
+Sagemaker Code User Profiles can be imported using the `arn`, e.g.
+
+```
+$ terraform import aws_sagemaker_user_profile.test_user_profile arn:aws:sagemaker:us-west-2:123456789012:user-profile/domain-id/profile-name
+```

--- a/website/docs/r/sagemaker_user_profile.html.markdown
+++ b/website/docs/r/sagemaker_user_profile.html.markdown
@@ -27,8 +27,8 @@ The following arguments are supported:
 
 * `user_profile_name` - (Required) The name for the User Profile.
 * `domain_id` - (Required) The ID of the associated Domain.
-* `single_sign_on_user_indentifier` - (Optional) A specifier for the type of value specified in `single_sign_on_user_value`. Currently, the only supported value is `UserName`. If the Domain's AuthMode is SSO, this field is required. If the Domain's AuthMode is not SSO, this field cannot be specified.
-* `single_sign_on_user_value` - (Required) The username of the associated AWS Single Sign-On User for this UserProfile. If the Domain's AuthMode is SSO, this field is required, and must match a valid username of a user in your directory. If the Domain's AuthMode is not SSO, this field cannot be specified.
+* `single_sign_on_user_identifier` - (Optional) A specifier for the type of value specified in `single_sign_on_user_value`. Currently, the only supported value is `UserName`. If the Domain's AuthMode is SSO, this field is required. If the Domain's AuthMode is not SSO, this field cannot be specified.
+* `single_sign_on_user_value` - (Required) The username of the associated AWS Single Sign-On User for this User Profile. If the Domain's AuthMode is SSO, this field is required, and must match a valid username of a user in your directory. If the Domain's AuthMode is not SSO, this field cannot be specified.
 * `user_settings` - (Required) The user settings. See [User Settings](#user-settings) below.
 * `tags` - (Optional) A map of tags to assign to the resource.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14453

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sagemaker_domain - delete implicit EFS file system
resource_aws_sagemaker_user_profile - add new resource


```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerUserProfile_'
--- PASS: TestAccAWSSagemakerUserProfile_basic (362.62s)
--- PASS: TestAccAWSSagemakerUserProfile_kernelGatewayAppSettings (265.57s)
--- PASS: TestAccAWSSagemakerUserProfile_disappears (377.09s)
--- PASS: TestAccAWSSagemakerUserProfile_jupyterServerAppSettings (325.61s)
--- PASS: TestAccAWSSagemakerUserProfile_tensorboardAppSettings (274.40s)
--- PASS: TestAccAWSSagemakerUserProfile_tensorboardAppSettingsWithImage (335.52s)
--- PASS: TestAccAWSSagemakerUserProfile_tags (357.21s)
```
