### PR TITLE
r/codebuild_report_group -  Allow deleting reports for report group delete

### DIFF
--- a/.changelog/17338.txt
+++ b/.changelog/17338.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/codebuild_report_group: Wait for report group to be deleted
+```

--- a/.changelog/17338.txt
+++ b/.changelog/17338.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-resource/codebuild_report_group: Wait for report group to be deleted
+```release-note:enhancement
+resource/codebuild_report_group: Allow for deleting reports when deleting a report group
 ```

--- a/.changelog/17338.txt
+++ b/.changelog/17338.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/codebuild_report_group: Allow for deleting reports when deleting a report group
+resource/aws_codebuild_report_group: Add `delete_reports` argument
 ```

--- a/aws/internal/service/codebuild/finder/finder.go
+++ b/aws/internal/service/codebuild/finder/finder.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ReportGroupByArn returns the Report Group corresponding to the specified Arn.
-func ReportGroupByArn(conn *codebuild.CodeBuild, arn string) (*codebuild.BatchGetReportGroupsOutput, error) {
+func ReportGroupByArn(conn *codebuild.CodeBuild, arn string) (*codebuild.ReportGroup, error) {
 
 	output, err := conn.BatchGetReportGroups(&codebuild.BatchGetReportGroupsInput{
 		ReportGroupArns: aws.StringSlice([]string{arn}),
@@ -15,5 +15,18 @@ func ReportGroupByArn(conn *codebuild.CodeBuild, arn string) (*codebuild.BatchGe
 		return nil, err
 	}
 
-	return output, nil
+	if output == nil {
+		return nil, nil
+	}
+
+	if len(output.ReportGroups) == 0 {
+		return nil, nil
+	}
+
+	reportGroup := output.ReportGroups[0]
+	if reportGroup == nil {
+		return nil, nil
+	}
+
+	return reportGroup, nil
 }

--- a/aws/internal/service/codebuild/finder/finder.go
+++ b/aws/internal/service/codebuild/finder/finder.go
@@ -1,0 +1,19 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+)
+
+// ReportGroupByArn returns the Report Group corresponding to the specified Arn.
+func ReportGroupByArn(conn *codebuild.CodeBuild, arn string) (*codebuild.BatchGetReportGroupsOutput, error) {
+
+	output, err := conn.BatchGetReportGroups(&codebuild.BatchGetReportGroupsInput{
+		ReportGroupArns: aws.StringSlice([]string{arn}),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/aws/internal/service/codebuild/waiter/status.go
+++ b/aws/internal/service/codebuild/waiter/status.go
@@ -1,0 +1,38 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/codebuild/finder"
+)
+
+const (
+	ReportGroupStatusUnknown  = "Unknown"
+	ReportGroupStatusNotFound = "NotFound"
+)
+
+// ReportGroupStatus fetches the Report Group and its Status
+func ReportGroupStatus(conn *codebuild.CodeBuild, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.ReportGroupByArn(conn, arn)
+		if err != nil {
+			return nil, ReportGroupStatusUnknown, err
+		}
+
+		if output == nil {
+			return nil, ReportGroupStatusNotFound, nil
+		}
+
+		if len(output.ReportGroups) == 0 {
+			return nil, ReportGroupStatusNotFound, nil
+		}
+
+		reportGroup := output.ReportGroups[0]
+		if reportGroup == nil {
+			return nil, ReportGroupStatusUnknown, nil
+		}
+
+		return output, aws.StringValue(reportGroup.Status), nil
+	}
+}

--- a/aws/internal/service/codebuild/waiter/status.go
+++ b/aws/internal/service/codebuild/waiter/status.go
@@ -24,15 +24,6 @@ func ReportGroupStatus(conn *codebuild.CodeBuild, arn string) resource.StateRefr
 			return nil, ReportGroupStatusNotFound, nil
 		}
 
-		if len(output.ReportGroups) == 0 {
-			return nil, ReportGroupStatusNotFound, nil
-		}
-
-		reportGroup := output.ReportGroups[0]
-		if reportGroup == nil {
-			return nil, ReportGroupStatusUnknown, nil
-		}
-
-		return output, aws.StringValue(reportGroup.Status), nil
+		return output, aws.StringValue(output.Status), nil
 	}
 }

