### PR TITLE
resource/aws_ec2_capacity_reservation: Fix to set ARN from its response and add owner_id attribute

### DIFF
--- a/aws/resource_aws_ec2_capacity_reservation.go
+++ b/aws/resource_aws_ec2_capacity_reservation.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -209,22 +208,14 @@ func resourceAwsEc2CapacityReservationRead(d *schema.ResourceData, meta interfac
 	d.Set("instance_match_criteria", reservation.InstanceMatchCriteria)
 	d.Set("instance_platform", reservation.InstancePlatform)
 	d.Set("instance_type", reservation.InstanceType)
+	d.Set("owner_id", reservation.OwnerId)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(reservation.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	d.Set("tenancy", reservation.Tenancy)
-
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "ec2",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("capacity-reservation/%s", d.Id()),
-	}.String()
-
-	d.Set("arn", arn)
+	d.Set("arn", reservation.CapacityReservationArn)
 
 	return nil
 }

--- a/aws/resource_aws_ec2_capacity_reservation.go
+++ b/aws/resource_aws_ec2_capacity_reservation.go
@@ -97,6 +97,10 @@ func resourceAwsEc2CapacityReservation() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tagsSchema(),
 			"tenancy": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_ec2_capacity_reservation_test.go
+++ b/aws/resource_aws_ec2_capacity_reservation_test.go
@@ -88,7 +88,7 @@ func TestAccAWSEc2CapacityReservation_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_match_criteria", "open"),
 					resource.TestCheckResourceAttr(resourceName, "instance_platform", "Linux/UNIX"),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.micro"),
-					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tenancy", "default"),
 				),

--- a/aws/resource_aws_ec2_capacity_reservation_test.go
+++ b/aws/resource_aws_ec2_capacity_reservation_test.go
@@ -88,6 +88,7 @@ func TestAccAWSEc2CapacityReservation_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_match_criteria", "open"),
 					resource.TestCheckResourceAttr(resourceName, "instance_platform", "Linux/UNIX"),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.micro"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tenancy", "default"),
 				),

--- a/website/docs/r/ec2_capacity_reservation.html.markdown
+++ b/website/docs/r/ec2_capacity_reservation.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Capacity Reservation ID.
+* `owner_id` - The ID of the AWS account that owns the Capacity Reservation.
 * `arn` - The ARN of the Capacity Reservation.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16978

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_ec2_capacity_reservation: Add owner_id attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2CapacityReservation_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2CapacityReservation_* -timeout 120m
=== RUN   TestAccAWSEc2CapacityReservation_basic
=== PAUSE TestAccAWSEc2CapacityReservation_basic
=== RUN   TestAccAWSEc2CapacityReservation_ebsOptimized
=== PAUSE TestAccAWSEc2CapacityReservation_ebsOptimized
=== RUN   TestAccAWSEc2CapacityReservation_endDate
=== PAUSE TestAccAWSEc2CapacityReservation_endDate
=== RUN   TestAccAWSEc2CapacityReservation_endDateType
=== PAUSE TestAccAWSEc2CapacityReservation_endDateType
=== RUN   TestAccAWSEc2CapacityReservation_ephemeralStorage
=== PAUSE TestAccAWSEc2CapacityReservation_ephemeralStorage
=== RUN   TestAccAWSEc2CapacityReservation_instanceCount
=== PAUSE TestAccAWSEc2CapacityReservation_instanceCount
=== RUN   TestAccAWSEc2CapacityReservation_instanceMatchCriteria
=== PAUSE TestAccAWSEc2CapacityReservation_instanceMatchCriteria
=== RUN   TestAccAWSEc2CapacityReservation_instanceType
=== PAUSE TestAccAWSEc2CapacityReservation_instanceType
=== RUN   TestAccAWSEc2CapacityReservation_tags
=== PAUSE TestAccAWSEc2CapacityReservation_tags
=== RUN   TestAccAWSEc2CapacityReservation_disappears
=== PAUSE TestAccAWSEc2CapacityReservation_disappears
=== RUN   TestAccAWSEc2CapacityReservation_tenancy
    provider_test.go:56: EC2 Capacity Reservations do not currently support dedicated tenancy.
--- SKIP: TestAccAWSEc2CapacityReservation_tenancy (0.00s)
=== CONT  TestAccAWSEc2CapacityReservation_basic
=== CONT  TestAccAWSEc2CapacityReservation_instanceMatchCriteria
=== CONT  TestAccAWSEc2CapacityReservation_disappears
=== CONT  TestAccAWSEc2CapacityReservation_instanceType
=== CONT  TestAccAWSEc2CapacityReservation_endDateType
=== CONT  TestAccAWSEc2CapacityReservation_instanceCount
=== CONT  TestAccAWSEc2CapacityReservation_tags
=== CONT  TestAccAWSEc2CapacityReservation_ephemeralStorage
=== CONT  TestAccAWSEc2CapacityReservation_endDate
=== CONT  TestAccAWSEc2CapacityReservation_ebsOptimized
--- PASS: TestAccAWSEc2CapacityReservation_disappears (50.26s)
--- PASS: TestAccAWSEc2CapacityReservation_ebsOptimized (54.86s)
--- PASS: TestAccAWSEc2CapacityReservation_instanceMatchCriteria (59.14s)
--- PASS: TestAccAWSEc2CapacityReservation_ephemeralStorage (59.20s)
--- PASS: TestAccAWSEc2CapacityReservation_basic (59.57s)
--- PASS: TestAccAWSEc2CapacityReservation_instanceType (81.62s)
--- PASS: TestAccAWSEc2CapacityReservation_instanceCount (84.38s)
--- PASS: TestAccAWSEc2CapacityReservation_endDate (84.71s)
--- PASS: TestAccAWSEc2CapacityReservation_tags (104.90s)
--- PASS: TestAccAWSEc2CapacityReservation_endDateType (107.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	109.433s
```

Thank you for your review! 👍 