### PR TITLE
r/glue_catalog_table - add support for specifying schema

### DIFF
--- a/.changelog/17335.txt
+++ b/.changelog/17335.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_catalog_table: Adds support for specifying schema from schema registry.
+```

--- a/aws/internal/service/glue/finder/finder.go
+++ b/aws/internal/service/glue/finder/finder.go
@@ -6,6 +6,22 @@ import (
 	tfglue "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/glue"
 )
 
+// TableByName returns the Table corresponding to the specified name.
+func TableByName(conn *glue.Glue, catalogID, dbName, name string) (*glue.GetTableOutput, error) {
+	input := &glue.GetTableInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		Name:         aws.String(name),
+	}
+
+	output, err := conn.GetTable(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
 // RegistryByID returns the Registry corresponding to the specified ID.
 func RegistryByID(conn *glue.Glue, id string) (*glue.GetRegistryOutput, error) {
 	input := &glue.GetRegistryInput{

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -108,6 +108,7 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 						"columns": {
 							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"comment": {
@@ -206,8 +207,9 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 													ExactlyOneOf: []string{"storage_descriptor.0.schema_reference.0.schema_id.0.schema_arn", "storage_descriptor.0.schema_reference.0.schema_id.0.schema_name"},
 												},
 												"registry_name": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:          schema.TypeString,
+													Optional:      true,
+													ConflictsWith: []string{"storage_descriptor.0.schema_reference.0.schema_id.0.schema_arn"},
 												},
 											},
 										},
@@ -219,7 +221,7 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 									},
 									"schema_version_number": {
 										Type:         schema.TypeInt,
-										Optional:     true,
+										Required:     true,
 										ValidateFunc: validation.IntBetween(1, 100000),
 									},
 								},

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/glue/finder"
 )
 
 func resourceAwsGlueCatalogTable() *schema.Resource {
@@ -181,6 +182,49 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 								},
 							},
 						},
+						"schema_reference": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"schema_id": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"schema_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateArn,
+													ExactlyOneOf: []string{"storage_descriptor.0.schema_reference.0.schema_id.0.schema_arn", "storage_descriptor.0.schema_reference.0.schema_id.0.schema_name"},
+												},
+												"schema_name": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ExactlyOneOf: []string{"storage_descriptor.0.schema_reference.0.schema_id.0.schema_arn", "storage_descriptor.0.schema_reference.0.schema_id.0.schema_name"},
+												},
+												"registry_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+									"schema_version_id": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ExactlyOneOf: []string{"storage_descriptor.0.schema_reference.0.schema_version_id", "storage_descriptor.0.schema_reference.0.schema_id"},
+									},
+									"schema_version_number": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 100000),
+									},
+								},
+							},
+						},
 						"skewed_info": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -316,13 +360,7 @@ func resourceAwsGlueCatalogTableRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	input := &glue.GetTableInput{
-		CatalogId:    aws.String(catalogID),
-		DatabaseName: aws.String(dbName),
-		Name:         aws.String(name),
-	}
-
-	out, err := conn.GetTable(input)
+	out, err := finder.TableByName(conn, catalogID, dbName, name)
 	if err != nil {
 
 		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
@@ -548,6 +586,10 @@ func expandGlueStorageDescriptor(l []interface{}) *glue.StorageDescriptor {
 		storageDescriptor.StoredAsSubDirectories = aws.Bool(v.(bool))
 	}
 
+	if v, ok := s["schema_reference"]; ok {
+		storageDescriptor.SchemaReference = expandGlueTableSchemaReference(v.([]interface{}))
+	}
+
 	return storageDescriptor
 }
 
@@ -644,6 +686,52 @@ func expandGlueSkewedInfo(l []interface{}) *glue.SkewedInfo {
 	return skewedInfo
 }
 
+func expandGlueTableSchemaReference(l []interface{}) *glue.SchemaReference {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	s := l[0].(map[string]interface{})
+	schemaRef := &glue.SchemaReference{}
+
+	if v, ok := s["schema_version_id"].(string); ok && v != "" {
+		schemaRef.SchemaVersionId = aws.String(v)
+	}
+
+	if v, ok := s["schema_id"]; ok {
+		schemaRef.SchemaId = expandGlueTableSchemaReferenceSchemaID(v.([]interface{}))
+	}
+
+	if v, ok := s["schema_version_number"].(int); ok {
+		schemaRef.SchemaVersionNumber = aws.Int64(int64(v))
+	}
+
+	return schemaRef
+}
+
+func expandGlueTableSchemaReferenceSchemaID(l []interface{}) *glue.SchemaId {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	s := l[0].(map[string]interface{})
+	schemaID := &glue.SchemaId{}
+
+	if v, ok := s["registry_name"].(string); ok && v != "" {
+		schemaID.RegistryName = aws.String(v)
+	}
+
+	if v, ok := s["schema_name"].(string); ok && v != "" {
+		schemaID.SchemaName = aws.String(v)
+	}
+
+	if v, ok := s["schema_arn"].(string); ok && v != "" {
+		schemaID.SchemaArn = aws.String(v)
+	}
+
+	return schemaID
+}
+
 func flattenGlueStorageDescriptor(s *glue.StorageDescriptor) []map[string]interface{} {
 	if s == nil {
 		storageDescriptors := make([]map[string]interface{}, 0)
@@ -665,6 +753,7 @@ func flattenGlueStorageDescriptor(s *glue.StorageDescriptor) []map[string]interf
 	storageDescriptor["sort_columns"] = flattenGlueOrders(s.SortColumns)
 	storageDescriptor["parameters"] = aws.StringValueMap(s.Parameters)
 	storageDescriptor["skewed_info"] = flattenGlueSkewedInfo(s.SkewedInfo)
+	storageDescriptor["schema_reference"] = flattenGlueTableSchemaReference(s.SchemaReference)
 	storageDescriptor["stored_as_sub_directories"] = aws.BoolValue(s.StoredAsSubDirectories)
 
 	storageDescriptors[0] = storageDescriptor
@@ -796,4 +885,58 @@ func flattenGlueSkewedInfo(s *glue.SkewedInfo) []map[string]interface{} {
 	skewedInfoSlice[0] = skewedInfo
 
 	return skewedInfoSlice
+}
+
+func flattenGlueTableSchemaReference(s *glue.SchemaReference) []map[string]interface{} {
+	if s == nil {
+		schemaReferenceInfoSlice := make([]map[string]interface{}, 0)
+		return schemaReferenceInfoSlice
+	}
+
+	schemaReferenceInfoSlice := make([]map[string]interface{}, 1)
+
+	schemaReferenceInfo := make(map[string]interface{})
+
+	if s.SchemaVersionId != nil {
+		schemaReferenceInfo["schema_version_id"] = aws.StringValue(s.SchemaVersionId)
+	}
+
+	if s.SchemaVersionNumber != nil {
+		schemaReferenceInfo["schema_version_number"] = aws.Int64Value(s.SchemaVersionNumber)
+	}
+
+	if s.SchemaId != nil {
+		schemaReferenceInfo["schema_id"] = flattenGlueTableSchemaReferenceSchemaID(s.SchemaId)
+	}
+
+	schemaReferenceInfoSlice[0] = schemaReferenceInfo
+
+	return schemaReferenceInfoSlice
+}
+
+func flattenGlueTableSchemaReferenceSchemaID(s *glue.SchemaId) []map[string]interface{} {
+	if s == nil {
+		schemaIDInfoSlice := make([]map[string]interface{}, 0)
+		return schemaIDInfoSlice
+	}
+
+	schemaIDInfoSlice := make([]map[string]interface{}, 1)
+
+	schemaIDInfo := make(map[string]interface{})
+
+	if s.RegistryName != nil {
+		schemaIDInfo["registry_name"] = aws.StringValue(s.RegistryName)
+	}
+
+	if s.SchemaArn != nil {
+		schemaIDInfo["schema_arn"] = aws.StringValue(s.SchemaArn)
+	}
+
+	if s.SchemaName != nil {
+		schemaIDInfo["schema_name"] = aws.StringValue(s.SchemaName)
+	}
+
+	schemaIDInfoSlice[0] = schemaIDInfo
+
+	return schemaIDInfoSlice
 }

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -445,6 +445,11 @@ func TestAccAWSGlueCatalogTable_StorageDescriptor_schemaReference(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.#", "2"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -468,6 +473,11 @@ func TestAccAWSGlueCatalogTable_StorageDescriptor_schemaReferenceArn(t *testing.
 					resource.TestCheckResourceAttrPair(resourceName, "storage_descriptor.0.schema_reference.0.schema_id.0.schema_arn", "aws_glue_schema.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -897,13 +897,13 @@ resource "aws_glue_catalog_table" "test" {
 
   storage_descriptor {
     schema_reference {
-	  schema_id {
+      schema_id {
         schema_name   = aws_glue_schema.test.schema_name
-        registry_name = aws_glue_schema.test.registry_name		  
-	  }
-	  
-	  schema_version_number = aws_glue_schema.test.latest_schema_version
-	}
+        registry_name = aws_glue_schema.test.registry_name
+      }
+
+      schema_version_number = aws_glue_schema.test.latest_schema_version
+    }
   }
 }
 `, rName)
