### PR TITLE
resource/instance: Fix invalid address set

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -208,7 +208,7 @@ func dataSourceAwsInstance() *schema.Resource {
 							Computed: true,
 						},
 
-						"tags": tagsSchema(),
+						"tags": tagsSchemaComputed(),
 
 						"throughput": {
 							Type:     schema.TypeInt,
@@ -270,7 +270,7 @@ func dataSourceAwsInstance() *schema.Resource {
 							Computed: true,
 						},
 
-						"tags": tagsSchema(),
+						"tags": tagsSchemaComputed(),
 
 						"throughput": {
 							Type:     schema.TypeInt,

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -208,6 +208,8 @@ func dataSourceAwsInstance() *schema.Resource {
 							Computed: true,
 						},
 
+						"tags": tagsSchema(),
+
 						"throughput": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -267,6 +269,8 @@ func dataSourceAwsInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+
+						"tags": tagsSchema(),
 
 						"throughput": {
 							Type:     schema.TypeInt,

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1790,7 +1790,7 @@ func readBlockDevicesFromInstance(d *schema.ResourceData, instance *ec2.Instance
 		if instanceBd.DeviceName != nil {
 			bd["device_name"] = aws.StringValue(instanceBd.DeviceName)
 		}
-		if _, ok := d.GetOk("volume_tags"); !ok && vol.Tags != nil {
+		if v, ok := d.GetOk("volume_tags"); (!ok || v == nil || len(v.(map[string]interface{})) == 0) && vol.Tags != nil {
 			bd["tags"] = keyvaluetags.Ec2KeyValueTags(vol.Tags).IgnoreAws().Map()
 		}
 

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1790,7 +1790,7 @@ func readBlockDevicesFromInstance(d *schema.ResourceData, instance *ec2.Instance
 		if instanceBd.DeviceName != nil {
 			bd["device_name"] = aws.StringValue(instanceBd.DeviceName)
 		}
-		if v, ok := d.GetOk("volume_tags"); (!ok || v == nil) && vol.Tags != nil {
+		if _, ok := d.GetOk("volume_tags"); !ok && vol.Tags != nil {
 			bd["tags"] = keyvaluetags.Ec2KeyValueTags(vol.Tags).IgnoreAws().Map()
 		}
 

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1790,7 +1790,7 @@ func readBlockDevicesFromInstance(d *schema.ResourceData, instance *ec2.Instance
 		if instanceBd.DeviceName != nil {
 			bd["device_name"] = aws.StringValue(instanceBd.DeviceName)
 		}
-		if _, ok := d.GetOk("volume_tags"); !ok && vol.Tags != nil {
+		if v, ok := d.GetOk("volume_tags"); (!ok || v == nil) && vol.Tags != nil {
 			bd["tags"] = keyvaluetags.Ec2KeyValueTags(vol.Tags).IgnoreAws().Map()
 		}
 

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1220,33 +1220,6 @@ func TestAccAWSInstance_blockDeviceTags_ebsAndRoot(t *testing.T) {
 	})
 }
 
-func TestAccAWSInstance_blockDeviceTags_noDevices(t *testing.T) {
-	// https://github.com/hashicorp/terraform-provider-aws/issues/17125
-	var v ec2.Instance
-	resourceName := "aws_instance.test"
-	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandString(12))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstanceConfigBlockDeviceTagsNoTags(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &v),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ephemeral_block_device"},
-			},
-		},
-	})
-}
-
 func TestAccAWSInstance_instanceProfileChange(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
@@ -4232,23 +4205,6 @@ resource "aws_instance" "test" {
   }
 }
 `)
-}
-
-func testAccInstanceConfigBlockDeviceTagsNoTags(rName string) string {
-	// https://github.com/hashicorp/terraform-provider-aws/issues/17125
-	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t1.micro", "m1.small", "t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName))
 }
 
 func testAccInstanceConfigBlockDeviceTagsEBSTagsConflict() string {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1220,6 +1220,33 @@ func TestAccAWSInstance_blockDeviceTags_ebsAndRoot(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstance_blockDeviceTags_noDevices(t *testing.T) {
+	// https://github.com/hashicorp/terraform-provider-aws/issues/17125
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandString(12))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfigBlockDeviceTagsNoTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ephemeral_block_device"},
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_instanceProfileChange(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
@@ -4205,6 +4232,23 @@ resource "aws_instance" "test" {
   }
 }
 `)
+}
+
+func testAccInstanceConfigBlockDeviceTagsNoTags(rName string) string {
+	// https://github.com/hashicorp/terraform-provider-aws/issues/17125
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t1.micro", "m1.small", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
 }
 
 func testAccInstanceConfigBlockDeviceTagsEBSTagsConflict() string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17125

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```

--- PASS: TestAccAWSInstanceDataSource_AzUserData (103.65s)
--- PASS: TestAccAWSInstanceDataSource_basic (94.54s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (128.76s)
--- PASS: TestAccAWSInstanceDataSource_blockDeviceTags (100.29s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (115.35s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (117.58s)
--- PASS: TestAccAWSInstanceDataSource_enclaveOptions (98.72s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (169.44s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (192.69s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (213.88s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (192.48s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (83.98s)
--- PASS: TestAccAWSInstanceDataSource_gp3ThroughputDevice (121.12s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (98.52s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (126.65s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (95.63s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (116.34s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (111.73s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (336.25s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (127.10s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (99.23s)
--- PASS: TestAccAWSInstanceDataSource_tags (92.82s)
--- PASS: TestAccAWSInstanceDataSource_VPC (118.99s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (126.92s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (192.69s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (269.52s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (151.34s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (159.80s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (203.60s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (183.28s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (149.94s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (151.65s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (167.87s)
--- PASS: TestAccAWSInstance_atLeastOneOtherEbsVolume (177.68s)
--- PASS: TestAccAWSInstance_basic (102.60s)
--- PASS: TestAccAWSInstance_blockDevices (89.52s)
--- PASS: TestAccAWSInstance_blockDeviceTags_ebsAndRoot (159.85s)
--- PASS: TestAccAWSInstance_blockDeviceTags_volumeTags (189.93s)
--- PASS: TestAccAWSInstance_blockDeviceTags_withAttachedVolume (172.29s)
--- PASS: TestAccAWSInstance_changeInstanceType (165.75s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (328.42s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (206.56s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (197.12s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (483.38s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (195.46s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (159.97s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (224.61s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (566.66s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (112.68s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (127.49s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (287.14s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (242.49s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (253.18s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (326.92s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (271.79s)
--- PASS: TestAccAWSInstance_dedicatedInstance (114.92s)
--- PASS: TestAccAWSInstance_disableApiTermination (127.78s)
--- PASS: TestAccAWSInstance_disappears (84.36s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType (8.16s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidThroughputForVolumeType (7.93s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (109.74s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (98.24s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (220.37s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (123.25s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1 (132.79s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2 (261.79s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (146.27s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyThroughput_Gp3 (164.16s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (127.68s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (133.58s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (132.42s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (216.79s)
--- PASS: TestAccAWSInstance_Empty_PrivateIP (104.84s)
--- PASS: TestAccAWSInstance_enclaveOptions (480.93s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (278.63s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (208.91s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (234.96s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (82.33s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (7.93s)
--- PASS: TestAccAWSInstance_hibernation (420.14s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (104.15s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (157.11s)
--- PASS: TestAccAWSInstance_inEc2Classic (120.50s)
--- PASS: TestAccAWSInstance_instanceProfileChange (212.95s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (111.47s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (230.65s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (16.54s)
--- PASS: TestAccAWSInstance_keyPairCheck (195.64s)
--- PASS: TestAccAWSInstance_metadataOptions (257.18s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (132.84s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (130.61s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (122.39s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs (144.85s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate (241.42s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs (162.98s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate (241.81s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs (336.09s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (77.85s)
--- PASS: TestAccAWSInstance_placementGroup (114.21s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (135.96s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (136.94s)
--- PASS: TestAccAWSInstance_privateIP (104.01s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (114.27s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (93.96s)
--- PASS: TestAccAWSInstance_rootInstanceStore (79.89s)
--- PASS: TestAccAWSInstance_sourceDestCheck (211.77s)
--- PASS: TestAccAWSInstance_tags (134.86s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (238.76s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (268.56s)
--- PASS: TestAccAWSInstance_userDataBase64 (114.99s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (105.05s)
--- SKIP: TestAccAWSInstance_outpost (1.14s)
```

