### PR TITLE
Add cloudfront_cache_policy resource

### DIFF
--- a/aws/cloudfront_cache_policy_structure.go
+++ b/aws/cloudfront_cache_policy_structure.go
@@ -1,0 +1,230 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func expandCloudFrontCachePolicyCookieNames(cookieNamesFlat map[string]interface{}) *cloudfront.CookieNames {
+	cookieNames := &cloudfront.CookieNames{}
+
+	var newCookieItems []*string
+	for _, cookie := range cookieNamesFlat["items"].(*schema.Set).List() {
+		newCookieItems = append(newCookieItems, aws.String(cookie.(string)))
+	}
+	cookieNames.Items = newCookieItems
+	cookieNames.Quantity = aws.Int64(int64(len(newCookieItems)))
+
+	return cookieNames
+}
+
+func expandCloudFrontCachePolicyCookiesConfig(cookiesConfigFlat map[string]interface{}) *cloudfront.CachePolicyCookiesConfig {
+	cookies := &cloudfront.CookieNames{
+		Quantity: aws.Int64(int64(0)),
+	}
+
+	if cookiesFlat, ok := cookiesConfigFlat["cookies"].([]interface{}); ok && len(cookiesFlat) == 1 {
+		cookies = expandCloudFrontCachePolicyCookieNames(cookiesFlat[0].(map[string]interface{}))
+	} else {
+		cookies = nil
+	}
+
+	cookiesConfig := &cloudfront.CachePolicyCookiesConfig{
+		CookieBehavior: aws.String(cookiesConfigFlat["cookie_behavior"].(string)),
+		Cookies:        cookies,
+	}
+
+	return cookiesConfig
+}
+
+func expandCloudFrontCachePolicyHeaders(headerNamesFlat map[string]interface{}) *cloudfront.Headers {
+	headers := &cloudfront.Headers{}
+
+	var newHeaderItems []*string
+	for _, header := range headerNamesFlat["items"].(*schema.Set).List() {
+		newHeaderItems = append(newHeaderItems, aws.String(header.(string)))
+	}
+	headers.Items = newHeaderItems
+	headers.Quantity = aws.Int64(int64(len(newHeaderItems)))
+
+	return headers
+}
+
+func expandCloudFrontCachePolicyHeadersConfig(headersConfigFlat map[string]interface{}) *cloudfront.CachePolicyHeadersConfig {
+	headers := &cloudfront.Headers{}
+
+	if headersFlat, ok := headersConfigFlat["headers"].([]interface{}); ok && len(headersFlat) == 1 && headersConfigFlat["header_behavior"] != "none" {
+		headers = expandCloudFrontCachePolicyHeaders(headersFlat[0].(map[string]interface{}))
+	} else {
+		headers = nil
+	}
+
+	headersConfig := &cloudfront.CachePolicyHeadersConfig{
+		HeaderBehavior: aws.String(headersConfigFlat["header_behavior"].(string)),
+		Headers:        headers,
+	}
+
+	return headersConfig
+}
+
+func expandCloudFrontCachePolicyQueryStringNames(queryStringNamesFlat map[string]interface{}) *cloudfront.QueryStringNames {
+	queryStringNames := &cloudfront.QueryStringNames{}
+
+	var newQueryStringItems []*string
+	for _, queryString := range queryStringNamesFlat["items"].(*schema.Set).List() {
+		newQueryStringItems = append(newQueryStringItems, aws.String(queryString.(string)))
+	}
+	queryStringNames.Items = newQueryStringItems
+	queryStringNames.Quantity = aws.Int64(int64(len(newQueryStringItems)))
+
+	return queryStringNames
+}
+
+func expandCloudFrontCachePolicyQueryStringConfig(queryStringConfigFlat map[string]interface{}) *cloudfront.CachePolicyQueryStringsConfig {
+	queryStrings := &cloudfront.QueryStringNames{
+		Quantity: aws.Int64(int64(0)),
+	}
+
+	if queryStringFlat, ok := queryStringConfigFlat["query_strings"].([]interface{}); ok && len(queryStringFlat) == 1 {
+		queryStrings = expandCloudFrontCachePolicyQueryStringNames(queryStringFlat[0].(map[string]interface{}))
+	} else {
+		queryStrings = nil
+	}
+
+	queryStringConfig := &cloudfront.CachePolicyQueryStringsConfig{
+		QueryStringBehavior: aws.String(queryStringConfigFlat["query_string_behavior"].(string)),
+		QueryStrings:        queryStrings,
+	}
+
+	return queryStringConfig
+}
+
+func expandCloudFrontCachePolicyParametersConfig(parameters map[string]interface{}) *cloudfront.ParametersInCacheKeyAndForwardedToOrigin {
+	var cookiesConfig *cloudfront.CachePolicyCookiesConfig
+	var headersConfig *cloudfront.CachePolicyHeadersConfig
+	var queryStringsConfig *cloudfront.CachePolicyQueryStringsConfig
+
+	if cookiesFlat, ok := parameters["cookies_config"].([]interface{}); ok && len(cookiesFlat) == 1 {
+		cookiesConfig = expandCloudFrontCachePolicyCookiesConfig(cookiesFlat[0].(map[string]interface{}))
+	}
+
+	if headersFlat, ok := parameters["headers_config"].([]interface{}); ok && len(headersFlat) == 1 {
+		headersConfig = expandCloudFrontCachePolicyHeadersConfig(headersFlat[0].(map[string]interface{}))
+	}
+
+	if queryStringsFlat, ok := parameters["query_strings_config"].([]interface{}); ok && len(queryStringsFlat) == 1 {
+		queryStringsConfig = expandCloudFrontCachePolicyQueryStringConfig(queryStringsFlat[0].(map[string]interface{}))
+	}
+
+	parametersConfig := &cloudfront.ParametersInCacheKeyAndForwardedToOrigin{
+		CookiesConfig:              cookiesConfig,
+		EnableAcceptEncodingBrotli: aws.Bool(parameters["enable_accept_encoding_brotli"].(bool)),
+		EnableAcceptEncodingGzip:   aws.Bool(parameters["enable_accept_encoding_gzip"].(bool)),
+		HeadersConfig:              headersConfig,
+		QueryStringsConfig:         queryStringsConfig,
+	}
+
+	return parametersConfig
+}
+
+func expandCloudFrontCachePolicyConfig(d *schema.ResourceData) *cloudfront.CachePolicyConfig {
+	parametersConfig := &cloudfront.ParametersInCacheKeyAndForwardedToOrigin{}
+
+	if parametersFlat, ok := d.GetOk("parameters_in_cache_key_and_forwarded_to_origin"); ok {
+		parametersConfig = expandCloudFrontCachePolicyParametersConfig(parametersFlat.([]interface{})[0].(map[string]interface{}))
+	}
+	cachePolicy := &cloudfront.CachePolicyConfig{
+		Comment:                                  aws.String(d.Get("comment").(string)),
+		DefaultTTL:                               aws.Int64(int64(d.Get("default_ttl").(int))),
+		MaxTTL:                                   aws.Int64(int64(d.Get("max_ttl").(int))),
+		MinTTL:                                   aws.Int64(int64(d.Get("min_ttl").(int))),
+		Name:                                     aws.String(d.Get("name").(string)),
+		ParametersInCacheKeyAndForwardedToOrigin: parametersConfig,
+	}
+
+	return cachePolicy
+}
+
+func flattenCloudFrontCachePolicyCookiesConfig(cookiesConfig *cloudfront.CachePolicyCookiesConfig) []map[string]interface{} {
+	cookiesConfigFlat := map[string]interface{}{}
+
+	cookies := []map[string]interface{}{}
+	if cookiesConfig.Cookies != nil {
+		cookies = []map[string]interface{}{
+			{
+				"items": cookiesConfig.Cookies.Items,
+			},
+		}
+	}
+
+	cookiesConfigFlat["cookie_behavior"] = aws.StringValue(cookiesConfig.CookieBehavior)
+	cookiesConfigFlat["cookies"] = cookies
+
+	return []map[string]interface{}{
+		cookiesConfigFlat,
+	}
+}
+
+func flattenCloudFrontCachePolicyHeadersConfig(headersConfig *cloudfront.CachePolicyHeadersConfig) []map[string]interface{} {
+	headersConfigFlat := map[string]interface{}{}
+
+	headers := []map[string]interface{}{}
+	if headersConfig.Headers != nil {
+		headers = []map[string]interface{}{
+			{
+				"items": headersConfig.Headers.Items,
+			},
+		}
+	}
+
+	headersConfigFlat["header_behavior"] = aws.StringValue(headersConfig.HeaderBehavior)
+	headersConfigFlat["headers"] = headers
+
+	return []map[string]interface{}{
+		headersConfigFlat,
+	}
+}
+
+func flattenCloudFrontCachePolicyQueryStringsConfig(queryStringsConfig *cloudfront.CachePolicyQueryStringsConfig) []map[string]interface{} {
+	queryStringsConfigFlat := map[string]interface{}{}
+
+	queryStrings := []map[string]interface{}{}
+	if queryStringsConfig.QueryStrings != nil {
+		queryStrings = []map[string]interface{}{
+			{
+				"items": queryStringsConfig.QueryStrings.Items,
+			},
+		}
+	}
+
+	queryStringsConfigFlat["query_string_behavior"] = aws.StringValue(queryStringsConfig.QueryStringBehavior)
+	queryStringsConfigFlat["query_strings"] = queryStrings
+
+	return []map[string]interface{}{
+		queryStringsConfigFlat,
+	}
+}
+
+func flattenParametersConfig(parametersConfig *cloudfront.ParametersInCacheKeyAndForwardedToOrigin) []map[string]interface{} {
+	parametersConfigFlat := map[string]interface{}{
+		"enable_accept_encoding_brotli": aws.BoolValue(parametersConfig.EnableAcceptEncodingBrotli),
+		"enable_accept_encoding_gzip":   aws.BoolValue(parametersConfig.EnableAcceptEncodingGzip),
+		"cookies_config":                flattenCloudFrontCachePolicyCookiesConfig(parametersConfig.CookiesConfig),
+		"headers_config":                flattenCloudFrontCachePolicyHeadersConfig(parametersConfig.HeadersConfig),
+		"query_strings_config":          flattenCloudFrontCachePolicyQueryStringsConfig(parametersConfig.QueryStringsConfig),
+	}
+
+	return []map[string]interface{}{
+		parametersConfigFlat,
+	}
+}
+
+func flattenCloudFrontCachePolicy(d *schema.ResourceData, cachePolicy *cloudfront.CachePolicyConfig) {
+	d.Set("comment", aws.StringValue(cachePolicy.Comment))
+	d.Set("default_ttl", aws.Int64Value(cachePolicy.DefaultTTL))
+	d.Set("max_ttl", aws.Int64Value(cachePolicy.MaxTTL))
+	d.Set("min_ttl", aws.Int64Value(cachePolicy.MinTTL))
+	d.Set("name", aws.StringValue(cachePolicy.Name))
+	d.Set("parameters_in_cache_key_and_forwarded_to_origin", flattenParametersConfig(cachePolicy.ParametersInCacheKeyAndForwardedToOrigin))
+}

