### PR TITLE
aws_appautoscaling_scheduled_action to read config

### DIFF
--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccAWSAppautoscalingScheduledAction_dynamo(t *testing.T) {
+	rName := acctest.RandString(5)
 	ts := time.Now().AddDate(0, 0, 1).Format("2006-01-02T15:04:05")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,9 +21,15 @@ func TestAccAWSAppautoscalingScheduledAction_dynamo(t *testing.T) {
 		CheckDestroy: testAccCheckAwsAppautoscalingScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppautoscalingScheduledActionConfig_DynamoDB(acctest.RandString(5), ts),
+				Config: testAccAppautoscalingScheduledActionConfig_DynamoDB(rName, ts),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppautoscalingScheduledActionExists("aws_appautoscaling_scheduled_action.hoge"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "service_namespace", "dynamodb"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "resource_id", fmt.Sprintf("table/tf-ddb-%s", rName)),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_dimension", "dynamodb:table:ReadCapacityUnits"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "schedule", fmt.Sprintf("at(%s)", ts)),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_target_action.0.min_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_target_action.0.max_capacity", "10"),
 				),
 			},
 		},
@@ -30,6 +37,7 @@ func TestAccAWSAppautoscalingScheduledAction_dynamo(t *testing.T) {
 }
 
 func TestAccAWSAppautoscalingScheduledAction_ECS(t *testing.T) {
+	rName := acctest.RandString(5)
 	ts := time.Now().AddDate(0, 0, 1).Format("2006-01-02T15:04:05")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,9 +45,15 @@ func TestAccAWSAppautoscalingScheduledAction_ECS(t *testing.T) {
 		CheckDestroy: testAccCheckAwsAppautoscalingScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppautoscalingScheduledActionConfig_ECS(acctest.RandString(5), ts),
+				Config: testAccAppautoscalingScheduledActionConfig_ECS(rName, ts),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppautoscalingScheduledActionExists("aws_appautoscaling_scheduled_action.hoge"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "service_namespace", "ecs"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "resource_id", fmt.Sprintf("service/tf-ecs-cluster-%s/tf-ecs-service-%s", rName, rName)),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_dimension", "ecs:service:DesiredCount"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "schedule", fmt.Sprintf("at(%s)", ts)),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_target_action.0.min_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_target_action.0.max_capacity", "5"),
 				),
 			},
 		},
@@ -47,6 +61,7 @@ func TestAccAWSAppautoscalingScheduledAction_ECS(t *testing.T) {
 }
 
 func TestAccAWSAppautoscalingScheduledAction_EMR(t *testing.T) {
+	rName := acctest.RandString(5)
 	ts := time.Now().AddDate(0, 0, 1).Format("2006-01-02T15:04:05")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -54,9 +69,14 @@ func TestAccAWSAppautoscalingScheduledAction_EMR(t *testing.T) {
 		CheckDestroy: testAccCheckAwsAppautoscalingScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppautoscalingScheduledActionConfig_EMR(acctest.RandString(5), ts),
+				Config: testAccAppautoscalingScheduledActionConfig_EMR(rName, ts),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppautoscalingScheduledActionExists("aws_appautoscaling_scheduled_action.hoge"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "service_namespace", "elasticmapreduce"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_dimension", "elasticmapreduce:instancegroup:InstanceCount"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "schedule", fmt.Sprintf("at(%s)", ts)),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_target_action.0.min_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_target_action.0.max_capacity", "5"),
 				),
 			},
 		},
@@ -85,18 +105,23 @@ func TestAccAWSAppautoscalingScheduledAction_Name_Duplicate(t *testing.T) {
 }
 
 func TestAccAWSAppautoscalingScheduledAction_SpotFleet(t *testing.T) {
+	rName := acctest.RandString(5)
 	ts := time.Now().AddDate(0, 0, 1).Format("2006-01-02T15:04:05")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppautoscalingScheduledActionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppautoscalingScheduledActionConfig_SpotFleet(acctest.RandString(5), ts, validUntil),
+				Config: testAccAppautoscalingScheduledActionConfig_SpotFleet(rName, ts, validUntil),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppautoscalingScheduledActionExists("aws_appautoscaling_scheduled_action.hoge"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "service_namespace", "ec2"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_dimension", "ec2:spot-fleet-request:TargetCapacity"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "schedule", fmt.Sprintf("at(%s)", ts)),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_target_action.0.min_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_scheduled_action.hoge", "scalable_target_action.0.max_capacity", "3"),
 				),
 			},
 		},


