### PR TITLE
Fixes errorlint reports for data sources F-S

### DIFF
--- a/aws/data_source_aws_glue_script.go
+++ b/aws/data_source_aws_glue_script.go
@@ -115,7 +115,7 @@ func dataSourceAwsGlueScriptRead(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Creating Glue Script: %s", input)
 	output, err := conn.CreateScript(input)
 	if err != nil {
-		return fmt.Errorf("error creating Glue script: %s", err)
+		return fmt.Errorf("error creating Glue script: %w", err)
 	}
 
 	if output == nil {

--- a/aws/data_source_aws_guardduty_detector.go
+++ b/aws/data_source_aws_guardduty_detector.go
@@ -44,7 +44,7 @@ func dataSourceAwsGuarddutyDetectorRead(d *schema.ResourceData, meta interface{}
 
 		resp, err := conn.ListDetectors(input)
 		if err != nil {
-			return fmt.Errorf("error listing GuardDuty Detectors: %s ,", err)
+			return fmt.Errorf("error listing GuardDuty Detectors: %w", err)
 		}
 
 		if resp == nil || len(resp.DetectorIds) == 0 {

--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -79,7 +79,7 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 		return !lastPage
 	})
 	if err != nil {
-		return fmt.Errorf("Error getting group: %s", err)
+		return fmt.Errorf("Error getting group: %w", err)
 	}
 	if group == nil {
 		return fmt.Errorf("no IAM group found")
@@ -90,7 +90,7 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("path", group.Path)
 	d.Set("group_id", group.GroupId)
 	if err := d.Set("users", dataSourceUsersRead(users)); err != nil {
-		return fmt.Errorf("error setting users: %s", err)
+		return fmt.Errorf("error setting users: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_iam_instance_profile.go
+++ b/aws/data_source_aws_iam_instance_profile.go
@@ -58,7 +58,7 @@ func dataSourceAwsIAMInstanceProfileRead(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] Reading IAM Instance Profile: %s", req)
 	resp, err := iamconn.GetInstanceProfile(req)
 	if err != nil {
-		return fmt.Errorf("Error getting instance profiles: %s", err)
+		return fmt.Errorf("Error getting instance profiles: %w", err)
 	}
 	if resp == nil {
 		return fmt.Errorf("no IAM instance profile found")

--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -156,7 +156,7 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 					iamPolicyDecodeConfigStringList(resources), doc.Version,
 				)
 				if err != nil {
-					return fmt.Errorf("error reading resources: %s", err)
+					return fmt.Errorf("error reading resources: %w", err)
 				}
 			}
 			if notResources := cfgStmt["not_resources"].(*schema.Set).List(); len(notResources) > 0 {
@@ -165,7 +165,7 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 					iamPolicyDecodeConfigStringList(notResources), doc.Version,
 				)
 				if err != nil {
-					return fmt.Errorf("error reading not_resources: %s", err)
+					return fmt.Errorf("error reading not_resources: %w", err)
 				}
 			}
 
@@ -173,7 +173,7 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 				var err error
 				stmt.Principals, err = dataSourceAwsIamPolicyDocumentMakePrincipals(principals, doc.Version)
 				if err != nil {
-					return fmt.Errorf("error reading principals: %s", err)
+					return fmt.Errorf("error reading principals: %w", err)
 				}
 			}
 
@@ -181,7 +181,7 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 				var err error
 				stmt.NotPrincipals, err = dataSourceAwsIamPolicyDocumentMakePrincipals(notPrincipals, doc.Version)
 				if err != nil {
-					return fmt.Errorf("error reading not_principals: %s", err)
+					return fmt.Errorf("error reading not_principals: %w", err)
 				}
 			}
 
@@ -189,7 +189,7 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 				var err error
 				stmt.Conditions, err = dataSourceAwsIamPolicyDocumentMakeConditions(conditions, doc.Version)
 				if err != nil {
-					return fmt.Errorf("error reading condition: %s", err)
+					return fmt.Errorf("error reading condition: %w", err)
 				}
 			}
 
@@ -262,7 +262,7 @@ func dataSourceAwsIamPolicyDocumentMakeConditions(in []interface{}, version stri
 			), version,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error reading values: %s", err)
+			return nil, fmt.Errorf("error reading values: %w", err)
 		}
 	}
 	return IAMPolicyStatementConditionSet(out), nil
@@ -282,7 +282,7 @@ func dataSourceAwsIamPolicyDocumentMakePrincipals(in []interface{}, version stri
 			), version,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error reading identifiers: %s", err)
+			return nil, fmt.Errorf("error reading identifiers: %w", err)
 		}
 	}
 	return IAMPolicyStatementPrincipalSet(out), nil

--- a/aws/data_source_aws_iam_role.go
+++ b/aws/data_source_aws_iam_role.go
@@ -69,12 +69,12 @@ func dataSourceAwsIAMRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	output, err := iamconn.GetRole(input)
 	if err != nil {
-		return fmt.Errorf("error reading IAM Role (%s): %s", name, err)
+		return fmt.Errorf("error reading IAM Role (%s): %w", name, err)
 	}
 
 	d.Set("arn", output.Role.Arn)
 	if err := d.Set("create_date", output.Role.CreateDate.Format(time.RFC3339)); err != nil {
-		return fmt.Errorf("error setting create_date: %s", err)
+		return fmt.Errorf("error setting create_date: %w", err)
 	}
 	d.Set("description", output.Role.Description)
 	d.Set("max_session_duration", output.Role.MaxSessionDuration)
@@ -89,10 +89,10 @@ func dataSourceAwsIAMRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	assumRolePolicy, err := url.QueryUnescape(aws.StringValue(output.Role.AssumeRolePolicyDocument))
 	if err != nil {
-		return fmt.Errorf("error parsing assume role policy document: %s", err)
+		return fmt.Errorf("error parsing assume role policy document: %w", err)
 	}
 	if err := d.Set("assume_role_policy", assumRolePolicy); err != nil {
-		return fmt.Errorf("error setting assume_role_policy: %s", err)
+		return fmt.Errorf("error setting assume_role_policy: %w", err)
 	}
 
 	d.SetId(name)

