### PR TITLE
tests/service/imagebuilder: Fix distribution configuration InvalidParameterValueException

### DIFF
--- a/aws/data_source_aws_imagebuilder_distribution_configuration_test.go
+++ b/aws/data_source_aws_imagebuilder_distribution_configuration_test.go
@@ -42,6 +42,10 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   name = %[1]q
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.current.name
   }
 }

--- a/aws/resource_aws_imagebuilder_distribution_configuration_test.go
+++ b/aws/resource_aws_imagebuilder_distribution_configuration_test.go
@@ -585,6 +585,10 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   name        = %[1]q
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.current.name
   }
 }
@@ -605,10 +609,18 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   name = %[1]q
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.current.name
   }
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.alternate.name
   }
 }
@@ -821,6 +833,10 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   name = %[1]q
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.current.name
   }
 }
@@ -835,6 +851,10 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   name = %[1]q
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.current.name
   }
 
@@ -853,6 +873,10 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   name = %[1]q
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.current.name
   }
 

--- a/aws/resource_aws_imagebuilder_image_pipeline_test.go
+++ b/aws/resource_aws_imagebuilder_image_pipeline_test.go
@@ -651,6 +651,10 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   name = "%[1]s-1"
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.current.name
   }
 
@@ -676,6 +680,10 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   name = "%[1]s-2"
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.current.name
   }
 

