### PR TITLE
service/elasticache: use waiter and finder function pattern

### DIFF
--- a/aws/data_source_aws_elasticache_cluster.go
+++ b/aws/data_source_aws_elasticache_cluster.go
@@ -2,14 +2,13 @@ package aws
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func dataSourceAwsElastiCacheCluster() *schema.Resource {
@@ -154,25 +153,14 @@ func dataSourceAwsElastiCacheClusterRead(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).elasticacheconn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	req := &elasticache.DescribeCacheClustersInput{
-		CacheClusterId:    aws.String(d.Get("cluster_id").(string)),
-		ShowCacheNodeInfo: aws.Bool(true),
+	clusterID := d.Get("cluster_id").(string)
+	cluster, err := finder.CacheClusterWithNodeInfoByID(conn, clusterID)
+	if tfresource.NotFound(err) {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again")
 	}
-
-	log.Printf("[DEBUG] Reading ElastiCache Cluster: %s", req)
-	resp, err := conn.DescribeCacheClusters(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading ElastiCache Cache Cluster (%s): %w", clusterID, err)
 	}
-
-	if len(resp.CacheClusters) < 1 {
-		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
-	}
-	if len(resp.CacheClusters) > 1 {
-		return fmt.Errorf("Your query returned more than one result. Please try a more specific search criteria.")
-	}
-
-	cluster := resp.CacheClusters[0]
 
 	d.SetId(aws.StringValue(cluster.CacheClusterId))
 
@@ -214,23 +202,16 @@ func dataSourceAwsElastiCacheClusterRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "elasticache",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("cluster:%s", d.Id()),
-	}.String()
-	d.Set("arn", arn)
+	d.Set("arn", cluster.ARN)
 
-	tags, err := keyvaluetags.ElasticacheListTags(conn, arn)
+	tags, err := keyvaluetags.ElasticacheListTags(conn, aws.StringValue(cluster.ARN))
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Elasticache Cluster (%s): %s", arn, err)
+		return fmt.Errorf("error listing tags for Elasticache Cluster (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/finder"
 )
 
 func dataSourceAwsElasticacheReplicationGroup() *schema.Resource {
@@ -78,24 +78,11 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 	conn := meta.(*AWSClient).elasticacheconn
 
 	groupID := d.Get("replication_group_id").(string)
-	input := &elasticache.DescribeReplicationGroupsInput{
-		ReplicationGroupId: aws.String(groupID),
-	}
 
-	log.Printf("[DEBUG] Reading ElastiCache Replication Group: %s", input)
-	resp, err := conn.DescribeReplicationGroups(input)
+	rg, err := finder.ReplicationGroupByID(conn, groupID)
 	if err != nil {
-		if isAWSErr(err, elasticache.ErrCodeReplicationGroupNotFoundFault, "") {
-			return fmt.Errorf("ElastiCache Replication Group (%s) not found", groupID)
-		}
-		return fmt.Errorf("error reading replication group (%s): %w", groupID, err)
+		return fmt.Errorf("error reading ElastiCache Replication Group (%s): %w", groupID, err)
 	}
-
-	if resp == nil || len(resp.ReplicationGroups) == 0 {
-		return fmt.Errorf("error reading replication group (%s): empty output", groupID)
-	}
-
-	rg := resp.ReplicationGroups[0]
 
 	d.SetId(aws.StringValue(rg.ReplicationGroupId))
 	d.Set("replication_group_description", rg.Description)
@@ -115,7 +102,7 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 	} else {
 		if rg.NodeGroups == nil {
 			d.SetId("")
-			return fmt.Errorf("Elasticache Replication Group (%s) doesn't have node groups.", aws.StringValue(rg.ReplicationGroupId))
+			return fmt.Errorf("ElastiCache Replication Group (%s) doesn't have node groups", aws.StringValue(rg.ReplicationGroupId))
 		}
 		d.Set("port", rg.NodeGroups[0].PrimaryEndpoint.Port)
 		d.Set("primary_endpoint_address", rg.NodeGroups[0].PrimaryEndpoint.Address)

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -72,7 +72,7 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceAwsElasticacheReplicationGroupConfig_NonExistent,
-				ExpectError: regexp.MustCompile(`not found`),
+				ExpectError: regexp.MustCompile(`couldn't find resource`),
 			},
 		},
 	})

--- a/aws/internal/service/elasticache/finder/finder.go
+++ b/aws/internal/service/elasticache/finder/finder.go
@@ -1,0 +1,34 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// ReplicationGroupByID retrieves an ElastiCache Replication Group by id.
+func ReplicationGroupByID(conn *elasticache.ElastiCache, id string) (*elasticache.ReplicationGroup, error) {
+	input := &elasticache.DescribeReplicationGroupsInput{
+		ReplicationGroupId: aws.String(id),
+	}
+	result, err := conn.DescribeReplicationGroups(input)
+	if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeReplicationGroupNotFoundFault) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil || len(result.ReplicationGroups) == 0 || result.ReplicationGroups[0] == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return result.ReplicationGroups[0], nil
+}