--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -119,7 +119,7 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 		return true
 	})
 	if err != nil {
-		return fmt.Errorf("Error describing certificates: %s", err)
+		return fmt.Errorf("Error describing certificates: %w", err)
 	}
 
 	if len(metadatas) == 0 {

--- a/aws/data_source_aws_iam_user.go
+++ b/aws/data_source_aws_iam_user.go
@@ -52,7 +52,7 @@ func dataSourceAwsIAMUserRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading IAM User: %s", req)
 	resp, err := iamconn.GetUser(req)
 	if err != nil {
-		return fmt.Errorf("error getting user: %s", err)
+		return fmt.Errorf("error getting user: %w", err)
 	}
 
 	user := resp.User

--- a/aws/data_source_aws_inspector_rules_packages.go
+++ b/aws/data_source_aws_inspector_rules_packages.go
@@ -40,7 +40,7 @@ func dataSourceAwsInspectorRulesPackagesRead(d *schema.ResourceData, meta interf
 		return !lastPage
 	})
 	if err != nil {
-		return fmt.Errorf("Error fetching Rules Packages: %s", err)
+		return fmt.Errorf("Error fetching Rules Packages: %w", err)
 	}
 
 	if len(arns) == 0 {

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -495,7 +495,7 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 	}
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(instance.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	// Security Groups
@@ -549,20 +549,20 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 		// Ignore UnsupportedOperation errors for AWS China and GovCloud (US)
 		// Reference: https://github.com/hashicorp/terraform-provider-aws/pull/4362
 		if err != nil && !isAWSErr(err, "UnsupportedOperation", "") {
-			return fmt.Errorf("error getting EC2 Instance (%s) Credit Specifications: %s", d.Id(), err)
+			return fmt.Errorf("error getting EC2 Instance (%s) Credit Specifications: %w", d.Id(), err)
 		}
 	}
 
 	if err := d.Set("credit_specification", creditSpecifications); err != nil {
-		return fmt.Errorf("error setting credit_specification: %s", err)
+		return fmt.Errorf("error setting credit_specification: %w", err)
 	}
 
 	if err := d.Set("metadata_options", flattenEc2InstanceMetadataOptions(instance.MetadataOptions)); err != nil {
-		return fmt.Errorf("error setting metadata_options: %s", err)
+		return fmt.Errorf("error setting metadata_options: %w", err)
 	}
 
 	if err := d.Set("enclave_options", flattenEc2EnclaveOptions(instance.EnclaveOptions)); err != nil {
-		return fmt.Errorf("error setting enclave_options: %s", err)
+		return fmt.Errorf("error setting enclave_options: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_internet_gateway.go
+++ b/aws/data_source_aws_internet_gateway.go
@@ -90,7 +90,7 @@ func dataSourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) 
 	d.SetId(aws.StringValue(igw.InternetGatewayId))
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(igw.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("owner_id", igw.OwnerId)

--- a/aws/data_source_aws_iot_endpoint.go
+++ b/aws/data_source_aws_iot_endpoint.go
@@ -41,12 +41,12 @@ func dataSourceAwsIotEndpointRead(d *schema.ResourceData, meta interface{}) erro
 
 	output, err := conn.DescribeEndpoint(input)
 	if err != nil {
-		return fmt.Errorf("error while describing iot endpoint: %s", err)
+		return fmt.Errorf("error while describing iot endpoint: %w", err)
 	}
 	endpointAddress := aws.StringValue(output.EndpointAddress)
 	d.SetId(endpointAddress)
 	if err := d.Set("endpoint_address", endpointAddress); err != nil {
-		return fmt.Errorf("error setting endpoint_address: %s", err)
+		return fmt.Errorf("error setting endpoint_address: %w", err)
 	}
 	return nil
 }

--- a/aws/data_source_aws_ip_ranges.go
+++ b/aws/data_source_aws_ip_ranges.go
@@ -84,7 +84,7 @@ func dataSourceAwsIPRangesRead(d *schema.ResourceData, meta interface{}) error {
 	res, err := conn.Get(url)
 
 	if err != nil {
-		return fmt.Errorf("Error listing IP ranges from (%s): %s", url, err)
+		return fmt.Errorf("Error listing IP ranges from (%s): %w", url, err)
 	}
 
 	defer res.Body.Close()
@@ -92,29 +92,29 @@ func dataSourceAwsIPRangesRead(d *schema.ResourceData, meta interface{}) error {
 	data, err := ioutil.ReadAll(res.Body)
 
 	if err != nil {
-		return fmt.Errorf("Error reading response body from (%s): %s", url, err)
+		return fmt.Errorf("Error reading response body from (%s): %w", url, err)
 	}
 
 	result := new(dataSourceAwsIPRangesResult)
 
 	if err := json.Unmarshal(data, result); err != nil {
-		return fmt.Errorf("Error parsing result from (%s): %s", url, err)
+		return fmt.Errorf("Error parsing result from (%s): %w", url, err)
 	}
 
 	if err := d.Set("create_date", result.CreateDate); err != nil {
-		return fmt.Errorf("Error setting create date: %s", err)
+		return fmt.Errorf("Error setting create date: %w", err)
 	}
 
 	syncToken, err := strconv.Atoi(result.SyncToken)
 
 	if err != nil {
-		return fmt.Errorf("Error while converting sync token: %s", err)
+		return fmt.Errorf("Error while converting sync token: %w", err)
 	}
 
 	d.SetId(result.SyncToken)
 
 	if err := d.Set("sync_token", syncToken); err != nil {
-		return fmt.Errorf("Error setting sync token: %s", err)
+		return fmt.Errorf("Error setting sync token: %w", err)
 	}
 
 	get := func(key string) *schema.Set {
@@ -167,13 +167,13 @@ func dataSourceAwsIPRangesRead(d *schema.ResourceData, meta interface{}) error {
 	sort.Strings(ipPrefixes)
 
 	if err := d.Set("cidr_blocks", ipPrefixes); err != nil {
-		return fmt.Errorf("Error setting cidr_blocks: %s", err)
+		return fmt.Errorf("Error setting cidr_blocks: %w", err)
 	}
 
 	sort.Strings(ipv6Prefixes)
 
 	if err := d.Set("ipv6_cidr_blocks", ipv6Prefixes); err != nil {
-		return fmt.Errorf("Error setting ipv6_cidr_blocks: %s", err)
+		return fmt.Errorf("Error setting ipv6_cidr_blocks: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_kinesis_stream.go
+++ b/aws/data_source_aws_kinesis_stream.go
@@ -86,11 +86,11 @@ func dataSourceAwsKinesisStreamRead(d *schema.ResourceData, meta interface{}) er
 	tags, err := keyvaluetags.KinesisListTags(conn, sn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Kinesis Stream (%s): %s", sn, err)
+		return fmt.Errorf("error listing tags for Kinesis Stream (%s): %w", sn, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_kms_alias.go
+++ b/aws/data_source_aws_kms_alias.go
@@ -52,7 +52,7 @@ func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 		return true
 	})
 	if err != nil {
-		return fmt.Errorf("Error fetch KMS alias list: %s", err)
+		return fmt.Errorf("Error fetch KMS alias list: %w", err)
 	}
 
 	if alias == nil {
@@ -78,7 +78,7 @@ func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	resp, err := conn.DescribeKey(req)
 	if err != nil {
-		return fmt.Errorf("Error calling KMS DescribeKey: %s", err)
+		return fmt.Errorf("Error calling KMS DescribeKey: %w", err)
 	}
 
 	d.Set("target_key_arn", resp.KeyMetadata.Arn)

--- a/aws/data_source_aws_kms_key.go
+++ b/aws/data_source_aws_kms_key.go
@@ -92,7 +92,7 @@ func dataSourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	output, err := conn.DescribeKey(input)
 	if err != nil {
-		return fmt.Errorf("error while describing key [%s]: %s", keyId, err)
+		return fmt.Errorf("error while describing key [%s]: %w", keyId, err)
 	}
 	d.SetId(aws.StringValue(output.KeyMetadata.KeyId))
 	d.Set("arn", output.KeyMetadata.Arn)

--- a/aws/data_source_aws_kms_secrets.go
+++ b/aws/data_source_aws_kms_secrets.go
@@ -63,7 +63,7 @@ func dataSourceAwsKmsSecretsRead(d *schema.ResourceData, meta interface{}) error
 		// base64 decode the payload
 		payload, err := base64.StdEncoding.DecodeString(secret["payload"].(string))
 		if err != nil {
-			return fmt.Errorf("Invalid base64 value for secret '%s': %v", secret["name"].(string), err)
+			return fmt.Errorf("Invalid base64 value for secret '%s': %w", secret["name"].(string), err)
 		}
 
 		// build the kms decrypt params
@@ -86,7 +86,7 @@ func dataSourceAwsKmsSecretsRead(d *schema.ResourceData, meta interface{}) error
 		// decrypt
 		resp, err := conn.Decrypt(params)
 		if err != nil {
-			return fmt.Errorf("Failed to decrypt '%s': %s", secret["name"].(string), err)
+			return fmt.Errorf("Failed to decrypt '%s': %w", secret["name"].(string), err)
 		}
 
 		// Set the secret via the name
@@ -95,7 +95,7 @@ func dataSourceAwsKmsSecretsRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if err := d.Set("plaintext", plaintext); err != nil {
-		return fmt.Errorf("error setting plaintext: %s", err)
+		return fmt.Errorf("error setting plaintext: %w", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)

--- a/aws/data_source_aws_lambda_alias.go
+++ b/aws/data_source_aws_lambda_alias.go
@@ -59,7 +59,7 @@ func dataSourceAwsLambdaAliasRead(d *schema.ResourceData, meta interface{}) erro
 
 	aliasConfiguration, err := conn.GetAlias(params)
 	if err != nil {
-		return fmt.Errorf("Error getting Lambda alias: %s", err)
+		return fmt.Errorf("Error getting Lambda alias: %w", err)
 	}
 
 	d.SetId(aws.StringValue(aliasConfiguration.AliasArn))

--- a/aws/data_source_aws_lambda_code_signing_config.go
+++ b/aws/data_source_aws_lambda_code_signing_config.go
@@ -72,7 +72,7 @@ func dataSourceAwsLambdaCodeSigningConfigRead(d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		return fmt.Errorf("error getting Lambda code signing config (%s): %s", arn, err)
+		return fmt.Errorf("error getting Lambda code signing config (%s): %w", arn, err)
 	}
 
 	if configOutput == nil {
@@ -85,19 +85,19 @@ func dataSourceAwsLambdaCodeSigningConfigRead(d *schema.ResourceData, meta inter
 	}
 
 	if err := d.Set("config_id", codeSigningConfig.CodeSigningConfigId); err != nil {
-		return fmt.Errorf("error setting lambda code signing config id: %s", err)
+		return fmt.Errorf("error setting lambda code signing config id: %w", err)
 	}
 
 	if err := d.Set("description", codeSigningConfig.Description); err != nil {
-		return fmt.Errorf("error setting lambda code signing config description: %s", err)
+		return fmt.Errorf("error setting lambda code signing config description: %w", err)
 	}
 
 	if err := d.Set("last_modified", codeSigningConfig.LastModified); err != nil {
-		return fmt.Errorf("error setting lambda code signing config last modified: %s", err)
+		return fmt.Errorf("error setting lambda code signing config last modified: %w", err)
 	}
 
 	if err := d.Set("allowed_publishers", flattenLambdaCodeSigningConfigAllowedPublishers(codeSigningConfig.AllowedPublishers)); err != nil {
-		return fmt.Errorf("error setting lambda code signing config allowed publishers: %s", err)
+		return fmt.Errorf("error setting lambda code signing config allowed publishers: %w", err)
 	}
 
 	if err := d.Set("policies", []interface{}{
@@ -105,7 +105,7 @@ func dataSourceAwsLambdaCodeSigningConfigRead(d *schema.ResourceData, meta inter
 			"untrusted_artifact_on_deployment": codeSigningConfig.CodeSigningPolicies.UntrustedArtifactOnDeployment,
 		},
 	}); err != nil {
-		return fmt.Errorf("error setting lambda code signing config code signing policies: %s", err)
+		return fmt.Errorf("error setting lambda code signing config code signing policies: %w", err)
 	}
 
 	d.SetId(aws.StringValue(codeSigningConfig.CodeSigningConfigArn))

--- a/aws/data_source_aws_lambda_function.go
+++ b/aws/data_source_aws_lambda_function.go
@@ -204,7 +204,7 @@ func dataSourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) e
 	output, err := conn.GetFunction(input)
 
 	if err != nil {
-		return fmt.Errorf("error getting Lambda Function (%s): %s", functionName, err)
+		return fmt.Errorf("error getting Lambda Function (%s): %w", functionName, err)
 	}
 
 	if output == nil {
@@ -235,13 +235,13 @@ func dataSourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 	if err := d.Set("dead_letter_config", deadLetterConfig); err != nil {
-		return fmt.Errorf("error setting dead_letter_config: %s", err)
+		return fmt.Errorf("error setting dead_letter_config: %w", err)
 	}
 
 	d.Set("description", function.Description)
 
 	if err := d.Set("environment", flattenLambdaEnvironment(function.Environment)); err != nil {
-		return fmt.Errorf("error setting environment: %s", err)
+		return fmt.Errorf("error setting environment: %w", err)
 	}
 
 	d.Set("handler", function.Handler)
@@ -250,7 +250,7 @@ func dataSourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("last_modified", function.LastModified)
 
 	if err := d.Set("layers", flattenLambdaLayers(function.Layers)); err != nil {
-		return fmt.Errorf("Error setting layers for Lambda Function (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error setting layers for Lambda Function (%s): %w", d.Id(), err)
 	}
 
 	d.Set("memory_size", function.MemorySize)
@@ -258,12 +258,12 @@ func dataSourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) e
 
 	// Add Signing Profile Version ARN
 	if err := d.Set("signing_profile_version_arn", function.SigningProfileVersionArn); err != nil {
-		return fmt.Errorf("Error setting signing profile version arn for Lambda Function: %s", err)
+		return fmt.Errorf("Error setting signing profile version arn for Lambda Function: %w", err)
 	}
 
 	// Add Signing Job ARN
 	if err := d.Set("signing_job_arn", function.SigningJobArn); err != nil {
-		return fmt.Errorf("Error setting signing job arn for Lambda Function: %s", err)
+		return fmt.Errorf("Error setting signing job arn for Lambda Function: %w", err)
 	}
 
 	reservedConcurrentExecutions := int64(-1)
@@ -278,7 +278,7 @@ func dataSourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("source_code_size", function.CodeSize)
 
 	if err := d.Set("tags", keyvaluetags.LambdaKeyValueTags(output.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	tracingConfig := []map[string]interface{}{
@@ -297,11 +297,11 @@ func dataSourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("version", function.Version)
 
 	if err := d.Set("vpc_config", flattenLambdaVpcConfigResponse(function.VpcConfig)); err != nil {
-		return fmt.Errorf("error setting vpc_config: %s", err)
+		return fmt.Errorf("error setting vpc_config: %w", err)
 	}
 
 	if err := d.Set("file_system_config", flattenLambdaFileSystemConfigs(function.FileSystemConfigs)); err != nil {
-		return fmt.Errorf("error setting file_system_config: %s", err)
+		return fmt.Errorf("error setting file_system_config: %w", err)
 	}
 
 	// Currently, this functionality is only enabled in AWS Commercial partition

--- a/aws/data_source_aws_lambda_layer_version.go
+++ b/aws/data_source_aws_lambda_layer_version.go
@@ -97,7 +97,7 @@ func dataSourceAwsLambdaLayerVersionRead(d *schema.ResourceData, meta interface{
 		log.Printf("[DEBUG] Looking up latest version for lambda layer %s", layerName)
 		listOutput, err := conn.ListLayerVersions(listInput)
 		if err != nil {
-			return fmt.Errorf("error listing Lambda Layer Versions (%s): %s", layerName, err)
+			return fmt.Errorf("error listing Lambda Layer Versions (%s): %w", layerName, err)
 		}
 
 		if len(listOutput.LayerVersions) == 0 {
@@ -116,7 +116,7 @@ func dataSourceAwsLambdaLayerVersionRead(d *schema.ResourceData, meta interface{
 	output, err := conn.GetLayerVersion(input)
 
 	if err != nil {
-		return fmt.Errorf("error getting Lambda Layer Version (%s, version %d): %s", layerName, version, err)
+		return fmt.Errorf("error getting Lambda Layer Version (%s, version %d): %w", layerName, version, err)
 	}
 
 	if output == nil {
@@ -124,37 +124,37 @@ func dataSourceAwsLambdaLayerVersionRead(d *schema.ResourceData, meta interface{
 	}
 
 	if err := d.Set("version", int(aws.Int64Value(output.Version))); err != nil {
-		return fmt.Errorf("error setting lambda layer version: %s", err)
+		return fmt.Errorf("error setting lambda layer version: %w", err)
 	}
 	if err := d.Set("compatible_runtimes", flattenStringList(output.CompatibleRuntimes)); err != nil {
-		return fmt.Errorf("error setting lambda layer compatible runtimes: %s", err)
+		return fmt.Errorf("error setting lambda layer compatible runtimes: %w", err)
 	}
 	if err := d.Set("description", output.Description); err != nil {
-		return fmt.Errorf("error setting lambda layer description: %s", err)
+		return fmt.Errorf("error setting lambda layer description: %w", err)
 	}
 	if err := d.Set("license_info", output.LicenseInfo); err != nil {
-		return fmt.Errorf("error setting lambda layer license info: %s", err)
+		return fmt.Errorf("error setting lambda layer license info: %w", err)
 	}
 	if err := d.Set("arn", output.LayerVersionArn); err != nil {
-		return fmt.Errorf("error setting lambda layer version arn: %s", err)
+		return fmt.Errorf("error setting lambda layer version arn: %w", err)
 	}
 	if err := d.Set("layer_arn", output.LayerArn); err != nil {
-		return fmt.Errorf("error setting lambda layer arn: %s", err)
+		return fmt.Errorf("error setting lambda layer arn: %w", err)
 	}
 	if err := d.Set("created_date", output.CreatedDate); err != nil {
-		return fmt.Errorf("error setting lambda layer created date: %s", err)
+		return fmt.Errorf("error setting lambda layer created date: %w", err)
 	}
 	if err := d.Set("source_code_hash", output.Content.CodeSha256); err != nil {
-		return fmt.Errorf("error setting lambda layer source code hash: %s", err)
+		return fmt.Errorf("error setting lambda layer source code hash: %w", err)
 	}
 	if err := d.Set("source_code_size", output.Content.CodeSize); err != nil {
-		return fmt.Errorf("error setting lambda layer source code size: %s", err)
+		return fmt.Errorf("error setting lambda layer source code size: %w", err)
 	}
 	if err := d.Set("signing_profile_version_arn", output.Content.SigningProfileVersionArn); err != nil {
-		return fmt.Errorf("Error setting lambda layer signing profile arn: %s", err)
+		return fmt.Errorf("Error setting lambda layer signing profile arn: %w", err)
 	}
 	if err := d.Set("signing_job_arn", output.Content.SigningJobArn); err != nil {
-		return fmt.Errorf("Error setting lambda layer signing job arn: %s", err)
+		return fmt.Errorf("Error setting lambda layer signing job arn: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.LayerVersionArn))

--- a/aws/data_source_aws_launch_configuration.go
+++ b/aws/data_source_aws_launch_configuration.go
@@ -228,7 +228,7 @@ func dataSourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] launch configuration describe configuration: %s", describeOpts)
 	describConfs, err := autoscalingconn.DescribeLaunchConfigurations(&describeOpts)
 	if err != nil {
-		return fmt.Errorf("Error retrieving launch configuration: %s", err)
+		return fmt.Errorf("Error retrieving launch configuration: %w", err)
 	}
 
 	if describConfs == nil || len(describConfs.LaunchConfigurations) == 0 {
@@ -263,11 +263,11 @@ func dataSourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface
 		vpcSGs = append(vpcSGs, *sg)
 	}
 	if err := d.Set("security_groups", vpcSGs); err != nil {
-		return fmt.Errorf("error setting security_groups: %s", err)
+		return fmt.Errorf("error setting security_groups: %w", err)
 	}
 
 	if err := d.Set("metadata_options", flattenLaunchConfigInstanceMetadataOptions(lc.MetadataOptions)); err != nil {
-		return fmt.Errorf("error setting metadata_options: %s", err)
+		return fmt.Errorf("error setting metadata_options: %w", err)
 	}
 
 	classicSGs := make([]string, 0, len(lc.ClassicLinkVPCSecurityGroups))
@@ -275,7 +275,7 @@ func dataSourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface
 		classicSGs = append(classicSGs, *sg)
 	}
 	if err := d.Set("vpc_classic_link_security_groups", classicSGs); err != nil {
-		return fmt.Errorf("error setting vpc_classic_link_security_groups: %s", err)
+		return fmt.Errorf("error setting vpc_classic_link_security_groups: %w", err)
 	}
 
 	if err := readLCBlockDevices(d, lc, ec2conn); err != nil {

--- a/aws/data_source_aws_lb.go
+++ b/aws/data_source_aws_lb.go
@@ -169,7 +169,7 @@ func dataSourceAwsLbRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Load Balancer: %s", describeLbOpts)
 	describeResp, err := conn.DescribeLoadBalancers(describeLbOpts)
 	if err != nil {
-		return fmt.Errorf("Error retrieving LB: %s", err)
+		return fmt.Errorf("Error retrieving LB: %w", err)
 	}
 	if len(describeResp.LoadBalancers) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(describeResp.LoadBalancers))

--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -175,7 +175,7 @@ func dataSourceAwsLbTargetGroupRead(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Reading Load Balancer Target Group: %s", describeTgOpts)
 	describeResp, err := elbconn.DescribeTargetGroups(describeTgOpts)
 	if err != nil {
-		return fmt.Errorf("Error retrieving LB Target Group: %s", err)
+		return fmt.Errorf("Error retrieving LB Target Group: %w", err)
 	}
 	if len(describeResp.TargetGroups) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(describeResp.TargetGroups))

--- a/aws/data_source_aws_msk_cluster.go
+++ b/aws/data_source_aws_msk_cluster.go
@@ -66,7 +66,7 @@ func dataSourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error
 		listClustersOutput, err := conn.ListClusters(listClustersInput)
 
 		if err != nil {
-			return fmt.Errorf("error listing MSK Clusters: %s", err)
+			return fmt.Errorf("error listing MSK Clusters: %w", err)
 		}
 
 		if listClustersOutput == nil {
@@ -99,7 +99,7 @@ func dataSourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error
 	bootstrapBrokersoOutput, err := conn.GetBootstrapBrokers(bootstrapBrokersInput)
 
 	if err != nil {
-		return fmt.Errorf("error reading MSK Cluster (%s) bootstrap brokers: %s", aws.StringValue(cluster.ClusterArn), err)
+		return fmt.Errorf("error reading MSK Cluster (%s) bootstrap brokers: %w", aws.StringValue(cluster.ClusterArn), err)
 	}
 
 	d.Set("arn", aws.StringValue(cluster.ClusterArn))
@@ -111,7 +111,7 @@ func dataSourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("number_of_broker_nodes", aws.Int64Value(cluster.NumberOfBrokerNodes))
 
 	if err := d.Set("tags", keyvaluetags.KafkaKeyValueTags(cluster.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("zookeeper_connect_string", aws.StringValue(cluster.ZookeeperConnectString))

--- a/aws/data_source_aws_msk_configuration.go
+++ b/aws/data_source_aws_msk_configuration.go
@@ -64,7 +64,7 @@ func dataSourceAwsMskConfigurationRead(d *schema.ResourceData, meta interface{})
 	})
 
 	if err != nil {
-		return fmt.Errorf("error listing MSK Configurations: %s", err)
+		return fmt.Errorf("error listing MSK Configurations: %w", err)
 	}
 
 	if configuration == nil {
@@ -84,7 +84,7 @@ func dataSourceAwsMskConfigurationRead(d *schema.ResourceData, meta interface{})
 	revisionOutput, err := conn.DescribeConfigurationRevision(revisionInput)
 
 	if err != nil {
-		return fmt.Errorf("error describing MSK Configuration (%s) Revision (%d): %s", d.Id(), aws.Int64Value(revision), err)
+		return fmt.Errorf("error describing MSK Configuration (%s) Revision (%d): %w", d.Id(), aws.Int64Value(revision), err)
 	}
 
 	if revisionOutput == nil {
@@ -95,7 +95,7 @@ func dataSourceAwsMskConfigurationRead(d *schema.ResourceData, meta interface{})
 	d.Set("description", aws.StringValue(configuration.Description))
 
 	if err := d.Set("kafka_versions", aws.StringValueSlice(configuration.KafkaVersions)); err != nil {
-		return fmt.Errorf("error setting kafka_versions: %s", err)
+		return fmt.Errorf("error setting kafka_versions: %w", err)
 	}
 
 	d.Set("latest_revision", aws.Int64Value(revision))

--- a/aws/data_source_aws_nat_gateway.go
+++ b/aws/data_source_aws_nat_gateway.go
@@ -126,7 +126,7 @@ func dataSourceAwsNatGatewayRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("vpc_id", ngw.VpcId)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(ngw.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	for _, address := range ngw.NatGatewayAddresses {

--- a/aws/data_source_aws_network_acls.go
+++ b/aws/data_source_aws_network_acls.go
@@ -86,7 +86,7 @@ func dataSourceAwsNetworkAclsRead(d *schema.ResourceData, meta interface{}) erro
 	d.SetId(meta.(*AWSClient).region)
 
 	if err := d.Set("ids", networkAcls); err != nil {
-		return fmt.Errorf("Error setting network ACL ids: %s", err)
+		return fmt.Errorf("Error setting network ACL ids: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_network_interface.go
+++ b/aws/data_source_aws_network_interface.go
@@ -197,7 +197,7 @@ func dataSourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{})
 	d.Set("vpc_id", eni.VpcId)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(eni.TagSet).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_network_interfaces.go
+++ b/aws/data_source_aws_network_interfaces.go
@@ -73,7 +73,7 @@ func dataSourceAwsNetworkInterfacesRead(d *schema.ResourceData, meta interface{}
 	d.SetId(meta.(*AWSClient).region)
 
 	if err := d.Set("ids", networkInterfaces); err != nil {
-		return fmt.Errorf("Error setting network interfaces ids: %s", err)
+		return fmt.Errorf("Error setting network interfaces ids: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_organizations_organization.go
+++ b/aws/data_source_aws_organizations_organization.go
@@ -146,7 +146,7 @@ func dataSourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta int
 
 	org, err := conn.DescribeOrganization(&organizations.DescribeOrganizationInput{})
 	if err != nil {
-		return fmt.Errorf("Error describing organization: %s", err)
+		return fmt.Errorf("Error describing organization: %w", err)
 	}
 
 	d.SetId(aws.StringValue(org.Organization.Id))
@@ -171,7 +171,7 @@ func dataSourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta int
 			return !lastPage
 		})
 		if err != nil {
-			return fmt.Errorf("error listing AWS Organization (%s) accounts: %s", d.Id(), err)
+			return fmt.Errorf("error listing AWS Organization (%s) accounts: %w", d.Id(), err)
 		}
 
 		var roots []*organizations.Root
@@ -180,7 +180,7 @@ func dataSourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta int
 			return !lastPage
 		})
 		if err != nil {
-			return fmt.Errorf("error listing AWS Organization (%s) roots: %s", d.Id(), err)
+			return fmt.Errorf("error listing AWS Organization (%s) roots: %w", d.Id(), err)
 		}
 
 		awsServiceAccessPrincipals := make([]string, 0)
@@ -194,7 +194,7 @@ func dataSourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta int
 			})
 
 			if err != nil {
-				return fmt.Errorf("error listing AWS Service Access for Organization (%s): %s", d.Id(), err)
+				return fmt.Errorf("error listing AWS Service Access for Organization (%s): %w", d.Id(), err)
 			}
 		}
 
@@ -206,23 +206,23 @@ func dataSourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta int
 		}
 
 		if err := d.Set("accounts", flattenOrganizationsAccounts(accounts)); err != nil {
-			return fmt.Errorf("error setting accounts: %s", err)
+			return fmt.Errorf("error setting accounts: %w", err)
 		}
 
 		if err := d.Set("aws_service_access_principals", awsServiceAccessPrincipals); err != nil {
-			return fmt.Errorf("error setting aws_service_access_principals: %s", err)
+			return fmt.Errorf("error setting aws_service_access_principals: %w", err)
 		}
 
 		if err := d.Set("enabled_policy_types", enabledPolicyTypes); err != nil {
-			return fmt.Errorf("error setting enabled_policy_types: %s", err)
+			return fmt.Errorf("error setting enabled_policy_types: %w", err)
 		}
 
 		if err := d.Set("non_master_accounts", flattenOrganizationsAccounts(nonMasterAccounts)); err != nil {
-			return fmt.Errorf("error setting non_master_accounts: %s", err)
+			return fmt.Errorf("error setting non_master_accounts: %w", err)
 		}
 
 		if err := d.Set("roots", flattenOrganizationsRoots(roots)); err != nil {
-			return fmt.Errorf("error setting roots: %s", err)
+			return fmt.Errorf("error setting roots: %w", err)
 		}
 
 	}

--- a/aws/data_source_aws_organizations_organizational_units.go
+++ b/aws/data_source_aws_organizations_organizational_units.go
@@ -60,13 +60,13 @@ func dataSourceAwsOrganizationsOrganizationalUnitsRead(d *schema.ResourceData, m
 		})
 
 	if err != nil {
-		return fmt.Errorf("error listing Organizations Organization Units for parent (%s): %s", parent_id, err)
+		return fmt.Errorf("error listing Organizations Organization Units for parent (%s): %w", parent_id, err)
 	}
 
 	d.SetId(parent_id)
 
 	if err := d.Set("children", flattenOrganizationsOrganizationalUnits(children)); err != nil {
-		return fmt.Errorf("Error setting children: %s", err)
+		return fmt.Errorf("error setting children: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_pricing_product.go
+++ b/aws/data_source_aws_pricing_product.go
@@ -65,7 +65,7 @@ func dataSourceAwsPricingProductRead(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Reading pricing of products: %s", params)
 	resp, err := conn.GetProducts(params)
 	if err != nil {
-		return fmt.Errorf("Error reading pricing of products: %s", err)
+		return fmt.Errorf("Error reading pricing of products: %w", err)
 	}
 
 	numberOfElements := len(resp.PriceList)
@@ -82,7 +82,7 @@ func dataSourceAwsPricingProductRead(d *schema.ResourceData, meta interface{}) e
 
 	pricingResult, err := json.Marshal(resp.PriceList[0])
 	if err != nil {
-		return fmt.Errorf("Invalid JSON value returned by AWS: %s", err)
+		return fmt.Errorf("Invalid JSON value returned by AWS: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%d", hashcode.String(params.String())))

--- a/aws/data_source_aws_qldb_ledger.go
+++ b/aws/data_source_aws_qldb_ledger.go
@@ -50,7 +50,7 @@ func dataSourceAwsQLDBLedgerRead(d *schema.ResourceData, meta interface{}) error
 	resp, err := conn.DescribeLedger(req)
 
 	if err != nil {
-		return fmt.Errorf("Error describing ledger: %s", err)
+		return fmt.Errorf("Error describing ledger: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.Name))

--- a/aws/data_source_aws_ram_resource_share.go
+++ b/aws/data_source_aws_ram_resource_share.go
@@ -97,7 +97,7 @@ func dataSourceAwsRamResourceShareRead(d *schema.ResourceData, meta interface{})
 		}
 
 		if resp == nil || len(resp.ResourceShares) == 0 {
-			return fmt.Errorf("No matching resource found: %s", err)
+			return fmt.Errorf("No matching resource found: %w", err)
 		}
 
 		for _, r := range resp.ResourceShares {
@@ -108,7 +108,7 @@ func dataSourceAwsRamResourceShareRead(d *schema.ResourceData, meta interface{})
 				d.Set("status", aws.StringValue(r.Status))
 
 				if err := d.Set("tags", keyvaluetags.RamKeyValueTags(r.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-					return fmt.Errorf("error setting tags: %s", err)
+					return fmt.Errorf("error setting tags: %w", err)
 				}
 
 				break

--- a/aws/data_source_aws_rds_cluster.go
+++ b/aws/data_source_aws_rds_cluster.go
@@ -176,7 +176,7 @@ func dataSourceAwsRdsClusterRead(d *schema.ResourceData, meta interface{}) error
 	resp, err := conn.DescribeDBClusters(params)
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving RDS cluster: %s", err)
+		return fmt.Errorf("Error retrieving RDS cluster: %w", err)
 	}
 
 	if resp == nil {
@@ -198,7 +198,7 @@ func dataSourceAwsRdsClusterRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(aws.StringValue(dbc.DBClusterIdentifier))
 
 	if err := d.Set("availability_zones", aws.StringValueSlice(dbc.AvailabilityZones)); err != nil {
-		return fmt.Errorf("error setting availability_zones: %s", err)
+		return fmt.Errorf("error setting availability_zones: %w", err)
 	}
 
 	arn := dbc.DBClusterArn
@@ -212,7 +212,7 @@ func dataSourceAwsRdsClusterRead(d *schema.ResourceData, meta interface{}) error
 		cm = append(cm, aws.StringValue(m.DBInstanceIdentifier))
 	}
 	if err := d.Set("cluster_members", cm); err != nil {
-		return fmt.Errorf("error setting cluster_members: %s", err)
+		return fmt.Errorf("error setting cluster_members: %w", err)
 	}
 
 	d.Set("cluster_resource_id", dbc.DbClusterResourceId)
@@ -229,7 +229,7 @@ func dataSourceAwsRdsClusterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
 
 	if err := d.Set("enabled_cloudwatch_logs_exports", aws.StringValueSlice(dbc.EnabledCloudwatchLogsExports)); err != nil {
-		return fmt.Errorf("error setting enabled_cloudwatch_logs_exports: %s", err)
+		return fmt.Errorf("error setting enabled_cloudwatch_logs_exports: %w", err)
 	}
 
 	d.Set("endpoint", dbc.Endpoint)
@@ -243,7 +243,7 @@ func dataSourceAwsRdsClusterRead(d *schema.ResourceData, meta interface{}) error
 		roles = append(roles, aws.StringValue(r.RoleArn))
 	}
 	if err := d.Set("iam_roles", roles); err != nil {
-		return fmt.Errorf("error setting iam_roles: %s", err)
+		return fmt.Errorf("error setting iam_roles: %w", err)
 	}
 
 	d.Set("kms_key_id", dbc.KmsKeyId)
@@ -261,17 +261,17 @@ func dataSourceAwsRdsClusterRead(d *schema.ResourceData, meta interface{}) error
 		vpcg = append(vpcg, aws.StringValue(g.VpcSecurityGroupId))
 	}
 	if err := d.Set("vpc_security_group_ids", vpcg); err != nil {
-		return fmt.Errorf("error setting vpc_security_group_ids: %s", err)
+		return fmt.Errorf("error setting vpc_security_group_ids: %w", err)
 	}
 
 	tags, err := keyvaluetags.RdsListTags(conn, *arn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for RDS Cluster (%s): %s", *arn, err)
+		return fmt.Errorf("error listing tags for RDS Cluster (%s): %w", *arn, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_redshift_cluster.go
+++ b/aws/data_source_aws_redshift_cluster.go
@@ -182,7 +182,7 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error describing Redshift Cluster: %s, error: %s", cluster, err)
+		return fmt.Errorf("Error describing Redshift Cluster: %s, error: %w", cluster, err)
 	}
 
 	if resp.Clusters == nil || len(resp.Clusters) == 0 {
@@ -209,7 +209,7 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 		csg = append(csg, *g.ClusterSecurityGroupName)
 	}
 	if err := d.Set("cluster_security_groups", csg); err != nil {
-		return fmt.Errorf("Error saving Cluster Security Group Names to state for Redshift Cluster (%s): %s", cluster, err)
+		return fmt.Errorf("Error saving Cluster Security Group Names to state for Redshift Cluster (%s): %w", cluster, err)
 	}
 
 	d.Set("cluster_subnet_group_name", rsc.ClusterSubnetGroupName)
@@ -240,7 +240,7 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 		iamRoles = append(iamRoles, *i.IamRoleArn)
 	}
 	if err := d.Set("iam_roles", iamRoles); err != nil {
-		return fmt.Errorf("Error saving IAM Roles to state for Redshift Cluster (%s): %s", cluster, err)
+		return fmt.Errorf("Error saving IAM Roles to state for Redshift Cluster (%s): %w", cluster, err)
 	}
 
 	d.Set("kms_key_id", rsc.KmsKeyId)
@@ -252,7 +252,7 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("publicly_accessible", rsc.PubliclyAccessible)
 
 	if err := d.Set("tags", keyvaluetags.RedshiftKeyValueTags(rsc.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("vpc_id", rsc.VpcId)
@@ -262,7 +262,7 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 		vpcg = append(vpcg, *g.VpcSecurityGroupId)
 	}
 	if err := d.Set("vpc_security_group_ids", vpcg); err != nil {
-		return fmt.Errorf("Error saving VPC Security Group IDs to state for Redshift Cluster (%s): %s", cluster, err)
+		return fmt.Errorf("Error saving VPC Security Group IDs to state for Redshift Cluster (%s): %w", cluster, err)
 	}
 
 	log.Printf("[INFO] Reading Redshift Cluster Logging Status: %s", cluster)

--- a/aws/data_source_aws_regions.go
+++ b/aws/data_source_aws_regions.go
@@ -44,7 +44,7 @@ func dataSourceAwsRegionsRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading regions for request: %s", request)
 	response, err := connection.DescribeRegions(request)
 	if err != nil {
-		return fmt.Errorf("Error fetching Regions: %s", err)
+		return fmt.Errorf("Error fetching Regions: %w", err)
 	}
 
 	names := []string{}
@@ -54,7 +54,7 @@ func dataSourceAwsRegionsRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(meta.(*AWSClient).partition)
 	if err := d.Set("names", names); err != nil {
-		return fmt.Errorf("error setting names: %s", err)
+		return fmt.Errorf("error setting names: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_route53_delegation_set.go
+++ b/aws/data_source_aws_route53_delegation_set.go
@@ -44,14 +44,14 @@ func dataSourceAwsDelegationSetRead(d *schema.ResourceData, meta interface{}) er
 
 	resp, err := conn.GetReusableDelegationSet(input)
 	if err != nil {
-		return fmt.Errorf("Failed getting Route53 delegation set: %s Set: %q", err, dSetID)
+		return fmt.Errorf("Failed getting Route53 delegation set (%s): %w", dSetID, err)
 	}
 
 	d.SetId(dSetID)
 	d.Set("caller_reference", resp.DelegationSet.CallerReference)
 
 	if err := d.Set("name_servers", expandNameServers(resp.DelegationSet.NameServers)); err != nil {
-		return fmt.Errorf("error setting name_servers: %s", err)
+		return fmt.Errorf("error setting name_servers: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_route53_resolver_endpoint.go
+++ b/aws/data_source_aws_route53_resolver_endpoint.go
@@ -140,7 +140,7 @@ func dataSourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta inter
 		ip, err := conn.ListResolverEndpointIpAddresses(params)
 
 		if err != nil {
-			return fmt.Errorf("error getting Route53 Resolver endpoint (%s) IP Addresses: %s", d.Id(), err)
+			return fmt.Errorf("error getting Route53 Resolver endpoint (%s) IP Addresses: %w", d.Id(), err)
 		}
 
 		for _, vIPAddresses := range ip.IpAddresses {

--- a/aws/data_source_aws_route53_resolver_rule.go
+++ b/aws/data_source_aws_route53_resolver_rule.go
@@ -86,7 +86,7 @@ func dataSourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface
 	if v, ok := d.GetOk("resolver_rule_id"); ok {
 		ruleRaw, state, err := route53ResolverRuleRefresh(conn, v.(string))()
 		if err != nil {
-			return fmt.Errorf("error getting Route53 Resolver rule (%s): %s", v, err)
+			return fmt.Errorf("error getting Route53 Resolver rule (%s): %w", v, err)
 		}
 
 		if state == route53ResolverRuleStatusDeleted {
@@ -107,7 +107,7 @@ func dataSourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface
 		log.Printf("[DEBUG] Listing Route53 Resolver rules: %s", req)
 		resp, err := conn.ListResolverRules(req)
 		if err != nil {
-			return fmt.Errorf("error getting Route53 Resolver rules: %s", err)
+			return fmt.Errorf("error getting Route53 Resolver rules: %w", err)
 		}
 
 		if n := len(resp.ResolverRules); n == 0 {
@@ -137,11 +137,11 @@ func dataSourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface
 		tags, err := keyvaluetags.Route53resolverListTags(conn, arn)
 
 		if err != nil {
-			return fmt.Errorf("error listing tags for Route 53 Resolver rule (%s): %s", arn, err)
+			return fmt.Errorf("error listing tags for Route 53 Resolver rule (%s): %w", arn, err)
 		}
 
 		if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-			return fmt.Errorf("error setting tags: %s", err)
+			return fmt.Errorf("error setting tags: %w", err)
 		}
 	}
 

--- a/aws/data_source_aws_route53_resolver_rules.go
+++ b/aws/data_source_aws_route53_resolver_rules.go
@@ -87,14 +87,14 @@ func dataSourceAwsRoute53ResolverRulesRead(d *schema.ResourceData, meta interfac
 		return !isLast
 	})
 	if err != nil {
-		return fmt.Errorf("error getting Route53 Resolver rules: %s", err)
+		return fmt.Errorf("error getting Route53 Resolver rules: %w", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)
 
 	err = d.Set("resolver_rule_ids", flattenStringSet(resolverRuleIds))
 	if err != nil {
-		return fmt.Errorf("error setting resolver_rule_ids: %s", err)
+		return fmt.Errorf("error setting resolver_rule_ids: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_route53_zone.go
+++ b/aws/data_source_aws_route53_zone.go
@@ -97,7 +97,7 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 		resp, err := conn.ListHostedZones(req)
 
 		if err != nil {
-			return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", err)
+			return fmt.Errorf("Error finding Route 53 Hosted Zone: %w", err)
 		}
 		for _, hostedZone := range resp.HostedZones {
 			hostedZoneId := cleanZoneID(aws.StringValue(hostedZone.Id))
@@ -113,7 +113,7 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 
 					respHostedZone, errHostedZone := conn.GetHostedZone(reqHostedZone)
 					if errHostedZone != nil {
-						return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", errHostedZone)
+						return fmt.Errorf("Error finding Route 53 Hosted Zone: %w", errHostedZone)
 					}
 					// we go through all VPCs
 					for _, vpc := range respHostedZone.VPCs {

--- a/aws/data_source_aws_route_table.go
+++ b/aws/data_source_aws_route_table.go
@@ -189,7 +189,7 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("vpc_id", rt.VpcId)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(rt.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("owner_id", rt.OwnerId)

--- a/aws/data_source_aws_route_tables.go
+++ b/aws/data_source_aws_route_tables.go
@@ -74,7 +74,7 @@ func dataSourceAwsRouteTablesRead(d *schema.ResourceData, meta interface{}) erro
 	d.SetId(meta.(*AWSClient).region)
 
 	if err = d.Set("ids", routeTables); err != nil {
-		return fmt.Errorf("error setting ids: %s", err)
+		return fmt.Errorf("error setting ids: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_s3_bucket.go
+++ b/aws/data_source_aws_s3_bucket.go
@@ -67,7 +67,7 @@ func dataSourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	_, err := conn.HeadBucket(input)
 
 	if err != nil {
-		return fmt.Errorf("Failed getting S3 bucket: %s Bucket: %q", err, bucket)
+		return fmt.Errorf("Failed getting S3 bucket (%s): %w", bucket, err)
 	}
 
 	d.SetId(bucket)
@@ -81,7 +81,7 @@ func dataSourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 
 	err = bucketLocation(meta.(*AWSClient), d, bucket)
 	if err != nil {
-		return fmt.Errorf("error getting S3 Bucket location: %s", err)
+		return fmt.Errorf("error getting S3 Bucket location: %w", err)
 	}
 
 	regionalDomainName, err := BucketRegionalDomainName(bucket, d.Get("region").(string))

--- a/aws/data_source_aws_s3_bucket_objects.go
+++ b/aws/data_source_aws_s3_bucket_objects.go
@@ -128,21 +128,21 @@ func dataSourceAwsS3BucketObjectsRead(d *schema.ResourceData, meta interface{}) 
 	})
 
 	if err != nil {
-		return fmt.Errorf("error listing S3 Bucket (%s) Objects: %s", bucket, err)
+		return fmt.Errorf("error listing S3 Bucket (%s) Objects: %w", bucket, err)
 	}
 
 	d.SetId(bucket)
 
 	if err := d.Set("common_prefixes", commonPrefixes); err != nil {
-		return fmt.Errorf("error setting common_prefixes: %s", err)
+		return fmt.Errorf("error setting common_prefixes: %w", err)
 	}
 
 	if err := d.Set("keys", keys); err != nil {
-		return fmt.Errorf("error setting keys: %s", err)
+		return fmt.Errorf("error setting keys: %w", err)
 	}
 
 	if err := d.Set("owners", owners); err != nil {
-		return fmt.Errorf("error setting owners: %s", err)
+		return fmt.Errorf("error setting owners: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_secretsmanager_secret.go
+++ b/aws/data_source_aws_secretsmanager_secret.go
@@ -101,7 +101,7 @@ func dataSourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interfac
 		if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") {
 			return fmt.Errorf("Secrets Manager Secret %q not found", secretID)
 		}
-		return fmt.Errorf("error reading Secrets Manager Secret: %s", err)
+		return fmt.Errorf("error reading Secrets Manager Secret: %w", err)
 	}
 
 	if output.ARN == nil {
@@ -123,23 +123,23 @@ func dataSourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interfac
 	log.Printf("[DEBUG] Reading Secrets Manager Secret policy: %s", pIn)
 	pOut, err := conn.GetResourcePolicy(pIn)
 	if err != nil {
-		return fmt.Errorf("error reading Secrets Manager Secret policy: %s", err)
+		return fmt.Errorf("error reading Secrets Manager Secret policy: %w", err)
 	}
 
 	if pOut != nil && pOut.ResourcePolicy != nil {
 		policy, err := structure.NormalizeJsonString(aws.StringValue(pOut.ResourcePolicy))
 		if err != nil {
-			return fmt.Errorf("policy contains an invalid JSON: %s", err)
+			return fmt.Errorf("policy contains an invalid JSON: %w", err)
 		}
 		d.Set("policy", policy)
 	}
 
 	if err := d.Set("rotation_rules", flattenSecretsManagerRotationRules(output.RotationRules)); err != nil {
-		return fmt.Errorf("error setting rotation_rules: %s", err)
+		return fmt.Errorf("error setting rotation_rules: %w", err)
 	}
 
 	if err := d.Set("tags", keyvaluetags.SecretsmanagerKeyValueTags(output.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_secretsmanager_secret_rotation.go
+++ b/aws/data_source_aws_secretsmanager_secret_rotation.go
@@ -55,7 +55,7 @@ func dataSourceAwsSecretsManagerSecretRotationRead(d *schema.ResourceData, meta 
 	log.Printf("[DEBUG] Reading Secrets Manager Secret: %s", input)
 	output, err := conn.DescribeSecret(input)
 	if err != nil {
-		return fmt.Errorf("error reading Secrets Manager Secret: %s", err)
+		return fmt.Errorf("error reading Secrets Manager Secret: %w", err)
 	}
 
 	if output.ARN == nil {
@@ -67,7 +67,7 @@ func dataSourceAwsSecretsManagerSecretRotationRead(d *schema.ResourceData, meta 
 	d.Set("rotation_lambda_arn", output.RotationLambdaARN)
 
 	if err := d.Set("rotation_rules", flattenSecretsManagerRotationRules(output.RotationRules)); err != nil {
-		return fmt.Errorf("error setting rotation_rules: %s", err)
+		return fmt.Errorf("error setting rotation_rules: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_secretsmanager_secret_version.go
+++ b/aws/data_source_aws_secretsmanager_secret_version.go
@@ -79,7 +79,7 @@ func dataSourceAwsSecretsManagerSecretVersionRead(d *schema.ResourceData, meta i
 		if isAWSErr(err, secretsmanager.ErrCodeInvalidRequestException, "You can’t perform this operation on the secret because it was deleted") {
 			return fmt.Errorf("Secrets Manager Secret %q Version %q not found", secretID, version)
 		}
-		return fmt.Errorf("error reading Secrets Manager Secret Version: %s", err)
+		return fmt.Errorf("error reading Secrets Manager Secret Version: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s|%s", secretID, version))
@@ -90,7 +90,7 @@ func dataSourceAwsSecretsManagerSecretVersionRead(d *schema.ResourceData, meta i
 	d.Set("arn", output.ARN)
 
 	if err := d.Set("version_stages", flattenStringList(output.VersionStages)); err != nil {
-		return fmt.Errorf("error setting version_stages: %s", err)
+		return fmt.Errorf("error setting version_stages: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -96,7 +96,7 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("vpc_id", sg.VpcId)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(sg.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	arn := arn.ARN{

--- a/aws/data_source_aws_security_groups.go
+++ b/aws/data_source_aws_security_groups.go
@@ -59,7 +59,7 @@ func dataSourceAwsSecurityGroupsRead(d *schema.ResourceData, meta interface{}) e
 	for {
 		resp, err := conn.DescribeSecurityGroups(req)
 		if err != nil {
-			return fmt.Errorf("error reading security groups: %s", err)
+			return fmt.Errorf("error reading security groups: %w", err)
 		}
 
 		for _, sg := range resp.SecurityGroups {

--- a/aws/data_source_aws_servicequotas_service.go
+++ b/aws/data_source_aws_servicequotas_service.go
@@ -45,7 +45,7 @@ func dataSourceAwsServiceQuotasServiceRead(d *schema.ResourceData, meta interfac
 	})
 
 	if err != nil {
-		return fmt.Errorf("error listing Services: %s", err)
+		return fmt.Errorf("error listing Services: %w", err)
 	}
 
 	if service == nil {

--- a/aws/data_source_aws_servicequotas_service_quota.go
+++ b/aws/data_source_aws_servicequotas_service_quota.go
@@ -87,7 +87,7 @@ func dataSourceAwsServiceQuotasServiceQuotaRead(d *schema.ResourceData, meta int
 		})
 
 		if err != nil {
-			return fmt.Errorf("error listing Service (%s) Quotas: %s", serviceCode, err)
+			return fmt.Errorf("error listing Service (%s) Quotas: %w", serviceCode, err)
 		}
 
 		if serviceQuota == nil {
@@ -102,7 +102,7 @@ func dataSourceAwsServiceQuotasServiceQuotaRead(d *schema.ResourceData, meta int
 		output, err := conn.GetServiceQuota(input)
 
 		if err != nil {
-			return fmt.Errorf("error getting Service (%s) Quota (%s): %s", serviceCode, quotaCode, err)
+			return fmt.Errorf("error getting Service (%s) Quota (%s): %w", serviceCode, quotaCode, err)
 		}
 
 		if output == nil {
@@ -120,7 +120,7 @@ func dataSourceAwsServiceQuotasServiceQuotaRead(d *schema.ResourceData, meta int
 	output, err := conn.GetAWSDefaultServiceQuota(input)
 
 	if err != nil {
-		return fmt.Errorf("error getting Service (%s) Default Quota (%s): %s", serviceCode, aws.StringValue(serviceQuota.QuotaCode), err)
+		return fmt.Errorf("error getting Service (%s) Default Quota (%s): %w", serviceCode, aws.StringValue(serviceQuota.QuotaCode), err)
 	}
 
 	if output == nil {

--- a/aws/data_source_aws_sfn_activity.go
+++ b/aws/data_source_aws_sfn_activity.go
@@ -60,7 +60,7 @@ func dataSourceAwsSfnActivityRead(d *schema.ResourceData, meta interface{}) erro
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error listing activities: %s", err)
+			return fmt.Errorf("Error listing activities: %w", err)
 		}
 
 		if len(acts) == 0 {
@@ -89,7 +89,7 @@ func dataSourceAwsSfnActivityRead(d *schema.ResourceData, meta interface{}) erro
 
 		act, err := conn.DescribeActivity(params)
 		if err != nil {
-			return fmt.Errorf("Error describing activities: %s", err)
+			return fmt.Errorf("Error describing activities: %w", err)
 		}
 
 		if act == nil {

--- a/aws/data_source_aws_sfn_state_machine.go
+++ b/aws/data_source_aws_sfn_state_machine.go
@@ -60,7 +60,7 @@ func dataSourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) 
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error listing state machines: %s", err)
+		return fmt.Errorf("Error listing state machines: %w", err)
 	}
 
 	if len(arns) == 0 {

--- a/aws/data_source_aws_signer_signing_job.go
+++ b/aws/data_source_aws_signer_signing_job.go
@@ -151,47 +151,47 @@ func dataSourceAwsSignerSigningJobRead(d *schema.ResourceData, meta interface{})
 	})
 
 	if err != nil {
-		return fmt.Errorf("error reading Signer signing job (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading Signer signing job (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("completed_at", aws.TimeValue(describeSigningJobOutput.CompletedAt).Format(time.RFC3339)); err != nil {
-		return fmt.Errorf("error setting signer signing job completed at: %s", err)
+		return fmt.Errorf("error setting signer signing job completed at: %w", err)
 	}
 
 	if err := d.Set("created_at", aws.TimeValue(describeSigningJobOutput.CreatedAt).Format(time.RFC3339)); err != nil {
-		return fmt.Errorf("error setting signer signing job created at: %s", err)
+		return fmt.Errorf("error setting signer signing job created at: %w", err)
 	}
 
 	if err := d.Set("job_invoker", describeSigningJobOutput.JobInvoker); err != nil {
-		return fmt.Errorf("error setting signer signing job invoker: %s", err)
+		return fmt.Errorf("error setting signer signing job invoker: %w", err)
 	}
 
 	if err := d.Set("job_owner", describeSigningJobOutput.JobOwner); err != nil {
-		return fmt.Errorf("error setting signer signing job owner: %s", err)
+		return fmt.Errorf("error setting signer signing job owner: %w", err)
 	}
 
 	if err := d.Set("platform_display_name", describeSigningJobOutput.PlatformDisplayName); err != nil {
-		return fmt.Errorf("error setting signer signing job platform display name: %s", err)
+		return fmt.Errorf("error setting signer signing job platform display name: %w", err)
 	}
 
 	if err := d.Set("platform_id", describeSigningJobOutput.PlatformId); err != nil {
-		return fmt.Errorf("error setting signer signing job platform id: %s", err)
+		return fmt.Errorf("error setting signer signing job platform id: %w", err)
 	}
 
 	if err := d.Set("profile_name", describeSigningJobOutput.ProfileName); err != nil {
-		return fmt.Errorf("error setting signer signing job profile name: %s", err)
+		return fmt.Errorf("error setting signer signing job profile name: %w", err)
 	}
 
 	if err := d.Set("profile_version", describeSigningJobOutput.ProfileVersion); err != nil {
-		return fmt.Errorf("error setting signer signing job profile version: %s", err)
+		return fmt.Errorf("error setting signer signing job profile version: %w", err)
 	}
 
 	if err := d.Set("requested_by", describeSigningJobOutput.RequestedBy); err != nil {
-		return fmt.Errorf("error setting signer signing job requested by: %s", err)
+		return fmt.Errorf("error setting signer signing job requested by: %w", err)
 	}
 
 	if err := d.Set("revocation_record", flattenSignerSigningJobRevocationRecord(describeSigningJobOutput.RevocationRecord)); err != nil {
-		return fmt.Errorf("error setting signer signing job revocation record: %s", err)
+		return fmt.Errorf("error setting signer signing job revocation record: %w", err)
 	}
 
 	signatureExpiresAt := ""
@@ -199,23 +199,23 @@ func dataSourceAwsSignerSigningJobRead(d *schema.ResourceData, meta interface{})
 		signatureExpiresAt = aws.TimeValue(describeSigningJobOutput.SignatureExpiresAt).Format(time.RFC3339)
 	}
 	if err := d.Set("signature_expires_at", signatureExpiresAt); err != nil {
-		return fmt.Errorf("error setting signer signing job requested by: %s", err)
+		return fmt.Errorf("error setting signer signing job requested by: %w", err)
 	}
 
 	if err := d.Set("signed_object", flattenSignerSigningJobSignedObject(describeSigningJobOutput.SignedObject)); err != nil {
-		return fmt.Errorf("error setting signer signing job signed object: %s", err)
+		return fmt.Errorf("error setting signer signing job signed object: %w", err)
 	}
 
 	if err := d.Set("source", flattenSignerSigningJobSource(describeSigningJobOutput.Source)); err != nil {
-		return fmt.Errorf("error setting signer signing job source: %s", err)
+		return fmt.Errorf("error setting signer signing job source: %w", err)
 	}
 
 	if err := d.Set("status", describeSigningJobOutput.Status); err != nil {
-		return fmt.Errorf("error setting signer signing job status: %s", err)
+		return fmt.Errorf("error setting signer signing job status: %w", err)
 	}
 
 	if err := d.Set("status_reason", describeSigningJobOutput.StatusReason); err != nil {
-		return fmt.Errorf("error setting signer signing job status reason: %s", err)
+		return fmt.Errorf("error setting signer signing job status reason: %w", err)
 	}
 
 	d.SetId(aws.StringValue(describeSigningJobOutput.JobId))

--- a/aws/data_source_aws_signer_signing_profile.go
+++ b/aws/data_source_aws_signer_signing_profile.go
@@ -93,11 +93,11 @@ func dataSourceAwsSignerSigningProfileRead(d *schema.ResourceData, meta interfac
 	})
 
 	if err != nil {
-		return fmt.Errorf("error reading Signer signing profile (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading Signer signing profile (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("platform_id", signingProfileOutput.PlatformId); err != nil {
-		return fmt.Errorf("error setting signer signing profile platform id: %s", err)
+		return fmt.Errorf("error setting signer signing profile platform id: %w", err)
 	}
 
 	if err := d.Set("signature_validity_period", []interface{}{
@@ -106,35 +106,35 @@ func dataSourceAwsSignerSigningProfileRead(d *schema.ResourceData, meta interfac
 			"type":  signingProfileOutput.SignatureValidityPeriod.Type,
 		},
 	}); err != nil {
-		return fmt.Errorf("error setting signer signing profile signature validity period: %s", err)
+		return fmt.Errorf("error setting signer signing profile signature validity period: %w", err)
 	}
 
 	if err := d.Set("platform_display_name", signingProfileOutput.PlatformDisplayName); err != nil {
-		return fmt.Errorf("error setting signer signing profile platform display name: %s", err)
+		return fmt.Errorf("error setting signer signing profile platform display name: %w", err)
 	}
 
 	if err := d.Set("arn", signingProfileOutput.Arn); err != nil {
-		return fmt.Errorf("error setting signer signing profile arn: %s", err)
+		return fmt.Errorf("error setting signer signing profile arn: %w", err)
 	}
 
 	if err := d.Set("version", signingProfileOutput.ProfileVersion); err != nil {
-		return fmt.Errorf("error setting signer signing profile version: %s", err)
+		return fmt.Errorf("error setting signer signing profile version: %w", err)
 	}
 
 	if err := d.Set("version_arn", signingProfileOutput.ProfileVersionArn); err != nil {
-		return fmt.Errorf("error setting signer signing profile version arn: %s", err)
+		return fmt.Errorf("error setting signer signing profile version arn: %w", err)
 	}
 
 	if err := d.Set("status", signingProfileOutput.Status); err != nil {
-		return fmt.Errorf("error setting signer signing profile status: %s", err)
+		return fmt.Errorf("error setting signer signing profile status: %w", err)
 	}
 
 	if err := d.Set("tags", keyvaluetags.SignerKeyValueTags(signingProfileOutput.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting signer signing profile tags: %s", err)
+		return fmt.Errorf("error setting signer signing profile tags: %w", err)
 	}
 
 	if err := d.Set("revocation_record", flattenSignerSigningProfileRevocationRecord(signingProfileOutput.RevocationRecord)); err != nil {
-		return fmt.Errorf("error setting signer signing profile revocation record: %s", err)
+		return fmt.Errorf("error setting signer signing profile revocation record: %w", err)
 	}
 
 	d.SetId(aws.StringValue(signingProfileOutput.ProfileName))

--- a/aws/data_source_aws_sns.go
+++ b/aws/data_source_aws_sns.go
@@ -54,7 +54,7 @@ func dataSourceAwsSnsTopicsRead(d *schema.ResourceData, meta interface{}) error 
 		return true
 	})
 	if err != nil {
-		return fmt.Errorf("Error describing topics: %s", err)
+		return fmt.Errorf("Error describing topics: %w", err)
 	}
 
 	if len(arns) == 0 {

--- a/aws/data_source_aws_sqs_queue.go
+++ b/aws/data_source_aws_sqs_queue.go
@@ -40,7 +40,7 @@ func dataSourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 		QueueName: aws.String(name),
 	})
 	if err != nil || urlOutput.QueueUrl == nil {
-		return fmt.Errorf("Error getting queue URL: %s", err)
+		return fmt.Errorf("Error getting queue URL: %w", err)
 	}
 
 	queueURL := aws.StringValue(urlOutput.QueueUrl)
@@ -50,7 +50,7 @@ func dataSourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 		AttributeNames: []*string{aws.String(sqs.QueueAttributeNameQueueArn)},
 	})
 	if err != nil {
-		return fmt.Errorf("Error getting queue attributes: %s", err)
+		return fmt.Errorf("Error getting queue attributes: %w", err)
 	}
 
 	d.Set("arn", aws.StringValue(attributesOutput.Attributes[sqs.QueueAttributeNameQueueArn]))
@@ -60,11 +60,11 @@ func dataSourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := keyvaluetags.SqsListTags(conn, queueURL)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for SQS Queue (%s): %s", queueURL, err)
+		return fmt.Errorf("error listing tags for SQS Queue (%s): %w", queueURL, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_ssm_document.go
+++ b/aws/data_source_aws_ssm_document.go
@@ -66,7 +66,7 @@ func dataAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := ssmconn.GetDocument(docInput)
 
 	if err != nil {
-		return fmt.Errorf("Error reading SSM Document: %s", err)
+		return fmt.Errorf("Error reading SSM Document: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.Name))

--- a/aws/data_source_aws_ssm_patch_baseline.go
+++ b/aws/data_source_aws_ssm_patch_baseline.go
@@ -76,7 +76,7 @@ func dataAwsSsmPatchBaselineRead(d *schema.ResourceData, meta interface{}) error
 	resp, err := ssmconn.DescribePatchBaselines(params)
 
 	if err != nil {
-		return fmt.Errorf("Error describing SSM PatchBaselines: %s", err)
+		return fmt.Errorf("Error describing SSM PatchBaselines: %w", err)
 	}
 
 	var filteredBaselines []*ssm.PatchBaselineIdentity

--- a/aws/data_source_aws_storagegateway_local_disk.go
+++ b/aws/data_source_aws_storagegateway_local_disk.go
@@ -46,7 +46,7 @@ func dataSourceAwsStorageGatewayLocalDiskRead(d *schema.ResourceData, meta inter
 	log.Printf("[DEBUG] Reading Storage Gateway Local Disk: %s", input)
 	output, err := conn.ListLocalDisks(input)
 	if err != nil {
-		return fmt.Errorf("error reading Storage Gateway Local Disk: %s", err)
+		return fmt.Errorf("error reading Storage Gateway Local Disk: %w", err)
 	}
 
 	if output == nil || len(output.Disks) == 0 {

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -186,7 +186,7 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("outpost_arn", subnet.OutpostArn)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(subnet.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("assign_ipv6_address_on_creation", subnet.AssignIpv6AddressOnCreation)


### PR DESCRIPTION
Fixes [`errorlint`](https://github.com/polyfloyd/go-errorlint) reports for data sources F-S.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15891

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDataSourceIAMGroup\|TestAccAWSInspectorRulesPackages\|TestResourceSortByExpirationDate\|TestAccDataSourceAwsNetworkInterface\|TestAccAWSIPRanges\|TestAccAWSKmsSecretsDataSource\|TestAccAWSDataSourceIAMPolicyDocument\|TestAccDataSourceAwsNetworkInterfaces\|TestAccDataSourceAWSLBTargetGroup\|TestAccDataSourceAWSLB\|TestAccDataSourceAWSLambdaLayerVersion\|TestAccAWSLaunchConfigurationDataSource\|TestAccDataSourceAwsNetworkAcls\|TestAccLaunchConfigurationDataSource\|TestAccDataSourceAWSALBTargetGroup\|TestAccAWSDataSourceIAMRole\|TestAccDataSourceAwsInternetGateway\|TestAccDataSourceAWSLambdaFunction\|TestAccDataSourceAWSGlueScript\|TestAccAWSDataSourceIAMInstanceProfile\|TestAccAWSDataSourceIAMServerCertificate\|TestAccDataSourceAWSLambdaAlias\|TestAccAWSMskConfigurationDataSource\|TestAccAWSKinesisStreamDataSource\|TestAccAWSInstanceDataSource\|TestAccDataSourceAWSLambdaCodeSigningConfig\|TestAccDataSourceAwsKmsKey\|TestAccAWSIotEndpointDataSource\|TestAccAWSMskClusterDataSource\|TestAccAWSDataSourceIAMUser\|TestAccDataSourceAwsKmsAlias\|TestAccDataSourceAwsNatGateway'

--- PASS: TestResourceSortByExpirationDate (0.00s)
--- SKIP: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsGov (0.85s)
--- PASS: TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix (10.90s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (53.46s)
--- PASS: TestAccDataSourceAWSGlueScript_Language_Scala (53.59s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (54.15s)
--- PASS: TestAccDataSourceAWSGlueScript_Language_Python (54.41s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals (55.32s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice (55.34s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (55.68s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (56.08s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (56.56s)
--- PASS: TestAccAWSDataSourceIAMGroup_basic (58.25s)
--- PASS: TestAccAWSDataSourceIAMRole_basic (58.64s)
--- PASS: TestAccAWSDataSourceIAMRole_tags (58.98s)
--- PASS: TestAccAWSDataSourceIAMServerCertificate_basic (59.46s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (60.74s)
--- PASS: TestAccAWSDataSourceIAMInstanceProfile_basic (61.95s)
--- PASS: TestAccAWSDataSourceIAMServerCertificate_path (62.38s)
--- PASS: TestAccAWSDataSourceIAMUser_basic (58.89s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Version_20081017 (81.90s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (83.52s)
--- PASS: TestAccAWSInspectorRulesPackages_basic (31.43s)
--- PASS: TestAccAWSDataSourceIAMUser_tags (79.95s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (80.12s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (84.85s)
--- PASS: TestAccAWSInstanceDataSource_basic (97.46s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (97.97s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (103.92s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (101.63s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (101.83s)
--- PASS: TestAccAWSInstanceDataSource_tags (107.19s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (110.24s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (112.06s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (100.73s)
--- PASS: TestAccAWSInstanceDataSource_gp3ThroughputDevice (117.66s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTCredentialProvider (13.60s)
--- PASS: TestAccAWSIotEndpointDataSource_basic (14.34s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (95.68s)
--- PASS: TestAccAWSInstanceDataSource_VPC (115.84s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTData (24.70s)
--- PASS: TestAccDataSourceAwsInternetGateway_typical (31.42s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTDataATS (34.31s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTJobs (35.83s)
--- PASS: TestAccAWSIPRanges_basic (40.62s)
--- PASS: TestAccDataSourceAwsKmsAlias_AwsService (38.92s)
--- PASS: TestAccAWSIPRanges_Url (40.90s)
--- PASS: TestAccDataSourceAwsKmsAlias_CMK (40.11s)
--- PASS: TestAccDataSourceAwsKmsKey_basic (41.30s)
--- PASS: TestAccDataSourceAWSLambdaCodeSigningConfig_basic (31.46s)
--- PASS: TestAccDataSourceAWSLambdaCodeSigningConfig_Description (27.38s)
--- PASS: TestAccDataSourceAWSLambdaCodeSigningConfig_PolicyConfigId (30.08s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (104.84s)
--- PASS: TestAccAWSKmsSecretsDataSource_basic (59.05s)
--- SKIP: TestAccDataSourceAWSLambdaFunction_imageConfig (0.66s)
--- PASS: TestAccAWSInstanceDataSource_blockDeviceTags (93.13s)
--- PASS: TestAccDataSourceAWSLambdaAlias_basic (50.47s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (177.29s)
--- PASS: TestAccDataSourceAWSLambdaFunction_basic (47.11s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (113.45s)
--- PASS: TestAccAWSInstanceDataSource_enclaveOptions (111.97s)
--- PASS: TestAccDataSourceAWSLambdaFunction_version (49.65s)
--- PASS: TestAccAWSDataSourceIAMGroup_users (271.41s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (192.09s)
--- PASS: TestAccDataSourceAWSLambdaLayerVersion_basic (27.16s)
--- PASS: TestAccDataSourceAWSLambdaFunction_alias (52.86s)
--- PASS: TestAccDataSourceAWSLambdaLayerVersion_runtime (32.87s)
--- PASS: TestAccDataSourceAWSLambdaLayerVersion_version (35.79s)
--- PASS: TestAccDataSourceAWSLambdaFunction_layers (54.74s)
--- SKIP: TestAccDataSourceAWSLB_outpost (1.01s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (160.98s)
--- PASS: TestAccDataSourceAWSLambdaFunction_environment (51.55s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (37.72s)
--- PASS: TestAccLaunchConfigurationDataSource_metadataOptions (37.03s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (38.60s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_ebsNoDevice (41.55s)
--- PASS: TestAccAWSKinesisStreamDataSource_basic (135.99s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (183.98s)
--- PASS: TestAccAWSMskConfigurationDataSource_Name (20.58s)
--- PASS: TestAccDataSourceAwsNetworkAcls_Filter (16.96s)
--- SKIP: TestAccDataSourceAwsNetworkInterface_CarrierIPAssociation (0.84s)
--- PASS: TestAccDataSourceAwsNetworkAcls_Tags (16.51s)
--- PASS: TestAccDataSourceAwsNetworkAcls_VpcID (16.15s)
--- PASS: TestAccDataSourceAwsNetworkAcls_basic (28.25s)
--- PASS: TestAccDataSourceAwsNetworkInterface_basic (47.73s)
--- PASS: TestAccDataSourceAwsNetworkInterface_filters (48.29s)
--- PASS: TestAccDataSourceAwsNetworkInterfaces_Filter (46.97s)
--- PASS: TestAccDataSourceAwsNetworkInterfaces_Tags (45.01s)
--- PASS: TestAccDataSourceAwsNetworkInterface_PublicIPAssociation (58.77s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (341.15s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (361.08s)
--- PASS: TestAccDataSourceAWSLBListener_basic (162.93s)
--- PASS: TestAccDataSourceAWSLBListener_DefaultAction_Forward (163.13s)
--- PASS: TestAccDataSourceAWSALBTargetGroup_basic (161.72s)
--- PASS: TestAccDataSourceAWSLBListener_BackwardsCompatibility (177.80s)
--- PASS: TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility (162.46s)
--- PASS: TestAccDataSourceAWSLBListener_https (179.69s)
--- PASS: TestAccDataSourceAWSLB_BackwardsCompatibility (170.33s)
--- PASS: TestAccDataSourceAWSLB_basic (181.84s)
--- PASS: TestAccDataSourceAWSLambdaFunction_vpc (243.29s)
--- PASS: TestAccDataSourceAwsNatGateway_basic (201.00s)
--- PASS: TestAccDataSourceAWSLambdaFunction_fileSystemConfig (314.48s)
--- PASS: TestAccAWSMskClusterDataSource_Name (1573.45s)
```
