### PR TITLE
r/aws_sns_topic_subscription: add firehose protocol support

### DIFF
--- a/.changelog/17307.txt
+++ b/.changelog/17307.txt
@@ -1,3 +1,3 @@
 ```release-notes:enhancement
-resource/sns_topic_subscription: Add `firehose` protocol option with `subscription_role_arn`attribute
+resource/sns_topic_subscription: Add `firehose` protocol option with `subscription_role_arn` attribute
 ```

--- a/.changelog/17307.txt
+++ b/.changelog/17307.txt
@@ -1,0 +1,3 @@
+```release-notes:enhancement
+resource/sns_topic_subscription: Add `firehose` protocol option with `subscription_role_arn`attribute
+```

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -270,7 +270,8 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 	if strings.Contains(protocol, "firehose") && subscription_role_arn == "" {
 		return nil, fmt.Errorf("Protocol firehose must contain subscription_role_arn!")
 	}
-	if !string.Contains(protocol, "firehose") && subscription_role_arn != "" {
+
+	if !strings.Contains(protocol, "firehose") && subscription_role_arn != "" {
 		return nil, fmt.Errorf("Only protocol firehose supports subscription_role_arn!")
 	}
 

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -158,12 +158,6 @@ func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	if d.HasChange("redrive_policy") {
-		if err := snsSubscriptionAttributeUpdate(snsconn, d.Id(), "RedrivePolicy", d.Get("redrive_policy").(string)); err != nil {
-			return err
-		}
-	}
-
 	if d.HasChange("subscription_role_arn") {
 		protocol := d.Get("protocol").(string)
 		subscription_role_arn := d.Get("subscription_role_arn").(string)
@@ -175,6 +169,12 @@ func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interfac
 		}
 
 		if err := snsSubscriptionAttributeUpdate(snsconn, d.Id(), "SubscriptionRoleArn", subscription_role_arn); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("redrive_policy") {
+		if err := snsSubscriptionAttributeUpdate(snsconn, d.Id(), "RedrivePolicy", d.Get("redrive_policy").(string)); err != nil {
 			return err
 		}
 	}

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -196,7 +196,6 @@ func resourceAwsSnsTopicSubscriptionRead(d *schema.ResourceData, meta interface{
 	d.Set("endpoint", attributeOutput.Attributes["Endpoint"])
 	d.Set("filter_policy", attributeOutput.Attributes["FilterPolicy"])
 	d.Set("protocol", attributeOutput.Attributes["Protocol"])
-	d.Set("subscription_role_arn", attributeOutput.Attributes["SubscriptionRoleArn"])
 
 	d.Set("raw_message_delivery", false)
 	if v, ok := attributeOutput.Attributes["RawMessageDelivery"]; ok && aws.StringValue(v) == "true" {
@@ -204,6 +203,11 @@ func resourceAwsSnsTopicSubscriptionRead(d *schema.ResourceData, meta interface{
 	}
 
 	d.Set("redrive_policy", attributeOutput.Attributes["RedrivePolicy"])
+	d.Set("subscription_role_arn", "")
+	if v, ok := attributeOutput.Attributes["SubscriptionRoleArn"]; ok {
+		d.Set("subscription_role_arn", aws.StringValue(v))
+	}
+
 	d.Set("topic_arn", attributeOutput.Attributes["TopicArn"])
 
 	return nil

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -267,8 +267,11 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 		return nil, fmt.Errorf("Protocol http/https is only supported for endpoints which auto confirms!")
 	}
 
-	if strings.Contains(protocol, "firehose") && !subscription_role_arn {
+	if strings.Contains(protocol, "firehose") && subscription_role_arn == "" {
 		return nil, fmt.Errorf("Protocol firehose must contain subscription_role_arn!")
+	}
+	if !string.Contains(protocol, "firehose") && subscription_role_arn != "" {
+		return nil, fmt.Errorf("Only protocol firehose supports subscription_role_arn!")
 	}
 
 	log.Printf("[DEBUG] SNS create topic subscription: %s (%s) @ '%s'", endpoint, protocol, topic_arn)

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -372,7 +372,7 @@ func TestAccAWSSNSTopicSubscription_firehose(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSNSTopicSubscriptionConfig_firehose(ri),
+				Config: testAccAWSSNSTopicSubscriptionConfig_firehose(ri, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicSubscriptionExists(resourceName, attributes),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "sns", regexp.MustCompile(fmt.Sprintf("terraform-test-topic-%d:.+", ri))),
@@ -393,6 +393,14 @@ func TestAccAWSSNSTopicSubscription_firehose(t *testing.T) {
 					"confirmation_timeout_in_minutes",
 					"endpoint_auto_confirms",
 				},
+			},
+			// Test attribute update
+			{
+				Config: testAccAWSSNSTopicSubscriptionConfig_firehose(ri, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicSubscriptionExists(resourceName, attributes),
+					resource.TestCheckResourceAttrPair(resourceName, "subscription_role_arn", "aws_iam_role.firehose_role", "arn"),
+				),
 			},
 		},
 	})
@@ -941,7 +949,7 @@ resource "aws_sns_topic_subscription" "test_subscription" {
 `, i, i, i, i, i, i, i, i, i, username, password, username, password)
 }
 
-func testAccAWSSNSTopicSubscriptionConfig_firehose(i int) string {
+func testAccAWSSNSTopicSubscriptionConfig_firehose(i, n int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test_topic" {
   name = "terraform-test-topic-%d"
@@ -959,7 +967,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_iam_role" "firehose_role" {
-  name = "tf-test-firehose-role-%d"
+  name = "tf-test-firehose-role-%d-%d"
 
   assume_role_policy = <<EOF
 {
@@ -987,5 +995,5 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     bucket_arn = aws_s3_bucket.bucket.arn
   }
 }
-`, i, i, i, i)
+`, i, i, n, i, i)
 }

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -361,6 +361,43 @@ func TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint(t *testing.T) 
 	})
 }
 
+func TestAccAWSSNSTopicSubscription_firehose(t *testing.T) {
+	attributes := make(map[string]string)
+	resourceName := "aws_sns_topic_subscription.test_subscription"
+	ri := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSNSTopicSubscriptionConfig_firehose(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSNSTopicSubscriptionExists(resourceName, attributes),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "sns", regexp.MustCompile(fmt.Sprintf("terraform-test-topic-%d:.+", ri))),
+					resource.TestCheckResourceAttr(resourceName, "delivery_policy", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint", "aws_kinesis_firehose_delivery_stream.test_stream", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "firehose"),
+					resource.TestCheckResourceAttr(resourceName, "raw_message_delivery", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "topic_arn", "aws_sns_topic.test_topic", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "subscription_role_arn", "aws_iam_role.firehose_role", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"confirmation_timeout_in_minutes",
+					"endpoint_auto_confirms",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckAWSSNSTopicSubscriptionDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).snsconn
 
@@ -902,4 +939,53 @@ resource "aws_sns_topic_subscription" "test_subscription" {
   endpoint_auto_confirms = true
 }
 `, i, i, i, i, i, i, i, i, i, username, password, username, password)
+}
+
+func testAccAWSSNSTopicSubscriptionConfig_firehose(i int) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test_topic" {
+  name = "terraform-test-topic-%d"
+}
+
+resource "aws_sns_topic_subscription" "test_subscription" {
+  endpoint              = aws_kinesis_firehose_delivery_stream.test_stream.arn
+  protocol              = "firehose"
+  topic_arn             = aws_sns_topic.test_topic.arn
+  subscription_role_arn = aws_iam_role.firehose_role.arn
+}
+resource "aws_s3_bucket" "bucket" {
+  bucket = "tf-test-bucket-%d"
+  acl    = "private"
+}
+
+resource "aws_iam_role" "firehose_role" {
+  name = "tf-test-firehose-role-%d"
+
+  assume_role_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+	"Action": "sts:AssumeRole",
+	"Principal": {
+	  "Service": ["sns.amazonaws.com","firehose.amazonaws.com"]
+	},
+	"Effect": "Allow",
+	"Sid": ""
+  }
+]
+}
+EOF
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
+  name        = "tf-test-firehose-stream-%d"
+  destination = "s3"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose_role.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
+}
+`, i, i, i, i)
 }

--- a/website/docs/r/sns_topic_subscription.html.markdown
+++ b/website/docs/r/sns_topic_subscription.html.markdown
@@ -238,11 +238,8 @@ The following arguments are supported:
 * `raw_message_delivery` - (Optional) Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property) (default is false).
 * `filter_policy` - (Optional) JSON String with the filter policy that will be used in the subscription to filter messages seen by the target resource. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html) for more details.
 * `delivery_policy` - (Optional) JSON String with the delivery policy (retries, backoff, etc.) that will be used in the subscription - this only applies to HTTP/S subscriptions. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/DeliveryPolicies.html) for more details.
-<<<<<<< HEAD
 * `redrive_policy` - (Optional) JSON String with the redrive policy that will be used in the subscription. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html#how-messages-moved-into-dead-letter-queue) for more details.
-=======
-* `subscription_role_arn` - (Optional) Required ARN of the IAM role to publish to Kinesis Data Firehose delivery stream. Require for `firehose` protocol. Refer to [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/sns-firehose-as-subscriber.html)
->>>>>>> a95bbe357 (docs update)
+* `subscription_role_arn` - (Optional) Required ARN of the IAM role to publish to Kinesis Data Firehose delivery stream. Require for `firehose` protocol. Refer to [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/sns-firehose-as-subscriber.html).
 
 ### Protocols supported
 

--- a/website/docs/r/sns_topic_subscription.html.markdown
+++ b/website/docs/r/sns_topic_subscription.html.markdown
@@ -231,14 +231,18 @@ resource "aws_sns_topic_subscription" "sns-topic" {
 The following arguments are supported:
 
 * `topic_arn` - (Required) The ARN of the SNS topic to subscribe to
-* `protocol` - (Required) The protocol to use. The possible values for this are: `sqs`, `sms`, `lambda`, `application`. (`http` or `https` are partially supported, see below) (`email` is an option but is unsupported, see below).
+* `protocol` - (Required) The protocol to use. The possible values for this are: `sqs`, `sms`, `lambda`, `application`, `firehose`. (`http` or `https` are partially supported, see below) (`email` is an option but is unsupported, see below).
 * `endpoint` - (Required) The endpoint to send data to, the contents will vary with the protocol. (see below for more information)
 * `endpoint_auto_confirms` - (Optional) Boolean indicating whether the end point is capable of [auto confirming subscription](http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html#SendMessageToHttp.prepare) e.g., PagerDuty (default is false)
 * `confirmation_timeout_in_minutes` - (Optional) Integer indicating number of minutes to wait in retying mode for fetching subscription arn before marking it as failure. Only applicable for http and https protocols (default is 1 minute).
 * `raw_message_delivery` - (Optional) Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property) (default is false).
 * `filter_policy` - (Optional) JSON String with the filter policy that will be used in the subscription to filter messages seen by the target resource. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html) for more details.
 * `delivery_policy` - (Optional) JSON String with the delivery policy (retries, backoff, etc.) that will be used in the subscription - this only applies to HTTP/S subscriptions. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/DeliveryPolicies.html) for more details.
+<<<<<<< HEAD
 * `redrive_policy` - (Optional) JSON String with the redrive policy that will be used in the subscription. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html#how-messages-moved-into-dead-letter-queue) for more details.
+=======
+* `subscription_role_arn` - (Optional) Required ARN of the IAM role to publish to Kinesis Data Firehose delivery stream. Require for `firehose` protocol. Refer to [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/sns-firehose-as-subscriber.html)
+>>>>>>> a95bbe357 (docs update)
 
 ### Protocols supported
 
@@ -248,6 +252,7 @@ Supported SNS protocols include:
 * `sqs` -- delivery of JSON-encoded message to an Amazon SQS queue
 * `application` -- delivery of JSON-encoded message to an EndpointArn for a mobile app and device
 * `sms` -- delivery text message
+* `firehose` -- delivery of JSON-encoded message to an Amazon Kinesis Data Firehose delivery stream
 
 Partially supported SNS protocols include:
 
@@ -269,6 +274,8 @@ Endpoints have different format requirements according to the protocol that is c
 
 * SQS endpoints come in the form of the SQS queue's ARN (not the URL of the queue) e.g: `arn:aws:sqs:us-west-2:432981146916:terraform-queue-too`
 * Application endpoints are also the endpoint ARN for the mobile app and device.
+* Firehose endpoints are in the form of Firehose ARN e.g:
+`arn:aws:firehose:us-east-1:123456789012:deliverystream/ticketUploadStream`
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17303

Output from acceptance testing:
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccAWSSNSTopicSubscription_firehose'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSNSTopicSubscription_firehose -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_firehose
=== PAUSE TestAccAWSSNSTopicSubscription_firehose
=== CONT  TestAccAWSSNSTopicSubscription_firehose
--- PASS: TestAccAWSSNSTopicSubscription_firehose (77.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       77.916s
...
```
