### PR TITLE
tests/provider: Prevent skip issues with special region testing involving multiple tests

### DIFF
--- a/aws/api_gateway_domain_name_test.go
+++ b/aws/api_gateway_domain_name_test.go
@@ -37,16 +37,16 @@ var testAccProviderApigatewayEdgeDomainNameConfigure sync.Once
 func testAccPreCheckApigatewayEdgeDomainName(t *testing.T) {
 	testAccPartitionHasServicePreCheck(apigateway.EndpointsID, t)
 
+	region := testAccGetApigatewayEdgeDomainNameRegion()
+
+	if region == "" {
+		t.Skip("API Gateway Domain Name not available in this AWS Partition")
+	}
+
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderApigatewayEdgeDomainNameConfigure.Do(func() {
 		testAccProviderApigatewayEdgeDomainName = Provider()
-
-		region := testAccGetApigatewayEdgeDomainNameRegion()
-
-		if region == "" {
-			t.Skip("API Gateway Domain Name not available in this AWS Partition")
-		}
 
 		config := map[string]interface{}{
 			"region": region,

--- a/aws/cognito_user_pool_domain_test.go
+++ b/aws/cognito_user_pool_domain_test.go
@@ -34,16 +34,16 @@ var testAccProviderCognitoUserPoolCustomDomainConfigure sync.Once
 func testAccPreCheckCognitoUserPoolCustomDomain(t *testing.T) {
 	testAccPartitionHasServicePreCheck(cognitoidentityprovider.EndpointsID, t)
 
+	region := testAccGetCognitoUserPoolCustomDomainRegion()
+
+	if region == "" {
+		t.Skip("Cognito User Pool Custom Domains not available in this AWS Partition")
+	}
+
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderCognitoUserPoolCustomDomainConfigure.Do(func() {
 		testAccProviderCognitoUserPoolCustomDomain = Provider()
-
-		region := testAccGetCognitoUserPoolCustomDomainRegion()
-
-		if region == "" {
-			t.Skip("Cognito User Pool Custom Domains not available in this AWS Partition")
-		}
 
 		config := map[string]interface{}{
 			"region": region,

--- a/aws/lightsail_domain_test.go
+++ b/aws/lightsail_domain_test.go
@@ -39,15 +39,15 @@ func init() {
 func testAccPreCheckLightsailDomain(t *testing.T) {
 	testAccPartitionHasServicePreCheck(lightsail.EndpointsID, t)
 
+	region := testAccGetLightsailDomainRegion()
+
+	if region == "" {
+		t.Skip("Lightsail Domains not available in this AWS Partition")
+	}
+
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderLightsailDomainConfigure.Do(func() {
-		region := testAccGetLightsailDomainRegion()
-
-		if region == "" {
-			t.Skip("Lightsail Domains not available in this AWS Partition")
-		}
-
 		config := map[string]interface{}{
 			"region": region,
 		}

--- a/aws/route53_query_log_test.go
+++ b/aws/route53_query_log_test.go
@@ -34,16 +34,16 @@ var testAccProviderRoute53QueryLogConfigure sync.Once
 func testAccPreCheckRoute53QueryLog(t *testing.T) {
 	testAccPartitionHasServicePreCheck(route53.EndpointsID, t)
 
+	region := testAccGetRoute53QueryLogRegion()
+
+	if region == "" {
+		t.Skip("Route 53 Query Log not available in this AWS Partition")
+	}
+
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderRoute53QueryLogConfigure.Do(func() {
 		testAccProviderRoute53QueryLog = Provider()
-
-		region := testAccGetRoute53QueryLogRegion()
-
-		if region == "" {
-			t.Skip("Route 53 Query Log not available in this AWS Partition")
-		}
 
 		config := map[string]interface{}{
 			"region": region,

--- a/aws/waf_logging_configuration_test.go
+++ b/aws/waf_logging_configuration_test.go
@@ -34,16 +34,16 @@ var testAccProviderWafLoggingConfigurationConfigure sync.Once
 func testAccPreCheckWafLoggingConfiguration(t *testing.T) {
 	testAccPartitionHasServicePreCheck(waf.EndpointsID, t)
 
+	region := testAccGetWafLoggingConfigurationRegion()
+
+	if region == "" {
+		t.Skip("WAF Logging Configuration not available in this AWS Partition")
+	}
+
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderWafLoggingConfigurationConfigure.Do(func() {
 		testAccProviderWafLoggingConfiguration = Provider()
-
-		region := testAccGetWafLoggingConfigurationRegion()
-
-		if region == "" {
-			t.Skip("WAF Logging Configuration not available in this AWS Partition")
-		}
 
 		config := map[string]interface{}{
 			"region": region,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/pull/16840#pullrequestreview-581632353

Output from acceptance testing in AWS Commercial:

```
--- FAIL: TestAccAWSAPIGatewayDomainName_CertificateArn (965.31s) # https://github.com/hashicorp/terraform-provider-aws/issues/17420
--- PASS: TestAccAWSAPIGatewayDomainName_disappears (152.03s)
--- PASS: TestAccAWSAPIGatewayDomainName_RegionalCertificateArn (110.11s)
--- PASS: TestAccAWSAPIGatewayDomainName_SecurityPolicy (115.66s)
--- PASS: TestAccAWSAPIGatewayDomainName_Tags (126.40s)
--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateName (0.00s)
--- SKIP: TestAccAWSAPIGatewayDomainName_RegionalCertificateName (0.00s)

--- PASS: TestAccAWSCognitoUserPoolDomain_basic (29.57s)
--- PASS: TestAccAWSCognitoUserPoolDomain_custom (770.94s)
--- PASS: TestAccAWSCognitoUserPoolDomain_disappears (27.19s)

--- PASS: TestAccAWSLightsailDomain_basic (23.82s)
--- PASS: TestAccAWSLightsailDomain_disappears (20.95s)

--- PASS: TestAccAWSRoute53QueryLog_basic (51.64s)

--- PASS: TestAccAWSWafWebAcl_basic (20.01s)
--- PASS: TestAccAWSWafWebAcl_changeNameForceNew (45.63s)
--- PASS: TestAccAWSWafWebAcl_DefaultAction (36.54s)
--- PASS: TestAccAWSWafWebAcl_disappears (21.46s)
--- PASS: TestAccAWSWafWebAcl_LoggingConfiguration (110.88s)
--- PASS: TestAccAWSWafWebAcl_Rules (60.21s)
--- PASS: TestAccAWSWafWebAcl_Tags (50.74s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSAPIGatewayDomainName_disappears (28.66s)
--- PASS: TestAccAWSAPIGatewayDomainName_RegionalCertificateArn (79.60s)
--- PASS: TestAccAWSAPIGatewayDomainName_SecurityPolicy (110.56s)
--- PASS: TestAccAWSAPIGatewayDomainName_Tags (139.40s)
--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateArn (0.00s)
--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateName (0.00s)
--- SKIP: TestAccAWSAPIGatewayDomainName_RegionalCertificateName (0.00s)

--- PASS: TestAccAWSCognitoUserPoolDomain_basic (29.53s)
--- PASS: TestAccAWSCognitoUserPoolDomain_disappears (25.98s)
--- SKIP: TestAccAWSCognitoUserPoolDomain_custom (0.00s)

--- SKIP: TestAccAWSLightsailDomain_basic (3.48s)
--- SKIP: TestAccAWSLightsailDomain_disappears (3.48s)

--- SKIP: TestAccAWSRoute53QueryLog_basic (3.48s)

--- SKIP: TestAccAWSWafWebAcl_basic (27.40s)
--- SKIP: TestAccAWSWafWebAcl_changeNameForceNew (27.75s)
--- SKIP: TestAccAWSWafWebAcl_DefaultAction (21.04s)
--- SKIP: TestAccAWSWafWebAcl_disappears (25.19s)
--- SKIP: TestAccAWSWafWebAcl_LoggingConfiguration (28.85s)
--- SKIP: TestAccAWSWafWebAcl_Rules (30.87s)
--- SKIP: TestAccAWSWafWebAcl_Tags (29.67s)
```