--- a/aws/resource_aws_imagebuilder_image_test.go
+++ b/aws/resource_aws_imagebuilder_image_test.go
@@ -452,6 +452,10 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   name = %[1]q
 
   distribution {
+    ami_distribution_configuration {
+      name = "{{ imagebuilder:buildDate }}"
+    }
+
     region = data.aws_region.current.name
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17390

The Image Builder service in AWS Commercial is now performing additional validation on Distribution Configuration creation, presumably due to the launch of container distribution support:

```
=== CONT  TestAccAwsImageBuilderDistributionConfigurationDataSource_Arn
data_source_aws_imagebuilder_distribution_configuration_test.go:16: Step 1/1 error: Error running apply:
Error: error creating Image Builder Distribution Configuration: InvalidParameterValueException: The value supplied for parameter 'distributions[0]' is not valid. One or more outputs should be provided for each region in a distribution configuration.
--- FAIL: TestAccAwsImageBuilderDistributionConfigurationDataSource_Arn (8.02s)

=== CONT  TestAccAwsImageBuilderDistributionConfiguration_basic
resource_aws_imagebuilder_distribution_configuration_test.go:80: Step 1/2 error: Error running apply:
Error: error creating Image Builder Distribution Configuration: InvalidParameterValueException: The value supplied for parameter 'distributions[0]' is not valid. One or more outputs should be provided for each region in a distribution configuration.
--- FAIL: TestAccAwsImageBuilderDistributionConfiguration_basic (29.55s)

=== CONT  TestAccAwsImageBuilderDistributionConfiguration_disappears
resource_aws_imagebuilder_distribution_configuration_test.go:110: Step 1/1 error: Error running apply:
Error: error creating Image Builder Distribution Configuration: InvalidParameterValueException: The value supplied for parameter 'distributions[0]' is not valid. One or more outputs should be provided for each region in a distribution configuration.
--- FAIL: TestAccAwsImageBuilderDistributionConfiguration_disappears (32.72s)

=== CONT  TestAccAwsImageBuilderDistributionConfiguration_Description
resource_aws_imagebuilder_distribution_configuration_test.go:131: Step 1/3 error: Error running apply:
Error: error creating Image Builder Distribution Configuration: InvalidParameterValueException: The value supplied for parameter 'distributions[0]' is not valid. One or more outputs should be provided for each region in a distribution configuration.
--- FAIL: TestAccAwsImageBuilderDistributionConfiguration_Description (33.09s)

=== CONT  TestAccAwsImageBuilderDistributionConfiguration_Distribution
resource_aws_imagebuilder_distribution_configuration_test.go:164: Step 1/2 error: Error running apply:
Error: error creating Image Builder Distribution Configuration: InvalidParameterValueException: The value supplied for parameter 'distributions[0]' is not valid. One or more outputs should be provided for each region in a distribution configuration.
--- FAIL: TestAccAwsImageBuilderDistributionConfiguration_Distribution (44.85s)

=== CONT  TestAccAwsImageBuilderDistributionConfiguration_Tags
resource_aws_imagebuilder_distribution_configuration_test.go:487: Step 1/4 error: Error running apply:
Error: error creating Image Builder Distribution Configuration: InvalidParameterValueException: The value supplied for parameter 'distributions[0]' is not valid. One or more outputs should be provided for each region in a distribution configuration.
--- FAIL: TestAccAwsImageBuilderDistributionConfiguration_Tags (33.09s)

=== CONT  TestAccAwsImageBuilderImagePipeline_DistributionConfigurationArn
resource_aws_imagebuilder_image_pipeline_test.go:178: Step 1/3 error: Error running apply:
Error: error creating Image Builder Distribution Configuration: InvalidParameterValueException: The value supplied for parameter 'distributions[0]' is not valid. One or more outputs should be provided for each region in a distribution configuration.
--- FAIL: TestAccAwsImageBuilderImagePipeline_DistributionConfigurationArn (48.35s)

=== CONT  TestAccAwsImageBuilderImage_DistributionConfigurationArn
resource_aws_imagebuilder_image_test.go:146: Step 1/2 error: Error running apply:
Error: error creating Image Builder Distribution Configuration: InvalidParameterValueException: The value supplied for parameter 'distributions[0]' is not valid. One or more outputs should be provided for each region in a distribution configuration.
--- FAIL: TestAccAwsImageBuilderImage_DistributionConfigurationArn (54.05s)
```

The test configurations are updated to include limited AMI distribution configuration so testing can pass without adding container distribution support.

Output from acceptance testing in AWS Commercial:

```
--- FAIL: TestAccAwsImageBuilderImagePipeline_Schedule_PipelineExecutionStartCondition (37.70s) # https://github.com/hashicorp/terraform-provider-aws/issues/17396
--- FAIL: TestAccAwsImageBuilderImagePipeline_Schedule_ScheduleExpression (34.62s) # https://github.com/hashicorp/terraform-provider-aws/issues/17396
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_basic (30.84s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Description (51.76s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_disappears (27.33s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution (30.73s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_AmiTags (60.25s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_Description (47.60s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_KmsKeyId (66.08s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_LaunchPermission_UserGroups (48.36s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_LaunchPermission_UserIds (63.06s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_Name (72.42s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_TargetAccountIds (73.19s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_LicenseConfigurationArns (69.33s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Tags (92.68s)

--- PASS: TestAccAwsImageBuilderDistributionConfigurationDataSource_Arn (35.66s)

--- PASS: TestAccAwsImageBuilderImage_basic (1449.31s)
--- PASS: TestAccAwsImageBuilderImage_disappears (1449.08s)
--- PASS: TestAccAwsImageBuilderImage_DistributionConfigurationArn (1829.34s)
--- PASS: TestAccAwsImageBuilderImage_EnhancedImageMetadataEnabled (1207.33s)
--- PASS: TestAccAwsImageBuilderImage_ImageTestsConfiguration_ImageTestsEnabled (1095.28s)
--- PASS: TestAccAwsImageBuilderImage_ImageTestsConfiguration_TimeoutMinutes (1222.96s)
--- PASS: TestAccAwsImageBuilderImage_Tags (1661.80s)

--- PASS: TestAccAwsImageBuilderImagePipeline_basic (65.25s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Description (96.68s)
--- PASS: TestAccAwsImageBuilderImagePipeline_disappears (60.46s)
--- PASS: TestAccAwsImageBuilderImagePipeline_DistributionConfigurationArn (112.52s)
--- PASS: TestAccAwsImageBuilderImagePipeline_EnhancedImageMetadataEnabled (95.24s)
--- PASS: TestAccAwsImageBuilderImagePipeline_ImageRecipeArn (96.45s)
--- PASS: TestAccAwsImageBuilderImagePipeline_ImageTestsConfiguration_ImageTestsEnabled (88.54s)
--- PASS: TestAccAwsImageBuilderImagePipeline_ImageTestsConfiguration_TimeoutMinutes (107.57s)
--- PASS: TestAccAwsImageBuilderImagePipeline_InfrastructureConfigurationArn (100.25s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Status (96.04s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Tags (121.74s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_basic (30.27s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Description (72.88s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_disappears (37.27s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution (51.44s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_AmiTags (50.52s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_Description (57.29s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_KmsKeyId (72.36s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_LaunchPermission_UserGroups (43.11s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_LaunchPermission_UserIds (76.37s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_Name (48.78s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_TargetAccountIds (54.17s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_LicenseConfigurationArns (81.88s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Tags (82.35s)

--- PASS: TestAccAwsImageBuilderDistributionConfigurationDataSource_Arn (41.36s)

--- PASS: TestAccAwsImageBuilderImage_basic (1481.43s)
--- PASS: TestAccAwsImageBuilderImage_disappears (1354.00s)
--- PASS: TestAccAwsImageBuilderImage_DistributionConfigurationArn (1731.97s)
--- PASS: TestAccAwsImageBuilderImage_EnhancedImageMetadataEnabled (976.74s)
--- PASS: TestAccAwsImageBuilderImage_ImageTestsConfiguration_ImageTestsEnabled (976.18s)
--- PASS: TestAccAwsImageBuilderImage_ImageTestsConfiguration_TimeoutMinutes (1472.80s)
--- PASS: TestAccAwsImageBuilderImage_Tags (1287.54s)

--- PASS: TestAccAwsImageBuilderImagePipeline_basic (63.98s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Description (107.93s)
--- PASS: TestAccAwsImageBuilderImagePipeline_disappears (61.53s)
--- PASS: TestAccAwsImageBuilderImagePipeline_DistributionConfigurationArn (108.80s)
--- PASS: TestAccAwsImageBuilderImagePipeline_EnhancedImageMetadataEnabled (106.06s)
--- PASS: TestAccAwsImageBuilderImagePipeline_ImageRecipeArn (65.08s)
--- PASS: TestAccAwsImageBuilderImagePipeline_ImageTestsConfiguration_ImageTestsEnabled (65.10s)
--- PASS: TestAccAwsImageBuilderImagePipeline_ImageTestsConfiguration_TimeoutMinutes (64.33s)
--- PASS: TestAccAwsImageBuilderImagePipeline_InfrastructureConfigurationArn (107.98s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Schedule_PipelineExecutionStartCondition (63.33s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Schedule_ScheduleExpression (105.97s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Status (100.15s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Tags (129.05s)
```
