### PR TITLE
resource/aws_api_gateway_method_settings: Prevent unexpected errors during creation and deletion

### DIFF
--- a/.changelog/17234.txt
+++ b/.changelog/17234.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_api_gateway_method_settings: Prevent confusing Terraform error on resource disappearance during creation
+```
+
+```release-note:bug
+resource/aws_api_gateway_method_settings: Ignore non-existent resource errors during deletion
+```

--- a/aws/resource_aws_api_gateway_method_settings.go
+++ b/aws/resource_aws_api_gateway_method_settings.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -112,6 +113,10 @@ func resourceAwsApiGatewayMethodSettings() *schema.Resource {
 }
 
 func flattenAwsApiGatewayMethodSettings(settings *apigateway.MethodSetting) []interface{} {
+	if settings == nil {
+		return nil
+	}
+
 	return []interface{}{
 		map[string]interface{}{
 			"metrics_enabled":                            settings.MetricsEnabled,
@@ -131,26 +136,28 @@ func flattenAwsApiGatewayMethodSettings(settings *apigateway.MethodSetting) []in
 func resourceAwsApiGatewayMethodSettingsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigatewayconn
 
-	log.Printf("[DEBUG] Reading API Gateway Method Settings %s", d.Id())
-	input := apigateway.GetStageInput{
+	input := &apigateway.GetStageInput{
 		RestApiId: aws.String(d.Get("rest_api_id").(string)),
 		StageName: aws.String(d.Get("stage_name").(string)),
 	}
-	stage, err := conn.GetStage(&input)
-	if err != nil {
-		if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
-			log.Printf("[WARN] API Gateway Stage (%s) not found, removing method settings", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+
+	stage, err := conn.GetStage(input)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
+		log.Printf("[WARN] API Gateway Stage Method Settings (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
-	log.Printf("[DEBUG] Received API Gateway Stage: %s", stage)
+
+	if err != nil {
+		return fmt.Errorf("error getting API Gateway Stage Method Settings (%s): %w", d.Id(), err)
+	}
 
 	methodPath := d.Get("method_path").(string)
 	settings, ok := stage.MethodSettings[methodPath]
-	if !ok {
-		log.Printf("[WARN] API Gateway Method Settings for %q not found, removing", methodPath)
+
+	if !d.IsNewResource() && !ok {
+		log.Printf("[WARN] API Gateway Stage Method Settings (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -265,9 +272,8 @@ func resourceAwsApiGatewayMethodSettingsUpdate(d *schema.ResourceData, meta inte
 
 func resourceAwsApiGatewayMethodSettingsDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigatewayconn
-	log.Printf("[DEBUG] Deleting API Gateway Method Settings: %s", d.Id())
 
-	input := apigateway.UpdateStageInput{
+	input := &apigateway.UpdateStageInput{
 		RestApiId: aws.String(d.Get("rest_api_id").(string)),
 		StageName: aws.String(d.Get("stage_name").(string)),
 		PatchOperations: []*apigateway.PatchOperation{
@@ -277,12 +283,20 @@ func resourceAwsApiGatewayMethodSettingsDelete(d *schema.ResourceData, meta inte
 			},
 		},
 	}
-	log.Printf("[DEBUG] Updating API Gateway Stage: %s", input)
 
-	_, err := conn.UpdateStage(&input)
+	_, err := conn.UpdateStage(input)
+
+	if tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
+		return nil
+	}
+
+	// BadRequestException: Cannot remove method setting */* because there is no method setting for this method
+	if tfawserr.ErrMessageContains(err, apigateway.ErrCodeBadRequestException, "no method setting for this method") {
+		return nil
+	}
 
 	if err != nil {
-		return fmt.Errorf("updating API Gateway Stage failed: %w", err)
+		return fmt.Errorf("error deleting API Gateway Stage Method Settings (%s): %w", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13985
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16796

Fixing this as part of API Gateway service spike work. As mentioned in the issue this will not help mitigate the cause of the problem, but will at least give a better error message.

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayMethodSettings_basic (25.35s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_disappears (247.81s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted (147.06s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds (340.17s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled (448.46s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled (216.61s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel (55.96s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled (397.43s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_Multiple (692.67s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl (178.96s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit (118.97s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimitDisabledByDefault (86.39s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit (515.72s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimitDisabledByDefault (484.35s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy (312.16s)
```
