### PR TITLE
Fixes errorlint reports for data sources T-Z

### DIFF
--- a/aws/data_source_aws_transfer_server.go
+++ b/aws/data_source_aws_transfer_server.go
@@ -57,7 +57,7 @@ func dataSourceAwsTransferServerRead(d *schema.ResourceData, meta interface{}) e
 
 	resp, err := conn.DescribeServer(input)
 	if err != nil {
-		return fmt.Errorf("error describing Transfer Server (%s): %s", serverID, err)
+		return fmt.Errorf("error describing Transfer Server (%s): %w", serverID, err)
 	}
 
 	endpoint := meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.server.transfer", serverID))

--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -184,7 +184,7 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("state", vpc.State)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpc.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("owner_id", vpc.OwnerId)
@@ -208,7 +208,7 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 		cidrAssociations = append(cidrAssociations, association)
 	}
 	if err := d.Set("cidr_block_associations", cidrAssociations); err != nil {
-		return fmt.Errorf("error setting cidr_block_associations: %s", err)
+		return fmt.Errorf("error setting cidr_block_associations: %w", err)
 	}
 
 	if vpc.Ipv6CidrBlockAssociationSet != nil {

--- a/aws/data_source_aws_vpc_dhcp_options.go
+++ b/aws/data_source_aws_vpc_dhcp_options.go
@@ -84,7 +84,7 @@ func dataSourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) e
 		if isNoSuchDhcpOptionIDErr(err) {
 			return errors.New("No matching EC2 DHCP Options found")
 		}
