### PR TITLE
Allow zero value for cookie_expiration_period

### DIFF
--- a/.changelog/17204.txt
+++ b/.changelog/17204.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb_cookie_stickiness_policy: Allow zero value for `cookie_expiration_period`
+```

--- a/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -44,7 +44,7 @@ func resourceAwsLBCookieStickinessPolicy() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntAtLeast(1),
+				ValidateFunc: validation.IntAtLeast(0),
 			},
 		},
 	}

--- a/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestAccAWSLBCookieStickinessPolicy_basic(t *testing.T) {
 	lbName := fmt.Sprintf("tf-test-lb-%s", acctest.RandString(5))
+	resourceName := "aws_lb_cookie_stickiness_policy.foo"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -22,6 +23,7 @@ func TestAccAWSLBCookieStickinessPolicy_basic(t *testing.T) {
 			{
 				Config: testAccLBCookieStickinessPolicyConfig(lbName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cookie_expiration_period", "300"),
 					testAccCheckLBCookieStickinessPolicy(
 						"aws_elb.lb",
 						"aws_lb_cookie_stickiness_policy.foo",
@@ -31,6 +33,7 @@ func TestAccAWSLBCookieStickinessPolicy_basic(t *testing.T) {
 			{
 				Config: testAccLBCookieStickinessPolicyConfigUpdate(lbName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cookie_expiration_period", "0"),
 					testAccCheckLBCookieStickinessPolicy(
 						"aws_elb.lb",
 						"aws_lb_cookie_stickiness_policy.foo",
@@ -164,7 +167,7 @@ resource "aws_lb_cookie_stickiness_policy" "foo" {
 `, rName))
 }
 
-// Sets the cookie_expiration_period to 300s.
+// Sets the cookie_expiration_period to 0s.
 func testAccLBCookieStickinessPolicyConfigUpdate(rName string) string {
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "lb" {

--- a/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -156,9 +156,9 @@ resource "aws_elb" "lb" {
 }
 
 resource "aws_lb_cookie_stickiness_policy" "foo" {
-  name          = "foo-policy"
-  load_balancer = aws_elb.lb.id
-  lb_port       = 80
+  name                     = "foo-policy"
+  load_balancer            = aws_elb.lb.id
+  lb_port                  = 80
   cookie_expiration_period = 300
 }
 `, rName))

--- a/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -159,6 +159,7 @@ resource "aws_lb_cookie_stickiness_policy" "foo" {
   name          = "foo-policy"
   load_balancer = aws_elb.lb.id
   lb_port       = 80
+  cookie_expiration_period = 0
 }
 `, rName))
 }

--- a/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -159,7 +159,7 @@ resource "aws_lb_cookie_stickiness_policy" "foo" {
   name          = "foo-policy"
   load_balancer = aws_elb.lb.id
   lb_port       = 80
-  cookie_expiration_period = 0
+  cookie_expiration_period = 300
 }
 `, rName))
 }
@@ -183,7 +183,7 @@ resource "aws_lb_cookie_stickiness_policy" "foo" {
   name                     = "foo-policy"
   load_balancer            = aws_elb.lb.id
   lb_port                  = 80
-  cookie_expiration_period = 300
+  cookie_expiration_period = 0
 }
 `, rName))
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #12678

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):


```
Allow zero value for cookie_expiration_period in `aws_lb_cookie_stickiness_policy` resource.

```

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBCookieStickinessPolicy_basic -timeout 120m
=== RUN   TestAccAWSLBCookieStickinessPolicy_basic
=== PAUSE TestAccAWSLBCookieStickinessPolicy_basic
=== CONT  TestAccAWSLBCookieStickinessPolicy_basic
--- PASS: TestAccAWSLBCookieStickinessPolicy_basic (27.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.935s
```
