### PR TITLE
Allow use of resource_type and resource_type_list

### DIFF
--- a/.changelog/17418.txt
+++ b/.changelog/17418.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fms_policy: Allow use of `resource_type` or `resource_type_list` attributes
+```

--- a/aws/resource_aws_fms_policy.go
+++ b/aws/resource_aws_fms_policy.go
@@ -93,13 +93,20 @@ func resourceAwsFmsPolicy() *schema.Resource {
 			},
 
 			"resource_type_list": {
-				Type:     schema.TypeSet,
-				Required: true,
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Set:           schema.HashString,
+				ConflictsWith: []string{"resource_type"},
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{"AWS::ApiGateway::Stage", "AWS::ElasticLoadBalancingV2::LoadBalancer", "AWS::CloudFront::Distribution", "AWS::EC2::NetworkInterface", "AWS::EC2::Instance", "AWS::EC2::SecurityGroup"}, false),
 				},
-				Set: schema.HashString,
+			},
+
+			"resource_type": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"resource_type_list"},
 			},
 
 			"policy_update_token": {
@@ -138,31 +145,7 @@ func resourceAwsFmsPolicy() *schema.Resource {
 func resourceAwsFmsPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).fmsconn
 
-	fmsPolicy := &fms.Policy{
-		PolicyName:          aws.String(d.Get("name").(string)),
-		RemediationEnabled:  aws.Bool(d.Get("remediation_enabled").(bool)),
-		ResourceType:        aws.String("ResourceTypeList"),
-		ResourceTypeList:    expandStringSet(d.Get("resource_type_list").(*schema.Set)),
-		ExcludeResourceTags: aws.Bool(d.Get("exclude_resource_tags").(bool)),
-	}
-
-	securityServicePolicy := d.Get("security_service_policy_data").([]interface{})[0].(map[string]interface{})
-	fmsPolicy.SecurityServicePolicyData = &fms.SecurityServicePolicyData{
-		ManagedServiceData: aws.String(securityServicePolicy["managed_service_data"].(string)),
-		Type:               aws.String(securityServicePolicy["type"].(string)),
-	}
-
-	if rTags, tagsOk := d.GetOk("resource_tags"); tagsOk {
-		fmsPolicy.ResourceTags = constructResourceTags(rTags)
-	}
-
-	if v, ok := d.GetOk("include_map"); ok {
-		fmsPolicy.IncludeMap = expandFMSPolicyMap(v.([]interface{}))
-	}
-
-	if v, ok := d.GetOk("exclude_map"); ok {
-		fmsPolicy.ExcludeMap = expandFMSPolicyMap(v.([]interface{}))
-	}
+	fmsPolicy := resourceAwsFmsPolicyExpandPolicy(d)
 
 	params := &fms.PutPolicyInput{
 		Policy: fmsPolicy,
@@ -201,22 +184,29 @@ func resourceAwsFmsPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	return resourceAwsFmsPolicyFlattenPolicy(d, resp)
+}
+
+func resourceAwsFmsPolicyFlattenPolicy(d *schema.ResourceData, resp *fms.GetPolicyOutput) error {
 	d.Set("arn", aws.StringValue(resp.PolicyArn))
 
 	d.Set("name", aws.StringValue(resp.Policy.PolicyName))
 	d.Set("exclude_resource_tags", aws.BoolValue(resp.Policy.ExcludeResourceTags))
-	if err = d.Set("exclude_map", flattenFMSPolicyMap(resp.Policy.ExcludeMap)); err != nil {
+	if err := d.Set("exclude_map", flattenFMSPolicyMap(resp.Policy.ExcludeMap)); err != nil {
 		return err
 	}
-	if err = d.Set("include_map", flattenFMSPolicyMap(resp.Policy.IncludeMap)); err != nil {
+	if err := d.Set("include_map", flattenFMSPolicyMap(resp.Policy.IncludeMap)); err != nil {
 		return err
 	}
 	d.Set("remediation_enabled", aws.BoolValue(resp.Policy.RemediationEnabled))
-	if err = d.Set("resource_type_list", resp.Policy.ResourceTypeList); err != nil {
+	if err := d.Set("resource_type_list", resp.Policy.ResourceTypeList); err != nil {
 		return err
 	}
+	if aws.StringValue(resp.Policy.ResourceType) != "ResourceTypeList" {
+		d.Set("resource_type", aws.StringValue(resp.Policy.ResourceType))
+	}
 	d.Set("policy_update_token", aws.StringValue(resp.Policy.PolicyUpdateToken))
-	if err = d.Set("resource_tags", flattenFMSResourceTags(resp.Policy.ResourceTags)); err != nil {
+	if err := d.Set("resource_tags", flattenFMSResourceTags(resp.Policy.ResourceTags)); err != nil {
 		return err
 	}
 
@@ -224,23 +214,27 @@ func resourceAwsFmsPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		"type":                 *resp.Policy.SecurityServicePolicyData.Type,
 		"managed_service_data": *resp.Policy.SecurityServicePolicyData.ManagedServiceData,
 	}}
-	if err = d.Set("security_service_policy_data", securityServicePolicy); err != nil {
+	if err := d.Set("security_service_policy_data", securityServicePolicy); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func resourceAwsFmsPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).fmsconn
+func resourceAwsFmsPolicyExpandPolicy(d *schema.ResourceData) *fms.Policy {
+	resourceType := aws.String("ResourceTypeList")
+	resourceTypeList := expandStringSet(d.Get("resource_type_list").(*schema.Set))
+	if t, ok := d.GetOk("resource_type"); ok {
+		resourceType = aws.String(t.(string))
+	}
 
 	fmsPolicy := &fms.Policy{
 		PolicyName:          aws.String(d.Get("name").(string)),
 		PolicyId:            aws.String(d.Id()),
 		PolicyUpdateToken:   aws.String(d.Get("policy_update_token").(string)),
 		RemediationEnabled:  aws.Bool(d.Get("remediation_enabled").(bool)),
-		ResourceType:        aws.String("ResourceTypeList"),
-		ResourceTypeList:    expandStringSet(d.Get("resource_type_list").(*schema.Set)),
+		ResourceType:        resourceType,
+		ResourceTypeList:    resourceTypeList,
 		ExcludeResourceTags: aws.Bool(d.Get("exclude_resource_tags").(bool)),
 	}
 
@@ -255,6 +249,14 @@ func resourceAwsFmsPolicyUpdate(d *schema.ResourceData, meta interface{}) error 
 		ManagedServiceData: aws.String(securityServicePolicy["managed_service_data"].(string)),
 		Type:               aws.String(securityServicePolicy["type"].(string)),
 	}
+
+	return fmsPolicy
+}
+
+func resourceAwsFmsPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).fmsconn
+
+	fmsPolicy := resourceAwsFmsPolicyExpandPolicy(d)
 
 	params := &fms.PutPolicyInput{Policy: fmsPolicy}
 	_, err := conn.PutPolicy(params)

--- a/website/docs/r/fms_policy.html.markdown
+++ b/website/docs/r/fms_policy.html.markdown
@@ -59,7 +59,8 @@ The following arguments are supported:
 * `include_map` - (Optional) A map of lists, with a single key named 'account' with a list of AWS Account IDs to include for this policy.
 * `remediation_enabled` - (Required) A boolean value, indicates if the policy should automatically applied to resources that already exist in the account.
 * `resource_tags` - (Optional) A map of resource tags, that if present will filter protections on resources based on the exclude_resource_tags.
-* `resource_type_list` - (Required, Forces new resource) A list of resource types to protect, valid values are: `AWS::ElasticLoadBalancingV2::LoadBalancer`, `AWS::ApiGateway::Stage`, `AWS::CloudFront::Distribution`.
+* `resource_type` - (Optional) A resource type to protect, valid values are: `AWS::ElasticLoadBalancingV2::LoadBalancer`, `AWS::ApiGateway::Stage`, `AWS::CloudFront::Distribution`. Conflicts with `resource_type_list`.
+* `resource_type_list` - (Optional) A list of resource types to protect, valid values are: `AWS::ElasticLoadBalancingV2::LoadBalancer`, `AWS::ApiGateway::Stage`, `AWS::CloudFront::Distribution`. Conflicts with `resource_type`.
 * `security_service_policy_data` - (Required) The objects to include in Security Service Policy Data. Documented below.
 
 ## `exclude_map` Configuration Block

--- a/website/docs/r/fms_policy.html.markdown
+++ b/website/docs/r/fms_policy.html.markdown
@@ -59,8 +59,8 @@ The following arguments are supported:
 * `include_map` - (Optional) A map of lists, with a single key named 'account' with a list of AWS Account IDs to include for this policy.
 * `remediation_enabled` - (Required) A boolean value, indicates if the policy should automatically applied to resources that already exist in the account.
 * `resource_tags` - (Optional) A map of resource tags, that if present will filter protections on resources based on the exclude_resource_tags.
-* `resource_type` - (Optional) A resource type to protect, valid values are: `AWS::ElasticLoadBalancingV2::LoadBalancer`, `AWS::ApiGateway::Stage`, `AWS::CloudFront::Distribution`. Conflicts with `resource_type_list`.
-* `resource_type_list` - (Optional) A list of resource types to protect, valid values are: `AWS::ElasticLoadBalancingV2::LoadBalancer`, `AWS::ApiGateway::Stage`, `AWS::CloudFront::Distribution`. Conflicts with `resource_type`.
+* `resource_type` - (Optional) A resource type to protect, valid values are: `AWS::ElasticLoadBalancingV2::LoadBalancer`, `AWS::ApiGateway::Stage`, `AWS::CloudFront::Distribution`, `AWS::EC2::Instance`, `AWS::EC2::NetworkInterface`, `AWS::EC2::SecurityGroup`. Conflicts with `resource_type_list`.
+* `resource_type_list` - (Optional) A list of resource types to protect, valid values are: `AWS::ElasticLoadBalancingV2::LoadBalancer`, `AWS::ApiGateway::Stage`, `AWS::CloudFront::Distribution`, `AWS::EC2::Instance`, `AWS::EC2::NetworkInterface`, `AWS::EC2::SecurityGroup`. Conflicts with `resource_type`.
 * `security_service_policy_data` - (Required) The objects to include in Security Service Policy Data. Documented below.
 
 ## `exclude_map` Configuration Block


### PR DESCRIPTION
`AWS::CloudFront::Distribution` is only allowed in `resource_type`. Originally `fms_policy` put all resource types into `resource_type_list`. This PR allows the use of both.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSFmsPolicy_ -timeout 120m
=== RUN   TestAccAWSFmsPolicy_basic
=== PAUSE TestAccAWSFmsPolicy_basic
=== RUN   TestAccAWSFmsPolicy_cloudfrontDistribution
=== PAUSE TestAccAWSFmsPolicy_cloudfrontDistribution
=== RUN   TestAccAWSFmsPolicy_includeMap
=== PAUSE TestAccAWSFmsPolicy_includeMap
=== RUN   TestAccAWSFmsPolicy_update
=== PAUSE TestAccAWSFmsPolicy_update
=== RUN   TestAccAWSFmsPolicy_tags
=== PAUSE TestAccAWSFmsPolicy_tags
=== CONT  TestAccAWSFmsPolicy_basic
=== CONT  TestAccAWSFmsPolicy_update
=== CONT  TestAccAWSFmsPolicy_tags
=== CONT  TestAccAWSFmsPolicy_includeMap
=== CONT  TestAccAWSFmsPolicy_cloudfrontDistribution
--- PASS: TestAccAWSFmsPolicy_basic (31.81s)
--- PASS: TestAccAWSFmsPolicy_includeMap (33.09s)
--- PASS: TestAccAWSFmsPolicy_tags (34.23s)
--- PASS: TestAccAWSFmsPolicy_update (51.61s)
--- PASS: TestAccAWSFmsPolicy_cloudfrontDistribution (106.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	106.214s

```
