### PR TITLE
tests/provider: Migrate environment variable functionality into shared package with constants and testing

### DIFF
--- a/aws/internal/envvar/consts.go
+++ b/aws/internal/envvar/consts.go
@@ -1,0 +1,50 @@
+package envvar
+
+// Standard AWS environment variables used in the Terraform AWS Provider testing.
+// These are not provided as constants in the AWS Go SDK currently.
+const (
+	// Default static credential identifier for tests (AWS Go SDK does not provide this as constant)
+	// See also AWS_SECRET_ACCESS_KEY and AWS_PROFILE
+	AwsAccessKeyId = "AWS_ACCESS_KEY_ID"
+
+	// Container credentials endpoint
+	// See also AWS_ACCESS_KEY_ID and AWS_PROFILE
+	AwsContainerCredentialsFullUri = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
+
+	// Default AWS region for tests (AWS Go SDK does not provide this as constant)
+	AwsDefaultRegion = "AWS_DEFAULT_REGION"
+
+	// Default AWS shared configuration profile for tests (AWS Go SDK does not provide this as constant)
+	AwsProfile = "AWS_PROFILE"
+
+	// Default static credential value for tests (AWS Go SDK does not provide this as constant)
+	// See also AWS_ACCESS_KEY_ID and AWS_PROFILE
+	AwsSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+)
+
+// Custom environment variables used in the Terraform AWS Provider testing.
+// Additions should also be documented in the Environment Variable Dictionary
+// of the Maintainers Guide: docs/MAINTAINING.md
+const (
+	// For tests using an alternate AWS account, the equivalent of AWS_ACCESS_KEY_ID for that account
+	AwsAlternateAccessKeyId = "AWS_ALTERNATE_ACCESS_KEY_ID"
+
+	// For tests using an alternate AWS account, the equivalent of AWS_PROFILE for that account
+	AwsAlternateProfile = "AWS_PROFILE"
+
+	// For tests using an alternate AWS region, the equivalent of AWS_DEFAULT_REGION for that account
+	AwsAlternateRegion = "AWS_ALTERNATE_REGION"
+
+	// For tests using an alternate AWS account, the equivalent of AWS_SECRET_ACCESS_KEY for that account
+	AwsAlternateSecretAccessKey = "AWS_ALTERNATE_SECRET_ACCESS_KEY"
+
+	// For tests using a third AWS region, the equivalent of AWS_DEFAULT_REGION for that region
+	AwsThirdRegion = "AWS_THIRD_REGION"
+
+	// For tests requiring GitHub permissions
+	GithubToken = "GITHUB_TOKEN"
+
+	// For tests requiring restricted IAM permissions, an existing IAM Role to assume
+	// An inline assume role policy is then used to deny actions for the test
+	TfAccAssumeRoleArn = "TF_ACC_ASSUME_ROLE_ARN"
+)

--- a/aws/internal/envvar/doc.go
+++ b/aws/internal/envvar/doc.go
@@ -1,0 +1,2 @@
+// envvar contains constants and helpers for environment variable usage in testing.
+package envvar

--- a/aws/internal/envvar/funcs.go
+++ b/aws/internal/envvar/funcs.go
@@ -1,0 +1,16 @@
+package envvar
+
+import (
+	"os"
+)
+
+// GetWithDefault gets an environment variable value if non-empty or returns the default.
+func GetWithDefault(variable string, defaultValue string) string {
+	value := os.Getenv(variable)
+
+	if value == "" {
+		return defaultValue
+	}
+
+	return value
+}

