### PR TITLE
tests/data-source/aws_pricing_product: Adjust redshift query precision

### DIFF
--- a/aws/data_source_aws_pricing_product_test.go
+++ b/aws/data_source_aws_pricing_product_test.go
@@ -114,6 +114,11 @@ data "aws_pricing_product" "test" {
     field = "location"
     value = data.aws_region.current.description
   }
+
+  filters {
+    field = "productFamily"
+    value = "Compute Instance"
+  }
 }
 `)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16720

Previously:

```
=== CONT  TestAccDataSourceAwsPricingProduct_redshift
TestAccDataSourceAwsPricingProduct_redshift: data_source_aws_pricing_product_test.go:29: Step 1/1 error: Error running pre-apply refresh:
Error: Pricing product query not precise enough. Returned more than one element: ....
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccDataSourceAwsPricingProduct_redshift (8.55s)
```

Output from acceptance testing in AWS GovCloud (US):

```
=== CONT  TestAccDataSourceAwsPricingProduct_redshift
    provider_test.go:697: skipping tests; partition aws-us-gov does not support api.pricing service
--- SKIP: TestAccDataSourceAwsPricingProduct_redshift (1.38s)
```