### PR TITLE
r/aws_sqs_queue: append .fifo suffix for FIFO queue if name unspecified

### DIFF
--- a/aws/internal/service/sqs/consts.go
+++ b/aws/internal/service/sqs/consts.go
@@ -1,0 +1,5 @@
+package sqs
+
+const (
+	FifoQueueNameSuffix = ".fifo"
+)

--- a/aws/resource_aws_sns_topic_test.go
+++ b/aws/resource_aws_sns_topic_test.go
@@ -168,10 +168,9 @@ func TestAccAWSSNSTopic_NamePrefix(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name_prefix"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -390,10 +389,9 @@ func TestAccAWSSNSTopic_NamePrefix_FIFOTopic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name_prefix"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -1,9 +1,11 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +19,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
+	tfsqs "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs"
 )
 
 var sqsQueueAttributeMap = map[string]string{
@@ -46,19 +50,20 @@ func resourceAwsSqsQueue() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		CustomizeDiff: resourceAwsSqsQueueCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				Computed:      true,
+				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validateSQSQueueName,
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
 			},
@@ -136,38 +141,12 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	sqsconn := meta.(*AWSClient).sqsconn
 
 	var name string
-	appendFifoSuffix := false
+	fifoQueue := d.Get("fifo_queue").(bool)
 
-	fq := d.Get("fifo_queue").(bool)
-
-	if v, ok := d.GetOk("name"); ok {
-		name = v.(string)
-	} else if v, ok := d.GetOk("name_prefix"); ok {
-		name = resource.PrefixedUniqueId(v.(string))
-		appendFifoSuffix = true
+	if fifoQueue {
+		name = naming.GenerateWithSuffix(d.Get("name").(string), d.Get("name_prefix").(string), tfsqs.FifoQueueNameSuffix)
 	} else {
-		name = resource.UniqueId()
-		appendFifoSuffix = true
-	}
-
-	if fq && appendFifoSuffix {
-		name += ".fifo"
-	}
-
-	cbd := d.Get("content_based_deduplication").(bool)
-
-	if fq {
-		if errors := validateSQSFifoQueueName(name); len(errors) > 0 {
-			return fmt.Errorf("Error validating the FIFO queue name: %v", errors)
-		}
-	} else {
-		if errors := validateSQSNonFifoQueueName(name); len(errors) > 0 {
-			return fmt.Errorf("Error validating SQS queue name: %v", errors)
-		}
-	}
-
-	if !fq && cbd {
-		return fmt.Errorf("Content based deduplication can only be set with FIFO queues")
+		name = naming.Generate(d.Get("name").(string), d.Get("name_prefix").(string))
 	}
 
 	log.Printf("[DEBUG] SQS queue create: %s", name)
@@ -305,16 +284,16 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	fifoQueue := false
+
 	// Always set attribute defaults
 	d.Set("arn", "")
 	d.Set("content_based_deduplication", false)
 	d.Set("delay_seconds", 0)
-	d.Set("fifo_queue", false)
 	d.Set("kms_data_key_reuse_period_seconds", 300)
 	d.Set("kms_master_key_id", "")
 	d.Set("max_message_size", 262144)
 	d.Set("message_retention_seconds", 345600)
-	d.Set("name", name)
 	d.Set("policy", "")
 	d.Set("receive_wait_time_seconds", 0)
 	d.Set("redrive_policy", "")
@@ -354,7 +333,7 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("error parsing fifo_queue value (%s) into boolean: %s", v, err)
 			}
 
