### PR TITLE
feat: add support for retry policies and dead letter config for aws_cloudwatch_event_target resources

### DIFF
--- a/.changelog/17241.txt
+++ b/.changelog/17241.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_cloudwatch_event_target: Adds `retry_policy` attributes
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_event_target: Adds `dead_letter_config` attributes
+```

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -530,12 +530,12 @@ func expandAwsCloudWatchEventRetryPolicyParameters(rp []interface{}) *events.Ret
 	for _, v := range rp {
 		params := v.(map[string]interface{})
 
-		if val, ok := params["maximum_event_age_in_seconds"]; ok {
-			retryPolicy.MaximumEventAgeInSeconds = aws.Int64(int64(params["maximum_event_age_in_seconds"].(int)))
+		if val, ok := params["maximum_event_age_in_seconds"].(int); ok {
+			retryPolicy.MaximumEventAgeInSeconds = aws.Int64(int64(val))
 		}
 
-		if val, ok := params["maximum_retry_attempts"]; ok {
-			retryPolicy.MaximumRetryAttempts = aws.Int64(int64(params["maximum_retry_attempts"].(int)))
+		if val, ok := params["maximum_retry_attempts"].(int); ok {
+			retryPolicy.MaximumRetryAttempts = aws.Int64(int64(val))
 		}
 	}
 

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -248,6 +248,36 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 					},
 				},
 			},
+
+			"retry_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"maximum_event_age_in_seconds": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"maximum_retry_attempts": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+
+				"dead_letter_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"arn": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -252,6 +252,7 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 			"retry_policy": {
 				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"maximum_event_age_in_seconds": {
@@ -270,6 +271,7 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 			"dead_letter_config": {
 				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"arn": {

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -384,6 +384,18 @@ func resourceAwsCloudWatchEventTargetRead(d *schema.ResourceData, meta interface
 		}
 	}
 
+	if t.RetryPolicy != nil {
+		if err := d.Set("retry_policy", flatternAwsCloudWatchEventTargetRetryPolicy(t.RetryPolicy)); err != nil {
+			return fmt.Errorf("Error setting retry_policy error: #{err}")
+		}
+	}
+
+	if t.DeadLetterConfig != nil {
+		if err := d.Set("dead_letter_config", flatternAwsCloudWatchEventTargetDeadLetterConfig(t.DeadLetterConfig)); err != nil {
+			return fmt.Errorf("Error setting dead_letter_config error: #{err}")
+		}
+	}
+
 	return nil
 }
 
@@ -728,6 +740,25 @@ func flattenAwsCloudWatchInputTransformer(inputTransformer *events.InputTransfor
 	}
 	config["input_template"] = aws.StringValue(inputTransformer.InputTemplate)
 	config["input_paths"] = inputPathsMap
+
+	result := []map[string]interface{}{config}
+	return result
+}
+
+func flatternAwsCloudWatchEventTargetRetryPolicy(rp *events.RetryPolicy) []map[string]interface{} {
+	config := make(map[string]interface{})
+
+	config["maximum_event_age_in_seconds"] = aws.Int64Value(rp.MaximumEventAgeInSeconds)
+	config["maximum_retry_attempts"] = aws.Int64Value(rp.MaximumRetryAttempts)
+
+	result := []map[string]interface{}{config}
+	return result
+}
+
+func flatternAwsCloudWatchEventTargetDeadLetterConfig(dlc *events.DeadLetterConfig) []map[string]interface{} {
+	config := make(map[string]interface{})
+
+	config["arn"] = aws.StringValue(dlc.Arn)
 
 	result := []map[string]interface{}{config}
 	return result

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -255,8 +255,9 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"maximum_event_age_in_seconds": {
-							Type:     schema.TypeInt,
-							Optional: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtLeast(60),
 						},
 						"maximum_retry_attempts": {
 							Type:     schema.TypeInt,
@@ -272,8 +273,9 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"arn": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
 						},
 					},
 				},

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -247,6 +247,39 @@ func TestAccAWSCloudWatchEventTarget_GeneratedTargetId(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudWatchEventTarget_retrypolicy_dlc(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_target.test"
+	kinesisStreamResourceName := "aws_kinesis_stream.test"
+	queueResourceName := "aws_sqs_queue.test"
+	var v events.Target
+
+	ruleName := acctest.RandomWithPrefix("tf-acc-cw-event-rule-full")
+	ssmDocumentName := acctest.RandomWithPrefix("tf_ssm_Document")
+	targetID := acctest.RandomWithPrefix("tf-acc-cw-target-full")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchEventTargetConfig_retrypolicy_dlc(ruleName, targetID, ssmDocumentName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "rule", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "target_id", targetID),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", kinesisStreamResourceName, "arn"),
+					testAccCheckResourceAttrEquivalentJSON(resourceName, "input", `{"source": ["aws.cloudtrail"]}`),
+					resource.TestCheckResourceAttr(resourceName, "input_path", ""),
+					resource.TestCheckResourceAttr(resourceName, "retry_policy.0.maximum_event_age_in_seconds", "60"),
+					resource.TestCheckResourceAttr(resourceName, "retry_policy.0.maximum_retry_attempts", "5"),
+					resource.TestCheckResourceAttrPair(resourceName, "dead_letter_config.0.arn", queueResourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudWatchEventTarget_full(t *testing.T) {
 	resourceName := "aws_cloudwatch_event_target.test"
 	kinesisStreamResourceName := "aws_kinesis_stream.test"
@@ -626,6 +659,8 @@ func testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName string) resou
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
 
+		fmt.Printf("%#v", rs.Primary.Attributes)
+
 		return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["event_bus_name"], rs.Primary.Attributes["rule"], rs.Primary.Attributes["target_id"]), nil
 	}
 }
@@ -728,6 +763,89 @@ resource "aws_sns_topic" "test" {
   name = "%s"
 }
 `, ruleName, snsTopicName)
