### PR TITLE
Prefer tfresource.NotFound() over checking error type

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -128,3 +128,23 @@ rules:
           ...
           return ...
     severity: WARNING
+
+  - id: is-not-found-error
+    languages: [go]
+    message: Check for resource.NotFoundError errors with tfresource.NotFound()
+    paths:
+      include:
+        - aws/
+    patterns:
+      - pattern-either:
+        - patterns:
+          - pattern: |
+              var $CAST *resource.NotFoundError
+              ...
+              errors.As($ERR, &$CAST)
+          - pattern-not-inside: func NotFound(err error) bool { ... }
+        - patterns:
+          - pattern: |
+              $X, $Y := $ERR.(*resource.NotFoundError)
+          - pattern-not-inside: func isResourceNotFoundError(err error) bool { ... }
+    severity: WARNING

--- a/aws/resource_aws_cloudwatch_log_metric_filter.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsCloudWatchLogMetricFilter() *schema.Resource {
@@ -125,7 +126,7 @@ func resourceAwsCloudWatchLogMetricFilterRead(d *schema.ResourceData, meta inter
 	mf, err := lookupCloudWatchLogMetricFilter(conn, d.Get("name").(string),
 		d.Get("log_group_name").(string), nil)
 	if err != nil {
-		if _, ok := err.(*resource.NotFoundError); ok {
+		if tfresource.NotFound(err) {
 			log.Printf("[WARN] Removing CloudWatch Log Metric Filter as it is gone")
 			d.SetId("")
 			return nil

--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 var LambdaFunctionRegexp = `^(arn:[\w-]+:lambda:)?([a-z]{2}-(?:[a-z]+-){1,2}\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
@@ -252,8 +253,8 @@ func resourceAwsLambdaPermissionRead(d *schema.ResourceData, meta interface{}) e
 		}
 
 		// Missing permission inside valid policy
-		if nfErr, ok := err.(*resource.NotFoundError); ok {
-			log.Printf("[WARN] %s", nfErr)
+		if tfresource.NotFound(err) {
+			log.Printf("[WARN] %s", err)
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Adds a `semgrep` check to find uses of error type checking for `resource.NotFoundError`. Prefers use of `tfresource.NotFound()`.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchLogMetricFilter_\|TestAccAWSLambdaPermission_'

--- PASS: TestAccAWSLambdaPermission_withS3 (114.22s)
--- PASS: TestAccAWSLambdaPermission_withRawFunctionName (120.25s)
--- PASS: TestAccAWSLambdaPermission_basic (141.55s)
--- PASS: TestAccAWSLambdaPermission_withIAMRole (148.88s)
--- PASS: TestAccAWSLambdaPermission_withSNS (157.79s)
--- PASS: TestAccAWSLambdaPermission_StatementId_Duplicate (160.98s)
--- PASS: TestAccAWSLambdaPermission_withStatementIdPrefix (164.13s)
--- PASS: TestAccAWSCloudWatchLogMetricFilter_basic (165.83s)
--- PASS: TestAccAWSLambdaPermission_withQualifier (169.04s)
--- PASS: TestAccAWSLambdaPermission_disappears (181.29s)
--- PASS: TestAccAWSLambdaPermission_multiplePerms (210.64s)
```
