### PR TITLE
r/sagemaker_image_version - new resource

### DIFF
--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -24,14 +24,33 @@ func CodeRepositoryByName(conn *sagemaker.SageMaker, name string) (*sagemaker.De
 	return output, nil
 }
 
-// ImageByName returns the code repository corresponding to the specified name.
-// Returns nil if no code repository is found.
+// ImageByName returns the Image corresponding to the specified name.
+// Returns nil if no Image is found.
 func ImageByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeImageOutput, error) {
 	input := &sagemaker.DescribeImageInput{
 		ImageName: aws.String(name),
 	}
 
 	output, err := conn.DescribeImage(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output, nil
+}
+
+// ImageVersionByName returns the Image Version corresponding to the specified name.
+// Returns nil if no Image Version is found.
+func ImageVersionByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeImageVersionOutput, error) {
+	input := &sagemaker.DescribeImageVersionInput{
+		ImageName: aws.String(name),
+	}
+
+	output, err := conn.DescribeImageVersion(input)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/internal/service/sagemaker/waiter/waiter.go
+++ b/aws/internal/service/sagemaker/waiter/waiter.go
@@ -13,6 +13,8 @@ const (
 	NotebookInstanceDeletedTimeout   = 10 * time.Minute
 	ImageCreatedTimeout              = 10 * time.Minute
 	ImageDeletedTimeout              = 10 * time.Minute
+	ImageVersionCreatedTimeout       = 10 * time.Minute
+	ImageVersionDeletedTimeout       = 10 * time.Minute
 	DomainInServiceTimeout           = 10 * time.Minute
 	DomainDeletedTimeout             = 10 * time.Minute
 	FeatureGroupCreatedTimeout       = 10 * time.Minute
@@ -116,6 +118,44 @@ func ImageDeleted(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeIm
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*sagemaker.DescribeImageOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+// ImageVersionCreated waits for a ImageVersion to return Created
+func ImageVersionCreated(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeImageVersionOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			sagemaker.ImageVersionStatusCreating,
+		},
+		Target:  []string{sagemaker.ImageVersionStatusCreated},
+		Refresh: ImageVersionStatus(conn, name),
+		Timeout: ImageVersionCreatedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sagemaker.DescribeImageVersionOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+// ImageVersionDeleted waits for a ImageVersion to return Deleted
+func ImageVersionDeleted(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeImageVersionOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{sagemaker.ImageVersionStatusDeleting},
+		Target:  []string{},
+		Refresh: ImageVersionStatus(conn, name),
+		Timeout: ImageVersionDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sagemaker.DescribeImageVersionOutput); ok {
 		return output, err
 	}
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -881,6 +881,7 @@ func Provider() *schema.Provider {
 			"aws_sagemaker_endpoint_configuration":                    resourceAwsSagemakerEndpointConfiguration(),
 			"aws_sagemaker_feature_group":                             resourceAwsSagemakerFeatureGroup(),
 			"aws_sagemaker_image":                                     resourceAwsSagemakerImage(),
+			"aws_sagemaker_image_version":                             resourceAwsSagemakerImageVersion(),
 			"aws_sagemaker_model":                                     resourceAwsSagemakerModel(),
 			"aws_sagemaker_notebook_instance_lifecycle_configuration": resourceAwsSagemakerNotebookInstanceLifeCycleConfiguration(),
 			"aws_sagemaker_notebook_instance":                         resourceAwsSagemakerNotebookInstance(),

--- a/aws/resource_aws_sagemaker_image.go
+++ b/aws/resource_aws_sagemaker_image.go
@@ -104,7 +104,7 @@ func resourceAwsSagemakerImageRead(d *schema.ResourceData, meta interface{}) err
 
 	image, err := finder.ImageByName(conn, d.Id())
 	if err != nil {
-		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "No Image with the name") {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "does not exist") {
 			d.SetId("")
 			log.Printf("[WARN] Unable to find SageMaker Image (%s); removing from state", d.Id())
 			return nil

--- a/aws/resource_aws_sagemaker_image_version.go
+++ b/aws/resource_aws_sagemaker_image_version.go
@@ -26,22 +26,22 @@ func resourceAwsSagemakerImageVersion() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"image_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"base_image": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"container_image": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"image_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"container_image": {
+			"image_name": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Required: true,
+				ForceNew: true,
 			},
 			"version": {
 				Type:     schema.TypeInt,

--- a/aws/resource_aws_sagemaker_image_version.go
+++ b/aws/resource_aws_sagemaker_image_version.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/waiter"
+)
+
+func resourceAwsSagemakerImageVersion() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerImageVersionCreate,
+		Read:   resourceAwsSagemakerImageVersionRead,
+		Update: resourceAwsSagemakerImageVersionCreate,
+		Delete: resourceAwsSagemakerImageVersionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"base_image": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"image_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"container_image": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSagemakerImageVersionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	name := d.Get("image_name").(string)
+	input := &sagemaker.CreateImageVersionInput{
+		ImageName: aws.String(name),
+		BaseImage: aws.String(d.Get("base_image").(string)),
+	}
+
+	_, err := conn.CreateImageVersion(input)
+	if err != nil {
+		return fmt.Errorf("error creating Sagemaker Image Version %s: %w", name, err)
+	}
+
+	d.SetId(name)
+
+	if _, err := waiter.ImageVersionCreated(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for SageMaker Image Version (%s) to be created: %w", d.Id(), err)
+	}
+
+	return resourceAwsSagemakerImageVersionRead(d, meta)
+}
+
+func resourceAwsSagemakerImageVersionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	image, err := finder.ImageVersionByName(conn, d.Id())
+	if err != nil {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "does not exist") {
+			d.SetId("")
+			log.Printf("[WARN] Unable to find Sagemaker Image Version (%s); removing from state", d.Id())
+			return nil
+		}
+		return fmt.Errorf("error reading Sagemaker Image Version (%s): %w", d.Id(), err)
+
+	}
+
+	d.Set("arn", image.ImageVersionArn)
+	d.Set("base_image", image.BaseImage)
+	d.Set("image_arn", image.ImageArn)
+	d.Set("container_image", image.ContainerImage)
+	d.Set("version", image.Version)
+	d.Set("image_name", d.Id())
+
+	return nil
+}
+
+func resourceAwsSagemakerImageVersionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	input := &sagemaker.DeleteImageVersionInput{
+		ImageName: aws.String(d.Id()),
+		Version:   aws.Int64(int64(d.Get("version").(int))),
+	}
+
+	if _, err := conn.DeleteImageVersion(input); err != nil {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "does not exist") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Sagemaker Image Version (%s): %w", d.Id(), err)
+	}
+
+	if _, err := waiter.ImageVersionDeleted(conn, d.Id()); err != nil {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "does not exist") {
+			return nil
+		}
+		return fmt.Errorf("error waiting for SageMaker Image Version (%s) to delete: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_sagemaker_image_version.go
+++ b/aws/resource_aws_sagemaker_image_version.go
@@ -15,7 +15,6 @@ func resourceAwsSagemakerImageVersion() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsSagemakerImageVersionCreate,
 		Read:   resourceAwsSagemakerImageVersionRead,
-		Update: resourceAwsSagemakerImageVersionCreate,
 		Delete: resourceAwsSagemakerImageVersionDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -29,6 +28,7 @@ func resourceAwsSagemakerImageVersion() *schema.Resource {
 			"base_image": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"container_image": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_sagemaker_image_version_test.go
+++ b/aws/resource_aws_sagemaker_image_version_test.go
@@ -1,0 +1,215 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+)
+
+// func init() {
+// 	resource.AddTestSweepers("aws_sagemaker_image", &resource.Sweeper{
+// 		Name: "aws_sagemaker_image",
+// 		F:    testSweepSagemakerImages,
+// 	})
+// }
+
+// func testSweepSagemakerImages(region string) error {
+// 	client, err := sharedClientForRegion(region)
+// 	if err != nil {
+// 		return fmt.Errorf("error getting client: %s", err)
+// 	}
+// 	conn := client.(*AWSClient).sagemakerconn
+
+// 	err = conn.ListImagesPages(&sagemaker.ListImagesInput{}, func(page *sagemaker.ListImagesOutput, lastPage bool) bool {
+// 		for _, Image := range page.Images {
+// 			name := aws.StringValue(Image.ImageName)
+
+// 			input := &sagemaker.DeleteImageInput{
+// 				ImageName: Image.ImageName,
+// 			}
+
+// 			log.Printf("[INFO] Deleting SageMaker Image: %s", name)
+// 			if _, err := conn.DeleteImage(input); err != nil {
+// 				log.Printf("[ERROR] Error deleting SageMaker Image (%s): %s", name, err)
+// 				continue
+// 			}
+// 		}
+
+// 		return !lastPage
+// 	})
+
+// 	if testSweepSkipSweepError(err) {
+// 		log.Printf("[WARN] Skipping SageMaker Image sweep for %s: %s", region, err)
+// 		return nil
+// 	}
+
+// 	if err != nil {
+// 		return fmt.Errorf("Error retrieving SageMaker Images: %w", err)
+// 	}
+
+// 	return nil
+// }
+
+func TestAccAWSSagemakerImageVersion_basic(t *testing.T) {
+	var image sagemaker.DescribeImageVersionOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_image_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerImageVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerImageVersionBasicConfig(rName, "544685987707.dkr.ecr.us-west-2.amazonaws.com/smstudio-custom:latest"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerImageVersionExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "base_image", "544685987707.dkr.ecr.us-west-2.amazonaws.com/smstudio-custom:latest"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "image_arn", "sagemaker", fmt.Sprintf("image/%s", rName)),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("image-version/%s/1", rName)),
+					resource.TestCheckResourceAttrSet(resourceName, "container_image"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerImageVersion_disappears(t *testing.T) {
+	var image sagemaker.DescribeImageVersionOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_image_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerImageVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerImageVersionBasicConfig(rName, "544685987707.dkr.ecr.us-west-2.amazonaws.com/smstudio-custom:latest"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerImageVersionExists(resourceName, &image),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerImageVersion(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerImageVersion_disappears_image(t *testing.T) {
+	var image sagemaker.DescribeImageVersionOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_image_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerImageVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerImageVersionBasicConfig(rName, "544685987707.dkr.ecr.us-west-2.amazonaws.com/smstudio-custom:latest"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerImageVersionExists(resourceName, &image),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerImage(), "aws_sagemaker_image.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSagemakerImageVersionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_image_version" {
+			continue
+		}
+
+		imageVersion, err := finder.ImageVersionByName(conn, rs.Primary.ID)
+		if err != nil {
+			return nil
+		}
+
+		if aws.StringValue(imageVersion.ImageVersionArn) == rs.Primary.Attributes["arn"] {
+			return fmt.Errorf("SageMaker Image Version %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSSagemakerImageVersionExists(n string, image *sagemaker.DescribeImageVersionOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No sagmaker Image ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+		resp, err := finder.ImageVersionByName(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*image = *resp
+
+		return nil
+	}
+}
+
+func testAccAWSSagemakerImageVersionBasicConfig(rName, baseImage string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.${data.aws_partition.current.dns_suffix}"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+}
+
+resource "aws_sagemaker_image" "test" {
+  image_name = %[1]q
+  role_arn   = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+
+resource "aws_sagemaker_image_version" "test" {
+  image_name = aws_sagemaker_image.test.id
+  base_image = %[2]q
+}
+`, rName, baseImage)
+}

--- a/aws/resource_aws_sagemaker_image_version_test.go
+++ b/aws/resource_aws_sagemaker_image_version_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,54 +13,16 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
-// func init() {
-// 	resource.AddTestSweepers("aws_sagemaker_image", &resource.Sweeper{
-// 		Name: "aws_sagemaker_image",
-// 		F:    testSweepSagemakerImages,
-// 	})
-// }
-
-// func testSweepSagemakerImages(region string) error {
-// 	client, err := sharedClientForRegion(region)
-// 	if err != nil {
-// 		return fmt.Errorf("error getting client: %s", err)
-// 	}
-// 	conn := client.(*AWSClient).sagemakerconn
-
-// 	err = conn.ListImagesPages(&sagemaker.ListImagesInput{}, func(page *sagemaker.ListImagesOutput, lastPage bool) bool {
-// 		for _, Image := range page.Images {
-// 			name := aws.StringValue(Image.ImageName)
-
-// 			input := &sagemaker.DeleteImageInput{
-// 				ImageName: Image.ImageName,
-// 			}
-
-// 			log.Printf("[INFO] Deleting SageMaker Image: %s", name)
-// 			if _, err := conn.DeleteImage(input); err != nil {
-// 				log.Printf("[ERROR] Error deleting SageMaker Image (%s): %s", name, err)
-// 				continue
-// 			}
-// 		}
-
-// 		return !lastPage
-// 	})
-
-// 	if testSweepSkipSweepError(err) {
-// 		log.Printf("[WARN] Skipping SageMaker Image sweep for %s: %s", region, err)
-// 		return nil
-// 	}
-
-// 	if err != nil {
-// 		return fmt.Errorf("Error retrieving SageMaker Images: %w", err)
-// 	}
-
-// 	return nil
-// }
-
 func TestAccAWSSagemakerImageVersion_basic(t *testing.T) {
+
+	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE") == "" {
+		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BAES_IMAGE is not set")
+	}
+
 	var image sagemaker.DescribeImageVersionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_image_version.test"
+	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -67,11 +30,11 @@ func TestAccAWSSagemakerImageVersion_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSagemakerImageVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerImageVersionBasicConfig(rName, "544685987707.dkr.ecr.us-west-2.amazonaws.com/smstudio-custom:latest"),
+				Config: testAccAWSSagemakerImageVersionBasicConfig(rName, baseImage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerImageVersionExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "base_image", "544685987707.dkr.ecr.us-west-2.amazonaws.com/smstudio-custom:latest"),
+					resource.TestCheckResourceAttr(resourceName, "base_image", baseImage),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
 					testAccCheckResourceAttrRegionalARN(resourceName, "image_arn", "sagemaker", fmt.Sprintf("image/%s", rName)),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("image-version/%s/1", rName)),
@@ -88,9 +51,15 @@ func TestAccAWSSagemakerImageVersion_basic(t *testing.T) {
 }
 
 func TestAccAWSSagemakerImageVersion_disappears(t *testing.T) {
+
+	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE") == "" {
+		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BAES_IMAGE is not set")
+	}
+
 	var image sagemaker.DescribeImageVersionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_image_version.test"
+	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -98,7 +67,7 @@ func TestAccAWSSagemakerImageVersion_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSagemakerImageVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerImageVersionBasicConfig(rName, "544685987707.dkr.ecr.us-west-2.amazonaws.com/smstudio-custom:latest"),
+				Config: testAccAWSSagemakerImageVersionBasicConfig(rName, baseImage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerImageVersionExists(resourceName, &image),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerImageVersion(), resourceName),
@@ -110,9 +79,15 @@ func TestAccAWSSagemakerImageVersion_disappears(t *testing.T) {
 }
 
 func TestAccAWSSagemakerImageVersion_disappears_image(t *testing.T) {
+
+	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE") == "" {
+		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BAES_IMAGE is not set")
+	}
+
 	var image sagemaker.DescribeImageVersionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_image_version.test"
+	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -120,7 +95,7 @@ func TestAccAWSSagemakerImageVersion_disappears_image(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSagemakerImageVersionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerImageVersionBasicConfig(rName, "544685987707.dkr.ecr.us-west-2.amazonaws.com/smstudio-custom:latest"),
+				Config: testAccAWSSagemakerImageVersionBasicConfig(rName, baseImage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerImageVersionExists(resourceName, &image),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerImage(), "aws_sagemaker_image.test"),

--- a/aws/resource_aws_sagemaker_image_version_test.go
+++ b/aws/resource_aws_sagemaker_image_version_test.go
@@ -15,14 +15,14 @@ import (
 
 func TestAccAWSSagemakerImageVersion_basic(t *testing.T) {
 
-	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE") == "" {
-		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BAES_IMAGE is not set")
+	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
+		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
 	}
 
 	var image sagemaker.DescribeImageVersionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_image_version.test"
-	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE")
+	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -52,14 +52,14 @@ func TestAccAWSSagemakerImageVersion_basic(t *testing.T) {
 
 func TestAccAWSSagemakerImageVersion_disappears(t *testing.T) {
 
-	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE") == "" {
-		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BAES_IMAGE is not set")
+	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
+		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
 	}
 
 	var image sagemaker.DescribeImageVersionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_image_version.test"
-	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE")
+	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -80,14 +80,14 @@ func TestAccAWSSagemakerImageVersion_disappears(t *testing.T) {
 
 func TestAccAWSSagemakerImageVersion_disappears_image(t *testing.T) {
 
-	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE") == "" {
-		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BAES_IMAGE is not set")
+	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
+		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
 	}
 
 	var image sagemaker.DescribeImageVersionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_image_version.test"
-	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BAES_IMAGE")
+	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_sagemaker_image_version_test.go
+++ b/aws/resource_aws_sagemaker_image_version_test.go
@@ -172,7 +172,7 @@ data "aws_iam_policy_document" "test" {
 
 resource "aws_iam_role_policy_attachment" "test" {
   role       = aws_iam_role.test.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
 }
 
 resource "aws_sagemaker_image" "test" {

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -410,6 +410,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `GCM_API_KEY` | API Key for Google Cloud Messaging in Pinpoint and SNS Platform Application testing. |
 | `GITHUB_TOKEN` | GitHub token for CodePipeline testing. |
 | `MACIE_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for Macie Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |
+| `SAGEMAKER_IMAGE_VERSION_BASE_IMAGE` | Sagemaker base image to use for tests. |
 | `SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE` | Quota Code for Service Quotas testing (submits support case). |
 | `SERVICEQUOTAS_INCREASE_ON_CREATE_SERVICE_CODE` | Service Code for Service Quotas testing (submits support case). |
 | `SERVICEQUOTAS_INCREASE_ON_CREATE_VALUE` | Value of quota increase for Service Quotas testing (submits support case). |

--- a/website/docs/r/sagemaker_image_version.html.markdown
+++ b/website/docs/r/sagemaker_image_version.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "Sagemaker"
+layout: "aws"
+page_title: "AWS: aws_sagemaker_image_version"
+description: |-
+  Provides a Sagemaker Image Version resource.
+---
+
+# Resource: aws_sagemaker_image_version
+
+Provides a Sagemaker Image Version resource.
+
+## Example Usage
+
+### Basic usage
+
+```hcl
+resource "aws_sagemaker_image_version" "test" {
+  image_name = aws_sagemaker_image.test.id
+  base_image = "012345678912.dkr.ecr.us-west-2.amazonaws.com/image:latest
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `image_name` - (Required) The name of the image. Must be unique to your account.
+* `base_image` - (Required) The registry path of the container image on which this image version is based.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The name of the Image.
+* `arn` - The Amazon Resource Name (ARN) assigned by AWS to this Image Version.
+* `image_arn`- The Amazon Resource Name (ARN) of the image the version is based on.
+* `container_image` - The registry path of the container image that contains this image version.
+
+## Import
+
+Sagemaker Image Versions can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_sagemaker_image_version.test_image my-code-repo
+```

--- a/website/docs/r/sagemaker_image_version.html.markdown
+++ b/website/docs/r/sagemaker_image_version.html.markdown
@@ -17,7 +17,7 @@ Provides a Sagemaker Image Version resource.
 ```hcl
 resource "aws_sagemaker_image_version" "test" {
   image_name = aws_sagemaker_image.test.id
-  base_image = "012345678912.dkr.ecr.us-west-2.amazonaws.com/image:latest
+  base_image = "012345678912.dkr.ecr.us-west-2.amazonaws.com/image:latest"
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14453

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sagemaker_image - fix catching image not found on read error
resource_aws_sagemaker_image_version - new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerImage'
--- PASS: TestAccAWSSagemakerImage_disappears (110.02s)
--- PASS: TestAccAWSSagemakerImage_basic (110.20s)
--- PASS: TestAccAWSSagemakerImage_description (170.08s)
--- PASS: TestAccAWSSagemakerImage_tags (175.43s)
--- PASS: TestAccAWSSagemakerImage_displayName (177.31s)

--- PASS: TestAccAWSSagemakerImageVersion_disappears_image (113.48s)
--- PASS: TestAccAWSSagemakerImageVersion_disappears (120.02s)
--- PASS: TestAccAWSSagemakerImageVersion_basic (120.24s)
```