--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -223,13 +223,28 @@ func expandCloudFrontDefaultCacheBehavior(m map[string]interface{}) *cloudfront.
 }
 
 func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
+	var forwardedValues *cloudfront.ForwardedValues
+	if forwardedValuesFlat, ok := m["forwarded_values"].([]interface{}); ok && len(forwardedValuesFlat) == 1 {
+		forwardedValues = expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{}))
+	}
+
+	minTTL := aws.Int64(int64(m["min_ttl"].(int)))
+	maxTTL := aws.Int64(int64(m["max_ttl"].(int)))
+	defaultTTL := aws.Int64(int64(m["default_ttl"].(int)))
+	if m["cache_policy_id"].(string) != "" {
+		minTTL = nil
+		maxTTL = nil
+		defaultTTL = nil
+	}
+
 	cb := &cloudfront.CacheBehavior{
+		CachePolicyId:          aws.String(m["cache_policy_id"].(string)),
 		Compress:               aws.Bool(m["compress"].(bool)),
-		DefaultTTL:             aws.Int64(int64(m["default_ttl"].(int))),
+		DefaultTTL:             defaultTTL,
 		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
-		ForwardedValues:        expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{})),
-		MaxTTL:                 aws.Int64(int64(m["max_ttl"].(int))),
-		MinTTL:                 aws.Int64(int64(m["min_ttl"].(int))),
+		ForwardedValues:        forwardedValues,
+		MaxTTL:                 maxTTL,
+		MinTTL:                 minTTL,
 		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
 		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
 	}
