### PR TITLE
Add protocol_version to lb_target_group

### DIFF
--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -40,6 +40,11 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 				Computed: true,
 			},
 
+			"protocol_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -26,6 +26,7 @@ func TestAccDataSourceAWSALBTargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceNameArn, "arn_suffix"),
 					resource.TestCheckResourceAttr(resourceNameArn, "port", "8080"),
 					resource.TestCheckResourceAttr(resourceNameArn, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceNameArn, "protocol_version", "HTTP1"),
 					resource.TestCheckResourceAttrSet(resourceNameArn, "vpc_id"),
 					resource.TestCheckResourceAttrSet(resourceNameArn, "load_balancing_algorithm_type"),
 					resource.TestCheckResourceAttr(resourceNameArn, "deregistration_delay", "300"),

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
 
 * `port` - (Optional, Forces new resource) The port on which targets receive traffic, unless overridden when registering a specific target. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 * `protocol` - (Optional, Forces new resource) The protocol to use for routing traffic to the targets. Should be one of `GENEVE`, `HTTP`, `HTTPS`, `TCP`, `TCP_UDP`, `TLS`, or `UDP`. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
+* `protocol_version` - (Optional, Forces new resource) Only applicable when `protocol` is `HTTP` or `HTTPS`. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1
 * `vpc_id` - (Optional, Forces new resource) The identifier of the VPC in which to create the target group. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.


