### PR TITLE
Add "linkTag" SES event dimension options to docs

### DIFF
--- a/website/docs/r/ses_event_destination.markdown
+++ b/website/docs/r/ses_event_destination.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `default_value` - (Required) The default value for the event
 * `dimension_name` - (Required) The name for the dimension
-* `value_source` - (Required) The source for the value. It can be either `"messageTag"` or `"emailHeader"`
+* `value_source` - (Required) The source for the value. May be any of `"messageTag"`, `"emailHeader"` or `"linkTag"`.
 
 ### kinesis_destination Argument Reference
 


### PR DESCRIPTION
### Aligning website doc with the code

Add "linkTag" option to the documentation of SES events CloudWatch destination dimensions.

It seems cloudwatch_destination schema validation is [already aware](https://github.com/hashicorp/terraform-provider-aws/blob/dff8af6af2a3cfe1dc1ab9d3d376943e8b594fc1/aws/resource_aws_ses_event_destination.go#L86) of ```linkTag``` option.
```
  "value_source": {
	  Type:     schema.TypeString,
	  Required: true,
	  ValidateFunc: validation.StringInSlice([]string{
		  ses.DimensionValueSourceMessageTag,
		  ses.DimensionValueSourceEmailHeader,
		  ses.DimensionValueSourceLinkTag,
	  }, false),
  }
```


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
