### PR TITLE
tests/resource/aws_iot_policy: Remove TestAccAWSIoTPolicy_invalidJson test

### DIFF
--- a/aws/resource_aws_iot_policy_test.go
+++ b/aws/resource_aws_iot_policy_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -59,22 +58,6 @@ func TestAccAWSIoTPolicy_disappears(t *testing.T) {
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsIotPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSIoTPolicy_invalidJson(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSIoTPolicyDestroy_basic,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSIoTPolicyInvalidJsonConfig(rName),
-				ExpectError: regexp.MustCompile("MalformedPolicyException.*"),
 			},
 		},
 	})
@@ -140,32 +123,6 @@ func testAccCheckAWSIoTPolicyExists(n string, v *iot.GetPolicyOutput) resource.T
 }
 
 func testAccAWSIoTPolicyConfigInitialState(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_iot_policy" "test" {
-  name = "%s"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:*"
-      ],
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
-}
-EOF
-
-}
-`, rName)
-}
-
-func testAccAWSIoTPolicyInvalidJsonConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iot_policy" "test" {
   name = "%s"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17397

During Terraform 0.12 syntax upgrades in the test configurations, the JSON policy was accidentally fixed so the API no longer threw the error the test was expecting:

```
=== CONT  TestAccAWSIoTPolicy_invalidJson
resource_aws_iot_policy_test.go:70: Step 1/1, expected an error but got none
--- FAIL: TestAccAWSIoTPolicy_invalidJson (16.73s)
```

Testing API errors is not a goal of our acceptance testing and this test should be removed rather than "broken" again.

Output from acceptance testing:

```
--- PASS: TestAccAWSIoTPolicy_disappears (12.15s)
--- PASS: TestAccAWSIoTPolicy_basic (16.11s)
```
