### PR TITLE
tests/aws_emr_managed_scaling_policy: add ErrorCheck to tests w/known unsupported feature errors

### DIFF
--- a/aws/resource_aws_emr_managed_scaling_policy_test.go
+++ b/aws/resource_aws_emr_managed_scaling_policy_test.go
@@ -17,6 +17,7 @@ func TestAccAwsEmrManagedScalingPolicy_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipEmrManagedScalingPolicy(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEmrManagedScalingPolicyDestroy,
 
@@ -41,6 +42,7 @@ func TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumCoreCapacityUnits(t 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipEmrManagedScalingPolicy(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEmrManagedScalingPolicyDestroy,
 
@@ -65,6 +67,7 @@ func TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumOndemandCapacityUnit
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipEmrManagedScalingPolicy(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEmrManagedScalingPolicyDestroy,
 
@@ -89,6 +92,7 @@ func TestAccAwsEmrManagedScalingPolicy_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipEmrManagedScalingPolicy(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEmrManagedScalingPolicyDestroy,
 		Steps: []resource.TestStep{
@@ -102,6 +106,13 @@ func TestAccAwsEmrManagedScalingPolicy_disappears(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testAccErrorCheckSkipEmrManagedScalingPolicy skips tests that have error messages indicating unsupported features
+func testAccErrorCheckSkipEmrManagedScalingPolicy(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"Managed scaling is not available",
+	)
 }
 
 func testAccAWSEmrManagedScalingPolicy_basic(r string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17442 

Output from acceptance testing is UsGov:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
--- SKIP: TestAccAwsEmrManagedScalingPolicy_basic (444.23s)
--- SKIP: TestAccAwsEmrManagedScalingPolicy_disappears (444.26s)
--- SKIP: TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumOndemandCapacityUnits (460.34s)
--- SKIP: TestAccAwsEmrManagedScalingPolicy_ComputeLimits_MaximumCoreCapacityUnits (470.56s)
```