-			d.Set("fifo_queue", vBool)
+			fifoQueue = vBool
 		}
 
 		if v, ok := queueAttributes[sqs.QueueAttributeNameKmsDataKeyReusePeriodSeconds]; ok && v != "" {
@@ -420,6 +399,14 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	d.Set("fifo_queue", fifoQueue)
+	d.Set("name", name)
+	if fifoQueue {
+		d.Set("name_prefix", naming.NamePrefixFromNameWithSuffix(name, tfsqs.FifoQueueNameSuffix))
+	} else {
+		d.Set("name_prefix", naming.NamePrefixFromName(name))
+	}
+
 	tags, err := keyvaluetags.SqsListTags(sqsconn, d.Id())
 
 	if err != nil {
@@ -446,6 +433,42 @@ func resourceAwsSqsQueueDelete(d *schema.ResourceData, meta interface{}) error {
 		QueueUrl: aws.String(d.Id()),
 	})
 	return err
+}
+
+func resourceAwsSqsQueueCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	fifoQueue := diff.Get("fifo_queue").(bool)
+	contentBasedDeduplication := diff.Get("content_based_deduplication").(bool)
+
+	if diff.Id() == "" {
+		// Create.
+
+		var name string
+
+		if fifoQueue {
+			name = naming.GenerateWithSuffix(diff.Get("name").(string), diff.Get("name_prefix").(string), tfsqs.FifoQueueNameSuffix)
+		} else {
+			name = naming.Generate(diff.Get("name").(string), diff.Get("name_prefix").(string))
+		}
+
+		var re *regexp.Regexp
+
+		if fifoQueue {
+			re = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,75}\.fifo$`)
+		} else {
+			re = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,80}$`)
+		}
+
+		if !re.MatchString(name) {
+			return fmt.Errorf("invalid queue name: %s", name)
+		}
+
+	}
+
+	if !fifoQueue && contentBasedDeduplication {
+		return fmt.Errorf("content-based deduplication can only be set for FIFO queue")
+	}
+
+	return nil
 }
 
 func extractNameFromSqsQueueUrl(queue string) (string, error) {

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -136,6 +136,7 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	sqsconn := meta.(*AWSClient).sqsconn
 
 	var name string
+	appendFifoSuffix := false
 
 	fq := d.Get("fifo_queue").(bool)
 
@@ -143,11 +144,14 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 		name = v.(string)
 	} else if v, ok := d.GetOk("name_prefix"); ok {
 		name = resource.PrefixedUniqueId(v.(string))
-		if fq {
-			name += ".fifo"
-		}
+		appendFifoSuffix = true
 	} else {
 		name = resource.UniqueId()
+		appendFifoSuffix = true
+	}
+
+	if fq && appendFifoSuffix {
+		name += ".fifo"
 	}
 
 	cbd := d.Get("content_based_deduplication").(bool)

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -385,7 +385,7 @@ func TestAccAWSSQSQueue_FIFOExpectNameError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSSQSConfigWithFIFOExpectError(acctest.RandString(10)),
-				ExpectError: regexp.MustCompile(`Error validating the FIFO queue name`),
+				ExpectError: regexp.MustCompile(`invalid queue name:`),
 			},
 		},
 	})
@@ -430,7 +430,7 @@ func TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccExpectContentBasedDeduplicationError(acctest.RandString(10)),
-				ExpectError: regexp.MustCompile(`Content based deduplication can only be set with FIFO queues`),
+				ExpectError: regexp.MustCompile(`content-based deduplication can only be set for FIFO queue`),
 			},
 		},
 	})

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -465,6 +465,33 @@ func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 	})
 }
 
