### PR TITLE
resource/aws_lb_target_group: Prevent eventual consistency related tagging errors on creation

### DIFF
--- a/aws/internal/service/elbv2/waiter/waiter.go
+++ b/aws/internal/service/elbv2/waiter/waiter.go
@@ -16,6 +16,9 @@ const (
 
 	// Default maximum amount of time to wait for a Load Balancer to be deleted
 	LoadBalancerDeleteTimeout = 10 * time.Minute
+
+	// Default maximum amount of time to wait for Tag Propagation for a Load Balancer
+	TagPropagationTimeout = 2 * time.Minute
 )
 
 // LoadBalancerActive waits for a Load Balancer to return active

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -359,10 +359,10 @@ func resourceAwsLbRead(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving ALB: %s", err)
+		return fmt.Errorf("error retrieving ALB: %w", err)
 	}
 	if len(describeResp.LoadBalancers) != 1 {
-		return fmt.Errorf("Unable to find ALB: %#v", describeResp.LoadBalancers)
+		return fmt.Errorf("unable to find ALB: %#v", describeResp.LoadBalancers)
 	}
 
 	return flattenAwsLbResource(d, meta, describeResp.LoadBalancers[0])
@@ -377,7 +377,8 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := resource.Retry(waiter.TagPropagationTimeout, func() *resource.RetryError {
 			err := keyvaluetags.Elbv2UpdateTags(conn, d.Id(), o, n)
 
-			if d.IsNewResource() && isAWSErr(err, elbv2.ErrCodeTargetGroupNotFoundException, "") {
+			if d.IsNewResource() && isAWSErr(err, elbv2.ErrCodeLoadBalancerNotFoundException, "") {
+				log.Printf("[DEBUG] Retrying tagging of LB (%s)", d.Id())
 				return resource.RetryableError(err)
 			}
 
@@ -393,7 +394,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating LB (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("error updating LB (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -478,7 +479,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] ALB Modify Load Balancer Attributes Request: %#v", input)
 		_, err := conn.ModifyLoadBalancerAttributes(input)
 		if err != nil {
-			return fmt.Errorf("Failure configuring LB attributes: %s", err)
+			return fmt.Errorf("failure configuring LB attributes: %w", err)
 		}
 	}
 
@@ -491,7 +492,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		_, err := conn.SetSecurityGroups(params)
 		if err != nil {
-			return fmt.Errorf("Failure Setting LB Security Groups: %s", err)
+			return fmt.Errorf("failure Setting LB Security Groups: %w", err)
 		}
 
 	}
@@ -510,7 +511,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		_, err := conn.SetSubnets(params)
 		if err != nil {
-			return fmt.Errorf("Failure Setting LB Subnets: %s", err)
+			return fmt.Errorf("failure Setting LB Subnets: %w", err)
 		}
 	}
 
@@ -523,7 +524,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		_, err := conn.SetIpAddressType(params)
 		if err != nil {
-			return fmt.Errorf("Failure Setting LB IP Address Type: %s", err)
+			return fmt.Errorf("failure Setting LB IP Address Type: %w", err)
 		}
 	}
 
@@ -545,7 +546,7 @@ func resourceAwsLbDelete(d *schema.ResourceData, meta interface{}) error {
 		LoadBalancerArn: aws.String(d.Id()),
 	}
 	if _, err := conn.DeleteLoadBalancer(&deleteElbOpts); err != nil {
-		return fmt.Errorf("Error deleting LB: %s", err)
+		return fmt.Errorf("error deleting LB: %w", err)
 	}
 
 	ec2conn := meta.(*AWSClient).ec2conn
