### PR TITLE
correct example aws_ssoadmin_permission_set name

### DIFF
--- a/website/docs/r/ssoadmin_account_assignment.html.markdown
+++ b/website/docs/r/ssoadmin_account_assignment.html.markdown
@@ -21,7 +21,7 @@ data "aws_ssoadmin_permission_set" "example" {
 }
 
 data "aws_identitystore_group" "example" {
-  identity_store_id = tolist(data.aws_ssoadmin_instances.selected.identity_store_ids)[0]
+  identity_store_id = tolist(data.aws_ssoadmin_instances.example.identity_store_ids)[0]
 
   filter {
     attribute_path  = "DisplayName"


### PR DESCRIPTION
The previously used name of `selected` appears to be invalid.

Perhaps this is a remnant from copying [other examples from the terraform-provider-aws docs](https://github.com/hashicorp/terraform-provider-aws/search?q=%22selected%22).

Correcting this to `example` resolves the error.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
