### PR TITLE
r/ssoadmin_permission_set: include relay_state in the UpdatePermissionSet request when available

### DIFF
--- a/.changelog/17423.txt
+++ b/.changelog/17423.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssoadmin_permission_set: Properly update resource with `relay_state` argument
+```

--- a/aws/resource_aws_ssoadmin_permission_set.go
+++ b/aws/resource_aws_ssoadmin_permission_set.go
@@ -194,8 +194,11 @@ func resourceAwsSsoAdminPermissionSetUpdate(d *schema.ResourceData, meta interfa
 			input.Description = aws.String(d.Get("description").(string))
 		}
 
-		if d.HasChange("relay_state") {
-			input.RelayState = aws.String(d.Get("relay_state").(string))
+		// The AWS SSO API requires we send the RelayState value regardless if it's unchanged
+		// else the existing Permission Set's RelayState value will be cleared
+		// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/17411
+		if v, ok := d.GetOk("relay_state"); ok {
+			input.RelayState = aws.String(v.(string))
 		}
 
 		if d.HasChange("session_duration") {

--- a/aws/resource_aws_ssoadmin_permission_set.go
+++ b/aws/resource_aws_ssoadmin_permission_set.go
@@ -190,19 +190,21 @@ func resourceAwsSsoAdminPermissionSetUpdate(d *schema.ResourceData, meta interfa
 			PermissionSetArn: aws.String(arn),
 		}
 
-		if d.HasChange("description") {
-			input.Description = aws.String(d.Get("description").(string))
+		// The AWS SSO API requires we send the RelayState value regardless if it's unchanged
+		// else the existing Permission Set's RelayState value will be cleared;
+		// for consistency, we'll check for the "presence of" instead of "if changed" for all input fields
+		// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/17411
+
+		if v, ok := d.GetOk("description"); ok {
+			input.Description = aws.String(v.(string))
 		}
 
-		// The AWS SSO API requires we send the RelayState value regardless if it's unchanged
-		// else the existing Permission Set's RelayState value will be cleared
-		// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/17411
 		if v, ok := d.GetOk("relay_state"); ok {
 			input.RelayState = aws.String(v.(string))
 		}
 
-		if d.HasChange("session_duration") {
-			input.SessionDuration = aws.String(d.Get("session_duration").(string))
+		if v, ok := d.GetOk("session_duration"); ok {
+			input.SessionDuration = aws.String(v.(string))
 		}
 
 		_, err := conn.UpdatePermissionSet(input)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17411 

Output from acceptance test _before_ change:
```
    TestAccAWSSSOAdminPermissionSet_updateOnlySessionDuration: resource_aws_ssoadmin_permission_set_test.go:282: 
Step 2/3 error: Check failed: Check 4/5 error: aws_ssoadmin_permission_set.test: Attribute 'relay_state' expected "https://example.com", got ""
--- FAIL: TestAccAWSSSOAdminPermissionSet_updateOnlySessionDuration (18.79s)
```

Output from complete resource acceptance testing _after_ change:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSSSOAdminPermissionSet_basic (11.95s)
--- PASS: TestAccAWSSSOAdminPermissionSet_relayState_updateSessionDuration (24.29s)
--- PASS: TestAccAWSSSOAdminPermissionSet_updateDescription (25.25s)
--- PASS: TestAccAWSSSOAdminPermissionSet_updateSessionDuration (27.61s)
--- PASS: TestAccAWSSSOAdminPermissionSet_updateRelayState (48.18s)
--- PASS: TestAccAWSSSOAdminPermissionSet_mixedPolicyAttachments (51.67s)
```
