### PR TITLE
r/aws_imagebuilder_image_recipe: Add support for 'volume_type = "gp3"'

### DIFF
--- a/.changelog/17286.txt
+++ b/.changelog/17286.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_image_recipe: Add `gp3` as a valid value for the `volume_type` attribute
+```

--- a/aws/internal/service/imagebuilder/id.go
+++ b/aws/internal/service/imagebuilder/id.go
@@ -1,0 +1,7 @@
+package imagebuilder
+
+const (
+	// Missing from upstream aws-sdk-go.
+	// https://github.com/aws/aws-sdk-go/issues/3751.
+	EbsVolumeTypeGp3 = "gp3"
+)

--- a/aws/resource_aws_imagebuilder_image_recipe.go
+++ b/aws/resource_aws_imagebuilder_image_recipe.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	tfimagebuilder "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/imagebuilder"
 )
 
 func resourceAwsImageBuilderImageRecipe() *schema.Resource {
@@ -94,10 +95,11 @@ func resourceAwsImageBuilderImageRecipe() *schema.Resource {
 										ValidateFunc: validation.IntBetween(1, 16000),
 									},
 									"volume_type": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice(imagebuilder.EbsVolumeType_Values(), false),
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										// https://github.com/hashicorp/terraform-provider-aws/issues/17274.
+										ValidateFunc: validation.StringInSlice(append(imagebuilder.EbsVolumeType_Values(), tfimagebuilder.EbsVolumeTypeGp3), false),
 									},
 								},
 							},

--- a/aws/resource_aws_imagebuilder_image_recipe_test.go
+++ b/aws/resource_aws_imagebuilder_image_recipe_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfimagebuilder "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/imagebuilder"
 )
 
 func init() {
@@ -326,7 +327,7 @@ func TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeSize(t *test
 	})
 }
 
-func TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeType(t *testing.T) {
+func TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp2(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
@@ -342,6 +343,34 @@ func TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeType(t *test
 					resource.TestCheckResourceAttr(resourceName, "block_device_mapping.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "block_device_mapping.*", map[string]string{
 						"ebs.0.volume_type": imagebuilder.EbsVolumeTypeGp2,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp3(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_imagebuilder_image_recipe.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsImageBuilderImageRecipeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsImageBuilderImageRecipeConfigBlockDeviceMappingEbsVolumeType(rName, tfimagebuilder.EbsVolumeTypeGp3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsImageBuilderImageRecipeExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mapping.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "block_device_mapping.*", map[string]string{
+						"ebs.0.volume_type": tfimagebuilder.EbsVolumeTypeGp3,
 					}),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17274.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeType -timeout 120m
=== RUN   TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp2
=== PAUSE TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp2
=== RUN   TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp3
=== PAUSE TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp3
=== CONT  TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp2
=== CONT  TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp3
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp3 (22.45s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp2 (22.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	22.956s
```
