### PR TITLE
r/aws_route: 'destination_prefix_list_id' attribute can be specified for managed prefix list destinations

### DIFF
--- a/.changelog/17291.txt
+++ b/.changelog/17291.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route: `destination_prefix_list_id` attribute can be specified for managed prefix list destinations
+```

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -254,6 +254,23 @@ func RouteByIPv6Destination(conn *ec2.EC2, routeTableID, destinationIpv6Cidr str
 	return nil, &resource.NotFoundError{}
 }
 
+// RouteByPrefixListIDDestination returns the route corresponding to the specified prefix list destination.
+// Returns NotFoundError if no route is found.
+func RouteByPrefixListIDDestination(conn *ec2.EC2, routeTableID, prefixListID string) (*ec2.Route, error) {
+	routeTable, err := RouteTableByID(conn, routeTableID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, route := range routeTable.Routes {
+		if aws.StringValue(route.DestinationPrefixListId) == prefixListID {
+			return route, nil
+		}
+	}
+
+	return nil, &resource.NotFoundError{}
+}
+
 // SecurityGroupByID looks up a security group by ID. When not found, returns nil and potentially an API error.
 func SecurityGroupByID(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
 	req := &ec2.DescribeSecurityGroupsInput{

--- a/aws/internal/service/ec2/id.go
+++ b/aws/internal/service/ec2/id.go
@@ -7,6 +7,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 )
 
+const (
+	ManagedPrefixListOwnerIdAWS = "AWS"
+)
+
 const clientVpnAuthorizationRuleIDSeparator = ","
 
 func ClientVpnAuthorizationRuleCreateID(endpointID, targetNetworkCidr, accessGroupID string) string {

--- a/aws/internal/service/ec2/id.go
+++ b/aws/internal/service/ec2/id.go
@@ -7,10 +7,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 )
 
-const (
-	ManagedPrefixListOwnerIdAWS = "AWS"
-)
-
 const clientVpnAuthorizationRuleIDSeparator = ","
 
 func ClientVpnAuthorizationRuleCreateID(endpointID, targetNetworkCidr, accessGroupID string) string {

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -70,7 +70,6 @@ func resourceAwsRoute() *schema.Resource {
 					validateIpv4CIDRNetworkAddress,
 				),
 			},
-
 			"destination_ipv6_cidr_block": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -81,7 +80,6 @@ func resourceAwsRoute() *schema.Resource {
 				),
 				DiffSuppressFunc: suppressEqualCIDRBlockDiffs,
 			},
-
 			"destination_prefix_list_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -97,53 +95,45 @@ func resourceAwsRoute() *schema.Resource {
 				ExactlyOneOf:  routeValidTargets,
 				ConflictsWith: []string{"destination_ipv6_cidr_block"}, // IPv4 destinations only.
 			},
-
 			"egress_only_gateway_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ExactlyOneOf:  routeValidTargets,
 				ConflictsWith: []string{"destination_cidr_block"}, // IPv6 destinations only.
 			},
-
 			"gateway_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ExactlyOneOf: routeValidTargets,
 			},
-
 			"instance_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ExactlyOneOf: routeValidTargets,
 			},
-
 			"local_gateway_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ExactlyOneOf: routeValidTargets,
 			},
-
 			"nat_gateway_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ExactlyOneOf:  routeValidTargets,
 				ConflictsWith: []string{"destination_ipv6_cidr_block"}, // IPv4 destinations only.
 			},
-
 			"network_interface_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ExactlyOneOf: routeValidTargets,
 			},
-
 			"transit_gateway_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ExactlyOneOf: routeValidTargets,
 			},
-
 			"vpc_endpoint_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -153,7 +143,6 @@ func resourceAwsRoute() *schema.Resource {
 					"destination_prefix_list_id",  // "Cannot create or replace a prefix list route targeting a VPC Endpoint."
 				},
 			},
-
 			"vpc_peering_connection_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -167,12 +156,10 @@ func resourceAwsRoute() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"origin": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"state": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -292,7 +279,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if tfresource.NotFound(err) {
-		return fmt.Errorf("Route in Route Table (%s) with destination (%s) not found", routeTableID, destination)
+		return fmt.Errorf("route in Route Table (%s) with destination (%s) not found", routeTableID, destination)
 	}
 
 	d.SetId(tfec2.RouteCreateID(routeTableID, destination))

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -506,16 +506,6 @@ func resourceAwsRouteImport(d *schema.ResourceData, meta interface{}) ([]*schema
 	} else if strings.Contains(destination, ".") {
 		d.Set("destination_cidr_block", destination)
 	} else {
-		managedPrefixList, err := finder.ManagedPrefixListByID(meta.(*AWSClient).ec2conn, destination)
-
-		if err != nil {
-			return nil, err
-		}
-
-		if managedPrefixList != nil && aws.StringValue(managedPrefixList.OwnerId) == tfec2.ManagedPrefixListOwnerIdAWS {
-			return nil, fmt.Errorf("Managed prefix list (%s) is owned by AWS", destination)
-		}
-
 		d.Set("destination_prefix_list_id", destination)
 	}
 

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -145,10 +145,13 @@ func resourceAwsRoute() *schema.Resource {
 			},
 
 			"vpc_endpoint_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ExactlyOneOf:  routeValidTargets,
-				ConflictsWith: []string{"destination_ipv6_cidr_block"}, // IPv4 destinations only.
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: routeValidTargets,
+				ConflictsWith: []string{
+					"destination_ipv6_cidr_block", // IPv4 destinations only.
+					"destination_prefix_list_id",  // "Cannot create or replace a prefix list route targeting a VPC Endpoint."
+				},
 			},
 
 			"vpc_peering_connection_id": {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -1481,7 +1481,7 @@ func TestAccAWSRoute_PrefixList_To_InternetGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1525,7 +1525,7 @@ func TestAccAWSRoute_PrefixList_To_VpnGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1569,7 +1569,7 @@ func TestAccAWSRoute_PrefixList_To_Instance(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1613,7 +1613,7 @@ func TestAccAWSRoute_PrefixList_To_NetworkInterface_Unattached(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1658,7 +1658,7 @@ func TestAccAWSRoute_PrefixList_To_NetworkInterface_Attached(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1702,7 +1702,7 @@ func TestAccAWSRoute_PrefixList_To_VpcPeeringConnection(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1746,7 +1746,7 @@ func TestAccAWSRoute_PrefixList_To_NatGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1790,7 +1790,7 @@ func TestAccAWSRoute_PrefixList_To_TransitGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1834,7 +1834,11 @@ func TestAccAWSRoute_PrefixList_To_CarrierGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckEc2ManagedPrefixList(t)
+			testAccPreCheckAWSWavelengthZoneAvailable(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1878,7 +1882,11 @@ func TestAccAWSRoute_PrefixList_To_LocalGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckEc2ManagedPrefixList(t)
+			testAccPreCheckAWSOutpostsOutposts(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1922,7 +1930,7 @@ func TestAccAWSRoute_PrefixList_To_EgressOnlyInternetGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -847,6 +847,7 @@ func TestAccAWSRoute_IPv6_To_TransitGateway(t *testing.T) {
 		},
 	})
 }
+
 func TestAccAWSRoute_IPv4_To_CarrierGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
@@ -1482,6 +1483,7 @@ func TestAccAWSRoute_PrefixList_To_InternetGateway(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1526,6 +1528,7 @@ func TestAccAWSRoute_PrefixList_To_VpnGateway(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1570,6 +1573,7 @@ func TestAccAWSRoute_PrefixList_To_Instance(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1614,6 +1618,7 @@ func TestAccAWSRoute_PrefixList_To_NetworkInterface_Unattached(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1659,6 +1664,7 @@ func TestAccAWSRoute_PrefixList_To_NetworkInterface_Attached(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1703,6 +1709,7 @@ func TestAccAWSRoute_PrefixList_To_VpcPeeringConnection(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1747,6 +1754,7 @@ func TestAccAWSRoute_PrefixList_To_NatGateway(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1791,6 +1799,7 @@ func TestAccAWSRoute_PrefixList_To_TransitGateway(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1839,6 +1848,7 @@ func TestAccAWSRoute_PrefixList_To_CarrierGateway(t *testing.T) {
 			testAccPreCheckEc2ManagedPrefixList(t)
 			testAccPreCheckAWSWavelengthZoneAvailable(t)
 		},
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1887,6 +1897,7 @@ func TestAccAWSRoute_PrefixList_To_LocalGateway(t *testing.T) {
 			testAccPreCheckEc2ManagedPrefixList(t)
 			testAccPreCheckAWSOutpostsOutposts(t)
 		},
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
@@ -1931,6 +1942,7 @@ func TestAccAWSRoute_PrefixList_To_EgressOnlyInternetGateway(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -1492,6 +1492,8 @@ func testAccCheckAWSRouteExists(n string, v *ec2.Route) resource.TestCheckFunc {
 			route, err = finder.RouteByIPv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
 			route, err = finder.RouteByIPv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+		} else if v := rs.Primary.Attributes["destination_prefix_list_id"]; v != "" {
+			route, err = finder.RouteByPrefixListIDDestination(conn, rs.Primary.Attributes["route_table_id"], v)
 		}
 
 		if err != nil {
@@ -1517,6 +1519,8 @@ func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 			_, err = finder.RouteByIPv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
 			_, err = finder.RouteByIPv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+		} else if v := rs.Primary.Attributes["destination_prefix_list_id"]; v != "" {
+			_, err = finder.RouteByPrefixListIDDestination(conn, rs.Primary.Attributes["route_table_id"], v)
 		}
 
 		if tfresource.NotFound(err) {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -1489,11 +1489,453 @@ func TestAccAWSRoute_PrefixList_To_InternetGateway(t *testing.T) {
 				Config: testAccAWSRouteConfigPrefixListInternetGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_VpnGateway(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	vgwResourceName := "aws_vpn_gateway.test"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListVpnGateway(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_Instance(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	instanceResourceName := "aws_instance.test"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListInstance(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_NetworkInterface_Unattached(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	eniResourceName := "aws_network_interface.test"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListNetworkInterfaceUnattached(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_NetworkInterface_Attached(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	eniResourceName := "aws_network_interface.test"
+	instanceResourceName := "aws_instance.test"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListNetworkInterfaceAttached(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_VpcPeeringConnection(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	pcxResourceName := "aws_vpc_peering_connection.test"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListVpcPeeringConnection(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_NatGateway(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	ngwResourceName := "aws_nat_gateway.test"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListNatGateway(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "nat_gateway_id", ngwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_TransitGateway(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	tgwResourceName := "aws_ec2_transit_gateway.test"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListTransitGateway(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", tgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_CarrierGateway(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	cgwResourceName := "aws_ec2_carrier_gateway.test"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListCarrierGateway(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttrPair(resourceName, "carrier_gateway_id", cgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_LocalGateway(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	localGatewayDataSourceName := "data.aws_ec2_local_gateway.first"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListLocalGateway(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "local_gateway_id", localGatewayDataSourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_endpoint_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute_PrefixList_To_EgressOnlyInternetGateway(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	eoigwResourceName := "aws_egress_only_internet_gateway.test"
+	plResourceName := "aws_ec2_managed_prefix_list.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigPrefixListEgressOnlyInternetGateway(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "carrier_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_prefix_list_id", plResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "egress_only_gateway_id", eoigwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "local_gateway_id", ""),
@@ -1674,46 +2116,6 @@ resource "aws_route" "test" {
   gateway_id                  = aws_internet_gateway.test.id
 }
 `, rName, destinationCidr)