@@ -933,12 +933,12 @@ resource "aws_glue_catalog_table" "test" {
 
   storage_descriptor {
     schema_reference {
-	  schema_id {
+      schema_id {
         schema_arn = aws_glue_schema.test.arn
-	  }
-	  
-	  schema_version_number = aws_glue_schema.test.latest_schema_version
-	}
+      }
+
+      schema_version_number = aws_glue_schema.test.latest_schema_version
+    }
   }
 }
 `, rName)

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -334,8 +334,6 @@ func TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock(t *tes
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueCatalogTableExists(resourceName),
 				),
-				// Expect non-empty instead of panic
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/glue/finder"
 )
 
 func TestAccAWSGlueCatalogTable_basic(t *testing.T) {
@@ -895,12 +896,7 @@ func testAccCheckGlueTableDestroy(s *terraform.State) error {
 			return err
 		}
 
-		input := &glue.GetTableInput{
-			DatabaseName: aws.String(dbName),
-			CatalogId:    aws.String(catalogId),
-			Name:         aws.String(resourceName),
-		}
-		if _, err := conn.GetTable(input); err != nil {
+		if _, err := finder.TableByName(conn, catalogId, dbName, resourceName); err != nil {
 			//Verify the error is what we want
 			if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
 				continue
@@ -930,12 +926,7 @@ func testAccCheckGlueCatalogTableExists(name string) resource.TestCheckFunc {
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).glueconn
-		out, err := conn.GetTable(&glue.GetTableInput{
-			CatalogId:    aws.String(catalogId),
-			DatabaseName: aws.String(dbName),
-			Name:         aws.String(resourceName),
-		})
-
+		out, err := finder.TableByName(conn, catalogId, dbName, resourceName)
 		if err != nil {
 			return err
 		}

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -123,6 +123,7 @@ The following arguments are supported:
 * `parameters` - (Optional) User-supplied properties in key-value form.
 * `skewed_info` - (Optional) Information about values that appear very frequently in a column (skewed values).
 * `stored_as_sub_directories` - (Optional) True if the table data is stored in subdirectories, or False if not.
+* `schema_reference` - (Optional) An object that references a schema stored in the AWS Glue Schema Registry. When creating a table, you can pass an empty list of columns for the schema, and instead use a schema reference. See [Schema Reference](#schema-reference) below.
 
 ##### Column
 
@@ -148,6 +149,17 @@ The following arguments are supported:
 * `skewed_column_value_location_maps` - (Optional) A list of values that appear so frequently as to be considered skewed.
 * `skewed_column_values` - (Optional) A map of skewed values to the columns that contain them.
 
+##### Schema Reference
+
+* `schema_id` - (Optional) A structure that contains schema identity fields. Either this or the `schema_version_id` has to be provided. See [Schema ID](#schema-id) below.
+* `schema_version_id` - (Optional) The unique ID assigned to a version of the schema. Either this or the `schema_id` has to be provided.
+* `schema_version_number` - (Required) The version number of the schema.
+
+###### Schema ID
+
+* `schema_arn` - (Optional) The Amazon Resource Name (ARN) of the schema. One of `schema_arn` or `schema_name` has to be provided.
+* `schema_name` - (Optional) The name of the schema. One of `schema_arn` or `schema_name` has to be provided.
+* `registry_name` - (Optional) The name of the schema registry that contains the schema. Must be provided when `schema_name` is specified and conflicts with `schema_arn`.
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -160,6 +160,7 @@ The following arguments are supported:
 * `schema_arn` - (Optional) The Amazon Resource Name (ARN) of the schema. One of `schema_arn` or `schema_name` has to be provided.
 * `schema_name` - (Optional) The name of the schema. One of `schema_arn` or `schema_name` has to be provided.
 * `registry_name` - (Optional) The name of the schema registry that contains the schema. Must be provided when `schema_name` is specified and conflicts with `schema_arn`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17302

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCatalogTable_'
--- PASS: TestAccAWSGlueCatalogTable_disappears_database (33.80s)
--- PASS: TestAccAWSGlueCatalogTable_disappears (37.91s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock (38.69s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock (38.69s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock (40.98s)
--- PASS: TestAccAWSGlueCatalogTable_partitionIndexesSingle (45.24s)
--- PASS: TestAccAWSGlueCatalogTable_full (46.48s)
--- PASS: TestAccAWSGlueCatalogTable_columnParameters (46.78s)
--- PASS: TestAccAWSGlueCatalogTable_basic (47.16s)
--- PASS: TestAccAWSGlueCatalogTable_partitionIndexesMultiple (48.08s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_schemaReferenceArn (60.65s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_schemaReference (61.27s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_UpdateValues (75.00s)
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (75.84s)
--- PASS: TestAccAWSGlueCatalogTable_update_replaceValues (75.95s)
```
