### PR TITLE
resource/aws_route53_record: Add DS record type support

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -20,7 +20,7 @@ import (
 
 var r53NoRecordsFound = errors.New("No matching records found")
 var r53NoHostedZoneFound = errors.New("No matching Hosted Zone found")
-var r53ValidRecordTypes = regexp.MustCompile("^(A|AAAA|CAA|CNAME|MX|NAPTR|NS|PTR|SOA|SPF|SRV|TXT)$")
+var r53ValidRecordTypes = regexp.MustCompile("^(A|AAAA|CAA|CNAME|MX|NAPTR|NS|PTR|SOA|SPF|SRV|TXT|DS)$")
 
 func resourceAwsRoute53Record() *schema.Resource {
 	//lintignore:R011
@@ -69,6 +69,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 					route53.RRTypeSpf,
 					route53.RRTypeAaaa,
 					route53.RRTypeCaa,
+					route53.RRTypeDs,
 				}, false),
 			},
 

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -361,6 +361,33 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53Record_dsSupport(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheckSkipRoute53(t),
+		IDRefreshName:   resourceName,
+		IDRefreshIgnore: []string{"zone_id"}, // just for this test
+		Providers:       testAccProviders,
+		CheckDestroy:    testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53RecordConfigDS,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists(resourceName, &record1),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight", "zone_id"},
+			},
+		},
+	})
+}
 func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 	var record1 route53.ResourceRecordSet
 	resourceName := "aws_route53_record.default"