-}
-
-func testAccAWSRouteConfigPrefixListInternetGateway(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_internet_gateway" "test" {
-  vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_ec2_managed_prefix_list" "test" {
-  address_family = "IPv4"
-  max_entries    = 1
-  name           = %[1]q
-}
-
-resource "aws_route_table" "test" {
-  vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_route" "test" {
-  route_table_id             = aws_route_table.test.id
-  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
-  gateway_id                 = aws_internet_gateway.test.id
-}
-`, rName)
 }
 
 func testAccAWSRouteConfigIpv6NetworkInterfaceUnattached(rName, destinationCidr string) string {
@@ -2843,7 +3245,6 @@ resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = %[2]q
 
-  carrier_gateway_id        = (local.target_attr == "carrier_gateway_id") ? local.target_value : null
   egress_only_gateway_id    = (local.target_attr == "egress_only_gateway_id") ? local.target_value : null
   gateway_id                = (local.target_attr == "gateway_id") ? local.target_value : null
   instance_id               = (local.target_attr == "instance_id") ? local.target_value : null
@@ -2965,7 +3366,6 @@ resource "aws_route" "test" {
   route_table_id              = aws_route_table.test.id
   destination_ipv6_cidr_block = %[2]q
 
-  carrier_gateway_id        = (local.target_attr == "carrier_gateway_id") ? local.target_value : null
   egress_only_gateway_id    = (local.target_attr == "egress_only_gateway_id") ? local.target_value : null
   gateway_id                = (local.target_attr == "gateway_id") ? local.target_value : null
   instance_id               = (local.target_attr == "instance_id") ? local.target_value : null
@@ -3009,6 +3409,581 @@ resource "aws_route" "test" {
   gateway_id             = "local"
 }
 `)