--- a/aws/internal/service/elasticache/finder/finder.go
+++ b/aws/internal/service/elasticache/finder/finder.go
@@ -32,3 +32,43 @@ func ReplicationGroupByID(conn *elasticache.ElastiCache, id string) (*elasticach
 
 	return result.ReplicationGroups[0], nil
 }
+
+// CacheClusterByID retrieves an ElastiCache Cache Cluster by id.
+func CacheClusterByID(conn *elasticache.ElastiCache, id string) (*elasticache.CacheCluster, error) {
+	input := &elasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String(id),
+	}
+	return CacheCluster(conn, input)
+}
+
+// CacheClusterWithNodeInfoByID retrieves an ElastiCache Cache Cluster with Node Info by id.
+func CacheClusterWithNodeInfoByID(conn *elasticache.ElastiCache, id string) (*elasticache.CacheCluster, error) {
+	input := &elasticache.DescribeCacheClustersInput{
+		CacheClusterId:    aws.String(id),
+		ShowCacheNodeInfo: aws.Bool(true),
+	}
+	return CacheCluster(conn, input)
+}
+
+// CacheCluster retrieves an ElastiCache Cache Cluster using DescribeCacheClustersInput.
+func CacheCluster(conn *elasticache.ElastiCache, input *elasticache.DescribeCacheClustersInput) (*elasticache.CacheCluster, error) {
+	result, err := conn.DescribeCacheClusters(input)
+	if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeCacheClusterNotFoundFault) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil || len(result.CacheClusters) == 0 || result.CacheClusters[0] == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return result.CacheClusters[0], nil
+}

--- a/aws/internal/service/elasticache/waiter/status.go
+++ b/aws/internal/service/elasticache/waiter/status.go
@@ -1,0 +1,33 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+const (
+	ReplicationGroupStatusCreating     = "creating"
+	ReplicationGroupStatusAvailable    = "available"
+	ReplicationGroupStatusModifying    = "modifying"
+	ReplicationGroupStatusDeleting     = "deleting"
+	ReplicationGroupStatusCreateFailed = "create-failed"
+	ReplicationGroupStatusSnapshotting = "snapshotting"
+)
+
+// ReplicationGroupStatus fetches the ReplicationGroup and its Status
+func ReplicationGroupStatus(conn *elasticache.ElastiCache, replicationGroupID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		rg, err := finder.ReplicationGroupByID(conn, replicationGroupID)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+
+		return rg, aws.StringValue(rg.Status), nil
+	}
+}

--- a/aws/internal/service/elasticache/waiter/status.go
+++ b/aws/internal/service/elasticache/waiter/status.go
@@ -31,3 +31,30 @@ func ReplicationGroupStatus(conn *elasticache.ElastiCache, replicationGroupID st
 		return rg, aws.StringValue(rg.Status), nil
 	}
 }
+
+const (
+	CacheClusterStatusAvailable             = "available"
+	CacheClusterStatusCreating              = "creating"
+	CacheClusterStatusDeleted               = "deleted"
+	CacheClusterStatusDeleting              = "deleting"
+	CacheClusterStatusIncompatibleNetwork   = "incompatible-network"
+	CacheClusterStatusModifying             = "modifying"
+	CacheClusterStatusRebootingClusterNodes = "rebooting cluster nodes"
+	CacheClusterStatusRestoreFailed         = "restore-failed"
+	CacheClusterStatusSnapshotting          = "snapshotting"
+)
+
+// CacheClusterStatus fetches the CacheCluster and its Status
+func CacheClusterStatus(conn *elasticache.ElastiCache, cacheClusterID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		c, err := finder.CacheClusterByID(conn, cacheClusterID)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+
+		return c, aws.StringValue(c.CacheClusterStatus), nil
+	}
+}

--- a/aws/internal/service/elasticache/waiter/waiter.go
+++ b/aws/internal/service/elasticache/waiter/waiter.go
@@ -1,0 +1,52 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	replicationGroupAvailableMinTimeout = 10 * time.Second
+	replicationGroupAvailableDelay      = 30 * time.Second
+
+	replicationGroupDeletedMinTimeout = 10 * time.Second
+	replicationGroupDeletedDelay      = 30 * time.Second
+)
+
+// ReplicationGroupAvailable waits for a ReplicationGroup to return Available
+func ReplicationGroupAvailable(conn *elasticache.ElastiCache, replicationGroupID string, timeout time.Duration) (*elasticache.ReplicationGroup, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{ReplicationGroupStatusCreating, ReplicationGroupStatusModifying, ReplicationGroupStatusSnapshotting},
+		Target:     []string{ReplicationGroupStatusAvailable},
+		Refresh:    ReplicationGroupStatus(conn, replicationGroupID),
+		Timeout:    timeout,
+		MinTimeout: replicationGroupAvailableMinTimeout,
+		Delay:      replicationGroupAvailableDelay,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+	if v, ok := outputRaw.(*elasticache.ReplicationGroup); ok {
+		return v, err
+	}
+	return nil, err
+}
+
+// ReplicationGroupDeleted waits for a ReplicationGroup to be deleted
+func ReplicationGroupDeleted(conn *elasticache.ElastiCache, replicationGroupID string, timeout time.Duration) (*elasticache.ReplicationGroup, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{ReplicationGroupStatusCreating, ReplicationGroupStatusAvailable, ReplicationGroupStatusDeleting},
+		Target:     []string{},
+		Refresh:    ReplicationGroupStatus(conn, replicationGroupID),
+		Timeout:    timeout,
+		MinTimeout: replicationGroupDeletedMinTimeout,
+		Delay:      replicationGroupDeletedDelay,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+	if v, ok := outputRaw.(*elasticache.ReplicationGroup); ok {
+		return v, err
+	}
+	return nil, err
+}