+func TestAccAWSSQSQueue_FIFO_MinusName(t *testing.T) {
+	var queueAttributes map[string]*string
+
+	resourceName := "aws_sqs_queue.queue"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigWithFIFOMinusName(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckAWSSQSQueueDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).sqsconn
 
@@ -800,4 +827,12 @@ resource "aws_sqs_queue" "queue" {
   }
 }
 `, r)
+}
+
+func testAccAWSSQSConfigWithFIFOMinusName() string {
+	return `
+resource "aws_sqs_queue" "queue" {
+  fifo_queue = true
+}
+`
 }

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	awspolicy "github.com/jen20/awspolicyequivalence"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
+	tfsqs "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs"
 )
 
 func init() {
@@ -94,9 +96,6 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
 			},
 			{
 				Config: testAccAWSSQSConfigWithOverrides(queueName),
@@ -140,9 +139,6 @@ func TestAccAWSSQSQueue_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
 			},
 			{
 				Config: testAccAWSSQSConfigWithTagsChanged(queueName),
@@ -165,42 +161,67 @@ func TestAccAWSSQSQueue_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSSQSQueue_namePrefix(t *testing.T) {
+func TestAccAWSSQSQueue_Name_Generated(t *testing.T) {
 	var queueAttributes map[string]*string
+	resourceName := "aws_sqs_queue.test"
 
-	resourceName := "aws_sqs_queue.queue"
-	prefix := "acctest-sqs-queue"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
 		Providers:    testAccProviders,
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSConfigWithNamePrefix(prefix),
+				Config: testAccAWSSQSQueueConfigNameGenerated,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
-					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(`^acctest-sqs-queue`)),
+					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
 			},
 		},
 	})
 }
 
-func TestAccAWSSQSQueue_namePrefix_fifo(t *testing.T) {
+func TestAccAWSSQSQueue_Name_Generated_FIFOQueue(t *testing.T) {
 	var queueAttributes map[string]*string
+	resourceName := "aws_sqs_queue.test"
 
-	resourceName := "aws_sqs_queue.queue"
-	prefix := "acctest-sqs-queue"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSQueueConfigNameGeneratedFIFOQueue,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					naming.TestCheckResourceAttrNameWithSuffixGenerated(resourceName, "name", tfsqs.FifoQueueNameSuffix),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_NamePrefix(t *testing.T) {
+	var queueAttributes map[string]*string
+	resourceName := "aws_sqs_queue.test"
+	rName := "tf-acc-test-prefix-"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -208,20 +229,49 @@ func TestAccAWSSQSQueue_namePrefix_fifo(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSFifoConfigWithNamePrefix(prefix),
+				Config: testAccAWSSQSQueueConfigNamePrefix(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
 					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
-					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(`^acctest-sqs-queue.*\.fifo$`)),
+					naming.TestCheckResourceAttrNameFromPrefix(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", rName),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_NamePrefix_FIFOQueue(t *testing.T) {
+	var queueAttributes map[string]*string
+	resourceName := "aws_sqs_queue.test"
+	rName := "tf-acc-test-prefix-"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSQueueConfigNamePrefixFIFOQueue(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					naming.TestCheckResourceAttrNameWithSuffixFromPrefix(resourceName, "name", rName, tfsqs.FifoQueueNameSuffix),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", rName),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -250,9 +300,6 @@ func TestAccAWSSQSQueue_policy(t *testing.T) {
 				ResourceName:      "aws_sqs_queue.test-email-events",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
 			},
 		},
 	})
@@ -308,9 +355,6 @@ func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 				ResourceName:      "aws_sqs_queue.my_dead_letter_queue",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
 			},
 		},
 	})
@@ -339,9 +383,6 @@ func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
 				ResourceName:      "aws_sqs_queue.test-email-events",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
 			},
 		},
 	})
@@ -368,9 +409,6 @@ func TestAccAWSSQSQueue_FIFO(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
 			},
 		},
 	})
@@ -413,9 +451,6 @@ func TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
 			},
 		},
 	})
@@ -457,36 +492,6 @@ func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
-			},
-		},
-	})
-}
-
-func TestAccAWSSQSQueue_FIFO_MinusName(t *testing.T) {
-	var queueAttributes map[string]*string
-
-	resourceName := "aws_sqs_queue.queue"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSConfigWithFIFOMinusName(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name_prefix",
-				},
 			},
 		},
 	})
@@ -639,6 +644,16 @@ func testAccCheckAWSSQSQueueOverrideAttributes(queueAttributes *map[string]*stri
 	}
 }
 
+const testAccAWSSQSQueueConfigNameGenerated = `
+resource "aws_sqs_queue" "test" {}
+`
+
+const testAccAWSSQSQueueConfigNameGeneratedFIFOQueue = `
+resource "aws_sqs_queue" "test" {
+  fifo_queue = true
+}
+`
+
 func testAccAWSSQSConfigWithDefaults(r string) string {
 	return fmt.Sprintf(`
 resource "aws_sqs_queue" "queue" {
@@ -647,21 +662,21 @@ resource "aws_sqs_queue" "queue" {
 `, r)
 }
 
-func testAccAWSSQSConfigWithNamePrefix(r string) string {
+func testAccAWSSQSQueueConfigNamePrefix(prefix string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name_prefix = "%s"
+resource "aws_sqs_queue" "test" {
+  name_prefix = %[1]q
 }
-`, r)
+`, prefix)
 }
 
-func testAccAWSSQSFifoConfigWithNamePrefix(r string) string {
+func testAccAWSSQSQueueConfigNamePrefixFIFOQueue(prefix string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name_prefix = "%s"
+resource "aws_sqs_queue" "test" {
+  name_prefix = %[1]q
   fifo_queue  = true
 }
-`, r)
+`, prefix)
 }
 
 func testAccAWSSQSConfigWithOverrides(r string) string {
@@ -827,12 +842,4 @@ resource "aws_sqs_queue" "queue" {
   }
 }
 `, r)