@@ -643,7 +644,7 @@ func waitForNLBNetworkInterfacesToDetach(conn *ec2.EC2, lbArn string) error {
 		niCount := len(out.NetworkInterfaces)
 		if niCount > 0 {
 			log.Printf("[DEBUG] Found %d ENIs to cleanup for NLB %q", niCount, lbArn)
-			return resource.RetryableError(fmt.Errorf("Waiting for %d ENIs of %q to clean up", niCount, lbArn))
+			return resource.RetryableError(fmt.Errorf("waiting for %d ENIs of %q to clean up", niCount, lbArn))
 		}
 		log.Printf("[DEBUG] ENIs gone for NLB %q", lbArn)
 
@@ -652,15 +653,15 @@ func waitForNLBNetworkInterfacesToDetach(conn *ec2.EC2, lbArn string) error {
 	if isResourceTimeoutError(err) {
 		out, err = conn.DescribeNetworkInterfaces(input)
 		if err != nil {
-			return fmt.Errorf("Error describing network inferfaces: %s", err)
+			return fmt.Errorf("error describing network inferfaces: %w", err)
 		}
 		niCount := len(out.NetworkInterfaces)
 		if niCount > 0 {
-			return fmt.Errorf("Error waiting for %d ENIs of %q to clean up", niCount, lbArn)
+			return fmt.Errorf("error waiting for %d ENIs of %q to clean up", niCount, lbArn)
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("Error describing network inferfaces: %s", err)
+		return fmt.Errorf("error describing network inferfaces: %w", err)
 	}
 	return nil
 }
@@ -669,7 +670,7 @@ func getLbNameFromArn(arn string) (string, error) {
 	re := regexp.MustCompile("([^/]+/[^/]+/[^/]+)$")
 	matches := re.FindStringSubmatch(arn)
 	if len(matches) != 2 {
-		return "", fmt.Errorf("Unexpected ARN format: %q", arn)
+		return "", fmt.Errorf("unexpected ARN format: %q", arn)
 	}
 
 	// e.g. app/example-alb/b26e625cdde161e6
@@ -736,28 +737,28 @@ func flattenAwsLbResource(d *schema.ResourceData, meta interface{}, lb *elbv2.Lo
 	d.Set("customer_owned_ipv4_pool", lb.CustomerOwnedIpv4Pool)
 
 	if err := d.Set("subnets", flattenSubnetsFromAvailabilityZones(lb.AvailabilityZones)); err != nil {
-		return fmt.Errorf("error setting subnets: %s", err)
+		return fmt.Errorf("error setting subnets: %w", err)
 	}
 
 	if err := d.Set("subnet_mapping", flattenSubnetMappingsFromAvailabilityZones(lb.AvailabilityZones)); err != nil {
-		return fmt.Errorf("error setting subnet_mapping: %s", err)
+		return fmt.Errorf("error setting subnet_mapping: %w", err)
 	}
 
 	tags, err := keyvaluetags.Elbv2ListTags(conn, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for (%s): %s", d.Id(), err)
+		return fmt.Errorf("error listing tags for (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	attributesResp, err := conn.DescribeLoadBalancerAttributes(&elbv2.DescribeLoadBalancerAttributesInput{
 		LoadBalancerArn: aws.String(d.Id()),
 	})
 	if err != nil {
-		return fmt.Errorf("Error retrieving LB Attributes: %s", err)
+		return fmt.Errorf("error retrieving LB Attributes: %w", err)
 	}
 
 	accessLogMap := map[string]interface{}{
@@ -777,7 +778,7 @@ func flattenAwsLbResource(d *schema.ResourceData, meta interface{}, lb *elbv2.Lo
 		case "idle_timeout.timeout_seconds":
 			timeout, err := strconv.Atoi(aws.StringValue(attr.Value))
 			if err != nil {
-				return fmt.Errorf("Error parsing ALB timeout: %s", err)
+				return fmt.Errorf("error parsing ALB timeout: %w", err)
 			}
 			log.Printf("[DEBUG] Setting ALB Timeout Seconds: %d", timeout)
 			d.Set("idle_timeout", timeout)
@@ -801,7 +802,7 @@ func flattenAwsLbResource(d *schema.ResourceData, meta interface{}, lb *elbv2.Lo
 	}
 
 	if err := d.Set("access_logs", []interface{}{accessLogMap}); err != nil {
-		return fmt.Errorf("error setting access_logs: %s", err)
+		return fmt.Errorf("error setting access_logs: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elbv2/waiter"
 )
 
 func resourceAwsLbTargetGroup() *schema.Resource {
@@ -406,7 +407,7 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
-		err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		err := resource.Retry(waiter.TagPropagationTimeout, func() *resource.RetryError {
 			err := keyvaluetags.Elbv2UpdateTags(elbconn, d.Id(), o, n)
 
 			if d.IsNewResource() && isAWSErr(err, elbv2.ErrCodeTargetGroupNotFoundException, "") {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/16860

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLBTargetGroup_tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBTargetGroup_tags -timeout 120m
=== RUN   TestAccAWSLBTargetGroup_tags
=== PAUSE TestAccAWSLBTargetGroup_tags
=== CONT  TestAccAWSLBTargetGroup_tags
--- PASS: TestAccAWSLBTargetGroup_tags (209.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	211.805s
```

As I wrote in the issue, I myself could not reproduce the problem locally. However, many people seem to experience it so I added a retry mechanism to adding tags following https://github.com/hashicorp/terraform-provider-aws/pull/12738. Thank you for your review!