### PR TITLE
docs/resource/aws_api_gateway_integration_response: Remove "-" selection pattern documentation

### DIFF
--- a/website/docs/r/api_gateway_integration_response.html.markdown
+++ b/website/docs/r/api_gateway_integration_response.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 * `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `ANY`)
 * `status_code` - (Required) The HTTP status code
 * `selection_pattern` - (Optional) Specifies the regular expression pattern used to choose
-  an integration response based on the response from the backend. Setting this to `-` makes the integration the default one.
+  an integration response based on the response from the backend. Omit configuring this to make the integration the default one.
   If the backend is an `AWS` Lambda function, the AWS Lambda function error header is matched.
   For all other `HTTP` and `AWS` backends, the HTTP status code is matched.
 * `response_templates` - (Optional) A map specifying the templates used to transform the integration response body


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10222
Closes #14204
Closes #16950

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
API Gateway now expects the selection pattern to not be configured to set the default mapping. The current AWS documentation makes no mention of the "-" value. Verified in the AWS Console and with the AWS CLI that the API response is empty with no selectionPattern or no value for the default mapping.

Output from acceptance testing: N/A (documentation)