### PR TITLE
Update lb_listener datasource schema to match lb_listener default_action forward schema

### DIFF
--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -213,6 +213,46 @@ func dataSourceAwsLbListener() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"forward": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"target_group": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"arn": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"weight": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"stickiness": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enabled": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"duration": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12574
Relates #10942

---

### Bug description

When the weighted target group functionality was added back in June 2020 in #12547, the lb_listener `default_action` block schema was not updated.

---


### Affected Resource(s)

```
aws_lb_listener (datasource)
```

### Expected Behavior

Terraform should retrieve the specified AWS ELB listener configuration object for cases where there is a single target group configured, or weighted target groups are used on the resource.

###  Actual Behavior

If the `aws_lb_listener` datasource tries to retrieve a listener configured with a weighted target group forward default action:

```
data "aws_lb_listener" "example" {
  load_balancer_arn = aws_alb.example.arn
  port              = 443
}

locals {
  default_lb_listener_action = data.aws_lb_listener.example.default_action
}

output "default_lb_listener_action" {
  value = local.default_lb_listener_action
}
```

Terraform stops with an error:

```
Error: error setting default_action: Invalid address to set: []string{"default_action", "0", "forward"}
```

### Steps to Reproduce

```
terraform apply
```

### Terraform Configuration Files

This bug prevents gathering the current weight configured in the default action of an AWS ALB listener, needed for example to detect the current Target Group ARN that is currently receiving the 100% of the traffic (very useful for active side detection in blue-green deployments):

```
resource "aws_alb" "example" {
  name            = "example-alb"
  subnets         = module.vpc.public_subnets
  internal        = false
}

resource "aws_alb_listener" "example" {
  load_balancer_arn = aws_alb.example.arn
  port              = 443
  protocol          = "tcp"

  default_action {
    type = "forward"
    forward {
      target_group {
        arn    = "arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/tg-one/abcdefgh1234567"
        weight = 1
      }
      target_group {
        arn    = "arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/tg-two/abcdefgh1234567"
        weight = 0
      }
    }
  }
}

data "aws_lb_listener" "example" {
  load_balancer_arn = aws_alb.example.arn
  port              = 443
}

locals {
  default_lb_listener_action_targets = data.aws_lb_listener.example.default_action[0].forward[0].target_group
  lb_listener_forwarding_target_arn  = [for target_group in local.default_lb_listener_action_targets : target_group.arn if target_group.weight == 1][0]
}

output "lb_listener_forwarding_target_arn" {
  value = local.lb_listener_forwarding_target_arn
}
```


---

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):

```
* data-source/aws_lb_listener: Prevent error when retrieving a listener whose default action contains weighted target groups
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSLBListener'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSLBListener -timeout 120m
=== RUN   TestAccDataSourceAWSLBListener_basic
=== PAUSE TestAccDataSourceAWSLBListener_basic
=== RUN   TestAccDataSourceAWSLBListener_BackwardsCompatibility
=== PAUSE TestAccDataSourceAWSLBListener_BackwardsCompatibility
=== RUN   TestAccDataSourceAWSLBListener_https
=== PAUSE TestAccDataSourceAWSLBListener_https
=== CONT  TestAccDataSourceAWSLBListener_basic
=== CONT  TestAccDataSourceAWSLBListener_https
=== CONT  TestAccDataSourceAWSLBListener_BackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBListener_basic (206.34s)
--- PASS: TestAccDataSourceAWSLBListener_https (216.49s)
--- PASS: TestAccDataSourceAWSLBListener_BackwardsCompatibility (217.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       219.182s
```
