### PR TITLE
Fixes acceptance test Terraform linting

### DIFF
--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -54,7 +54,7 @@ jobs:
       - run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ steps.go-version.outputs.content }}
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/cache@v2
         continue-on-error: true
         timeout-minutes: 2

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -719,7 +719,7 @@ resource "aws_glue_catalog_table" "test" {
 }
 
 resource "aws_lakeformation_data_lake_settings" "test" {
-  // this will result in multiple permissions for iam role
+  # this will result in multiple permissions for iam role
   admins = [aws_iam_role.test.arn, data.aws_caller_identity.current.arn]
 }
 

--- a/scripts/validate-terraform.sh
+++ b/scripts/validate-terraform.sh
@@ -29,7 +29,6 @@ rules=(
     "--only=aws_route_specified_multiple_targets"
 )
 while read -r filename ; do
-    echo "$filename"
     block_number=0
 
     while IFS= read -r block ; do


### PR DESCRIPTION
Fixes one linting error in `resource_aws_lakeformation_permissions_test.go`

Corrects workflow configuration to no longer reference non-existent step and allow it to run in [`act`](https://github.com/nektos/act)