### PR DESCRIPTION
This PR extends `aws_appautoscaling_scheduled_action` so that it reads the configuration of the deployed resource, rather than just the ARN. This will assist in Terraform detecting when the configuration in AWS has drifted from the desired state.

The test cases have also been extended to test for resource configuration & and the `scalable_dimension` attribute has been changed to `Required` as per the API and documentation.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17100 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_appautoscaling_scheduled_action will now detect drift of configuration in AWS
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAppautoscalingScheduledAction'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAppautoscalingScheduledAction -timeout 120m
=== RUN   TestAccAWSAppautoscalingScheduledAction_dynamo
=== PAUSE TestAccAWSAppautoscalingScheduledAction_dynamo
=== RUN   TestAccAWSAppautoscalingScheduledAction_ECS
=== PAUSE TestAccAWSAppautoscalingScheduledAction_ECS
=== RUN   TestAccAWSAppautoscalingScheduledAction_EMR
=== PAUSE TestAccAWSAppautoscalingScheduledAction_EMR
=== RUN   TestAccAWSAppautoscalingScheduledAction_Name_Duplicate
=== PAUSE TestAccAWSAppautoscalingScheduledAction_Name_Duplicate
=== RUN   TestAccAWSAppautoscalingScheduledAction_SpotFleet
=== PAUSE TestAccAWSAppautoscalingScheduledAction_SpotFleet
=== CONT  TestAccAWSAppautoscalingScheduledAction_dynamo
=== CONT  TestAccAWSAppautoscalingScheduledAction_Name_Duplicate
=== CONT  TestAccAWSAppautoscalingScheduledAction_SpotFleet
=== CONT  TestAccAWSAppautoscalingScheduledAction_EMR
=== CONT  TestAccAWSAppautoscalingScheduledAction_ECS
--- PASS: TestAccAWSAppautoscalingScheduledAction_dynamo (28.72s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_Name_Duplicate (30.40s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_ECS (54.50s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_SpotFleet (80.52s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_EMR (653.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       653.033s
...
```

I also built the provider and tested the drift behaviour locally:
```
$ terraform show      
# aws_appautoscaling_scheduled_action.hoge:
resource "aws_appautoscaling_scheduled_action" "hoge" {
    arn                = "arn:aws:autoscaling:ap-southeast-2:REDACTED:scheduledAction:REDACTED:resource/dynamodb/table/tf-ddb-test:scheduledActionName/tf-appauto-test"
    id                 = "tf-appauto-test-dynamodb-table/tf-ddb-test"
    name               = "tf-appauto-test"
    resource_id        = "table/tf-ddb-test"
    scalable_dimension = "dynamodb:table:ReadCapacityUnits"
    schedule           = "at(2021-01-22T12:00:00)"
    service_namespace  = "dynamodb"

    scalable_target_action {
        max_capacity = 10
        min_capacity = 1
    }
}
--- SNIP remainder of state ---

$ aws application-autoscaling put-scheduled-action --service-namespace dynamodb --scalable-dimension dynamodb:table:ReadCapacityUnits --resource-id table/tf-ddb-test --scheduled-action-name tf-appauto-test --schedule "at(2021-01-22T12:00:00)" --scalable-target-action MinCapacity=2,MaxCapacity=10 --region ap-southeast-2 

$ ➜ terraform plan
aws_dynamodb_table.hoge: Refreshing state... [id=tf-ddb-test]
aws_appautoscaling_target.read: Refreshing state... [id=table/tf-ddb-test]
aws_appautoscaling_scheduled_action.hoge: Refreshing state... [id=tf-appauto-test-dynamodb-table/tf-ddb-test]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_appautoscaling_scheduled_action.hoge must be replaced
-/+ resource "aws_appautoscaling_scheduled_action" "hoge" {
      ~ arn                = "arn:aws:autoscaling:ap-southeast-2:REDACTED:scheduledAction:REDACTED:resource/dynamodb/table/tf-ddb-test:scheduledActionName/tf-appauto-test" -> (known after apply)
      ~ id                 = "tf-appauto-test-dynamodb-table/tf-ddb-test" -> (known after apply)
        name               = "tf-appauto-test"
        # (4 unchanged attributes hidden)

      ~ scalable_target_action {
          ~ min_capacity = 2 -> 1 # forces replacement
            # (1 unchanged attribute hidden)
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.

------------------------------------------------------------------------
```