### PR TITLE
r/glue_trigger -  Support starting ON_DEMAND triggers via `enabled` flag

### DIFF
--- a/.changelog/17488.txt
+++ b/.changelog/17488.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_trigger: Support starting ON_DEMAND triggers via `enabled` flag.
+```

--- a/aws/internal/service/glue/finder/finder.go
+++ b/aws/internal/service/glue/finder/finder.go
@@ -22,6 +22,20 @@ func TableByName(conn *glue.Glue, catalogID, dbName, name string) (*glue.GetTabl
 	return output, nil
 }
 
+// TriggerByName returns the Trigger corresponding to the specified name.
+func TriggerByName(conn *glue.Glue, name string) (*glue.GetTriggerOutput, error) {
+	input := &glue.GetTriggerInput{
+		Name: aws.String(name),
+	}
+
+	output, err := conn.GetTrigger(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
 // RegistryByID returns the Registry corresponding to the specified ID.
 func RegistryByID(conn *glue.Glue, id string) (*glue.GetRegistryOutput, error) {
 	input := &glue.GetRegistryInput{

--- a/aws/internal/service/glue/waiter/waiter.go
+++ b/aws/internal/service/glue/waiter/waiter.go
@@ -114,6 +114,7 @@ func TriggerCreated(conn *glue.Glue, triggerName string) (*glue.GetTriggerOutput
 		Pending: []string{
 			glue.TriggerStateActivating,
 			glue.TriggerStateCreating,
+			glue.TriggerStateUpdating,
 		},
 		Target: []string{
 			glue.TriggerStateActivated,

--- a/website/docs/r/glue_trigger.html.markdown
+++ b/website/docs/r/glue_trigger.html.markdown
@@ -107,35 +107,35 @@ resource "aws_glue_trigger" "example" {
 
 The following arguments are supported:
 
-* `actions` – (Required) List of actions initiated by this trigger when it fires. Defined below.
+* `actions` – (Required) List of actions initiated by this trigger when it fires. See [Actions](#actions) Below.
 * `description` – (Optional) A description of the new trigger.
-* `enabled` – (Optional) Start the trigger. Defaults to `true`. Not valid to disable for `ON_DEMAND` type.
+* `enabled` – (Optional) Start the trigger. Defaults to `true`.
 * `name` – (Required) The name of the trigger.
-* `predicate` – (Optional) A predicate to specify when the new trigger should fire. Required when trigger type is `CONDITIONAL`. Defined below.
+* `predicate` – (Optional) A predicate to specify when the new trigger should fire. Required when trigger type is `CONDITIONAL`. See [Predicate](#predicate) Below.
 * `schedule` – (Optional) A cron expression used to specify the schedule. [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html)
 * `tags` - (Optional) Key-value map of resource tags
 * `type` – (Required) The type of trigger. Valid values are `CONDITIONAL`, `ON_DEMAND`, and `SCHEDULED`.
 * `workflow_name` - (Optional) A workflow to which the trigger should be associated to. Every workflow graph (DAG) needs a starting trigger (`ON_DEMAND` or `SCHEDULED` type) and can contain multiple additional `CONDITIONAL` triggers.
 
-### actions Argument Reference
+### Actions
 
 * `arguments` - (Optional) Arguments to be passed to the job. You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.
 * `crawler_name` - (Optional) The name of the crawler to be executed. Conflicts with `job_name`.
 * `job_name` - (Optional) The name of a job to be executed. Conflicts with `crawler_name`.
 * `timeout` - (Optional) The job run timeout in minutes. It overrides the timeout value of the job.
 * `security_configuration` - (Optional) The name of the Security Configuration structure to be used with this action.
-* `notification_property` - (Optional) Specifies configuration properties of a job run notification. see [Notification Property](#notification-property) details below.
+* `notification_property` - (Optional) Specifies configuration properties of a job run notification. See [Notification Property](#notification-property) details below.
 
 #### Notification Property
 
 * `notify_delay_after` - (Optional) After a job run starts, the number of minutes to wait before sending a job run delay notification.
 
-### predicate Argument Reference
+### Predicate
 
-* `conditions` - (Required) A list of the conditions that determine when the trigger will fire. Defined below.
+* `conditions` - (Required) A list of the conditions that determine when the trigger will fire. See [Conditions](#conditions).
 * `logical` - (Optional) How to handle multiple conditions. Defaults to `AND`. Valid values are `AND` or `ANY`.
 
-#### conditions Argument Reference
+#### Conditions
 
 * `job_name` - (Optional) The name of the job to watch. If this is specified, `state` must also be specified. Conflicts with `crawler_name`.
 * `state` - (Optional) The condition job state. Currently, the values supported are `SUCCEEDED`, `STOPPED`, `TIMEOUT` and `FAILED`. If this is specified, `job_name` must also be specified. Conflicts with `crawler_state`.
@@ -149,6 +149,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of Glue Trigger
 * `id` - Trigger name
+* `state` - The current state of the trigger.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17413

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueTrigger_'
--- PASS: TestAccAWSGlueTrigger_disappears (86.34s)
--- PASS: TestAccAWSGlueTrigger_actions_securityConfig (87.34s)
--- PASS: TestAccAWSGlueTrigger_WorkflowName (87.97s)
--- PASS: TestAccAWSGlueTrigger_basic (91.18s)
--- PASS: TestAccAWSGlueTrigger_Description (147.68s)
--- PASS: TestAccAWSGlueTrigger_Schedule (152.14s)
--- PASS: TestAccAWSGlueTrigger_Tags (162.07s)
--- PASS: TestAccAWSGlueTrigger_Crawler (164.02s)
--- PASS: TestAccAWSGlueTrigger_actions_notify (166.83s)
--- PASS: TestAccAWSGlueTrigger_onDemandDisable (169.79s)
--- PASS: TestAccAWSGlueTrigger_Predicate (183.41s)
--- PASS: TestAccAWSGlueTrigger_Enabled (193.86s)
```