+}
+
+func testAccAWSCloudWatchEventTargetConfig_retrypolicy_dlc(ruleName, targetName, rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_rule" "test" {
+	name                = %[1]q
+	schedule_expression = "rate(1 hour)"
+	role_arn            = aws_iam_role.test.arn
+}
+
+resource "aws_iam_role" "test" {
+  name = %[2]q
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "events.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = "%[2]s_policy"
+  role = aws_iam_role.test.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "kinesis:PutRecord",
+        "kinesis:PutRecords"
+      ],
+      "Resource": [
+        "*"
+      ],
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_sqs_queue" "test" {
+}
+
+resource "aws_cloudwatch_event_target" "test" {
+  rule      = aws_cloudwatch_event_rule.test.name
+  target_id = %[3]q
+
+  input = <<INPUT
+{ "source": ["aws.cloudtrail"] }
+INPUT
+
+  arn = aws_kinesis_stream.test.arn
+
+  retry_policy {
+    maximum_event_age_in_seconds = 60
+		maximum_retry_attempts = 5
+  }
+
+	dead_letter_config {
+		arn = aws_sqs_queue.test.arn
+	}
+}
+
+resource "aws_kinesis_stream" "test" {
+  name        = "%[2]s_kinesis_test"
+  shard_count = 1
+}
+
+data "aws_partition" "current" {}
+`, ruleName, rName, targetName)
 }
 
 func testAccAWSCloudWatchEventTargetConfig_full(ruleName, targetName, rName string) string {

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -247,7 +247,7 @@ func TestAccAWSCloudWatchEventTarget_GeneratedTargetId(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudWatchEventTarget_retrypolicy_dlc(t *testing.T) {
+func TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig(t *testing.T) {
 	resourceName := "aws_cloudwatch_event_target.test"
 	kinesisStreamResourceName := "aws_kinesis_stream.test"
 	queueResourceName := "aws_sqs_queue.test"
@@ -263,7 +263,7 @@ func TestAccAWSCloudWatchEventTarget_retrypolicy_dlc(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudWatchEventTargetConfig_retrypolicy_dlc(ruleName, targetID, ssmDocumentName),
+				Config: testAccAWSCloudWatchEventTargetConfig_retryPolicyDlc(ruleName, targetID, ssmDocumentName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventTargetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "rule", ruleName),
@@ -765,7 +765,7 @@ resource "aws_sns_topic" "test" {
 `, ruleName, snsTopicName)
 }
 