-}
-
-func testAccAWSSQSConfigWithFIFOMinusName() string {
-	return `
-resource "aws_sqs_queue" "queue" {
-  fifo_queue = true
-}
-`
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1033,54 +1033,6 @@ func validateApiGatewayIntegrationContentHandling() schema.SchemaValidateFunc {
 	}, false)
 }
 
-func validateSQSQueueName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 80 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters", k))
-	}
-
-	if !regexp.MustCompile(`^[0-9A-Za-z-_]+(\.fifo)?$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("only alphanumeric characters and hyphens allowed in %q", k))
-	}
-	return
-}
-
-func validateSQSNonFifoQueueName(v interface{}) (errors []error) {
-	k := "name"
-	value := v.(string)
-	if len(value) > 80 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters", k))
-	}
-
-	if !regexp.MustCompile(`^[0-9A-Za-z-_]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("only alphanumeric characters and hyphens allowed in %q", k))
-	}
-	return
-}
-
-func validateSQSFifoQueueName(v interface{}) (errors []error) {
-	k := "name"
-	value := v.(string)
-
-	if len(value) > 80 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters", k))
-	}
-
-	if !regexp.MustCompile(`^[0-9A-Za-z-_.]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("only alphanumeric characters and hyphens allowed in %q", k))
-	}
-
-	if regexp.MustCompile(`^[^a-zA-Z0-9-_]`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("FIFO queue name must start with one of these characters [a-zA-Z0-9-_]: %v", value))
-	}
-
-	if !regexp.MustCompile(`\.fifo$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("FIFO queue name should end with \".fifo\": %v", value))
-	}
-
-	return
-}
-
 func validateOnceAWeekWindowFormat(v interface{}, k string) (ws []string, errors []error) {
 	// valid time format is "ddd:hh24:mi"
 	validTimeFormat := "(sun|mon|tue|wed|thu|fri|sat):([0-1][0-9]|2[0-3]):([0-5][0-9])"

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -970,92 +969,6 @@ func TestValidateStringIsJsonOrYaml(t *testing.T) {
 		_, errors := validateStringIsJsonOrYaml(tc.Value, "template")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
-		}
-	}
-}
-
-func TestValidateSQSQueueName(t *testing.T) {
-	validNames := []string{
-		"valid-name",
-		"valid02-name",
-		"Valid-Name1",
-		"_",
-		"-",
-		strings.Repeat("W", 80),
-	}
-	for _, v := range validNames {
-		if _, errors := validateSQSQueueName(v, "test_attribute"); len(errors) > 0 {
-			t.Fatalf("%q should be a valid SQS queue Name", v)
-		}
-
-		if errors := validateSQSNonFifoQueueName(v); len(errors) > 0 {
-			t.Fatalf("%q should be a valid SQS non-fifo queue Name", v)
-		}
-	}
-
-	invalidNames := []string{
-		"Here is a name with: colon",
-		"another * invalid name",
-		"also $ invalid",
-		"This . is also %% invalid@!)+(",
-		"*",
-		"",
-		" ",
-		".",
-		strings.Repeat("W", 81), // length > 80
-	}
-	for _, v := range invalidNames {
-		if _, errors := validateSQSQueueName(v, "test_attribute"); len(errors) == 0 {
-			t.Fatalf("%q should be an invalid SQS queue Name", v)
-		}
-
-		if errors := validateSQSNonFifoQueueName(v); len(errors) == 0 {
-			t.Fatalf("%q should be an invalid SQS non-fifo queue Name", v)
-		}
-	}
-}
-
-func TestValidateSQSFifoQueueName(t *testing.T) {
-	validNames := []string{
-		"valid-name.fifo",
-		"valid02-name.fifo",
-		"Valid-Name1.fifo",
-		"_.fifo",
-		"a.fifo",
-		"A.fifo",
-		"9.fifo",
-		"-.fifo",
-		fmt.Sprintf("%s.fifo", strings.Repeat("W", 75)),
-	}
-	for _, v := range validNames {
-		if _, errors := validateSQSQueueName(v, "test_attribute"); len(errors) > 0 {
-			t.Fatalf("%q should be a valid SQS queue Name", v)
-		}
-
-		if errors := validateSQSFifoQueueName(v); len(errors) > 0 {
-			t.Fatalf("%q should be a valid SQS FIFO queue Name: %v", v, errors)
-		}
-	}
-
-	invalidNames := []string{
-		"Here is a name with: colon",
-		"another * invalid name",
-		"also $ invalid",
-		"This . is also %% invalid@!)+(",
-		".fifo",
-		"*",
-		"",
-		" ",
-		".",
-		strings.Repeat("W", 81), // length > 80
-	}
-	for _, v := range invalidNames {
-		if _, errors := validateSQSQueueName(v, "test_attribute"); len(errors) == 0 {
-			t.Fatalf("%q should be an invalid SQS queue Name", v)
-		}
-
-		if errors := validateSQSFifoQueueName(v); len(errors) == 0 {
-			t.Fatalf("%q should be an invalid SQS FIFO queue Name: %v", v, errors)
 		}
 	}
 }

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -52,8 +52,8 @@ resource "aws_sqs_queue" "terraform_queue" {
 
 The following arguments are supported:
 
-* `name` - (Optional) This is the human-readable name of the queue. If omitted, Terraform will assign a random name.
-* `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `name` - (Optional) The name of the queue. Queue names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 80 characters long. For a FIFO (first-in-first-out) queue, the name must end with the `.fifo` suffix. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`
 * `visibility_timeout_seconds` - (Optional) The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30. For more information about visibility timeout, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html).
 * `message_retention_seconds` - (Optional) The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days). The default for this attribute is 345600 (4 days).
 * `max_message_size` - (Optional) The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB). The default for this attribute is 262144 (256 KiB).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17005

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
append .fifo suffix for FIFO queue if name unspecified
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make testacc TEST=./aws TESTARGS='-run=TestAccAWSSQSQueue'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSQSQueue -timeout 120m
=== RUN   TestAccAWSSQSQueuePolicy_basic
=== PAUSE TestAccAWSSQSQueuePolicy_basic
=== RUN   TestAccAWSSQSQueuePolicy_disappears_queue
=== PAUSE TestAccAWSSQSQueuePolicy_disappears_queue
=== RUN   TestAccAWSSQSQueuePolicy_disappears
=== PAUSE TestAccAWSSQSQueuePolicy_disappears
=== RUN   TestAccAWSSQSQueue_basic
=== PAUSE TestAccAWSSQSQueue_basic
=== RUN   TestAccAWSSQSQueue_tags
=== PAUSE TestAccAWSSQSQueue_tags
=== RUN   TestAccAWSSQSQueue_namePrefix
=== PAUSE TestAccAWSSQSQueue_namePrefix
=== RUN   TestAccAWSSQSQueue_namePrefix_fifo
=== PAUSE TestAccAWSSQSQueue_namePrefix_fifo
=== RUN   TestAccAWSSQSQueue_policy
=== PAUSE TestAccAWSSQSQueue_policy
=== RUN   TestAccAWSSQSQueue_queueDeletedRecently
=== PAUSE TestAccAWSSQSQueue_queueDeletedRecently
=== RUN   TestAccAWSSQSQueue_redrivePolicy
=== PAUSE TestAccAWSSQSQueue_redrivePolicy
=== RUN   TestAccAWSSQSQueue_Policybasic
=== PAUSE TestAccAWSSQSQueue_Policybasic
=== RUN   TestAccAWSSQSQueue_FIFO
=== PAUSE TestAccAWSSQSQueue_FIFO
=== RUN   TestAccAWSSQSQueue_FIFOExpectNameError
=== PAUSE TestAccAWSSQSQueue_FIFOExpectNameError
=== RUN   TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== PAUSE TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== RUN   TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== PAUSE TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== RUN   TestAccAWSSQSQueue_Encryption
=== PAUSE TestAccAWSSQSQueue_Encryption
=== RUN   TestAccAWSSQSQueue_FIFO_MinusName
=== PAUSE TestAccAWSSQSQueue_FIFO_MinusName
=== CONT  TestAccAWSSQSQueuePolicy_basic
=== CONT  TestAccAWSSQSQueue_redrivePolicy
=== CONT  TestAccAWSSQSQueuePolicy_disappears_queue
=== CONT  TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== CONT  TestAccAWSSQSQueue_FIFOExpectNameError
=== CONT  TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== CONT  TestAccAWSSQSQueue_FIFO_MinusName
=== CONT  TestAccAWSSQSQueue_Policybasic
=== CONT  TestAccAWSSQSQueue_Encryption
=== CONT  TestAccAWSSQSQueue_policy
=== CONT  TestAccAWSSQSQueue_FIFO
=== CONT  TestAccAWSSQSQueue_namePrefix
=== CONT  TestAccAWSSQSQueue_basic
=== CONT  TestAccAWSSQSQueue_queueDeletedRecently
=== CONT  TestAccAWSSQSQueue_namePrefix_fifo
=== CONT  TestAccAWSSQSQueuePolicy_disappears
=== CONT  TestAccAWSSQSQueue_tags
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (11.06s)
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (11.85s)
--- PASS: TestAccAWSSQSQueuePolicy_disappears_queue (25.90s)
--- PASS: TestAccAWSSQSQueuePolicy_disappears (31.18s)
--- PASS: TestAccAWSSQSQueue_FIFO_MinusName (32.58s)
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (32.79s)
--- PASS: TestAccAWSSQSQueue_Encryption (33.02s)
--- PASS: TestAccAWSSQSQueue_FIFO (33.16s)
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (33.22s)
--- PASS: TestAccAWSSQSQueue_namePrefix (33.38s)
--- PASS: TestAccAWSSQSQueue_redrivePolicy (33.59s)
--- PASS: TestAccAWSSQSQueue_Policybasic (35.33s)
--- PASS: TestAccAWSSQSQueue_policy (35.86s)
--- PASS: TestAccAWSSQSQueuePolicy_basic (39.98s)
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (40.16s)
--- PASS: TestAccAWSSQSQueue_basic (50.78s)
--- PASS: TestAccAWSSQSQueue_tags (50.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       50.937s

...
```