--- a/aws/internal/envvar/funcs_test.go
+++ b/aws/internal/envvar/funcs_test.go
@@ -1,0 +1,50 @@
+package envvar_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/envvar"
+)
+
+func TestGetWithDefault(t *testing.T) {
+	envVar := "TESTENVVAR_GETWITHDEFAULT"
+
+	t.Run("missing", func(t *testing.T) {
+		want := "default"
+
+		os.Unsetenv(envVar)
+
+		got := envvar.GetWithDefault(envVar, want)
+
+		if got != want {
+			t.Fatalf("expected %s, got %s", want, got)
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		want := "default"
+
+		os.Setenv(envVar, "")
+		defer os.Unsetenv(envVar)
+
+		got := envvar.GetWithDefault(envVar, want)
+
+		if got != want {
+			t.Fatalf("expected %s, got %s", want, got)
+		}
+	})
+
+	t.Run("not empty", func(t *testing.T) {
+		want := "notempty"
+
+		os.Setenv(envVar, want)
+		defer os.Unsetenv(envVar)
+
+		got := envvar.GetWithDefault(envVar, "default")
+
+		if got != want {
+			t.Fatalf("expected %s, got %s", want, got)
+		}
+	})
+}

--- a/aws/internal/envvar/testing_funcs.go
+++ b/aws/internal/envvar/testing_funcs.go
@@ -1,0 +1,56 @@
+package envvar
+
+import (
+	"os"
+
+	"github.com/mitchellh/go-testing-interface"
+)
+
+// TestFailIfAllEmpty verifies that at least one environment variable is non-empty or fails the test.
+//
+// If at lease one environment variable is non-empty, returns the first name and value.
+func TestFailIfAllEmpty(t testing.T, names []string, usageMessage string) (string, string) {
+	t.Helper()
+
+	for _, variable := range names {
+		value := os.Getenv(variable)
+
+		if value != "" {
+			return variable, value
+		}
+	}
+
+	t.Fatalf("at least one environment variable of %v must be set. Usage: %s", names, usageMessage)
+
+	return "", ""
+}
+
+// TestFailIfEmpty verifies that an environment variable is non-empty or fails the test.
+//
+// For acceptance tests, this function must be used outside PreCheck functions to set values for configurations.
+func TestFailIfEmpty(t testing.T, name string, usageMessage string) string {
+	t.Helper()
+
+	value := os.Getenv(name)
+
+	if value == "" {
+		t.Fatalf("environment variable %s must be set. Usage: %s", name, usageMessage)
+	}
+
+	return value
+}
+
+// TestSkipIfEmpty verifies that an environment variable is non-empty or skips the test.
+//
+// For acceptance tests, this function must be used outside PreCheck functions to set values for configurations.
+func TestSkipIfEmpty(t testing.T, name string, usageMessage string) string {
+	t.Helper()
+
+	value := os.Getenv(name)
+
+	if value == "" {
+		t.Skipf("skipping test; environment variable %s must be set. Usage: %s", name, usageMessage)
+	}
+
+	return value
+}

--- a/aws/internal/envvar/testing_funcs_test.go
+++ b/aws/internal/envvar/testing_funcs_test.go
@@ -1,0 +1,170 @@
+package envvar_test
+
+import (
+	"os"
+	"testing"
+
+	testingiface "github.com/mitchellh/go-testing-interface"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/envvar"
+)
+
+func TestTestFailIfAllEmpty(t *testing.T) {
+	envVar1 := "TESTENVVAR_FAILIFALLEMPTY1"
+	envVar2 := "TESTENVVAR_FAILIFALLEMPTY2"
+	envVars := []string{envVar1, envVar2}
+
+	t.Run("missing", func(t *testing.T) {
+		defer testingifaceRecover()
+
+		for _, envVar := range envVars {
+			os.Unsetenv(envVar)
+		}
+
+		envvar.TestFailIfAllEmpty(&testingiface.RuntimeT{}, envVars, "usage")
+
+		t.Fatal("expected to fail previously")
+	})
+
+	t.Run("all empty", func(t *testing.T) {
+		defer testingifaceRecover()
+
+		os.Setenv(envVar1, "")
+		os.Setenv(envVar2, "")
+		defer unsetEnvVars(envVars)
+
+		envvar.TestFailIfAllEmpty(&testingiface.RuntimeT{}, envVars, "usage")
+
+		t.Fatal("expected to fail previously")
+	})
+
+	t.Run("some empty", func(t *testing.T) {
+		wantValue := "pickme"
+
+		os.Setenv(envVar1, "")
+		os.Setenv(envVar2, wantValue)
+		defer unsetEnvVars(envVars)
+
+		gotName, gotValue := envvar.TestFailIfAllEmpty(&testingiface.RuntimeT{}, envVars, "usage")
+
+		if gotName != envVar2 {
+			t.Fatalf("expected name: %s, got: %s", envVar2, gotName)
+		}
+
+		if gotValue != wantValue {
+			t.Fatalf("expected value: %s, got: %s", wantValue, gotValue)
+		}
+	})
+
+	t.Run("all not empty", func(t *testing.T) {
+		wantValue := "pickme"
+
+		os.Setenv(envVar1, wantValue)
+		os.Setenv(envVar2, "other")
+		defer unsetEnvVars(envVars)
+
+		gotName, gotValue := envvar.TestFailIfAllEmpty(&testingiface.RuntimeT{}, envVars, "usage")
+
+		if gotName != envVar1 {
+			t.Fatalf("expected name: %s, got: %s", envVar1, gotName)
+		}
+
+		if gotValue != wantValue {
+			t.Fatalf("expected value: %s, got: %s", wantValue, gotValue)
+		}
+	})
+}
+
+func TestTestFailIfEmpty(t *testing.T) {
+	envVar := "TESTENVVAR_FAILIFEMPTY"
+
+	t.Run("missing", func(t *testing.T) {
+		defer testingifaceRecover()
+
+		os.Unsetenv(envVar)
+
+		envvar.TestFailIfEmpty(&testingiface.RuntimeT{}, envVar, "usage")
+
+		t.Fatal("expected to fail previously")
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		defer testingifaceRecover()
+
+		os.Setenv(envVar, "")
+		defer os.Unsetenv(envVar)
+
+		envvar.TestFailIfEmpty(&testingiface.RuntimeT{}, envVar, "usage")
+
+		t.Fatal("expected to fail previously")
+	})
+
+	t.Run("not empty", func(t *testing.T) {
+		want := "notempty"
+
+		os.Setenv(envVar, want)
+		defer os.Unsetenv(envVar)
+
+		got := envvar.TestFailIfEmpty(&testingiface.RuntimeT{}, envVar, "usage")
+
+		if got != want {
+			t.Fatalf("expected value: %s, got: %s", want, got)
+		}
+	})
+}
+
+func TestTestSkipIfEmpty(t *testing.T) {
+	envVar := "TESTENVVAR_SKIPIFEMPTY"
+
+	t.Run("missing", func(t *testing.T) {
+		mockT := &testingiface.RuntimeT{}
+
+		os.Unsetenv(envVar)
+
+		envvar.TestSkipIfEmpty(mockT, envVar, "usage")
+
+		if !mockT.Skipped() {
+			t.Fatal("expected to skip previously")
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		mockT := &testingiface.RuntimeT{}
+
+		os.Setenv(envVar, "")
+		defer os.Unsetenv(envVar)
+
+		envvar.TestSkipIfEmpty(mockT, envVar, "usage")
+
+		if !mockT.Skipped() {
+			t.Fatal("expected to skip previously")
+		}
+	})
+
+	t.Run("not empty", func(t *testing.T) {
+		want := "notempty"
+
+		os.Setenv(envVar, want)
+		defer os.Unsetenv(envVar)
+
+		got := envvar.TestSkipIfEmpty(&testingiface.RuntimeT{}, envVar, "usage")
+
+		if got != want {
+			t.Fatalf("expected value: %s, got: %s", want, got)
+		}
+	})
+}
+
+func testingifaceRecover() {
+	r := recover()
+
+	// this string is hardcoded in github.com/mitchellh/go-testing-interface
+	if s, ok := r.(string); !ok || s != "testing.T failed, see logs for output (if any)" {
+		panic(r)
+	}
+}
+
+func unsetEnvVars(envVars []string) {
+	for _, envVar := range envVars {
+		os.Unsetenv(envVar)
+	}
+}

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/envvar"
 )
 
 const (
@@ -191,12 +192,10 @@ func testAccPreCheck(t *testing.T) {
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderConfigure.Do(func() {
-		if os.Getenv("AWS_PROFILE") == "" && os.Getenv("AWS_ACCESS_KEY_ID") == "" && os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") == "" {
-			t.Fatal("AWS_ACCESS_KEY_ID, AWS_PROFILE, or AWS_CONTAINER_CREDENTIALS_FULL_URI must be set for acceptance tests")
-		}
+		envvar.TestFailIfAllEmpty(t, []string{envvar.AwsProfile, envvar.AwsAccessKeyId, envvar.AwsContainerCredentialsFullUri}, "credentials for running acceptance testing")
 
-		if os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-			t.Fatal("AWS_SECRET_ACCESS_KEY must be set for acceptance tests")
+		if os.Getenv(envvar.AwsAccessKeyId) != "" {
+			envvar.TestFailIfEmpty(t, envvar.AwsSecretAccessKey, "static credentials value when using "+envvar.AwsAccessKeyId)
 		}
 
 		// Setting the AWS_DEFAULT_REGION environment variable here allows all tests to omit
@@ -207,7 +206,7 @@ func testAccPreCheck(t *testing.T) {
 		//   * AWS_DEFAULT_REGION is required and checked above (should mention us-west-2 default)
 		//   * Region is automatically handled via shared AWS configuration file and still verified
 		region := testAccGetRegion()
-		os.Setenv("AWS_DEFAULT_REGION", region)
+		os.Setenv(envvar.AwsDefaultRegion, region)
 
 		err := testAccProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
 		if err != nil {
@@ -610,27 +609,15 @@ func testAccGetAccountID() string {
 }
 
 func testAccGetRegion() string {
-	v := os.Getenv("AWS_DEFAULT_REGION")
-	if v == "" {
-		return "us-west-2" // lintignore:AWSAT003
-	}
-	return v
+	return envvar.GetWithDefault(envvar.AwsDefaultRegion, endpoints.UsWest2RegionID)
 }
 
 func testAccGetAlternateRegion() string {
-	v := os.Getenv("AWS_ALTERNATE_REGION")
-	if v == "" {
-		return "us-east-1" // lintignore:AWSAT003
-	}
-	return v
+	return envvar.GetWithDefault(envvar.AwsAlternateRegion, endpoints.UsEast1RegionID)
 }
 
 func testAccGetThirdRegion() string {
-	v := os.Getenv("AWS_THIRD_REGION")
-	if v == "" {
-		return "us-east-2" // lintignore:AWSAT003
-	}
-	return v
+	return envvar.GetWithDefault(envvar.AwsThirdRegion, endpoints.UsEast2RegionID)
 }
 
 func testAccGetPartition() string {
@@ -672,12 +659,10 @@ func testAccGetThirdRegionPartition() string {
 }
 
 func testAccAlternateAccountPreCheck(t *testing.T) {
-	if os.Getenv("AWS_ALTERNATE_PROFILE") == "" && os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID") == "" {
-		t.Fatal("AWS_ALTERNATE_ACCESS_KEY_ID or AWS_ALTERNATE_PROFILE must be set for acceptance tests")
-	}
+	envvar.TestFailIfAllEmpty(t, []string{envvar.AwsAlternateProfile, envvar.AwsAlternateAccessKeyId}, "credentials for running acceptance testing in alternate AWS account")
 
-	if os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID") != "" && os.Getenv("AWS_ALTERNATE_SECRET_ACCESS_KEY") == "" {
-		t.Fatal("AWS_ALTERNATE_SECRET_ACCESS_KEY must be set for acceptance tests")
+	if os.Getenv(envvar.AwsAlternateAccessKeyId) != "" {
+		envvar.TestFailIfEmpty(t, envvar.AwsAlternateSecretAccessKey, "static credentials value when using "+envvar.AwsAlternateAccessKeyId)
 	}
 }
 
@@ -701,24 +686,24 @@ func testAccPartitionHasServicePreCheck(serviceId string, t *testing.T) {
 
 func testAccMultipleRegionPreCheck(t *testing.T, regions int) {
 	if testAccGetRegion() == testAccGetAlternateRegion() {
-		t.Fatal("AWS_DEFAULT_REGION and AWS_ALTERNATE_REGION must be set to different values for acceptance tests")
+		t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.AwsDefaultRegion, envvar.AwsAlternateRegion)
 	}
 
 	if testAccGetPartition() != testAccGetAlternateRegionPartition() {
-		t.Fatalf("AWS_ALTERNATE_REGION partition (%s) does not match AWS_DEFAULT_REGION partition (%s)", testAccGetAlternateRegionPartition(), testAccGetPartition())
+		t.Fatalf("%s partition (%s) does not match %s partition (%s)", envvar.AwsAlternateRegion, testAccGetAlternateRegionPartition(), envvar.AwsDefaultRegion, testAccGetPartition())
 	}
 
 	if regions >= 3 {
 		if testAccGetRegion() == testAccGetThirdRegion() {
-			t.Fatal("AWS_DEFAULT_REGION and AWS_THIRD_REGION must be set to different values for acceptance tests")
+			t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.AwsDefaultRegion, envvar.AwsThirdRegion)
 		}
 
 		if testAccGetAlternateRegion() == testAccGetThirdRegion() {
-			t.Fatal("AWS_ALTERNATE_REGION and AWS_THIRD_REGION must be set to different values for acceptance tests")
+			t.Fatalf("%s and %s must be set to different values for acceptance tests", envvar.AwsAlternateRegion, envvar.AwsThirdRegion)
 		}
 
 		if testAccGetPartition() != testAccGetThirdRegionPartition() {
-			t.Fatalf("AWS_THIRD_REGION partition (%s) does not match AWS_DEFAULT_REGION partition (%s)", testAccGetThirdRegionPartition(), testAccGetPartition())
+			t.Fatalf("%s partition (%s) does not match %s partition (%s)", envvar.AwsThirdRegion, testAccGetThirdRegionPartition(), envvar.AwsDefaultRegion, testAccGetPartition())
 		}
 	}
 
@@ -732,7 +717,7 @@ func testAccMultipleRegionPreCheck(t *testing.T, regions int) {
 // testAccRegionPreCheck checks that the test region is the specified region.
 func testAccRegionPreCheck(t *testing.T, region string) {
 	if testAccGetRegion() != region {
-		t.Skipf("skipping tests; AWS_DEFAULT_REGION (%s) does not equal %s", testAccGetRegion(), region)
+		t.Skipf("skipping tests; %s (%s) does not equal %s", envvar.AwsDefaultRegion, testAccGetRegion(), region)
 	}
 }
 
@@ -798,12 +783,6 @@ func testAccPreCheckIamServiceLinkedRole(t *testing.T, pathPrefix string) {
 	}
 }
 
-func testAccEnvironmentVariableSetPreCheck(variable string, t *testing.T) {
-	if os.Getenv(variable) == "" {
-		t.Skipf("skipping tests; environment variable %s must be set", variable)
-	}
-}
-
 func testAccAlternateAccountProviderConfig() string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
@@ -812,7 +791,7 @@ provider "awsalternate" {
   profile    = %[2]q
   secret_key = %[3]q
 }
-`, os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID"), os.Getenv("AWS_ALTERNATE_PROFILE"), os.Getenv("AWS_ALTERNATE_SECRET_ACCESS_KEY"))
+`, os.Getenv(envvar.AwsAlternateAccessKeyId), os.Getenv(envvar.AwsAlternateProfile), os.Getenv(envvar.AwsAlternateSecretAccessKey))
 }
 
 func testAccAlternateAccountAlternateRegionProviderConfig() string {
@@ -824,7 +803,7 @@ provider "awsalternate" {
   region     = %[3]q
   secret_key = %[4]q
 }
-`, os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID"), os.Getenv("AWS_ALTERNATE_PROFILE"), testAccGetAlternateRegion(), os.Getenv("AWS_ALTERNATE_SECRET_ACCESS_KEY"))
+`, os.Getenv(envvar.AwsAlternateAccessKeyId), os.Getenv(envvar.AwsAlternateProfile), testAccGetAlternateRegion(), os.Getenv(envvar.AwsAlternateSecretAccessKey))
 }
 
 // When testing needs to distinguish a second region and second account in the same region
@@ -848,7 +827,7 @@ provider "awsalternateaccountsameregion" {
 provider "awssameaccountalternateregion" {
   region = %[3]q
 }
-`, os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID"), os.Getenv("AWS_ALTERNATE_PROFILE"), testAccGetAlternateRegion(), os.Getenv("AWS_ALTERNATE_SECRET_ACCESS_KEY"))
+`, os.Getenv(envvar.AwsAlternateAccessKeyId), os.Getenv(envvar.AwsAlternateProfile), testAccGetAlternateRegion(), os.Getenv(envvar.AwsAlternateSecretAccessKey))
 }
 
 // Deprecated: Use testAccMultipleRegionProviderConfig instead
@@ -1814,10 +1793,7 @@ data "aws_arn" "test" {
 }
 
 func testAccAssumeRoleARNPreCheck(t *testing.T) {
-	v := os.Getenv("TF_ACC_ASSUME_ROLE_ARN")
-	if v == "" {
-		t.Skip("skipping tests; TF_ACC_ASSUME_ROLE_ARN must be set")
-	}
+	envvar.TestSkipIfEmpty(t, envvar.TfAccAssumeRoleArn, "Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions")
 }
 
 func testAccProviderConfigAssumeRolePolicy(policy string) string {
@@ -1829,7 +1805,7 @@ provider "aws" {
     policy   = %q
   }
 }
-`, os.Getenv("TF_ACC_ASSUME_ROLE_ARN"), policy)
+`, os.Getenv(envvar.TfAccAssumeRoleArn), policy)
 }
 
 const testAccCheckAWSProviderConfigAssumeRoleEmpty = `

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/envvar"
 )
 
 func TestAccAWSCodePipeline_basic(t *testing.T) {
@@ -467,15 +467,15 @@ func TestAccAWSCodePipeline_WithNamespace(t *testing.T) {
 }
 
 func TestAccAWSCodePipeline_WithGitHubv1SourceAction(t *testing.T) {
+	githubToken := envvar.TestSkipIfEmpty(t, envvar.GithubToken, "token with GitHub permissions to repository for CodePipeline source configuration")
+
 	var v codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
 	resourceName := "aws_codepipeline.test"
-	githubToken := os.Getenv("GITHUB_TOKEN")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccEnvironmentVariableSetPreCheck("GITHUB_TOKEN", t)
 			testAccPreCheckAWSCodePipelineSupported(t)
 		},
 		Providers:    testAccProviders,

--- a/aws/resource_aws_codepipeline_webhook_test.go
+++ b/aws/resource_aws_codepipeline_webhook_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,10 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/envvar"
 )
 
+const envVarGithubTokenUsageCodePipelineWebhook = "token with GitHub permissions to repository for CodePipeline webhook creation"
+
 func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
-	githubToken := os.Getenv("GITHUB_TOKEN")
+	githubToken := envvar.TestSkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageCodePipelineWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -22,7 +24,6 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccEnvironmentVariableSetPreCheck("GITHUB_TOKEN", t)
 			testAccPreCheckAWSCodePipelineSupported(t)
 		},
 		Providers:    testAccProviders,
@@ -48,7 +49,7 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
-	githubToken := os.Getenv("GITHUB_TOKEN")
+	githubToken := envvar.TestSkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageCodePipelineWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -57,7 +58,6 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccEnvironmentVariableSetPreCheck("GITHUB_TOKEN", t)
 			testAccPreCheckAWSCodePipelineSupported(t)
 		},
 		Providers:    testAccProviders,
@@ -83,7 +83,7 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
-	githubToken := os.Getenv("GITHUB_TOKEN")
+	githubToken := envvar.TestSkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageCodePipelineWebhook)
 
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -92,7 +92,6 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccEnvironmentVariableSetPreCheck("GITHUB_TOKEN", t)
 			testAccPreCheckAWSCodePipelineSupported(t)
 		},
 		Providers:    testAccProviders,
@@ -116,7 +115,7 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
-	githubToken := os.Getenv("GITHUB_TOKEN")
+	githubToken := envvar.TestSkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageCodePipelineWebhook)
 
 	var v1, v2, v3 codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -125,7 +124,6 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccEnvironmentVariableSetPreCheck("GITHUB_TOKEN", t)
 			testAccPreCheckAWSCodePipelineSupported(t)
 		},
 		Providers:    testAccProviders,
@@ -180,7 +178,7 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken(t *testing.T) {
-	githubToken := os.Getenv("GITHUB_TOKEN")
+	githubToken := envvar.TestSkipIfEmpty(t, envvar.GithubToken, envVarGithubTokenUsageCodePipelineWebhook)
 
 	var v1, v2 codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -189,7 +187,6 @@ func TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccEnvironmentVariableSetPreCheck("GITHUB_TOKEN", t)
 			testAccPreCheckAWSCodePipelineSupported(t)
 		},
 		Providers:    testAccProviders,

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -355,7 +355,7 @@ Additional branch naming recommendations can be found in the [Pull Request Submi
 
 ## Environment Variable Dictionary
 
-Environment variables (beyond standard AWS Go SDK ones) used by acceptance testing.
+Environment variables (beyond standard AWS Go SDK ones) used by acceptance testing. See also the `aws/internal/envvar` package.
 
 | Variable | Description |
 |----------|-------------|


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17083

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Other environment variable handling in the code and testing can be migrated in the future for consistency. Please note that if attempting to use the returned value in a test configuration function, it must be done outside the test PreCheck function due to execution during compilation versus run.

Without GITHUB_TOKEN set:

```
=== RUN   TestAccAWSCodePipeline_WithGitHubv1SourceAction
    resource_aws_codepipeline_test.go:470: skipping test; environment variable GITHUB_TOKEN must be set. Usage: token with GitHub permissions to repository for CodePipeline source configuration
