### PR TITLE
provider: Fix reverse DNS prefix handling and save to AWSClient

### DIFF
--- a/.changelog/17142.txt
+++ b/.changelog/17142.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_partition: Correct `reverse_dns_prefix` value in AWS China, C2S, and SC2S
+```

--- a/aws/config.go
+++ b/aws/config.go
@@ -329,6 +329,7 @@ type AWSClient struct {
 	region                              string
 	resourcegroupsconn                  *resourcegroups.ResourceGroups
 	resourcegroupstaggingapiconn        *resourcegroupstaggingapi.ResourceGroupsTaggingAPI
+	reverseDnsPrefix                    string
 	route53domainsconn                  *route53domains.Route53Domains
 	route53resolverconn                 *route53resolver.Route53Resolver
 	s3conn                              *s3.S3
@@ -566,6 +567,7 @@ func (c *Config) Client() (interface{}, error) {
 		region:                              c.Region,
 		resourcegroupsconn:                  resourcegroups.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["resourcegroups"])})),
 		resourcegroupstaggingapiconn:        resourcegroupstaggingapi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["resourcegroupstaggingapi"])})),
+		reverseDnsPrefix:                    ReverseDns(dnsSuffix),
 		route53domainsconn:                  route53domains.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["route53domains"])})),
 		route53resolverconn:                 route53resolver.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["route53resolver"])})),
 		s3controlconn:                       s3control.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["s3control"])})),

--- a/aws/data_source_aws_partition.go
+++ b/aws/data_source_aws_partition.go
@@ -2,8 +2,6 @@ package aws
 
 import (
 	"log"
-	"sort"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -43,11 +41,8 @@ func dataSourceAwsPartitionRead(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] Setting AWS URL Suffix to %s.", client.dnsSuffix)
 	d.Set("dns_suffix", meta.(*AWSClient).dnsSuffix)
 
-	dnsParts := strings.Split(meta.(*AWSClient).dnsSuffix, ".")
-	sort.Sort(sort.Reverse(sort.StringSlice(dnsParts)))
-	servicePrefix := strings.Join(dnsParts, ".")
-	d.Set("reverse_dns_prefix", servicePrefix)
-	log.Printf("[DEBUG] Setting service prefix to %s.", servicePrefix)
+	d.Set("reverse_dns_prefix", meta.(*AWSClient).reverseDnsPrefix)
+	log.Printf("[DEBUG] Setting service prefix to %s.", meta.(*AWSClient).reverseDnsPrefix)
 
 	return nil
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -1502,4 +1503,15 @@ func expandProviderIgnoreTags(l []interface{}) *keyvaluetags.IgnoreConfig {
 	}
 
 	return ignoreConfig
+}
+
+// ReverseDns switches a DNS hostname to reverse DNS and vice-versa.
+func ReverseDns(hostname string) string {
+	parts := strings.Split(hostname, ".")
+
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+
+	return strings.Join(parts, ".")
 }

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -177,6 +176,49 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ *schema.Provider = Provider()
+}
+
+func TestReverseDns(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "amazonaws.com",
+			input:    "amazonaws.com",
+			expected: "com.amazonaws",
+		},
+		{
+			name:     "amazonaws.com.cn",
+			input:    "amazonaws.com.cn",
+			expected: "cn.com.amazonaws",
+		},
+		{
+			name:     "sc2s.sgov.gov",
+			input:    "sc2s.sgov.gov",
+			expected: "gov.sgov.sc2s",
+		},
+		{
+			name:     "c2s.ic.gov",
+			input:    "c2s.ic.gov",
+			expected: "gov.ic.c2s",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if got, want := ReverseDns(testCase.input), testCase.expected; got != want {
+				t.Errorf("got: %s, expected: %s", got, want)
+			}
+		})
+	}
 }
 
 // testAccPreCheck verifies and sets required provider testing configuration
@@ -649,9 +691,7 @@ func testAccGetPartitionDNSSuffix() string {
 
 func testAccGetPartitionReverseDNSPrefix() string {
 	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), testAccGetRegion()); ok {
-		dnsParts := strings.Split(partition.DNSSuffix(), ".")
-		sort.Sort(sort.Reverse(sort.StringSlice(dnsParts)))
-		return strings.Join(dnsParts, ".")
+		return ReverseDns(partition.DNSSuffix())
 	}
 
 	return "com.amazonaws"
@@ -1246,6 +1286,27 @@ func TestAccAWSProvider_IgnoreTags_Keys_Multiple(t *testing.T) {
 	})
 }
 
+func TestAccAWSProvider_Region_AwsC2S(t *testing.T) {
+	var providers []*schema.Provider
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactoriesInternal(&providers),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSProviderConfigRegion("us-iso-east-1"), // lintignore:AWSAT003
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSProviderDnsSuffix(&providers, "c2s.ic.gov"),
+					testAccCheckAWSProviderPartition(&providers, "aws-iso"),
+					testAccCheckAWSProviderReverseDnsPrefix(&providers, "gov.ic.c2s"),
+				),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSProvider_Region_AwsChina(t *testing.T) {
 	var providers []*schema.Provider
 
@@ -1259,6 +1320,7 @@ func TestAccAWSProvider_Region_AwsChina(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSProviderDnsSuffix(&providers, "amazonaws.com.cn"),
 					testAccCheckAWSProviderPartition(&providers, "aws-cn"),
+					testAccCheckAWSProviderReverseDnsPrefix(&providers, "cn.com.amazonaws"),
 				),
 				PlanOnly: true,
 			},
@@ -1279,6 +1341,7 @@ func TestAccAWSProvider_Region_AwsCommercial(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSProviderDnsSuffix(&providers, "amazonaws.com"),
 					testAccCheckAWSProviderPartition(&providers, "aws"),
+					testAccCheckAWSProviderReverseDnsPrefix(&providers, "com.amazonaws"),
 				),
 				PlanOnly: true,
 			},
@@ -1299,6 +1362,28 @@ func TestAccAWSProvider_Region_AwsGovCloudUs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSProviderDnsSuffix(&providers, "amazonaws.com"),
 					testAccCheckAWSProviderPartition(&providers, "aws-us-gov"),
+					testAccCheckAWSProviderReverseDnsPrefix(&providers, "com.amazonaws"),
+				),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSProvider_Region_AwsSC2S(t *testing.T) {
+	var providers []*schema.Provider
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactoriesInternal(&providers),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSProviderConfigRegion("us-isob-east-1"), // lintignore:AWSAT003
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSProviderDnsSuffix(&providers, "sc2s.sgov.gov"),
+					testAccCheckAWSProviderPartition(&providers, "aws-iso-b"),
+					testAccCheckAWSProviderReverseDnsPrefix(&providers, "gov.sgov.sc2s"),
 				),
 				PlanOnly: true,
 			},
@@ -1560,6 +1645,28 @@ func testAccCheckAWSProviderPartition(providers *[]*schema.Provider, expectedPar
 
 			if providerPartition != expectedPartition {
 				return fmt.Errorf("expected DNS Suffix (%s), got: %s", expectedPartition, providerPartition)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSProviderReverseDnsPrefix(providers *[]*schema.Provider, expectedReverseDnsPrefix string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if providers == nil {
+			return fmt.Errorf("no providers initialized")
+		}
+
+		for _, provider := range *providers {
+			if provider == nil || provider.Meta() == nil || provider.Meta().(*AWSClient) == nil {
+				continue
+			}
+
+			providerReverseDnsPrefix := provider.Meta().(*AWSClient).reverseDnsPrefix
+
+			if providerReverseDnsPrefix != expectedReverseDnsPrefix {
+				return fmt.Errorf("expected DNS Suffix (%s), got: %s", expectedReverseDnsPrefix, providerReverseDnsPrefix)
 			}
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17140

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_partition: Correct `reverse_dns_prefix` value in AWS China, C2S, and SC2S
```

Output from acceptance testing:

```
--- PASS: TestAccAWSPartition_basic (8.02s)

--- PASS: TestAccAWSProvider_AssumeRole_Empty (18.41s)
--- PASS: TestAccAWSProvider_Endpoints (16.22s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (15.68s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (15.57s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (15.56s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (15.84s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (15.92s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (15.99s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (16.10s)
--- PASS: TestAccAWSProvider_Region_AwsC2S (13.71s)
--- PASS: TestAccAWSProvider_Region_AwsChina (13.27s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (12.85s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (12.59s)
--- PASS: TestAccAWSProvider_Region_AwsSC2S (14.52s)
```