### PR TITLE
tests/resource/aws_emr_managed_scaling_policy: CheckDestroy update for API changes

### DIFF
--- a/aws/resource_aws_emr_managed_scaling_policy_test.go
+++ b/aws/resource_aws_emr_managed_scaling_policy_test.go
@@ -191,11 +191,11 @@ func testAccCheckAWSEmrManagedScalingPolicyDestroy(s *terraform.State) error {
 		}
 
 		if err != nil {
-			return err
+			return fmt.Errorf("error reading EMR Managed Scaling Policy (%s): %w", rs.Primary.ID, err)
 		}
 
-		if resp != nil {
-			return fmt.Errorf("Error: EMR Managed Scaling Policy still exists")
+		if resp != nil && resp.ManagedScalingPolicy != nil {
+			return fmt.Errorf("EMR Managed Scaling Policy (%s) still exists", rs.Primary.ID)
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17400

Due to an EMR API change, there are test failures with the following acceptance tests:

```
=== CONT  TestAccAwsEmrManagedScalingPolicy_basic
testing_new.go:63: Error running post-test destroy, there may be dangling resources: Error: EMR Managed Scaling Policy still exists
--- FAIL: TestAccAwsEmrManagedScalingPolicy_basic (499.57s)

=== CONT  TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumCoreCapacityUnits
testing_new.go:63: Error running post-test destroy, there may be dangling resources: Error: EMR Managed Scaling Policy still exists
--- FAIL: TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumCoreCapacityUnits (426.45s)

=== CONT  TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumOndemandCapacityUnits
testing_new.go:63: Error running post-test destroy, there may be dangling resources: Error: EMR Managed Scaling Policy still exists
--- FAIL: TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumOndemandCapacityUnits (476.03s)
```

The `CheckDestroy` function needs to account for the API response with a successful response, but no object.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumCoreCapacityUnits (464.08s)
--- PASS: TestAccAwsEmrManagedScalingPolicy_basic (468.20s)
--- PASS: TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumOndemandCapacityUnits (472.76s)
--- PASS: TestAccAwsEmrManagedScalingPolicy_disappears (476.09s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- FAIL: TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumOndemandCapacityUnits (421.03s) # https://github.com/hashicorp/terraform-provider-aws/issues/17442
--- FAIL: TestAccAwsEmrManagedScalingPolicy_disappears (445.83s) # https://github.com/hashicorp/terraform-provider-aws/issues/17442
--- FAIL: TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumCoreCapacityUnits (462.71s) # https://github.com/hashicorp/terraform-provider-aws/issues/17442
--- FAIL: TestAccAwsEmrManagedScalingPolicy_basic (466.76s) # https://github.com/hashicorp/terraform-provider-aws/issues/17442
```
