### PR TITLE
resource/lakeformation permissions: Fix multiple permissions bug

### DIFF
--- a/.changelog/17189.txt
+++ b/.changelog/17189.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/lakeformation_permissions: Handle resources with multiple permissions
+```
+
+```release-note:bug
+resource/lakeformation_data_lake_settings: Avoid unnecessary resource cycling
+```

--- a/aws/data_source_aws_lakeformation_data_lake_settings.go
+++ b/aws/data_source_aws_lakeformation_data_lake_settings.go
@@ -17,7 +17,7 @@ func dataSourceAwsLakeFormationDataLakeSettings() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"admins": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/aws/data_source_aws_lakeformation_permissions.go
+++ b/aws/data_source_aws_lakeformation_permissions.go
@@ -177,8 +177,8 @@ func dataSourceAwsLakeFormationPermissionsRead(d *schema.ResourceData, meta inte
 		input.CatalogId = aws.String(v.(string))
 	}
 
-	input.Resource = expandLakeFormationResource(d, meta, true)
-	matchResource := expandLakeFormationResource(d, meta, false)
+	input.Resource = expandLakeFormationResource(d, true)
+	matchResource := expandLakeFormationResource(d, false)
 
 	log.Printf("[DEBUG] Reading Lake Formation permissions: %v", input)
 	var principalResourcePermissions []*lakeformation.PrincipalResourcePermissions

--- a/aws/data_source_aws_lakeformation_permissions.go
+++ b/aws/data_source_aws_lakeformation_permissions.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"reflect"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -190,7 +189,7 @@ func dataSourceAwsLakeFormationPermissionsRead(d *schema.ResourceData, meta inte
 					continue
 				}
 
-				if reflect.DeepEqual(matchResource, permission.Resource) {
+				if resourceAwsLakeFormationPermissionsCompareResource(*matchResource, *permission.Resource) {
 					principalResourcePermissions = append(principalResourcePermissions, permission)
 				}
 			}
@@ -213,7 +212,7 @@ func dataSourceAwsLakeFormationPermissionsRead(d *schema.ResourceData, meta inte
 					continue
 				}
 
-				if reflect.DeepEqual(matchResource, permission.Resource) {
+				if resourceAwsLakeFormationPermissionsCompareResource(*matchResource, *permission.Resource) {
 					principalResourcePermissions = append(principalResourcePermissions, permission)
 				}
 			}

--- a/aws/data_source_aws_lakeformation_permissions.go
+++ b/aws/data_source_aws_lakeformation_permissions.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -176,7 +177,8 @@ func dataSourceAwsLakeFormationPermissionsRead(d *schema.ResourceData, meta inte
 		input.CatalogId = aws.String(v.(string))
 	}
 
-	input.Resource = expandLakeFormationResource(d, true)
+	input.Resource = expandLakeFormationResource(d, meta, true)
+	matchResource := expandLakeFormationResource(d, meta, false)
 
 	log.Printf("[DEBUG] Reading Lake Formation permissions: %v", input)
 	var principalResourcePermissions []*lakeformation.PrincipalResourcePermissions
@@ -188,7 +190,9 @@ func dataSourceAwsLakeFormationPermissionsRead(d *schema.ResourceData, meta inte
 					continue
 				}
 
-				principalResourcePermissions = append(principalResourcePermissions, permission)
+				if reflect.DeepEqual(matchResource, permission.Resource) {
+					principalResourcePermissions = append(principalResourcePermissions, permission)
+				}
 			}
 			return !lastPage
 		})
@@ -209,7 +213,9 @@ func dataSourceAwsLakeFormationPermissionsRead(d *schema.ResourceData, meta inte
 					continue
 				}
 
-				principalResourcePermissions = append(principalResourcePermissions, permission)
+				if reflect.DeepEqual(matchResource, permission.Resource) {
+					principalResourcePermissions = append(principalResourcePermissions, permission)
+				}
 			}
 			return !lastPage
 		})

--- a/aws/data_source_aws_lakeformation_permissions_test.go
+++ b/aws/data_source_aws_lakeformation_permissions_test.go
@@ -228,6 +228,8 @@ resource "aws_lakeformation_permissions" "test" {
   data_location {
     arn = aws_s3_bucket.test.arn
   }
+
+  depends_on = ["aws_lakeformation_data_lake_settings.test"]
 }
 
 data "aws_lakeformation_permissions" "test" {

--- a/aws/resource_aws_lakeformation_data_lake_settings.go
+++ b/aws/resource_aws_lakeformation_data_lake_settings.go
@@ -298,16 +298,16 @@ func expandDataLakeSettingsAdmins(tfSet *schema.Set) []*lakeformation.DataLakePr
 	return apiObjects
 }
 
-func flattenDataLakeSettingsAdmins(apiObjects []*lakeformation.DataLakePrincipal) *schema.Set {
+func flattenDataLakeSettingsAdmins(apiObjects []*lakeformation.DataLakePrincipal) []interface{} {
 	if apiObjects == nil {
 		return nil
 	}
 
-	tfSlice := make([]*string, 0, len(apiObjects))
+	tfSlice := make([]interface{}, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfSlice = append(tfSlice, apiObject.DataLakePrincipalIdentifier)
+		tfSlice = append(tfSlice, *apiObject.DataLakePrincipalIdentifier)
 	}
 
-	return flattenStringSet(tfSlice)
+	return tfSlice
 }

--- a/aws/resource_aws_lakeformation_data_lake_settings.go
+++ b/aws/resource_aws_lakeformation_data_lake_settings.go
@@ -26,7 +26,7 @@ func resourceAwsLakeFormationDataLakeSettings() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"admins": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Optional: true,
 				Elem: &schema.Schema{
@@ -122,7 +122,7 @@ func resourceAwsLakeFormationDataLakeSettingsCreate(d *schema.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("admins"); ok {
-		settings.DataLakeAdmins = expandDataLakeSettingsAdmins(v.([]interface{}))
+		settings.DataLakeAdmins = expandDataLakeSettingsAdmins(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("trusted_resource_owners"); ok {
@@ -282,7 +282,8 @@ func flattenDataLakeSettingsCreateDefaultPermission(apiObject *lakeformation.Pri
 	return tfMap
 }
 
-func expandDataLakeSettingsAdmins(tfSlice []interface{}) []*lakeformation.DataLakePrincipal {
+func expandDataLakeSettingsAdmins(tfSet *schema.Set) []*lakeformation.DataLakePrincipal {
+	tfSlice := tfSet.List()
 	apiObjects := make([]*lakeformation.DataLakePrincipal, 0, len(tfSlice))
 
 	for _, tfItem := range tfSlice {
@@ -297,16 +298,16 @@ func expandDataLakeSettingsAdmins(tfSlice []interface{}) []*lakeformation.DataLa
 	return apiObjects
 }
 
-func flattenDataLakeSettingsAdmins(apiObjects []*lakeformation.DataLakePrincipal) []interface{} {
+func flattenDataLakeSettingsAdmins(apiObjects []*lakeformation.DataLakePrincipal) *schema.Set {
 	if apiObjects == nil {
 		return nil
 	}
 
-	tfSlice := make([]interface{}, 0, len(apiObjects))
+	tfSlice := make([]*string, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfSlice = append(tfSlice, *apiObject.DataLakePrincipalIdentifier)
+		tfSlice = append(tfSlice, apiObject.DataLakePrincipalIdentifier)
 	}
 
-	return tfSlice
+	return flattenStringSet(tfSlice)
 }

--- a/aws/resource_aws_lakeformation_permissions.go
+++ b/aws/resource_aws_lakeformation_permissions.go
@@ -397,19 +397,19 @@ func resourceAwsLakeFormationPermissionsDelete(d *schema.ResourceData, meta inte
 
 func resourceAwsLakeFormationPermissionsCompareResource(in, out lakeformation.Resource) bool {
 	if in.DataLocation != nil && out.DataLocation != nil && in.DataLocation.CatalogId == nil {
-		out.DataLocation.CatalogId = nil
+		in.DataLocation.CatalogId = out.DataLocation.CatalogId
 	}
 
 	if in.Database != nil && out.Database != nil && in.Database.CatalogId == nil {
-		out.Database.CatalogId = nil
+		in.Database.CatalogId = out.Database.CatalogId
 	}
 
 	if in.Table != nil && out.Table != nil && in.Table.CatalogId == nil {
-		out.Table.CatalogId = nil
+		in.Table.CatalogId = out.Table.CatalogId
 	}
 
 	if in.TableWithColumns != nil && out.TableWithColumns != nil && in.TableWithColumns.CatalogId == nil {
-		out.TableWithColumns.CatalogId = nil
+		in.TableWithColumns.CatalogId = out.TableWithColumns.CatalogId
 	}
 
 	return reflect.DeepEqual(in, out)

--- a/aws/resource_aws_lakeformation_permissions.go
+++ b/aws/resource_aws_lakeformation_permissions.go
@@ -300,7 +300,8 @@ func resourceAwsLakeFormationPermissionsRead(d *schema.ResourceData, meta interf
 	}
 
 	if len(principalResourcePermissions) > 1 {
-		return fmt.Errorf("error reading Lake Formation permissions: %s", "multiple permissions found")
+		//return fmt.Errorf("error reading Lake Formation permissions: %s", "multiple permissions found")
+		return fmt.Errorf("error reading Lake Formation permissions: %v\nINPUT: %v", principalResourcePermissions, input)
 	}
 
 	for _, permissions := range principalResourcePermissions {

--- a/aws/resource_aws_lakeformation_permissions.go
+++ b/aws/resource_aws_lakeformation_permissions.go
@@ -418,7 +418,7 @@ func resourceAwsLakeFormationPermissionsCompareResource(in, out lakeformation.Re
 // expandLakeFormationResourceType returns the Lake Formation resource type represented by the resource.
 // This is helpful in distinguishing between TABLE and TABLE_WITH_COLUMNS types when filtering ListPermission results.
 func expandLakeFormationResourceType(d *schema.ResourceData) string {
-	if v, ok := d.GetOk("catalog_resource"); ok && v.(bool) == true {
+	if d.Get("catalog_resource").(bool) {
 		return lakeformation.DataLakeResourceTypeCatalog
 	}
 

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -558,8 +558,8 @@ resource "aws_lakeformation_data_lake_settings" "test" {
 }
 
 resource "aws_lakeformation_permissions" "test" {
-  permissions = ["SELECT"]
-  principal   = aws_iam_role.test.arn
+  permissions = ["ALTER", "SELECT"]
+  principal   = data.aws_caller_identity.current.arn
 
   table_with_columns {
     database_name = aws_glue_catalog_table.test.database_name

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -661,5 +661,15 @@ resource "aws_lakeformation_permissions" "test" {
     column_names  = ["event", "timestamp"]
   }
 }
+
+resource "aws_lakeformation_permissions" "table" {
+  permissions = ["ALL"]
+  principal   = aws_lakeformation_permissions.test.principal
+
+  table {
+    database_name = aws_glue_catalog_table.test.database_name
+    name          = aws_glue_catalog_table.test.name
+  }
+}
 `, rName)
 }

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -648,7 +648,8 @@ resource "aws_glue_catalog_table" "test" {
 }
 
 resource "aws_lakeformation_data_lake_settings" "test" {
-  admins = [data.aws_caller_identity.current.arn, aws_iam_role.test.arn]
+  // this will result in multiple permissions for iam role
+  admins = [aws_iam_role.test.arn, data.aws_caller_identity.current.arn]
 }
 
 resource "aws_lakeformation_permissions" "test" {
@@ -659,16 +660,6 @@ resource "aws_lakeformation_permissions" "test" {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
     column_names  = ["event", "timestamp"]
-  }
-}
-
-resource "aws_lakeformation_permissions" "table" {
-  permissions = ["ALL"]
-  principal   = aws_lakeformation_permissions.test.principal
-
-  table {
-    database_name = aws_glue_catalog_table.test.database_name
-    name          = aws_glue_catalog_table.test.name
   }
 }
 `, rName)

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -28,7 +28,7 @@ func testAccAWSLakeFormationPermissions_basic(t *testing.T) {
 					testAccCheckAWSLakeFormationPermissionsExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "principal", roleName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.0", "CREATE_DATABASE"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", lakeformation.PermissionCreateDatabase),
 					resource.TestCheckResourceAttr(resourceName, "catalog_resource", "true"),
 				),
 			},
@@ -53,7 +53,7 @@ func testAccAWSLakeFormationPermissions_dataLocation(t *testing.T) {
 					testAccCheckAWSLakeFormationPermissionsExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "principal", roleName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.0", "DATA_LOCATION_ACCESS"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", lakeformation.PermissionDataLocationAccess),
 					resource.TestCheckResourceAttr(resourceName, "catalog_resource", "false"),
 					resource.TestCheckResourceAttr(resourceName, "data_location.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "data_location.0.arn", bucketName, "arn"),
@@ -85,10 +85,10 @@ func testAccAWSLakeFormationPermissions_database(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "database.0.name", dbName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.0", "ALTER"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.1", "CREATE_TABLE"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.2", "DROP"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.1", lakeformation.PermissionCreateTable),
+					resource.TestCheckResourceAttr(resourceName, "permissions.2", lakeformation.PermissionDrop),
 					resource.TestCheckResourceAttr(resourceName, "permissions_with_grant_option.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "permissions_with_grant_option.0", "CREATE_TABLE"),
+					resource.TestCheckResourceAttr(resourceName, "permissions_with_grant_option.0", lakeformation.PermissionCreateTable),
 				),
 			},
 		},
@@ -114,8 +114,10 @@ func testAccAWSLakeFormationPermissions_table(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "table.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.database_name", tableName, "database_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "table.0.name", tableName, "name"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.0", "ALL"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", lakeformation.PermissionAlter),
+					resource.TestCheckResourceAttr(resourceName, "permissions.1", lakeformation.PermissionDelete),
+					resource.TestCheckResourceAttr(resourceName, "permissions.2", lakeformation.PermissionDescribe),
 				),
 			},
 		},
@@ -145,7 +147,37 @@ func testAccAWSLakeFormationPermissions_tableWithColumns(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "table_with_columns.0.column_names.0", "event"),
 					resource.TestCheckResourceAttr(resourceName, "table_with_columns.0.column_names.1", "timestamp"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.0", "SELECT"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", lakeformation.PermissionSelect),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSLakeFormationPermissions_tableWithColumnsAndTable(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lakeformation_permissions.test"
+	roleName := "aws_iam_role.test"
+	tableName := "aws_glue_catalog_table.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lakeformation.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLakeFormationPermissionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLakeFormationPermissionsConfig_tableWithColumnsAndTable(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLakeFormationPermissionsExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "principal", roleName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "table_with_columns.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "table_with_columns.0.database_name", tableName, "database_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "table_with_columns.0.name", tableName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "table_with_columns.0.column_names.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "table_with_columns.0.column_names.0", "event"),
+					resource.TestCheckResourceAttr(resourceName, "table_with_columns.0.column_names.1", "timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", lakeformation.PermissionSelect),
 				),
 			},
 		},
@@ -420,10 +452,6 @@ EOF
 
 data "aws_caller_identity" "current" {}
 
-resource "aws_s3_bucket" "test" {
-  bucket = %[1]q
-}
-
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -473,10 +501,6 @@ EOF
 
 data "aws_caller_identity" "current" {}
 
-resource "aws_s3_bucket" "test" {
-  bucket = %[1]q
-}
-
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -491,7 +515,7 @@ resource "aws_lakeformation_data_lake_settings" "test" {
 }
 
 resource "aws_lakeformation_permissions" "test" {
-  permissions = ["ALL"]
+  permissions = ["ALTER", "DELETE", "DESCRIBE"]
   principal   = aws_iam_role.test.arn
 
   table {
@@ -558,8 +582,8 @@ resource "aws_lakeformation_data_lake_settings" "test" {
 }
 
 resource "aws_lakeformation_permissions" "test" {
-  permissions = ["ALTER", "SELECT"]
-  principal   = data.aws_caller_identity.current.arn
+  permissions = ["SELECT"]
+  principal   = aws_iam_role.test.arn
 
   table_with_columns {
     database_name = aws_glue_catalog_table.test.database_name
@@ -568,6 +592,74 @@ resource "aws_lakeformation_permissions" "test" {
   }
 
   depends_on = ["aws_lakeformation_data_lake_settings.test"]
+}
+`, rName)
+}
+
+func testAccAWSLakeFormationPermissionsConfig_tableWithColumnsAndTable(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "glue.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+
+  storage_descriptor {
+    columns {
+      name = "event"
+      type = "string"
+    }
+    columns {
+      name = "timestamp"
+      type = "date"
+    }
+    columns {
+      name = "value"
+      type = "double"
+    }
+  }
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+  admins = [data.aws_caller_identity.current.arn, aws_iam_role.test.arn]
+}
+
+resource "aws_lakeformation_permissions" "test" {
+  permissions = ["SELECT"]
+  principal   = aws_iam_role.test.arn
+
+  table_with_columns {
+    database_name = aws_glue_catalog_table.test.database_name
+    name          = aws_glue_catalog_table.test.name
+    column_names  = ["event", "timestamp"]
+  }
 }
 `, rName)
 }

--- a/aws/resource_aws_lakeformation_test.go
+++ b/aws/resource_aws_lakeformation_test.go
@@ -18,6 +18,7 @@ func TestAccAWSLakeFormation_serial(t *testing.T) {
 			"database":                   testAccAWSLakeFormationPermissions_database,
 			"table":                      testAccAWSLakeFormationPermissions_table,
 			"tableWithColumns":           testAccAWSLakeFormationPermissions_tableWithColumns,
+			"tableWithColumnsAndTable":   testAccAWSLakeFormationPermissions_tableWithColumnsAndTable,
 			"basicDataSource":            testAccAWSLakeFormationPermissionsDataSource_basic,
 			"dataLocationDataSource":     testAccAWSLakeFormationPermissionsDataSource_dataLocation,
 			"databaseDataSource":         testAccAWSLakeFormationPermissionsDataSource_database,

--- a/website/docs/r/lakeformation_data_lake_settings.html.markdown
+++ b/website/docs/r/lakeformation_data_lake_settings.html.markdown
@@ -44,7 +44,7 @@ resource "aws_lakeformation_data_lake_settings" "example" {
 
 The following arguments are optional:
 
-* `admins` – (Optional) List of ARNs of AWS Lake Formation principals (IAM users or roles).
+* `admins` – (Optional) Set of ARNs of AWS Lake Formation principals (IAM users or roles).
 * `catalog_id` – (Optional) Identifier for the Data Catalog. By default, the account ID.
 * `create_database_default_permissions` - (Optional) Up to three configuration blocks of principal permissions for default create database permissions. Detailed below.
 * `create_table_default_permissions` - (Optional) Up to three configuration blocks of principal permissions for default create table permissions. Detailed below.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17047

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/lakeformation_permissions: Fix multiple permissions bug
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSLakeFormation_serial (347.89s)
    --- PASS: TestAccAWSLakeFormation_serial/DataLakeSettings (60.78s)
        --- PASS: TestAccAWSLakeFormation_serial/DataLakeSettings/basic (15.88s)
        --- PASS: TestAccAWSLakeFormation_serial/DataLakeSettings/disappears (14.67s)
        --- PASS: TestAccAWSLakeFormation_serial/DataLakeSettings/withoutCatalogId (14.48s)
        --- PASS: TestAccAWSLakeFormation_serial/DataLakeSettings/dataSource (15.74s)
    --- PASS: TestAccAWSLakeFormation_serial/Permissions (287.11s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/tableDataSource (29.12s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/basic (24.26s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/database (21.74s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/table (23.90s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/tableWithColumns (28.37s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/basicDataSource (25.09s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/databaseDataSource (28.06s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/dataLocation (26.15s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/tableWithColumnsAndTable (23.79s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/dataLocationDataSource (28.97s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/tableWithColumnsDataSource (27.67s)
```