@@ -261,6 +276,7 @@ func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
 
 func flattenCloudFrontDefaultCacheBehavior(dcb *cloudfront.DefaultCacheBehavior) map[string]interface{} {
 	m := map[string]interface{}{
+		"cache_policy_id":           aws.StringValue(dcb.CachePolicyId),
 		"compress":                  aws.BoolValue(dcb.Compress),
 		"field_level_encryption_id": aws.StringValue(dcb.FieldLevelEncryptionId),
 		"viewer_protocol_policy":    aws.StringValue(dcb.ViewerProtocolPolicy),
@@ -299,6 +315,7 @@ func flattenCloudFrontDefaultCacheBehavior(dcb *cloudfront.DefaultCacheBehavior)
 func flattenCacheBehavior(cb *cloudfront.CacheBehavior) map[string]interface{} {
 	m := make(map[string]interface{})
 
+	m["cache_policy_id"] = aws.StringValue(cb.CachePolicyId)
 	m["compress"] = aws.BoolValue(cb.Compress)
 	m["field_level_encryption_id"] = aws.StringValue(cb.FieldLevelEncryptionId)
 	m["viewer_protocol_policy"] = aws.StringValue(cb.ViewerProtocolPolicy)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -483,6 +483,7 @@ func Provider() *schema.Provider {
 			"aws_cloudformation_stack":                                resourceAwsCloudFormationStack(),
 			"aws_cloudformation_stack_set":                            resourceAwsCloudFormationStackSet(),
 			"aws_cloudformation_stack_set_instance":                   resourceAwsCloudFormationStackSetInstance(),
+			"aws_cloudfront_cache_policy":                             resourceAwsCloudFrontCachePolicy(),
 			"aws_cloudfront_distribution":                             resourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_origin_access_identity":                   resourceAwsCloudFrontOriginAccessIdentity(),
 			"aws_cloudfront_public_key":                               resourceAwsCloudFrontPublicKey(),

--- a/aws/resource_aws_cloudfront_cache_policy.go
+++ b/aws/resource_aws_cloudfront_cache_policy.go
@@ -1,0 +1,223 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsCloudFrontCachePolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudFrontCachePolicyCreate,
+		Read:   resourceAwsCloudFrontCachePolicyRead,
+		Update: resourceAwsCloudFrontCachePolicyUpdate,
+		Delete: resourceAwsCloudFrontCachePolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"comment": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"default_ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  86400,
+			},
+			"max_ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  31536000,
+			},
+			"min_ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"parameters_in_cache_key_and_forwarded_to_origin": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cookies_config": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cookie_behavior": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"none", "whitelist", "allExcept", "all"}, false),
+									},
+									"cookies": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"items": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"enable_accept_encoding_brotli": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"enable_accept_encoding_gzip": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"headers_config": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"header_behavior": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"none", "whitelist"}, false),
+									},
+									"headers": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"items": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"query_strings_config": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"query_string_behavior": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"none", "whitelist", "allExcept", "all"}, false),
+									},
+									"query_strings": {
+										Type:     schema.TypeList,
+										MaxItems: 1,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"items": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsCloudFrontCachePolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	request := &cloudfront.CreateCachePolicyInput{
+		CachePolicyConfig: expandCloudFrontCachePolicyConfig(d),
+	}
+
+	resp, err := conn.CreateCachePolicy(request)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(aws.StringValue(resp.CachePolicy.Id))
+
+	return resourceAwsCloudFrontCachePolicyRead(d, meta)
+}
+
+func resourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+	request := &cloudfront.GetCachePolicyInput{
+		Id: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetCachePolicy(request)
+	if err != nil {
+		return err
+	}
+	d.Set("etag", aws.StringValue(resp.ETag))
+
+	flattenCloudFrontCachePolicy(d, resp.CachePolicy.CachePolicyConfig)
+
+	return nil
+}
+
+func resourceAwsCloudFrontCachePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	request := &cloudfront.UpdateCachePolicyInput{
+		CachePolicyConfig: expandCloudFrontCachePolicyConfig(d),
+		Id:                aws.String(d.Id()),
+		IfMatch:           aws.String(d.Get("etag").(string)),
+	}
+
+	_, err := conn.UpdateCachePolicy(request)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsCloudFrontCachePolicyRead(d, meta)
+}
+
+func resourceAwsCloudFrontCachePolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	request := &cloudfront.DeleteCachePolicyInput{
+		Id:      aws.String(d.Id()),
+		IfMatch: aws.String(d.Get("etag").(string)),
+	}
+
+	_, err := conn.DeleteCachePolicy(request)
+	if err != nil {
+		if isAWSErr(err, cloudfront.ErrCodeNoSuchCachePolicy, "") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_cloudfront_cache_policy_test.go
+++ b/aws/resource_aws_cloudfront_cache_policy_test.go
@@ -1,0 +1,208 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSCloudFrontCachePolicy_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontCachePolicyConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "50"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "1"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "100"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
+				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_cache_policy.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontCachePolicy_update(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontCachePolicyConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "50"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "1"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "100"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFrontCachePolicyConfigUpdate(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment updated"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "51"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "2"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "101"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "allExcept"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test2"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "none"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.#", "0"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "allExcept"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test2"),
+				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_cache_policy.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontCachePolicy_noneBehavior(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontCachePolicyConfigNoneBehavior(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "50"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "1"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "100"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "none"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.#", "0"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "none"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.#", "0"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "none"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.#", "0"),
+				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_cache_policy.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func testAccAWSCloudFrontCachePolicyConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_cache_policy" "example" {
+  name        = "test-policy%[1]d"
+  comment     = "test comment"
+  default_ttl = 50
+  max_ttl     = 100
+  min_ttl     = 1
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "whitelist"
+      cookies {
+        items = ["test"]
+      }
+    }
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = ["test"]
+      }
+    }
+    query_strings_config {
+      query_string_behavior = "whitelist"
+      query_strings {
+        items = ["test"]
+      }
+    }
+  }
+}
+`, rInt)
+}
+
+func testAccAWSCloudFrontCachePolicyConfigUpdate(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_cache_policy" "example" {
+  name        = "test-policy-updated%[1]d"
+  comment     = "test comment updated"
+  default_ttl = 51
+  max_ttl     = 101
+  min_ttl     = 2
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "allExcept"
+      cookies {
+        items = ["test2"]
+      }
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "allExcept"
+      query_strings {
+        items = ["test2"]
+      }
+    }
+  }
+}
+`, rInt)
+}
+
+func testAccAWSCloudFrontCachePolicyConfigNoneBehavior(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_cache_policy" "example" {
+  name        = "test-policy-updated%[1]d"
+  comment     = "test comment"
+  default_ttl = 50
+  max_ttl     = 100
+  min_ttl     = 1
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+  }
+}
+`, rInt)
+}

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -58,6 +58,10 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"cache_policy_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"compress": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -66,7 +70,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"default_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  86400,
+							Computed: true,
 						},
 						"field_level_encryption_id": {
 							Type:     schema.TypeString,
@@ -74,7 +78,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						},
 						"forwarded_values": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -104,6 +108,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"headers": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 									"query_string": {
@@ -113,6 +118,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"query_string_cache_keys": {
 										Type:     schema.TypeList,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
@@ -144,7 +150,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"max_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  31536000,
+							Computed: true,
 						},
 						"min_ttl": {
 							Type:     schema.TypeInt,
@@ -220,6 +226,10 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"cache_policy_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"compress": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -258,6 +268,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 												"whitelisted_names": {
 													Type:     schema.TypeSet,
 													Optional: true,
+													Computed: true,
 													Elem:     &schema.Schema{Type: schema.TypeString},
 												},
 											},
@@ -266,6 +277,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"headers": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 									"query_string": {
@@ -275,6 +287,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"query_string_cache_keys": {
 										Type:     schema.TypeList,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
@@ -324,6 +337,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"trusted_signers": {
 							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"viewer_protocol_policy": {
@@ -521,6 +535,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"locations": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 									"restriction_type": {

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -285,6 +285,35 @@ func TestAccAWSCloudFrontDistribution_orderedCacheBehavior(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy(t *testing.T) {
+	var distribution cloudfront.Distribution
+	resourceName := "aws_cloudfront_distribution.main"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontDistributionOrderedCacheBehaviorCachePolicy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "ordered_cache_behavior.0.path_pattern", "images2/*.jpg"),
+					resource.TestMatchResourceAttr(resourceName, "ordered_cache_behavior.0.cache_policy_id", regexp.MustCompile(`^[a-z0-9]+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
@@ -1907,6 +1936,90 @@ resource "aws_cloudfront_distribution" "main" {
 
   %s
 }