--- SKIP: TestAccAWSCodePipeline_WithGitHubv1SourceAction (0.00s)

=== RUN   TestAccAWSCodePipelineWebhook_basic
    resource_aws_codepipeline_webhook_test.go:18: skipping test; environment variable GITHUB_TOKEN must be set. Usage: token with GitHub permissions to repository for CodePipeline webhook creation
--- SKIP: TestAccAWSCodePipelineWebhook_basic (0.00s)
=== RUN   TestAccAWSCodePipelineWebhook_ipAuth
    resource_aws_codepipeline_webhook_test.go:52: skipping test; environment variable GITHUB_TOKEN must be set. Usage: token with GitHub permissions to repository for CodePipeline webhook creation
--- SKIP: TestAccAWSCodePipelineWebhook_ipAuth (0.00s)
=== RUN   TestAccAWSCodePipelineWebhook_unauthenticated
    resource_aws_codepipeline_webhook_test.go:86: skipping test; environment variable GITHUB_TOKEN must be set. Usage: token with GitHub permissions to repository for CodePipeline webhook creation
--- SKIP: TestAccAWSCodePipelineWebhook_unauthenticated (0.00s)
=== RUN   TestAccAWSCodePipelineWebhook_tags
    resource_aws_codepipeline_webhook_test.go:118: skipping test; environment variable GITHUB_TOKEN must be set. Usage: token with GitHub permissions to repository for CodePipeline webhook creation
