### PR TITLE
[resource/aws_elasticsearch_domain] Add support for configurable creation timeout on ES domain

### DIFF
--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -321,6 +321,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `aws_elasticsearch_domain` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
 
+* `create` - (Optional, Default: `60m`) How long to wait for creation.
 * `update` - (Optional, Default: `60m`) How long to wait for updates.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Closes https://github.com/hashicorp/terraform-provider-aws/issues/15707

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
%~> awsex sbox -- make testacc TESTARGS='-run=TestAccAWSElasticSearchDomain_WithCreateTimeout'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticsearch -v -count 1 -parallel 20 -run=TestAccAWSElasticSearchDomain_WithCreateTimeout -timeout 180m
=== RUN   TestAccAWSElasticSearchDomain_WithCreateTimeout
=== PAUSE TestAccAWSElasticSearchDomain_WithCreateTimeout
=== CONT  TestAccAWSElasticSearchDomain_WithCreateTimeout
--- PASS: TestAccAWSElasticSearchDomain_WithCreateTimeout (911.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch      912.407s
```