+`, acctest.RandInt(), testAccAWSCloudFrontDistributionRetainConfig())
+
+var testAccAWSCloudFrontDistributionOrderedCacheBehaviorCachePolicy = fmt.Sprintf(`
+variable rand_id {
+  default = %d
+}
+
+resource "aws_cloudfront_distribution" "main" {
+  origin {
+    domain_name = "www.hashicorp.com"
+    origin_id   = "myCustomOrigin"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["SSLv3", "TLSv1"]
+    }
+  }
+
+  enabled = true
+  comment = "Some comment"
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "myCustomOrigin"
+    smooth_streaming = true
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+  }
+
+  ordered_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "myCustomOrigin"
+
+    cache_policy_id = aws_cloudfront_cache_policy.cache_policy.id
+
+    viewer_protocol_policy = "allow-all"
+    path_pattern           = "images2/*.jpg"
+  }
+
+  price_class = "PriceClass_All"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  %s
+}
+
+resource "aws_cloudfront_cache_policy" "cache_policy" {
+	name        = "test-policy%[1]d"
+	comment     = "test comment"
+	default_ttl = 50
+	max_ttl     = 100
+	parameters_in_cache_key_and_forwarded_to_origin {
+	  cookies_config {
+		  cookie_behavior = "none"
+		}
+		headers_config {
+		  header_behavior = "none"
+		}
+		query_strings_config {
+		  query_string_behavior = "none"
+		}
+	}
+}
+
 `, acctest.RandInt(), testAccAWSCloudFrontDistributionRetainConfig())
 
 var testAccAWSCloudFrontDistributionOriginGroupsConfig = `

