### PR TITLE
tests/data-source/aws_workspaces_workspace: Fix TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName for any Terraform CLI version

### DIFF
--- a/aws/data_source_aws_workspaces_workspace_test.go
+++ b/aws/data_source_aws_workspaces_workspace_test.go
@@ -67,7 +67,6 @@ func TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName(t *testing.T
 					resource.TestCheckResourceAttrPair(dataSourceName, "workspace_properties.0.user_volume_size_gib", resourceName, "workspace_properties.0.user_volume_size_gib"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
 				),
-				ExpectNonEmptyPlan: true, // Hack to overcome data source with depends_on refresh
 			},
 		},
 	})
@@ -137,10 +136,8 @@ resource "aws_workspaces_workspace" "test" {
 }
 
 data "aws_workspaces_workspace" "test" {
-  directory_id = aws_workspaces_directory.test.id
-  user_name    = "Administrator"
-
-  depends_on = [aws_workspaces_workspace.test]
+  directory_id = aws_workspaces_workspace.test.directory_id
+  user_name    = aws_workspaces_workspace.test.user_name
 }
 `)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17401

This acceptance test is currently failing on Terraform 0.14:

```
=== CONT  TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName
data_source_aws_workspaces_workspace_test.go:48: Step 1/1 error: Expected a non-empty plan, but got an empty plan
--- FAIL: TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName (1701.01s)
```

Using `depends_on` with a data source after Terraform 0.12 (or 0.13, I forget off the top of head) will not show a perpetual plan difference. Instead of using `depends_on`, we should be able to passthrough the graph ordering via  `directory_id = aws_workspace_workspace.test.directory_id` and remove the `ExpectNonEmptyPlan` for all Terraform versions.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName (1736.18s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- FAIL: TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName (21.31s) # https://github.com/hashicorp/terraform-provider-aws/issues/17401
```
