### PR TITLE
Fixes errorlint reports for internal packages and data sources A-E

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/accessanalyzer"
@@ -667,11 +666,7 @@ func (c *Config) Client() (interface{}, error) {
 		if !strings.HasPrefix(r.Operation.Name, "Describe") && !strings.HasPrefix(r.Operation.Name, "List") {
 			return
 		}
-		err, ok := r.Error.(awserr.Error)
-		if !ok || err == nil {
-			return
-		}
-		if err.Code() == applicationautoscaling.ErrCodeFailedResourceAccessException {
+		if tfawserr.ErrCodeEquals(r.Error, applicationautoscaling.ErrCodeFailedResourceAccessException) {
 			r.Retryable = aws.Bool(true)
 		}
 	})

--- a/aws/configservice.go
+++ b/aws/configservice.go
@@ -116,7 +116,7 @@ func configRefreshOrganizationConfigRuleStatus(conn *configservice.ConfigService
 			memberAccountStatuses, err := configGetOrganizationConfigRuleDetailedStatus(conn, name, aws.StringValue(status.OrganizationRuleStatus))
 
 			if err != nil {
-				return status, aws.StringValue(status.OrganizationRuleStatus), fmt.Errorf("unable to get Organization Config Rule detailed status for showing member account errors: %s", err)
+				return status, aws.StringValue(status.OrganizationRuleStatus), fmt.Errorf("unable to get Organization Config Rule detailed status for showing member account errors: %w", err)
 			}
 
 			var errBuilder strings.Builder

--- a/aws/data_source_aws_acm_certificate.go
+++ b/aws/data_source_aws_acm_certificate.go
@@ -91,7 +91,7 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 		return true
 	})
 	if err != nil {
-		return fmt.Errorf("Error listing certificates: %q", err)
+		return fmt.Errorf("Error listing certificates: %w", err)
 	}
 
 	if len(arns) == 0 {
@@ -119,7 +119,7 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[DEBUG] Describing ACM Certificate: %s", input)
 		output, err := conn.DescribeCertificate(input)
 		if err != nil {
-			return fmt.Errorf("Error describing ACM certificate: %q", err)
+			return fmt.Errorf("Error describing ACM certificate: %w", err)
 		}
 		certificate := output.Certificate
 
@@ -174,11 +174,11 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 	tags, err := keyvaluetags.AcmListTags(conn, aws.StringValue(matchedCertificate.CertificateArn))
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for ACM Certificate (%s): %s", d.Id(), err)
+		return fmt.Errorf("error listing tags for ACM Certificate (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_acmpca_certificate_authority.go
+++ b/aws/data_source_aws_acmpca_certificate_authority.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acmpca"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
@@ -106,7 +107,7 @@ func dataSourceAwsAcmpcaCertificateAuthorityRead(d *schema.ResourceData, meta in
 
 	describeCertificateAuthorityOutput, err := conn.DescribeCertificateAuthority(describeCertificateAuthorityInput)
 	if err != nil {
-		return fmt.Errorf("error reading ACMPCA Certificate Authority: %s", err)
+		return fmt.Errorf("error reading ACMPCA Certificate Authority: %w", err)
 	}
 
 	if describeCertificateAuthorityOutput.CertificateAuthority == nil {
@@ -119,7 +120,7 @@ func dataSourceAwsAcmpcaCertificateAuthorityRead(d *schema.ResourceData, meta in
 	d.Set("not_before", aws.TimeValue(certificateAuthority.NotBefore).Format(time.RFC3339))
 
 	if err := d.Set("revocation_configuration", flattenAcmpcaRevocationConfiguration(certificateAuthority.RevocationConfiguration)); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("serial", certificateAuthority.Serial)
@@ -136,8 +137,8 @@ func dataSourceAwsAcmpcaCertificateAuthorityRead(d *schema.ResourceData, meta in
 	if err != nil {
 		// Returned when in PENDING_CERTIFICATE status
 		// InvalidStateException: The certificate authority XXXXX is not in the correct state to have a certificate signing request.
-		if !isAWSErr(err, acmpca.ErrCodeInvalidStateException, "") {
-			return fmt.Errorf("error reading ACMPCA Certificate Authority Certificate: %s", err)
+		if !tfawserr.ErrCodeEquals(err, acmpca.ErrCodeInvalidStateException) {
+			return fmt.Errorf("error reading ACMPCA Certificate Authority Certificate: %w", err)
 		}
 	}
 
@@ -156,7 +157,7 @@ func dataSourceAwsAcmpcaCertificateAuthorityRead(d *schema.ResourceData, meta in
 
 	getCertificateAuthorityCsrOutput, err := conn.GetCertificateAuthorityCsr(getCertificateAuthorityCsrInput)
 	if err != nil {
-		return fmt.Errorf("error reading ACMPCA Certificate Authority Certificate Signing Request: %s", err)
+		return fmt.Errorf("error reading ACMPCA Certificate Authority Certificate Signing Request: %w", err)
 	}
 
 	d.Set("certificate_signing_request", "")
@@ -167,11 +168,11 @@ func dataSourceAwsAcmpcaCertificateAuthorityRead(d *schema.ResourceData, meta in
 	tags, err := keyvaluetags.AcmpcaListTags(conn, certificateAuthorityArn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for ACMPCA Certificate Authority (%s): %s", certificateAuthorityArn, err)
+		return fmt.Errorf("error listing tags for ACMPCA Certificate Authority (%s): %w", certificateAuthorityArn, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.SetId(certificateAuthorityArn)

--- a/aws/data_source_aws_ami.go
+++ b/aws/data_source_aws_ami.go
@@ -298,7 +298,7 @@ func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image, meta int
 		return err
 	}
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(image.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	imageArn := arn.ARN{

--- a/aws/data_source_aws_api_gateway_api_key.go
+++ b/aws/data_source_aws_api_gateway_api_key.go
@@ -70,7 +70,7 @@ func dataSourceAwsApiGatewayApiKeyRead(d *schema.ResourceData, meta interface{})
 	d.Set("last_updated_date", aws.TimeValue(apiKey.LastUpdatedDate).Format(time.RFC3339))
 
 	if err := d.Set("tags", keyvaluetags.ApigatewayKeyValueTags(apiKey.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 	return nil
 }

--- a/aws/data_source_aws_api_gateway_domain_name.go
+++ b/aws/data_source_aws_api_gateway_domain_name.go
@@ -118,7 +118,7 @@ func dataSourceAwsApiGatewayDomainNameRead(d *schema.ResourceData, meta interfac
 	d.Set("domain_name", domainName.DomainName)
 
 	if err := d.Set("endpoint_configuration", flattenApiGatewayEndpointConfiguration(domainName.EndpointConfiguration)); err != nil {
-		return fmt.Errorf("error setting endpoint_configuration: %s", err)
+		return fmt.Errorf("error setting endpoint_configuration: %w", err)
 	}
 
 	d.Set("regional_certificate_arn", domainName.RegionalCertificateArn)
@@ -128,7 +128,7 @@ func dataSourceAwsApiGatewayDomainNameRead(d *schema.ResourceData, meta interfac
 	d.Set("security_policy", domainName.SecurityPolicy)
 
 	if err := d.Set("tags", keyvaluetags.ApigatewayKeyValueTags(domainName.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_api_gateway_resource.go
+++ b/aws/data_source_aws_api_gateway_resource.go
@@ -52,7 +52,7 @@ func dataSourceAwsApiGatewayResourceRead(d *schema.ResourceData, meta interface{
 		return !lastPage
 	})
 	if err != nil {
-		return fmt.Errorf("error describing API Gateway Resources: %s", err)
+		return fmt.Errorf("error describing API Gateway Resources: %w", err)
 	}
 
 	if match == nil {

--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -93,7 +93,7 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 		return !lastPage
 	})
 	if err != nil {
-		return fmt.Errorf("error describing API Gateway REST APIs: %s", err)
+		return fmt.Errorf("error describing API Gateway REST APIs: %w", err)
 	}
 
 	if len(matchedApis) == 0 {
@@ -126,11 +126,11 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 	}
 
 	if err := d.Set("endpoint_configuration", flattenApiGatewayEndpointConfiguration(match.EndpointConfiguration)); err != nil {
-		return fmt.Errorf("error setting endpoint_configuration: %s", err)
+		return fmt.Errorf("error setting endpoint_configuration: %w", err)
 	}
 
 	if err := d.Set("tags", keyvaluetags.ApigatewayKeyValueTags(match.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	executionArn := arn.ARN{

--- a/aws/data_source_aws_api_gateway_vpc_link.go
+++ b/aws/data_source_aws_api_gateway_vpc_link.go
@@ -64,7 +64,7 @@ func dataSourceAwsApiGatewayVpcLinkRead(d *schema.ResourceData, meta interface{}
 		return !lastPage
 	})
 	if err != nil {
-		return fmt.Errorf("error describing API Gateway VPC links: %s", err)
+		return fmt.Errorf("error describing API Gateway VPC links: %w", err)
 	}
 
 	if len(matchedVpcLinks) == 0 {
@@ -84,7 +84,7 @@ func dataSourceAwsApiGatewayVpcLinkRead(d *schema.ResourceData, meta interface{}
 	d.Set("target_arns", flattenStringList(match.TargetArns))
 
 	if err := d.Set("tags", keyvaluetags.ApigatewayKeyValueTags(match.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_arn.go
+++ b/aws/data_source_aws_arn.go
@@ -45,7 +45,7 @@ func dataSourceAwsArnRead(d *schema.ResourceData, meta interface{}) error {
 	v := d.Get("arn").(string)
 	arn, err := arn.Parse(v)
 	if err != nil {
-		return fmt.Errorf("Error parsing '%s': %s", v, err.Error())
+		return fmt.Errorf("Error parsing '%s': %w", v, err)
 	}
 
 	d.SetId(arn.String())

--- a/aws/data_source_aws_autoscaling_groups.go
+++ b/aws/data_source_aws_autoscaling_groups.go
@@ -98,7 +98,7 @@ func dataSourceAwsAutoscalingGroupsRead(d *schema.ResourceData, meta interface{}
 		})
 	}
 	if err != nil {
-		return fmt.Errorf("Error fetching Autoscaling Groups: %s", err)
+		return fmt.Errorf("Error fetching Autoscaling Groups: %w", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)
@@ -107,11 +107,11 @@ func dataSourceAwsAutoscalingGroupsRead(d *schema.ResourceData, meta interface{}
 	sort.Strings(rawArn)
 
 	if err := d.Set("names", rawName); err != nil {
-		return fmt.Errorf("[WARN] Error setting Autoscaling Group Names: %s", err)
+		return fmt.Errorf("[WARN] Error setting Autoscaling Group Names: %w", err)
 	}
 
 	if err := d.Set("arns", rawArn); err != nil {
-		return fmt.Errorf("[WARN] Error setting Autoscaling Group Arns: %s", err)
+		return fmt.Errorf("[WARN] Error setting Autoscaling Group ARNs: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_availability_zones.go
+++ b/aws/data_source_aws_availability_zones.go
@@ -94,7 +94,7 @@ func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Reading Availability Zones: %s", request)
 	resp, err := conn.DescribeAvailabilityZones(request)
 	if err != nil {
-		return fmt.Errorf("Error fetching Availability Zones: %s", err)
+		return fmt.Errorf("Error fetching Availability Zones: %w", err)
 	}
 
 	sort.Slice(resp.AvailabilityZones, func(i, j int) bool {
@@ -131,13 +131,13 @@ func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}
 	d.SetId(meta.(*AWSClient).region)
 
 	if err := d.Set("group_names", groupNames); err != nil {
-		return fmt.Errorf("error setting group_names: %s", err)
+		return fmt.Errorf("error setting group_names: %w", err)
 	}
 	if err := d.Set("names", names); err != nil {
-		return fmt.Errorf("Error setting Availability Zone names: %s", err)
+		return fmt.Errorf("Error setting Availability Zone names: %w", err)
 	}
 	if err := d.Set("zone_ids", zoneIds); err != nil {
-		return fmt.Errorf("Error setting Availability Zone IDs: %s", err)
+		return fmt.Errorf("Error setting Availability Zone IDs: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_backup_plan.go
+++ b/aws/data_source_aws_backup_plan.go
@@ -45,7 +45,7 @@ func dataSourceAwsBackupPlanRead(d *schema.ResourceData, meta interface{}) error
 		BackupPlanId: aws.String(id),
 	})
 	if err != nil {
-		return fmt.Errorf("Error getting Backup Plan: %v", err)
+		return fmt.Errorf("Error getting Backup Plan: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.BackupPlanId))
@@ -55,10 +55,10 @@ func dataSourceAwsBackupPlanRead(d *schema.ResourceData, meta interface{}) error
 
 	tags, err := keyvaluetags.BackupListTags(conn, aws.StringValue(resp.BackupPlanArn))
 	if err != nil {
-		return fmt.Errorf("error listing tags for Backup Plan (%s): %s", id, err)
+		return fmt.Errorf("error listing tags for Backup Plan (%s): %w", id, err)
 	}
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_backup_selection.go
+++ b/aws/data_source_aws_backup_selection.go
@@ -48,7 +48,7 @@ func dataSourceAwsBackupSelectionRead(d *schema.ResourceData, meta interface{}) 
 
 	resp, err := conn.GetBackupSelection(input)
 	if err != nil {
-		return fmt.Errorf("Error getting Backup Selection: %s", err)
+		return fmt.Errorf("Error getting Backup Selection: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.SelectionId))
@@ -57,7 +57,7 @@ func dataSourceAwsBackupSelectionRead(d *schema.ResourceData, meta interface{}) 
 
 	if resp.BackupSelection.Resources != nil {
 		if err := d.Set("resources", aws.StringValueSlice(resp.BackupSelection.Resources)); err != nil {
-			return fmt.Errorf("error setting resources: %s", err)
+			return fmt.Errorf("error setting resources: %w", err)
 		}
 	}
 

--- a/aws/data_source_aws_backup_vault.go
+++ b/aws/data_source_aws_backup_vault.go
@@ -46,7 +46,7 @@ func dataSourceAwsBackupVaultRead(d *schema.ResourceData, meta interface{}) erro
 
 	resp, err := conn.DescribeBackupVault(input)
 	if err != nil {
-		return fmt.Errorf("Error getting Backup Vault: %v", err)
+		return fmt.Errorf("Error getting Backup Vault: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.BackupVaultName))
@@ -57,10 +57,10 @@ func dataSourceAwsBackupVaultRead(d *schema.ResourceData, meta interface{}) erro
 
 	tags, err := keyvaluetags.BackupListTags(conn, aws.StringValue(resp.BackupVaultArn))
 	if err != nil {
-		return fmt.Errorf("error listing tags for Backup Vault (%s): %s", name, err)
+		return fmt.Errorf("error listing tags for Backup Vault (%s): %w", name, err)
 	}
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_batch_job_queue.go
+++ b/aws/data_source_aws_batch_job_queue.go
@@ -106,11 +106,11 @@ func dataSourceAwsBatchJobQueueRead(d *schema.ResourceData, meta interface{}) er
 		ceos = append(ceos, ceo)
 	}
 	if err := d.Set("compute_environment_order", ceos); err != nil {
-		return fmt.Errorf("error setting compute_environment_order: %s", err)
+		return fmt.Errorf("error setting compute_environment_order: %w", err)
 	}
 
 	if err := d.Set("tags", keyvaluetags.BatchKeyValueTags(jobQueue.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_caller_identity.go
+++ b/aws/data_source_aws_caller_identity.go
@@ -39,7 +39,7 @@ func dataSourceAwsCallerIdentityRead(d *schema.ResourceData, meta interface{}) e
 	res, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 
 	if err != nil {
-		return fmt.Errorf("Error getting Caller Identity: %v", err)
+		return fmt.Errorf("Error getting Caller Identity: %w", err)
 	}
 
 	log.Printf("[DEBUG] Received Caller Identity: %s", res)

--- a/aws/data_source_aws_cloudformation_export.go
+++ b/aws/data_source_aws_cloudformation_export.go
@@ -49,7 +49,7 @@ func dataSourceAwsCloudFormationExportRead(d *schema.ResourceData, meta interfac
 			return !lastPage
 		})
 	if err != nil {
-		return fmt.Errorf("Failed listing CloudFormation exports: %s", err)
+		return fmt.Errorf("Failed listing CloudFormation exports: %w", err)
 	}
 	if value == "" {
 		return fmt.Errorf("%s was not found in CloudFormation Exports for region %s", name, region)

--- a/aws/data_source_aws_cloudformation_stack.go
+++ b/aws/data_source_aws_cloudformation_stack.go
@@ -78,7 +78,7 @@ func dataSourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Reading CloudFormation Stack: %s", input)
 	out, err := conn.DescribeStacks(input)
 	if err != nil {
-		return fmt.Errorf("Failed describing CloudFormation stack (%s): %s", name, err)
+		return fmt.Errorf("Failed describing CloudFormation stack (%s): %w", name, err)
 	}
 	if l := len(out.Stacks); l != 1 {
 		return fmt.Errorf("Expected 1 CloudFormation stack (%s), found %d", name, l)
@@ -97,7 +97,7 @@ func dataSourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface
 
 	d.Set("parameters", flattenAllCloudFormationParameters(stack.Parameters))
 	if err := d.Set("tags", keyvaluetags.CloudformationKeyValueTags(stack.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 	d.Set("outputs", flattenCloudFormationOutputs(stack.Outputs))
 
@@ -115,7 +115,7 @@ func dataSourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface
 
 	template, err := normalizeJsonOrYamlString(*tOut.TemplateBody)
 	if err != nil {
-		return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
+		return fmt.Errorf("template body contains an invalid JSON or YAML: %w", err)
 	}
 	d.Set("template_body", template)
 

--- a/aws/data_source_aws_cloudfront_distribution.go
+++ b/aws/data_source_aws_cloudfront_distribution.go
@@ -88,7 +88,7 @@ func dataSourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("error listing tags for CloudFront Distribution (%s): %w", d.Id(), err)
 	}
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("hosted_zone_id", cloudFrontRoute53ZoneID)

--- a/aws/data_source_aws_cloudfront_origin_request_policy.go
+++ b/aws/data_source_aws_cloudfront_origin_request_policy.go
@@ -113,7 +113,7 @@ func dataSourceAwsCloudFrontOriginRequestPolicyRead(d *schema.ResourceData, meta
 
 	if d.Get("id").(string) == "" {
 		if err := dataSourceAwsCloudFrontOriginRequestPolicyFindByName(d, conn); err != nil {
-			return fmt.Errorf("Unable to find origin request policy by name: %s", err.Error())
+			return fmt.Errorf("Unable to find origin request policy by name: %w", err)
 		}
 	}
 
@@ -124,7 +124,7 @@ func dataSourceAwsCloudFrontOriginRequestPolicyRead(d *schema.ResourceData, meta
 
 		resp, err := conn.GetOriginRequestPolicy(request)
 		if err != nil {
-			return fmt.Errorf("Unable to retrieve origin request policy with ID %s: %s", d.Id(), err.Error())
+			return fmt.Errorf("Unable to retrieve origin request policy with ID %s: %w", d.Id(), err)
 		}
 		d.Set("etag", aws.StringValue(resp.ETag))
 

--- a/aws/data_source_aws_cloudhsm2_cluster.go
+++ b/aws/data_source_aws_cloudhsm2_cluster.go
@@ -94,7 +94,7 @@ func dataSourceCloudHsmV2ClusterRead(d *schema.ResourceData, meta interface{}) e
 	out, err := conn.DescribeClusters(input)
 
 	if err != nil {
-		return fmt.Errorf("error describing CloudHSM v2 Cluster: %s", err)
+		return fmt.Errorf("error describing CloudHSM v2 Cluster: %w", err)
 	}
 
 	var cluster *cloudhsmv2.Cluster
@@ -114,7 +114,7 @@ func dataSourceCloudHsmV2ClusterRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("security_group_id", cluster.SecurityGroup)
 	d.Set("cluster_state", cluster.State)
 	if err := d.Set("cluster_certificates", readCloudHsmV2ClusterCertificates(cluster)); err != nil {
-		return fmt.Errorf("error setting cluster_certificates: %s", err)
+		return fmt.Errorf("error setting cluster_certificates: %w", err)
 	}
 
 	var subnets []string
@@ -123,7 +123,7 @@ func dataSourceCloudHsmV2ClusterRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if err := d.Set("subnet_ids", subnets); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving Subnet IDs to state for CloudHSM v2 Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("[DEBUG] Error saving Subnet IDs to state for CloudHSM v2 Cluster (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/data_source_aws_cloudwatch_log_group.go
+++ b/aws/data_source_aws_cloudwatch_log_group.go
@@ -59,11 +59,11 @@ func dataSourceAwsCloudwatchLogGroupRead(d *schema.ResourceData, meta interface{
 	tags, err := keyvaluetags.CloudwatchlogsListTags(conn, name)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for CloudWatch Logs Group (%s): %s", name, err)
+		return fmt.Errorf("error listing tags for CloudWatch Logs Group (%s): %w", name, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_codecommit_repository.go
+++ b/aws/data_source_aws_codecommit_repository.go
@@ -59,7 +59,7 @@ func dataSourceAwsCodeCommitRepositoryRead(d *schema.ResourceData, meta interfac
 			d.SetId("")
 			return fmt.Errorf("Resource codecommit repository not found for %s", repositoryName)
 		} else {
-			return fmt.Errorf("Error reading CodeCommit Repository: %s", err.Error())
+			return fmt.Errorf("Error reading CodeCommit Repository: %w", err)
 		}
 	}
 

--- a/aws/data_source_aws_cognito_user_pools.go
+++ b/aws/data_source_aws_cognito_user_pools.go
@@ -39,7 +39,7 @@ func dataSourceAwsCognitoUserPoolsRead(d *schema.ResourceData, meta interface{})
 
 	pools, err := getAllCognitoUserPools(conn)
 	if err != nil {
-		return fmt.Errorf("Error listing cognito user pools: %s", err)
+		return fmt.Errorf("Error listing cognito user pools: %w", err)
 	}
 	for _, pool := range pools {
 		if name == aws.StringValue(pool.Name) {

--- a/aws/data_source_aws_customer_gateway.go
+++ b/aws/data_source_aws_customer_gateway.go
@@ -63,7 +63,7 @@ func dataSourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) 
 	output, err := conn.DescribeCustomerGateways(&input)
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Customer Gateways: %s", err)
+		return fmt.Errorf("error reading EC2 Customer Gateways: %w", err)
 	}
 
 	if output == nil || len(output.CustomerGateways) == 0 {
@@ -86,14 +86,14 @@ func dataSourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) 
 	if v := aws.StringValue(cg.BgpAsn); v != "" {
 		asn, err := strconv.ParseInt(v, 0, 0)
 		if err != nil {
-			return fmt.Errorf("error parsing BGP ASN %q: %s", v, err)
+			return fmt.Errorf("error parsing BGP ASN %q: %w", v, err)
 		}
 
 		d.Set("bgp_asn", int(asn))
 	}
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(cg.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags for EC2 Customer Gateway %q: %s", aws.StringValue(cg.CustomerGatewayId), err)
+		return fmt.Errorf("error setting tags for EC2 Customer Gateway %q: %w", aws.StringValue(cg.CustomerGatewayId), err)
 	}
 
 	arn := arn.ARN{

--- a/aws/data_source_aws_db_cluster_snapshot.go
+++ b/aws/data_source_aws_db_cluster_snapshot.go
@@ -161,7 +161,7 @@ func dataSourceAwsDbClusterSnapshotRead(d *schema.ResourceData, meta interface{}
 	d.SetId(aws.StringValue(snapshot.DBClusterSnapshotIdentifier))
 	d.Set("allocated_storage", snapshot.AllocatedStorage)
 	if err := d.Set("availability_zones", flattenStringList(snapshot.AvailabilityZones)); err != nil {
-		return fmt.Errorf("error setting availability_zones: %s", err)
+		return fmt.Errorf("error setting availability_zones: %w", err)
 	}
 	d.Set("db_cluster_identifier", snapshot.DBClusterIdentifier)
 	d.Set("db_cluster_snapshot_arn", snapshot.DBClusterSnapshotArn)
@@ -183,11 +183,11 @@ func dataSourceAwsDbClusterSnapshotRead(d *schema.ResourceData, meta interface{}
 	tags, err := keyvaluetags.RdsListTags(conn, d.Get("db_cluster_snapshot_arn").(string))
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for RDS DB Cluster Snapshot (%s): %s", d.Get("db_cluster_snapshot_arn").(string), err)
+		return fmt.Errorf("error listing tags for RDS DB Cluster Snapshot (%s): %w", d.Get("db_cluster_snapshot_arn").(string), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_db_event_categories.go
+++ b/aws/data_source_aws_db_event_categories.go
@@ -57,7 +57,7 @@ func dataSourceAwsDbEventCategoriesRead(d *schema.ResourceData, meta interface{}
 
 	d.SetId(meta.(*AWSClient).region)
 	if err := d.Set("event_categories", eventCategories); err != nil {
-		return fmt.Errorf("Error setting Event Categories: %s", err)
+		return fmt.Errorf("Error setting Event Categories: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -256,7 +256,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		parameterGroups = append(parameterGroups, *v.DBParameterGroupName)
 	}
 	if err := d.Set("db_parameter_groups", parameterGroups); err != nil {
-		return fmt.Errorf("Error setting db_parameter_groups attribute: %#v, error: %#v", parameterGroups, err)
+		return fmt.Errorf("Error setting db_parameter_groups attribute: %#v, error: %w", parameterGroups, err)
 	}
 
 	var dbSecurityGroups []string
@@ -264,7 +264,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		dbSecurityGroups = append(dbSecurityGroups, *v.DBSecurityGroupName)
 	}
 	if err := d.Set("db_security_groups", dbSecurityGroups); err != nil {
-		return fmt.Errorf("Error setting db_security_groups attribute: %#v, error: %#v", dbSecurityGroups, err)
+		return fmt.Errorf("Error setting db_security_groups attribute: %#v, error: %w", dbSecurityGroups, err)
 	}
 
 	if dbInstance.DBSubnetGroup != nil {
@@ -289,7 +289,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("endpoint", fmt.Sprintf("%s:%d", *dbInstance.Endpoint.Address, *dbInstance.Endpoint.Port))
 
 	if err := d.Set("enabled_cloudwatch_logs_exports", aws.StringValueSlice(dbInstance.EnabledCloudwatchLogsExports)); err != nil {
-		return fmt.Errorf("error setting enabled_cloudwatch_logs_exports: %#v", err)
+		return fmt.Errorf("error setting enabled_cloudwatch_logs_exports: %w", err)
 	}
 
 	var optionGroups []string
@@ -297,7 +297,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		optionGroups = append(optionGroups, *v.OptionGroupName)
 	}
 	if err := d.Set("option_group_memberships", optionGroups); err != nil {
-		return fmt.Errorf("Error setting option_group_memberships attribute: %#v, error: %#v", optionGroups, err)
+		return fmt.Errorf("Error setting option_group_memberships attribute: %#v, error: %w", optionGroups, err)
 	}
 
 	d.Set("preferred_backup_window", dbInstance.PreferredBackupWindow)
@@ -314,17 +314,17 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		vpcSecurityGroups = append(vpcSecurityGroups, *v.VpcSecurityGroupId)
 	}
 	if err := d.Set("vpc_security_groups", vpcSecurityGroups); err != nil {
-		return fmt.Errorf("Error setting vpc_security_groups attribute: %#v, error: %#v", vpcSecurityGroups, err)
+		return fmt.Errorf("Error setting vpc_security_groups attribute: %#v, error: %w", vpcSecurityGroups, err)
 	}
 
 	tags, err := keyvaluetags.RdsListTags(conn, d.Get("db_instance_arn").(string))
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for RDS DB Instance (%s): %s", d.Get("db_instance_arn").(string), err)
+		return fmt.Errorf("error listing tags for RDS DB Instance (%s): %w", d.Get("db_instance_arn").(string), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_dx_gateway.go
+++ b/aws/data_source_aws_dx_gateway.go
@@ -40,7 +40,7 @@ func dataSourceAwsDxGatewayRead(d *schema.ResourceData, meta interface{}) error 
 	for {
 		output, err := conn.DescribeDirectConnectGateways(input)
 		if err != nil {
-			return fmt.Errorf("error reading Direct Connect Gateway: %s", err)
+			return fmt.Errorf("error reading Direct Connect Gateway: %w", err)
 		}
 		for _, gateway := range output.DirectConnectGateways {
 			if aws.StringValue(gateway.DirectConnectGatewayName) == name {

--- a/aws/data_source_aws_dynamodb_table.go
+++ b/aws/data_source_aws_dynamodb_table.go
@@ -221,7 +221,7 @@ func dataSourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) er
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving DynamoDB table: %s", err)
+		return fmt.Errorf("Error retrieving DynamoDB table: %w", err)
 	}
 
 	d.SetId(aws.StringValue(result.Table.TableName))
@@ -235,20 +235,20 @@ func dataSourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) er
 		TableName: aws.String(d.Id()),
 	})
 	if err != nil {
-		return fmt.Errorf("error describing DynamoDB Table (%s) Time to Live: %s", d.Id(), err)
+		return fmt.Errorf("error describing DynamoDB Table (%s) Time to Live: %w", d.Id(), err)
 	}
 	if err := d.Set("ttl", flattenDynamoDbTtl(ttlOut)); err != nil {
-		return fmt.Errorf("error setting ttl: %s", err)
+		return fmt.Errorf("error setting ttl: %w", err)
 	}
 
 	tags, err := keyvaluetags.DynamodbListTags(conn, d.Get("arn").(string))
 
 	if err != nil && !isAWSErr(err, "UnknownOperationException", "Tagging is not currently supported in DynamoDB Local.") {
-		return fmt.Errorf("error listing tags for DynamoDB Table (%s): %s", d.Get("arn").(string), err)
+		return fmt.Errorf("error listing tags for DynamoDB Table (%s): %w", d.Get("arn").(string), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	pitrOut, err := conn.DescribeContinuousBackups(&dynamodb.DescribeContinuousBackupsInput{

--- a/aws/data_source_aws_ebs_default_kms_key.go
+++ b/aws/data_source_aws_ebs_default_kms_key.go
@@ -24,7 +24,7 @@ func dataSourceAwsEbsDefaultKmsKeyRead(d *schema.ResourceData, meta interface{})
 
 	res, err := conn.GetEbsDefaultKmsKeyId(&ec2.GetEbsDefaultKmsKeyIdInput{})
 	if err != nil {
-		return fmt.Errorf("Error reading EBS default KMS key: %q", err)
+		return fmt.Errorf("Error reading EBS default KMS key: %w", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)

--- a/aws/data_source_aws_ebs_encryption_by_default.go
+++ b/aws/data_source_aws_ebs_encryption_by_default.go
@@ -24,7 +24,7 @@ func dataSourceAwsEbsEncryptionByDefaultRead(d *schema.ResourceData, meta interf
 
 	res, err := conn.GetEbsEncryptionByDefault(&ec2.GetEbsEncryptionByDefaultInput{})
 	if err != nil {
-		return fmt.Errorf("Error reading default EBS encryption toggle: %q", err)
+		return fmt.Errorf("Error reading default EBS encryption toggle: %w", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)

--- a/aws/data_source_aws_ebs_snapshot.go
+++ b/aws/data_source_aws_ebs_snapshot.go
@@ -155,7 +155,7 @@ func snapshotDescriptionAttributes(d *schema.ResourceData, snapshot *ec2.Snapsho
 	d.Set("owner_alias", snapshot.OwnerAlias)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(snapshot.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	snapshotArn := arn.ARN{

--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -158,7 +158,7 @@ func volumeDescriptionAttributes(d *schema.ResourceData, client *AWSClient, volu
 	d.Set("throughput", volume.Throughput)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(volume.Tags).IgnoreAws().IgnoreConfig(client.IgnoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_ec2_coip_pool.go
+++ b/aws/data_source_aws_ec2_coip_pool.go
@@ -92,13 +92,13 @@ func dataSourceAwsEc2CoipPoolRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("local_gateway_route_table_id", coip.LocalGatewayRouteTableId)
 
 	if err := d.Set("pool_cidrs", aws.StringValueSlice(coip.PoolCidrs)); err != nil {
-		return fmt.Errorf("error setting pool_cidrs: %s", err)
+		return fmt.Errorf("error setting pool_cidrs: %w", err)
 	}
 
 	d.Set("pool_id", coip.PoolId)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(coip.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_ec2_instance_type_offerings.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings.go
@@ -75,7 +75,7 @@ func dataSourceAwsEc2InstanceTypeOfferingsRead(d *schema.ResourceData, meta inte
 	}
 
 	if err := d.Set("instance_types", instanceTypes); err != nil {
-		return fmt.Errorf("error setting instance_types: %s", err)
+		return fmt.Errorf("error setting instance_types: %w", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)

--- a/aws/data_source_aws_ec2_local_gateway.go
+++ b/aws/data_source_aws_ec2_local_gateway.go
@@ -94,7 +94,7 @@ func dataSourceAwsEc2LocalGatewayRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("state", localGateway.State)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(localGateway.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_ec2_local_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_local_gateway_route_table.go
@@ -97,7 +97,7 @@ func dataSourceAwsEc2LocalGatewayRouteTableRead(d *schema.ResourceData, meta int
 	d.Set("state", localgatewayroutetable.State)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(localgatewayroutetable.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_ec2_transit_gateway.go
+++ b/aws/data_source_aws_ec2_transit_gateway.go
@@ -89,7 +89,7 @@ func dataSourceAwsEc2TransitGatewayRead(d *schema.ResourceData, meta interface{}
 	output, err := conn.DescribeTransitGateways(input)
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Transit Gateway: %s", err)
+		return fmt.Errorf("error reading EC2 Transit Gateway: %w", err)
 	}
 
 	if output == nil || len(output.TransitGateways) == 0 {
@@ -122,7 +122,7 @@ func dataSourceAwsEc2TransitGatewayRead(d *schema.ResourceData, meta interface{}
 	d.Set("propagation_default_route_table_id", transitGateway.Options.PropagationDefaultRouteTableId)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGateway.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("vpn_ecmp_support", transitGateway.Options.VpnEcmpSupport)

--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
@@ -72,7 +72,7 @@ func dataSourceAwsEc2TransitGatewayDxGatewayAttachmentRead(d *schema.ResourceDat
 	output, err := conn.DescribeTransitGatewayAttachments(input)
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Transit Gateway Direct Connect Gateway Attachment: %s", err)
+		return fmt.Errorf("error reading EC2 Transit Gateway Direct Connect Gateway Attachment: %w", err)
 	}
 
 	if output == nil || len(output.TransitGatewayAttachments) == 0 || output.TransitGatewayAttachments[0] == nil {
@@ -86,7 +86,7 @@ func dataSourceAwsEc2TransitGatewayDxGatewayAttachmentRead(d *schema.ResourceDat
 	transitGatewayAttachment := output.TransitGatewayAttachments[0]
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayAttachment.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("transit_gateway_id", aws.StringValue(transitGatewayAttachment.TransitGatewayId))

--- a/aws/data_source_aws_ec2_transit_gateway_peering_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_peering_attachment.go
@@ -66,7 +66,7 @@ func dataSourceAwsEc2TransitGatewayPeeringAttachmentRead(d *schema.ResourceData,
 	output, err := conn.DescribeTransitGatewayPeeringAttachments(input)
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Transit Gateway Peering Attachments: %s", err)
+		return fmt.Errorf("error reading EC2 Transit Gateway Peering Attachments: %ws", err)
 	}
 
 	if output == nil || len(output.TransitGatewayPeeringAttachments) == 0 {
@@ -97,7 +97,7 @@ func dataSourceAwsEc2TransitGatewayPeeringAttachmentRead(d *schema.ResourceData,
 	d.Set("transit_gateway_id", local.TransitGatewayId)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayPeeringAttachment.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.SetId(aws.StringValue(transitGatewayPeeringAttachment.TransitGatewayAttachmentId))

--- a/aws/data_source_aws_ec2_transit_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table.go
@@ -62,7 +62,7 @@ func dataSourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta i
 	output, err := conn.DescribeTransitGatewayRouteTables(input)
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Transit Gateway Route Table: %s", err)
+		return fmt.Errorf("error reading EC2 Transit Gateway Route Table: %w", err)
 	}
 
 	if output == nil || len(output.TransitGatewayRouteTables) == 0 {
@@ -83,7 +83,7 @@ func dataSourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta i
 	d.Set("default_propagation_route_table", aws.BoolValue(transitGatewayRouteTable.DefaultPropagationRouteTable))
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayRouteTable.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("transit_gateway_id", aws.StringValue(transitGatewayRouteTable.TransitGatewayId))

--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
@@ -74,7 +74,7 @@ func dataSourceAwsEc2TransitGatewayVpcAttachmentRead(d *schema.ResourceData, met
 	output, err := conn.DescribeTransitGatewayVpcAttachments(input)
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Transit Gateway Route Table: %s", err)
+		return fmt.Errorf("error reading EC2 Transit Gateway Route Table: %w", err)
 	}
 
 	if output == nil || len(output.TransitGatewayVpcAttachments) == 0 {
@@ -100,11 +100,11 @@ func dataSourceAwsEc2TransitGatewayVpcAttachmentRead(d *schema.ResourceData, met
 	d.Set("ipv6_support", transitGatewayVpcAttachment.Options.Ipv6Support)
 
 	if err := d.Set("subnet_ids", aws.StringValueSlice(transitGatewayVpcAttachment.SubnetIds)); err != nil {
-		return fmt.Errorf("error setting subnet_ids: %s", err)
+		return fmt.Errorf("error setting subnet_ids: %w", err)
 	}
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayVpcAttachment.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("transit_gateway_id", aws.StringValue(transitGatewayVpcAttachment.TransitGatewayId))

--- a/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
@@ -72,7 +72,7 @@ func dataSourceAwsEc2TransitGatewayVpnAttachmentRead(d *schema.ResourceData, met
 	output, err := conn.DescribeTransitGatewayAttachments(input)
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Transit Gateway VPN Attachment: %s", err)
+		return fmt.Errorf("error reading EC2 Transit Gateway VPN Attachment: %w", err)
 	}
 
 	if output == nil || len(output.TransitGatewayAttachments) == 0 || output.TransitGatewayAttachments[0] == nil {
@@ -86,7 +86,7 @@ func dataSourceAwsEc2TransitGatewayVpnAttachmentRead(d *schema.ResourceData, met
 	transitGatewayAttachment := output.TransitGatewayAttachments[0]
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayAttachment.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("transit_gateway_id", aws.StringValue(transitGatewayAttachment.TransitGatewayId))

--- a/aws/data_source_aws_ecr_authorization_token.go
+++ b/aws/data_source_aws_ecr_authorization_token.go
@@ -56,7 +56,7 @@ func dataSourceAwsEcrAuthorizationTokenRead(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Getting ECR authorization token")
 	out, err := conn.GetAuthorizationToken(params)
 	if err != nil {
-		return fmt.Errorf("error getting ECR authorization token: %s", err)
+		return fmt.Errorf("error getting ECR authorization token: %w", err)
 	}
 	log.Printf("[DEBUG] Received ECR AuthorizationData %v", out.AuthorizationData)
 	authorizationData := out.AuthorizationData[0]
@@ -66,7 +66,7 @@ func dataSourceAwsEcrAuthorizationTokenRead(d *schema.ResourceData, meta interfa
 	authBytes, err := base64.URLEncoding.DecodeString(authorizationToken)
 	if err != nil {
 		d.SetId("")
-		return fmt.Errorf("error decoding ECR authorization token: %s", err)
+		return fmt.Errorf("error decoding ECR authorization token: %w", err)
 	}
 	basicAuthorization := strings.Split(string(authBytes), ":")
 	if len(basicAuthorization) != 2 {

--- a/aws/data_source_aws_ecr_image.go
+++ b/aws/data_source_aws_ecr_image.go
@@ -85,7 +85,7 @@ func dataSourceAwsEcrImageRead(d *schema.ResourceData, meta interface{}) error {
 		return true
 	})
 	if err != nil {
-		return fmt.Errorf("Error describing ECR images: %q", err)
+		return fmt.Errorf("Error describing ECR images: %w", err)
 	}
 
 	if len(imageDetails) == 0 {
@@ -99,19 +99,19 @@ func dataSourceAwsEcrImageRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(aws.StringValue(image.ImageDigest))
 	if err = d.Set("registry_id", aws.StringValue(image.RegistryId)); err != nil {
-		return fmt.Errorf("failed to set registry_id: %s", err)
+		return fmt.Errorf("failed to set registry_id: %w", err)
 	}
 	if err = d.Set("image_digest", aws.StringValue(image.ImageDigest)); err != nil {
-		return fmt.Errorf("failed to set image_digest: %s", err)
+		return fmt.Errorf("failed to set image_digest: %w", err)
 	}
 	if err = d.Set("image_pushed_at", image.ImagePushedAt.Unix()); err != nil {
-		return fmt.Errorf("failed to set image_pushed_at: %s", err)
+		return fmt.Errorf("failed to set image_pushed_at: %w", err)
 	}
 	if err = d.Set("image_size_in_bytes", aws.Int64Value(image.ImageSizeInBytes)); err != nil {
-		return fmt.Errorf("failed to set image_size_in_bytes: %s", err)
+		return fmt.Errorf("failed to set image_size_in_bytes: %w", err)
 	}
 	if err := d.Set("image_tags", aws.StringValueSlice(image.ImageTags)); err != nil {
-		return fmt.Errorf("failed to set image_tags: %s", err)
+		return fmt.Errorf("failed to set image_tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_ecs_cluster.go
+++ b/aws/data_source_aws_ecs_cluster.go
@@ -94,7 +94,7 @@ func dataSourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("registered_container_instances_count", cluster.RegisteredContainerInstancesCount)
 
 	if err := d.Set("setting", flattenEcsSettings(cluster.Settings)); err != nil {
-		return fmt.Errorf("error setting setting: %s", err)
+		return fmt.Errorf("error setting setting: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_ecs_task_definition.go
+++ b/aws/data_source_aws_ecs_task_definition.go
@@ -53,7 +53,7 @@ func dataSourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}
 	desc, err := conn.DescribeTaskDefinition(params)
 
 	if err != nil {
-		return fmt.Errorf("Failed getting task definition %s %q", err, d.Get("task_definition").(string))
+		return fmt.Errorf("Failed getting task definition %q: %w", d.Get("task_definition").(string), err)
 	}
 
 	taskDefinition := *desc.TaskDefinition

--- a/aws/data_source_aws_efs_access_point.go
+++ b/aws/data_source_aws_efs_access_point.go
@@ -103,7 +103,7 @@ func dataSourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) e
 		AccessPointId: aws.String(d.Get("access_point_id").(string)),
 	})
 	if err != nil {
-		return fmt.Errorf("Error reading EFS access point %s: %s", d.Id(), err)
+		return fmt.Errorf("Error reading EFS access point %s: %w", d.Id(), err)
 	}
 	if len(resp.AccessPoints) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(resp.AccessPoints))
@@ -129,15 +129,15 @@ func dataSourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("owner_id", ap.OwnerId)
 
 	if err := d.Set("posix_user", flattenEfsAccessPointPosixUser(ap.PosixUser)); err != nil {
-		return fmt.Errorf("error setting posix user: %s", err)
+		return fmt.Errorf("error setting posix user: %w", err)
 	}
 
 	if err := d.Set("root_directory", flattenEfsAccessPointRootDirectory(ap.RootDirectory)); err != nil {
-		return fmt.Errorf("error setting root directory: %s", err)
+		return fmt.Errorf("error setting root directory: %w", err)
 	}
 
 	if err := d.Set("tags", keyvaluetags.EfsKeyValueTags(ap.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_efs_file_system.go
+++ b/aws/data_source_aws_efs_file_system.go
@@ -131,7 +131,7 @@ func dataSourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err := d.Set("tags", keyvaluetags.EfsKeyValueTags(fs.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	res, err := efsconn.DescribeLifecycleConfiguration(&efs.DescribeLifecycleConfigurationInput{

--- a/aws/data_source_aws_efs_mount_target.go
+++ b/aws/data_source_aws_efs_mount_target.go
@@ -78,7 +78,7 @@ func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Reading EFS Mount Target: %s", describeEfsOpts)
 	resp, err := conn.DescribeMountTargets(describeEfsOpts)
 	if err != nil {
-		return fmt.Errorf("Error retrieving EFS Mount Target: %s", err)
+		return fmt.Errorf("Error retrieving EFS Mount Target: %w", err)
 	}
 	if len(resp.MountTargets) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(resp.MountTargets))

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -112,7 +112,7 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.DescribeAddresses(req)
 	if err != nil {
-		return fmt.Errorf("error describing EC2 Address: %s", err)
+		return fmt.Errorf("error describing EC2 Address: %w", err)
 	}
 	if resp == nil || len(resp.Addresses) == 0 {
 		return fmt.Errorf("no matching Elastic IP found")
@@ -153,7 +153,7 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("customer_owned_ip", eip.CustomerOwnedIp)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(eip.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_eks_cluster.go
+++ b/aws/data_source_aws_eks_cluster.go
@@ -156,7 +156,7 @@ func dataSourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Reading EKS Cluster: %s", input)
 	output, err := conn.DescribeCluster(input)
 	if err != nil {
-		return fmt.Errorf("error reading EKS Cluster (%s): %s", name, err)
+		return fmt.Errorf("error reading EKS Cluster (%s): %w", name, err)
 	}
 
 	cluster := output.Cluster
@@ -168,17 +168,17 @@ func dataSourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("arn", cluster.Arn)
 
 	if err := d.Set("certificate_authority", flattenEksCertificate(cluster.CertificateAuthority)); err != nil {
-		return fmt.Errorf("error setting certificate_authority: %s", err)
+		return fmt.Errorf("error setting certificate_authority: %w", err)
 	}
 
 	d.Set("created_at", aws.TimeValue(cluster.CreatedAt).String())
 	if err := d.Set("enabled_cluster_log_types", flattenEksEnabledLogTypes(cluster.Logging)); err != nil {
-		return fmt.Errorf("error setting enabled_cluster_log_types: %s", err)
+		return fmt.Errorf("error setting enabled_cluster_log_types: %w", err)
 	}
 	d.Set("endpoint", cluster.Endpoint)
 
 	if err := d.Set("identity", flattenEksIdentity(cluster.Identity)); err != nil {
-		return fmt.Errorf("error setting identity: %s", err)
+		return fmt.Errorf("error setting identity: %w", err)
 	}
 
 	d.Set("name", cluster.Name)
@@ -187,13 +187,13 @@ func dataSourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("status", cluster.Status)
 
 	if err := d.Set("tags", keyvaluetags.EksKeyValueTags(cluster.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("version", cluster.Version)
 
 	if err := d.Set("vpc_config", flattenEksVpcConfigResponse(cluster.ResourcesVpcConfig)); err != nil {
-		return fmt.Errorf("error setting vpc_config: %s", err)
+		return fmt.Errorf("error setting vpc_config: %w", err)
 	}
 
 	if err := d.Set("kubernetes_network_config", flattenEksNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {

--- a/aws/data_source_aws_eks_cluster_auth.go
+++ b/aws/data_source_aws_eks_cluster_auth.go
@@ -33,11 +33,11 @@ func dataSourceAwsEksClusterAuthRead(d *schema.ResourceData, meta interface{}) e
 	name := d.Get("name").(string)
 	generator, err := token.NewGenerator(false, false)
 	if err != nil {
-		return fmt.Errorf("error getting token generator: %v", err)
+		return fmt.Errorf("error getting token generator: %w", err)
 	}
 	token, err := generator.GetWithSTS(name, conn)
 	if err != nil {
-		return fmt.Errorf("error getting token: %v", err)
+		return fmt.Errorf("error getting token: %w", err)
 	}
 
 	d.SetId(name)

--- a/aws/data_source_aws_elastic_beanstalk_application.go
+++ b/aws/data_source_aws_elastic_beanstalk_application.go
@@ -63,7 +63,7 @@ func dataSourceAwsElasticBeanstalkApplicationRead(d *schema.ResourceData, meta i
 		ApplicationNames: []*string{aws.String(name)},
 	})
 	if err != nil {
-		return fmt.Errorf("Error describing Applications (%s): %s", name, err)
+		return fmt.Errorf("Error describing Applications (%s): %w", name, err)
 	}
 
 	if len(resp.Applications) > 1 || len(resp.Applications) < 1 {

--- a/aws/data_source_aws_elasticsearch_domain.go
+++ b/aws/data_source_aws_elasticsearch_domain.go
@@ -285,7 +285,7 @@ func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface
 
 	resp, err := esconn.DescribeElasticsearchDomain(req)
 	if err != nil {
-		return fmt.Errorf("error querying elasticsearch_domain: %s", err)
+		return fmt.Errorf("error querying elasticsearch_domain: %w", err)
 	}
 
 	if resp.DomainStatus == nil {
@@ -296,16 +296,16 @@ func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface
 
 	d.SetId(aws.StringValue(ds.ARN))
 
-	if ds.AccessPolicies != nil && *ds.AccessPolicies != "" {
+	if ds.AccessPolicies != nil && aws.StringValue(ds.AccessPolicies) != "" {
 		policies, err := structure.NormalizeJsonString(*ds.AccessPolicies)
 		if err != nil {
-			return fmt.Errorf("access policies contain an invalid JSON: %s", err)
+			return fmt.Errorf("access policies contain an invalid JSON: %w", err)
 		}
 		d.Set("access_policies", policies)
 	}
 
 	if err := d.Set("advanced_options", pointersMapToStringList(ds.AdvancedOptions)); err != nil {
-		return fmt.Errorf("error setting advanced_options: %s", err)
+		return fmt.Errorf("error setting advanced_options: %w", err)
 	}
 
 	d.Set("arn", ds.ARN)
@@ -318,33 +318,33 @@ func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface
 	}
 
 	if err := d.Set("ebs_options", flattenESEBSOptions(ds.EBSOptions)); err != nil {
-		return fmt.Errorf("error setting ebs_options: %s", err)
+		return fmt.Errorf("error setting ebs_options: %w", err)
 	}
 
 	if err := d.Set("encryption_at_rest", flattenESEncryptAtRestOptions(ds.EncryptionAtRestOptions)); err != nil {
-		return fmt.Errorf("error setting encryption_at_rest: %s", err)
+		return fmt.Errorf("error setting encryption_at_rest: %w", err)
 	}
 
 	if err := d.Set("node_to_node_encryption", flattenESNodeToNodeEncryptionOptions(ds.NodeToNodeEncryptionOptions)); err != nil {
-		return fmt.Errorf("error setting node_to_node_encryption: %s", err)
+		return fmt.Errorf("error setting node_to_node_encryption: %w", err)
 	}
 
 	if err := d.Set("cluster_config", flattenESClusterConfig(ds.ElasticsearchClusterConfig)); err != nil {
-		return fmt.Errorf("error setting cluster_config: %s", err)
+		return fmt.Errorf("error setting cluster_config: %w", err)
 	}
 
 	if err := d.Set("snapshot_options", flattenESSnapshotOptions(ds.SnapshotOptions)); err != nil {
-		return fmt.Errorf("error setting snapshot_options: %s", err)
+		return fmt.Errorf("error setting snapshot_options: %w", err)
 	}
 
 	if ds.VPCOptions != nil {
 		if err := d.Set("vpc_options", flattenESVPCDerivedInfo(ds.VPCOptions)); err != nil {
-			return fmt.Errorf("error setting vpc_options: %s", err)
+			return fmt.Errorf("error setting vpc_options: %w", err)
 		}
 
 		endpoints := pointersMapToStringList(ds.Endpoints)
 		if err := d.Set("endpoint", endpoints["vpc"]); err != nil {
-			return fmt.Errorf("error setting endpoint: %s", err)
+			return fmt.Errorf("error setting endpoint: %w", err)
 		}
 		d.Set("kibana_endpoint", getKibanaEndpoint(d))
 		if ds.Endpoint != nil {
@@ -377,7 +377,7 @@ func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface
 	d.Set("elasticsearch_version", ds.ElasticsearchVersion)
 
 	if err := d.Set("cognito_options", flattenESCognitoOptions(ds.CognitoOptions)); err != nil {
-		return fmt.Errorf("error setting cognito_options: %s", err)
+		return fmt.Errorf("error setting cognito_options: %w", err)
 	}
 
 	d.Set("created", ds.Created)
@@ -388,11 +388,11 @@ func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface
 	tags, err := keyvaluetags.ElasticsearchserviceListTags(esconn, d.Id())
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Elasticsearch Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("error listing tags for Elasticsearch Cluster (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_elb.go
+++ b/aws/data_source_aws_elb.go
@@ -207,7 +207,7 @@ func dataSourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading ELB: %s", input)
 	resp, err := elbconn.DescribeLoadBalancers(input)
 	if err != nil {
-		return fmt.Errorf("Error retrieving LB: %s", err)
+		return fmt.Errorf("Error retrieving LB: %w", err)
 	}
 	if len(resp.LoadBalancerDescriptions) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(resp.LoadBalancerDescriptions))

--- a/aws/internal/naming/naming.go
+++ b/aws/internal/naming/naming.go
@@ -64,7 +64,7 @@ func TestCheckResourceAttrNameFromPrefix(resourceName string, attributeName stri
 		attributeMatch, err := regexp.Compile(nameRegexpPattern)
 
 		if err != nil {
-			return fmt.Errorf("Unable to compile name regexp (%s): %s", nameRegexpPattern, err)
+			return fmt.Errorf("Unable to compile name regexp (%s): %w", nameRegexpPattern, err)
 		}
 
 		return resource.TestMatchResourceAttr(resourceName, attributeName, attributeMatch)(s)

--- a/aws/internal/service/cloudformation/waiter/status.go
+++ b/aws/internal/service/cloudformation/waiter/status.go
@@ -66,7 +66,7 @@ func StackSetOperationStatus(conn *cloudformation.CloudFormation, stackSetName, 
 				listOperationResultsOutput, err := conn.ListStackSetOperationResults(listOperationResultsInput)
 
 				if err != nil {
-					return output.StackSetOperation, cloudformation.StackSetOperationStatusFailed, fmt.Errorf("error listing Operation (%s) errors: %s", operationID, err)
+					return output.StackSetOperation, cloudformation.StackSetOperationStatusFailed, fmt.Errorf("error listing Operation (%s) errors: %w", operationID, err)
 				}
 
 				if listOperationResultsOutput == nil {

--- a/aws/internal/service/eks/token/arn.go
+++ b/aws/internal/service/eks/token/arn.go
@@ -4,6 +4,7 @@ https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/7547c74e660f8d34d9
 
 With the following modifications:
  - Rename package from arn to token for simplication
+ - Ignore errorlint reports
 */
 
 package token
@@ -28,7 +29,7 @@ import (
 func Canonicalize(arn string) (string, error) {
 	parsed, err := awsarn.Parse(arn)
 	if err != nil {
-		return "", fmt.Errorf("arn '%s' is invalid: '%v'", arn, err)
+		return "", fmt.Errorf("arn '%s' is invalid: '%v'", arn, err) // nolint:errorlint
 	}
 
 	if err := checkPartition(parsed.Partition); err != nil {

--- a/aws/internal/service/eks/token/token.go
+++ b/aws/internal/service/eks/token/token.go
@@ -9,6 +9,7 @@ With the following modifications:
  - Use *sts.STS instead of stsiface.STSAPI in Generator interface and GetWithSTS implementation
  - Hard copy and use local Canonicalize implementation instead of "sigs.k8s.io/aws-iam-authenticator/pkg/arn"
  - Fix staticcheck reports
+ - Ignore errorlint reports
 */
 
 /*
@@ -308,7 +309,7 @@ func (v tokenVerifier) Verify(token string) (*Identity, error) {
 	response, err := v.client.Do(req)
 	if err != nil {
 		// special case to avoid printing the full URL if possible
-		if urlErr, ok := err.(*url.Error); ok {
+		if urlErr, ok := err.(*url.Error); ok { // nolint:errorlint
 			return nil, NewSTSError(fmt.Sprintf("error during GET: %v", urlErr.Err))
 		}
 		return nil, NewSTSError(fmt.Sprintf("error during GET: %v", err))

--- a/aws/internal/service/eks/token/token_test.go
+++ b/aws/internal/service/eks/token/token_test.go
@@ -5,6 +5,7 @@ https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/7547c74e660f8d34d9
 With the following modifications:
 
  - Fix staticcheck reports
+ - Ignore errorlint reports
 */
 
 package token
@@ -49,7 +50,7 @@ func errorContains(t *testing.T, err error, expectedErr string) {
 
 func assertSTSError(t *testing.T, err error) {
 	t.Helper()
-	if _, ok := err.(STSError); !ok {
+	if _, ok := err.(STSError); !ok { // nolint:errorlint
 		t.Errorf("Expected err %v to be an STSError but was not", err)
 	}
 }

--- a/aws/internal/tfresource/errors.go
+++ b/aws/internal/tfresource/errors.go
@@ -19,6 +19,7 @@ func NotFound(err error) bool {
 //  * err is of type resource.TimeoutError
 //  * TimeoutError.LastError is nil
 func TimedOut(err error) bool {
-	timeoutErr, ok := err.(*resource.TimeoutError)
+	// This explicitly does *not* match wrapped TimeoutErrors
+	timeoutErr, ok := err.(*resource.TimeoutError) // nolint:errorlint
 	return ok && timeoutErr.LastError == nil
 }

--- a/aws/opsworks_layers.go
+++ b/aws/opsworks_layers.go
@@ -357,7 +357,7 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, client *opsworks.OpsWo
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/docs/contributing/contribution-checklists.md
+++ b/docs/contributing/contribution-checklists.md
@@ -308,7 +308,7 @@ More details about this code generation, including fixes for potential error mes
   ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
   if err := d.Set("tags", keyvaluetags.EksKeyValueTags(cluster.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-    return fmt.Errorf("error setting tags: %s", err)
+    return fmt.Errorf("error setting tags: %w", err)
   }
   ```
 
@@ -325,7 +325,7 @@ More details about this code generation, including fixes for potential error mes
   }
 
   if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-    return fmt.Errorf("error setting tags: %s", err)
+    return fmt.Errorf("error setting tags: %w", err)
   }
   ```
 


### PR DESCRIPTION
Fixes [`errorlint`](https://github.com/polyfloyd/go-errorlint) reports for internal packages and data sources A-E.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15891

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeCommitRepositoryDataSource\|TestAccAWSCallerIdentity\|TestAccDataSourceAwsCognitoUserPools\|TestAccAWSAcmCertificateDataSource\|TestAccAWSCloudFrontDataSourceOriginRequestPolicy\|TestAccDataSourceAwsApiGatewayDomainName\|TestAccAWSAvailabilityZones\|TestAccDataSourceAwsAcmpcaCertificateAuthority\|TestAccDataSourceAwsApiGatewayVpcLink\|TestAccDataSourceAwsApiGatewayApiKey\|TestAccAWSAmiDataSource\|TestAccAWSDataSourceCloudFrontDistribution\|TestAccAWSBackupVaultDataSource\|TestAccAWSDbEventCategories\|TestAccDataSourceAwsApiGatewayResource\|TestAccDataSourceAwsArn\|TestAccAWSDbClusterSnapshotDataSource\|TestAccDataSourceAwsApiGatewayRestApi\|TestAccAWSCloudFormationStack\|TestAccAWSAutoscalingGroups\|TestAccAWSCloudformationExportDataSource\|TestAccAWSCloudwatchLogGroupDataSource\|TestAvailabilityZonesSort\|TestAccAWSCustomerGatewayDataSource\|TestAccAWSBackupSelectionDataSource\|TestAccAWSBackupPlanDataSource\|TestAccDataSourceCloudHsmV2Cluster\|TestAccDataSourceAwsBatchJobQueue'

--- SKIP: TestAccAWSAcmCertificateDataSource_singleIssued (0.00s)
--- SKIP: TestAccAWSAcmCertificateDataSource_multipleIssued (0.00s)
--- SKIP: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (0.00s)
--- PASS: TestAvailabilityZonesSort (0.00s)
--- PASS: TestAccAWSAvailabilityZones_basic (48.19s)
--- PASS: TestAccDataSourceAwsApiGatewayApiKey_basic (49.18s)
--- PASS: TestAccAWSAvailabilityZones_AllAvailabilityZones (48.82s)
--- PASS: TestAccDataSourceAwsApiGatewayRestApi_basic (50.35s)
--- PASS: TestAccAWSAvailabilityZones_Filter (49.93s)
--- PASS: TestAccDataSourceAwsArn_basic (50.66s)
--- PASS: TestAccAWSAvailabilityZones_ExcludeZoneIds (50.15s)
--- PASS: TestAccAWSAvailabilityZones_ExcludeNames (50.95s)
--- PASS: TestAccAWSAmiDataSource_natInstance (57.99s)
--- PASS: TestAccAWSAmiDataSource_windowsInstance (58.17s)
--- PASS: TestAccAWSAmiDataSource_instanceStore (60.02s)
--- PASS: TestAccDataSourceAwsAcmpcaCertificateAuthority_basic (60.70s)
--- PASS: TestAccAWSAmiDataSource_localNameFilter (62.26s)
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (66.38s)
--- PASS: TestAccAWSAvailabilityZones_stateFilter (36.18s)
--- PASS: TestAccAWSAmiDataSource_Gp3BlockDevice (84.99s)
--- PASS: TestAccAWSCallerIdentity_basic (34.80s)
--- PASS: TestAccAWSBackupPlanDataSource_basic (37.47s)
--- PASS: TestAccAWSBackupVaultDataSource_basic (36.30s)
--- PASS: TestAccAWSBackupSelectionDataSource_basic (38.16s)
--- PASS: TestAccAWSCloudwatchLogGroupDataSource_basic (28.20s)
--- PASS: TestAccAWSCloudFrontDataSourceOriginRequestPolicy_basic (34.56s)
--- PASS: TestAccDataSourceAwsApiGatewayResource_basic (98.18s)
--- PASS: TestAccDataSourceAwsApiGatewayDomainName_basic (99.47s)
--- PASS: TestAccAWSCloudformationExportDataSource_basic (52.75s)
--- PASS: TestAccAWSCloudwatchLogGroupDataSource_tags (31.88s)
--- PASS: TestAccAWSCodeCommitRepositoryDataSource_basic (32.61s)
--- PASS: TestAccAWSCloudwatchLogGroupDataSource_retention (33.93s)
--- PASS: TestAccAWSCloudwatchLogGroupDataSource_kms (34.85s)
--- FAIL: TestAccAWSDbEventCategories_basic (21.71s)
--- PASS: TestAccDataSourceAwsCognitoUserPools_basic (41.07s)
--- PASS: TestAccAWSCustomerGatewayDataSource_Filter (43.40s)
--- PASS: TestAccAWSCustomerGatewayDataSource_ID (39.86s)
--- PASS: TestAccAWSDbEventCategories_sourceType (20.67s)
--- PASS: TestAccAWSCloudformationExportDataSource_ResourceReference (89.42s)
--- PASS: TestAccAWSAutoscalingGroups_basic (143.38s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (90.77s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (91.67s)
--- PASS: TestAccAWSCloudFormationStackSet_basic (18.93s)
--- PASS: TestAccAWSCloudFormationStackSet_disappears (15.85s)
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_Default (0.00s)
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_NoEcho (0.00s)
--- PASS: TestAccDataSourceAwsApiGatewayRestApi_EndpointConfiguration_VpcEndpointIds (162.69s)
--- PASS: TestAccDataSourceAwsBatchJobQueue_basic (111.70s)
--- PASS: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (43.16s)
--- PASS: TestAccAWSCloudFormationStackSet_ExecutionRoleName (44.52s)
--- PASS: TestAccAWSCloudFormationStackSet_Description (47.52s)
--- PASS: TestAccAWSCloudFormationStackSet_Name (49.23s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateBody (51.97s)
--- PASS: TestAccAWSCloudFormationStack_CreationFailure_Delete (21.63s)
--- PASS: TestAccAWSCloudFormationStack_CreationFailure_DoNothing (31.18s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateUrl (51.73s)
--- PASS: TestAccAWSCloudFormationStack_CreationFailure_Rollback (35.26s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (116.59s)
--- PASS: TestAccAWSCloudFormationStack_basic (75.75s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears (118.98s)
--- PASS: TestAccAWSCloudFormationStackSet_Parameters (95.28s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_basic (125.83s)
--- PASS: TestAccAWSCloudFormationStackSet_Tags (101.81s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_DbClusterSnapshotIdentifier (172.69s)
--- PASS: TestAccAWSCloudFormationStack_disappears (66.16s)
--- PASS: TestAccAWSCloudFormationStack_yaml (72.07s)
--- PASS: TestAccAWSCloudFormationStack_defaultParams (70.79s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_DbClusterIdentifier (190.23s)
--- PASS: TestAccAWSCloudFormationStack_withTransform (49.93s)
--- PASS: TestAccAWSCloudFormationStack_allAttributes (81.89s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_RetainStack (167.80s)
--- PASS: TestAccDataSourceCloudHsmV2Cluster_basic (236.70s)
--- PASS: TestAccAWSCloudFormationStack_UpdateFailure (100.87s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (71.26s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_MostRecent (230.18s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (91.61s)
--- PASS: TestAccAWSCloudFormationStack_withParams (121.37s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (233.60s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (126.62s)
--- PASS: TestAccAWSDataSourceCloudFrontDistribution_basic (310.60s)
--- PASS: TestAccDataSourceAwsApiGatewayVpcLink_basic (701.74s)
```

`TestAccAWSDbEventCategories_basic` is a pre-existing failure