--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -1,0 +1,93 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_cache_policy"
+description: |-
+  Provides a cache policy for a CloudFront ditribution. When it’s attached to a cache behavior, 
+  the cache policy determines the the values that CloudFront includes in the cache key. These 
+  values can include HTTP headers, cookies, and URL query strings. CloudFront uses the cache 
+  key to find an object in its cache that it can return to the viewer. It also determines the 
+  default, minimum, and maximum time to live (TTL) values that you want objects to stay in the 
+  CloudFront cache. 
+---
+
+# Resource: aws_cloudfront_cache_policy
+
+## Example Usage
+
+The following example below creates a CloudFront public key.
+
+```hcl
+resource "aws_cloudfront_cache_policy" "example" {                                  
+  name        = "example-policy"                                                  
+  comment     = "test comment"                                                      
+  default_ttl = 50                                                               
+  max_ttl     = 100                                                                 
+  min_ttl     = 1                                                                   
+  parameters_in_cache_key_and_forwarded_to_origin {                                 
+    cookies_config {                                                                
+      cookie_behavior = "whitelist"                                                 
+      cookies {                                                                     
+        items = [ "example" ]                                                       
+      }                                                                          
+    }                                                                            
+    headers_config {                                                             
+      header_behavior = "whitelist"                                              
+      headers {                                                                  
+        items = [ "example" ]                                                       
+      }                                                                          
+    }                                                                            
+    query_strings_config {                                                       
+      query_string_behavior = "whitelist"                                           
+      query_strings {                                                               
+        items = [ "example" ]                                                          
+      }                                                                             
+    }                                                                               
+  }                                                                              
+}  
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name to identify the cache policy.
+* `min_ttl` - (Required) The minimum amount of time, in seconds, that you want objects to stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated.
+* `max_ttl` - (Optional) The maximum amount of time, in seconds, that objects stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated.
+* `default_ttl` - (Optional) The default amount of time, in seconds, that you want objects to stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated.
+* `comment` - (Optional) A comment to describe the cache policy.
+* `parameters_in_cache_key_and_forwarded_to_origin` - (Optional) The HTTP headers, cookies, and URL query strings to include in the cache key. See [Parameters In Cache Key And Forwarded To Origin](#parameters-in-cache-key-and-forwarded-to-origin) for more information.
+
+### Parameters In Cache Key And Forwarded To Origin
+
+* `cookies_config` - (Required) An object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
+* `cookies_config` - (Required) An object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
+* `cookies_config` - (Required) An object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
+* `enable_accept_encoding_brotli` - (Optional) A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
+* `enable_accept_encoding_gzip` - (Optional) A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
+
+### Cookies Config
+
+`cookie_behavior` - (Required) Determines whether any cookies in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
+`cookies` - (Optional) An object that contains a list of cookie names. See [Items](#items) for more information.
+
+### Headers Config
+
+`header_behavior` - (Required) Determines whether any HTTP headers are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`.
+`headers` - (Optional) An object that contains a list of header names. See [Items](#items) for more information.
+
+### Query String Config
+
+`query_string_behavior` - (Required) Determines whether any URL query strings in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
+`query_strings` - (Optional) An object that contains a list of query string names. See [Items](#items) for more information.
+
+### Items
+
+`items` - (Required) A list of item names (cookies, headers, or query strings).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `etag` - The current version of the cache policy.
+* `id` - The identifier for the cache policy. 

--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-The following example below creates a CloudFront public key.
+The following example below creates a CloudFront cache policy.
 
 ```hcl
 resource "aws_cloudfront_cache_policy" "example" {                                  

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -271,6 +271,9 @@ of several sub-resources - these resources are laid out below.
 * `cached_methods` (Required) - Controls whether CloudFront caches the
     response to requests using the specified HTTP methods.
 
+* `cache_policy_id` (Optional) - The unique identifier of the cache policy that
+    is attached to the cache behavior.
+
 * `compress` (Optional) - Whether you want CloudFront to automatically
     compress content for web requests that include `Accept-Encoding: gzip` in
     the request header (default: `false`).


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #14373

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontDistribution_ -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_disappears
=== PAUSE TestAccAWSCloudFrontDistribution_disappears
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
=== PAUSE TestAccAWSCloudFrontDistribution_S3Origin
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== PAUSE TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_customOrigin
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_multiOrigin
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
=== PAUSE TestAccAWSCloudFrontDistribution_HTTP11Config
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== PAUSE TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== RUN   TestAccAWSCloudFrontDistribution_Enabled
=== PAUSE TestAccAWSCloudFrontDistribution_Enabled
=== RUN   TestAccAWSCloudFrontDistribution_RetainOnDelete
=== PAUSE TestAccAWSCloudFrontDistribution_RetainOnDelete
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccAWSCloudFrontDistribution_WaitForDeployment
=== PAUSE TestAccAWSCloudFrontDistribution_WaitForDeployment
=== RUN   TestAccAWSCloudFrontDistribution_OriginGroups
=== PAUSE TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_disappears
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_Enabled
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== CONT  TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== CONT  TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== CONT  TestAccAWSCloudFrontDistribution_HTTP11Config
=== CONT  TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== CONT  TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_WaitForDeployment
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== CONT  TestAccAWSCloudFrontDistribution_multiOrigin
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== CONT  TestAccAWSCloudFrontDistribution_RetainOnDelete
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (2.48s)
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (2.57s)
=== CONT  TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (181.82s)
=== CONT  TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (189.79s)
=== CONT  TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (191.64s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (194.28s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (205.76s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (212.63s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (218.51s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (224.00s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (332.41s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (338.10s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (338.61s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (340.35s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (363.33s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (372.26s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (372.13s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy (375.30s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (386.71s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (440.79s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (300.25s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (322.06s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (511.21s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (543.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	543.842s


==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontCachePolicy_ -timeout 120m
=== RUN   TestAccAWSCloudFrontCachePolicy_basic
=== PAUSE TestAccAWSCloudFrontCachePolicy_basic
=== RUN   TestAccAWSCloudFrontCachePolicy_update
=== PAUSE TestAccAWSCloudFrontCachePolicy_update
=== RUN   TestAccAWSCloudFrontCachePolicy_noneBehavior
=== PAUSE TestAccAWSCloudFrontCachePolicy_noneBehavior
=== CONT  TestAccAWSCloudFrontCachePolicy_basic
=== CONT  TestAccAWSCloudFrontCachePolicy_noneBehavior
=== CONT  TestAccAWSCloudFrontCachePolicy_update
--- PASS: TestAccAWSCloudFrontCachePolicy_basic (14.56s)
--- PASS: TestAccAWSCloudFrontCachePolicy_noneBehavior (14.59s)
--- PASS: TestAccAWSCloudFrontCachePolicy_update (24.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.394s

```