GovCloud:

Unrelated failures due to unsupported features:
```
--- FAIL: TestAccAWSInstanceDataSource_enclaveOptions (23.06s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (150.14s)
--- PASS: TestAccAWSInstanceDataSource_basic (159.17s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (111.86s)
--- PASS: TestAccAWSInstanceDataSource_blockDeviceTags (110.97s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (128.58s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (116.03s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (212.48s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (220.84s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (329.48s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (339.59s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (137.45s)
--- PASS: TestAccAWSInstanceDataSource_gp3ThroughputDevice (126.84s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (132.24s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (144.27s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (221.49s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (182.40s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (99.66s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (104.09s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (147.33s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (141.93s)
--- PASS: TestAccAWSInstanceDataSource_tags (97.77s)
--- PASS: TestAccAWSInstanceDataSource_VPC (172.96s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (153.99s)
--- FAIL: TestAccAWSInstance_dedicatedInstance (16.52s)
--- FAIL: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2 (19.01s)
--- FAIL: TestAccAWSInstance_enclaveOptions (20.55s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (235.37s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (216.45s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (153.70s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (134.95s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (131.69s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (103.07s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (137.09s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (260.39s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (166.86s)
--- PASS: TestAccAWSInstance_atLeastOneOtherEbsVolume (191.70s)
--- PASS: TestAccAWSInstance_basic (94.51s)
--- PASS: TestAccAWSInstance_blockDevices (114.74s)
--- PASS: TestAccAWSInstance_blockDeviceTags_ebsAndRoot (187.79s)
--- PASS: TestAccAWSInstance_blockDeviceTags_volumeTags (271.06s)
--- PASS: TestAccAWSInstance_blockDeviceTags_withAttachedVolume (207.11s)
--- PASS: TestAccAWSInstance_changeInstanceType (232.05s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (170.56s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (100.93s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (128.29s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (423.86s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (102.82s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (133.55s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (131.95s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (409.30s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (97.74s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (106.58s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (149.37s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (112.58s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (157.16s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (129.02s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (168.74s)
--- PASS: TestAccAWSInstance_disableApiTermination (171.72s)
--- PASS: TestAccAWSInstance_disappears (64.74s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType (9.46s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidThroughputForVolumeType (9.58s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (95.10s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (158.50s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (172.80s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (135.10s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1 (191.03s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (241.25s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyThroughput_Gp3 (290.53s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (217.33s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (151.63s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (170.79s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (222.23s)
--- PASS: TestAccAWSInstance_Empty_PrivateIP (160.60s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (329.37s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (147.16s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (246.93s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (103.87s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (8.97s)
--- PASS: TestAccAWSInstance_hibernation (196.94s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (114.71s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (122.98s)
--- PASS: TestAccAWSInstance_instanceProfileChange (243.44s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (161.79s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (189.34s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (24.00s)
--- PASS: TestAccAWSInstance_keyPairCheck (124.38s)
--- PASS: TestAccAWSInstance_metadataOptions (186.76s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (192.21s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (168.63s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (164.69s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs (121.57s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate (376.96s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs (159.00s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate (261.96s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs (219.76s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (111.29s)
--- PASS: TestAccAWSInstance_placementGroup (110.70s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (178.10s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (156.06s)
--- PASS: TestAccAWSInstance_privateIP (151.63s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (130.10s)
--- PASS: TestAccAWSInstance_rootInstanceStore (159.31s)
--- PASS: TestAccAWSInstance_sourceDestCheck (195.83s)
--- PASS: TestAccAWSInstance_tags (104.12s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (128.27s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (121.32s)
--- PASS: TestAccAWSInstance_userDataBase64 (151.25s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (114.93s)
--- SKIP: TestAccAWSInstance_inEc2Classic (0.99s)
--- SKIP: TestAccAWSInstance_outpost (1.01s)
--- SKIP: TestAccAWSInstance_rootBlockDeviceMismatch (0.00s)
```