### PR TITLE
aws/resource_aws_lambda_function: imageConfig can be null

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -1315,7 +1315,7 @@ func expandLambdaFileSystemConfigs(fscMaps []interface{}) []*lambda.FileSystemCo
 func flattenLambdaImageConfig(response *lambda.ImageConfigResponse) []map[string]interface{} {
 	settings := make(map[string]interface{})
 
-	if response == nil || response.Error != nil {
+	if response == nil || response.Error != nil || response.ImageConfig == nil {
 		return nil
 	}
 

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -3140,3 +3140,9 @@ resource "aws_lambda_function" "test" {
 }
 `, rName, runtime))
 }
+
+func TestFlattenLambdaImageConfigShouldNotFailWithEmptyImageConfig(t *testing.T) {
+	t.Parallel()
+	response := lambda.ImageConfigResponse{}
+	flattenLambdaImageConfig(&response)
+}


### PR DESCRIPTION
Allow flattenLambdaImageConfig to not fail if ImageConfig == null

Reproducible by importing a lambda function where the image config has not been set to anything:

```
 runtime error: invalid memory address or nil pointer dereference
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x484cae2]
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: goroutine 26 [running]:
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: github.com/terraform-providers/terraform-provider-aws/aws.flattenLambdaImageConfig(...)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/hashicorp/terraform-provider-aws/aws/resource_aws_lambda_function.go:1322
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsLambdaFunctionRead(0xc001deee00, 0x5aee120, 0xc001162000, 0xa68abe0, 0x69151d0)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/hashicorp/terraform-provider-aws/aws/resource_aws_lambda_function.go:724 +0x2f62
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc000a460c0, 0x7235c00, 0xc0017670c0, 0xc001deee00, 0x5aee120, 0xc001162000, 0x0, 0x0, 0x0)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.1/helper/schema/resource.go:290 +0x88
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000a460c0, 0x7235c00, 0xc0017670c0, 0xc000a307e0, 0x5aee120, 0xc001162000, 0xc00011ea58, 0x0, 0x0, 0x0)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.1/helper/schema/resource.go:564 +0x1cb
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc000cf0300, 0x7235c00, 0xc0017670c0, 0xc001767100, 0xc0017670c0, 0x6340b20, 0x65debe0)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.1/helper/schema/grpc_provider.go:575 +0x43b
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadResource(0xc0018c8840, 0x7235c00, 0xc0017670c0, 0xc00063f9e0, 0xc0018c8840, 0xc0011c34a0, 0xc001d5eba0)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.2.1/tfprotov5/server/server.go:298 +0x105
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler(0x65debe0, 0xc0018c8840, 0x7235cc0, 0xc0011c34a0, 0xc00063f920, 0x0, 0x7235cc0, 0xc0011c34a0, 0xc0011d4580, 0x285)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.2.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:344 +0x214
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: google.golang.org/grpc.(*Server).processUnaryRPC(0xc000566fc0, 0x7258ba0, 0xc000130600, 0xc001dfe200, 0xc0015f2b70, 0xa649490, 0x0, 0x0, 0x0)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0x522
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: google.golang.org/grpc.(*Server).handleStream(0xc000566fc0, 0x7258ba0, 0xc000130600, 0xc001dfe200, 0x0)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0xd05
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc000bdedb0, 0xc000566fc0, 0x7258ba0, 0xc000130600, 0xc001dfe200)
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0xa5
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5: created by google.golang.org/grpc.(*Server).serveStreams.func1
2021-01-29T16:58:16.670+0100 [DEBUG] plugin.terraform-provider-aws_v3.26.0_x5:  /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd
2021-01-29T16:58:16.675+0100 [DEBUG] plugin: plugin process exited: path=.terraform/providers/registry.terraform.io/hashicorp/aws/3.26.0/linux_amd64/terraform-provider-aws_v3.26.0_x5 pid=163969 error="exit status 2"
2021-01-29T16:58:16.675+0100 [WARN]  plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"
```

The ImageConfig can be null.

```json
{
    ...
    "Configuration": {
        ...
        "ImageConfigResponse": {
            "Error": null,
            "ImageConfig": null
        },
    },
}
```
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ go test -run TestFlattenLambdaImageConfigShouldNotFailWithEmptyImageConfig\$ . 
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.041s

...
```