--- a/aws/internal/service/elasticache/waiter/waiter.go
+++ b/aws/internal/service/elasticache/waiter/waiter.go
@@ -8,6 +8,10 @@ import (
 )
 
 const (
+	ReplicationGroupDefaultCreatedTimeout = 60 * time.Minute
+	ReplicationGroupDefaultUpdatedTimeout = 40 * time.Minute
+	ReplicationGroupDefaultDeletedTimeout = 40 * time.Minute
+
 	replicationGroupAvailableMinTimeout = 10 * time.Second
 	replicationGroupAvailableDelay      = 30 * time.Second
 

--- a/aws/internal/service/elasticache/waiter/waiter.go
+++ b/aws/internal/service/elasticache/waiter/waiter.go
@@ -18,7 +18,11 @@ const (
 // ReplicationGroupAvailable waits for a ReplicationGroup to return Available
 func ReplicationGroupAvailable(conn *elasticache.ElastiCache, replicationGroupID string, timeout time.Duration) (*elasticache.ReplicationGroup, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{ReplicationGroupStatusCreating, ReplicationGroupStatusModifying, ReplicationGroupStatusSnapshotting},
+		Pending: []string{
+			ReplicationGroupStatusCreating,
+			ReplicationGroupStatusModifying,
+			ReplicationGroupStatusSnapshotting,
+		},
 		Target:     []string{ReplicationGroupStatusAvailable},
 		Refresh:    ReplicationGroupStatus(conn, replicationGroupID),
 		Timeout:    timeout,
@@ -36,12 +40,77 @@ func ReplicationGroupAvailable(conn *elasticache.ElastiCache, replicationGroupID
 // ReplicationGroupDeleted waits for a ReplicationGroup to be deleted
 func ReplicationGroupDeleted(conn *elasticache.ElastiCache, replicationGroupID string, timeout time.Duration) (*elasticache.ReplicationGroup, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{ReplicationGroupStatusCreating, ReplicationGroupStatusAvailable, ReplicationGroupStatusDeleting},
+		Pending: []string{
+			ReplicationGroupStatusCreating,
+			ReplicationGroupStatusAvailable,
+			ReplicationGroupStatusDeleting,
+		},
 		Target:     []string{},
 		Refresh:    ReplicationGroupStatus(conn, replicationGroupID),
 		Timeout:    timeout,
 		MinTimeout: replicationGroupDeletedMinTimeout,
 		Delay:      replicationGroupDeletedDelay,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+	if v, ok := outputRaw.(*elasticache.ReplicationGroup); ok {
+		return v, err
+	}
+	return nil, err
+}
+
+const (
+	CacheClusterCreatedTimeout = 40 * time.Minute
+	CacheClusterUpdatedTimeout = 80 * time.Minute
+	CacheClusterDeletedTimeout = 40 * time.Minute
+
+	cacheClusterAvailableMinTimeout = 10 * time.Second
+	cacheClusterAvailableDelay      = 30 * time.Second
+
+	cacheClusterDeletedMinTimeout = 10 * time.Second
+	cacheClusterDeletedDelay      = 30 * time.Second
+)
+
+// CacheClusterAvailable waits for a ReplicationGroup to return Available
+func CacheClusterAvailable(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) (*elasticache.ReplicationGroup, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			CacheClusterStatusCreating,
+			CacheClusterStatusModifying,
+			CacheClusterStatusSnapshotting,
+			CacheClusterStatusRebootingClusterNodes,
+		},
+		Target:     []string{CacheClusterStatusAvailable},
+		Refresh:    CacheClusterStatus(conn, cacheClusterID),
+		Timeout:    timeout,
+		MinTimeout: cacheClusterAvailableMinTimeout,
+		Delay:      cacheClusterAvailableDelay,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+	if v, ok := outputRaw.(*elasticache.ReplicationGroup); ok {
+		return v, err
+	}
+	return nil, err
+}
+
+// CacheClusterDeleted waits for a ReplicationGroup to be deleted
+func CacheClusterDeleted(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) (*elasticache.ReplicationGroup, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			CacheClusterStatusCreating,
+			CacheClusterStatusAvailable,
+			CacheClusterStatusModifying,
+			CacheClusterStatusDeleting,
+			CacheClusterStatusIncompatibleNetwork,
+			CacheClusterStatusRestoreFailed,
+			CacheClusterStatusSnapshotting,
+		},
+		Target:     []string{},
+		Refresh:    CacheClusterStatus(conn, cacheClusterID),
+		Timeout:    timeout,
+		MinTimeout: cacheClusterDeletedMinTimeout,
+		Delay:      cacheClusterDeletedDelay,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -428,7 +428,7 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	c, err := finder.CacheClusterWithNodeInfoByID(conn, d.Id())
-	if tfresource.NotFound(err) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] ElastiCache Cache Cluster (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	gversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -19,6 +18,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsElasticacheCluster() *schema.Resource {
@@ -89,7 +91,7 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				StateFunc: func(val interface{}) string {
-					// Elasticache normalizes cluster ids to lowercase,
+					// ElastiCache normalizes cluster ids to lowercase,
 					// so we have to do this too or else we can end up
 					// with non-converging diffs.
 					return strings.ToLower(val.(string))
@@ -122,7 +124,7 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				StateFunc: func(val interface{}) string {
-					// Elasticache always changes the maintenance
+					// ElastiCache always changes the maintenance
 					// to lowercase
 					return strings.ToLower(val.(string))
 				},
@@ -408,14 +410,14 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 
 	id, err := createElasticacheCacheCluster(conn, req)
 	if err != nil {
-		return fmt.Errorf("error creating Elasticache Cache Cluster: %s", err)
+		return fmt.Errorf("error creating ElastiCache Cache Cluster: %w", err)
 	}
 
 	d.SetId(id)
 
-	err = waitForCreateElasticacheCacheCluster(conn, d.Id(), 40*time.Minute)
+	_, err = waiter.CacheClusterAvailable(conn, d.Id(), 40*time.Minute)
 	if err != nil {
-		return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be created: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for ElastiCache Cache Cluster (%s) to be created: %w", d.Id(), err)
 	}
 
 	return resourceAwsElasticacheClusterRead(d, meta)
@@ -425,85 +427,68 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).elasticacheconn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	req := &elasticache.DescribeCacheClustersInput{
-		CacheClusterId:    aws.String(d.Id()),
-		ShowCacheNodeInfo: aws.Bool(true),
+	c, err := finder.CacheClusterWithNodeInfoByID(conn, d.Id())
+	if tfresource.NotFound(err) {
+		log.Printf("[WARN] ElastiCache Cache Cluster (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading ElastiCache Cache Cluster (%s): %w", d.Id(), err)
 	}
 
-	res, err := conn.DescribeCacheClusters(req)
-	if err != nil {
-		if isAWSErr(err, elasticache.ErrCodeCacheClusterNotFoundFault, "") {
-			log.Printf("[WARN] ElastiCache Cluster (%s) not found", d.Id())
-			d.SetId("")
-			return nil
-		}
+	d.Set("cluster_id", c.CacheClusterId)
+	d.Set("node_type", c.CacheNodeType)
+	d.Set("num_cache_nodes", c.NumCacheNodes)
+	d.Set("engine", c.Engine)
+	d.Set("engine_version", c.EngineVersion)
+	if c.ConfigurationEndpoint != nil {
+		d.Set("port", c.ConfigurationEndpoint.Port)
+		d.Set("configuration_endpoint", aws.String(fmt.Sprintf("%s:%d", *c.ConfigurationEndpoint.Address, *c.ConfigurationEndpoint.Port)))
+		d.Set("cluster_address", aws.String((*c.ConfigurationEndpoint.Address)))
+	} else if len(c.CacheNodes) > 0 {
+		d.Set("port", int(aws.Int64Value(c.CacheNodes[0].Endpoint.Port)))
+	}
 
+	if c.ReplicationGroupId != nil {
+		d.Set("replication_group_id", c.ReplicationGroupId)
+	}
+
+	d.Set("subnet_group_name", c.CacheSubnetGroupName)
+	d.Set("security_group_names", flattenElastiCacheSecurityGroupNames(c.CacheSecurityGroups))
+	d.Set("security_group_ids", flattenElastiCacheSecurityGroupIds(c.SecurityGroups))
+	if c.CacheParameterGroup != nil {
+		d.Set("parameter_group_name", c.CacheParameterGroup.CacheParameterGroupName)
+	}
+	d.Set("maintenance_window", c.PreferredMaintenanceWindow)
+	d.Set("snapshot_window", c.SnapshotWindow)
+	d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)
+	if c.NotificationConfiguration != nil {
+		if *c.NotificationConfiguration.TopicStatus == "active" {
+			d.Set("notification_topic_arn", c.NotificationConfiguration.TopicArn)
+		}
+	}
+	d.Set("availability_zone", c.PreferredAvailabilityZone)
+	if *c.PreferredAvailabilityZone == "Multiple" {
+		d.Set("az_mode", "cross-az")
+	} else {
+		d.Set("az_mode", "single-az")
+	}
+
+	if err := setCacheNodeData(d, c); err != nil {
 		return err
 	}
 
-	if len(res.CacheClusters) == 1 {
-		c := res.CacheClusters[0]
-		d.Set("cluster_id", c.CacheClusterId)
-		d.Set("node_type", c.CacheNodeType)
-		d.Set("num_cache_nodes", c.NumCacheNodes)
-		d.Set("engine", c.Engine)
-		d.Set("engine_version", c.EngineVersion)
-		if c.ConfigurationEndpoint != nil {
-			d.Set("port", c.ConfigurationEndpoint.Port)
-			d.Set("configuration_endpoint", aws.String(fmt.Sprintf("%s:%d", *c.ConfigurationEndpoint.Address, *c.ConfigurationEndpoint.Port)))
-			d.Set("cluster_address", aws.String((*c.ConfigurationEndpoint.Address)))
-		} else if len(c.CacheNodes) > 0 {
-			d.Set("port", int(aws.Int64Value(c.CacheNodes[0].Endpoint.Port)))
-		}
+	d.Set("arn", c.ARN)
 
-		if c.ReplicationGroupId != nil {
-			d.Set("replication_group_id", c.ReplicationGroupId)
-		}
+	tags, err := keyvaluetags.ElasticacheListTags(conn, aws.StringValue(c.ARN))
 
-		d.Set("subnet_group_name", c.CacheSubnetGroupName)
-		d.Set("security_group_names", flattenElastiCacheSecurityGroupNames(c.CacheSecurityGroups))
-		d.Set("security_group_ids", flattenElastiCacheSecurityGroupIds(c.SecurityGroups))
-		if c.CacheParameterGroup != nil {
-			d.Set("parameter_group_name", c.CacheParameterGroup.CacheParameterGroupName)
-		}
-		d.Set("maintenance_window", c.PreferredMaintenanceWindow)
-		d.Set("snapshot_window", c.SnapshotWindow)
-		d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)
-		if c.NotificationConfiguration != nil {
-			if *c.NotificationConfiguration.TopicStatus == "active" {
-				d.Set("notification_topic_arn", c.NotificationConfiguration.TopicArn)
-			}
-		}
-		d.Set("availability_zone", c.PreferredAvailabilityZone)
-		if *c.PreferredAvailabilityZone == "Multiple" {
-			d.Set("az_mode", "cross-az")
-		} else {
-			d.Set("az_mode", "single-az")
-		}
+	if err != nil {
+		return fmt.Errorf("error listing tags for ElastiCache Cluster (%s): %w", d.Id(), err)
+	}
 
-		if err := setCacheNodeData(d, c); err != nil {
-			return err
-		}
-
-		arn := arn.ARN{
-			Partition: meta.(*AWSClient).partition,
-			Service:   "elasticache",
-			Region:    meta.(*AWSClient).region,
-			AccountID: meta.(*AWSClient).accountid,
-			Resource:  fmt.Sprintf("cluster:%s", d.Id()),
-		}.String()
-
-		d.Set("arn", arn)
-
-		tags, err := keyvaluetags.ElasticacheListTags(conn, arn)
-
-		if err != nil {
-			return fmt.Errorf("error listing tags for Elasticache Cluster (%s): %s", arn, err)
-		}
-
-		if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-			return fmt.Errorf("error setting tags: %s", err)
-		}
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil
@@ -516,7 +501,7 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 		o, n := d.GetChange("tags")
 
 		if err := keyvaluetags.ElasticacheUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Elasticache Cluster (%s) tags: %s", d.Get("arn").(string), err)
+			return fmt.Errorf("error updating ElastiCache Cluster (%s) tags: %w", d.Get("arn").(string), err)
 		}
 	}
 
@@ -613,23 +598,12 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 		log.Printf("[DEBUG] Modifying ElastiCache Cluster (%s), opts:\n%s", d.Id(), req)
 		_, err := conn.ModifyCacheCluster(req)
 		if err != nil {
-			return fmt.Errorf("Error updating ElastiCache cluster (%s), error: %s", d.Id(), err)
+			return fmt.Errorf("Error updating ElastiCache cluster (%s), error: %w", d.Id(), err)
 		}
 
-		log.Printf("[DEBUG] Waiting for update: %s", d.Id())
-		pending := []string{"modifying", "rebooting cache cluster nodes", "snapshotting"}
-		stateConf := &resource.StateChangeConf{
-			Pending:    pending,
-			Target:     []string{"available"},
-			Refresh:    cacheClusterStateRefreshFunc(conn, d.Id(), "available", pending),
-			Timeout:    80 * time.Minute,
-			MinTimeout: 10 * time.Second,
-			Delay:      30 * time.Second,
-		}
-
-		_, sterr := stateConf.WaitForState()
-		if sterr != nil {
-			return fmt.Errorf("Error waiting for elasticache (%s) to update: %s", d.Id(), sterr)
+		_, err = waiter.CacheClusterAvailable(conn, d.Id(), waiter.CacheClusterUpdatedTimeout)
+		if err != nil {
+			return fmt.Errorf("error waiting for ElastiCache Cache Cluster (%s) to update: %w", d.Id(), err)
 		}
 	}
 
@@ -686,89 +660,18 @@ func resourceAwsElasticacheClusterDelete(d *schema.ResourceData, meta interface{
 		if isAWSErr(err, elasticache.ErrCodeCacheClusterNotFoundFault, "") {
 			return nil
 		}
-		return fmt.Errorf("error deleting Elasticache Cache Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting ElastiCache Cache Cluster (%s): %w", d.Id(), err)
 	}
-	err = waitForDeleteElasticacheCacheCluster(conn, d.Id(), 40*time.Minute)
+	_, err = waiter.CacheClusterDeleted(conn, d.Id(), waiter.CacheClusterDeletedTimeout)
 	if err != nil {
-		return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be deleted: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for ElastiCache Cache Cluster (%s) to be deleted: %w", d.Id(), err)
 	}
 
 	return nil
 }
 
-func cacheClusterStateRefreshFunc(conn *elasticache.ElastiCache, clusterID, givenState string, pending []string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeCacheClusters(&elasticache.DescribeCacheClustersInput{
-			CacheClusterId:    aws.String(clusterID),
-			ShowCacheNodeInfo: aws.Bool(true),
-		})
-		if err != nil {
-			if isAWSErr(err, elasticache.ErrCodeCacheClusterNotFoundFault, "") {
-				log.Printf("[DEBUG] Detect deletion")
-				return nil, "", nil
-			}
-
-			log.Printf("[ERROR] CacheClusterStateRefreshFunc: %s", err)
-			return nil, "", err
-		}
-
-		if len(resp.CacheClusters) == 0 {
-			return nil, "", fmt.Errorf("Error: no Cache Clusters found for id (%s)", clusterID)
-		}
-
-		var c *elasticache.CacheCluster
-		for _, cluster := range resp.CacheClusters {
-			if *cluster.CacheClusterId == clusterID {
-				log.Printf("[DEBUG] Found matching ElastiCache cluster: %s", *cluster.CacheClusterId)
-				c = cluster
-			}
-		}
-
-		if c == nil {
-			return nil, "", fmt.Errorf("Error: no matching Elastic Cache cluster for id (%s)", clusterID)
-		}
-
-		log.Printf("[DEBUG] ElastiCache Cluster (%s) status: %v", clusterID, *c.CacheClusterStatus)
-
-		// return the current state if it's in the pending array
-		for _, p := range pending {
-			log.Printf("[DEBUG] ElastiCache: checking pending state (%s) for cluster (%s), cluster status: %s", pending, clusterID, *c.CacheClusterStatus)
-			s := *c.CacheClusterStatus
-			if p == s {
-				log.Printf("[DEBUG] Return with status: %v", *c.CacheClusterStatus)
-				return c, p, nil
-			}
-		}
-
-		// return given state if it's not in pending
-		if givenState != "" {
-			log.Printf("[DEBUG] ElastiCache: checking given state (%s) of cluster (%s) against cluster status (%s)", givenState, clusterID, *c.CacheClusterStatus)
-			// check to make sure we have the node count we're expecting
-			if int64(len(c.CacheNodes)) != *c.NumCacheNodes {
-				log.Printf("[DEBUG] Node count is not what is expected: %d found, %d expected", len(c.CacheNodes), *c.NumCacheNodes)
-				return nil, "creating", nil
-			}
-
-			log.Printf("[DEBUG] Node count matched (%d)", len(c.CacheNodes))
-			// loop the nodes and check their status as well
-			for _, n := range c.CacheNodes {
-				log.Printf("[DEBUG] Checking cache node for status: %s", n)
-				if n.CacheNodeStatus != nil && *n.CacheNodeStatus != "available" {
-					log.Printf("[DEBUG] Node (%s) is not yet available, status: %s", *n.CacheNodeId, *n.CacheNodeStatus)
-					return nil, "creating", nil
-				}
-				log.Printf("[DEBUG] Cache node not in expected state")
-			}
-			log.Printf("[DEBUG] ElastiCache returning given state (%s), cluster: %s", givenState, c)
-			return c, givenState, nil
-		}
-		log.Printf("[DEBUG] current status: %v", *c.CacheClusterStatus)
-		return c, *c.CacheClusterStatus, nil
-	}
-}
-
 func createElasticacheCacheCluster(conn *elasticache.ElastiCache, input *elasticache.CreateCacheClusterInput) (string, error) {
-	log.Printf("[DEBUG] Creating Elasticache Cache Cluster: %s", input)
+	log.Printf("[DEBUG] Creating ElastiCache Cache Cluster: %s", input)
 	output, err := conn.CreateCacheCluster(input)
 	if err != nil {
 		return "", err
@@ -782,22 +685,6 @@ func createElasticacheCacheCluster(conn *elasticache.ElastiCache, input *elastic
 	return strings.ToLower(aws.StringValue(output.CacheCluster.CacheClusterId)), nil
 }
 
-func waitForCreateElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) error {
-	pending := []string{"creating", "modifying", "restoring", "snapshotting"}
-	stateConf := &resource.StateChangeConf{
-		Pending:    pending,
-		Target:     []string{"available"},
-		Refresh:    cacheClusterStateRefreshFunc(conn, cacheClusterID, "available", pending),
-		Timeout:    timeout,
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second,
-	}
-
-	log.Printf("[DEBUG] Waiting for Elasticache Cache Cluster (%s) to be created", cacheClusterID)
-	_, err := stateConf.WaitForState()
-	return err
-}
-
 func deleteElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID string, finalSnapshotID string) error {
 	input := &elasticache.DeleteCacheClusterInput{
 		CacheClusterId: aws.String(cacheClusterID),
@@ -806,7 +693,7 @@ func deleteElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID
 		input.FinalSnapshotIdentifier = aws.String(finalSnapshotID)
 	}
 
-	log.Printf("[DEBUG] Deleting Elasticache Cache Cluster: %s", input)
+	log.Printf("[DEBUG] Deleting ElastiCache Cache Cluster: %s", input)
 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteCacheCluster(input)
 		if err != nil {
@@ -826,20 +713,5 @@ func deleteElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID
 		_, err = conn.DeleteCacheCluster(input)
 	}
 
-	return err
-}
-
-func waitForDeleteElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"creating", "available", "deleting", "incompatible-parameters", "incompatible-network", "restore-failed", "snapshotting"},
-		Target:     []string{},
-		Refresh:    cacheClusterStateRefreshFunc(conn, cacheClusterID, "", []string{}),
-		Timeout:    timeout,
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second,
-	}
-	log.Printf("[DEBUG] Waiting for Elasticache Cache Cluster deletion: %v", cacheClusterID)
-
-	_, err := stateConf.WaitForState()
 	return err
 }

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -445,7 +445,7 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 	if c.ConfigurationEndpoint != nil {
 		d.Set("port", c.ConfigurationEndpoint.Port)
 		d.Set("configuration_endpoint", aws.String(fmt.Sprintf("%s:%d", aws.StringValue(c.ConfigurationEndpoint.Address), aws.Int64Value(c.ConfigurationEndpoint.Port))))
-		d.Set("cluster_address", aws.String((*c.ConfigurationEndpoint.Address)))
+		d.Set("cluster_address", c.ConfigurationEndpoint.Address)
 	} else if len(c.CacheNodes) > 0 {
 		d.Set("port", int(aws.Int64Value(c.CacheNodes[0].Endpoint.Port)))
 	}

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -444,7 +444,7 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 	d.Set("engine_version", c.EngineVersion)
 	if c.ConfigurationEndpoint != nil {
 		d.Set("port", c.ConfigurationEndpoint.Port)
-		d.Set("configuration_endpoint", aws.String(fmt.Sprintf("%s:%d", *c.ConfigurationEndpoint.Address, *c.ConfigurationEndpoint.Port)))
+		d.Set("configuration_endpoint", aws.String(fmt.Sprintf("%s:%d", aws.StringValue(c.ConfigurationEndpoint.Address), aws.Int64Value(c.ConfigurationEndpoint.Port))))
 		d.Set("cluster_address", aws.String((*c.ConfigurationEndpoint.Address)))
 	} else if len(c.CacheNodes) > 0 {
 		d.Set("port", int(aws.Int64Value(c.CacheNodes[0].Endpoint.Port)))

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -469,7 +469,7 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 		}
 	}
 	d.Set("availability_zone", c.PreferredAvailabilityZone)
