### PR TITLE
docs/contributing: Update invalid S3 bucket name and add note for bucket policy size.

### DIFF
--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -31,7 +31,7 @@ resource "aws_s3_bucket_policy" "b" {
       "Sid": "IPAllow",
       "Effect": "Deny",
       "Principal": "*",
-      "Action": "s3:*",˜
+      "Action": "s3:*",
       "Resource": "arn:aws:s3:::my-tf-test-bucket/*",
       "Condition": {
          "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -16,7 +16,7 @@ Attaches a policy to an S3 bucket resource.
 
 ```hcl
 resource "aws_s3_bucket" "b" {
-  bucket = "my_tf_test_bucket"
+  bucket = "my-tf-test-bucket"
 }
 
 resource "aws_s3_bucket_policy" "b" {
@@ -31,8 +31,8 @@ resource "aws_s3_bucket_policy" "b" {
       "Sid": "IPAllow",
       "Effect": "Deny",
       "Principal": "*",
-      "Action": "s3:*",
-      "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
+      "Action": "s3:*",˜
+      "Resource": "arn:aws:s3:::my-tf-test-bucket/*",
       "Condition": {
          "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
       }
@@ -48,7 +48,8 @@ POLICY
 The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to which to apply the policy.
-* `policy` - (Required) The text of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
+* `policy` - (Required) The text of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy). Note: Bucket policies are limited to 20 KB in size.
+
 
 ## Import
 


### PR DESCRIPTION
As per https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html, S3 bucket name cannot have `underscores (_)`.
 
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->