-func testAccAWSCloudWatchEventTargetConfig_retrypolicy_dlc(ruleName, targetName, rName string) string {
+func testAccAWSCloudWatchEventTargetConfig_retryPolicyDlc(ruleName, targetName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_rule" "test" {
   name                = %[1]q

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -768,9 +768,9 @@ resource "aws_sns_topic" "test" {
 func testAccAWSCloudWatchEventTargetConfig_retrypolicy_dlc(ruleName, targetName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_rule" "test" {
-	name                = %[1]q
-	schedule_expression = "rate(1 hour)"
-	role_arn            = aws_iam_role.test.arn
+  name                = %[1]q
+  schedule_expression = "rate(1 hour)"
+  role_arn            = aws_iam_role.test.arn
 }
 
 resource "aws_iam_role" "test" {
@@ -831,12 +831,12 @@ INPUT
 
   retry_policy {
     maximum_event_age_in_seconds = 60
-		maximum_retry_attempts = 5
+    maximum_retry_attempts       = 5
   }
 
-	dead_letter_config {
-		arn = aws_sqs_queue.test.arn
-	}
+  dead_letter_config {
+    arn = aws_sqs_queue.test.arn
+  }
 }
 
 resource "aws_kinesis_stream" "test" {

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -307,6 +307,8 @@ The following arguments are supported:
 * `kinesis_target` - (Optional) Parameters used when you are using the rule to invoke an Amazon Kinesis Stream. Documented below. A maximum of 1 are allowed.
 * `sqs_target` - (Optional) Parameters used when you are using the rule to invoke an Amazon SQS Queue. Documented below. A maximum of 1 are allowed.
 * `input_transformer` - (Optional) Parameters used when you are providing a custom input to a target based on certain event data. Conflicts with `input` and `input_path`.
+* `retry_policy` - (Optional)  Parameters used when you are providing retry policies. Documented below. A maximum of 1 are allowed.
+* `dead_letter_config` - (Optional)  Parameters used when you are providing a dead letter conifg. Documented below. A maximum of 1 are allowed.
 
 `run_command_targets` support the following:
 
@@ -353,6 +355,15 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
     * The keys can't start with "AWS".
 
 * `input_template` - (Required) Template to customize data sent to the target. Must be valid JSON. To send a string value, the string value must include double quotes. Values must be escaped for both JSON and Terraform, e.g. `"\"Your string goes here.\\nA new line.\""`
+
+`retry_policy` support the following:
+
+* `maximum_event_age_in_seconds` - (Optional) The age in seconds to continue to make retry attempts.
+* `maximum_retry_attempts` - (Optional) maximum number of retry attempts to make before the request fails
+
+`dead_letter_config` support the following:
+
+* `arn` - (Optional) - ARN of the SQS queue specified as the target for the dead-letter queue.
 
 ## Import
 


### PR DESCRIPTION
Intro
This PR adds support to create Archives in EventBridge.

Release note for CHANGELOG:

resource_aws_cloudwatch_event_target - adds retry policies and dead letter config for aws_cloudwatch_event_target resources

### Tasks

[x] Acceptance test
[x] Update docs

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #17240

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
thulsimo@3c22fbef9550 terraform-provider-aws % make testacc TESTARGS='-run=^TestAccAWSCloudWatchEventTarget_retrypolicy_dlc$'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=^TestAccAWSCloudWatchEventTarget_retrypolicy_dlc -timeout 120m
=== RUN   TestAccAWSCloudWatchEventTarget_retrypolicy_dlc
=== PAUSE TestAccAWSCloudWatchEventTarget_retrypolicy_dlc
=== CONT  TestAccAWSCloudWatchEventTarget_retrypolicy_dlc
--- PASS: TestAccAWSCloudWatchEventTarget_retrypolicy_dlc (80.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       84.015s


...
```
