### PR TITLE
r/glue_catalog_database - Add sweeper + use catalog_id when deleting

### DIFF
--- a/.changelog/17489.txt
+++ b/.changelog/17489.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_database: Use Catalog Id when deleting Databases.
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCatalogDatabase_'
--- PASS: TestAccAWSGlueCatalogDatabase_disappears (28.82s)
--- PASS: TestAccAWSGlueCatalogDatabase_full (95.61s)
```
