### PR TITLE
tests/resource/aws_ecs_service: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion Out of Date

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -876,13 +876,6 @@ func TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion(t *testing.T) 
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithLaunchTypeFargateAndPlatformVersion(sg1Name, sg2Name, clusterName, tdName, svcName, "1.2.0"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsServiceExists("aws_ecs_service.main", &service),
-					resource.TestCheckResourceAttr("aws_ecs_service.main", "platform_version", "1.2.0"),
-				),
-			},
-			{
 				Config: testAccAWSEcsServiceWithLaunchTypeFargateAndPlatformVersion(sg1Name, sg2Name, clusterName, tdName, svcName, "1.3.0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.main", &service),
@@ -894,6 +887,13 @@ func TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion(t *testing.T) 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.main", &service),
 					resource.TestCheckResourceAttr("aws_ecs_service.main", "platform_version", "LATEST"),
+				),
+			},
+			{
+				Config: testAccAWSEcsServiceWithLaunchTypeFargateAndPlatformVersion(sg1Name, sg2Name, clusterName, tdName, svcName, "1.4.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.main", &service),
+					resource.TestCheckResourceAttr("aws_ecs_service.main", "platform_version", "1.4.0"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17395
Reference: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html
Reference: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-versions-retired.html
Reference: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Operations.html

The `TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion` acceptance test currently fails because it references an out of date platform version:

```
=== CONT  TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
resource_aws_ecs_service_test.go:873: Step 1/3 error: Error running apply:
Error: AccessDeniedException: You do not have authorization to access the specified platform. "tf-acc-svc-ltf-w-pv-kje3nytw"
--- FAIL: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (19.51s)
```

The ECS API does not provide a lookup operation for these. For now we can switch from `1.3.0` to `1.4.0` and from `1.2.0` to `1.3.0`. Note the `LATEST` move from step 3 to 2 is to keep existing test behavior since `LATEST` is confusingly still `1.3.0`.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (159.33s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (170.16s)
```