### PR DESCRIPTION
Add `protocol_version` to `lb_target_group` resource and data source.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #15929

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=AWSALBTargetGroup_ -timeout 120m
=== RUN   TestAccDataSourceAWSALBTargetGroup_basic
=== PAUSE TestAccDataSourceAWSALBTargetGroup_basic
=== RUN   TestAccAWSALBTargetGroup_basic
=== PAUSE TestAccAWSALBTargetGroup_basic
=== RUN   TestAccAWSALBTargetGroup_namePrefix
=== PAUSE TestAccAWSALBTargetGroup_namePrefix
=== RUN   TestAccAWSALBTargetGroup_generatedName
=== PAUSE TestAccAWSALBTargetGroup_generatedName
=== RUN   TestAccAWSALBTargetGroup_changeNameForceNew
=== PAUSE TestAccAWSALBTargetGroup_changeNameForceNew
=== RUN   TestAccAWSALBTargetGroup_changeProtocolForceNew
=== PAUSE TestAccAWSALBTargetGroup_changeProtocolForceNew
=== RUN   TestAccAWSALBTargetGroup_changePortForceNew
=== PAUSE TestAccAWSALBTargetGroup_changePortForceNew
=== RUN   TestAccAWSALBTargetGroup_changeVpcForceNew
=== PAUSE TestAccAWSALBTargetGroup_changeVpcForceNew
=== RUN   TestAccAWSALBTargetGroup_tags
=== PAUSE TestAccAWSALBTargetGroup_tags
=== RUN   TestAccAWSALBTargetGroup_updateHealthCheck
=== PAUSE TestAccAWSALBTargetGroup_updateHealthCheck
=== RUN   TestAccAWSALBTargetGroup_updateSticknessEnabled
=== PAUSE TestAccAWSALBTargetGroup_updateSticknessEnabled
=== RUN   TestAccAWSALBTargetGroup_setAndUpdateSlowStart
=== PAUSE TestAccAWSALBTargetGroup_setAndUpdateSlowStart
=== RUN   TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType
=== PAUSE TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType
=== RUN   TestAccAWSALBTargetGroup_lambda
=== PAUSE TestAccAWSALBTargetGroup_lambda
=== RUN   TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled
=== PAUSE TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled
=== RUN   TestAccAWSALBTargetGroup_missingPortProtocolVpc
=== PAUSE TestAccAWSALBTargetGroup_missingPortProtocolVpc
=== CONT  TestAccDataSourceAWSALBTargetGroup_basic
=== CONT  TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType
=== CONT  TestAccAWSALBTargetGroup_generatedName
=== CONT  TestAccAWSALBTargetGroup_tags
=== CONT  TestAccAWSALBTargetGroup_updateSticknessEnabled
=== CONT  TestAccAWSALBTargetGroup_updateHealthCheck
=== CONT  TestAccAWSALBTargetGroup_changeNameForceNew
=== CONT  TestAccAWSALBTargetGroup_setAndUpdateSlowStart
=== CONT  TestAccAWSALBTargetGroup_changeProtocolForceNew
=== CONT  TestAccAWSALBTargetGroup_namePrefix
=== CONT  TestAccAWSALBTargetGroup_changeVpcForceNew
=== CONT  TestAccAWSALBTargetGroup_basic
=== CONT  TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled
=== CONT  TestAccAWSALBTargetGroup_missingPortProtocolVpc
=== CONT  TestAccAWSALBTargetGroup_changePortForceNew
=== CONT  TestAccAWSALBTargetGroup_lambda
--- PASS: TestAccAWSALBTargetGroup_lambda (37.39s)
--- PASS: TestAccAWSALBTargetGroup_missingPortProtocolVpc (39.46s)
--- PASS: TestAccAWSALBTargetGroup_generatedName (41.43s)
--- PASS: TestAccAWSALBTargetGroup_namePrefix (41.88s)
--- PASS: TestAccAWSALBTargetGroup_basic (47.14s)
--- PASS: TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled (55.49s)
--- PASS: TestAccAWSALBTargetGroup_setAndUpdateSlowStart (58.53s)
--- PASS: TestAccAWSALBTargetGroup_changeVpcForceNew (58.62s)
--- PASS: TestAccAWSALBTargetGroup_changePortForceNew (61.12s)
--- PASS: TestAccAWSALBTargetGroup_tags (61.15s)
--- PASS: TestAccAWSALBTargetGroup_updateHealthCheck (62.69s)
--- PASS: TestAccAWSALBTargetGroup_changeProtocolForceNew (64.50s)
--- PASS: TestAccAWSALBTargetGroup_changeNameForceNew (66.91s)
--- PASS: TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType (71.04s)
--- PASS: TestAccAWSALBTargetGroup_updateSticknessEnabled (73.57s)
--- PASS: TestAccDataSourceAWSALBTargetGroup_basic (194.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	194.211s

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBTargetGroup -timeout 120m
=== RUN   TestAccAWSLBTargetGroupAttachment_basic
=== PAUSE TestAccAWSLBTargetGroupAttachment_basic
=== RUN   TestAccAWSLBTargetGroupAttachment_disappears
=== PAUSE TestAccAWSLBTargetGroupAttachment_disappears
=== RUN   TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility
=== PAUSE TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility
=== RUN   TestAccAWSLBTargetGroupAttachment_Port
=== PAUSE TestAccAWSLBTargetGroupAttachment_Port
=== RUN   TestAccAWSLBTargetGroupAttachment_ipAddress
=== PAUSE TestAccAWSLBTargetGroupAttachment_ipAddress
=== RUN   TestAccAWSLBTargetGroupAttachment_lambda
=== PAUSE TestAccAWSLBTargetGroupAttachment_lambda
=== RUN   TestAccAWSLBTargetGroup_basic
=== PAUSE TestAccAWSLBTargetGroup_basic
=== RUN   TestAccAWSLBTargetGroup_basicUdp
=== PAUSE TestAccAWSLBTargetGroup_basicUdp
=== RUN   TestAccAWSLBTargetGroup_ProtocolVersion
=== PAUSE TestAccAWSLBTargetGroup_ProtocolVersion
=== RUN   TestAccAWSLBTargetGroup_withoutHealthcheck
=== PAUSE TestAccAWSLBTargetGroup_withoutHealthcheck
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== RUN   TestAccAWSLBTargetGroup_Protocol_Geneve
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Geneve
=== RUN   TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
=== RUN   TestAccAWSLBTargetGroup_Protocol_Tls
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Tls
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== RUN   TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== RUN   TestAccAWSLBTargetGroup_BackwardsCompatibility
=== PAUSE TestAccAWSLBTargetGroup_BackwardsCompatibility
=== RUN   TestAccAWSLBTargetGroup_namePrefix
=== PAUSE TestAccAWSLBTargetGroup_namePrefix
=== RUN   TestAccAWSLBTargetGroup_generatedName
=== PAUSE TestAccAWSLBTargetGroup_generatedName
=== RUN   TestAccAWSLBTargetGroup_changeNameForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeNameForceNew
=== RUN   TestAccAWSLBTargetGroup_changeProtocolForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeProtocolForceNew
=== RUN   TestAccAWSLBTargetGroup_changePortForceNew
=== PAUSE TestAccAWSLBTargetGroup_changePortForceNew
=== RUN   TestAccAWSLBTargetGroup_changeVpcForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeVpcForceNew
=== RUN   TestAccAWSLBTargetGroup_tags
=== PAUSE TestAccAWSLBTargetGroup_tags
=== RUN   TestAccAWSLBTargetGroup_enableHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_enableHealthCheck
=== RUN   TestAccAWSLBTargetGroup_updateHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_updateHealthCheck
=== RUN   TestAccAWSLBTargetGroup_updateSticknessEnabled
=== PAUSE TestAccAWSLBTargetGroup_updateSticknessEnabled
=== RUN   TestAccAWSLBTargetGroup_defaults_application
=== PAUSE TestAccAWSLBTargetGroup_defaults_application
=== RUN   TestAccAWSLBTargetGroup_defaults_network
=== PAUSE TestAccAWSLBTargetGroup_defaults_network
=== RUN   TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessDefaultALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessDefaultALB
=== RUN   TestAccAWSLBTargetGroup_stickinessValidNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessValidNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessValidALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessValidALB
=== RUN   TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessInvalidALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessInvalidALB
=== CONT  TestAccAWSLBTargetGroupAttachment_basic
=== CONT  TestAccAWSLBTargetGroup_generatedName
=== CONT  TestAccAWSLBTargetGroup_defaults_application
=== CONT  TestAccAWSLBTargetGroup_stickinessValidNLB
=== CONT  TestAccAWSLBTargetGroup_stickinessDefaultALB
=== CONT  TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== CONT  TestAccAWSLBTargetGroup_defaults_network
=== CONT  TestAccAWSLBTargetGroup_stickinessInvalidALB
=== CONT  TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== CONT  TestAccAWSLBTargetGroup_stickinessValidALB
=== CONT  TestAccAWSLBTargetGroup_updateHealthCheck
=== CONT  TestAccAWSLBTargetGroup_tags
=== CONT  TestAccAWSLBTargetGroup_withoutHealthcheck
=== CONT  TestAccAWSLBTargetGroup_namePrefix
=== CONT  TestAccAWSLBTargetGroup_updateSticknessEnabled
=== CONT  TestAccAWSLBTargetGroup_BackwardsCompatibility
=== CONT  TestAccAWSLBTargetGroup_basicUdp
=== CONT  TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== CONT  TestAccAWSLBTargetGroup_enableHealthCheck
=== CONT  TestAccAWSLBTargetGroup_ProtocolVersion
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (19.28s)
=== CONT  TestAccAWSLBTargetGroupAttachment_lambda
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (27.57s)
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
--- PASS: TestAccAWSLBTargetGroup_namePrefix (27.58s)
=== CONT  TestAccAWSLBTargetGroupAttachment_Port
--- PASS: TestAccAWSLBTargetGroup_generatedName (28.89s)
=== CONT  TestAccAWSLBTargetGroup_Protocol_Tls
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (30.40s)
=== CONT  TestAccAWSLBTargetGroup_basic
--- PASS: TestAccAWSLBTargetGroup_defaults_network (31.98s)
=== CONT  TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
--- PASS: TestAccAWSLBTargetGroup_basicUdp (33.13s)
=== CONT  TestAccAWSLBTargetGroup_Protocol_Geneve
--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (35.03s)
=== CONT  TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion (35.92s)
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroup
--- PASS: TestAccAWSLBTargetGroup_defaults_application (40.90s)
=== CONT  TestAccAWSLBTargetGroupAttachment_disappears
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (43.07s)
=== CONT  TestAccAWSLBTargetGroup_changePortForceNew
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (15.42s)
=== CONT  TestAccAWSLBTargetGroupAttachment_ipAddress
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (47.32s)
=== CONT  TestAccAWSLBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (50.07s)
=== CONT  TestAccAWSLBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSLBTargetGroup_Protocol_Geneve (24.50s)
=== CONT  TestAccAWSLBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSLBTargetGroupAttachment_lambda (39.40s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (64.29s)
--- PASS: TestAccAWSLBTargetGroup_tags (68.58s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (70.88s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (72.51s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (75.58s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (51.33s)
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (45.55s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (59.87s)
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (45.45s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (50.00s)
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (97.42s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (46.22s)
--- PASS: TestAccAWSLBTargetGroup_basic (75.59s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (74.94s)
--- PASS: TestAccAWSLBTargetGroupAttachment_Port (91.40s)
--- PASS: TestAccAWSLBTargetGroupAttachment_ipAddress (80.33s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (126.58s)
--- PASS: TestAccAWSLBTargetGroupAttachment_disappears (93.99s)
--- PASS: TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility (193.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	228.745s

```