--- SKIP: TestAccAWSCodePipelineWebhook_tags (0.00s)
=== RUN   TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken
    resource_aws_codepipeline_webhook_test.go:181: skipping test; environment variable GITHUB_TOKEN must be set. Usage: token with GitHub permissions to repository for CodePipeline webhook creation
--- SKIP: TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken (0.00s)
```

Output from acceptance testing:

```
# Verify GITHUB_TOKEN working

--- PASS: TestAccAWSCodePipeline_WithGitHubv1SourceAction (55.64s)

--- PASS: TestAccAWSCodePipelineWebhook_basic (32.74s)
--- PASS: TestAccAWSCodePipelineWebhook_ipAuth (33.24s)
--- PASS: TestAccAWSCodePipelineWebhook_tags (71.80s)
--- PASS: TestAccAWSCodePipelineWebhook_unauthenticated (32.65s)
--- PASS: TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken (54.08s)

# Verify cross-region and cross-account

--- PASS: TestAccAWSDynamoDbTable_Replica_Multiple (1646.42s)

--- PASS: TestAccAWSRoute53ZoneAssociation_CrossAccount (160.38s)

--- PASS: TestAccAWSProvider_AssumeRole_Empty (15.68s)
--- PASS: TestAccAWSProvider_Endpoints (13.10s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (12.44s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (12.87s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (12.49s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (12.71s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (12.57s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (12.23s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (12.71s)
--- PASS: TestAccAWSProvider_Region_AwsChina (9.82s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (10.42s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (11.37s)
```
