### PR TITLE
r/sagemaker_app - new resource

### DIFF
--- a/.changelog/17251.txt
+++ b/.changelog/17251.txt
@@ -9,3 +9,7 @@ resource/aws_sagemaker_user_profile: Fix destory check in acceptance tests
 ```release-note:enhancement
 resource/aws_sagemaker_domain: Add support `sagemaker_image_version_arn` for `default_resource_spec` config block for the `tensor_board_app_settings`, `jupyter_server_app_settings` and `kernel_gateway_app_settings` config blocks.
 ```
+
+```release-note:enhancement
+resource/aws_sagemaker_domain: Make `default_resource_spec` optional for the `tensor_board_app_settings`, `jupyter_server_app_settings` and `kernel_gateway_app_settings` config blocks. 
+```

--- a/.changelog/17251.txt
+++ b/.changelog/17251.txt
@@ -5,3 +5,7 @@ aws_sagemaker_app
 ```release-note:enhancement
 resource/aws_sagemaker_domain: Make `default_resource_spec` optional for the `tensor_board_app_settings`, `jupyter_server_app_settings` and `kernel_gateway_app_settings` config blocks. 
 ```
+
+```release-note:bug
+resource/aws_sagemaker_domain: Wait for update to finish.
+```

--- a/.changelog/17251.txt
+++ b/.changelog/17251.txt
@@ -7,9 +7,5 @@ resource/aws_sagemaker_user_profile: Fix destory check in acceptance tests
 ```
 
 ```release-note:enhancement
-resource/aws_sagemaker_domain: Add support `sagemaker_image_version_arn` for `default_resource_spec` config block for the `tensor_board_app_settings`, `jupyter_server_app_settings` and `kernel_gateway_app_settings` config blocks.
-```
-
-```release-note:enhancement
 resource/aws_sagemaker_domain: Make `default_resource_spec` optional for the `tensor_board_app_settings`, `jupyter_server_app_settings` and `kernel_gateway_app_settings` config blocks. 
 ```

--- a/.changelog/17251.txt
+++ b/.changelog/17251.txt
@@ -3,9 +3,5 @@ aws_sagemaker_app
 ```
 
 ```release-note:enhancement
-resource/aws_sagemaker_user_profile: Fix destory check in acceptance tests
-```
-
-```release-note:enhancement
 resource/aws_sagemaker_domain: Make `default_resource_spec` optional for the `tensor_board_app_settings`, `jupyter_server_app_settings` and `kernel_gateway_app_settings` config blocks. 
 ```

--- a/.changelog/17251.txt
+++ b/.changelog/17251.txt
@@ -1,0 +1,11 @@
+```release-note:new-resource
+aws_sagemaker_app
+```
+
+```release-note:enhancement
+resource/aws_sagemaker_user_profile: Fix destory check in acceptance tests
+```
+
+```release-note:enhancement
+resource/aws_sagemaker_domain: Add support `sagemaker_image_version_arn` for `default_resource_spec` config block for the `tensor_board_app_settings`, `jupyter_server_app_settings` and `kernel_gateway_app_settings` config blocks.
+```

