### PR TITLE
Fix fmtcheck error in 'tools/main.go'

### DIFF
--- a/tools/main.go
+++ b/tools/main.go
@@ -6,7 +6,7 @@ import (
 	_ "github.com/bflad/tfproviderdocs"
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/hashicorp/go-changelog/cmd/changelog-build"
 	_ "github.com/katbyte/terrafmt"
 	_ "github.com/terraform-linters/tflint"
-	_ "github.com/hashicorp/go-changelog/cmd/changelog-build"	
 )


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Correct order of package imports.

```console
$ make test
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./tools/main.go
You can use the command: `make fmt` to reformat code.
GNUmakefile:45: recipe for target 'fmtcheck' failed
make: *** [fmtcheck] Error 1
```

No CHANGELOG entry required.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```
