### PR TITLE
resource/aws_s3_bucket_object: Retry read after creation for 404 status code

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -12,14 +12,16 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mitchellh/go-homedir"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
+
+const s3BucketObjectCreationTimeout = 2 * time.Minute
 
 func resourceAwsS3BucketObject() *schema.Resource {
 	return &schema.Resource{
@@ -304,15 +306,35 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 
-	resp, err := s3conn.HeadObject(
-		&s3.HeadObjectInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(key),
-		})
+	input := &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+
+	var resp *s3.HeadObjectOutput
+	var err error
+
+	err = resource.Retry(s3BucketObjectCreationTimeout, func() *resource.RetryError {
+		resp, err = s3conn.HeadObject(input)
+
+		if d.IsNewResource() && isAWSErrRequestFailureStatusCode(err, 404) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		resp, err = s3conn.HeadObject(input)
+	}
 
 	if err != nil {
 		// If S3 returns a 404 Request Failure, mark the object as destroyed
-		if awsErr, ok := err.(awserr.RequestFailure); ok && awsErr.StatusCode() == 404 {
+		if isAWSErrRequestFailureStatusCode(err, 404) {
 			d.SetId("")
 			log.Printf("[WARN] Error Reading Object (%s), object not found (HTTP status 404)", key)
 			return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/9725

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccAWSS3BucketObject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccAWSS3BucketObject_noNameNoKey
=== PAUSE TestAccAWSS3BucketObject_noNameNoKey
=== RUN   TestAccAWSS3BucketObject_empty
=== PAUSE TestAccAWSS3BucketObject_empty
=== RUN   TestAccAWSS3BucketObject_source
=== PAUSE TestAccAWSS3BucketObject_source
=== RUN   TestAccAWSS3BucketObject_content
=== PAUSE TestAccAWSS3BucketObject_content
=== RUN   TestAccAWSS3BucketObject_etagEncryption
=== PAUSE TestAccAWSS3BucketObject_etagEncryption
=== RUN   TestAccAWSS3BucketObject_contentBase64
=== PAUSE TestAccAWSS3BucketObject_contentBase64
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
=== PAUSE TestAccAWSS3BucketObject_withContentCharacteristics
=== RUN   TestAccAWSS3BucketObject_NonVersioned
=== PAUSE TestAccAWSS3BucketObject_NonVersioned
=== RUN   TestAccAWSS3BucketObject_updates
=== PAUSE TestAccAWSS3BucketObject_updates
=== RUN   TestAccAWSS3BucketObject_updateSameFile
=== PAUSE TestAccAWSS3BucketObject_updateSameFile
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioning
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== RUN   TestAccAWSS3BucketObject_kms
=== PAUSE TestAccAWSS3BucketObject_kms
=== RUN   TestAccAWSS3BucketObject_sse
=== PAUSE TestAccAWSS3BucketObject_sse
=== RUN   TestAccAWSS3BucketObject_acl
=== PAUSE TestAccAWSS3BucketObject_acl
=== RUN   TestAccAWSS3BucketObject_metadata
=== PAUSE TestAccAWSS3BucketObject_metadata
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== RUN   TestAccAWSS3BucketObject_tags
=== PAUSE TestAccAWSS3BucketObject_tags
=== RUN   TestAccAWSS3BucketObject_tagsLeadingSlash
=== PAUSE TestAccAWSS3BucketObject_tagsLeadingSlash
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== RUN   TestAccAWSS3BucketObject_defaultBucketSSE
=== PAUSE TestAccAWSS3BucketObject_defaultBucketSSE
=== RUN   TestAccAWSS3BucketObject_ignoreTags
=== PAUSE TestAccAWSS3BucketObject_ignoreTags
=== CONT  TestAccAWSS3BucketObject_noNameNoKey
=== CONT  TestAccAWSS3BucketObject_sse
=== CONT  TestAccAWSS3BucketObject_NonVersioned
=== CONT  TestAccAWSS3BucketObject_tagsLeadingSlash
=== CONT  TestAccAWSS3BucketObject_tags
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== CONT  TestAccAWSS3BucketObject_metadata
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== CONT  TestAccAWSS3BucketObject_storageClass
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== CONT  TestAccAWSS3BucketObject_acl
=== CONT  TestAccAWSS3BucketObject_etagEncryption
=== CONT  TestAccAWSS3BucketObject_withContentCharacteristics
=== CONT  TestAccAWSS3BucketObject_ignoreTags
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioning
=== CONT  TestAccAWSS3BucketObject_kms
=== CONT  TestAccAWSS3BucketObject_contentBase64
=== CONT  TestAccAWSS3BucketObject_defaultBucketSSE
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== CONT  TestAccAWSS3BucketObject_NonVersioned
    provider_test.go:1819: skipping tests; TF_ACC_ASSUME_ROLE_ARN must be set
--- SKIP: TestAccAWSS3BucketObject_NonVersioned (1.80s)
=== CONT  TestAccAWSS3BucketObject_source
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (48.07s)
=== CONT  TestAccAWSS3BucketObject_content
=== CONT  TestAccAWSS3BucketObject_ignoreTags
    resource_aws_s3_bucket_object_test.go:986: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout


        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_s3_bucket_object.object will be updated in-place
          ~ resource "aws_s3_bucket_object" "object" {
                id            = "test-key"
              ~ tags          = {
                  - "ignorekey1" = "ignorevalue1" -> null
                }
                # (10 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAWSS3BucketObject_ignoreTags (134.43s)
=== CONT  TestAccAWSS3BucketObject_empty
--- PASS: TestAccAWSS3BucketObject_contentBase64 (134.84s)
=== CONT  TestAccAWSS3BucketObject_updateSameFile
--- PASS: TestAccAWSS3BucketObject_source (133.31s)
=== CONT  TestAccAWSS3BucketObject_updates
--- PASS: TestAccAWSS3BucketObject_kms (135.71s)
--- PASS: TestAccAWSS3BucketObject_defaultBucketSSE (136.06s)
--- PASS: TestAccAWSS3BucketObject_sse (136.31s)
--- PASS: TestAccAWSS3BucketObject_etagEncryption (136.66s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (137.25s)
--- PASS: TestAccAWSS3BucketObject_content (106.49s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (203.97s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (208.76s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (209.92s)
--- PASS: TestAccAWSS3BucketObject_empty (81.51s)
--- PASS: TestAccAWSS3BucketObject_metadata (254.73s)
--- PASS: TestAccAWSS3BucketObject_acl (254.93s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (256.57s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (258.79s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (129.40s)
--- PASS: TestAccAWSS3BucketObject_updates (129.18s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (287.59s)
--- PASS: TestAccAWSS3BucketObject_tags (288.28s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (288.44s)
--- PASS: TestAccAWSS3BucketObject_storageClass (313.48s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	316.843s
FAIL
make: *** [testacc] Error 1
```

There might be other eventual consistency problems and if I run `TestAccAWSS3BucketObject_ignoreTags` separately it succeeds.

```
make testacc TESTARGS='-run=TestAccAWSS3BucketObject_ignoreTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketObject_ignoreTags -timeout 120m
=== RUN   TestAccAWSS3BucketObject_ignoreTags
=== PAUSE TestAccAWSS3BucketObject_ignoreTags
=== CONT  TestAccAWSS3BucketObject_ignoreTags
--- PASS: TestAccAWSS3BucketObject_ignoreTags (67.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.218s
```

Also, the same problem happens without this change so I think it does not relate to the changes on this PR.

Thank you for your review! 👍 