@@ -1434,6 +1461,20 @@ resource "aws_route53_record" "default" {
   ttl     = "30"
 
   records = ["0 issue \"exampleca.com;\""]
+}
+`
+
+const testAccRoute53RecordConfigDS = `
+resource "aws_route53_zone" "main" {
+  name = "notexample.com"
+}
+
+resource "aws_route53_record" "default" {
+  zone_id = "/hostedzone/${aws_route53_zone.main.zone_id}"
+  name    = "test"
+  type    = "DS"
+  ttl     = "30"
+  records = ["123 4 5 1234567890ABCDEF1234567890ABCDEF"]
 }
 `
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17040

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_route53_record: Add DS record type support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53Record_'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRoute53Record_ -timeout 120m
=== RUN   TestAccAWSRoute53Record_basic
=== PAUSE TestAccAWSRoute53Record_basic
=== RUN   TestAccAWSRoute53Record_underscored
=== PAUSE TestAccAWSRoute53Record_underscored
=== RUN   TestAccAWSRoute53Record_disappears
=== PAUSE TestAccAWSRoute53Record_disappears
=== RUN   TestAccAWSRoute53Record_disappears_MultipleRecords
=== PAUSE TestAccAWSRoute53Record_disappears_MultipleRecords
=== RUN   TestAccAWSRoute53Record_basic_fqdn
=== PAUSE TestAccAWSRoute53Record_basic_fqdn
=== RUN   TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID
=== PAUSE TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID
=== RUN   TestAccAWSRoute53Record_txtSupport
=== PAUSE TestAccAWSRoute53Record_txtSupport
=== RUN   TestAccAWSRoute53Record_spfSupport
=== PAUSE TestAccAWSRoute53Record_spfSupport
=== RUN   TestAccAWSRoute53Record_caaSupport
=== PAUSE TestAccAWSRoute53Record_caaSupport
=== RUN   TestAccAWSRoute53Record_dsSupport
=== PAUSE TestAccAWSRoute53Record_dsSupport
=== RUN   TestAccAWSRoute53Record_generatesSuffix
=== PAUSE TestAccAWSRoute53Record_generatesSuffix
=== RUN   TestAccAWSRoute53Record_wildcard
=== PAUSE TestAccAWSRoute53Record_wildcard
=== RUN   TestAccAWSRoute53Record_failover
=== PAUSE TestAccAWSRoute53Record_failover
=== RUN   TestAccAWSRoute53Record_weighted_basic
=== PAUSE TestAccAWSRoute53Record_weighted_basic
=== RUN   TestAccAWSRoute53Record_weighted_to_simple_basic
=== PAUSE TestAccAWSRoute53Record_weighted_to_simple_basic
=== RUN   TestAccAWSRoute53Record_Alias_Elb
=== PAUSE TestAccAWSRoute53Record_Alias_Elb
=== RUN   TestAccAWSRoute53Record_Alias_S3
=== PAUSE TestAccAWSRoute53Record_Alias_S3
=== RUN   TestAccAWSRoute53Record_Alias_VpcEndpoint
=== PAUSE TestAccAWSRoute53Record_Alias_VpcEndpoint
=== RUN   TestAccAWSRoute53Record_Alias_Uppercase
=== PAUSE TestAccAWSRoute53Record_Alias_Uppercase
=== RUN   TestAccAWSRoute53Record_weighted_alias
=== PAUSE TestAccAWSRoute53Record_weighted_alias
=== RUN   TestAccAWSRoute53Record_geolocation_basic
=== PAUSE TestAccAWSRoute53Record_geolocation_basic
=== RUN   TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange
=== PAUSE TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange
=== RUN   TestAccAWSRoute53Record_HealthCheckId_TypeChange
=== PAUSE TestAccAWSRoute53Record_HealthCheckId_TypeChange
=== RUN   TestAccAWSRoute53Record_latency_basic
=== PAUSE TestAccAWSRoute53Record_latency_basic
=== RUN   TestAccAWSRoute53Record_TypeChange
=== PAUSE TestAccAWSRoute53Record_TypeChange
=== RUN   TestAccAWSRoute53Record_NameChange
=== PAUSE TestAccAWSRoute53Record_NameChange
=== RUN   TestAccAWSRoute53Record_SetIdentifierChange
=== PAUSE TestAccAWSRoute53Record_SetIdentifierChange
=== RUN   TestAccAWSRoute53Record_AliasChange
=== PAUSE TestAccAWSRoute53Record_AliasChange
=== RUN   TestAccAWSRoute53Record_empty
=== PAUSE TestAccAWSRoute53Record_empty
=== RUN   TestAccAWSRoute53Record_longTXTrecord
=== PAUSE TestAccAWSRoute53Record_longTXTrecord
=== RUN   TestAccAWSRoute53Record_multivalue_answer_basic
=== PAUSE TestAccAWSRoute53Record_multivalue_answer_basic
=== RUN   TestAccAWSRoute53Record_doNotAllowOverwrite
=== PAUSE TestAccAWSRoute53Record_doNotAllowOverwrite
=== RUN   TestAccAWSRoute53Record_allowOverwrite
=== PAUSE TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_basic
=== CONT  TestAccAWSRoute53Record_Alias_Uppercase
=== CONT  TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_dsSupport
=== CONT  TestAccAWSRoute53Record_Alias_VpcEndpoint
=== CONT  TestAccAWSRoute53Record_Alias_S3
=== CONT  TestAccAWSRoute53Record_Alias_Elb
=== CONT  TestAccAWSRoute53Record_weighted_to_simple_basic
=== CONT  TestAccAWSRoute53Record_weighted_basic
=== CONT  TestAccAWSRoute53Record_failover
=== CONT  TestAccAWSRoute53Record_wildcard
=== CONT  TestAccAWSRoute53Record_generatesSuffix
=== CONT  TestAccAWSRoute53Record_HealthCheckId_TypeChange
=== CONT  TestAccAWSRoute53Record_NameChange
=== CONT  TestAccAWSRoute53Record_TypeChange
=== CONT  TestAccAWSRoute53Record_SetIdentifierChange
=== CONT  TestAccAWSRoute53Record_latency_basic
=== CONT  TestAccAWSRoute53Record_longTXTrecord
=== CONT  TestAccAWSRoute53Record_doNotAllowOverwrite
=== CONT  TestAccAWSRoute53Record_multivalue_answer_basic
--- PASS: TestAccAWSRoute53Record_doNotAllowOverwrite (132.43s)
=== CONT  TestAccAWSRoute53Record_geolocation_basic
--- PASS: TestAccAWSRoute53Record_weighted_basic (166.95s)
=== CONT  TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange
--- PASS: TestAccAWSRoute53Record_dsSupport (169.99s)
=== CONT  TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID
--- PASS: TestAccAWSRoute53Record_longTXTrecord (181.90s)
=== CONT  TestAccAWSRoute53Record_caaSupport
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (182.22s)
=== CONT  TestAccAWSRoute53Record_spfSupport
--- PASS: TestAccAWSRoute53Record_latency_basic (184.75s)
=== CONT  TestAccAWSRoute53Record_txtSupport
--- PASS: TestAccAWSRoute53Record_Alias_Elb (195.57s)
=== CONT  TestAccAWSRoute53Record_empty
--- PASS: TestAccAWSRoute53Record_Alias_S3 (197.07s)
=== CONT  TestAccAWSRoute53Record_weighted_alias
--- PASS: TestAccAWSRoute53Record_basic (203.24s)
=== CONT  TestAccAWSRoute53Record_disappears_MultipleRecords
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (206.67s)
=== CONT  TestAccAWSRoute53Record_basic_fqdn
--- PASS: TestAccAWSRoute53Record_generatesSuffix (212.01s)
=== CONT  TestAccAWSRoute53Record_AliasChange
--- PASS: TestAccAWSRoute53Record_failover (221.07s)
=== CONT  TestAccAWSRoute53Record_disappears
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (237.10s)
=== CONT  TestAccAWSRoute53Record_underscored
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (254.04s)
--- PASS: TestAccAWSRoute53Record_wildcard (255.43s)
--- PASS: TestAccAWSRoute53Record_TypeChange (257.53s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (259.10s)
--- PASS: TestAccAWSRoute53Record_HealthCheckId_TypeChange (268.12s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (152.71s)
--- PASS: TestAccAWSRoute53Record_NameChange (292.99s)
--- PASS: TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID (152.96s)
--- PASS: TestAccAWSRoute53Record_spfSupport (151.47s)
--- PASS: TestAccAWSRoute53Record_caaSupport (152.40s)
--- PASS: TestAccAWSRoute53Record_txtSupport (151.66s)
--- PASS: TestAccAWSRoute53Record_empty (145.18s)
--- PASS: TestAccAWSRoute53Record_disappears (137.50s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (178.83s)
--- PASS: TestAccAWSRoute53Record_underscored (144.96s)
--- PASS: TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange (227.47s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (187.99s)
--- PASS: TestAccAWSRoute53Record_AliasChange (237.31s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (307.38s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (559.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       561.392s
```
