### PR TITLE
resource/aws_licensemanager_license_configuration: Add arn and owner_account_id attributes

### DIFF
--- a/aws/resource_aws_licensemanager_license_configuration.go
+++ b/aws/resource_aws_licensemanager_license_configuration.go
@@ -23,6 +23,10 @@ func resourceAwsLicenseManagerLicenseConfiguration() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -59,6 +63,10 @@ func resourceAwsLicenseManagerLicenseConfiguration() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"owner_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"tags": tagsSchema(),
 		},
@@ -120,6 +128,7 @@ func resourceAwsLicenseManagerLicenseConfigurationRead(d *schema.ResourceData, m
 		return fmt.Errorf("Error reading License Manager license configuration: %s", err)
 	}
 
+	d.Set("arn", resp.LicenseConfigurationArn)
 	d.Set("description", resp.Description)
 	d.Set("license_count", resp.LicenseCount)
 	d.Set("license_count_hard_limit", resp.LicenseCountHardLimit)
@@ -128,6 +137,7 @@ func resourceAwsLicenseManagerLicenseConfigurationRead(d *schema.ResourceData, m
 		return fmt.Errorf("error setting license_rules: %s", err)
 	}
 	d.Set("name", resp.Name)
+	d.Set("owner_account_id", resp.OwnerAccountId)
 
 	if err := d.Set("tags", keyvaluetags.LicensemanagerKeyValueTags(resp.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/resource_aws_licensemanager_license_configuration_test.go
+++ b/aws/resource_aws_licensemanager_license_configuration_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -72,6 +73,7 @@ func TestAccAWSLicenseManagerLicenseConfiguration_basic(t *testing.T) {
 				Config: testAccLicenseManagerLicenseConfigurationConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLicenseManagerLicenseConfigurationExists(resourceName, &licenseConfiguration),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "license-manager", regexp.MustCompile(`license-configuration:lic-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", "Example"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Example"),
 					resource.TestCheckResourceAttr(resourceName, "license_count", "10"),
@@ -79,6 +81,7 @@ func TestAccAWSLicenseManagerLicenseConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "license_counting_type", "Socket"),
 					resource.TestCheckResourceAttr(resourceName, "license_rules.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "license_rules.0", "#minimumSockets=3"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "barr"),
 				),

--- a/website/docs/r/licensemanager_license_configuration.markdown
+++ b/website/docs/r/licensemanager_license_configuration.markdown
@@ -60,7 +60,9 @@ License rules should be in the format of `#RuleType=RuleValue`. Supported rule t
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The license configuration ARN.
 * `id` - The license configuration ARN.
+* `owner_account_id` - Account ID of the owner of the license configuration.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16978

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_licensemanager_license_configuration: Add arn and owner_account_id attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLicenseManagerLicenseConfiguration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLicenseManagerLicenseConfiguration_ -timeout 120m
=== RUN   TestAccAWSLicenseManagerLicenseConfiguration_basic
=== PAUSE TestAccAWSLicenseManagerLicenseConfiguration_basic
=== RUN   TestAccAWSLicenseManagerLicenseConfiguration_update
=== PAUSE TestAccAWSLicenseManagerLicenseConfiguration_update
=== CONT  TestAccAWSLicenseManagerLicenseConfiguration_basic
=== CONT  TestAccAWSLicenseManagerLicenseConfiguration_update
--- PASS: TestAccAWSLicenseManagerLicenseConfiguration_basic (41.56s)
--- PASS: TestAccAWSLicenseManagerLicenseConfiguration_update (66.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	68.796s
```

Thank you for your review!