--- a/aws/internal/service/codebuild/waiter/waiter.go
+++ b/aws/internal/service/codebuild/waiter/waiter.go
@@ -1,0 +1,31 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	// Maximum amount of time to wait for an Operation to return Deleted
+	ReportGroupDeleteTimeout = 2 * time.Minute
+)
+
+// ReportGroupDeleted waits for an ReportGroup to return Deleted
+func ReportGroupDeleted(conn *codebuild.CodeBuild, arn string) (*codebuild.BatchGetReportGroupsOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{codebuild.ReportGroupStatusTypeDeleting},
+		Target:  []string{},
+		Refresh: ReportGroupStatus(conn, arn),
+		Timeout: ReportGroupDeleteTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*codebuild.BatchGetReportGroupsOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/internal/service/codebuild/waiter/waiter.go
+++ b/aws/internal/service/codebuild/waiter/waiter.go
@@ -13,7 +13,7 @@ const (
 )
 
 // ReportGroupDeleted waits for an ReportGroup to return Deleted
-func ReportGroupDeleted(conn *codebuild.CodeBuild, arn string) (*codebuild.BatchGetReportGroupsOutput, error) {
+func ReportGroupDeleted(conn *codebuild.CodeBuild, arn string) (*codebuild.ReportGroup, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{codebuild.ReportGroupStatusTypeDeleting},
 		Target:  []string{},
@@ -23,7 +23,7 @@ func ReportGroupDeleted(conn *codebuild.CodeBuild, arn string) (*codebuild.Batch
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*codebuild.BatchGetReportGroupsOutput); ok {
+	if output, ok := outputRaw.(*codebuild.ReportGroup); ok {
 		return output, err
 	}
 

--- a/aws/resource_aws_codebuild_report_group.go
+++ b/aws/resource_aws_codebuild_report_group.go
@@ -191,7 +191,7 @@ func resourceAwsCodeBuildReportGroupDelete(d *schema.ResourceData, meta interfac
 	}
 
 	if _, err := waiter.ReportGroupDeleted(conn, d.Id()); err != nil {
-		return fmt.Errorf("error while waiting for CodeBuild Report Group (%s) to become deleted: %s", d.Id(), err)
+		return fmt.Errorf("error while waiting for CodeBuild Report Group (%s) to become deleted: %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_codebuild_report_group.go
+++ b/aws/resource_aws_codebuild_report_group.go
@@ -92,6 +92,11 @@ func resourceAwsCodeBuildReportGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"delete_reports": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -185,7 +190,8 @@ func resourceAwsCodeBuildReportGroupDelete(d *schema.ResourceData, meta interfac
 	conn := meta.(*AWSClient).codebuildconn
 
 	deleteOpts := &codebuild.DeleteReportGroupInput{
-		Arn: aws.String(d.Id()),
+		Arn:           aws.String(d.Id()),
+		DeleteReports: aws.Bool(d.Get("delete_reports").(bool)),
 	}
 
 	if _, err := conn.DeleteReportGroup(deleteOpts); err != nil {
@@ -193,7 +199,7 @@ func resourceAwsCodeBuildReportGroupDelete(d *schema.ResourceData, meta interfac
 	}
 
 	if _, err := waiter.ReportGroupDeleted(conn, d.Id()); err != nil {
-		return fmt.Errorf("error while waiting for CodeBuild Report Group (%s) to become terminated: %s", d.Id(), err)
+		return fmt.Errorf("error while waiting for CodeBuild Report Group (%s) to become deleted: %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_codebuild_report_group.go
+++ b/aws/resource_aws_codebuild_report_group.go
@@ -125,18 +125,10 @@ func resourceAwsCodeBuildReportGroupRead(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).codebuildconn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	resp, err := finder.ReportGroupByArn(conn, d.Id())
+	reportGroup, err := finder.ReportGroupByArn(conn, d.Id())
 	if err != nil {
 		return fmt.Errorf("error Listing CodeBuild Report Groups: %w", err)
 	}
-
-	if len(resp.ReportGroups) == 0 {
-		log.Printf("[WARN] CodeBuild Report Group (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
-	reportGroup := resp.ReportGroups[0]
 
 	if reportGroup == nil {
 		log.Printf("[WARN] CodeBuild Report Group (%s) not found, removing from state", d.Id())

--- a/aws/resource_aws_codebuild_report_group_test.go
+++ b/aws/resource_aws_codebuild_report_group_test.go
@@ -90,9 +90,10 @@ func TestAccAWSCodeBuildReportGroup_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_reports"},
 			},
 		},
 	})
@@ -124,9 +125,10 @@ func TestAccAWSCodeBuildReportGroup_export_s3(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_reports"},
 			},
 			{
 				Config: testAccAWSCodeBuildReportGroupS3ExportUpdatedConfig(rName),
@@ -165,9 +167,10 @@ func TestAccAWSCodeBuildReportGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_reports"},
 			},
 			{
 				Config: testAccAWSCodeBuildReportGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -208,10 +211,10 @@ func TestAccAWSCodeBuildReportGroup_deleteReports(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				// ImportStateVerifyIgnore: []string{"delete_reports"},
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_reports"},
 			},
 		},
 	})
@@ -269,7 +272,7 @@ func testAccCheckAWSCodeBuildReportGroupDestroy(s *terraform.State) error {
 		}
 
 		if resp != nil {
-			return fmt.Errorf("Found Report Groups %s", rs.Primary.ID)
+			return fmt.Errorf("Found Report Group %s", rs.Primary.ID)
 		}
 
 		return nil
@@ -291,7 +294,7 @@ func testAccCheckAWSCodeBuildReportGroupExists(name string, reportGroup *codebui
 			return err
 		}
 
-		if resp != nil {
+		if resp == nil {
 			return fmt.Errorf("Report Group %s not found", rs.Primary.ID)
 		}
 

--- a/aws/resource_aws_codebuild_report_group_test.go
+++ b/aws/resource_aws_codebuild_report_group_test.go
@@ -275,7 +275,6 @@ func testAccCheckAWSCodeBuildReportGroupDestroy(s *terraform.State) error {
 			return fmt.Errorf("Found Report Group %s", rs.Primary.ID)
 		}
 
-		return nil
 	}
 	return nil
 }

--- a/aws/resource_aws_codebuild_report_group_test.go
+++ b/aws/resource_aws_codebuild_report_group_test.go
@@ -201,17 +201,17 @@ func TestAccAWSCodeBuildReportGroup_deleteReports(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeBuildReportGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodeBuildReportGroupBasicConfig(rName),
+				Config: testAccAWSCodeBuildReportGroupDeleteReportsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildReportGroupExists(resourceName, &reportGroup),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"delete_reports"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// ImportStateVerifyIgnore: []string{"delete_reports"},
 			},
 		},
 	})
@@ -268,15 +268,11 @@ func testAccCheckAWSCodeBuildReportGroupDestroy(s *terraform.State) error {
 			return err
 		}
 
-		if len(resp.ReportGroups) == 0 {
-			return nil
+		if resp != nil {
+			return fmt.Errorf("Found Report Groups %s", rs.Primary.ID)
 		}
 
-		for _, reportGroup := range resp.ReportGroups {
-			if rs.Primary.ID == aws.StringValue(reportGroup.Arn) {
-				return fmt.Errorf("Found Report Groups %s", rs.Primary.ID)
-			}
-		}
+		return nil
 	}
 	return nil
 }
@@ -295,12 +291,11 @@ func testAccCheckAWSCodeBuildReportGroupExists(name string, reportGroup *codebui
 			return err
 		}
 
-		if len(resp.ReportGroups) != 1 ||
-			aws.StringValue(resp.ReportGroups[0].Arn) != rs.Primary.ID {
+		if resp != nil {
 			return fmt.Errorf("Report Group %s not found", rs.Primary.ID)
 		}
 
-		*reportGroup = *resp.ReportGroups[0]
+		*reportGroup = *resp
 
 		return nil
 	}

--- a/aws/resource_aws_codebuild_report_group_test.go
+++ b/aws/resource_aws_codebuild_report_group_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/codebuild/finder"
 )
 
 func TestAccAWSCodeBuildReportGroup_basic(t *testing.T) {
@@ -179,9 +180,7 @@ func testAccCheckAWSCodeBuildReportGroupDestroy(s *terraform.State) error {
 			continue
 		}
 
-		resp, err := conn.BatchGetReportGroups(&codebuild.BatchGetReportGroupsInput{
-			ReportGroupArns: aws.StringSlice([]string{rs.Primary.ID}),
-		})
+		resp, err := finder.ReportGroupByArn(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -208,9 +207,7 @@ func testAccCheckAWSCodeBuildReportGroupExists(name string, reportGroup *codebui
 
 		conn := testAccProvider.Meta().(*AWSClient).codebuildconn
 
-		resp, err := conn.BatchGetReportGroups(&codebuild.BatchGetReportGroupsInput{
-			ReportGroupArns: aws.StringSlice([]string{rs.Primary.ID}),
-		})
+		resp, err := finder.ReportGroupByArn(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/website/docs/r/codebuild_report_group.html.markdown
+++ b/website/docs/r/codebuild_report_group.html.markdown
@@ -65,6 +65,7 @@ The following arguments are supported:
 * `name` - (Required) The name of a Report Group.
 * `type` - (Required) The type of the Report Group. Valid value are `TEST` and `CODE_COVERAGE`.
 * `export_config` - (Required) Information about the destination where the raw data of this Report Group is exported. see [Export Config](#export-config) documented below.
+* `delete_reports` - (Optional) If `true`, deletes any reports that belong to a report group before deleting the report group. If `false`, you must delete any reports in the report group before deleting it. Default value is `false`.
 * `tags` - (Optional) Key-value mapping of resource tags
 
 ### Export Config


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17290

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeBuildReportGroup_'
--- PASS: TestAccAWSCodeBuildReportGroup_disappears (27.56s)
--- PASS: TestAccAWSCodeBuildReportGroup_basic (36.17s)
--- PASS: TestAccAWSCodeBuildReportGroup_deleteReports (36.49s)
--- PASS: TestAccAWSCodeBuildReportGroup_tags (84.09s)
--- PASS: TestAccAWSCodeBuildReportGroup_export_s3 (123.29s)
```
