### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Use IAM timeout constant for retries, add LakeFormation permissions retries and configuration to tests

### DIFF
--- a/.changelog/17254.txt
+++ b/.changelog/17254.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kinesis_firehose_delivery_stream: Use standard retry timeout for IAM eventual consistency and retry on LakeFormation access errors
+```

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -10,10 +10,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
 const (
@@ -2515,30 +2517,31 @@ func resourceAwsKinesisFirehoseDeliveryStreamCreate(d *schema.ResourceData, meta
 		createInput.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().FirehoseTags()
 	}
 
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 		_, err := conn.CreateDeliveryStream(createInput)
 		if err != nil {
-			log.Printf("[DEBUG] Error creating Firehose Delivery Stream: %s", err)
+			// Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions.
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Access was denied") {
+				return resource.RetryableError(err)
+			}
 
-			// Retry for IAM eventual consistency
-			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "is not authorized to") {
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "is not authorized to") {
 				return resource.RetryableError(err)
 			}
-			// Retry for IAM eventual consistency
-			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "Please make sure the role specified in VpcConfiguration has permissions") {
+
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Please make sure the role specified in VpcConfiguration has permissions") {
 				return resource.RetryableError(err)
 			}
+
 			// InvalidArgumentException: Verify that the IAM role has access to the ElasticSearch domain.
-			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "Verify that the IAM role has access") {
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Verify that the IAM role has access") {
 				return resource.RetryableError(err)
 			}
-			// IAM roles can take ~10 seconds to propagate in AWS:
-			// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
-			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "Firehose is unable to assume role") {
-				log.Printf("[DEBUG] Firehose could not assume role referenced, retrying...")
+
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Firehose is unable to assume role") {
 				return resource.RetryableError(err)
 			}
-			// Not retryable
+
 			return resource.NonRetryableError(err)
 		}
 
@@ -2660,30 +2663,31 @@ func resourceAwsKinesisFirehoseDeliveryStreamUpdate(d *schema.ResourceData, meta
 		}
 	}
 
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 		_, err := conn.UpdateDestination(updateInput)
 		if err != nil {
-			log.Printf("[DEBUG] Error updating Firehose Delivery Stream: %s", err)
+			// Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions.
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Access was denied") {
+				return resource.RetryableError(err)
+			}
 
-			// Retry for IAM eventual consistency
-			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "is not authorized to") {
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "is not authorized to") {
 				return resource.RetryableError(err)
 			}
-			// Retry for IAM eventual consistency
-			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "Please make sure the role specified in VpcConfiguration has permissions") {
+
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Please make sure the role specified in VpcConfiguration has permissions") {
 				return resource.RetryableError(err)
 			}
+
 			// InvalidArgumentException: Verify that the IAM role has access to the ElasticSearch domain.
-			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "Verify that the IAM role has access") {
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Verify that the IAM role has access") {
 				return resource.RetryableError(err)
 			}
-			// IAM roles can take ~10 seconds to propagate in AWS:
-			// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
-			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "Firehose is unable to assume role") {
-				log.Printf("[DEBUG] Firehose could not assume role referenced, retrying...")
+
+			if tfawserr.ErrMessageContains(err, firehose.ErrCodeInvalidArgumentException, "Firehose is unable to assume role") {
 				return resource.RetryableError(err)
 			}
-			// Not retryable
+
 			return resource.NonRetryableError(err)
 		}
 

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1833,11 +1833,21 @@ resource "aws_iam_role_policy" "firehose" {
       "Sid": "GlueAccess",
       "Effect": "Allow",
       "Action": [
+        "glue:GetTable",
+        "glue:GetTableVersion",
         "glue:GetTableVersions"
       ],
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Sid": "LakeFormationDataAccess",
+      "Effect": "Allow",
+      "Action": [
+        "lakeformation:GetDataAccess"
+      ],
+      "Resource": "*"
     }
   ]
 }
@@ -2226,6 +2236,16 @@ resource "aws_glue_catalog_table" "test" {
   }
 }
 
+resource "aws_lakeformation_permissions" "test" {
+  permissions = ["ALL"]
+  principal   = aws_iam_role.firehose.arn
+
+  table {
+    database_name = aws_glue_catalog_database.test.name
+    name          = aws_glue_catalog_table.test.name
+  }
+}
+
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
   name        = %[1]q
@@ -2259,7 +2279,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     }
   }
 
-  depends_on = [aws_iam_role_policy.firehose]
+  depends_on = [aws_iam_role_policy.firehose, aws_lakeformation_permissions.test]
 }
 `, rName, enabled)
 }
@@ -2279,6 +2299,16 @@ resource "aws_glue_catalog_table" "test" {
       name = "test"
       type = "string"
     }
+  }
+}
+
+resource "aws_lakeformation_permissions" "test" {
+  permissions = ["ALL"]
+  principal   = aws_iam_role.firehose.arn
+
+  table {
+    database_name = aws_glue_catalog_database.test.name
+    name          = aws_glue_catalog_table.test.name
   }
 }
 
@@ -2313,7 +2343,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     }
   }
 
-  depends_on = [aws_iam_role_policy.firehose]
+  depends_on = [aws_iam_role_policy.firehose, aws_lakeformation_permissions.test]
 }
 `, rName)
 }
@@ -2350,6 +2380,16 @@ resource "aws_glue_catalog_table" "test" {
   }
 }
 
+resource "aws_lakeformation_permissions" "test" {
+  permissions = ["ALL"]
+  principal   = aws_iam_role.firehose.arn
+
+  table {
+    database_name = aws_glue_catalog_database.test.name
+    name          = aws_glue_catalog_table.test.name
+  }
+}
+
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
   name        = %[1]q
@@ -2381,7 +2421,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     }
   }
 
-  depends_on = [aws_iam_role_policy.firehose]
+  depends_on = [aws_iam_role_policy.firehose, aws_lakeformation_permissions.test]
 }
 `, rName)
 }
