### PR TITLE
IPv6 subnet mapping for lb

### DIFF
--- a/aws/data_source_aws_lb.go
+++ b/aws/data_source_aws_lb.go
@@ -74,6 +74,10 @@ func dataSourceAwsLb() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"ipv6_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -109,6 +109,12 @@ func resourceAwsLb() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"ipv6_address": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IsIPv6Address,
+						},
 						"outpost_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -297,6 +303,10 @@ func resourceAwsLbCreate(d *schema.ResourceData, meta interface{}) error {
 
 			if subnetMap["private_ipv4_address"].(string) != "" {
 				elbOpts.SubnetMappings[i].PrivateIPv4Address = aws.String(subnetMap["private_ipv4_address"].(string))
+			}
+
+			if subnetMap["ipv6_address"].(string) != "" {
+				elbOpts.SubnetMappings[i].IPv6Address = aws.String(subnetMap["ipv6_address"].(string))
 			}
 		}
 	}
@@ -668,6 +678,7 @@ func flattenSubnetMappingsFromAvailabilityZones(availabilityZones []*elbv2.Avail
 		for _, loadBalancerAddress := range availabilityZone.LoadBalancerAddresses {
 			m["allocation_id"] = aws.StringValue(loadBalancerAddress.AllocationId)
 			m["private_ipv4_address"] = aws.StringValue(loadBalancerAddress.PrivateIPv4Address)
+			m["ipv6_address"] = aws.StringValue(loadBalancerAddress.IPv6Address)
 		}
 
 		l = append(l, m)

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -194,6 +194,37 @@ func TestAccAWSLB_LoadBalancerType_Gateway(t *testing.T) {
 	})
 }
 
