### PR TITLE
Add sweepers for aws_elasticache_subnet_group and aws_elasticache_parameter_group

### DIFF
--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,6 +15,58 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_elasticache_parameter_group", &resource.Sweeper{
+		Name: "aws_elasticache_parameter_group",
+		F:    testSweepElasticacheParameterGroups,
+		Dependencies: []string{
+			"aws_elasticache_cluster",
+			"aws_elasticache_replication_group",
+		},
+	})
+}
+
+func testSweepElasticacheParameterGroups(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).elasticacheconn
+
+	err = conn.DescribeCacheParameterGroupsPages(&elasticache.DescribeCacheParameterGroupsInput{}, func(page *elasticache.DescribeCacheParameterGroupsOutput, isLast bool) bool {
+		if len(page.CacheParameterGroups) == 0 {
+			log.Print("[DEBUG] No Elasticache Parameter Groups to sweep")
+			return false
+		}
+
+		for _, parameterGroup := range page.CacheParameterGroups {
+			name := aws.StringValue(parameterGroup.CacheParameterGroupName)
+
+			if strings.HasPrefix(name, "default.") {
+				log.Printf("[INFO] Skipping Elasticache Cache Parameter Group: %s", name)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Elasticache Parameter Group: %s", name)
+			_, err := conn.DeleteCacheParameterGroup(&elasticache.DeleteCacheParameterGroupInput{
+				CacheParameterGroupName: aws.String(name),
+			})
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete Elasticache Parameter Group (%s): %s", name, err)
+			}
+		}
+		return !isLast
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Elasticache Parameter Group sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Elasticache Parameter Group: %s", err)
+	}
+	return nil
+}
 
 func TestAccAWSElasticacheParameterGroup_basic(t *testing.T) {
 	var v elasticache.CacheParameterGroup


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/17033

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**aws_elasticache_subnet_group**

```
$ SWEEP=ap-northeast-1 SWEEPARGS=-sweep-run=aws_elasticache_subnet_group make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=ap-northeast-1 -sweep-run=aws_elasticache_subnet_group -timeout 60m
2021/01/23 14:34:01 [DEBUG] Running Sweepers for region (ap-northeast-1):
2021/01/23 14:34:01 [DEBUG] Sweeper (aws_elasticache_subnet_group) has dependency (aws_elasticache_cluster), running..
2021/01/23 14:34:01 [DEBUG] Sweeper (aws_elasticache_cluster) has dependency (aws_elasticache_replication_group), running..
2021/01/23 14:34:01 [DEBUG] Running Sweeper (aws_elasticache_replication_group) in region (ap-northeast-1)
2021/01/23 14:34:01 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2021/01/23 14:34:01 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/01/23 14:34:02 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/01/23 14:34:03 [DEBUG] No ElastiCache Replicaton Groups to sweep
2021/01/23 14:34:03 [DEBUG] Running Sweeper (aws_elasticache_cluster) in region (ap-northeast-1)
2021/01/23 14:34:03 [DEBUG] No ElastiCache Replicaton Groups to sweep
2021/01/23 14:34:03 [DEBUG] Sweeper (aws_elasticache_subnet_group) has dependency (aws_elasticache_replication_group), running..
2021/01/23 14:34:03 [DEBUG] Sweeper (aws_elasticache_replication_group) already ran in region (ap-northeast-1)
2021/01/23 14:34:03 [DEBUG] Running Sweeper (aws_elasticache_subnet_group) in region (ap-northeast-1)
2021/01/23 14:34:03 [INFO] Deleting Elasticache Subnet Group: redis-group
2021/01/23 14:34:03 [DEBUG] Sweeper (aws_elasticache_cluster) has dependency (aws_elasticache_replication_group), running..
2021/01/23 14:34:03 [DEBUG] Sweeper (aws_elasticache_replication_group) already ran in region (ap-northeast-1)
2021/01/23 14:34:03 [DEBUG] Sweeper (aws_elasticache_cluster) already ran in region (ap-northeast-1)
2021/01/23 14:34:03 [DEBUG] Sweeper (aws_elasticache_replication_group) already ran in region (ap-northeast-1)
2021/01/23 14:34:03 Sweeper Tests ran successfully:
	- aws_elasticache_cluster
	- aws_elasticache_subnet_group
	- aws_elasticache_replication_group
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.421s
```

**aws_elasticache_parameter_group**

```
$ SWEEP=ap-northeast-1 SWEEPARGS=-sweep-run=aws_elasticache_parameter_group make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=ap-northeast-1 -sweep-run=aws_elasticache_parameter_group -timeout 60m
2021/01/23 14:44:16 [DEBUG] Running Sweepers for region (ap-northeast-1):
2021/01/23 14:44:16 [DEBUG] Sweeper (aws_elasticache_parameter_group) has dependency (aws_elasticache_cluster), running..
2021/01/23 14:44:16 [DEBUG] Sweeper (aws_elasticache_cluster) has dependency (aws_elasticache_replication_group), running..
2021/01/23 14:44:16 [DEBUG] Running Sweeper (aws_elasticache_replication_group) in region (ap-northeast-1)
2021/01/23 14:44:16 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2021/01/23 14:44:16 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/01/23 14:44:17 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/01/23 14:44:18 [DEBUG] No ElastiCache Replicaton Groups to sweep
2021/01/23 14:44:18 [DEBUG] Running Sweeper (aws_elasticache_cluster) in region (ap-northeast-1)
2021/01/23 14:44:18 [DEBUG] No ElastiCache Replicaton Groups to sweep
2021/01/23 14:44:18 [DEBUG] Sweeper (aws_elasticache_parameter_group) has dependency (aws_elasticache_replication_group), running..
2021/01/23 14:44:18 [DEBUG] Sweeper (aws_elasticache_replication_group) already ran in region (ap-northeast-1)
2021/01/23 14:44:18 [DEBUG] Running Sweeper (aws_elasticache_parameter_group) in region (ap-northeast-1)
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.memcached1.4
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.memcached1.5
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.memcached1.6
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis2.6
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis2.8
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis3.2
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis3.2.cluster.on
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis4.0
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis4.0.cluster.on
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis5.0
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis5.0.cluster.on
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis6.x
2021/01/23 14:44:18 [INFO] Skipping Elasticache Cache Parameter Group: default.redis6.x.cluster.on
2021/01/23 14:44:18 [INFO] Deleting Elasticache Parameter Group: test
2021/01/23 14:44:18 [DEBUG] Sweeper (aws_elasticache_cluster) has dependency (aws_elasticache_replication_group), running..
2021/01/23 14:44:18 [DEBUG] Sweeper (aws_elasticache_replication_group) already ran in region (ap-northeast-1)
2021/01/23 14:44:18 [DEBUG] Sweeper (aws_elasticache_cluster) already ran in region (ap-northeast-1)
2021/01/23 14:44:18 [DEBUG] Sweeper (aws_elasticache_replication_group) already ran in region (ap-northeast-1)
2021/01/23 14:44:18 Sweeper Tests ran successfully:
	- aws_elasticache_replication_group
	- aws_elasticache_cluster
	- aws_elasticache_parameter_group
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.397s
```

Thank you for your review!