### PR TITLE
r/codeartifact_domain - make encryption_key optional

### DIFF
--- a/.changelog/17262.txt
+++ b/.changelog/17262.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codeartifact_domain: make `encryption_key` optional
+```

--- a/.changelog/17262.txt
+++ b/.changelog/17262.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_codeartifact_domain: make `encryption_key` optional
+resource/aws_codeartifact_domain: Make `encryption_key` optional
 ```

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -36,6 +36,7 @@ func resourceAwsCodeArtifactDomain() *schema.Resource {
 			"encryption_key": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validateArn,
 			},

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -66,9 +66,12 @@ func resourceAwsCodeArtifactDomainCreate(d *schema.ResourceData, meta interface{
 	log.Print("[DEBUG] Creating CodeArtifact Domain")
 
 	params := &codeartifact.CreateDomainInput{
-		Domain:        aws.String(d.Get("domain").(string)),
-		EncryptionKey: aws.String(d.Get("encryption_key").(string)),
-		Tags:          keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().CodeartifactTags(),
+		Domain: aws.String(d.Get("domain").(string)),
+		Tags:   keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().CodeartifactTags(),
+	}
+
+	if v, ok := d.GetOk("encryption_key"); ok {
+		params.EncryptionKey = aws.String(v.(string))
 	}
 
 	domain, err := conn.CreateDomain(params)

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -35,7 +35,7 @@ func resourceAwsCodeArtifactDomain() *schema.Resource {
 			},
 			"encryption_key": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateArn,
 			},

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -98,9 +98,6 @@ func TestAccAWSCodeArtifactDomain_basic(t *testing.T) {
 	})
 }
 
-<<<<<<< HEAD
-func TestAccAWSCodeArtifactDomain_tags(t *testing.T) {
-=======
 func TestAccAWSCodeArtifactDomain_defaultencryptionkey(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codeartifact_domain.test"
@@ -131,8 +128,7 @@ func TestAccAWSCodeArtifactDomain_defaultencryptionkey(t *testing.T) {
 	})
 }
 
-func TestAccAWSCodeArtifactDomain_disappears(t *testing.T) {
->>>>>>> a4649a922 (Add acceptance test + docs)
+func TestAccAWSCodeArtifactDomain_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codeartifact_domain.test"
 
@@ -305,6 +301,7 @@ resource "aws_codeartifact_domain" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
 
 func testAccAWSCodeArtifactDomainDefaultEncryptionKeyConfig(rName string) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -112,6 +113,7 @@ func TestAccAWSCodeArtifactDomain_defaultencryptionkey(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeArtifactDomainExists(resourceName),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "codeartifact", fmt.Sprintf("domain/%s", rName)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "encryption_key", "kms", regexp.MustCompile(`key/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "domain", rName),
 					resource.TestCheckResourceAttr(resourceName, "asset_size_bytes", "0"),
 					resource.TestCheckResourceAttr(resourceName, "repository_count", "0"),
@@ -180,7 +182,7 @@ func TestAccAWSCodeArtifactDomain_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeArtifactDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodeArtifactDomainBasicConfig(rName),
+				Config: testAccAWSCodeArtifactDomainDefaultEncryptionKeyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeArtifactDomainExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsCodeArtifactDomain(), resourceName),
@@ -268,14 +270,8 @@ resource "aws_codeartifact_domain" "test" {
 
 func testAccAWSCodeArtifactDomainConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {
-  description             = %[1]q
-  deletion_window_in_days = 7
-}
-
 resource "aws_codeartifact_domain" "test" {
   domain         = %[1]q
-  encryption_key = aws_kms_key.test.arn
 
   tags = {
     %[2]q = %[3]q
@@ -286,14 +282,8 @@ resource "aws_codeartifact_domain" "test" {
 
 func testAccAWSCodeArtifactDomainConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {
-  description             = %[1]q
-  deletion_window_in_days = 7
-}
-
 resource "aws_codeartifact_domain" "test" {
   domain         = %[1]q
-  encryption_key = aws_kms_key.test.arn
 
   tags = {
     %[2]q = %[3]q

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -271,7 +271,7 @@ resource "aws_codeartifact_domain" "test" {
 func testAccAWSCodeArtifactDomainConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_codeartifact_domain" "test" {
-  domain         = %[1]q
+  domain = %[1]q
 
   tags = {
     %[2]q = %[3]q
@@ -283,7 +283,7 @@ resource "aws_codeartifact_domain" "test" {
 func testAccAWSCodeArtifactDomainConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_codeartifact_domain" "test" {
-  domain         = %[1]q
+  domain = %[1]q
 
   tags = {
     %[2]q = %[3]q

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -98,7 +98,41 @@ func TestAccAWSCodeArtifactDomain_basic(t *testing.T) {
 	})
 }
 
+<<<<<<< HEAD
 func TestAccAWSCodeArtifactDomain_tags(t *testing.T) {
+=======
+func TestAccAWSCodeArtifactDomain_defaultencryptionkey(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codeartifact_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("codeartifact", t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeArtifactDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeArtifactDomainDefaultEncryptionKeyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeArtifactDomainExists(resourceName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "codeartifact", fmt.Sprintf("domain/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "domain", rName),
+					resource.TestCheckResourceAttr(resourceName, "asset_size_bytes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "repository_count", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeArtifactDomain_disappears(t *testing.T) {
+>>>>>>> a4649a922 (Add acceptance test + docs)
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codeartifact_domain.test"
 
@@ -271,4 +305,11 @@ resource "aws_codeartifact_domain" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+
+func testAccAWSCodeArtifactDomainDefaultEncryptionKeyConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codeartifact_domain" "test" {
+  domain = %[1]q
+}
+`, rName)
 }

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -14,7 +14,7 @@ Provides a CodeArtifact Domain Resource.
 
 ```hcl
 resource "aws_codeartifact_domain" "example" {
-  domain         = "example"
+  domain = "example"
 }
 ```
 

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -13,13 +13,8 @@ Provides a CodeArtifact Domain Resource.
 ## Example Usage
 
 ```hcl
-resource "aws_kms_key" "example" {
-  description = "domain key"
-}
-
 resource "aws_codeartifact_domain" "example" {
   domain         = "example"
-  encryption_key = aws_kms_key.example.arn
 }
 ```
 
@@ -28,7 +23,7 @@ resource "aws_codeartifact_domain" "example" {
 The following arguments are supported:
 
 * `domain` - (Required) The name of the domain to create. All domain names in an AWS Region that are in the same AWS account must be unique. The domain name is used as the prefix in DNS hostnames. Do not use sensitive information in a domain name because it is publicly discoverable.
-* `encryption_key` - (Required) The encryption key for the domain. This is used to encrypt content stored in a domain. The KMS Key Amazon Resource Name (ARN).
+* `encryption_key` - (Optional) The encryption key for the domain. This is used to encrypt content stored in a domain. The KMS Key Amazon Resource Name (ARN). The default aws/codeartifact AWS KMS master key is used if this element is absent.
 * `tags` - (Optional) Key-value map of resource tags.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #15573 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeArtifactDomain_'
--- PASS: TestAccAWSCodeArtifactDomain_basic (53.16s)
--- PASS: TestAccAWSCodeArtifactDomain_disappears (27.66s)
--- PASS: TestAccAWSCodeArtifactDomain_tags (96.89s)
--- PASS: TestAccAWSCodeArtifactDomain_defaultencryptionkey (39.81s)
```
