### PR TITLE
chore(docs): apigw policy uses execution_arn

### DIFF
--- a/website/docs/r/api_gateway_rest_api_policy.html.markdown
+++ b/website/docs/r/api_gateway_rest_api_policy.html.markdown
@@ -34,7 +34,7 @@ resource "aws_api_gateway_rest_api_policy" "test" {
         "AWS": "*"
       },
       "Action": "execute-api:Invoke",
-      "Resource": "${aws_api_gateway_rest_api.test.arn}",
+      "Resource": "${aws_api_gateway_rest_api.test.execution_arn}",
       "Condition": {
         "IpAddress": {
           "aws:SourceIp": "123.123.123.123/32"


### PR DESCRIPTION
Docs incorrectly uses REST GW arn in policy.
It should use execution_arn, like here: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-resource-policies-examples.html

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

