### PR TITLE
CloudFront Cache Policy

### DIFF
--- a/.changelog/17336.txt
+++ b/.changelog/17336.txt
@@ -1,0 +1,11 @@
+```release-note:new-data-source
+aws_cloudfront_cache_policy
+```
+
+```release-note:new-resource
+aws_cloudfront_cache_policy
+```
+
+```release-note:enhancement
+resource/aws_cloudfront_distribution: Add `cache_policy_id` attribute
+```

--- a/aws/cloudfront_cache_policy_structure.go
+++ b/aws/cloudfront_cache_policy_structure.go
@@ -6,102 +6,133 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func expandCloudFrontCachePolicyCookieNames(cookieNamesFlat map[string]interface{}) *cloudfront.CookieNames {
-	cookieNames := &cloudfront.CookieNames{}
-
-	var newCookieItems []*string
-	for _, cookie := range cookieNamesFlat["items"].(*schema.Set).List() {
-		newCookieItems = append(newCookieItems, aws.String(cookie.(string)))
+func expandCloudFrontCachePolicyCookieNames(tfMap map[string]interface{}) *cloudfront.CookieNames {
+	if tfMap == nil {
+		return nil
 	}
-	cookieNames.Items = newCookieItems
-	cookieNames.Quantity = aws.Int64(int64(len(newCookieItems)))
 
-	return cookieNames
+	var items []*string
+	for _, item := range tfMap["items"].(*schema.Set).List() {
+		items = append(items, aws.String(item.(string)))
+	}
+
+	apiObject := &cloudfront.CookieNames{
+		Items:    items,
+		Quantity: aws.Int64(int64(len(items))),
+	}
+
+	return apiObject
 }
 
-func expandCloudFrontCachePolicyCookiesConfig(cookiesConfigFlat map[string]interface{}) *cloudfront.CachePolicyCookiesConfig {
-	cookiesConfig := &cloudfront.CachePolicyCookiesConfig{
-		CookieBehavior: aws.String(cookiesConfigFlat["cookie_behavior"].(string)),
+func expandCloudFrontCachePolicyCookiesConfig(tfMap map[string]interface{}) *cloudfront.CachePolicyCookiesConfig {
+	if tfMap == nil {
+		return nil
 	}
 
-	if cookiesFlat, ok := cookiesConfigFlat["cookies"].([]interface{}); ok && len(cookiesFlat) == 1 {
-		cookiesConfig.Cookies = expandCloudFrontCachePolicyCookieNames(cookiesFlat[0].(map[string]interface{}))
+	apiObject := &cloudfront.CachePolicyCookiesConfig{
+		CookieBehavior: aws.String(tfMap["cookie_behavior"].(string)),
 	}
 
-	return cookiesConfig
+	if items, ok := tfMap["cookies"].([]interface{}); ok && len(items) == 1 {
+		apiObject.Cookies = expandCloudFrontCachePolicyCookieNames(items[0].(map[string]interface{}))
+	}
+
+	return apiObject
 }
 
-func expandCloudFrontCachePolicyHeaders(headerNamesFlat map[string]interface{}) *cloudfront.Headers {
-	headers := &cloudfront.Headers{}
-
-	var newHeaderItems []*string
-	for _, header := range headerNamesFlat["items"].(*schema.Set).List() {
-		newHeaderItems = append(newHeaderItems, aws.String(header.(string)))
+func expandCloudFrontCachePolicyHeaders(tfMap map[string]interface{}) *cloudfront.Headers {
+	if tfMap == nil {
+		return nil
 	}
-	headers.Items = newHeaderItems
-	headers.Quantity = aws.Int64(int64(len(newHeaderItems)))
 
-	return headers
+	var items []*string
+	for _, item := range tfMap["items"].(*schema.Set).List() {
+		items = append(items, aws.String(item.(string)))
+	}
+
+	apiObject := &cloudfront.Headers{
+		Items:    items,
+		Quantity: aws.Int64(int64(len(items))),
+	}
+
+	return apiObject
 }
 
-func expandCloudFrontCachePolicyHeadersConfig(headersConfigFlat map[string]interface{}) *cloudfront.CachePolicyHeadersConfig {
-	headersConfig := &cloudfront.CachePolicyHeadersConfig{
-		HeaderBehavior: aws.String(headersConfigFlat["header_behavior"].(string)),
+func expandCloudFrontCachePolicyHeadersConfig(tfMap map[string]interface{}) *cloudfront.CachePolicyHeadersConfig {
+	if tfMap == nil {
+		return nil
 	}
 
-	if headersFlat, ok := headersConfigFlat["headers"].([]interface{}); ok && len(headersFlat) == 1 && headersConfigFlat["header_behavior"] != "none" {
-		headersConfig.Headers = expandCloudFrontCachePolicyHeaders(headersFlat[0].(map[string]interface{}))
+	apiObject := &cloudfront.CachePolicyHeadersConfig{
+		HeaderBehavior: aws.String(tfMap["header_behavior"].(string)),
 	}
 
-	return headersConfig
+	if items, ok := tfMap["headers"].([]interface{}); ok && len(items) == 1 && tfMap["header_behavior"] != "none" {
+		apiObject.Headers = expandCloudFrontCachePolicyHeaders(items[0].(map[string]interface{}))
+	}
+
+	return apiObject
 }
 
-func expandCloudFrontCachePolicyQueryStringNames(queryStringNamesFlat map[string]interface{}) *cloudfront.QueryStringNames {
-	queryStringNames := &cloudfront.QueryStringNames{}
-
-	var newQueryStringItems []*string
-	for _, queryString := range queryStringNamesFlat["items"].(*schema.Set).List() {
-		newQueryStringItems = append(newQueryStringItems, aws.String(queryString.(string)))
+func expandCloudFrontCachePolicyQueryStringNames(tfMap map[string]interface{}) *cloudfront.QueryStringNames {
+	if tfMap == nil {
+		return nil
 	}
-	queryStringNames.Items = newQueryStringItems
-	queryStringNames.Quantity = aws.Int64(int64(len(newQueryStringItems)))
 
-	return queryStringNames
+	var items []*string
+	for _, queryStringitesm := range tfMap["items"].(*schema.Set).List() {
+		items = append(items, aws.String(queryStringitesm.(string)))
+	}
+
+	apiObject := &cloudfront.QueryStringNames{
+		Items:    items,
+		Quantity: aws.Int64(int64(len(items))),
+	}
+
+	return apiObject
 }
 
-func expandCloudFrontCachePolicyQueryStringConfig(queryStringConfigFlat map[string]interface{}) *cloudfront.CachePolicyQueryStringsConfig {
-	queryStringConfig := &cloudfront.CachePolicyQueryStringsConfig{
-		QueryStringBehavior: aws.String(queryStringConfigFlat["query_string_behavior"].(string)),
+func expandCloudFrontCachePolicyQueryStringConfig(tfMap map[string]interface{}) *cloudfront.CachePolicyQueryStringsConfig {
+	if tfMap == nil {
+		return nil
 	}
 
-	if queryStringFlat, ok := queryStringConfigFlat["query_strings"].([]interface{}); ok && len(queryStringFlat) == 1 {
-		queryStringConfig.QueryStrings = expandCloudFrontCachePolicyQueryStringNames(queryStringFlat[0].(map[string]interface{}))
+	apiObject := &cloudfront.CachePolicyQueryStringsConfig{
+		QueryStringBehavior: aws.String(tfMap["query_string_behavior"].(string)),
 	}
 
-	return queryStringConfig
+	if items, ok := tfMap["query_strings"].([]interface{}); ok && len(items) == 1 {
+		apiObject.QueryStrings = expandCloudFrontCachePolicyQueryStringNames(items[0].(map[string]interface{}))
+	}
+
+	return apiObject
 }
 
-func expandCloudFrontCachePolicyParametersConfig(parameters map[string]interface{}) *cloudfront.ParametersInCacheKeyAndForwardedToOrigin {
+func expandCloudFrontCachePolicyParametersConfig(tfMap map[string]interface{}) *cloudfront.ParametersInCacheKeyAndForwardedToOrigin {
+	if tfMap == nil {
+		return nil
+	}
+
 	var cookiesConfig *cloudfront.CachePolicyCookiesConfig
 	var headersConfig *cloudfront.CachePolicyHeadersConfig
 	var queryStringsConfig *cloudfront.CachePolicyQueryStringsConfig
 
-	if cookiesFlat, ok := parameters["cookies_config"].([]interface{}); ok && len(cookiesFlat) == 1 {
+	if cookiesFlat, ok := tfMap["cookies_config"].([]interface{}); ok && len(cookiesFlat) == 1 {
 		cookiesConfig = expandCloudFrontCachePolicyCookiesConfig(cookiesFlat[0].(map[string]interface{}))
 	}
 
-	if headersFlat, ok := parameters["headers_config"].([]interface{}); ok && len(headersFlat) == 1 {
+	if headersFlat, ok := tfMap["headers_config"].([]interface{}); ok && len(headersFlat) == 1 {
 		headersConfig = expandCloudFrontCachePolicyHeadersConfig(headersFlat[0].(map[string]interface{}))
 	}
 
-	if queryStringsFlat, ok := parameters["query_strings_config"].([]interface{}); ok && len(queryStringsFlat) == 1 {
+	if queryStringsFlat, ok := tfMap["query_strings_config"].([]interface{}); ok && len(queryStringsFlat) == 1 {
 		queryStringsConfig = expandCloudFrontCachePolicyQueryStringConfig(queryStringsFlat[0].(map[string]interface{}))
 	}
 
 	parametersConfig := &cloudfront.ParametersInCacheKeyAndForwardedToOrigin{
 		CookiesConfig:              cookiesConfig,
-		EnableAcceptEncodingBrotli: aws.Bool(parameters["enable_accept_encoding_brotli"].(bool)),
-		EnableAcceptEncodingGzip:   aws.Bool(parameters["enable_accept_encoding_gzip"].(bool)),
+		EnableAcceptEncodingBrotli: aws.Bool(tfMap["enable_accept_encoding_brotli"].(bool)),
+		EnableAcceptEncodingGzip:   aws.Bool(tfMap["enable_accept_encoding_gzip"].(bool)),
 		HeadersConfig:              headersConfig,
 		QueryStringsConfig:         queryStringsConfig,
 	}

--- a/aws/cloudfront_cache_policy_structure.go
+++ b/aws/cloudfront_cache_policy_structure.go
@@ -20,17 +20,12 @@ func expandCloudFrontCachePolicyCookieNames(cookieNamesFlat map[string]interface
 }
 
 func expandCloudFrontCachePolicyCookiesConfig(cookiesConfigFlat map[string]interface{}) *cloudfront.CachePolicyCookiesConfig {
-	var cookies *cloudfront.CookieNames
-
-	if cookiesFlat, ok := cookiesConfigFlat["cookies"].([]interface{}); ok && len(cookiesFlat) == 1 {
-		cookies = expandCloudFrontCachePolicyCookieNames(cookiesFlat[0].(map[string]interface{}))
-	} else {
-		cookies = nil
-	}
-
 	cookiesConfig := &cloudfront.CachePolicyCookiesConfig{
 		CookieBehavior: aws.String(cookiesConfigFlat["cookie_behavior"].(string)),
-		Cookies:        cookies,
+	}
+
+	if cookiesFlat, ok := cookiesConfigFlat["cookies"].([]interface{}); ok && len(cookiesFlat) == 1 {
+		cookiesConfig.Cookies = expandCloudFrontCachePolicyCookieNames(cookiesFlat[0].(map[string]interface{}))
 	}
 
 	return cookiesConfig
@@ -50,17 +45,12 @@ func expandCloudFrontCachePolicyHeaders(headerNamesFlat map[string]interface{}) 
 }
 
 func expandCloudFrontCachePolicyHeadersConfig(headersConfigFlat map[string]interface{}) *cloudfront.CachePolicyHeadersConfig {
-	var headers *cloudfront.Headers
-
-	if headersFlat, ok := headersConfigFlat["headers"].([]interface{}); ok && len(headersFlat) == 1 && headersConfigFlat["header_behavior"] != "none" {
-		headers = expandCloudFrontCachePolicyHeaders(headersFlat[0].(map[string]interface{}))
-	} else {
-		headers = nil
-	}
-
 	headersConfig := &cloudfront.CachePolicyHeadersConfig{
 		HeaderBehavior: aws.String(headersConfigFlat["header_behavior"].(string)),
-		Headers:        headers,
+	}
+
+	if headersFlat, ok := headersConfigFlat["headers"].([]interface{}); ok && len(headersFlat) == 1 && headersConfigFlat["header_behavior"] != "none" {
+		headersConfig.Headers = expandCloudFrontCachePolicyHeaders(headersFlat[0].(map[string]interface{}))
 	}
 
 	return headersConfig
@@ -80,17 +70,12 @@ func expandCloudFrontCachePolicyQueryStringNames(queryStringNamesFlat map[string
 }
 
 func expandCloudFrontCachePolicyQueryStringConfig(queryStringConfigFlat map[string]interface{}) *cloudfront.CachePolicyQueryStringsConfig {
-	var queryStrings *cloudfront.QueryStringNames
-
-	if queryStringFlat, ok := queryStringConfigFlat["query_strings"].([]interface{}); ok && len(queryStringFlat) == 1 {
-		queryStrings = expandCloudFrontCachePolicyQueryStringNames(queryStringFlat[0].(map[string]interface{}))
-	} else {
-		queryStrings = nil
-	}
-
 	queryStringConfig := &cloudfront.CachePolicyQueryStringsConfig{
 		QueryStringBehavior: aws.String(queryStringConfigFlat["query_string_behavior"].(string)),
-		QueryStrings:        queryStrings,
+	}
+
+	if queryStringFlat, ok := queryStringConfigFlat["query_strings"].([]interface{}); ok && len(queryStringFlat) == 1 {
+		queryStringConfig.QueryStrings = expandCloudFrontCachePolicyQueryStringNames(queryStringFlat[0].(map[string]interface{}))
 	}
 
 	return queryStringConfig
@@ -202,7 +187,7 @@ func flattenCloudFrontCachePolicyQueryStringsConfig(queryStringsConfig *cloudfro
 	}
 }
 
-func flattenParametersConfig(parametersConfig *cloudfront.ParametersInCacheKeyAndForwardedToOrigin) []map[string]interface{} {
+func setParametersConfig(parametersConfig *cloudfront.ParametersInCacheKeyAndForwardedToOrigin) []map[string]interface{} {
 	parametersConfigFlat := map[string]interface{}{
 		"enable_accept_encoding_brotli": aws.BoolValue(parametersConfig.EnableAcceptEncodingBrotli),
 		"enable_accept_encoding_gzip":   aws.BoolValue(parametersConfig.EnableAcceptEncodingGzip),
@@ -216,11 +201,11 @@ func flattenParametersConfig(parametersConfig *cloudfront.ParametersInCacheKeyAn
 	}
 }
 
-func flattenCloudFrontCachePolicy(d *schema.ResourceData, cachePolicy *cloudfront.CachePolicyConfig) {
+func setCloudFrontCachePolicy(d *schema.ResourceData, cachePolicy *cloudfront.CachePolicyConfig) {
 	d.Set("comment", aws.StringValue(cachePolicy.Comment))
 	d.Set("default_ttl", aws.Int64Value(cachePolicy.DefaultTTL))
 	d.Set("max_ttl", aws.Int64Value(cachePolicy.MaxTTL))
 	d.Set("min_ttl", aws.Int64Value(cachePolicy.MinTTL))
 	d.Set("name", aws.StringValue(cachePolicy.Name))
-	d.Set("parameters_in_cache_key_and_forwarded_to_origin", flattenParametersConfig(cachePolicy.ParametersInCacheKeyAndForwardedToOrigin))
+	d.Set("parameters_in_cache_key_and_forwarded_to_origin", setParametersConfig(cachePolicy.ParametersInCacheKeyAndForwardedToOrigin))
 }

--- a/aws/cloudfront_cache_policy_structure.go
+++ b/aws/cloudfront_cache_policy_structure.go
@@ -20,9 +20,7 @@ func expandCloudFrontCachePolicyCookieNames(cookieNamesFlat map[string]interface
 }
 
 func expandCloudFrontCachePolicyCookiesConfig(cookiesConfigFlat map[string]interface{}) *cloudfront.CachePolicyCookiesConfig {
-	cookies := &cloudfront.CookieNames{
-		Quantity: aws.Int64(int64(0)),
-	}
+	var cookies *cloudfront.CookieNames
 
 	if cookiesFlat, ok := cookiesConfigFlat["cookies"].([]interface{}); ok && len(cookiesFlat) == 1 {
 		cookies = expandCloudFrontCachePolicyCookieNames(cookiesFlat[0].(map[string]interface{}))
@@ -52,7 +50,7 @@ func expandCloudFrontCachePolicyHeaders(headerNamesFlat map[string]interface{}) 
 }
 
 func expandCloudFrontCachePolicyHeadersConfig(headersConfigFlat map[string]interface{}) *cloudfront.CachePolicyHeadersConfig {
-	headers := &cloudfront.Headers{}
+	var headers *cloudfront.Headers
 
 	if headersFlat, ok := headersConfigFlat["headers"].([]interface{}); ok && len(headersFlat) == 1 && headersConfigFlat["header_behavior"] != "none" {
 		headers = expandCloudFrontCachePolicyHeaders(headersFlat[0].(map[string]interface{}))
@@ -82,9 +80,7 @@ func expandCloudFrontCachePolicyQueryStringNames(queryStringNamesFlat map[string
 }
 
 func expandCloudFrontCachePolicyQueryStringConfig(queryStringConfigFlat map[string]interface{}) *cloudfront.CachePolicyQueryStringsConfig {
-	queryStrings := &cloudfront.QueryStringNames{
-		Quantity: aws.Int64(int64(0)),
-	}
+	var queryStrings *cloudfront.QueryStringNames
 
 	if queryStringFlat, ok := queryStringConfigFlat["query_strings"].([]interface{}); ok && len(queryStringFlat) == 1 {
 		queryStrings = expandCloudFrontCachePolicyQueryStringNames(queryStringFlat[0].(map[string]interface{}))

--- a/aws/cloudfront_cache_policy_structure.go
+++ b/aws/cloudfront_cache_policy_structure.go
@@ -11,10 +11,7 @@ func expandCloudFrontCachePolicyCookieNames(tfMap map[string]interface{}) *cloud
 		return nil
 	}
 
-	var items []*string
-	for _, item := range tfMap["items"].(*schema.Set).List() {
-		items = append(items, aws.String(item.(string)))
-	}
+	items := expandStringSet(tfMap["items"].(*schema.Set))
 
 	apiObject := &cloudfront.CookieNames{
 		Items:    items,
@@ -45,10 +42,7 @@ func expandCloudFrontCachePolicyHeaders(tfMap map[string]interface{}) *cloudfron
 		return nil
 	}
 
-	var items []*string
-	for _, item := range tfMap["items"].(*schema.Set).List() {
-		items = append(items, aws.String(item.(string)))
-	}
+	items := expandStringSet(tfMap["items"].(*schema.Set))
 
 	apiObject := &cloudfront.Headers{
 		Items:    items,
@@ -79,10 +73,7 @@ func expandCloudFrontCachePolicyQueryStringNames(tfMap map[string]interface{}) *
 		return nil
 	}
 
-	var items []*string
-	for _, queryStringitesm := range tfMap["items"].(*schema.Set).List() {
-		items = append(items, aws.String(queryStringitesm.(string)))
-	}
+	items := expandStringSet(tfMap["items"].(*schema.Set))
 
 	apiObject := &cloudfront.QueryStringNames{
 		Items:    items,

--- a/aws/cloudfront_cache_policy_structure.go
+++ b/aws/cloudfront_cache_policy_structure.go
@@ -1,0 +1,230 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func expandCloudFrontCachePolicyCookieNames(cookieNamesFlat map[string]interface{}) *cloudfront.CookieNames {
+	cookieNames := &cloudfront.CookieNames{}
+
+	var newCookieItems []*string
+	for _, cookie := range cookieNamesFlat["items"].(*schema.Set).List() {
+		newCookieItems = append(newCookieItems, aws.String(cookie.(string)))
+	}
+	cookieNames.Items = newCookieItems
+	cookieNames.Quantity = aws.Int64(int64(len(newCookieItems)))
+
+	return cookieNames
+}
+
+func expandCloudFrontCachePolicyCookiesConfig(cookiesConfigFlat map[string]interface{}) *cloudfront.CachePolicyCookiesConfig {
+	cookies := &cloudfront.CookieNames{
+		Quantity: aws.Int64(int64(0)),
+	}
+
+	if cookiesFlat, ok := cookiesConfigFlat["cookies"].([]interface{}); ok && len(cookiesFlat) == 1 {
+		cookies = expandCloudFrontCachePolicyCookieNames(cookiesFlat[0].(map[string]interface{}))
+	} else {
+		cookies = nil
+	}
+
+	cookiesConfig := &cloudfront.CachePolicyCookiesConfig{
+		CookieBehavior: aws.String(cookiesConfigFlat["cookie_behavior"].(string)),
+		Cookies:        cookies,
+	}
+
+	return cookiesConfig
+}
+
+func expandCloudFrontCachePolicyHeaders(headerNamesFlat map[string]interface{}) *cloudfront.Headers {
+	headers := &cloudfront.Headers{}
+
+	var newHeaderItems []*string
+	for _, header := range headerNamesFlat["items"].(*schema.Set).List() {
+		newHeaderItems = append(newHeaderItems, aws.String(header.(string)))
+	}
+	headers.Items = newHeaderItems
+	headers.Quantity = aws.Int64(int64(len(newHeaderItems)))
+
+	return headers
+}
+
+func expandCloudFrontCachePolicyHeadersConfig(headersConfigFlat map[string]interface{}) *cloudfront.CachePolicyHeadersConfig {
+	headers := &cloudfront.Headers{}
+
+	if headersFlat, ok := headersConfigFlat["headers"].([]interface{}); ok && len(headersFlat) == 1 && headersConfigFlat["header_behavior"] != "none" {
+		headers = expandCloudFrontCachePolicyHeaders(headersFlat[0].(map[string]interface{}))
+	} else {
+		headers = nil
+	}
+
+	headersConfig := &cloudfront.CachePolicyHeadersConfig{
+		HeaderBehavior: aws.String(headersConfigFlat["header_behavior"].(string)),
+		Headers:        headers,
+	}
+
+	return headersConfig
+}
+
+func expandCloudFrontCachePolicyQueryStringNames(queryStringNamesFlat map[string]interface{}) *cloudfront.QueryStringNames {
+	queryStringNames := &cloudfront.QueryStringNames{}
+
+	var newQueryStringItems []*string
+	for _, queryString := range queryStringNamesFlat["items"].(*schema.Set).List() {
+		newQueryStringItems = append(newQueryStringItems, aws.String(queryString.(string)))
+	}
+	queryStringNames.Items = newQueryStringItems
+	queryStringNames.Quantity = aws.Int64(int64(len(newQueryStringItems)))
+
+	return queryStringNames
+}
+
+func expandCloudFrontCachePolicyQueryStringConfig(queryStringConfigFlat map[string]interface{}) *cloudfront.CachePolicyQueryStringsConfig {
+	queryStrings := &cloudfront.QueryStringNames{
+		Quantity: aws.Int64(int64(0)),
+	}
+
+	if queryStringFlat, ok := queryStringConfigFlat["query_strings"].([]interface{}); ok && len(queryStringFlat) == 1 {
+		queryStrings = expandCloudFrontCachePolicyQueryStringNames(queryStringFlat[0].(map[string]interface{}))
+	} else {
+		queryStrings = nil
+	}
+
+	queryStringConfig := &cloudfront.CachePolicyQueryStringsConfig{
+		QueryStringBehavior: aws.String(queryStringConfigFlat["query_string_behavior"].(string)),
+		QueryStrings:        queryStrings,
+	}
+
+	return queryStringConfig
+}
+
+func expandCloudFrontCachePolicyParametersConfig(parameters map[string]interface{}) *cloudfront.ParametersInCacheKeyAndForwardedToOrigin {
+	var cookiesConfig *cloudfront.CachePolicyCookiesConfig
+	var headersConfig *cloudfront.CachePolicyHeadersConfig
+	var queryStringsConfig *cloudfront.CachePolicyQueryStringsConfig
+
+	if cookiesFlat, ok := parameters["cookies_config"].([]interface{}); ok && len(cookiesFlat) == 1 {
+		cookiesConfig = expandCloudFrontCachePolicyCookiesConfig(cookiesFlat[0].(map[string]interface{}))
+	}
+
+	if headersFlat, ok := parameters["headers_config"].([]interface{}); ok && len(headersFlat) == 1 {
+		headersConfig = expandCloudFrontCachePolicyHeadersConfig(headersFlat[0].(map[string]interface{}))
+	}
+
+	if queryStringsFlat, ok := parameters["query_strings_config"].([]interface{}); ok && len(queryStringsFlat) == 1 {
+		queryStringsConfig = expandCloudFrontCachePolicyQueryStringConfig(queryStringsFlat[0].(map[string]interface{}))
+	}
+
+	parametersConfig := &cloudfront.ParametersInCacheKeyAndForwardedToOrigin{
+		CookiesConfig:              cookiesConfig,
+		EnableAcceptEncodingBrotli: aws.Bool(parameters["enable_accept_encoding_brotli"].(bool)),
+		EnableAcceptEncodingGzip:   aws.Bool(parameters["enable_accept_encoding_gzip"].(bool)),
+		HeadersConfig:              headersConfig,
+		QueryStringsConfig:         queryStringsConfig,
+	}
+
+	return parametersConfig
+}
+
+func expandCloudFrontCachePolicyConfig(d *schema.ResourceData) *cloudfront.CachePolicyConfig {
+	parametersConfig := &cloudfront.ParametersInCacheKeyAndForwardedToOrigin{}
+
+	if parametersFlat, ok := d.GetOk("parameters_in_cache_key_and_forwarded_to_origin"); ok {
+		parametersConfig = expandCloudFrontCachePolicyParametersConfig(parametersFlat.([]interface{})[0].(map[string]interface{}))
+	}
+	cachePolicy := &cloudfront.CachePolicyConfig{
+		Comment:                                  aws.String(d.Get("comment").(string)),
+		DefaultTTL:                               aws.Int64(int64(d.Get("default_ttl").(int))),
+		MaxTTL:                                   aws.Int64(int64(d.Get("max_ttl").(int))),
+		MinTTL:                                   aws.Int64(int64(d.Get("min_ttl").(int))),
+		Name:                                     aws.String(d.Get("name").(string)),
+		ParametersInCacheKeyAndForwardedToOrigin: parametersConfig,
+	}
+
+	return cachePolicy
+}
+
+func flattenCloudFrontCachePolicyCookiesConfig(cookiesConfig *cloudfront.CachePolicyCookiesConfig) []map[string]interface{} {
+	cookiesConfigFlat := map[string]interface{}{}
+
+	cookies := []map[string]interface{}{}
+	if cookiesConfig.Cookies != nil {
+		cookies = []map[string]interface{}{
+			{
+				"items": cookiesConfig.Cookies.Items,
+			},
+		}
+	}
+
+	cookiesConfigFlat["cookie_behavior"] = aws.StringValue(cookiesConfig.CookieBehavior)
+	cookiesConfigFlat["cookies"] = cookies
+
+	return []map[string]interface{}{
+		cookiesConfigFlat,
+	}
+}
+
+func flattenCloudFrontCachePolicyHeadersConfig(headersConfig *cloudfront.CachePolicyHeadersConfig) []map[string]interface{} {
+	headersConfigFlat := map[string]interface{}{}
+
+	headers := []map[string]interface{}{}
+	if headersConfig.Headers != nil {
+		headers = []map[string]interface{}{
+			{
+				"items": headersConfig.Headers.Items,
+			},
+		}
+	}
+
+	headersConfigFlat["header_behavior"] = aws.StringValue(headersConfig.HeaderBehavior)
+	headersConfigFlat["headers"] = headers
+
+	return []map[string]interface{}{
+		headersConfigFlat,
+	}
+}
+
+func flattenCloudFrontCachePolicyQueryStringsConfig(queryStringsConfig *cloudfront.CachePolicyQueryStringsConfig) []map[string]interface{} {
+	queryStringsConfigFlat := map[string]interface{}{}
+
+	queryStrings := []map[string]interface{}{}
+	if queryStringsConfig.QueryStrings != nil {
+		queryStrings = []map[string]interface{}{
+			{
+				"items": queryStringsConfig.QueryStrings.Items,
+			},
+		}
+	}
+
+	queryStringsConfigFlat["query_string_behavior"] = aws.StringValue(queryStringsConfig.QueryStringBehavior)
+	queryStringsConfigFlat["query_strings"] = queryStrings
+
+	return []map[string]interface{}{
+		queryStringsConfigFlat,
+	}
+}
+
+func flattenParametersConfig(parametersConfig *cloudfront.ParametersInCacheKeyAndForwardedToOrigin) []map[string]interface{} {
+	parametersConfigFlat := map[string]interface{}{
+		"enable_accept_encoding_brotli": aws.BoolValue(parametersConfig.EnableAcceptEncodingBrotli),
+		"enable_accept_encoding_gzip":   aws.BoolValue(parametersConfig.EnableAcceptEncodingGzip),
+		"cookies_config":                flattenCloudFrontCachePolicyCookiesConfig(parametersConfig.CookiesConfig),
+		"headers_config":                flattenCloudFrontCachePolicyHeadersConfig(parametersConfig.HeadersConfig),
+		"query_strings_config":          flattenCloudFrontCachePolicyQueryStringsConfig(parametersConfig.QueryStringsConfig),
+	}
+
+	return []map[string]interface{}{
+		parametersConfigFlat,
+	}
+}
+
+func flattenCloudFrontCachePolicy(d *schema.ResourceData, cachePolicy *cloudfront.CachePolicyConfig) {
+	d.Set("comment", aws.StringValue(cachePolicy.Comment))
+	d.Set("default_ttl", aws.Int64Value(cachePolicy.DefaultTTL))
+	d.Set("max_ttl", aws.Int64Value(cachePolicy.MaxTTL))
+	d.Set("min_ttl", aws.Int64Value(cachePolicy.MinTTL))
+	d.Set("name", aws.StringValue(cachePolicy.Name))
+	d.Set("parameters_in_cache_key_and_forwarded_to_origin", flattenParametersConfig(cachePolicy.ParametersInCacheKeyAndForwardedToOrigin))
+}

--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -224,18 +224,22 @@ func expandCloudFrontDefaultCacheBehavior(m map[string]interface{}) *cloudfront.
 }
 
 func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
+	var forwardedValues *cloudfront.ForwardedValues
+	if forwardedValuesFlat, ok := m["forwarded_values"].([]interface{}); ok && len(forwardedValuesFlat) == 1 {
+		forwardedValues = expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{}))
+	}
+
 	cb := &cloudfront.CacheBehavior{
 		CachePolicyId:          aws.String(m["cache_policy_id"].(string)),
 		Compress:               aws.Bool(m["compress"].(bool)),
-		DefaultTTL:             defaultTTL,
 		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
-		ForwardedValues:        expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{})),
+		ForwardedValues:        forwardedValues,
 		OriginRequestPolicyId:  aws.String(m["origin_request_policy_id"].(string)),
 		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
 		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
 	}
 
-	if m["cache_policy_id"].(string) != "" {
+	if m["cache_policy_id"].(string) == "" {
 		cb.MinTTL = aws.Int64(int64(m["min_ttl"].(int)))
 		cb.MaxTTL = aws.Int64(int64(m["max_ttl"].(int)))
 		cb.DefaultTTL = aws.Int64(int64(m["default_ttl"].(int)))

--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -189,15 +189,22 @@ func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) []interface{} {
 
 func expandCloudFrontDefaultCacheBehavior(m map[string]interface{}) *cloudfront.DefaultCacheBehavior {
 	dcb := &cloudfront.DefaultCacheBehavior{
+		CachePolicyId:          aws.String(m["cache_policy_id"].(string)),
 		Compress:               aws.Bool(m["compress"].(bool)),
-		DefaultTTL:             aws.Int64(int64(m["default_ttl"].(int))),
 		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
-		ForwardedValues:        expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{})),
-		MaxTTL:                 aws.Int64(int64(m["max_ttl"].(int))),
-		MinTTL:                 aws.Int64(int64(m["min_ttl"].(int))),
 		OriginRequestPolicyId:  aws.String(m["origin_request_policy_id"].(string)),
 		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
 		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
+	}
+
+	if forwardedValuesFlat, ok := m["forwarded_values"].([]interface{}); ok && len(forwardedValuesFlat) == 1 {
+		dcb.ForwardedValues = expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{}))
+	}
+
+	if m["cache_policy_id"].(string) == "" {
+		dcb.MinTTL = aws.Int64(int64(m["min_ttl"].(int)))
+		dcb.MaxTTL = aws.Int64(int64(m["max_ttl"].(int)))
+		dcb.DefaultTTL = aws.Int64(int64(m["default_ttl"].(int)))
 	}
 
 	if v, ok := m["trusted_signers"]; ok {

--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -224,31 +224,21 @@ func expandCloudFrontDefaultCacheBehavior(m map[string]interface{}) *cloudfront.
 }
 
 func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
-	var forwardedValues *cloudfront.ForwardedValues
-	if forwardedValuesFlat, ok := m["forwarded_values"].([]interface{}); ok && len(forwardedValuesFlat) == 1 {
-		forwardedValues = expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{}))
-	}
-
-	minTTL := aws.Int64(int64(m["min_ttl"].(int)))
-	maxTTL := aws.Int64(int64(m["max_ttl"].(int)))
-	defaultTTL := aws.Int64(int64(m["default_ttl"].(int)))
-	if m["cache_policy_id"].(string) != "" {
-		minTTL = nil
-		maxTTL = nil
-		defaultTTL = nil
-	}
-
 	cb := &cloudfront.CacheBehavior{
 		CachePolicyId:          aws.String(m["cache_policy_id"].(string)),
 		Compress:               aws.Bool(m["compress"].(bool)),
 		DefaultTTL:             defaultTTL,
 		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
-		ForwardedValues:        forwardedValues,
-		MaxTTL:                 maxTTL,
-		MinTTL:                 minTTL,
+		ForwardedValues:        expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{})),
 		OriginRequestPolicyId:  aws.String(m["origin_request_policy_id"].(string)),
 		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
 		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
+	}
+
+	if m["cache_policy_id"].(string) != "" {
+		cb.MinTTL = aws.Int64(int64(m["min_ttl"].(int)))
+		cb.MaxTTL = aws.Int64(int64(m["max_ttl"].(int)))
+		cb.DefaultTTL = aws.Int64(int64(m["default_ttl"].(int)))
 	}
 
 	if v, ok := m["trusted_signers"]; ok {
@@ -435,6 +425,10 @@ func flattenLambdaFunctionAssociation(lfa *cloudfront.LambdaFunctionAssociation)
 }
 
 func expandForwardedValues(m map[string]interface{}) *cloudfront.ForwardedValues {
+	if len(m) < 1 {
+		return nil
+	}
+
 	fv := &cloudfront.ForwardedValues{
 		QueryString: aws.Bool(m["query_string"].(bool)),
 	}

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -12,6 +12,7 @@ import (
 func defaultCacheBehaviorConf() map[string]interface{} {
 	return map[string]interface{}{
 		"viewer_protocol_policy":      "allow-all",
+		"cache_policy_id":             "",
 		"target_origin_id":            "myS3Origin",
 		"forwarded_values":            []interface{}{forwardedValuesConf()},
 		"min_ttl":                     0,

--- a/aws/data_source_aws_cloudfront_cache_policy.go
+++ b/aws/data_source_aws_cloudfront_cache_policy.go
@@ -13,20 +13,6 @@ func dataSourceAwsCloudFrontCachePolicy() *schema.Resource {
 		Read: dataSourceAwsCloudFrontCachePolicyRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:          schema.TypeString,
-				ConflictsWith: []string{"id"},
-				Optional:      true,
-			},
-			"id": {
-				Type:          schema.TypeString,
-				ConflictsWith: []string{"name"},
-				Optional:      true,
-			},
-			"etag": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"comment": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -35,6 +21,15 @@ func dataSourceAwsCloudFrontCachePolicy() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"name"},
+				Optional:      true,
+			},
 			"max_ttl": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -42,6 +37,11 @@ func dataSourceAwsCloudFrontCachePolicy() *schema.Resource {
 			"min_ttl": {
 				Type:     schema.TypeInt,
 				Computed: true,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"id"},
+				Optional:      true,
 			},
 			"parameters_in_cache_key_and_forwarded_to_origin": {
 				Type:     schema.TypeList,
@@ -137,28 +137,6 @@ func dataSourceAwsCloudFrontCachePolicy() *schema.Resource {
 		},
 	}
 }
-
-func dataSourceAwsCloudFrontCachePolicyFindByName(d *schema.ResourceData, conn *cloudfront.CloudFront) error {
-	var cachePolicy *cloudfront.CachePolicy
-	request := &cloudfront.ListCachePoliciesInput{}
-	resp, err := conn.ListCachePolicies(request)
-	if err != nil {
-		return err
-	}
-
-	for _, policySummary := range resp.CachePolicyList.Items {
-		if *policySummary.CachePolicy.CachePolicyConfig.Name == d.Get("name").(string) {
-			cachePolicy = policySummary.CachePolicy
-			break
-		}
-	}
-
-	if cachePolicy != nil {
-		d.SetId(aws.StringValue(cachePolicy.Id))
-	}
-	return nil
-}
-
 func dataSourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudfrontconn
 
@@ -183,5 +161,26 @@ func dataSourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interfa
 		setCloudFrontCachePolicy(d, resp.CachePolicy.CachePolicyConfig)
 	}
 
+	return nil
+}
+
+func dataSourceAwsCloudFrontCachePolicyFindByName(d *schema.ResourceData, conn *cloudfront.CloudFront) error {
+	var cachePolicy *cloudfront.CachePolicy
+	request := &cloudfront.ListCachePoliciesInput{}
+	resp, err := conn.ListCachePolicies(request)
+	if err != nil {
+		return err
+	}
+
+	for _, policySummary := range resp.CachePolicyList.Items {
+		if *policySummary.CachePolicy.CachePolicyConfig.Name == d.Get("name").(string) {
+			cachePolicy = policySummary.CachePolicy
+			break
+		}
+	}
+
+	if cachePolicy != nil {
+		d.SetId(aws.StringValue(cachePolicy.Id))
+	}
 	return nil
 }

--- a/aws/data_source_aws_cloudfront_cache_policy.go
+++ b/aws/data_source_aws_cloudfront_cache_policy.go
@@ -1,0 +1,185 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsCloudFrontCachePolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCloudFrontCachePolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"id"},
+				Optional:      true,
+			},
+			"id": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"name"},
+				Optional:      true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"comment": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default_ttl": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"max_ttl": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"min_ttl": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"parameters_in_cache_key_and_forwarded_to_origin": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cookies_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cookie_behavior": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"cookies": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"items": {
+													Type:     schema.TypeSet,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"enable_accept_encoding_brotli": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"enable_accept_encoding_gzip": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"headers_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"header_behavior": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"headers": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"items": {
+													Type:     schema.TypeSet,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"query_strings_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"query_string_behavior": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"query_strings": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"items": {
+													Type:     schema.TypeSet,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsCloudFrontCachePolicyFindByName(d *schema.ResourceData, conn *cloudfront.CloudFront) error {
+	var cachePolicy *cloudfront.CachePolicy
+	request := &cloudfront.ListCachePoliciesInput{}
+	resp, err := conn.ListCachePolicies(request)
+	if err != nil {
+		return err
+	}
+
+	for _, policySummary := range resp.CachePolicyList.Items {
+		if *policySummary.CachePolicy.CachePolicyConfig.Name == d.Get("name").(string) {
+			cachePolicy = policySummary.CachePolicy
+			break
+		}
+	}
+
+	if cachePolicy != nil {
+		d.SetId(aws.StringValue(cachePolicy.Id))
+	}
+	return nil
+}
+
+func dataSourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	if d.Id() == "" {
+		if err := dataSourceAwsCloudFrontCachePolicyFindByName(d, conn); err != nil {
+			return err
+		}
+	}
+
+	if d.Id() != "" {
+		d.Set("id", d.Id())
+		request := &cloudfront.GetCachePolicyInput{
+			Id: aws.String(d.Id()),
+		}
+
+		resp, err := conn.GetCachePolicy(request)
+		if err != nil {
+			return err
+		}
+		d.Set("etag", aws.StringValue(resp.ETag))
+
+		flattenCloudFrontCachePolicy(d, resp.CachePolicy.CachePolicyConfig)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_cloudfront_cache_policy.go
+++ b/aws/data_source_aws_cloudfront_cache_policy.go
@@ -142,7 +142,7 @@ func dataSourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interfa
 
 	if d.Id() == "" {
 		if err := dataSourceAwsCloudFrontCachePolicyFindByName(d, conn); err != nil {
-			return fmt.Errorf("Unable to locate cache policy by name: %s", err.Error())
+			return fmt.Errorf("unable to locate cache policy by name: %s", err.Error())
 		}
 	}
 
@@ -154,7 +154,7 @@ func dataSourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interfa
 
 		resp, err := conn.GetCachePolicy(request)
 		if err != nil {
-			return fmt.Errorf("Unable to retrieve cache policy with ID %s: %s", d.Id(), err.Error())
+			return fmt.Errorf("unable to retrieve cache policy with ID %s: %s", d.Id(), err.Error())
 		}
 		d.Set("etag", aws.StringValue(resp.ETag))
 

--- a/aws/data_source_aws_cloudfront_cache_policy.go
+++ b/aws/data_source_aws_cloudfront_cache_policy.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -162,7 +164,7 @@ func dataSourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interfa
 
 	if d.Id() == "" {
 		if err := dataSourceAwsCloudFrontCachePolicyFindByName(d, conn); err != nil {
-			return err
+			return fmt.Errorf("Unable to locate cache policy by name: %s", err.Error())
 		}
 	}
 
@@ -174,11 +176,11 @@ func dataSourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interfa
 
 		resp, err := conn.GetCachePolicy(request)
 		if err != nil {
-			return err
+			return fmt.Errorf("Unable to retrieve cache policy with ID %s: %s", d.Id(), err.Error())
 		}
 		d.Set("etag", aws.StringValue(resp.ETag))
 
-		flattenCloudFrontCachePolicy(d, resp.CachePolicy.CachePolicyConfig)
+		setCloudFrontCachePolicy(d, resp.CachePolicy.CachePolicyConfig)
 	}
 
 	return nil

--- a/aws/data_source_aws_cloudfront_cache_policy_test.go
+++ b/aws/data_source_aws_cloudfront_cache_policy_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccAWSCloudFrontDataSourceCachePolicy_basic(t *testing.T) {
 	rInt := acctest.RandInt()
+	dataSourceName := "data.aws_cloudfront_cache_policy.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
@@ -20,16 +21,16 @@ func TestAccAWSCloudFrontDataSourceCachePolicy_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontCachePolicyDataSourceNameConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "comment", "test comment"),
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "default_ttl", "50"),
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "min_ttl", "1"),
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "max_ttl", "100"),
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
-					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
+					resource.TestCheckResourceAttr(dataSourceName, "comment", "test comment"),
+					resource.TestCheckResourceAttr(dataSourceName, "default_ttl", "50"),
+					resource.TestCheckResourceAttr(dataSourceName, "min_ttl", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "max_ttl", "100"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(dataSourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
 				),
 			},
 			{

--- a/aws/data_source_aws_cloudfront_cache_policy_test.go
+++ b/aws/data_source_aws_cloudfront_cache_policy_test.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSCloudFrontDataSourceCachePolicy_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontCachePolicyDataSourceNameConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "comment", "test comment"),
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "default_ttl", "50"),
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "min_ttl", "1"),
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "max_ttl", "100"),
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("data.aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
+				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_cache_policy.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func testAccAWSCloudFrontCachePolicyDataSourceNameConfig(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_cloudfront_cache_policy" "example" {
+  name = aws_cloudfront_cache_policy.example.name
+}
+
+resource "aws_cloudfront_cache_policy" "example" {
+  name        = "test-policy%[1]d"
+  comment     = "test comment"
+  default_ttl = 50
+  max_ttl     = 100
+  min_ttl     = 1
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "whitelist"
+      cookies {
+        items = ["test"]
+      }
+    }
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = ["test"]
+      }
+    }
+    query_strings_config {
+      query_string_behavior = "whitelist"
+      query_strings {
+        items = ["test"]
+      }
+    }
+  }
+}
+`, rInt)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -486,6 +486,7 @@ func Provider() *schema.Provider {
 			"aws_cloudformation_stack":                                resourceAwsCloudFormationStack(),
 			"aws_cloudformation_stack_set":                            resourceAwsCloudFormationStackSet(),
 			"aws_cloudformation_stack_set_instance":                   resourceAwsCloudFormationStackSetInstance(),
+			"aws_cloudfront_cache_policy":                             resourceAwsCloudFrontCachePolicy(),
 			"aws_cloudfront_distribution":                             resourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_origin_access_identity":                   resourceAwsCloudFrontOriginAccessIdentity(),
 			"aws_cloudfront_origin_request_policy":                    resourceAwsCloudFrontOriginRequestPolicy(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -190,6 +190,7 @@ func Provider() *schema.Provider {
 			"aws_canonical_user_id":                          dataSourceAwsCanonicalUserId(),
 			"aws_cloudformation_export":                      dataSourceAwsCloudFormationExport(),
 			"aws_cloudformation_stack":                       dataSourceAwsCloudFormationStack(),
+			"aws_cloudfront_cache_policy":                    dataSourceAwsCloudFrontCachePolicy(),
 			"aws_cloudfront_distribution":                    dataSourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_origin_request_policy":           dataSourceAwsCloudFrontOriginRequestPolicy(),
 			"aws_cloudhsm_v2_cluster":                        dataSourceCloudHsmV2Cluster(),

--- a/aws/resource_aws_cloudfront_cache_policy.go
+++ b/aws/resource_aws_cloudfront_cache_policy.go
@@ -181,7 +181,7 @@ func resourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interface
 	}
 	d.Set("etag", aws.StringValue(resp.ETag))
 
-	flattenCloudFrontCachePolicy(d, resp.CachePolicy.CachePolicyConfig)
+	setCloudFrontCachePolicy(d, resp.CachePolicy.CachePolicyConfig)
 
 	return nil
 }

--- a/aws/resource_aws_cloudfront_cache_policy.go
+++ b/aws/resource_aws_cloudfront_cache_policy.go
@@ -176,6 +176,13 @@ func resourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interface
 	}
 
 	resp, err := conn.GetCachePolicy(request)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, "ResourceNotFoundException") {
+		log.Printf("[WARN] CloudFront Cache Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}

--- a/aws/resource_aws_cloudfront_cache_policy.go
+++ b/aws/resource_aws_cloudfront_cache_policy.go
@@ -27,6 +27,11 @@ func resourceAwsCloudFrontCachePolicy() *schema.Resource {
 				Optional: true,
 				Default:  86400,
 			},
+			"etag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"max_ttl": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -40,11 +45,6 @@ func resourceAwsCloudFrontCachePolicy() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-			},
-			"etag": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
 			},
 			"parameters_in_cache_key_and_forwarded_to_origin": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_cloudfront_cache_policy.go
+++ b/aws/resource_aws_cloudfront_cache_policy.go
@@ -1,8 +1,11 @@
 package aws
 
 import (
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/aws/resource_aws_cloudfront_cache_policy.go
+++ b/aws/resource_aws_cloudfront_cache_policy.go
@@ -1,0 +1,223 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsCloudFrontCachePolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudFrontCachePolicyCreate,
+		Read:   resourceAwsCloudFrontCachePolicyRead,
+		Update: resourceAwsCloudFrontCachePolicyUpdate,
+		Delete: resourceAwsCloudFrontCachePolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"comment": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"default_ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  86400,
+			},
+			"max_ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  31536000,
+			},
+			"min_ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"parameters_in_cache_key_and_forwarded_to_origin": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cookies_config": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cookie_behavior": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"none", "whitelist", "allExcept", "all"}, false),
+									},
+									"cookies": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"items": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"enable_accept_encoding_brotli": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"enable_accept_encoding_gzip": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"headers_config": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"header_behavior": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"none", "whitelist"}, false),
+									},
+									"headers": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"items": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"query_strings_config": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"query_string_behavior": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"none", "whitelist", "allExcept", "all"}, false),
+									},
+									"query_strings": {
+										Type:     schema.TypeList,
+										MaxItems: 1,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"items": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsCloudFrontCachePolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	request := &cloudfront.CreateCachePolicyInput{
+		CachePolicyConfig: expandCloudFrontCachePolicyConfig(d),
+	}
+
+	resp, err := conn.CreateCachePolicy(request)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(aws.StringValue(resp.CachePolicy.Id))
+
+	return resourceAwsCloudFrontCachePolicyRead(d, meta)
+}
+
+func resourceAwsCloudFrontCachePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+	request := &cloudfront.GetCachePolicyInput{
+		Id: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetCachePolicy(request)
+	if err != nil {
+		return err
+	}
+	d.Set("etag", aws.StringValue(resp.ETag))
+
+	flattenCloudFrontCachePolicy(d, resp.CachePolicy.CachePolicyConfig)
+
+	return nil
+}
+
+func resourceAwsCloudFrontCachePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	request := &cloudfront.UpdateCachePolicyInput{
+		CachePolicyConfig: expandCloudFrontCachePolicyConfig(d),
+		Id:                aws.String(d.Id()),
+		IfMatch:           aws.String(d.Get("etag").(string)),
+	}
+
+	_, err := conn.UpdateCachePolicy(request)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsCloudFrontCachePolicyRead(d, meta)
+}
+
+func resourceAwsCloudFrontCachePolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	request := &cloudfront.DeleteCachePolicyInput{
+		Id:      aws.String(d.Id()),
+		IfMatch: aws.String(d.Get("etag").(string)),
+	}
+
+	_, err := conn.DeleteCachePolicy(request)
+	if err != nil {
+		if isAWSErr(err, cloudfront.ErrCodeNoSuchCachePolicy, "") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_cloudfront_cache_policy_test.go
+++ b/aws/resource_aws_cloudfront_cache_policy_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccAWSCloudFrontCachePolicy_basic(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudfront_cache_policy.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
@@ -20,16 +21,16 @@ func TestAccAWSCloudFrontCachePolicy_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontCachePolicyConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "50"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "1"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "100"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "test comment"),
+					resource.TestCheckResourceAttr(resourceName, "default_ttl", "50"),
+					resource.TestCheckResourceAttr(resourceName, "min_ttl", "1"),
+					resource.TestCheckResourceAttr(resourceName, "max_ttl", "100"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
 				),
 			},
 			{
@@ -44,6 +45,7 @@ func TestAccAWSCloudFrontCachePolicy_basic(t *testing.T) {
 
 func TestAccAWSCloudFrontCachePolicy_update(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudfront_cache_policy.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
@@ -53,31 +55,31 @@ func TestAccAWSCloudFrontCachePolicy_update(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontCachePolicyConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "50"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "1"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "100"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "test comment"),
+					resource.TestCheckResourceAttr(resourceName, "default_ttl", "50"),
+					resource.TestCheckResourceAttr(resourceName, "min_ttl", "1"),
+					resource.TestCheckResourceAttr(resourceName, "max_ttl", "100"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
 				),
 			},
 			{
 				Config: testAccAWSCloudFrontCachePolicyConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment updated"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "51"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "2"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "101"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "allExcept"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test2"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "none"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.#", "0"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "allExcept"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test2"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "test comment updated"),
+					resource.TestCheckResourceAttr(resourceName, "default_ttl", "51"),
+					resource.TestCheckResourceAttr(resourceName, "min_ttl", "2"),
+					resource.TestCheckResourceAttr(resourceName, "max_ttl", "101"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "allExcept"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "none"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "allExcept"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test2"),
 				),
 			},
 			{
@@ -92,6 +94,7 @@ func TestAccAWSCloudFrontCachePolicy_update(t *testing.T) {
 
 func TestAccAWSCloudFrontCachePolicy_noneBehavior(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudfront_cache_policy.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
@@ -101,16 +104,16 @@ func TestAccAWSCloudFrontCachePolicy_noneBehavior(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontCachePolicyConfigNoneBehavior(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "50"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "1"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "100"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "none"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.#", "0"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "none"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.#", "0"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "none"),
-					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "test comment"),
+					resource.TestCheckResourceAttr(resourceName, "default_ttl", "50"),
+					resource.TestCheckResourceAttr(resourceName, "min_ttl", "1"),
+					resource.TestCheckResourceAttr(resourceName, "max_ttl", "100"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "none"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "none"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "none"),
+					resource.TestCheckResourceAttr(resourceName, "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.#", "0"),
 				),
 			},
 			{

--- a/aws/resource_aws_cloudfront_cache_policy_test.go
+++ b/aws/resource_aws_cloudfront_cache_policy_test.go
@@ -1,0 +1,208 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSCloudFrontCachePolicy_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontCachePolicyConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "50"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "1"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "100"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
+				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_cache_policy.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontCachePolicy_update(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontCachePolicyConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "50"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "1"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "100"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.0.items.0", "test"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "whitelist"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFrontCachePolicyConfigUpdate(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment updated"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "51"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "2"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "101"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "allExcept"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.0.items.0", "test2"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "none"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.#", "0"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "allExcept"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.0.items.0", "test2"),
+				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_cache_policy.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontCachePolicy_noneBehavior(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontCachePolicyConfigNoneBehavior(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "comment", "test comment"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "default_ttl", "50"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "min_ttl", "1"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "max_ttl", "100"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookie_behavior", "none"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.cookies_config.0.cookies.#", "0"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.header_behavior", "none"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.headers_config.0.headers.#", "0"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_string_behavior", "none"),
+					resource.TestCheckResourceAttr("aws_cloudfront_cache_policy.example", "parameters_in_cache_key_and_forwarded_to_origin.0.query_strings_config.0.query_strings.#", "0"),
+				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_cache_policy.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func testAccAWSCloudFrontCachePolicyConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_cache_policy" "example" {
+  name        = "test-policy%[1]d"
+  comment     = "test comment"
+  default_ttl = 50
+  max_ttl     = 100
+  min_ttl     = 1
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "whitelist"
+      cookies {
+        items = ["test"]
+      }
+    }
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = ["test"]
+      }
+    }
+    query_strings_config {
+      query_string_behavior = "whitelist"
+      query_strings {
+        items = ["test"]
+      }
+    }
+  }
+}
+`, rInt)
+}
+
+func testAccAWSCloudFrontCachePolicyConfigUpdate(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_cache_policy" "example" {
+  name        = "test-policy-updated%[1]d"
+  comment     = "test comment updated"
+  default_ttl = 51
+  max_ttl     = 101
+  min_ttl     = 2
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "allExcept"
+      cookies {
+        items = ["test2"]
+      }
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "allExcept"
+      query_strings {
+        items = ["test2"]
+      }
+    }
+  }
+}
+`, rInt)
+}
+
+func testAccAWSCloudFrontCachePolicyConfigNoneBehavior(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_cache_policy" "example" {
+  name        = "test-policy-updated%[1]d"
+  comment     = "test comment"
+  default_ttl = 50
+  max_ttl     = 100
+  min_ttl     = 1
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+  }
+}
+`, rInt)
+}

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -58,6 +58,10 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"cache_policy_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"compress": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -66,7 +70,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"default_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  86400,
+							Computed: true,
 						},
 						"field_level_encryption_id": {
 							Type:     schema.TypeString,
@@ -74,7 +78,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						},
 						"forwarded_values": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -104,6 +108,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"headers": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 									"query_string": {
@@ -113,6 +118,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"query_string_cache_keys": {
 										Type:     schema.TypeList,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
@@ -144,7 +150,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"max_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  31536000,
+							Computed: true,
 						},
 						"min_ttl": {
 							Type:     schema.TypeInt,
@@ -224,6 +230,10 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"cache_policy_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"compress": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -262,6 +272,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 												"whitelisted_names": {
 													Type:     schema.TypeSet,
 													Optional: true,
+													Computed: true,
 													Elem:     &schema.Schema{Type: schema.TypeString},
 												},
 											},
@@ -270,6 +281,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"headers": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 									"query_string": {
@@ -279,6 +291,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"query_string_cache_keys": {
 										Type:     schema.TypeList,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
@@ -332,6 +345,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"trusted_signers": {
 							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"viewer_protocol_policy": {
@@ -529,6 +543,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"locations": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 									"restriction_type": {

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -80,6 +80,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"cookies": {
@@ -242,7 +243,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"default_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  86400,
+							Computed: true,
 						},
 						"field_level_encryption_id": {
 							Type:     schema.TypeString,
@@ -250,7 +251,8 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						},
 						"forwarded_values": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
+							Computed: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -323,7 +325,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"max_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  31536000,
+							Computed: true,
 						},
 						"min_ttl": {
 							Type:     schema.TypeInt,

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -2147,21 +2147,21 @@ resource "aws_cloudfront_distribution" "main" {
 }
 
 resource "aws_cloudfront_cache_policy" "cache_policy" {
-	name        = "test-policy%[1]d"
-	comment     = "test comment"
-	default_ttl = 50
-	max_ttl     = 100
-	parameters_in_cache_key_and_forwarded_to_origin {
-	  cookies_config {
-		  cookie_behavior = "none"
-		}
-		headers_config {
-		  header_behavior = "none"
-		}
-		query_strings_config {
-		  query_string_behavior = "none"
-		}
-	}
+  name        = "test-policy%[1]d"
+  comment     = "test comment"
+  default_ttl = 50
+  max_ttl     = 100
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+  }
 }
 
 `, acctest.RandInt(), testAccAWSCloudFrontDistributionRetainConfig())

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -212,16 +212,41 @@ func TestAccAWSCloudFrontDistribution_customOrigin(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFrontDistribution_originPolicy(t *testing.T) {
+func TestAccAWSCloudFrontDistribution_originPolicyDefault(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFrontDistributionOriginRequestPolicyConfig,
+				Config: testAccAWSCloudFrontDistributionOriginRequestPolicyConfigDefault,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("aws_cloudfront_distribution.custom_distribution", "default_cache_behavior.0.origin_request_policy_id", regexp.MustCompile("[A-z0-9]+")),
+				),
+			},
+			{
+				ResourceName:      "aws_cloudfront_distribution.custom_distribution",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontDistribution_originPolicyOrdered(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontDistributionOriginRequestPolicyConfigOrdered,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_cloudfront_distribution.custom_distribution", "ordered_cache_behavior.0.origin_request_policy_id", regexp.MustCompile("[A-z0-9]+")),
 				),
 			},
 			{
@@ -391,7 +416,6 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.allowed_methods.#", "7"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.cached_methods.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.compress", "false"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.default_ttl", "86400"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.cookies.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.cookies.0.forward", "all"),
@@ -400,7 +424,6 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.query_string", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.query_string_cache_keys.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.lambda_function_association.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.max_ttl", "31536000"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.min_ttl", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.smooth_streaming", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.target_origin_id", "myCustomOrigin"),
@@ -1417,7 +1440,7 @@ resource "aws_cloudfront_distribution" "custom_distribution" {
 }
 `, acctest.RandInt(), logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 
-var testAccAWSCloudFrontDistributionOriginRequestPolicyConfig = fmt.Sprintf(`
+var testAccAWSCloudFrontDistributionOriginRequestPolicyConfigDefault = fmt.Sprintf(`
 variable rand_id {
   default = %[1]d
 }
@@ -1510,13 +1533,129 @@ resource "aws_cloudfront_distribution" "custom_distribution" {
     origin_request_policy_id = aws_cloudfront_origin_request_policy.test_policy.id
     cache_policy_id          = aws_cloudfront_cache_policy.example.id
 
-    forwarded_values {
-      query_string = false
+    viewer_protocol_policy = "allow-all"
+  }
 
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`, acctest.RandInt(), logBucket, testAccAWSCloudFrontDistributionRetainConfig())
+
+var testAccAWSCloudFrontDistributionOriginRequestPolicyConfigOrdered = fmt.Sprintf(`
+variable rand_id {
+  default = %[1]d
+}
+
+# log bucket
+%[2]s
+
+resource "aws_cloudfront_cache_policy" "example" {
+  name        = "test-policy%[1]d"
+  comment     = "test comment"
+  default_ttl = 50
+  max_ttl     = 100
+  min_ttl     = 1
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "whitelist"
       cookies {
-        forward = "all"
+        items = ["test"]
       }
     }
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = ["test"]
+      }
+    }
+    query_strings_config {
+      query_string_behavior = "whitelist"
+      query_strings {
+        items = ["test"]
+      }
+    }
+  }
+}
+
+resource "aws_cloudfront_origin_request_policy" "test_policy" {
+  name    = "test-policy%[1]d"
+  comment = "test comment"
+  cookies_config {
+    cookie_behavior = "whitelist"
+    cookies {
+      items = ["test"]
+    }
+  }
+  headers_config {
+    header_behavior = "whitelist"
+    headers {
+      items = ["test"]
+    }
+  }
+  query_strings_config {
+    query_string_behavior = "whitelist"
+    query_strings {
+      items = ["test"]
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "custom_distribution" {
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "myCustomOrigin"
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_protocol_policy   = "http-only"
+      origin_ssl_protocols     = ["SSLv3", "TLSv1"]
+      origin_read_timeout      = 30
+      origin_keepalive_timeout = 5
+    }
+  }
+
+  enabled             = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${aws_s3_bucket.s3_bucket_logs.id}.s3.amazonaws.com"
+    prefix          = "myprefix"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "myCustomOrigin"
+    smooth_streaming = false
+
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.test_policy.id
+    cache_policy_id          = aws_cloudfront_cache_policy.example.id
+
+    viewer_protocol_policy = "allow-all"
+  }
+
+  ordered_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "myCustomOrigin"
+    smooth_streaming = false
+    path_pattern     = "/*"
+
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.test_policy.id
+    cache_policy_id          = aws_cloudfront_cache_policy.example.id
 
     viewer_protocol_policy = "allow-all"
   }

--- a/website/docs/d/cloudfront_cache_policy.html.markdown
+++ b/website/docs/d/cloudfront_cache_policy.html.markdown
@@ -37,8 +37,8 @@ The following arguments are supported:
 ### Parameters In Cache Key And Forwarded To Origin
 
 * `cookies_config` - An object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
-* `cookies_config` - An object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
-* `cookies_config` - An object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
+* `headers_config` - An object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
+* `query_strings_config` - An object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
 * `enable_accept_encoding_brotli` - A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
 * `enable_accept_encoding_gzip` - A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
 

--- a/website/docs/d/cloudfront_cache_policy.html.markdown
+++ b/website/docs/d/cloudfront_cache_policy.html.markdown
@@ -36,26 +36,26 @@ The following arguments are supported:
 
 ### Parameters In Cache Key And Forwarded To Origin
 
-* `cookies_config` - An object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
-* `headers_config` - An object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
-* `query_strings_config` - An object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
+* `cookies_config` - Object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
+* `headers_config` - Object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
+* `query_strings_config` - Object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
 * `enable_accept_encoding_brotli` - A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
 * `enable_accept_encoding_gzip` - A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
 
 ### Cookies Config
 
 `cookie_behavior` - Determines whether any cookies in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
-`cookies` - An object that contains a list of cookie names. See [Items](#items) for more information.
+`cookies` - Object that contains a list of cookie names. See [Items](#items) for more information.
 
 ### Headers Config
 
 `header_behavior` - Determines whether any HTTP headers are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`.
-`headers` - An object that contains a list of header names. See [Items](#items) for more information.
+`headers` - Object that contains a list of header names. See [Items](#items) for more information.
 
 ### Query String Config
 
 `query_string_behavior` - Determines whether any URL query strings in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
-`query_strings` - An object that contains a list of query string names. See [Items](#items) for more information.
+`query_strings` - Object that contains a list of query string names. See [Items](#items) for more information.
 
 ### Items
 

--- a/website/docs/d/cloudfront_cache_policy.html.markdown
+++ b/website/docs/d/cloudfront_cache_policy.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_cache_policy"
+description: |-
+  Use this data source to retrieve information about a CloudFront cache policy.
+---
+
+# Resource: aws_cloudfront_cache_policy
+
+## Example Usage
+
+The following example below creates a CloudFront cache policy.
+
+```hcl
+data "aws_cloudfront_cache_policy" "example" {
+  name = "example-policy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) A unique name to identify the cache policy.
+* `id` - (Optional) The identifier for the cache policy.
+
+## Attributes Reference
+
+* `etag` - The current version of the cache policy.
+* `min_ttl` - The minimum amount of time, in seconds, that you want objects to stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated.
+* `max_ttl` - The maximum amount of time, in seconds, that objects stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated.
+* `default_ttl` - The default amount of time, in seconds, that you want objects to stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated.
+* `comment` - A comment to describe the cache policy.
+* `parameters_in_cache_key_and_forwarded_to_origin` - The HTTP headers, cookies, and URL query strings to include in the cache key. See [Parameters In Cache Key And Forwarded To Origin](#parameters-in-cache-key-and-forwarded-to-origin) for more information.
+
+### Parameters In Cache Key And Forwarded To Origin
+
+* `cookies_config` - An object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
+* `cookies_config` - An object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
+* `cookies_config` - An object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
+* `enable_accept_encoding_brotli` - A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
+* `enable_accept_encoding_gzip` - A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
+
+### Cookies Config
+
+`cookie_behavior` - Determines whether any cookies in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
+`cookies` - An object that contains a list of cookie names. See [Items](#items) for more information.
+
+### Headers Config
+
+`header_behavior` - Determines whether any HTTP headers are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`.
+`headers` - An object that contains a list of header names. See [Items](#items) for more information.
+
+### Query String Config
+
+`query_string_behavior` - Determines whether any URL query strings in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
+`query_strings` - An object that contains a list of query string names. See [Items](#items) for more information.
+
+### Items
+
+`items` - A list of item names (cookies, headers, or query strings).
+
+
+

--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -18,33 +18,33 @@ description: |-
 The following example below creates a CloudFront cache policy.
 
 ```hcl
-resource "aws_cloudfront_cache_policy" "example" {                                  
-  name        = "example-policy"                                                  
-  comment     = "test comment"                                                      
-  default_ttl = 50                                                               
-  max_ttl     = 100                                                                 
-  min_ttl     = 1                                                                   
-  parameters_in_cache_key_and_forwarded_to_origin {                                 
-    cookies_config {                                                                
-      cookie_behavior = "whitelist"                                                 
-      cookies {                                                                     
-        items = [ "example" ]                                                       
-      }                                                                          
-    }                                                                            
-    headers_config {                                                             
-      header_behavior = "whitelist"                                              
-      headers {                                                                  
-        items = [ "example" ]                                                       
-      }                                                                          
-    }                                                                            
-    query_strings_config {                                                       
-      query_string_behavior = "whitelist"                                           
-      query_strings {                                                               
-        items = [ "example" ]                                                          
-      }                                                                             
-    }                                                                               
-  }                                                                              
-}  
+resource "aws_cloudfront_cache_policy" "example" {
+  name        = "example-policy"
+  comment     = "test comment"
+  default_ttl = 50
+  max_ttl     = 100
+  min_ttl     = 1
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "whitelist"
+      cookies {
+        items = ["example"]
+      }
+    }
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = ["example"]
+      }
+    }
+    query_strings_config {
+      query_string_behavior = "whitelist"
+      query_strings {
+        items = ["example"]
+      }
+    }
+  }
+}
 ```
 
 ## Argument Reference
@@ -90,4 +90,4 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `etag` - The current version of the cache policy.
-* `id` - The identifier for the cache policy. 
+* `id` - The identifier for the cache policy.

--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -61,8 +61,8 @@ The following arguments are supported:
 ### Parameters In Cache Key And Forwarded To Origin
 
 * `cookies_config` - (Required) An object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
-* `cookies_config` - (Required) An object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
-* `cookies_config` - (Required) An object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
+* `headers_config` - (Required) An object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
+* `query_strings_config` - (Required) An object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
 * `enable_accept_encoding_brotli` - (Optional) A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
 * `enable_accept_encoding_gzip` - (Optional) A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
 

--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -60,26 +60,26 @@ The following arguments are supported:
 
 ### Parameters In Cache Key And Forwarded To Origin
 
-* `cookies_config` - (Required) An object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
-* `headers_config` - (Required) An object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
-* `query_strings_config` - (Required) An object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
+* `cookies_config` - (Required) Object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
+* `headers_config` - (Required) Object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
+* `query_strings_config` - (Required) Object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
 * `enable_accept_encoding_brotli` - (Optional) A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
 * `enable_accept_encoding_gzip` - (Optional) A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
 
 ### Cookies Config
 
 `cookie_behavior` - (Required) Determines whether any cookies in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
-`cookies` - (Optional) An object that contains a list of cookie names. See [Items](#items) for more information.
+`cookies` - (Optional) Object that contains a list of cookie names. See [Items](#items) for more information.
 
 ### Headers Config
 
 `header_behavior` - (Required) Determines whether any HTTP headers are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`.
-`headers` - (Optional) An object that contains a list of header names. See [Items](#items) for more information.
+`headers` - (Optional) Object that contains a list of header names. See [Items](#items) for more information.
 
 ### Query String Config
 
 `query_string_behavior` - (Required) Determines whether any URL query strings in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
-`query_strings` - (Optional) An object that contains a list of query string names. See [Items](#items) for more information.
+`query_strings` - (Optional) Object that contains a list of query string names. See [Items](#items) for more information.
 
 ### Items
 

--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -1,0 +1,93 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_cache_policy"
+description: |-
+  Provides a cache policy for a CloudFront ditribution. When it’s attached to a cache behavior, 
+  the cache policy determines the the values that CloudFront includes in the cache key. These 
+  values can include HTTP headers, cookies, and URL query strings. CloudFront uses the cache 
+  key to find an object in its cache that it can return to the viewer. It also determines the 
+  default, minimum, and maximum time to live (TTL) values that you want objects to stay in the 
+  CloudFront cache. 
+---
+
+# Resource: aws_cloudfront_cache_policy
+
+## Example Usage
+
+The following example below creates a CloudFront public key.
+
+```hcl
+resource "aws_cloudfront_cache_policy" "example" {                                  
+  name        = "example-policy"                                                  
+  comment     = "test comment"                                                      
+  default_ttl = 50                                                               
+  max_ttl     = 100                                                                 
+  min_ttl     = 1                                                                   
+  parameters_in_cache_key_and_forwarded_to_origin {                                 
+    cookies_config {                                                                
+      cookie_behavior = "whitelist"                                                 
+      cookies {                                                                     
+        items = [ "example" ]                                                       
+      }                                                                          
+    }                                                                            
+    headers_config {                                                             
+      header_behavior = "whitelist"                                              
+      headers {                                                                  
+        items = [ "example" ]                                                       
+      }                                                                          
+    }                                                                            
+    query_strings_config {                                                       
+      query_string_behavior = "whitelist"                                           
+      query_strings {                                                               
+        items = [ "example" ]                                                          
+      }                                                                             
+    }                                                                               
+  }                                                                              
+}  
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name to identify the cache policy.
+* `min_ttl` - (Required) The minimum amount of time, in seconds, that you want objects to stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated.
+* `max_ttl` - (Optional) The maximum amount of time, in seconds, that objects stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated.
+* `default_ttl` - (Optional) The default amount of time, in seconds, that you want objects to stay in the CloudFront cache before CloudFront sends another request to the origin to see if the object has been updated.
+* `comment` - (Optional) A comment to describe the cache policy.
+* `parameters_in_cache_key_and_forwarded_to_origin` - (Optional) The HTTP headers, cookies, and URL query strings to include in the cache key. See [Parameters In Cache Key And Forwarded To Origin](#parameters-in-cache-key-and-forwarded-to-origin) for more information.
+
+### Parameters In Cache Key And Forwarded To Origin
+
+* `cookies_config` - (Required) An object that determines whether any cookies in viewer requests (and if so, which cookies) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Cookies Config](#cookies-config) for more information.
+* `cookies_config` - (Required) An object that determines whether any HTTP headers (and if so, which headers) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Headers Config](#headers-config) for more information.
+* `cookies_config` - (Required) An object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the cache key and automatically included in requests that CloudFront sends to the origin. See [Query Strings Config](#query-strings-config) for more information.
+* `enable_accept_encoding_brotli` - (Optional) A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
+* `enable_accept_encoding_gzip` - (Optional) A flag that can affect whether the Accept-Encoding HTTP header is included in the cache key and included in requests that CloudFront sends to the origin.
+
+### Cookies Config
+
+`cookie_behavior` - (Required) Determines whether any cookies in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
+`cookies` - (Optional) An object that contains a list of cookie names. See [Items](#items) for more information.
+
+### Headers Config
+
+`header_behavior` - (Required) Determines whether any HTTP headers are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`.
+`headers` - (Optional) An object that contains a list of header names. See [Items](#items) for more information.
+
+### Query String Config
+
+`query_string_behavior` - (Required) Determines whether any URL query strings in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `none`, `whitelist`, `allExcept`, `all`.
+`query_strings` - (Optional) An object that contains a list of query string names. See [Items](#items) for more information.
+
+### Items
+
+`items` - (Required) A list of item names (cookies, headers, or query strings).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `etag` - The current version of the cache policy.
+* `id` - The identifier for the cache policy. 

--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-The following example below creates a CloudFront public key.
+The following example below creates a CloudFront cache policy.
 
 ```hcl
 resource "aws_cloudfront_cache_policy" "example" {                                  

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -280,8 +280,7 @@ of several sub-resources - these resources are laid out below.
 
 * `default_ttl` (Optional) - The default amount of time (in seconds) that an
     object is in a CloudFront cache before CloudFront forwards another request
-    in the absence of an `Cache-Control max-age` or `Expires` header. Defaults to
-    1 day.
+    in the absence of an `Cache-Control max-age` or `Expires` header.
 
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
@@ -295,7 +294,7 @@ of several sub-resources - these resources are laid out below.
     object is in a CloudFront cache before CloudFront forwards another request
     to your origin to determine whether the object has been updated. Only
     effective in the presence of `Cache-Control max-age`, `Cache-Control
-    s-maxage`, and `Expires` headers. Defaults to 365 days.
+    s-maxage`, and `Expires` headers.
 
 * `min_ttl` (Optional) - The minimum amount of time that you want objects to
     stay in CloudFront caches before CloudFront queries your origin to see

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -271,6 +271,9 @@ of several sub-resources - these resources are laid out below.
 * `cached_methods` (Required) - Controls whether CloudFront caches the
     response to requests using the specified HTTP methods.
 
+* `cache_policy_id` (Optional) - The unique identifier of the cache policy that
+    is attached to the cache behavior.
+
 * `compress` (Optional) - Whether you want CloudFront to automatically
     compress content for web requests that include `Accept-Encoding: gzip` in
     the request header (default: `false`).


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #14373

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontDistribution_ -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_disappears
=== PAUSE TestAccAWSCloudFrontDistribution_disappears
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
=== PAUSE TestAccAWSCloudFrontDistribution_S3Origin
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== PAUSE TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_customOrigin
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_multiOrigin
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
=== PAUSE TestAccAWSCloudFrontDistribution_HTTP11Config
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== PAUSE TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== RUN   TestAccAWSCloudFrontDistribution_Enabled
=== PAUSE TestAccAWSCloudFrontDistribution_Enabled
=== RUN   TestAccAWSCloudFrontDistribution_RetainOnDelete
=== PAUSE TestAccAWSCloudFrontDistribution_RetainOnDelete
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccAWSCloudFrontDistribution_WaitForDeployment
=== PAUSE TestAccAWSCloudFrontDistribution_WaitForDeployment
=== RUN   TestAccAWSCloudFrontDistribution_OriginGroups
=== PAUSE TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_disappears
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_Enabled
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== CONT  TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== CONT  TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== CONT  TestAccAWSCloudFrontDistribution_HTTP11Config
=== CONT  TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== CONT  TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_WaitForDeployment
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== CONT  TestAccAWSCloudFrontDistribution_multiOrigin
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== CONT  TestAccAWSCloudFrontDistribution_RetainOnDelete
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (2.48s)
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (2.57s)
=== CONT  TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (181.82s)
=== CONT  TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (189.79s)
=== CONT  TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (191.64s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (194.28s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (205.76s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (212.63s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (218.51s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (224.00s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (332.41s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (338.10s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (338.61s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (340.35s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (363.33s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (372.26s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (372.13s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy (375.30s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (386.71s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (440.79s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (300.25s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (322.06s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (511.21s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (543.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	543.842s


==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontCachePolicy_ -timeout 120m
=== RUN   TestAccAWSCloudFrontCachePolicy_basic
=== PAUSE TestAccAWSCloudFrontCachePolicy_basic
=== RUN   TestAccAWSCloudFrontCachePolicy_update
=== PAUSE TestAccAWSCloudFrontCachePolicy_update
=== RUN   TestAccAWSCloudFrontCachePolicy_noneBehavior
=== PAUSE TestAccAWSCloudFrontCachePolicy_noneBehavior
=== CONT  TestAccAWSCloudFrontCachePolicy_basic
=== CONT  TestAccAWSCloudFrontCachePolicy_noneBehavior
=== CONT  TestAccAWSCloudFrontCachePolicy_update
--- PASS: TestAccAWSCloudFrontCachePolicy_basic (14.56s)
--- PASS: TestAccAWSCloudFrontCachePolicy_noneBehavior (14.59s)
--- PASS: TestAccAWSCloudFrontCachePolicy_update (24.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.394s

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontDataSourceCachePolicy_basic -timeout 120m
=== RUN   TestAccAWSCloudFrontDataSourceCachePolicy_basic
=== PAUSE TestAccAWSCloudFrontDataSourceCachePolicy_basic
=== CONT  TestAccAWSCloudFrontDataSourceCachePolicy_basic
--- PASS: TestAccAWSCloudFrontDataSourceCachePolicy_basic (17.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	17.391s


```