-		return fmt.Errorf("error reading EC2 DHCP Options: %s", err)
+		return fmt.Errorf("error reading EC2 DHCP Options: %w", err)
 	}
 
 	if len(output.DhcpOptions) == 0 {
@@ -114,23 +114,23 @@ func dataSourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) e
 			d.Set(tfKey, aws.StringValue(dhcpConfiguration.Values[0].Value))
 		case "domain-name-servers":
 			if err := d.Set(tfKey, flattenEc2AttributeValues(dhcpConfiguration.Values)); err != nil {
-				return fmt.Errorf("error setting %s: %s", tfKey, err)
+				return fmt.Errorf("error setting %s: %w", tfKey, err)
 			}
 		case "netbios-name-servers":
 			if err := d.Set(tfKey, flattenEc2AttributeValues(dhcpConfiguration.Values)); err != nil {
-				return fmt.Errorf("error setting %s: %s", tfKey, err)
+				return fmt.Errorf("error setting %s: %w", tfKey, err)
 			}
 		case "netbios-node-type":
 			d.Set(tfKey, aws.StringValue(dhcpConfiguration.Values[0].Value))
 		case "ntp-servers":
 			if err := d.Set(tfKey, flattenEc2AttributeValues(dhcpConfiguration.Values)); err != nil {
-				return fmt.Errorf("error setting %s: %s", tfKey, err)
+				return fmt.Errorf("error setting %s: %w", tfKey, err)
 			}
 		}
 	}
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(output.DhcpOptions[0].Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 	d.Set("owner_id", output.DhcpOptions[0].OwnerId)
 

--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -147,7 +147,7 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Reading VPC Endpoint: %s", req)
 	respVpce, err := conn.DescribeVpcEndpoints(req)
 	if err != nil {
-		return fmt.Errorf("error reading VPC Endpoint: %s", err)
+		return fmt.Errorf("error reading VPC Endpoint: %w", err)
 	}
 	if respVpce == nil || len(respVpce.VpcEndpoints) == 0 {
 		return fmt.Errorf("no matching VPC Endpoint found")
@@ -179,7 +179,7 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 		}),
 	})
 	if err != nil {
-		return fmt.Errorf("error reading Prefix List (%s): %s", serviceName, err)
+		return fmt.Errorf("error reading Prefix List (%s): %w", serviceName, err)
 	}
 	if respPl == nil || len(respPl.PrefixLists) == 0 {
 		d.Set("cidr_blocks", []interface{}{})
@@ -191,41 +191,41 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("prefix_list_id", pl.PrefixListId)
 		err = d.Set("cidr_blocks", flattenStringList(pl.Cidrs))
 		if err != nil {
-			return fmt.Errorf("error setting cidr_blocks: %s", err)
+			return fmt.Errorf("error setting cidr_blocks: %w", err)
 		}
 	}
 
 	err = d.Set("dns_entry", flattenVpcEndpointDnsEntries(vpce.DnsEntries))
 	if err != nil {
-		return fmt.Errorf("error setting dns_entry: %s", err)
+		return fmt.Errorf("error setting dns_entry: %w", err)
 	}
 	err = d.Set("network_interface_ids", flattenStringSet(vpce.NetworkInterfaceIds))
 	if err != nil {
-		return fmt.Errorf("error setting network_interface_ids: %s", err)
+		return fmt.Errorf("error setting network_interface_ids: %w", err)
 	}
 	d.Set("owner_id", vpce.OwnerId)
 	policy, err := structure.NormalizeJsonString(aws.StringValue(vpce.PolicyDocument))
 	if err != nil {
-		return fmt.Errorf("policy contains an invalid JSON: %s", err)
+		return fmt.Errorf("policy contains an invalid JSON: %w", err)
 	}
 	d.Set("policy", policy)
 	d.Set("private_dns_enabled", vpce.PrivateDnsEnabled)
 	err = d.Set("route_table_ids", flattenStringSet(vpce.RouteTableIds))
 	if err != nil {
-		return fmt.Errorf("error setting route_table_ids: %s", err)
+		return fmt.Errorf("error setting route_table_ids: %w", err)
 	}
 	d.Set("requester_managed", vpce.RequesterManaged)
 	err = d.Set("security_group_ids", flattenVpcEndpointSecurityGroupIds(vpce.Groups))
 	if err != nil {
-		return fmt.Errorf("error setting security_group_ids: %s", err)
+		return fmt.Errorf("error setting security_group_ids: %w", err)
 	}
 	err = d.Set("subnet_ids", flattenStringSet(vpce.SubnetIds))
 	if err != nil {
-		return fmt.Errorf("error setting subnet_ids: %s", err)
+		return fmt.Errorf("error setting subnet_ids: %w", err)
 	}
 	err = d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpce.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map())
 	if err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 	// VPC endpoints don't have types in GovCloud, so set type to default if empty
 	if vpceType := aws.StringValue(vpce.VpcEndpointType); vpceType == "" {

--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -111,7 +111,7 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] Reading VPC Endpoint Service: %s", req)
 	resp, err := conn.DescribeVpcEndpointServices(req)
 	if err != nil {
-		return fmt.Errorf("error reading VPC Endpoint Service (%s): %s", serviceName, err)
+		return fmt.Errorf("error reading VPC Endpoint Service (%s): %w", serviceName, err)
 	}
 
 	if resp == nil || (len(resp.ServiceNames) == 0 && len(resp.ServiceDetails) == 0) {
@@ -174,11 +174,11 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 	d.Set("acceptance_required", sd.AcceptanceRequired)
 	err = d.Set("availability_zones", flattenStringSet(sd.AvailabilityZones))
 	if err != nil {
-		return fmt.Errorf("error setting availability_zones: %s", err)
+		return fmt.Errorf("error setting availability_zones: %w", err)
 	}
 	err = d.Set("base_endpoint_dns_names", flattenStringSet(sd.BaseEndpointDnsNames))
 	if err != nil {
-		return fmt.Errorf("error setting base_endpoint_dns_names: %s", err)
+		return fmt.Errorf("error setting base_endpoint_dns_names: %w", err)
 	}
 	d.Set("manages_vpc_endpoints", sd.ManagesVpcEndpoints)
 	d.Set("owner", sd.Owner)
@@ -188,7 +188,7 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 	d.Set("service_type", sd.ServiceType[0].ServiceType)
 	err = d.Set("tags", keyvaluetags.Ec2KeyValueTags(sd.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map())
 	if err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 	d.Set("vpc_endpoint_policy_supported", sd.VpcEndpointPolicySupported)
 

--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -188,7 +188,7 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 	}
 	d.Set("peer_region", pcx.AccepterVpcInfo.Region)
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(pcx.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	if pcx.AccepterVpcInfo.PeeringOptions != nil {

--- a/aws/data_source_aws_vpcs.go
+++ b/aws/data_source_aws_vpcs.go
@@ -68,7 +68,7 @@ func dataSourceAwsVpcsRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(meta.(*AWSClient).region)
 
 	if err := d.Set("ids", vpcs); err != nil {
-		return fmt.Errorf("Error setting vpc ids: %s", err)
+		return fmt.Errorf("error setting vpc ids: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_vpn_gateway.go
+++ b/aws/data_source_aws_vpn_gateway.go
@@ -114,7 +114,7 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(vgw.AmazonSideAsn), 10))
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vgw.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	for _, attachment := range vgw.VpcAttachments {

--- a/aws/data_source_aws_waf_ipset.go
+++ b/aws/data_source_aws_waf_ipset.go
@@ -31,7 +31,7 @@ func dataSourceAWSWafIpSetRead(d *schema.ResourceData, meta interface{}) error {
 	for {
 		output, err := conn.ListIPSets(input)
 		if err != nil {
-			return fmt.Errorf("Error reading WAF IP sets: %s", err)
+			return fmt.Errorf("Error reading WAF IP sets: %w", err)
 		}
 		for _, ipset := range output.IPSets {
 			if aws.StringValue(ipset.Name) == name {

--- a/aws/data_source_aws_waf_rate_based_rule.go
+++ b/aws/data_source_aws_waf_rate_based_rule.go
@@ -31,7 +31,7 @@ func dataSourceAwsWafRateBasedRuleRead(d *schema.ResourceData, meta interface{})
 	for {
 		output, err := conn.ListRateBasedRules(input)
 		if err != nil {
-			return fmt.Errorf("error reading WAF Rate Based Rules: %s", err)
+			return fmt.Errorf("error reading WAF Rate Based Rules: %w", err)
 		}
 		for _, rule := range output.Rules {
 			if aws.StringValue(rule.Name) == name {

--- a/aws/data_source_aws_waf_rule.go
+++ b/aws/data_source_aws_waf_rule.go
@@ -31,7 +31,7 @@ func dataSourceAwsWafRuleRead(d *schema.ResourceData, meta interface{}) error {
 	for {
 		output, err := conn.ListRules(input)
 		if err != nil {
-			return fmt.Errorf("error reading WAF Rules: %s", err)
+			return fmt.Errorf("error reading WAF Rules: %w", err)
 		}
 		for _, rule := range output.Rules {
 			if aws.StringValue(rule.Name) == name {

--- a/aws/data_source_aws_waf_web_acl.go
+++ b/aws/data_source_aws_waf_web_acl.go
@@ -31,7 +31,7 @@ func dataSourceAwsWafWebAclRead(d *schema.ResourceData, meta interface{}) error 
 	for {
 		output, err := conn.ListWebACLs(input)
 		if err != nil {
-			return fmt.Errorf("error reading web ACLs: %s", err)
+			return fmt.Errorf("error reading web ACLs: %w", err)
 		}
 		for _, acl := range output.WebACLs {
 			if aws.StringValue(acl.Name) == name {

--- a/aws/data_source_aws_wafregional_ipset.go
+++ b/aws/data_source_aws_wafregional_ipset.go
@@ -31,7 +31,7 @@ func dataSourceAWSWafRegionalIpSetRead(d *schema.ResourceData, meta interface{})
 	for {
 		output, err := conn.ListIPSets(input)
 		if err != nil {
-			return fmt.Errorf("Error reading WAF Regional IP sets: %s", err)
+			return fmt.Errorf("Error reading WAF Regional IP sets: %w", err)
 		}
 		for _, ipset := range output.IPSets {
 			if aws.StringValue(ipset.Name) == name {

--- a/aws/data_source_aws_wafregional_rate_based_rule.go
+++ b/aws/data_source_aws_wafregional_rate_based_rule.go
@@ -31,7 +31,7 @@ func dataSourceAwsWafRegionalRateBasedRuleRead(d *schema.ResourceData, meta inte
 	for {
 		output, err := conn.ListRateBasedRules(input)
 		if err != nil {
-			return fmt.Errorf("error reading WAF Rate Based Rules: %s", err)
+			return fmt.Errorf("error reading WAF Rate Based Rules: %w", err)
 		}
 		for _, rule := range output.Rules {
 			if aws.StringValue(rule.Name) == name {

--- a/aws/data_source_aws_wafregional_rule.go
+++ b/aws/data_source_aws_wafregional_rule.go
@@ -31,7 +31,7 @@ func dataSourceAwsWafRegionalRuleRead(d *schema.ResourceData, meta interface{}) 
 	for {
 		output, err := conn.ListRules(input)
 		if err != nil {
-			return fmt.Errorf("error reading WAF Rule: %s", err)
+			return fmt.Errorf("error reading WAF Rule: %w", err)
 		}
 		for _, rule := range output.Rules {
 			if aws.StringValue(rule.Name) == name {

--- a/aws/data_source_aws_wafregional_web_acl.go
+++ b/aws/data_source_aws_wafregional_web_acl.go
@@ -31,7 +31,7 @@ func dataSourceAwsWafRegionalWebAclRead(d *schema.ResourceData, meta interface{}
 	for {
 		output, err := conn.ListWebACLs(input)
 		if err != nil {
-			return fmt.Errorf("error reading web ACLs: %s", err)
+			return fmt.Errorf("error reading web ACLs: %w", err)
 		}
 		for _, acl := range output.WebACLs {
 			if aws.StringValue(acl.Name) == name {

--- a/aws/data_source_aws_wafv2_ip_set.go
+++ b/aws/data_source_aws_wafv2_ip_set.go
@@ -60,7 +60,7 @@ func dataSourceAwsWafv2IPSetRead(d *schema.ResourceData, meta interface{}) error
 	for {
 		resp, err := conn.ListIPSets(input)
 		if err != nil {
-			return fmt.Errorf("Error reading WAFv2 IPSets: %s", err)
+			return fmt.Errorf("Error reading WAFv2 IPSets: %w", err)
 		}
 
 		if resp == nil || resp.IPSets == nil {
@@ -91,7 +91,7 @@ func dataSourceAwsWafv2IPSetRead(d *schema.ResourceData, meta interface{}) error
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error reading WAFv2 IPSet: %s", err)
+		return fmt.Errorf("Error reading WAFv2 IPSet: %w", err)
 	}
 
 	if resp == nil || resp.IPSet == nil {
@@ -104,7 +104,7 @@ func dataSourceAwsWafv2IPSetRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("ip_address_version", aws.StringValue(resp.IPSet.IPAddressVersion))
 
 	if err := d.Set("addresses", flattenStringList(resp.IPSet.Addresses)); err != nil {
-		return fmt.Errorf("Error setting addresses: %s", err)
+		return fmt.Errorf("error setting addresses: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_wafv2_regex_pattern_set.go
+++ b/aws/data_source_aws_wafv2_regex_pattern_set.go
@@ -63,7 +63,7 @@ func dataSourceAwsWafv2RegexPatternSetRead(d *schema.ResourceData, meta interfac
 	for {
 		resp, err := conn.ListRegexPatternSets(input)
 		if err != nil {
-			return fmt.Errorf("Error reading WAFv2 RegexPatternSets: %s", err)
+			return fmt.Errorf("Error reading WAFv2 RegexPatternSets: %w", err)
 		}
 
 		if resp == nil || resp.RegexPatternSets == nil {
@@ -94,7 +94,7 @@ func dataSourceAwsWafv2RegexPatternSetRead(d *schema.ResourceData, meta interfac
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error reading WAFv2 RegexPatternSet: %s", err)
+		return fmt.Errorf("Error reading WAFv2 RegexPatternSet: %w", err)
 	}
 
 	if resp == nil || resp.RegexPatternSet == nil {
@@ -106,7 +106,7 @@ func dataSourceAwsWafv2RegexPatternSetRead(d *schema.ResourceData, meta interfac
 	d.Set("description", aws.StringValue(resp.RegexPatternSet.Description))
 
 	if err := d.Set("regular_expression", flattenWafv2RegexPatternSet(resp.RegexPatternSet.RegularExpressionList)); err != nil {
-		return fmt.Errorf("Error setting regular_expression: %s", err)
+		return fmt.Errorf("Error setting regular_expression: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_wafv2_rule_group.go
+++ b/aws/data_source_aws_wafv2_rule_group.go
@@ -51,7 +51,7 @@ func dataSourceAwsWafv2RuleGroupRead(d *schema.ResourceData, meta interface{}) e
 	for {
 		resp, err := conn.ListRuleGroups(input)
 		if err != nil {
-			return fmt.Errorf("Error reading WAFv2 RuleGroups: %s", err)
+			return fmt.Errorf("Error reading WAFv2 RuleGroups: %w", err)
 		}
 
 		if resp == nil || resp.RuleGroups == nil {

--- a/aws/data_source_aws_wafv2_web_acl.go
+++ b/aws/data_source_aws_wafv2_web_acl.go
@@ -51,7 +51,7 @@ func dataSourceAwsWafv2WebACLRead(d *schema.ResourceData, meta interface{}) erro
 	for {
 		resp, err := conn.ListWebACLs(input)
 		if err != nil {
-			return fmt.Errorf("Error reading WAFv2 WebACLs: %s", err)
+			return fmt.Errorf("Error reading WAFv2 WebACLs: %w", err)
 		}
 
 		if resp == nil || resp.WebACLs == nil {

--- a/aws/data_source_aws_workspaces_bundle.go
+++ b/aws/data_source_aws_workspaces_bundle.go
@@ -136,7 +136,7 @@ func dataSourceAwsWorkspaceBundleRead(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 	if err := d.Set("compute_type", computeType); err != nil {
-		return fmt.Errorf("error setting compute_type: %s", err)
+		return fmt.Errorf("error setting compute_type: %w", err)
 	}
 
 	rootStorage := make([]map[string]interface{}, 1)
@@ -146,7 +146,7 @@ func dataSourceAwsWorkspaceBundleRead(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 	if err := d.Set("root_storage", rootStorage); err != nil {
-		return fmt.Errorf("error setting root_storage: %s", err)
+		return fmt.Errorf("error setting root_storage: %w", err)
 	}
 
 	userStorage := make([]map[string]interface{}, 1)
@@ -156,7 +156,7 @@ func dataSourceAwsWorkspaceBundleRead(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 	if err := d.Set("user_storage", userStorage); err != nil {
-		return fmt.Errorf("error setting user_storage: %s", err)
+		return fmt.Errorf("error setting user_storage: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_workspaces_directory.go
+++ b/aws/data_source_aws_workspaces_directory.go
@@ -166,7 +166,7 @@ func dataSourceAwsWorkspacesDirectoryRead(d *schema.ResourceData, meta interface
 
 	rawOutput, state, err := waiter.DirectoryState(conn, directoryID)()
 	if err != nil {
-		return fmt.Errorf("error getting WorkSpaces Directory (%s): %s", directoryID, err)
+		return fmt.Errorf("error getting WorkSpaces Directory (%s): %w", directoryID, err)
 	}
 	if state == workspaces.WorkspaceDirectoryStateDeregistered {
 		return fmt.Errorf("WorkSpaces directory %s was not found", directoryID)
@@ -184,11 +184,11 @@ func dataSourceAwsWorkspacesDirectoryRead(d *schema.ResourceData, meta interface
 	d.Set("alias", directory.Alias)
 
 	if err := d.Set("subnet_ids", flattenStringSet(directory.SubnetIds)); err != nil {
-		return fmt.Errorf("error setting subnet_ids: %s", err)
+		return fmt.Errorf("error setting subnet_ids: %w", err)
 	}
 
 	if err := d.Set("self_service_permissions", flattenSelfServicePermissions(directory.SelfservicePermissions)); err != nil {
-		return fmt.Errorf("error setting self_service_permissions: %s", err)
+		return fmt.Errorf("error setting self_service_permissions: %w", err)
 	}
 
 	if err := d.Set("workspace_access_properties", flattenWorkspaceAccessProperties(directory.WorkspaceAccessProperties)); err != nil {
@@ -196,23 +196,23 @@ func dataSourceAwsWorkspacesDirectoryRead(d *schema.ResourceData, meta interface
 	}
 
 	if err := d.Set("workspace_creation_properties", flattenWorkspaceCreationProperties(directory.WorkspaceCreationProperties)); err != nil {
-		return fmt.Errorf("error setting workspace_creation_properties: %s", err)
+		return fmt.Errorf("error setting workspace_creation_properties: %w", err)
 	}
 
 	if err := d.Set("ip_group_ids", flattenStringSet(directory.IpGroupIds)); err != nil {
-		return fmt.Errorf("error setting ip_group_ids: %s", err)
+		return fmt.Errorf("error setting ip_group_ids: %w", err)
 	}
 
 	if err := d.Set("dns_ip_addresses", flattenStringSet(directory.DnsIpAddresses)); err != nil {
-		return fmt.Errorf("error setting dns_ip_addresses: %s", err)
+		return fmt.Errorf("error setting dns_ip_addresses: %w", err)
 	}
 
 	tags, err := keyvaluetags.WorkspacesListTags(conn, d.Id())
 	if err != nil {
-		return fmt.Errorf("error listing tags: %s", err)
+		return fmt.Errorf("error listing tags: %w", err)
 	}
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_workspaces_workspace.go
+++ b/aws/data_source_aws_workspaces_workspace.go
@@ -152,16 +152,16 @@ func dataSourceAwsWorkspacesWorkspaceRead(d *schema.ResourceData, meta interface
 	d.Set("user_volume_encryption_enabled", aws.BoolValue(workspace.UserVolumeEncryptionEnabled))
 	d.Set("volume_encryption_key", aws.StringValue(workspace.VolumeEncryptionKey))
 	if err := d.Set("workspace_properties", flattenWorkspaceProperties(workspace.WorkspaceProperties)); err != nil {
-		return fmt.Errorf("error setting workspace properties: %s", err)
+		return fmt.Errorf("error setting workspace properties: %w", err)
 	}
 
 	tags, err := keyvaluetags.WorkspacesListTags(conn, d.Id())
 	if err != nil {
-		return fmt.Errorf("error listing tags: %s", err)
+		return fmt.Errorf("error listing tags: %w", err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes [`errorlint`](https://github.com/polyfloyd/go-errorlint) reports for data sources T-Z.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15891

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsVpcDhcpOptions\|TestAccDataSourceAwsWorkspacesWorkspace\|TestAccDataSourceAwsWafv2WebACL\|TestAccDataSourceAwsWorkspacesDirectory\|TestAccDataSourceAwsWafRegionalIPSet\|TestAccDataSourceAwsWafRegionalRule\|TestAccDataSourceAwsWorkspaceBundle\|TestAccDataSourceAwsVpcEndpointService\|TestAccDataSourceAwsWafIPSet\|TestAccDataSourceAwsVpnGateway\|TestAccDataSourceAwsVpcEndpoint\|TestAccDataSourceAwsVpcPeeringConnection\|TestAccDataSourceAwsWafWebAcl\|TestAccDataSourceAwsWafv2RuleGroup\|TestAccDataSourceAwsVpc\|TestAccDataSourceAwsWafRegionalRateBasedRule\|TestAccDataSourceAwsWafRegionalWebAcl\|TestAccDataSourceAwsTransferServer\|TestAccDataSourceAwsWafRateBasedRule\|TestAccDataSourceAwsWafRule\|TestAccDataSourceAwsWafv2IPSet\|TestAccDataSourceAwsVpcs\|TestAccDataSourceAwsWafv2RegexPatternSet'

--- PASS: TestAccDataSourceAwsVpcEndpointService_ServiceType_Interface (41.18s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_ServiceType_Gateway (41.20s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (40.98s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (41.73s)
--- PASS: TestAccDataSourceAwsVpcPeeringConnection_CidrBlock (44.10s)
--- PASS: TestAccDataSourceAwsVpcPeeringConnection_Id (45.13s)
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_basic (45.24s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byFilter (56.46s)
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_Filter (56.51s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (58.34s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayBasic (58.56s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byTags (60.20s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags (61.39s)
--- PASS: TestAccDataSourceAwsVpcPeeringConnection_VpcId (34.06s)
--- PASS: TestAccDataSourceAwsVpcPeeringConnections_basic (33.64s)
--- PASS: TestAccDataSourceAwsVpcPeeringConnection_PeerVpcId (35.64s)
--- PASS: TestAccDataSourceAwsVpc_basic (33.30s)
--- PASS: TestAccDataSourceAwsVpcPeeringConnection_PeerCidrBlock (36.81s)
--- PASS: TestAccDataSourceAwsVpc_ipv6Associated (38.42s)
--- PASS: TestAccDataSourceAwsVpcs_basic (33.27s)
--- PASS: TestAccDataSourceAwsVpcs_tags (33.44s)
--- PASS: TestAccDataSourceAwsVpnGateway_unattached (34.03s)
--- PASS: TestAccDataSourceAwsVpcs_filters (35.55s)
--- PASS: TestAccDataSourceAwsWafIPSet_basic (40.41s)
--- PASS: TestAccDataSourceAwsVpc_multipleCidr (56.26s)
--- PASS: TestAccDataSourceAwsVpnGateway_attached (52.31s)
--- PASS: TestAccDataSourceAwsWafRegionalRateBasedRule_basic (38.70s)
--- PASS: TestAccDataSourceAwsWafRegionalIPSet_basic (39.34s)
--- SKIP: TestAccDataSourceAwsWorkspaceBundle_privateOwner (1.00s)
--- PASS: TestAccDataSourceAwsWafRule_basic (45.79s)
--- PASS: TestAccDataSourceAwsWafWebAcl_basic (45.51s)
--- PASS: TestAccDataSourceAwsWafRegionalRule_basic (39.02s)
--- PASS: TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict (5.78s)
--- PASS: TestAccDataSourceAwsWafRateBasedRule_basic (49.28s)
--- PASS: TestAccDataSourceAwsWafv2IPSet_basic (36.88s)
--- PASS: TestAccDataSourceAwsWorkspacesWorkspace_workspaceIDAndDirectoryIDConflict (4.60s)
--- PASS: TestAccDataSourceAwsWafRegionalWebAcl_basic (38.33s)
--- PASS: TestAccDataSourceAwsWafv2RegexPatternSet_basic (35.45s)
--- PASS: TestAccDataSourceAwsWafv2RuleGroup_basic (36.52s)
--- PASS: TestAccDataSourceAwsWorkspaceBundle_basic (29.71s)
--- PASS: TestAccDataSourceAwsWorkspaceBundle_byOwnerName (22.74s)
--- PASS: TestAccDataSourceAwsWafv2WebACL_basic (33.29s)
--- PASS: TestAccDataSourceAwsTransferServer_basic (202.88s)
--- PASS: TestAccDataSourceAwsTransferServer_apigateway (205.45s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_interface (222.86s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (231.71s)
--- PASS: TestAccDataSourceAwsTransferServer_service_managed (232.13s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter_tags (235.23s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter (250.55s)
--- PASS: TestAccDataSourceAwsWorkspacesDirectory_basic (603.13s)
--- PASS: TestAccDataSourceAwsWorkspacesWorkspace_byWorkspaceID (1604.15s)
--- PASS: TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName (1789.84s)
```