--- a/.changelog/17251.txt
+++ b/.changelog/17251.txt
@@ -9,3 +9,7 @@ resource/aws_sagemaker_domain: Make `default_resource_spec` optional for the `te
 ```release-note:bug
 resource/aws_sagemaker_domain: Wait for update to finish.
 ```
+
+```release-note:bug
+resource/aws_sagemaker_user_profile: Wait for update to finish.
+```

--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -157,3 +157,25 @@ func AppImageConfigByName(conn *sagemaker.SageMaker, appImageConfigID string) (*
 
 	return output, nil
 }
+
+// AppByName returns the domain corresponding to the specified domain id.
+// Returns nil if no domain is found.
+func AppByName(conn *sagemaker.SageMaker, domainID, userProfileName, appType, appName string) (*sagemaker.DescribeAppOutput, error) {
+	input := &sagemaker.DescribeAppInput{
+		DomainId:        aws.String(domainID),
+		UserProfileName: aws.String(userProfileName),
+		AppType:         aws.String(appType),
+		AppName:         aws.String(appName),
+	}
+
+	output, err := conn.DescribeApp(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output, nil
+}

--- a/aws/internal/service/sagemaker/waiter/waiter.go
+++ b/aws/internal/service/sagemaker/waiter/waiter.go
@@ -215,6 +215,7 @@ func DomainInService(conn *sagemaker.SageMaker, domainID string) (*sagemaker.Des
 		Pending: []string{
 			SagemakerDomainStatusNotFound,
 			sagemaker.DomainStatusPending,
+			sagemaker.DomainStatusUpdating,
 		},
 		Target:  []string{sagemaker.DomainStatusInService},
 		Refresh: DomainStatus(conn, domainID),

--- a/aws/internal/service/sagemaker/waiter/waiter.go
+++ b/aws/internal/service/sagemaker/waiter/waiter.go
@@ -23,6 +23,8 @@ const (
 	FeatureGroupDeletedTimeout        = 10 * time.Minute
 	UserProfileInServiceTimeout       = 10 * time.Minute
 	UserProfileDeletedTimeout         = 10 * time.Minute
+	AppInServiceTimeout               = 10 * time.Minute
+	AppDeletedTimeout                 = 10 * time.Minute
 )
 
 // NotebookInstanceInService waits for a NotebookInstance to return InService
@@ -320,6 +322,47 @@ func UserProfileDeleted(conn *sagemaker.SageMaker, domainID, userProfileName str
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*sagemaker.DescribeUserProfileOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+// AppInService waits for a App to return InService
+func AppInService(conn *sagemaker.SageMaker, domainID, userProfileName, appType, appName string) (*sagemaker.DescribeAppOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			SagemakerAppStatusNotFound,
+			sagemaker.AppStatusPending,
+		},
+		Target:  []string{sagemaker.AppStatusInService},
+		Refresh: AppStatus(conn, domainID, userProfileName, appType, appName),
+		Timeout: AppInServiceTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sagemaker.DescribeAppOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+// AppDeleted waits for a App to return Deleted
+func AppDeleted(conn *sagemaker.SageMaker, domainID, userProfileName, appType, appName string) (*sagemaker.DescribeAppOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			sagemaker.AppStatusDeleting,
+		},
+		Target:  []string{},
+		Refresh: AppStatus(conn, domainID, userProfileName, appType, appName),
+		Timeout: AppDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sagemaker.DescribeAppOutput); ok {
 		return output, err
 	}
 

--- a/aws/internal/service/sagemaker/waiter/waiter.go
+++ b/aws/internal/service/sagemaker/waiter/waiter.go
@@ -355,7 +355,9 @@ func AppDeleted(conn *sagemaker.SageMaker, domainID, userProfileName, appType, a
 		Pending: []string{
 			sagemaker.AppStatusDeleting,
 		},
-		Target:  []string{},
+		Target: []string{
+			sagemaker.AppStatusDeleted,
+		},
 		Refresh: AppStatus(conn, domainID, userProfileName, appType, appName),
 		Timeout: AppDeletedTimeout,
 	}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -895,6 +895,7 @@ func Provider() *schema.Provider {
 			"aws_route_table":                                         resourceAwsRouteTable(),
 			"aws_default_route_table":                                 resourceAwsDefaultRouteTable(),
 			"aws_route_table_association":                             resourceAwsRouteTableAssociation(),
+			"aws_sagemaker_app":                                       resourceAwsSagemakerApp(),
 			"aws_sagemaker_app_image_config":                          resourceAwsSagemakerAppImageConfig(),
 			"aws_sagemaker_code_repository":                           resourceAwsSagemakerCodeRepository(),
 			"aws_sagemaker_domain":                                    resourceAwsSagemakerDomain(),

--- a/aws/resource_aws_sagemaker_app.go
+++ b/aws/resource_aws_sagemaker_app.go
@@ -111,7 +111,7 @@ func resourceAwsSagemakerAppCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	appArn := aws.StringValue(output.AppArn)
-	domainID, userProfileName, appType, appName, err := decodeSagemakerAppID(d.Id())
+	domainID, userProfileName, appType, appName, err := decodeSagemakerAppID(appArn)
 	if err != nil {
 		return err
 	}
@@ -228,6 +228,15 @@ func decodeSagemakerAppID(id string) (string, string, string, string, error) {
 	domainID := parts[0]
 	userProfileName := parts[1]
 	appType := parts[2]
+
+	if appType == "jupyterserver" {
+		appType = sagemaker.AppTypeJupyterServer
+	} else if appType == "kernelgateway" {
+		appType = sagemaker.AppTypeKernelGateway
+	} else if appType == "tensorboard" {
+		appType = sagemaker.AppTypeTensorBoard
+	}
+
 	appName := parts[3]
 
 	return domainID, userProfileName, appType, appName, nil

--- a/aws/resource_aws_sagemaker_app.go
+++ b/aws/resource_aws_sagemaker_app.go
@@ -67,6 +67,7 @@ func resourceAwsSagemakerApp() *schema.Resource {
 						"sagemaker_image_arn": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validateArn,
 						},
 						"sagemaker_image_version_arn": {

--- a/aws/resource_aws_sagemaker_app.go
+++ b/aws/resource_aws_sagemaker_app.go
@@ -138,14 +138,18 @@ func resourceAwsSagemakerAppRead(d *schema.ResourceData, meta interface{}) error
 
 	app, err := finder.AppByName(conn, domainID, userProfileName, appType, appName)
 	if err != nil {
-		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") ||
-			isAWSErr(err, "ValidationException", "has already been deleted") ||
-			isAWSErr(err, "ValidationException", "previously failed and was automatically deleted") {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
 			d.SetId("")
 			log.Printf("[WARN] Unable to find SageMaker App (%s), removing from state", d.Id())
 			return nil
 		}
 		return fmt.Errorf("error reading SageMaker App (%s): %w", d.Id(), err)
+	}
+
+	if aws.StringValue(app.Status) == sagemaker.AppStatusDeleted {
+		d.SetId("")
+		log.Printf("[WARN] Unable to find SageMaker App (%s), removing from state", d.Id())
+		return nil
 	}
 
 	arn := aws.StringValue(app.AppArn)
@@ -203,11 +207,8 @@ func resourceAwsSagemakerAppDelete(d *schema.ResourceData, meta interface{}) err
 
 	if _, err := conn.DeleteApp(input); err != nil {
 
-		if isAWSErr(err, "ValidationException", "has already been deleted") {
-			return nil
-		}
-
-		if isAWSErr(err, "ValidationException", "previously failed and was automatically deleted") {
+		if isAWSErr(err, "ValidationException", "has already been deleted") ||
+			isAWSErr(err, "ValidationException", "previously failed and was automatically deleted") {
 			return nil
 		}
 

--- a/aws/resource_aws_sagemaker_app.go
+++ b/aws/resource_aws_sagemaker_app.go
@@ -46,7 +46,7 @@ func resourceAwsSagemakerApp() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice(sagemaker.AppType_Values(), false),
 			},
-			"app_id": {
+			"domain_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
@@ -92,7 +92,7 @@ func resourceAwsSagemakerAppCreate(d *schema.ResourceData, meta interface{}) err
 	input := &sagemaker.CreateAppInput{
 		AppName:         aws.String(d.Get("app_name").(string)),
 		AppType:         aws.String(d.Get("app_type").(string)),
-		DomainId:        aws.String(d.Get("app_id").(string)),
+		DomainId:        aws.String(d.Get("domain_id").(string)),
 		UserProfileName: aws.String(d.Get("user_profile_name").(string)),
 	}
 

--- a/aws/resource_aws_sagemaker_app.go
+++ b/aws/resource_aws_sagemaker_app.go
@@ -1,0 +1,234 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/waiter"
+)
+
+func resourceAwsSagemakerApp() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerAppCreate,
+		Read:   resourceAwsSagemakerAppRead,
+		Update: resourceAwsSagemakerAppUpdate,
+		Delete: resourceAwsSagemakerAppDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"app_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 63),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,62}`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
+				),
+			},
+			"app_type": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(sagemaker.AppType_Values(), false),
+			},
+			"app_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"resource_spec": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+						},
+						"sagemaker_image_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
+						},
+						"sagemaker_image_version_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"tags": tagsSchema(),
+			"user_profile_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSagemakerAppCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	input := &sagemaker.CreateAppInput{
+		AppName:         aws.String(d.Get("app_name").(string)),
+		AppType:         aws.String(d.Get("app_type").(string)),
+		DomainId:        aws.String(d.Get("app_id").(string)),
+		UserProfileName: aws.String(d.Get("user_profile_name").(string)),
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SagemakerTags()
+	}
+
+	if v, ok := d.GetOk("resource_spec"); ok {
+		input.ResourceSpec = expandSagemakerDomainDefaultResourceSpec(v.([]interface{}))
+	}
+
+	log.Printf("[DEBUG] Sagemaker App create config: %#v", *input)
+	output, err := conn.CreateApp(input)
+	if err != nil {
+		return fmt.Errorf("error creating SageMaker App: %w", err)
+	}
+
+	appArn := aws.StringValue(output.AppArn)
+	domainID, userProfileName, appType, appName, err := decodeSagemakerAppID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(appArn)
+
+	if _, err := waiter.AppInService(conn, domainID, userProfileName, appType, appName); err != nil {
+		return fmt.Errorf("error waiting for SageMaker App (%s) to create: %w", d.Id(), err)
+	}
+
+	return resourceAwsSagemakerAppRead(d, meta)
+}
+
+func resourceAwsSagemakerAppRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	domainID, userProfileName, appType, appName, err := decodeSagemakerAppID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	app, err := finder.AppByName(conn, domainID, userProfileName, appType, appName)
+	if err != nil {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
+			d.SetId("")
+			log.Printf("[WARN] Unable to find SageMaker App (%s), removing from state", d.Id())
+			return nil
+		}
+		return fmt.Errorf("error reading SageMaker App (%s): %w", d.Id(), err)
+	}
+
+	arn := aws.StringValue(app.AppArn)
+	d.Set("app_name", app.AppName)
+	d.Set("app_type", app.AppType)
+	d.Set("arn", arn)
+	d.Set("domain_id", app.DomainId)
+	d.Set("user_profile_name", app.UserProfileName)
+
+	if err := d.Set("resource_spec", flattenSagemakerDomainDefaultResourceSpec(app.ResourceSpec)); err != nil {
+		return fmt.Errorf("error setting resource_spec for SageMaker App (%s): %w", d.Id(), err)
+	}
+
+	tags, err := keyvaluetags.SagemakerListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for SageMaker App (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsSagemakerAppUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.SagemakerUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating SageMaker App (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsSagemakerAppRead(d, meta)
+}
+
+func resourceAwsSagemakerAppDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	appName := d.Get("app_name").(string)
+	appType := d.Get("app_type").(string)
+	domainID := d.Get("domain_id").(string)
+	userProfileName := d.Get("user_profile_name").(string)
+
+	input := &sagemaker.DeleteAppInput{
+		AppName:         aws.String(appName),
+		AppType:         aws.String(appType),
+		DomainId:        aws.String(domainID),
+		UserProfileName: aws.String(userProfileName),
+	}
+
+	if _, err := conn.DeleteApp(input); err != nil {
+		if !isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
+			return fmt.Errorf("error deleting SageMaker App (%s): %w", d.Id(), err)
+		}
+	}
+
+	if _, err := waiter.AppDeleted(conn, domainID, userProfileName, appType, appName); err != nil {
+		if !isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
+			return fmt.Errorf("error waiting for SageMaker App (%s) to delete: %w", d.Id(), err)
+		}
+	}
+
+	return nil
+}
+
+func decodeSagemakerAppID(id string) (string, string, string, string, error) {
+	appArn, err := arn.Parse(id)
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	appResourceName := strings.TrimPrefix(appArn.Resource, "app/")
+	parts := strings.Split(appResourceName, "/")
+
+	if len(parts) != 4 {
+		return "", "", "", "", fmt.Errorf("Unexpected format of ID (%q), expected DOMAIN-ID/USER-PROFILE-NAME/APP-TYPE/APP-NAME", appResourceName)
+	}
+
+	domainID := parts[0]
+	userProfileName := parts[1]
+	appType := parts[2]
+	appName := parts[3]
+
+	return domainID, userProfileName, appType, appName, nil
+}

