### PR TITLE
tests/resource/aws_db_security_group: Fix CheckDestroy and CheckExists Provider

### DIFF
--- a/aws/resource_aws_db_security_group_test.go
+++ b/aws/resource_aws_db_security_group_test.go
@@ -47,7 +47,7 @@ func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 }
 
 func testAccCheckAWSDBSecurityGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).rdsconn
+	conn := testAccProviderEc2Classic.Meta().(*AWSClient).rdsconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_db_security_group" {
@@ -114,7 +114,7 @@ func testAccCheckAWSDBSecurityGroupExists(n string, v *rds.DBSecurityGroup) reso
 			return fmt.Errorf("No DB Security Group ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).rdsconn
+		conn := testAccProviderEc2Classic.Meta().(*AWSClient).rdsconn
 
 		opts := rds.DescribeDBSecurityGroupsInput{
 			DBSecurityGroupName: aws.String(rs.Primary.ID),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17392

Currently the `TestAccAWSDBSecurityGroup_basic` acceptance test fails in TeamCity:

```
=== CONT  TestAccAWSDBSecurityGroup_basic
resource_aws_db_security_group_test.go:20: Step 1/2 error: Check failed: Check 1/8 error: DBSecurityGroupNotFound: DBSecurityGroup tf-acc-fwy4o not found.
  status code: 404, request id: fd813712-f78f-435a-99f5-cee60d22d51d
--- FAIL: TestAccAWSDBSecurityGroup_basic (15.08s)
```

The resource can only exist in an EC2-Classic enabled region. While the test function and configuration are set up to switch the region, the `testAccCheckAWSDBSecurityGroupDestroy` and `testAccCheckAWSDBSecurityGroupExists` use `testAccProvider` instead of `testAccProviderEc2Classic`.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDBSecurityGroup_basic (14.52s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSDBSecurityGroup_basic (2.76s)
```

