### PR TITLE
resource/aws_codebuild_project: Deprecate source and secondary_sources auth blocks

### DIFF
--- a/.changelog/17465.txt
+++ b/.changelog/17465.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_codebuild_project: The `source` and `secondary_sources` configuration block `auth` attributes have been deprecated to match the CodeBuild API documentation. Use the `aws_codebuild_source_credential` resource instead.
+```

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -402,9 +402,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"resource": {
-										Type:      schema.TypeString,
-										Sensitive: true,
-										Optional:  true,
+										Type:       schema.TypeString,
+										Sensitive:  true,
+										Optional:   true,
+										Deprecated: "Use the aws_codebuild_source_credential resource instead",
 									},
 									"type": {
 										Type:     schema.TypeString,
@@ -412,9 +413,11 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 										ValidateFunc: validation.StringInSlice([]string{
 											codebuild.SourceAuthTypeOauth,
 										}, false),
+										Deprecated: "Use the aws_codebuild_source_credential resource instead",
 									},
 								},
 							},
+							Deprecated: "Use the aws_codebuild_source_credential resource instead",
 						},
 						"buildspec": {
 							Type:     schema.TypeString,
@@ -486,9 +489,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"resource": {
-										Type:      schema.TypeString,
-										Sensitive: true,
-										Optional:  true,
+										Type:       schema.TypeString,
+										Sensitive:  true,
+										Optional:   true,
+										Deprecated: "Use the aws_codebuild_source_credential resource instead",
 									},
 									"type": {
 										Type:     schema.TypeString,
@@ -496,9 +500,11 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 										ValidateFunc: validation.StringInSlice([]string{
 											codebuild.SourceAuthTypeOauth,
 										}, false),
+										Deprecated: "Use the aws_codebuild_source_credential resource instead",
 									},
 								},
 							},
+							Deprecated: "Use the aws_codebuild_source_credential resource instead",
 						},
 						"buildspec": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -594,38 +594,6 @@ func TestAccAWSCodeBuildProject_LogsConfig_S3Logs(t *testing.T) {
 	})
 }
 
-func TestAccAWSCodeBuildProject_Source_Auth(t *testing.T) {
-	var project codebuild.Project
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_codebuild_project.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSCodeBuildProjectConfig_Source_Auth(rName, "FAKERESOURCE1", "INVALID"),
-				ExpectError: regexp.MustCompile(`expected source.0.auth.0.type to be one of`),
-			},
-			{
-				Config: testAccAWSCodeBuildProjectConfig_Source_Auth(rName, "FAKERESOURCE1", "OAUTH"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
-					resource.TestCheckResourceAttr(resourceName, "source.0.auth.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "source.0.auth.0.resource", "FAKERESOURCE1"),
-					resource.TestCheckResourceAttr(resourceName, "source.0.auth.0.type", "OAUTH"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSCodeBuildProject_Source_GitCloneDepth(t *testing.T) {
 	var project codebuild.Project
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -2833,35 +2801,6 @@ resource "aws_codebuild_project" "test" {
   }
 }
 `, rName, status, location, encryptionDisabled))
