### PR TITLE
.github/workflows: Remove goreleaser parallelism

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,7 +27,7 @@ jobs:
       - name: goreleaser release
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: release --parallelism 2 --rm-dist --skip-sign --snapshot --timeout 2h
+          args: release --rm-dist --skip-sign --snapshot --timeout 2h
       - name: artifact naming
         id: naming
         run: |

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -300,7 +300,7 @@ jobs:
       - name: goreleaser build
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: build --parallelism 2 --snapshot --timeout 2h
+          args: build --snapshot --timeout 2h
 
   semgrep:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/pull/17067
Reference: https://github.com/goreleaser/goreleaser/issues/2013
Reference: https://github.com/goreleaser/goreleaser-action#inputs

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Upstream `goreleaser` now includes parallelism that defaults to the number of CPUs. The `goreleaser/goreleaser-action` GitHub Action defaults to using the latest available version so no additional update required. Nice part is that older pull requests should now be picking up the fixed parallelism as well.

```console
$ system_profiler -detailLevel mini SPHardwareDataType
Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro15,1
      Processor Name: 8-Core Intel Core i9
      Processor Speed: 2.4 GHz
      Number of Processors: 1
      Total Number of Cores: 8
      L2 Cache (per Core): 256 KB
      L3 Cache: 16 MB
      Hyper-Threading Technology: Enabled
      Memory: 32 GB
      Boot ROM Version: 1037.147.4.0.0 (iBridge: 17.16.16610.0.0,0)
$ goreleaser --version
goreleaser version 0.155.0
commit: ba82f43c5f2eefcc82d8d14634fe21b37ffc1799
built by: homebrew
$ goreleaser build --help
Builds the current project
...
  -p, --parallelism int    Amount tasks to run concurrently (default 16)
```