+func TestAccAWSLB_IPv6SubnetMapping(t *testing.T) {
+	var conf elbv2.LoadBalancer
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lb.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSLBDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBConfig_IPv6(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBExists(resourceName, &conf),
+					resource.TestMatchResourceAttr(resourceName, "subnet_mapping.0.ipv6_address", regexp.MustCompile("[a-f0-6]+:[a-f0-6:]+")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"drop_invalid_header_fields",
+					"enable_http2",
+					"idle_timeout",
+				},
+			},
+		},
+	})
+}
+
 func TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1951,6 +1982,55 @@ resource "aws_lb" "test" {
 
   subnet_mapping {
     subnet_id = aws_subnet.test.id
+  }
+}
+`, rName))
+}
+
+func testAccAWSLBConfig_IPv6(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "10.10.10.0/25"
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = "main"
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 16)
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-load-balancer"
+  }
+}
+
+resource "aws_lb" "test" {
+  name                       = %[1]q
+  load_balancer_type         = "network"
+  enable_deletion_protection = false
+
+  subnet_mapping {
+    subnet_id    = aws_subnet.test.id
+    ipv6_address = cidrhost(cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 16), 5)
+  }
+
+  tags = {
+    Name = "TestAccAWSALB_ipv6address"
   }
 }
 `, rName))

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -208,7 +208,9 @@ func TestAccAWSLB_IPv6SubnetMapping(t *testing.T) {
 				Config: testAccAWSLBConfig_IPv6(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBExists(resourceName, &conf),
-					resource.TestMatchResourceAttr(resourceName, "subnet_mapping.0.ipv6_address", regexp.MustCompile("[a-f0-6]+:[a-f0-6:]+")),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "subnet_mapping.*", map[string]*regexp.Regexp{
+						"ipv6_address": regexp.MustCompile("[a-f0-6]+:[a-f0-6:]+"),
+					}),
 				),
 			},
 			{
@@ -2032,6 +2034,8 @@ resource "aws_lb" "test" {
   tags = {
     Name = "TestAccAWSALB_ipv6address"
   }
+
+	depends_on = [aws_internet_gateway.gw]
 }
 `, rName))
 }

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -2035,7 +2035,7 @@ resource "aws_lb" "test" {
     Name = "TestAccAWSALB_ipv6address"
   }
 
-	depends_on = [aws_internet_gateway.gw]
+  depends_on = [aws_internet_gateway.gw]
 }
 `, rName))
 }

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -200,7 +200,7 @@ func TestAccAWSLB_IPv6SubnetMapping(t *testing.T) {
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckElbv2GatewayLoadBalancer(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -135,7 +135,7 @@ Subnet Mapping (`subnet_mapping`) blocks support the following:
 * `subnet_id` - (Required) The id of the subnet of which to attach to the load balancer. You can specify only one subnet per Availability Zone.
 * `allocation_id` - (Optional) The allocation ID of the Elastic IP address.
 * `private_ipv4_address` - (Optional) A private ipv4 address within the subnet to assign to the internal-facing load balancer.
-* `ipv6_address` - (Optional) An ipv6 address within the subnet to assign to the internal-facing load balancer.
+* `ipv6_address` - (Optional) An ipv6 address within the subnet to assign to the internet-facing load balancer.
 
 ## Attributes Reference
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -135,6 +135,7 @@ Subnet Mapping (`subnet_mapping`) blocks support the following:
 * `subnet_id` - (Required) The id of the subnet of which to attach to the load balancer. You can specify only one subnet per Availability Zone.
 * `allocation_id` - (Optional) The allocation ID of the Elastic IP address.
 * `private_ipv4_address` - (Optional) A private ipv4 address within the subnet to assign to the internal-facing load balancer.
+* `ipv6_address` - (Optional) An ipv6 address within the subnet to assign to the internal-facing load balancer.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add support for IPv6 subnet mapping to the aws_lb resource.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Closes #17150

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
resource/aws_lb: Add support for IPv6 subnet mapping to the aws_lb resource.
```

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLB_ -timeout 120m
=== RUN   TestAccAWSLB_ALB_basic
=== PAUSE TestAccAWSLB_ALB_basic
=== RUN   TestAccAWSLB_NLB_basic
=== PAUSE TestAccAWSLB_NLB_basic
=== RUN   TestAccAWSLB_LoadBalancerType_Gateway
=== PAUSE TestAccAWSLB_LoadBalancerType_Gateway
=== RUN   TestAccAWSLB_IPv6SubnetMapping
=== PAUSE TestAccAWSLB_IPv6SubnetMapping
=== RUN   TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing
=== PAUSE TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing
=== RUN   TestAccAWSLB_ALB_outpost
=== PAUSE TestAccAWSLB_ALB_outpost
=== RUN   TestAccAWSLB_networkLoadbalancerEIP
=== PAUSE TestAccAWSLB_networkLoadbalancerEIP
=== RUN   TestAccAWSLB_NLB_privateipv4address
=== PAUSE TestAccAWSLB_NLB_privateipv4address
=== RUN   TestAccAWSLB_BackwardsCompatibility
=== PAUSE TestAccAWSLB_BackwardsCompatibility
=== RUN   TestAccAWSLB_generatedName
=== PAUSE TestAccAWSLB_generatedName
=== RUN   TestAccAWSLB_generatesNameForZeroValue
=== PAUSE TestAccAWSLB_generatesNameForZeroValue
=== RUN   TestAccAWSLB_namePrefix
=== PAUSE TestAccAWSLB_namePrefix
=== RUN   TestAccAWSLB_tags
=== PAUSE TestAccAWSLB_tags
=== RUN   TestAccAWSLB_networkLoadbalancer_updateCrossZone
=== PAUSE TestAccAWSLB_networkLoadbalancer_updateCrossZone
=== RUN   TestAccAWSLB_applicationLoadBalancer_updateHttp2
=== PAUSE TestAccAWSLB_applicationLoadBalancer_updateHttp2
=== RUN   TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields
=== PAUSE TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields
=== RUN   TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection
=== PAUSE TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection
=== RUN   TestAccAWSLB_updatedSecurityGroups
=== PAUSE TestAccAWSLB_updatedSecurityGroups
=== RUN   TestAccAWSLB_updatedSubnets
=== PAUSE TestAccAWSLB_updatedSubnets
=== RUN   TestAccAWSLB_updatedIpAddressType
=== PAUSE TestAccAWSLB_updatedIpAddressType
=== RUN   TestAccAWSLB_noSecurityGroup
=== PAUSE TestAccAWSLB_noSecurityGroup
=== RUN   TestAccAWSLB_ALB_AccessLogs
=== PAUSE TestAccAWSLB_ALB_AccessLogs
=== RUN   TestAccAWSLB_ALB_AccessLogs_Prefix
=== PAUSE TestAccAWSLB_ALB_AccessLogs_Prefix
=== RUN   TestAccAWSLB_NLB_AccessLogs
=== PAUSE TestAccAWSLB_NLB_AccessLogs
=== RUN   TestAccAWSLB_NLB_AccessLogs_Prefix
=== PAUSE TestAccAWSLB_NLB_AccessLogs_Prefix
=== RUN   TestAccAWSLB_networkLoadbalancer_subnet_change
=== PAUSE TestAccAWSLB_networkLoadbalancer_subnet_change
=== CONT  TestAccAWSLB_ALB_basic
=== CONT  TestAccAWSLB_applicationLoadBalancer_updateHttp2
=== CONT  TestAccAWSLB_noSecurityGroup
=== CONT  TestAccAWSLB_ALB_AccessLogs
=== CONT  TestAccAWSLB_updatedSubnets
=== CONT  TestAccAWSLB_networkLoadbalancer_subnet_change
=== CONT  TestAccAWSLB_NLB_AccessLogs_Prefix
=== CONT  TestAccAWSLB_NLB_AccessLogs
=== CONT  TestAccAWSLB_updatedIpAddressType
=== CONT  TestAccAWSLB_ALB_AccessLogs_Prefix
=== CONT  TestAccAWSLB_NLB_privateipv4address
=== CONT  TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields
=== CONT  TestAccAWSLB_networkLoadbalancer_updateCrossZone
=== CONT  TestAccAWSLB_tags
=== CONT  TestAccAWSLB_generatesNameForZeroValue
=== CONT  TestAccAWSLB_generatedName
=== CONT  TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection
=== CONT  TestAccAWSLB_namePrefix
=== CONT  TestAccAWSLB_BackwardsCompatibility
=== CONT  TestAccAWSLB_updatedSecurityGroups
--- PASS: TestAccAWSLB_generatesNameForZeroValue (159.88s)
=== CONT  TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing
--- PASS: TestAccAWSLB_ALB_basic (162.60s)
=== CONT  TestAccAWSLB_networkLoadbalancerEIP
--- PASS: TestAccAWSLB_namePrefix (163.47s)
=== CONT  TestAccAWSLB_ALB_outpost
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSLB_ALB_outpost (1.90s)
=== CONT  TestAccAWSLB_LoadBalancerType_Gateway
--- PASS: TestAccAWSLB_generatedName (179.57s)
=== CONT  TestAccAWSLB_NLB_basic
--- PASS: TestAccAWSLB_BackwardsCompatibility (181.73s)
=== CONT  TestAccAWSLB_IPv6SubnetMapping
--- PASS: TestAccAWSLB_noSecurityGroup (195.40s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (215.49s)
--- PASS: TestAccAWSLB_updatedIpAddressType (223.64s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (235.79s)
--- PASS: TestAccAWSLB_NLB_privateipv4address (245.66s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (262.48s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields (265.60s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (267.37s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (268.64s)
--- PASS: TestAccAWSLB_tags (269.86s)
--- PASS: TestAccAWSLB_updatedSubnets (282.59s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (292.55s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing (140.87s)
--- PASS: TestAccAWSLB_ALB_AccessLogs (321.26s)
--- PASS: TestAccAWSLB_IPv6SubnetMapping (187.56s)
--- PASS: TestAccAWSLB_NLB_basic (199.07s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (216.08s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (383.65s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway (219.48s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (419.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	419.868s

```