+}
+
+func testAccAWSRouteConfigPrefixListInternetGateway(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  gateway_id                 = aws_internet_gateway.test.id
+}
+`, rName)
+}
+
+func testAccAWSRouteConfigPrefixListVpnGateway(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  gateway_id                 = aws_vpn_gateway.test.id
+}
+`, rName)
+}
+
+func testAccAWSRouteConfigPrefixListInstance(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonNatInstanceAmiConfig(),
+		testAccAvailableAZsNoOptInConfig(),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-nat-instance.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  instance_id                = aws_instance.test.id
+}
+`, rName))
+}
+
+func testAccAWSRouteConfigPrefixListNetworkInterfaceUnattached(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  network_interface_id       = aws_network_interface.test.id
+}
+`, rName))
+}
+
+func testAccAWSRouteConfigPrefixListNetworkInterfaceAttached(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonNatInstanceAmiConfig(),
+		testAccAvailableAZsNoOptInConfig(),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-nat-instance.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+
+  network_interface {
+    device_index         = 0
+    network_interface_id = aws_network_interface.test.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  network_interface_id       = aws_network_interface.test.id
+
+  # Wait for the ENI attachment.
+  depends_on = [aws_instance.test]
+}
+`, rName))
+}
+
+func testAccAWSRouteConfigPrefixListVpcPeeringConnection(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "target" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id      = aws_vpc.test.id
+  peer_vpc_id = aws_vpc.target.id
+  auto_accept = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  vpc_peering_connection_id  = aws_vpc_peering_connection.test.id
+}
+`, rName)
+}
+
+func testAccAWSRouteConfigPrefixListNatGateway(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "10.1.1.0/24"
+  vpc_id     = aws_vpc.test.id
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_eip" "test" {
+  vpc = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_nat_gateway" "test" {
+  allocation_id = aws_eip.test.id
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+
+  depends_on = [aws_internet_gateway.test]
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  nat_gateway_id             = aws_nat_gateway.test.id
+}
+`, rName)
+}
+
+func testAccAWSRouteConfigPrefixListTransitGateway(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
+  subnet_ids         = [aws_subnet.test.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  transit_gateway_id         = aws_ec2_transit_gateway_vpc_attachment.test.transit_gateway_id
+}
+`, rName))
+}
+
+func testAccAWSRouteConfigPrefixListCarrierGateway(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_carrier_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  carrier_gateway_id         = aws_ec2_carrier_gateway.test.id
+}
+`, rName)
+}
+
+func testAccAWSRouteConfigPrefixListLocalGateway(rName string) string {
+	return fmt.Sprintf(`
+data "aws_ec2_local_gateways" "all" {}
+
+data "aws_ec2_local_gateway" "first" {
+  id = tolist(data.aws_ec2_local_gateways.all.ids)[0]
+}
+
+data "aws_ec2_local_gateway_route_tables" "all" {}
+
+data "aws_ec2_local_gateway_route_table" "first" {
+  local_gateway_route_table_id = tolist(data.aws_ec2_local_gateway_route_tables.all.ids)[0]
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_local_gateway_route_table_vpc_association" "example" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.first.id
+  vpc_id                       = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+
+  depends_on = [aws_ec2_local_gateway_route_table_vpc_association.example]
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  local_gateway_id           = data.aws_ec2_local_gateway.first.id
+}
+`, rName)
+}
+
+func testAccAWSRouteConfigPrefixListEgressOnlyInternetGateway(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_egress_only_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv6"
+  max_entries    = 1
+  name           = %[1]q
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id             = aws_route_table.test.id
+  destination_prefix_list_id = aws_ec2_managed_prefix_list.test.id
+  egress_only_gateway_id     = aws_egress_only_internet_gateway.test.id
+}
+`, rName)
 }
 
 func testAccAWSRouteConfigIpv4CarrierGateway(rName, destinationCidr string) string {

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -58,6 +58,7 @@ One of the following destination arguments must be supplied:
 
 * `destination_cidr_block` - (Optional) The destination CIDR block.
 * `destination_ipv6_cidr_block` - (Optional) The destination IPv6 CIDR block.
+* `destination_prefix_list_id` - (Optional) The ID of a [managed prefix list](ec2_managed_prefix_list.html) destination.
 
 One of the following target arguments must be supplied:
 
@@ -82,7 +83,10 @@ In addition to all arguments above, the following attributes are exported:
 ~> **NOTE:** Only the arguments that are configured (one of the above)
 will be exported as an attribute once the resource is created.
 
-* `id` - Route Table identifier and destination
+* `id` - Route identifier computed from the routing table identifier and route destination.
+* `instance_owner_id` - The AWS account ID of the owner of the EC2 instance.
+* `origin` - How the route was created - `CreateRouteTable`, `CreateRoute` or `EnableVgwRoutePropagation`.
+* `state` - The state of the route - `active` or `blackhole`.
 
 ## Timeouts
 
@@ -106,4 +110,10 @@ Import a route in route table `rtb-656C65616E6F72` with an IPv6 destination CIDR
 
 ```console
 $ terraform import aws_route.my_route rtb-656C65616E6F72_2620:0:2d0:200::8/125
+```
+
+Import a route in route table `rtb-656C65616E6F72` with a managed prefix list destination of `pl-0570a1d2d725c16be` similarly:
+
+```console
+$ terraform import aws_route.my_route rtb-656C65616E6F72_pl-0570a1d2d725c16be
 ```

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -10,11 +10,7 @@ description: |-
 
 Provides a resource to create a routing table entry (a route) in a VPC routing table.
 
-~> **NOTE on Route Tables and Routes:** Terraform currently
-provides both a standalone Route resource and a [Route Table](route_table.html) resource with routes
-defined in-line. At this time you cannot use a Route Table with in-line routes
-in conjunction with any Route resources. Doing so will cause
-a conflict of rule settings and will overwrite rules.
+~> **NOTE on Route Tables and Routes:** Terraform currently provides both a standalone Route resource and a [Route Table](route_table.html) resource with routes defined in-line. At this time you cannot use a Route Table with in-line routes in conjunction with any Route resources. Doing so will cause a conflict of rule settings and will overwrite rules.
 
 ~> **NOTE on `gateway_id` attribute:** The AWS API is very forgiving with the resource ID passed in the `gateway_id` attribute. For example an `aws_route` resource can be created with an [`aws_nat_gateway`](nat_gateway.html) or [`aws_egress_only_internet_gateway`](egress_only_internet_gateway.html) ID specified for the `gateway_id` attribute. Specifying anything other than an [`aws_internet_gateway`](internet_gateway.html) or [`aws_vpn_gateway`](vpn_gateway.html) ID will lead to Terraform reporting a permanent diff between your configuration and recorded state, as the AWS API returns the more-specific attribute. If you are experiencing constant diffs with an `aws_route` resource, the first thing to check is that the correct attribute is being specified.
 
@@ -73,15 +69,13 @@ One of the following target arguments must be supplied:
 * `vpc_endpoint_id` - (Optional) Identifier of a VPC Endpoint.
 * `vpc_peering_connection_id` - (Optional) Identifier of a VPC peering connection.
 
-Note that the default route, mapping the VPC's CIDR block to "local", is
-created implicitly and cannot be specified.
+Note that the default route, mapping the VPC's CIDR block to "local", is created implicitly and cannot be specified.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-~> **NOTE:** Only the arguments that are configured (one of the above)
-will be exported as an attribute once the resource is created.
+~> **NOTE:** Only the arguments that are configured (one of the above) will be exported as an attribute once the resource is created.
 
 * `id` - Route identifier computed from the routing table identifier and route destination.
 * `instance_owner_id` - The AWS account ID of the owner of the EC2 instance.
@@ -90,8 +84,7 @@ will be exported as an attribute once the resource is created.
 
 ## Timeouts
 
-`aws_route` provides the following
-[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+`aws_route` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
 
 - `create` - (Default `2 minutes`) Used for route creation
 - `delete` - (Default `5 minutes`) Used for route deletion


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Builds on: #14014, #16930, #16961
Dependents: #17295

Relates: #15273.
Replaces #17275.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSRoute_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSRoute_ -timeout 120m
=== RUN   TestAccAWSRoute_basic
=== PAUSE TestAccAWSRoute_basic
=== RUN   TestAccAWSRoute_disappears
=== PAUSE TestAccAWSRoute_disappears
=== RUN   TestAccAWSRoute_disappears_RouteTable
=== PAUSE TestAccAWSRoute_disappears_RouteTable
=== RUN   TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway
=== PAUSE TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway
=== RUN   TestAccAWSRoute_IPv6_To_InternetGateway
=== PAUSE TestAccAWSRoute_IPv6_To_InternetGateway
=== RUN   TestAccAWSRoute_IPv6_To_Instance
=== PAUSE TestAccAWSRoute_IPv6_To_Instance
=== RUN   TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached
=== PAUSE TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached
=== RUN   TestAccAWSRoute_IPv6_To_VpcPeeringConnection
=== PAUSE TestAccAWSRoute_IPv6_To_VpcPeeringConnection
=== RUN   TestAccAWSRoute_IPv6_To_VpnGateway
=== PAUSE TestAccAWSRoute_IPv6_To_VpnGateway
=== RUN   TestAccAWSRoute_IPv4_To_VpnGateway
=== PAUSE TestAccAWSRoute_IPv4_To_VpnGateway
=== RUN   TestAccAWSRoute_IPv4_To_Instance
=== PAUSE TestAccAWSRoute_IPv4_To_Instance
=== RUN   TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached
=== PAUSE TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached
=== RUN   TestAccAWSRoute_IPv4_To_NetworkInterface_Attached
=== PAUSE TestAccAWSRoute_IPv4_To_NetworkInterface_Attached
=== RUN   TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments
=== PAUSE TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments
=== RUN   TestAccAWSRoute_IPv4_To_VpcPeeringConnection
=== PAUSE TestAccAWSRoute_IPv4_To_VpcPeeringConnection
=== RUN   TestAccAWSRoute_IPv4_To_NatGateway
=== PAUSE TestAccAWSRoute_IPv4_To_NatGateway
=== RUN   TestAccAWSRoute_DoesNotCrashWithVpcEndpoint
=== PAUSE TestAccAWSRoute_DoesNotCrashWithVpcEndpoint
=== RUN   TestAccAWSRoute_IPv4_To_TransitGateway
=== PAUSE TestAccAWSRoute_IPv4_To_TransitGateway
=== RUN   TestAccAWSRoute_IPv6_To_TransitGateway
=== PAUSE TestAccAWSRoute_IPv6_To_TransitGateway
=== RUN   TestAccAWSRoute_IPv4_To_CarrierGateway
=== PAUSE TestAccAWSRoute_IPv4_To_CarrierGateway
=== RUN   TestAccAWSRoute_IPv4_To_LocalGateway
=== PAUSE TestAccAWSRoute_IPv4_To_LocalGateway
=== RUN   TestAccAWSRoute_IPv6_To_LocalGateway
=== PAUSE TestAccAWSRoute_IPv6_To_LocalGateway
=== RUN   TestAccAWSRoute_ConditionalCidrBlock
=== PAUSE TestAccAWSRoute_ConditionalCidrBlock
=== RUN   TestAccAWSRoute_IPv4_Update_Target
=== PAUSE TestAccAWSRoute_IPv4_Update_Target
=== RUN   TestAccAWSRoute_IPv6_Update_Target
=== PAUSE TestAccAWSRoute_IPv6_Update_Target
=== RUN   TestAccAWSRoute_IPv4_To_VpcEndpoint
=== PAUSE TestAccAWSRoute_IPv4_To_VpcEndpoint
=== RUN   TestAccAWSRoute_LocalRoute
=== PAUSE TestAccAWSRoute_LocalRoute
=== RUN   TestAccAWSRoute_PrefixList_To_InternetGateway
=== PAUSE TestAccAWSRoute_PrefixList_To_InternetGateway
=== RUN   TestAccAWSRoute_PrefixList_To_VpnGateway
=== PAUSE TestAccAWSRoute_PrefixList_To_VpnGateway
=== RUN   TestAccAWSRoute_PrefixList_To_Instance
=== PAUSE TestAccAWSRoute_PrefixList_To_Instance
=== RUN   TestAccAWSRoute_PrefixList_To_NetworkInterface_Unattached
=== PAUSE TestAccAWSRoute_PrefixList_To_NetworkInterface_Unattached
=== RUN   TestAccAWSRoute_PrefixList_To_NetworkInterface_Attached
=== PAUSE TestAccAWSRoute_PrefixList_To_NetworkInterface_Attached
=== RUN   TestAccAWSRoute_PrefixList_To_VpcPeeringConnection
=== PAUSE TestAccAWSRoute_PrefixList_To_VpcPeeringConnection
=== RUN   TestAccAWSRoute_PrefixList_To_NatGateway
=== PAUSE TestAccAWSRoute_PrefixList_To_NatGateway
=== RUN   TestAccAWSRoute_PrefixList_To_TransitGateway
=== PAUSE TestAccAWSRoute_PrefixList_To_TransitGateway
=== RUN   TestAccAWSRoute_PrefixList_To_CarrierGateway
=== PAUSE TestAccAWSRoute_PrefixList_To_CarrierGateway
=== RUN   TestAccAWSRoute_PrefixList_To_LocalGateway
=== PAUSE TestAccAWSRoute_PrefixList_To_LocalGateway
=== RUN   TestAccAWSRoute_PrefixList_To_EgressOnlyInternetGateway
=== PAUSE TestAccAWSRoute_PrefixList_To_EgressOnlyInternetGateway
=== CONT  TestAccAWSRoute_basic
=== CONT  TestAccAWSRoute_PrefixList_To_EgressOnlyInternetGateway
--- PASS: TestAccAWSRoute_PrefixList_To_EgressOnlyInternetGateway (34.30s)
=== CONT  TestAccAWSRoute_PrefixList_To_LocalGateway
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSRoute_PrefixList_To_LocalGateway (1.39s)
=== CONT  TestAccAWSRoute_PrefixList_To_CarrierGateway
--- PASS: TestAccAWSRoute_basic (36.19s)
=== CONT  TestAccAWSRoute_PrefixList_To_TransitGateway
--- PASS: TestAccAWSRoute_PrefixList_To_CarrierGateway (32.87s)
=== CONT  TestAccAWSRoute_PrefixList_To_NatGateway
--- PASS: TestAccAWSRoute_PrefixList_To_NatGateway (176.98s)
=== CONT  TestAccAWSRoute_PrefixList_To_VpcPeeringConnection
--- PASS: TestAccAWSRoute_PrefixList_To_VpcPeeringConnection (33.36s)
=== CONT  TestAccAWSRoute_PrefixList_To_NetworkInterface_Attached
--- PASS: TestAccAWSRoute_PrefixList_To_TransitGateway (379.41s)
=== CONT  TestAccAWSRoute_PrefixList_To_NetworkInterface_Unattached
--- PASS: TestAccAWSRoute_PrefixList_To_NetworkInterface_Unattached (62.90s)
=== CONT  TestAccAWSRoute_PrefixList_To_Instance
--- PASS: TestAccAWSRoute_PrefixList_To_NetworkInterface_Attached (364.41s)
=== CONT  TestAccAWSRoute_PrefixList_To_VpnGateway
--- PASS: TestAccAWSRoute_PrefixList_To_VpnGateway (60.04s)
=== CONT  TestAccAWSRoute_PrefixList_To_InternetGateway
--- PASS: TestAccAWSRoute_PrefixList_To_InternetGateway (34.69s)
=== CONT  TestAccAWSRoute_LocalRoute
--- PASS: TestAccAWSRoute_LocalRoute (22.35s)
=== CONT  TestAccAWSRoute_IPv4_To_VpcEndpoint
--- PASS: TestAccAWSRoute_PrefixList_To_Instance (306.41s)
=== CONT  TestAccAWSRoute_IPv6_Update_Target
--- PASS: TestAccAWSRoute_IPv6_Update_Target (217.12s)
=== CONT  TestAccAWSRoute_IPv4_Update_Target
--- PASS: TestAccAWSRoute_IPv4_To_VpcEndpoint (303.13s)
=== CONT  TestAccAWSRoute_ConditionalCidrBlock
--- PASS: TestAccAWSRoute_ConditionalCidrBlock (52.31s)
=== CONT  TestAccAWSRoute_IPv6_To_LocalGateway
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSRoute_IPv6_To_LocalGateway (1.14s)
=== CONT  TestAccAWSRoute_IPv4_To_LocalGateway
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSRoute_IPv4_To_LocalGateway (1.07s)
=== CONT  TestAccAWSRoute_IPv4_To_CarrierGateway
--- PASS: TestAccAWSRoute_IPv4_To_CarrierGateway (24.23s)
=== CONT  TestAccAWSRoute_IPv6_To_TransitGateway
=== CONT  TestAccAWSRoute_IPv4_Update_Target        
--- PASS: TestAccAWSRoute_IPv4_Update_Target (292.84s)
=== CONT  TestAccAWSRoute_IPv4_To_TransitGateway
--- PASS: TestAccAWSRoute_IPv6_To_TransitGateway (336.06s)
=== CONT  TestAccAWSRoute_DoesNotCrashWithVpcEndpoint
--- PASS: TestAccAWSRoute_DoesNotCrashWithVpcEndpoint (42.42s)
=== CONT  TestAccAWSRoute_IPv4_To_NatGateway
--- PASS: TestAccAWSRoute_IPv4_To_TransitGateway (357.41s)
=== CONT  TestAccAWSRoute_IPv4_To_VpcPeeringConnection
=== CONT  TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments
--- PASS: TestAccAWSRoute_IPv4_To_VpcPeeringConnection (25.58s)
--- PASS: TestAccAWSRoute_IPv4_To_NatGateway (209.45s)
=== CONT  TestAccAWSRoute_IPv4_To_NetworkInterface_Attached
--- PASS: TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments (135.25s)
=== CONT  TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached
=== CONT  TestAccAWSRoute_IPv4_To_Instance
--- PASS: TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached (57.79s)
--- PASS: TestAccAWSRoute_IPv4_To_Instance (76.36s)
=== CONT  TestAccAWSRoute_IPv4_To_VpnGateway
--- PASS: TestAccAWSRoute_IPv4_To_VpnGateway (55.43s)
=== CONT  TestAccAWSRoute_IPv6_To_VpnGateway
--- PASS: TestAccAWSRoute_IPv6_To_VpnGateway (61.25s)
=== CONT  TestAccAWSRoute_IPv6_To_VpcPeeringConnection
--- PASS: TestAccAWSRoute_IPv4_To_NetworkInterface_Attached (344.44s)
=== CONT  TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached
--- PASS: TestAccAWSRoute_IPv6_To_VpcPeeringConnection (26.00s)
=== CONT  TestAccAWSRoute_IPv6_To_Instance
--- PASS: TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached (59.16s)
=== CONT  TestAccAWSRoute_IPv6_To_InternetGateway
--- PASS: TestAccAWSRoute_IPv6_To_InternetGateway (34.89s)
=== CONT  TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway
--- PASS: TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway (37.72s)
=== CONT  TestAccAWSRoute_disappears_RouteTable
--- PASS: TestAccAWSRoute_disappears_RouteTable (33.42s)
=== CONT  TestAccAWSRoute_disappears
--- PASS: TestAccAWSRoute_disappears (32.43s)
--- PASS: TestAccAWSRoute_IPv6_To_Instance (328.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2418.681s
```
