### PR TITLE
resource/aws_subnet: Apply attribute waiter logic to map_public_ip_on_launch attribute and tidy up attribute testing

### DIFF
--- a/aws/internal/service/ec2/waiter/status.go
+++ b/aws/internal/service/ec2/waiter/status.go
@@ -259,6 +259,27 @@ func SubnetMapCustomerOwnedIpOnLaunch(conn *ec2.EC2, id string) resource.StateRe
 	}
 }
 
+// SubnetMapPublicIpOnLaunch fetches the Subnet and its MapPublicIpOnLaunch
+func SubnetMapPublicIpOnLaunch(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		subnet, err := finder.SubnetByID(conn, id)
+
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidSubnetIDNotFound) {
+			return nil, "false", nil
+		}
+
+		if err != nil {
+			return nil, "false", err
+		}
+
+		if subnet == nil {
+			return nil, "false", nil
+		}
+
+		return subnet, strconv.FormatBool(aws.BoolValue(subnet.MapPublicIpOnLaunch)), nil
+	}
+}
+
 const (
 	vpcPeeringConnectionStatusNotFound = "NotFound"
 	vpcPeeringConnectionStatusUnknown  = "Unknown"

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -272,6 +272,24 @@ func SubnetMapCustomerOwnedIpOnLaunchUpdated(conn *ec2.EC2, subnetID string, exp
 	return nil, err
 }
 
+func SubnetMapPublicIpOnLaunchUpdated(conn *ec2.EC2, subnetID string, expectedValue bool) (*ec2.Subnet, error) {
+	stateConf := &resource.StateChangeConf{
+		Target:     []string{strconv.FormatBool(expectedValue)},
+		Refresh:    SubnetMapPublicIpOnLaunch(conn, subnetID),
+		Timeout:    SubnetAttributePropagationTimeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.Subnet); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 const (
 	VpnGatewayVpcAttachmentAttachedTimeout = 15 * time.Minute
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16696

This resource attribute has long been the cause of flakey acceptance testing across the codebase, such as:

```
=== CONT  TestAccAWSLB_applicationLoadBalancer_updateHttp2
TestAccAWSLB_applicationLoadBalancer_updateHttp2: resource_aws_lb_test.go:522: Step 1/3 error: After applying this test step, the plan was not empty.
stdout:
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# aws_subnet.alb_test[0] will be updated in-place
~ resource "aws_subnet" "alb_test" {
id                              = "subnet-088715d2b9827af18"
~ map_public_ip_on_launch         = false -> true
tags                            = {
"Name" = "tf-acc-lb-basic-0"
}
# (7 unchanged attributes hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
```

Adding logic, similar to `SubnetMapCustomerOwnedIpOnLaunchUpdated` in https://github.com/hashicorp/terraform-provider-aws/pull/16676 can be used to ensure the attribute value has flipped correctly after calling the `ModifySubnetAttribute` API.

This attribute waiter setup will be added to a forthcoming Retries and Waiters section in the Contribution Guide.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (302.23s)

--- PASS: TestAccAWSSubnet_availabilityZoneId (37.76s)
--- PASS: TestAccAWSSubnet_basic (35.50s)
--- PASS: TestAccAWSSubnet_disappears (27.55s)
--- PASS: TestAccAWSSubnet_enableIpv6 (88.46s)
--- PASS: TestAccAWSSubnet_ignoreTags (57.96s)
--- PASS: TestAccAWSSubnet_ipv6 (99.54s)
--- PASS: TestAccAWSSubnet_MapPublicIpOnLaunch (99.92s)
--- PASS: TestAccAWSSubnet_tags (84.05s)
--- SKIP: TestAccAWSSubnet_CustomerOwnedIpv4Pool (7.36s)
--- SKIP: TestAccAWSSubnet_MapCustomerOwnedIpOnLaunch (1.82s)
--- SKIP: TestAccAWSSubnet_outpost (1.62s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (310.96s)

--- PASS: TestAccAWSSubnet_availabilityZoneId (42.49s)
--- PASS: TestAccAWSSubnet_basic (39.27s)
--- PASS: TestAccAWSSubnet_disappears (31.78s)
--- PASS: TestAccAWSSubnet_enableIpv6 (100.77s)
--- PASS: TestAccAWSSubnet_ignoreTags (67.49s)
--- PASS: TestAccAWSSubnet_ipv6 (108.38s)
--- PASS: TestAccAWSSubnet_MapPublicIpOnLaunch (109.87s)
--- PASS: TestAccAWSSubnet_tags (95.24s)
--- SKIP: TestAccAWSSubnet_CustomerOwnedIpv4Pool (7.11s)
--- SKIP: TestAccAWSSubnet_MapCustomerOwnedIpOnLaunch (2.17s)
--- SKIP: TestAccAWSSubnet_outpost (10.06s)
```