### PR TITLE
tests/sweeper/route53_resolver_dnssec_confg: update sweeper and waiter func

### DIFF
--- a/aws/internal/service/route53resolver/waiter/status.go
+++ b/aws/internal/service/route53resolver/waiter/status.go
@@ -66,6 +66,10 @@ func DnssecConfigStatus(conn *route53resolver.Route53Resolver, dnssecConfigID st
 	return func() (interface{}, string, error) {
 		dnssecConfig, err := finder.ResolverDnssecConfigByID(conn, dnssecConfigID)
 
+		if tfawserr.ErrCodeEquals(err, route53resolver.ErrCodeResourceNotFoundException) {
+			return nil, resolverDnssecConfigStatusNotFound, nil
+		}
+
 		if err != nil {
 			return nil, resolverDnssecConfigStatusUnknown, err
 		}

--- a/aws/internal/service/route53resolver/waiter/waiter.go
+++ b/aws/internal/service/route53resolver/waiter/waiter.go
@@ -117,8 +117,8 @@ func DnssecConfigCreated(conn *route53resolver.Route53Resolver, dnssecConfigID s
 	return nil, err
 }
 
-// DnssecConfigCreated waits for a DnssecConfig to return DELETED
-func DnssecConfigDeleted(conn *route53resolver.Route53Resolver, dnssecConfigID string) (*route53resolver.ResolverDnssecConfig, error) {
+// DnssecConfigDisabled waits for a DnssecConfig to return DISABLED
+func DnssecConfigDisabled(conn *route53resolver.Route53Resolver, dnssecConfigID string) (*route53resolver.ResolverDnssecConfig, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{route53resolver.ResolverDNSSECValidationStatusDisabling},
 		Target:  []string{route53resolver.ResolverDNSSECValidationStatusDisabled},

--- a/aws/resource_aws_route53_resolver_dnssec_config_test.go
+++ b/aws/resource_aws_route53_resolver_dnssec_config_test.go
@@ -5,14 +5,15 @@ import (
 	"log"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/route53resolver/finder"
 )
 
 func init() {
@@ -29,52 +30,53 @@ func testSweepRoute53ResolverDnssecConfig(region string) error {
 	}
 	conn := client.(*AWSClient).route53resolverconn
 
-	var errors error
+	var sweeperErrs *multierror.Error
 	err = conn.ListResolverDnssecConfigsPages(&route53resolver.ListResolverDnssecConfigsInput{}, func(page *route53resolver.ListResolverDnssecConfigsOutput, isLast bool) bool {
 		if page == nil {
 			return !isLast
 		}
 
 		for _, resolverDnssecConfig := range page.ResolverDnssecConfigs {
-			id := aws.StringValue(resolverDnssecConfig.ResourceId)
+			if resolverDnssecConfig == nil {
+				continue
+			}
+
+			id := aws.StringValue(resolverDnssecConfig.Id)
+			resourceId := aws.StringValue(resolverDnssecConfig.ResourceId)
 
 			log.Printf("[INFO] Deleting Route53 Resolver Dnssec config: %s", id)
-			_, err := conn.UpdateResolverDnssecConfig(&route53resolver.UpdateResolverDnssecConfigInput{
-				ResourceId: aws.String(id),
-				Validation: aws.String(route53resolver.ResolverDNSSECValidationStatusDisabled),
-			})
-			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-				continue
-			}
-			if err != nil {
-				errors = multierror.Append(errors, fmt.Errorf("error deleting Route53 Resolver Resolver Dnssec config (%s): %w", id, err))
-				continue
-			}
 
-			err = route53ResolverEndpointWaitUntilTargetState(conn, id, 10*time.Minute,
-				[]string{route53resolver.ResolverDNSSECValidationStatusDisabling},
-				[]string{route53resolver.ResolverDNSSECValidationStatusDisabled})
+			r := resourceAwsRoute53ResolverDnssecConfig()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(resolverDnssecConfig.Id))
+			d.Set("resource_id", resourceId)
+
+			err := r.Delete(d, client)
+
 			if err != nil {
-				errors = multierror.Append(errors, err)
+				sweeperErr := fmt.Errorf("error deleting Route53 Resolver Resolver Dnssec config (%s): %w", id, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 				continue
 			}
 		}
 
 		return !isLast
 	})
-	if err != nil {
-		if testSweepSkipSweepError(err) {
-			log.Printf("[WARN] Skipping Route53 Resolver Resolver Dnssec config sweep for %s: %s", region, err)
-			return nil
-		}
-		errors = multierror.Append(errors, fmt.Errorf("error retrieving Route53 Resolver Resolver Dnssec config: %w", err))
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Route53 Resolver Resolver Dnssec config sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil()
 	}
 
-	return errors
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Route53 Resolver Resolver Dnssec config: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
 }
 
 func TestAccAWSRoute53ResolverDnssecConfig_basic(t *testing.T) {
-	var config route53resolver.ResolverDnssecConfig
 	resourceName := "aws_route53_resolver_dnssec_config.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -87,7 +89,7 @@ func TestAccAWSRoute53ResolverDnssecConfig_basic(t *testing.T) {
 			{
 				Config: testAccRoute53ResolverDnssecConfigConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ResolverDnssecConfigExists(resourceName, &config),
+					testAccCheckRoute53ResolverDnssecConfigExists(resourceName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "route53resolver", regexp.MustCompile(`resolver-dnssec-config/.+$`)),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
@@ -105,7 +107,6 @@ func TestAccAWSRoute53ResolverDnssecConfig_basic(t *testing.T) {
 }
 
 func TestAccAWSRoute53ResolverDnssecConfig_disappear(t *testing.T) {
-	var config route53resolver.ResolverDnssecConfig
 	resourceName := "aws_route53_resolver_dnssec_config.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -118,7 +119,7 @@ func TestAccAWSRoute53ResolverDnssecConfig_disappear(t *testing.T) {
 			{
 				Config: testAccRoute53ResolverDnssecConfigConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ResolverDnssecConfigExists(resourceName, &config),
+					testAccCheckRoute53ResolverDnssecConfigExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53ResolverDnssecConfig(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -135,30 +136,18 @@ func testAccCheckRoute53ResolverDnssecConfigDestroy(s *terraform.State) error {
 			continue
 		}
 
-		input := &route53resolver.ListResolverDnssecConfigsInput{}
+		config, err := finder.ResolverDnssecConfigByID(conn, rs.Primary.ID)
 
-		var config *route53resolver.ResolverDnssecConfig
-		err := conn.ListResolverDnssecConfigsPages(input, func(page *route53resolver.ListResolverDnssecConfigsOutput, lastPage bool) bool {
-			if page == nil {
-				return !lastPage
-			}
-
-			for _, c := range page.ResolverDnssecConfigs {
-				if aws.StringValue(c.Id) == rs.Primary.ID {
-					config = c
-					return false
-				}
-			}
-
-			return !lastPage
-		})
+		if tfawserr.ErrCodeEquals(err, route53resolver.ErrCodeResourceNotFoundException) {
+			continue
+		}
 
 		if err != nil {
 			return err
 		}
 
-		if config == nil || aws.StringValue(config.ValidationStatus) == route53resolver.ResolverDNSSECValidationStatusDisabled {
-			return nil
+		if config == nil {
+			continue
 		}
 
 		return fmt.Errorf("Route 53 Resolver Dnssec config still exists: %s", rs.Primary.ID)
@@ -167,7 +156,7 @@ func testAccCheckRoute53ResolverDnssecConfigDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckRoute53ResolverDnssecConfigExists(n string, config *route53resolver.ResolverDnssecConfig) resource.TestCheckFunc {
+func testAccCheckRoute53ResolverDnssecConfigExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -178,34 +167,21 @@ func testAccCheckRoute53ResolverDnssecConfigExists(n string, config *route53reso
 			return fmt.Errorf("No Route 53 Resolver Dnssec config ID is set")
 		}
 
+		id := rs.Primary.ID
 		conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
-		input := &route53resolver.ListResolverDnssecConfigsInput{}
 
-		err := conn.ListResolverDnssecConfigsPages(input, func(page *route53resolver.ListResolverDnssecConfigsOutput, lastPage bool) bool {
-			if page == nil {
-				return !lastPage
-			}
-
-			for _, c := range page.ResolverDnssecConfigs {
-				if aws.StringValue(c.Id) == rs.Primary.ID {
-					config = c
-					return false
-				}
-			}
-
-			return !lastPage
-		})
+		config, err := finder.ResolverDnssecConfigByID(conn, id)
 
 		if err != nil {
 			return err
 		}
 
 		if config == nil {
-			return fmt.Errorf("No Route 53 Resolver Dnssec config found")
+			return fmt.Errorf("Route53 Resolver Dnssec config (%s) not found", id)
 		}
 
 		if aws.StringValue(config.ValidationStatus) != route53resolver.ResolverDNSSECValidationStatusEnabled {
-			return fmt.Errorf("Route 53 Resolver Dnssec config (%s) is not enabled", aws.StringValue(config.Id))
+			return fmt.Errorf("Route53 Resolver Dnssec config (%s) is not enabled", aws.StringValue(config.Id))
 		}
 
 		return nil

--- a/aws/resource_aws_route53_resolver_dnssec_config_test.go
+++ b/aws/resource_aws_route53_resolver_dnssec_config_test.go
@@ -44,7 +44,7 @@ func testSweepRoute53ResolverDnssecConfig(region string) error {
 			id := aws.StringValue(resolverDnssecConfig.Id)
 			resourceId := aws.StringValue(resolverDnssecConfig.ResourceId)
 
-			log.Printf("[INFO] Deleting Route53 Resolver Dnssec config: %s", id)
+			log.Printf("[INFO] Deleting Route 53 Resolver Dnssec config: %s", id)
 
 			r := resourceAwsRoute53ResolverDnssecConfig()
 			d := r.Data(nil)
@@ -54,7 +54,7 @@ func testSweepRoute53ResolverDnssecConfig(region string) error {
 			err := r.Delete(d, client)
 
 			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting Route53 Resolver Resolver Dnssec config (%s): %w", id, err)
+				sweeperErr := fmt.Errorf("error deleting Route 53 Resolver Resolver Dnssec config (%s): %w", id, err)
 				log.Printf("[ERROR] %s", sweeperErr)
 				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 				continue
@@ -65,12 +65,12 @@ func testSweepRoute53ResolverDnssecConfig(region string) error {
 	})
 
 	if testSweepSkipSweepError(err) {
-		log.Printf("[WARN] Skipping Route53 Resolver Resolver Dnssec config sweep for %s: %s", region, err)
+		log.Printf("[WARN] Skipping Route 53 Resolver Resolver Dnssec config sweep for %s: %s", region, err)
 		return sweeperErrs.ErrorOrNil()
 	}
 
 	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Route53 Resolver Resolver Dnssec config: %w", err))
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Route 53 Resolver Resolver Dnssec config: %w", err))
 	}
 
 	return sweeperErrs.ErrorOrNil()
@@ -177,11 +177,11 @@ func testAccCheckRoute53ResolverDnssecConfigExists(n string) resource.TestCheckF
 		}
 
 		if config == nil {
-			return fmt.Errorf("Route53 Resolver Dnssec config (%s) not found", id)
+			return fmt.Errorf("Route 53 Resolver Dnssec config (%s) not found", id)
 		}
 
 		if aws.StringValue(config.ValidationStatus) != route53resolver.ResolverDNSSECValidationStatusEnabled {
-			return fmt.Errorf("Route53 Resolver Dnssec config (%s) is not enabled", aws.StringValue(config.Id))
+			return fmt.Errorf("Route 53 Resolver Dnssec config (%s) is not enabled", aws.StringValue(config.Id))
 		}
 
 		return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17502

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSRoute53ResolverDnssecConfig_basic (392.59s)
--- PASS: TestAccAWSRoute53ResolverDnssecConfig_disappear (400.41s)
```

Output from sweeper:
```
$ make sweep SWEEPARGS='-sweep-run=aws_route53_resolver_dnssec_config'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_route53_resolver_dnssec_config -timeout 60m
2021/02/08 00:27:03 [DEBUG] Running Sweepers for region (us-east-1):
2021/02/08 00:27:03 [DEBUG] Running Sweeper (aws_route53_resolver_dnssec_config) in region (us-east-1)
2021/02/08 00:27:03 [INFO] AWS Auth provider used: "EnvProvider"
2021/02/08 00:27:03 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/02/08 00:27:03 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/02/08 00:27:03 Sweeper Tests ran successfully:
	- aws_route53_resolver_dnssec_config
2021/02/08 00:27:03 [DEBUG] Running Sweepers for region (us-west-2):
2021/02/08 00:27:03 [DEBUG] Running Sweeper (aws_route53_resolver_dnssec_config) in region (us-west-2)
2021/02/08 00:27:03 [INFO] AWS Auth provider used: "EnvProvider"
2021/02/08 00:27:03 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/02/08 00:27:03 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/02/08 00:27:04 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-44665e87ddf630a4
2021/02/08 00:27:04 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-44665e87ddf630a4
2021/02/08 00:27:05 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:05 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-4579d595f3433114
2021/02/08 00:27:05 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-4579d595f3433114
2021/02/08 00:27:05 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:06 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-47897780bb63316
2021/02/08 00:27:06 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-47897780bb63316
2021/02/08 00:27:06 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:06 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-55fcaceabe353ea1
2021/02/08 00:27:06 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-55fcaceabe353ea1
2021/02/08 00:27:07 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:07 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-5610e6442a993705
2021/02/08 00:27:07 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-5610e6442a993705
2021/02/08 00:27:08 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:08 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-5983758fc2da3dc7
2021/02/08 00:27:08 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-5983758fc2da3dc7
2021/02/08 00:27:08 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:09 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-5c3b43f4a863344b
2021/02/08 00:27:09 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-5c3b43f4a863344b
2021/02/08 00:27:09 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:09 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-61a2a098b0fa34a2
2021/02/08 00:27:09 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-61a2a098b0fa34a2
2021/02/08 00:27:10 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:10 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-6809ce740db53254
2021/02/08 00:27:10 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-6809ce740db53254
2021/02/08 00:27:10 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:11 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-6e4da6e72ffc3d4d
2021/02/08 00:27:11 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-6e4da6e72ffc3d4d
2021/02/08 00:27:11 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:11 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-6fb036d9edea3885
2021/02/08 00:27:11 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-6fb036d9edea3885
2021/02/08 00:27:12 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:12 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-74d592e94f593826
2021/02/08 00:27:12 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-74d592e94f593826
2021/02/08 00:27:12 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:13 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-81735941ac2e3692
2021/02/08 00:27:13 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-81735941ac2e3692
2021/02/08 00:27:13 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:14 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-8d60d79360763ca8
2021/02/08 00:27:14 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-8d60d79360763ca8
2021/02/08 00:27:14 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:14 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-8ebd95515dc43a06
2021/02/08 00:27:14 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-8ebd95515dc43a06
2021/02/08 00:27:15 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:15 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-8ec0eda94c0f3ba9
2021/02/08 00:27:15 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-8ec0eda94c0f3ba9
2021/02/08 00:27:15 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:16 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-976bf7d274173cc5
2021/02/08 00:27:16 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-976bf7d274173cc5
2021/02/08 00:27:16 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:16 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-9a6eeca8c78138dc
2021/02/08 00:27:16 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-9a6eeca8c78138dc
2021/02/08 00:27:17 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:17 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-9cca9a70eaee33ab
2021/02/08 00:27:17 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-9cca9a70eaee33ab
2021/02/08 00:27:17 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:18 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-a37d02db49713d61
2021/02/08 00:27:18 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-a37d02db49713d61
2021/02/08 00:27:19 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:19 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-a83283394de33deb
2021/02/08 00:27:19 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-a83283394de33deb
2021/02/08 00:27:20 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:21 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-b1624c3550133ed2
2021/02/08 00:27:21 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-b1624c3550133ed2
2021/02/08 00:27:21 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:22 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-b571d25b54a534ab
2021/02/08 00:27:22 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-b571d25b54a534ab
2021/02/08 00:27:22 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:23 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-cbeb8e156db435d3
2021/02/08 00:27:23 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-cbeb8e156db435d3
2021/02/08 00:27:23 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:23 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-cc63a23ee5503471
2021/02/08 00:27:23 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-cc63a23ee5503471
2021/02/08 00:27:24 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:24 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-d22988f9bfc730e3
2021/02/08 00:27:24 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-d22988f9bfc730e3
2021/02/08 00:27:24 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:25 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-d469ac7ff2df3cdc
2021/02/08 00:27:25 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-d469ac7ff2df3cdc
2021/02/08 00:27:25 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:25 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-d64d397c8d903521
2021/02/08 00:27:25 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-d64d397c8d903521
2021/02/08 00:27:26 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:26 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-dc5013564a6f3140
2021/02/08 00:27:26 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-dc5013564a6f3140
2021/02/08 00:27:27 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:27 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-e50310188c3f3594
2021/02/08 00:27:27 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-e50310188c3f3594
2021/02/08 00:27:27 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:28 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-e7a2163479cf369d
2021/02/08 00:27:28 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-e7a2163479cf369d
2021/02/08 00:27:28 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:28 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-e836144711563104
2021/02/08 00:27:28 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-e836144711563104
2021/02/08 00:27:29 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:29 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-ea8188ddb68c3613
2021/02/08 00:27:29 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-ea8188ddb68c3613
2021/02/08 00:27:29 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:30 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-ee93af43e5d3ca8
2021/02/08 00:27:30 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-ee93af43e5d3ca8
2021/02/08 00:27:30 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:30 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-f29607922f723719
2021/02/08 00:27:30 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-f29607922f723719
2021/02/08 00:27:31 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:31 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-f4a201d428733058
2021/02/08 00:27:31 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-f4a201d428733058
2021/02/08 00:27:31 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:32 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-f85d2722829530d7
2021/02/08 00:27:32 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-f85d2722829530d7
2021/02/08 00:27:32 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:32 [INFO] Deleting Route53 Resolver Dnssec config: rdsc-fb4581c1fdfc3b5b
2021/02/08 00:27:32 [DEBUG] Deleting Route53 Resolver DNSSEC config: rdsc-fb4581c1fdfc3b5b
2021/02/08 00:27:33 [DEBUG] Waiting for state to become: []
2021/02/08 00:27:33 Sweeper Tests ran successfully:
	- aws_route53_resolver_dnssec_config
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.423s
```

```sh
 $ aws route53resolver list-resolver-dnssec-configs

{
    "ResolverDnssecConfigs": []
}
```