-}
-
-func testAccAWSCodeBuildProjectConfig_Source_Auth(rName, authResource, authType string) string {
-	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
-resource "aws_codebuild_project" "test" {
-  name         = "%s"
-  service_role = aws_iam_role.test.arn
-
-  artifacts {
-    type = "NO_ARTIFACTS"
-  }
-
-  environment {
-    compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "2"
-    type         = "LINUX_CONTAINER"
-  }
-
-  source {
-    type     = "GITHUB"
-    location = "https://github.com/hashicorp/packer.git"
-
-    auth {
-      resource = "%s"
-      type     = "%s"
-    }
-  }
-}
-`, rName, authResource, authType))
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_GitCloneDepth(rName string, gitCloneDepth int) string {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -316,7 +316,7 @@ Credentials for access to a private Docker registry.
 
 ### secondary_sources
 
-* `auth` - (Optional) Configuration block. Detailed below.
+* `auth` - (Optional, **Deprecated**) Configuration block with the authorization settings for AWS CodeBuild to access the source code to be built. This information is for the AWS CodeBuild console's use only. Use the [`aws_codebuild_source_credential` resource](codebuild_source_credential.html) instead. Auth blocks are documented below.
 * `buildspec` - (Optional) Build specification to use for this build project's related builds.
 * `git_clone_depth` - (Optional) Truncate git history to this many commits. Use `0` for a `Full` checkout which you need to run commands like `git branch --show-current`. See [AWS CodePipeline User Guide: Tutorial: Use full clone with a GitHub pipeline source](https://docs.aws.amazon.com/codepipeline/latest/userguide/tutorials-github-gitclone.html) for details.
 * `git_submodules_config` - (Optional) Configuration block. Detailed below.
@@ -328,8 +328,8 @@ Credentials for access to a private Docker registry.
 
 #### secondary_sources: auth
 
-* `resource` - (Optional) Resource value that applies to the specified authorization type.
-* `type` - (Required) Authorization type to use. The only valid value is `OAUTH`.
+* `resource` - (Optional, **Deprecated**) Resource value that applies to the specified authorization type. Use the [`aws_codebuild_source_credential` resource](codebuild_source_credential.html) instead.
+* `type` - (Required, **Deprecated**) Authorization type to use. The only valid value is `OAUTH`. This data type is deprecated and is no longer accurate or used. Use the [`aws_codebuild_source_credential` resource](codebuild_source_credential.html) instead.
 
 #### secondary_sources: git_submodules_config
 
@@ -339,7 +339,7 @@ This block is only valid when the `type` is `CODECOMMIT`, `GITHUB` or `GITHUB_EN
 
 ### source
 
-* `auth` - (Optional) Configuration block. Detailed below.
+* `auth` - (Optional, **Deprecated**) Configuration block with the authorization settings for AWS CodeBuild to access the source code to be built. This information is for the AWS CodeBuild console's use only. Use the [`aws_codebuild_source_credential` resource](codebuild_source_credential.html) instead. Auth blocks are documented below.
 * `buildspec` - (Optional) Build specification to use for this build project's related builds. This must be set when `type` is `NO_SOURCE`.
 * `git_clone_depth` - (Optional) Truncate git history to this many commits. Use `0` for a `Full` checkout which you need to run commands like `git branch --show-current`. See [AWS CodePipeline User Guide: Tutorial: Use full clone with a GitHub pipeline source](https://docs.aws.amazon.com/codepipeline/latest/userguide/tutorials-github-gitclone.html) for details.
 * `git_submodules_config` - (Optional) Configuration block. Detailed below.
@@ -350,8 +350,8 @@ This block is only valid when the `type` is `CODECOMMIT`, `GITHUB` or `GITHUB_EN
 
 #### source: auth
 
-* `resource` - (Optional) Resource value that applies to the specified authorization type.
-* `type` - (Required) Authorization type to use. The only valid value is `OAUTH`.
+* `resource` - (Optional, **Deprecated**) Resource value that applies to the specified authorization type. Use the [`aws_codebuild_source_credential` resource](codebuild_source_credential.html) instead.
+* `type` - (Required, **Deprecated**) Authorization type to use. The only valid value is `OAUTH`. This data type is deprecated and is no longer accurate or used. Use the [`aws_codebuild_source_credential` resource](codebuild_source_credential.html) instead.
 
 #### source: git_submodules_config
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://docs.aws.amazon.com/codebuild/latest/APIReference/API_SourceAuth.html
Closes #13450

Currently, the following consistent test failure occurs in AWSCodeBuildProject acceptance testing:

```
--- FAIL: TestAccAWSCodeBuildProject_Source_Auth (11.50s)
    testing.go:683: Step 1 error: errors during apply:

        Error: Error creating CodeBuild project: InvalidInputException: No Access token found, please visit AWS CodeBuild console to connect to GitHub
```

The API documentation now very explicitly states this underlying API type is deprecated. Here we mark the block and underlying attributes as deprecated suggesting the `aws_codebuild_source_credential` resource and removing the problematic test rather than temporarily introducing a skipping mechanism.