@@ -2401,6 +2441,16 @@ resource "aws_glue_catalog_table" "test" {
       name = "test"
       type = "string"
     }
+  }
+}
+
+resource "aws_lakeformation_permissions" "test" {
+  permissions = ["ALL"]
+  principal   = aws_iam_role.firehose.arn
+
+  table {
+    database_name = aws_glue_catalog_database.test.name
+    name          = aws_glue_catalog_table.test.name
   }
 }
 
@@ -2435,7 +2485,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     }
   }
 
-  depends_on = [aws_iam_role_policy.firehose]
+  depends_on = [aws_iam_role_policy.firehose, aws_lakeformation_permissions.test]
 }
 `, rName)
 }
@@ -2455,6 +2505,16 @@ resource "aws_glue_catalog_table" "test" {
       name = "test"
       type = "string"
     }
+  }
+}
+
+resource "aws_lakeformation_permissions" "test" {
+  permissions = ["ALL"]
+  principal   = aws_iam_role.firehose.arn
+
+  table {
+    database_name = aws_glue_catalog_database.test.name
+    name          = aws_glue_catalog_table.test.name
   }
 }
 
@@ -2489,7 +2549,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     }
   }
 
-  depends_on = [aws_iam_role_policy.firehose]
+  depends_on = [aws_iam_role_policy.firehose, aws_lakeformation_permissions.test]
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16752

Previously:

```
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty
resource_aws_kinesis_firehose_delivery_stream_test.go:638: Step 1/2 error: Error running apply:
Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions. Insufficient Lake Formation permission(s) on tf-acc-test-4731441258578020859 (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: 67116cf3-6102-4d1e-9229-a8c0e63cf9f7; Proxy: null)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (21.32s)

=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update
resource_aws_kinesis_firehose_delivery_stream_test.go:596: Step 1/3 error: Error running apply:
Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions. Insufficient Lake Formation permission(s) on tf-acc-test-1453880257072042205 (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: a5a8ef8d-e7c8-419b-a5a3-b762145c6783; Proxy: null)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (30.13s)

=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty
resource_aws_kinesis_firehose_delivery_stream_test.go:669: Step 1/2 error: Error running apply:
Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions. Insufficient Lake Formation permission(s) on tf-acc-test-4296742326842474514 (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: 67b204a4-290f-4b8b-bba7-ec850759a4fe; Proxy: null)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (18.58s)

=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty
resource_aws_kinesis_firehose_delivery_stream_test.go:700: Step 1/2 error: Error running apply:
Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions. Insufficient Lake Formation permission(s) on tf-acc-test-4205955522949248362 (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: 9cd73bb5-9a58-4c35-b2da-4e3f12e17415; Proxy: null)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (21.11s)

=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty
resource_aws_kinesis_firehose_delivery_stream_test.go:731: Step 1/2 error: Error running apply:
Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions. Insufficient Lake Formation permission(s) on tf-acc-test-2371862365551213044 (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: 2e0188ba-98ba-496b-99f1-804376dc5862; Proxy: null)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (25.47s)

=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update
resource_aws_kinesis_firehose_delivery_stream_test.go:762: Step 1/3 error: Error running apply:
Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions. Insufficient Lake Formation permission(s) on tf-acc-test-2168117662921768660 (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: aa73610e-cac0-44a6-8e0a-fded3e5c6bd9; Proxy: null)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (25.85s)

=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled
resource_aws_kinesis_firehose_delivery_stream_test.go:490: Step 3/4 error: Error running apply:
Error: Error Updating Kinesis Firehose Delivery Stream: "tf-acc-test-8695271398619453258"
InvalidArgumentException: Access was denied when calling Glue. Please ensure that the role specified in the data format conversion configuration has the necessary permissions. Insufficient Lake Formation permission(s) on tf-acc-test-8695271398619453258 (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: c6b9cf64-3918-4140-b85b-fe53c0a4406b; Proxy: null)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (111.38s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_basic (131.86s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_disappears (90.21s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigEndpointUpdates (678.89s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (975.34s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates (1432.78s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (160.49s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (176.11s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (135.95s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (131.68s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (120.16s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (136.73s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (120.12s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (124.47s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate (162.47s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_KinesisStreamSource (95.95s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty (126.45s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (136.44s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (124.11s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (176.36s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_HttpEndpointConfiguration (135.22s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_HttpEndpointConfiguration_RetryDuration (126.68s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (126.21s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (437.94s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (104.37s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE (295.11s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSEAndKeyArn (260.98s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSEAndKeyType (248.31s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (140.47s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (197.64s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (94.39s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (81.40s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (156.62s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (18.19s) # unrelated; did not succeed while acquiring capacity
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_basic (112.04s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_disappears (82.08s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigEndpointUpdates (727.48s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (640.24s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates (1538.54s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (134.15s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (162.17s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (96.38s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (101.65s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (101.56s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (110.19s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (95.24s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (127.33s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate (122.80s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_KinesisStreamSource (103.54s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty (91.54s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (120.64s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (107.85s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (158.79s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_HttpEndpointConfiguration (108.81s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_HttpEndpointConfiguration_RetryDuration (113.39s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (101.69s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (66.63s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE (212.50s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSEAndKeyArn (191.54s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSEAndKeyType (218.06s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (126.11s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (169.25s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (105.90s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (94.65s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (148.60s)
```