-	if *c.PreferredAvailabilityZone == "Multiple" {
+	if aws.StringValue(c.PreferredAvailabilityZone) == "Multiple" {
 		d.Set("az_mode", "cross-az")
 	} else {
 		d.Set("az_mode", "single-az")

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -596,7 +596,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 
 			// Wait for all Cache Cluster creations
 			for _, cacheClusterID := range addClusterIDs {
-				err := waitForCreateElasticacheCacheCluster(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
+				_, err := waiter.CacheClusterAvailable(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return fmt.Errorf("error waiting for ElastiCache Cache Cluster (%s) to be created (adding replica): %w", cacheClusterID, err)
 				}
@@ -705,7 +705,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 
 			// Wait for all Cache Cluster deletions
 			for _, cacheClusterID := range removeClusterIDs {
-				err := waitForDeleteElasticacheCacheCluster(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
+				_, err := waiter.CacheClusterDeleted(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return fmt.Errorf("error waiting for ElastiCache Cache Cluster (%s) to be deleted (removing replica): %w", cacheClusterID, err)
 				}

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -881,14 +881,13 @@ func deleteElasticacheReplicationGroup(replicationGroupID string, conn *elastica
 	if isAWSErr(err, elasticache.ErrCodeReplicationGroupNotFoundFault, "") {
 		return nil
 	}
-
 	if err != nil {
-		return fmt.Errorf("error deleting ElastiCache Replication Group: %w", err)
+		return err
 	}
 
 	_, err = waiter.ReplicationGroupDeleted(conn, replicationGroupID, timeout)
 	if err != nil {
-		return fmt.Errorf("error waiting for ElastiCache Replication Group (%s) to delete: %w", err)
+		return err
 	}
 
 	return nil

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -270,9 +270,9 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(40 * time.Minute),
-			Update: schema.DefaultTimeout(40 * time.Minute),
+			Create: schema.DefaultTimeout(waiter.ReplicationGroupDefaultCreatedTimeout),
+			Delete: schema.DefaultTimeout(waiter.ReplicationGroupDefaultDeletedTimeout),
+			Update: schema.DefaultTimeout(waiter.ReplicationGroupDefaultUpdatedTimeout),
 		},
 	}
 }

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -887,7 +887,11 @@ func deleteElasticacheReplicationGroup(replicationGroupID string, conn *elastica
 	}
 
 	_, err = waiter.ReplicationGroupDeleted(conn, replicationGroupID, timeout)
-	return err
+	if err != nil {
+		return fmt.Errorf("error waiting for ElastiCache Replication Group (%s) to delete: %w", err)
+	}
+
+	return nil
 }
 
 func flattenElasticacheNodeGroupsToClusterMode(nodeGroups []*elasticache.NodeGroup) []map[string]interface{} {

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -292,10 +292,8 @@ func TestAccAWSElasticacheReplicationGroup_vpc(t *testing.T) {
 				Config: testAccAWSElasticacheReplicationGroupInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
-					resource.TestCheckResourceAttr(
-						resourceName, "number_cache_clusters", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 				),
 			},
 			{
@@ -922,9 +920,13 @@ func testAccCheckAWSElasticacheReplicationDestroy(s *terraform.State) error {
 			continue
 		}
 		_, err := finder.ReplicationGroupByID(conn, rs.Primary.ID)
-		if !tfresource.NotFound(err) {
+		if tfresource.NotFound(err) {
+			continue
+		}
+		if err != nil {
 			return err
 		}
+		return fmt.Errorf("ElastiCache Replication Group (%s) still exists", rs.Primary.ID)
 	}
 	return nil
 }


### PR DESCRIPTION
Refactors `aws_elasticache_cluster`, `aws_elasticache_replication_group`, `data.aws_elasticache_cluster`, and `data.aws_elasticache_replication_group` to use waiter and finder functions.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14959

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticacheCluster_\|TestAccAWSElasticacheReplicationGroup_\|TestAccAWSDataElasticacheCluster_\|TestAccDataSourceAwsElasticacheReplicationGroup_'

--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (66.55s)
--- PASS: TestAccAWSElasticacheCluster_Memcached_FinalSnapshot (71.95s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis (74.25s)
--- PASS: TestAccAWSDataElasticacheCluster_basic (737.15s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (986.85s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (987.69s)
--- PASS: TestAccAWSElasticacheReplicationGroup_useCmkKmsKeyId (1090.98s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1229.45s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached (1311.80s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (1396.08s)
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (1420.73s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1485.93s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis (1425.75s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica (1500.06s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis (1516.86s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica (1522.45s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone (1589.59s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached (1528.96s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (1644.84s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis (662.08s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached (648.89s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (1987.14s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent (10.49s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (783.12s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (2109.38s)
--- PASS: TestAccAWSElasticacheCluster_vpc (647.27s)
--- PASS: TestAccAWSElasticacheCluster_Port_Redis_Default (521.35s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (648.51s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (673.04s)
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (789.57s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached (635.77s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (917.38s)
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (852.65s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis (704.39s)
--- PASS: TestAccAWSElasticacheReplicationGroup_FinalSnapshot (1025.95s)
--- PASS: TestAccAWSElasticacheCluster_Redis_FinalSnapshot (854.12s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (1541.39s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1074.42s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (716.36s)
--- PASS: TestAccAWSElasticacheCluster_Port (649.82s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (2048.20s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode (1130.27s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_basic (907.52s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NonClusteredParameterGroup (827.12s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (861.43s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (3047.94s)
--- PASS: TestAccAWSElasticacheReplicationGroup_tags (918.84s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (1120.19s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups (4849.48s)
```