--- a/aws/resource_aws_sagemaker_app.go
+++ b/aws/resource_aws_sagemaker_app.go
@@ -70,11 +70,6 @@ func resourceAwsSagemakerApp() *schema.Resource {
 							Computed:     true,
 							ValidateFunc: validateArn,
 						},
-						"sagemaker_image_version_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validateArn,
-						},
 					},
 				},
 			},

--- a/aws/resource_aws_sagemaker_app_image_config_test.go
+++ b/aws/resource_aws_sagemaker_app_image_config_test.go
@@ -46,14 +46,12 @@ func testSweepSagemakerAppImageConfigs(region string) error {
 		}
 
 		for _, config := range output.AppImageConfigs {
+
 			name := aws.StringValue(config.AppImageConfigName)
-			input := &sagemaker.DeleteAppImageConfigInput{
-				AppImageConfigName: aws.String(name),
-			}
-
-			log.Printf("[INFO] Deleting SageMaker App Image Config: %s", name)
-			_, err := conn.DeleteAppImageConfig(input)
-
+			r := resourceAwsSagemakerAppImageConfig()
+			d := r.Data(nil)
+			d.SetId(name)
+			err = r.Delete(d, client)
 			if err != nil {
 				sweeperErr := fmt.Errorf("error deleting SageMaker App Image Config (%s): %w", name, err)
 				log.Printf("[ERROR] %s", sweeperErr)

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -317,6 +317,17 @@ func testAccCheckAWSSagemakerAppExists(n string, app *sagemaker.DescribeAppOutpu
 
 func testAccAWSSagemakerAppConfigBase(rName string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # Sagemaker compute resources are not available at usw2-az4.
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -326,8 +337,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id     = aws_vpc.test.id
-  cidr_block = "10.0.1.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.1.0/24"
 
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -15,6 +15,29 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
+func TestAccAWSSagemakerApp_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"App": {
+			"basic":        testAccAWSSagemakerApp_basic,
+			"disappears":   testAccAWSSagemakerApp_tags,
+			"tags":         testAccAWSSagemakerApp_disappears,
+			"resourceSpec": testAccAWSSagemakerApp_resourceSpec,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}
+
 func init() {
 	resource.AddTestSweepers("aws_sagemaker_app", &resource.Sweeper{
 		Name: "aws_sagemaker_app",
@@ -68,7 +91,7 @@ func testSweepSagemakerApps(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func TestAccAWSSagemakerApp_basic(t *testing.T) {
+func testAccAWSSagemakerApp_basic(t *testing.T) {
 	var app sagemaker.DescribeAppOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
@@ -101,7 +124,7 @@ func TestAccAWSSagemakerApp_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerApp_resourceSpec(t *testing.T) {
+func testAccAWSSagemakerApp_resourceSpec(t *testing.T) {
 	var app sagemaker.DescribeAppOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
@@ -130,7 +153,7 @@ func TestAccAWSSagemakerApp_resourceSpec(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerApp_tags(t *testing.T) {
+func testAccAWSSagemakerApp_tags(t *testing.T) {
 	var app sagemaker.DescribeAppOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
@@ -174,7 +197,7 @@ func TestAccAWSSagemakerApp_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerApp_disappears(t *testing.T) {
+func testAccAWSSagemakerApp_disappears(t *testing.T) {
 	var app sagemaker.DescribeAppOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -368,7 +368,7 @@ resource "aws_sagemaker_app" "test" {
   app_type          = "JupyterServer"
 
   resource_spec {
-	instance_type = "system"
+    instance_type = "system"
   }
 }
 `, rName)

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -15,29 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
-func TestAccAWSSagemakerApp_serial(t *testing.T) {
-	testCases := map[string]map[string]func(t *testing.T){
-		"App": {
-			"basic":        testAccAWSSagemakerApp_basic,
-			"disappears":   testAccAWSSagemakerApp_tags,
-			"tags":         testAccAWSSagemakerApp_disappears,
-			"resourceSpec": testAccAWSSagemakerApp_resourceSpec,
-		},
-	}
-
-	for group, m := range testCases {
-		m := m
-		t.Run(group, func(t *testing.T) {
-			for name, tc := range m {
-				tc := tc
-				t.Run(name, func(t *testing.T) {
-					tc(t)
-				})
-			}
-		})
-	}
-}
-
 func init() {
 	resource.AddTestSweepers("aws_sagemaker_app", &resource.Sweeper{
 		Name: "aws_sagemaker_app",

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -69,7 +69,7 @@ func testSweepSagemakerApps(region string) error {
 }
 
 func TestAccAWSSagemakerApp_basic(t *testing.T) {
-	var domain sagemaker.DescribeAppOutput
+	var app sagemaker.DescribeAppOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
 
@@ -81,7 +81,7 @@ func TestAccAWSSagemakerApp_basic(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerAppBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerAppExists(resourceName, &domain),
+					testAccCheckAWSSagemakerAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "app_name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "domain_id", "aws_sagemaker_domain.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "user_profile_name", "aws_sagemaker_user_profile.test", "user_profile_name"),
@@ -102,7 +102,7 @@ func TestAccAWSSagemakerApp_basic(t *testing.T) {
 }
 
 func TestAccAWSSagemakerApp_resourceSpec(t *testing.T) {
-	var domain sagemaker.DescribeAppOutput
+	var app sagemaker.DescribeAppOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
 
@@ -114,7 +114,7 @@ func TestAccAWSSagemakerApp_resourceSpec(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerAppResourceSpecConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerAppExists(resourceName, &domain),
+					testAccCheckAWSSagemakerAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "app_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "resource_spec.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "resource_spec.0.instance_type", "system"),
@@ -131,7 +131,7 @@ func TestAccAWSSagemakerApp_resourceSpec(t *testing.T) {
 }
 
 func TestAccAWSSagemakerApp_tags(t *testing.T) {
-	var domain sagemaker.DescribeAppOutput
+	var app sagemaker.DescribeAppOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
 
@@ -143,7 +143,7 @@ func TestAccAWSSagemakerApp_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerAppConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerAppExists(resourceName, &domain),
+					testAccCheckAWSSagemakerAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -156,7 +156,7 @@ func TestAccAWSSagemakerApp_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerAppConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerAppExists(resourceName, &domain),
+					testAccCheckAWSSagemakerAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -165,7 +165,7 @@ func TestAccAWSSagemakerApp_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerAppConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerAppExists(resourceName, &domain),
+					testAccCheckAWSSagemakerAppExists(resourceName, &app),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -175,9 +175,9 @@ func TestAccAWSSagemakerApp_tags(t *testing.T) {
 }
 
 func TestAccAWSSagemakerApp_disappears(t *testing.T) {
-	var domain sagemaker.DescribeAppOutput
+	var app sagemaker.DescribeAppOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_user_profile.test"
+	resourceName := "aws_sagemaker_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -187,7 +187,7 @@ func TestAccAWSSagemakerApp_disappears(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerAppBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerAppExists(resourceName, &domain),
+					testAccCheckAWSSagemakerAppExists(resourceName, &app),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerApp(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"testing"
 
@@ -118,71 +117,8 @@ func TestAccAWSSagemakerApp_resourceSpec(t *testing.T) {
 					testAccCheckAWSSagemakerAppExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "app_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "resource_spec.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_spec.0.instance_type", "ml.t3.micro"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSSagemakerApp_resourceSpecImage(t *testing.T) {
-	var domain sagemaker.DescribeAppOutput
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_app.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSagemakerAppDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSagemakerAppResourceSpecImageConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerAppExists(resourceName, &domain),
-					resource.TestCheckResourceAttr(resourceName, "app_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "resource_spec.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_spec.0.instance_type", "ml.t3.micro"),
-					resource.TestCheckResourceAttrPair(resourceName, "resource_spec.0.sagemaker_image_arn", "aws_sagemaker_image.test", "arn"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSSagemakerApp_resourceSpecImageVersion(t *testing.T) {
-
-	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
-		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
-	}
-
-	var domain sagemaker.DescribeAppOutput
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_sagemaker_app.test"
-	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSagemakerAppDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSagemakerAppResourceSpecImageVersionConfig(rName, baseImage),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerAppExists(resourceName, &domain),
-					resource.TestCheckResourceAttr(resourceName, "app_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "resource_spec.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_spec.0.instance_type", "ml.t3.micro"),
-					resource.TestCheckResourceAttrPair(resourceName, "resource_spec.0.sagemaker_image_version_arn", "aws_sagemaker_image_version.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "resource_spec.0.instance_type", "system"),
+					resource.TestCheckResourceAttrSet(resourceName, "resource_spec.0.sagemaker_image_arn"),
 				),
 			},
 			{
@@ -432,62 +368,8 @@ resource "aws_sagemaker_app" "test" {
   app_type          = "JupyterServer"
 
   resource_spec {
-	instance_type = "ml.t3.micro"
+	instance_type = "system"
   }
 }
 `, rName)
-}
-
-func testAccAWSSagemakerAppResourceSpecImageConfig(rName string) string {
-	return testAccAWSSagemakerAppConfigBase(rName) + fmt.Sprintf(`
-resource "aws_sagemaker_image" "test" {
-  image_name = %[1]q
-  role_arn   = aws_iam_role.test.arn
-}
-
-resource "aws_sagemaker_app" "test" {
-  domain_id         = aws_sagemaker_domain.test.id
-  user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
-  app_name          = %[1]q
-  app_type          = "JupyterServer"
-
-  resource_spec {
-	instance_type       = "ml.t3.micro"
-	sagemaker_image_arn = aws_sagemaker_image.test.arn
-  }
-}
-`, rName)
-}
-
-func testAccAWSSagemakerAppResourceSpecImageVersionConfig(rName, baseImage string) string {
-	return testAccAWSSagemakerAppConfigBase(rName) + fmt.Sprintf(`
-resource "aws_iam_role_policy_attachment" "test" {
-  role       = aws_iam_role.test.name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
-}
-
-resource "aws_sagemaker_image" "test" {
-  image_name = %[1]q
-  role_arn   = aws_iam_role.test.arn
-
-  depends_on = [aws_iam_role_policy_attachment.test]
-}
-
-resource "aws_sagemaker_image_version" "test" {
-  image_name = aws_sagemaker_image.test.id
-  base_image = %[2]q
-}
-
-resource "aws_sagemaker_app" "test" {
-  domain_id         = aws_sagemaker_domain.test.id
-  user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
-  app_name          = %[1]q
-  app_type          = "JupyterServer"
-
-  resource_spec {
-	instance_type               = "ml.t3.micro"
-	sagemaker_image_version_arn = aws_sagemaker_image_version.test.arn
-  }
-}
-`, rName, baseImage)
 }

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -73,7 +73,7 @@ func testAccAWSSagemakerApp_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerAppDestroy,
@@ -106,7 +106,7 @@ func testAccAWSSagemakerApp_resourceSpec(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerAppDestroy,
@@ -135,7 +135,7 @@ func testAccAWSSagemakerApp_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerAppDestroy,
@@ -179,7 +179,7 @@ func testAccAWSSagemakerApp_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_app.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerAppDestroy,

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -271,7 +271,7 @@ resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
   app_name          = %[1]q
-  app_type          = "AppTypeJupyterServer"
+  app_type          = "JupyterServer"
 }
 `, rName)
 }
@@ -282,7 +282,7 @@ resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
   app_name          = %[1]q
-  app_type          = "AppTypeJupyterServer"
+  app_type          = "JupyterServer"
 
   tags = {
     %[2]q = %[3]q
@@ -297,7 +297,7 @@ resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
   app_name          = %[1]q
-  app_type          = "AppTypeJupyterServer"
+  app_type          = "JupyterServer"
 
   tags = {
     %[2]q = %[3]q

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -136,11 +136,6 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 													Optional:     true,
 													ValidateFunc: validateArn,
 												},
-												"sagemaker_image_version_arn": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validateArn,
-												},
 											},
 										},
 									},
@@ -170,11 +165,6 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 													Optional:     true,
 													ValidateFunc: validateArn,
 												},
-												"sagemaker_image_version_arn": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validateArn,
-												},
 											},
 										},
 									},
@@ -200,11 +190,6 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
 												},
 												"sagemaker_image_arn": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validateArn,
-												},
-												"sagemaker_image_version_arn": {
 													Type:         schema.TypeString,
 													Optional:     true,
 													ValidateFunc: validateArn,
@@ -500,10 +485,6 @@ func expandSagemakerDomainDefaultResourceSpec(l []interface{}) *sagemaker.Resour
 		config.SageMakerImageArn = aws.String(v)
 	}
 
-	if v, ok := m["sagemaker_image_version_arn"].(string); ok && v != "" {
-		config.SageMakerImageVersionArn = aws.String(v)
-	}
-
 	return config
 }
 
@@ -597,10 +578,6 @@ func flattenSagemakerDomainDefaultResourceSpec(config *sagemaker.ResourceSpec) [
 
 	if config.SageMakerImageArn != nil {
 		m["sagemaker_image_arn"] = aws.StringValue(config.SageMakerImageArn)
-	}
-
-	if config.SageMakerImageVersionArn != nil {
-		m["sagemaker_image_version_arn"] = aws.StringValue(config.SageMakerImageVersionArn)
 	}
 
 	return []map[string]interface{}{m}

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -342,6 +342,10 @@ func resourceAwsSagemakerDomainUpdate(d *schema.ResourceData, meta interface{}) 
 		if err != nil {
 			return fmt.Errorf("error updating SageMaker domain: %w", err)
 		}
+
+		if _, err := waiter.DomainInService(conn, d.Id()); err != nil {
+			return fmt.Errorf("error waiting for SageMaker domain (%s) to update: %w", d.Id(), err)
+		}
 	}
 
 	if d.HasChange("tags") {

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -136,6 +136,11 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 													Optional:     true,
 													ValidateFunc: validateArn,
 												},
+												"sagemaker_image_version_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+												},
 											},
 										},
 									},
@@ -165,6 +170,11 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 													Optional:     true,
 													ValidateFunc: validateArn,
 												},
+												"sagemaker_image_version_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+												},
 											},
 										},
 									},
@@ -190,6 +200,11 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
 												},
 												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+												},
+												"sagemaker_image_version_arn": {
 													Type:         schema.TypeString,
 													Optional:     true,
 													ValidateFunc: validateArn,
@@ -485,6 +500,10 @@ func expandSagemakerDomainDefaultResourceSpec(l []interface{}) *sagemaker.Resour
 		config.SageMakerImageArn = aws.String(v)
 	}
 
+	if v, ok := m["sagemaker_image_version_arn"].(string); ok && v != "" {
+		config.SageMakerImageVersionArn = aws.String(v)
+	}
+
 	return config
 }
 
@@ -578,6 +597,10 @@ func flattenSagemakerDomainDefaultResourceSpec(config *sagemaker.ResourceSpec) [
 
 	if config.SageMakerImageArn != nil {
 		m["sagemaker_image_arn"] = aws.StringValue(config.SageMakerImageArn)
+	}
+
+	if config.SageMakerImageVersionArn != nil {
+		m["sagemaker_image_version_arn"] = aws.StringValue(config.SageMakerImageVersionArn)
 	}
 
 	return []map[string]interface{}{m}

--- a/aws/resource_aws_sagemaker_domain.go
+++ b/aws/resource_aws_sagemaker_domain.go
@@ -122,7 +122,7 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"default_resource_spec": {
 										Type:     schema.TypeList,
-										Required: true,
+										Optional: true,
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -156,7 +156,7 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"default_resource_spec": {
 										Type:     schema.TypeList,
-										Required: true,
+										Optional: true,
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -190,7 +190,7 @@ func resourceAwsSagemakerDomain() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"default_resource_spec": {
 										Type:     schema.TypeList,
-										Required: true,
+										Optional: true,
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
-// Tests are serialized as SagmMaker Domain resource are limited to 1 per account by default.
+// Tests are serialized as SagmMaker Domain resources are limited to 1 per account by default.
 // SageMaker UserProfile and App depend on the Domain resources and as such are also part of the serialized test suite.
 func TestAccAWSSagemakerDomain_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
+// SageMaker UserProfile and App depend on the Domain resourse and as such are also part of the serialized test suite.
 func TestAccAWSSagemakerDomain_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Domain": {
@@ -115,7 +116,7 @@ func testAccAWSSagemakerDomain_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -151,7 +152,7 @@ func testAccAWSSagemakerDomain_kms(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -177,7 +178,7 @@ func testAccAWSSagemakerDomain_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -221,7 +222,7 @@ func testAccAWSSagemakerDomain_securityGroup(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -256,7 +257,7 @@ func testAccAWSSagemakerDomain_sharingSettings(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -286,7 +287,7 @@ func testAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -315,7 +316,7 @@ func testAccAWSSagemakerDomain_tensorboardAppSettingsWithImage(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -345,7 +346,7 @@ func testAccAWSSagemakerDomain_kernelGatewayAppSettings(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -380,7 +381,7 @@ func testAccAWSSagemakerDomain_kernelGatewayAppSettings_customImage(t *testing.T
 	resourceName := "aws_sagemaker_domain.test"
 	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -411,7 +412,7 @@ func testAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,
@@ -440,7 +441,7 @@ func testAccAWSSagemakerDomain_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerDomainDestroy,

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
-func testAccAWSSagemakerDomain_serial(t *testing.T) {
+func TestAccAWSSagemakerDomain_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Domain": {
 			"basic":                                testAccAWSSagemakerDomain_basic,

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -782,10 +782,10 @@ resource "aws_sagemaker_domain" "test" {
     execution_role = aws_iam_role.test.arn
 
     kernel_gateway_app_settings {
-	  custom_image {
-		app_image_config_name = aws_sagemaker_app_image_config.test.app_image_config_name
+      custom_image {
+        app_image_config_name = aws_sagemaker_app_image_config.test.app_image_config_name
         image_name            = aws_sagemaker_image_version.test.image_name
-	  }
+      }
     }
   }
 }

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -36,7 +36,7 @@ func testSweepSagemakerDomains(region string) error {
 	err = conn.ListDomainsPages(&sagemaker.ListDomainsInput{}, func(page *sagemaker.ListDomainsOutput, lastPage bool) bool {
 		for _, domain := range page.Domains {
 
-			r := resourceAwsSagemakerUserProfile()
+			r := resourceAwsSagemakerDomain()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(domain.DomainId))
 			err = r.Delete(d, client)

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -43,7 +43,6 @@ func testSweepSagemakerDomains(region string) error {
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(domain.DomainId))
 			err = r.Delete(d, client)
-
 			if err != nil {
 				log.Printf("[ERROR] %s", err)
 				sweeperErrs = multierror.Append(sweeperErrs, err)

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -427,6 +427,8 @@ func testAccCheckAWSSagemakerDomainExists(n string, codeRepo *sagemaker.Describe
 
 func testAccAWSSagemakerDomainConfigBase(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -456,7 +458,7 @@ data "aws_iam_policy_document" "test" {
 
     principals {
       type        = "Service"
-      identifiers = ["sagemaker.amazonaws.com"]
+      identifiers = ["sagemaker.${data.aws_partition.current.dns_suffix}"]
     }
   }
 }

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
-// Tests are serialized as SagmMaker Domain resouce are limited to 1 per account by default.
+// Tests are serialized as SagmMaker Domain resource are limited to 1 per account by default.
 // SageMaker UserProfile and App depend on the Domain resources and as such are also part of the serialized test suite.
 func TestAccAWSSagemakerDomain_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
+// Tests are serialized as SagmMaker Domain resouce are limited to 1 per account by default.
 // SageMaker UserProfile and App depend on the Domain resourse and as such are also part of the serialized test suite.
 func TestAccAWSSagemakerDomain_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Tests are serialized as SagmMaker Domain resouce are limited to 1 per account by default.
-// SageMaker UserProfile and App depend on the Domain resourse and as such are also part of the serialized test suite.
+// SageMaker UserProfile and App depend on the Domain resources and as such are also part of the serialized test suite.
 func TestAccAWSSagemakerDomain_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Domain": {

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -20,6 +20,8 @@ func init() {
 		Name: "aws_sagemaker_domain",
 		F:    testSweepSagemakerDomains,
 		Dependencies: []string{
+			"aws_efs_mount_target",
+			"aws_efs_file_system",
 			"aws_sagemaker_user_profile",
 		},
 	})

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -16,6 +16,51 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
+func testAccAWSSagemakerDomain_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Domain": {
+			"basic":                                testAccAWSSagemakerDomain_basic,
+			"disappears":                           testAccAWSSagemakerDomain_tags,
+			"tags":                                 testAccAWSSagemakerDomain_disappears,
+			"tensorboardAppSettings":               testAccAWSSagemakerDomain_tensorboardAppSettings,
+			"tensorboardAppSettingsWithImage":      testAccAWSSagemakerDomain_tensorboardAppSettingsWithImage,
+			"kernelGatewayAppSettings":             testAccAWSSagemakerDomain_kernelGatewayAppSettings,
+			"kernelGatewayAppSettings_customImage": testAccAWSSagemakerDomain_kernelGatewayAppSettings_customImage,
+			"jupyterServerAppSettings":             testAccAWSSagemakerDomain_jupyterServerAppSettings,
+			"kms":                                  testAccAWSSagemakerDomain_kms,
+			"securityGroup":                        testAccAWSSagemakerDomain_securityGroup,
+			"sharingSettings":                      testAccAWSSagemakerDomain_sharingSettings,
+		},
+		"UserProfile": {
+			"basic":                           testAccAWSSagemakerUserProfile_basic,
+			"disappears":                      testAccAWSSagemakerUserProfile_tags,
+			"tags":                            testAccAWSSagemakerUserProfile_disappears,
+			"tensorboardAppSettings":          testAccAWSSagemakerUserProfile_tensorboardAppSettings,
+			"tensorboardAppSettingsWithImage": testAccAWSSagemakerUserProfile_tensorboardAppSettingsWithImage,
+			"kernelGatewayAppSettings":        testAccAWSSagemakerUserProfile_kernelGatewayAppSettings,
+			"jupyterServerAppSettings":        testAccAWSSagemakerUserProfile_jupyterServerAppSettings,
+		},
+		"App": {
+			"basic":        testAccAWSSagemakerApp_basic,
+			"disappears":   testAccAWSSagemakerApp_tags,
+			"tags":         testAccAWSSagemakerApp_disappears,
+			"resourceSpec": testAccAWSSagemakerApp_resourceSpec,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}
+
 func init() {
 	resource.AddTestSweepers("aws_sagemaker_domain", &resource.Sweeper{
 		Name: "aws_sagemaker_domain",
@@ -65,7 +110,7 @@ func testSweepSagemakerDomains(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func TestAccAWSSagemakerDomain_basic(t *testing.T) {
+func testAccAWSSagemakerDomain_basic(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
@@ -101,7 +146,7 @@ func TestAccAWSSagemakerDomain_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_kms(t *testing.T) {
+func testAccAWSSagemakerDomain_kms(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
@@ -127,7 +172,7 @@ func TestAccAWSSagemakerDomain_kms(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_tags(t *testing.T) {
+func testAccAWSSagemakerDomain_tags(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
@@ -171,7 +216,7 @@ func TestAccAWSSagemakerDomain_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_securityGroup(t *testing.T) {
+func testAccAWSSagemakerDomain_securityGroup(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
@@ -206,7 +251,7 @@ func TestAccAWSSagemakerDomain_securityGroup(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_sharingSettings(t *testing.T) {
+func testAccAWSSagemakerDomain_sharingSettings(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
@@ -236,7 +281,7 @@ func TestAccAWSSagemakerDomain_sharingSettings(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
+func testAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
@@ -265,7 +310,7 @@ func TestAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_tensorboardAppSettingsWithImage(t *testing.T) {
+func testAccAWSSagemakerDomain_tensorboardAppSettingsWithImage(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
@@ -295,7 +340,7 @@ func TestAccAWSSagemakerDomain_tensorboardAppSettingsWithImage(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_kernelGatewayAppSettings(t *testing.T) {
+func testAccAWSSagemakerDomain_kernelGatewayAppSettings(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
@@ -324,7 +369,7 @@ func TestAccAWSSagemakerDomain_kernelGatewayAppSettings(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_kernelGatewayAppSettings_customImage(t *testing.T) {
+func testAccAWSSagemakerDomain_kernelGatewayAppSettings_customImage(t *testing.T) {
 
 	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
 		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
@@ -361,7 +406,7 @@ func TestAccAWSSagemakerDomain_kernelGatewayAppSettings_customImage(t *testing.T
 	})
 }
 
-func TestAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
+func testAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"
@@ -390,7 +435,7 @@ func TestAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerDomain_disappears(t *testing.T) {
+func testAccAWSSagemakerDomain_disappears(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_domain.test"

--- a/aws/resource_aws_sagemaker_user_profile_test.go
+++ b/aws/resource_aws_sagemaker_user_profile_test.go
@@ -70,7 +70,7 @@ func testAccAWSSagemakerUserProfile_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
@@ -101,7 +101,7 @@ func testAccAWSSagemakerUserProfile_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
@@ -145,7 +145,7 @@ func testAccAWSSagemakerUserProfile_tensorboardAppSettings(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
@@ -174,7 +174,7 @@ func testAccAWSSagemakerUserProfile_tensorboardAppSettingsWithImage(t *testing.T
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
@@ -204,7 +204,7 @@ func testAccAWSSagemakerUserProfile_kernelGatewayAppSettings(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
@@ -233,7 +233,7 @@ func testAccAWSSagemakerUserProfile_jupyterServerAppSettings(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,
@@ -262,7 +262,7 @@ func testAccAWSSagemakerUserProfile_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerUserProfileDestroy,

--- a/aws/resource_aws_sagemaker_user_profile_test.go
+++ b/aws/resource_aws_sagemaker_user_profile_test.go
@@ -280,7 +280,7 @@ func testAccCheckAWSSagemakerUserProfileDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_sagemaker_user_settings" {
+		if rs.Type != "aws_sagemaker_user_profile" {
 			continue
 		}
 

--- a/aws/resource_aws_sagemaker_user_profile_test.go
+++ b/aws/resource_aws_sagemaker_user_profile_test.go
@@ -65,7 +65,7 @@ func testSweepSagemakerUserProfiles(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func TestAccAWSSagemakerUserProfile_basic(t *testing.T) {
+func testAccAWSSagemakerUserProfile_basic(t *testing.T) {
 	var domain sagemaker.DescribeUserProfileOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
@@ -96,7 +96,7 @@ func TestAccAWSSagemakerUserProfile_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerUserProfile_tags(t *testing.T) {
+func testAccAWSSagemakerUserProfile_tags(t *testing.T) {
 	var domain sagemaker.DescribeUserProfileOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
@@ -140,7 +140,7 @@ func TestAccAWSSagemakerUserProfile_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerUserProfile_tensorboardAppSettings(t *testing.T) {
+func testAccAWSSagemakerUserProfile_tensorboardAppSettings(t *testing.T) {
 	var domain sagemaker.DescribeUserProfileOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
@@ -169,7 +169,7 @@ func TestAccAWSSagemakerUserProfile_tensorboardAppSettings(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerUserProfile_tensorboardAppSettingsWithImage(t *testing.T) {
+func testAccAWSSagemakerUserProfile_tensorboardAppSettingsWithImage(t *testing.T) {
 	var domain sagemaker.DescribeUserProfileOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
@@ -199,7 +199,7 @@ func TestAccAWSSagemakerUserProfile_tensorboardAppSettingsWithImage(t *testing.T
 	})
 }
 
-func TestAccAWSSagemakerUserProfile_kernelGatewayAppSettings(t *testing.T) {
+func testAccAWSSagemakerUserProfile_kernelGatewayAppSettings(t *testing.T) {
 	var domain sagemaker.DescribeUserProfileOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
@@ -228,7 +228,7 @@ func TestAccAWSSagemakerUserProfile_kernelGatewayAppSettings(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerUserProfile_jupyterServerAppSettings(t *testing.T) {
+func testAccAWSSagemakerUserProfile_jupyterServerAppSettings(t *testing.T) {
 	var domain sagemaker.DescribeUserProfileOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"
@@ -257,7 +257,7 @@ func TestAccAWSSagemakerUserProfile_jupyterServerAppSettings(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerUserProfile_disappears(t *testing.T) {
+func testAccAWSSagemakerUserProfile_disappears(t *testing.T) {
 	var domain sagemaker.DescribeUserProfileOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_user_profile.test"

--- a/website/docs/r/sagemaker_app.html.markdown
+++ b/website/docs/r/sagemaker_app.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Sagemaker"
+layout: "aws"
+page_title: "AWS: aws_sagemaker_app"
+description: |-
+  Provides a Sagemaker App resource.
+---
+
+# Resource: aws_sagemaker_app
+
+Provides a Sagemaker App resource.
+
+## Example Usage
+
+### Basic usage
+
+```hcl
+resource "aws_sagemaker_app" "example" {
+  domain_id         = aws_sagemaker_domain.example.id
+  user_profile_name = aws_sagemaker_user_profile.example.user_profile_name
+  app_name          = "example"
+  app_type          = "JupyterServer"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `app_name` - (Required) The name of the app.
+* `app_type` - (Required) The type of app. Valid values are `JupyterServer`, `KernelGateway` and `TensorBoard`.
+* `domain_id` - (Required) The domain ID.
+* `user_profile_name` - (Required) The user profile name.
+* `resource_spec` - (Optional) The instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance.See [Resource Spec](#resource-spec) below.
+* `tags` - (Optional) A map of tags to assign to the resource.
+
+### Resource Spec
+
+* `instance_type` - (Optional) The instance type that the image version runs on. For valid values see [Sagemaker Instance Types](https://docs.aws.amazon.com/sagemaker/latest/dg/notebooks-available-instance-types.html).
+* `sagemaker_image_arn` - (Optional) The ARN of the SageMaker image that the image version belongs to.
+* `sagemaker_image_version_arn` - (Optional) The ARN of the image version created on the instance.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Amazon Resource Name (ARN) of the app.
+* `arn` - The Amazon Resource Name (ARN) of the app.
+
+
+## Import
+
+Sagemaker Code Apps can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_sagemaker_app.example arn:aws:sagemaker:us-west-2:012345678912:app/domain-id/user-profile-name/app-type/app-name
+```

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -77,10 +77,10 @@ resource "aws_sagemaker_domain" "test" {
     execution_role = aws_iam_role.test.arn
 
     kernel_gateway_app_settings {
-	    custom_image {
-		    app_image_config_name = aws_sagemaker_app_image_config.test.app_image_config_name
+      custom_image {
+        app_image_config_name = aws_sagemaker_app_image_config.test.app_image_config_name
         image_name            = aws_sagemaker_image_version.test.image_name
-	    }
+      }
     }
   }
 }

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -87,8 +87,9 @@ The following arguments are supported:
 
 ##### Default Resource Spec
 
-* `instance_type` - (Optional) The instance type.
-* `sagemaker_image_arn` - (Optional) The Amazon Resource Name (ARN) of the SageMaker image created on the instance.
+* `instance_type` - (Optional) The instance type that the image version runs on.. For valid values see [Sagemaker Instance Types](https://docs.aws.amazon.com/sagemaker/latest/dg/notebooks-available-instance-types.html).
+* `sagemaker_image_arn` - (Optional) The ARN of the SageMaker image that the image version belongs to.
+* `sagemaker_image_version_arn` - (Optional) The ARN of the image version created on the instance.
 
 ##### Custom Image
 

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -44,6 +44,48 @@ data "aws_iam_policy_document" "example" {
 }
 ```
 
+### Using Custom Images
+
+```hcl
+resource "aws_sagemaker_image" "test" {
+  image_name = "example"
+  role_arn   = aws_iam_role.test.arn
+}
+
+resource "aws_sagemaker_app_image_config" "test" {
+  app_image_config_name = "example"
+
+  kernel_gateway_image_config {
+    kernel_spec {
+      name = "example"
+    }
+  }
+}
+
+resource "aws_sagemaker_image_version" "test" {
+  image_name = aws_sagemaker_image.test.id
+  base_image = "base-image"
+}
+
+resource "aws_sagemaker_domain" "test" {
+  domain_name = "example"
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = [aws_subnet.test.id]
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+
+    kernel_gateway_app_settings {
+	    custom_image {
+		    app_image_config_name = aws_sagemaker_app_image_config.test.app_image_config_name
+        image_name            = aws_sagemaker_image_version.test.image_name
+	    }
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -89,7 +131,6 @@ The following arguments are supported:
 
 * `instance_type` - (Optional) The instance type that the image version runs on.. For valid values see [Sagemaker Instance Types](https://docs.aws.amazon.com/sagemaker/latest/dg/notebooks-available-instance-types.html).
 * `sagemaker_image_arn` - (Optional) The ARN of the SageMaker image that the image version belongs to.
-* `sagemaker_image_version_arn` - (Optional) The ARN of the image version created on the instance.
 
 ##### Custom Image
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17402

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ ACCTEST_PARALLELISM=1 make testacc TESTARGS='-run=TestAccAWSSagemakerApp_'

--- PASS: TestAccAWSSagemakerApp_tags (940.80s)
--- PASS: TestAccAWSSagemakerApp_basic (853.22s)
--- PASS: TestAccAWSSagemakerApp_resourceSpec (1016.37s)
--- PASS: TestAccAWSSagemakerApp_disappears (737.55s)
```

```
$ ACCTEST_PARALLELISM=1 make testacc TESTARGS='-run=TestAccAWSSagemakerUserProfile_disappears'

--- PASS: TestAccAWSSagemakerUserProfile_disappears (263.88s)
```

```
$ ACCTEST_PARALLELISM=1 make testacc TESTARGS='-run=TestAccAWSSagemakerDomain_kernelGatewayAppSettings_customImage'
--- PASS: TestAccAWSSagemakerDomain_kernelGatewayAppSettings_customImage (383.50s)
```
