### PR TITLE
Clarify minimum duration for assume_role setting

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -365,7 +365,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
 
 The `assume_role` configuration block supports the following optional arguments:
 
-* `duration_seconds` - (Optional) Number of seconds to restrict the assume role session duration. Must be set to a value of at least 900.
+* `duration_seconds` - (Optional) Number of seconds to restrict the assume role session duration. You can provide a value from 900 seconds (15 minutes) up to the maximum session duration setting for the role.
 * `external_id` - (Optional) External identifier to use when assuming the role.
 * `policy` - (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
 * `policy_arns` - (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -365,7 +365,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
 
 The `assume_role` configuration block supports the following optional arguments:
 
-* `duration_seconds` - (Optional) Number of seconds to restrict the assume role session duration.
+* `duration_seconds` - (Optional) Number of seconds to restrict the assume role session duration. Must be set to a value of at least 900.
 * `external_id` - (Optional) External identifier to use when assuming the role.
 * `policy` - (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
 * `policy_arns` - (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

While trying to use this assume_role, I was having trouble assuming the role. After setting `TF_LOG=DEBUG` and seeing the actual API response, I could finally see that it was because this number has to be at least 900.