### PR TITLE
Use gRPC matcher with gRPC protocol

### DIFF
--- a/.changelog/17534.txt
+++ b/.changelog/17534.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb_target_group: Use gRPC matcher when using gRPC protocol
+```

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -347,6 +347,7 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			m := healthCheck["matcher"].(string)
+			protocolVersion := d.Get("protocol_version").(string)
 			if m != "" {
 				if protocolVersion == "GRPC" {
 					params.Matcher = &elbv2.Matcher{

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -80,10 +80,20 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 					return strings.ToUpper(v.(string))
 				},
 				ValidateFunc: validation.StringInSlice([]string{
+					"GRPC",
 					"HTTP1",
 					"HTTP2",
-					"GRPC",
 				}, true),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("target_type").(string) == elbv2.TargetTypeEnumLambda {
+						return true
+					}
+					switch d.Get("protocol").(string) {
+					case elbv2.ProtocolEnumHttp, elbv2.ProtocolEnumHttps:
+						return false
+					}
+					return true
+				},
 			},
 
 			"vpc_id": {
@@ -338,8 +348,14 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 			m := healthCheck["matcher"].(string)
 			if m != "" {
-				params.Matcher = &elbv2.Matcher{
-					HttpCode: aws.String(m),
+				if protocolVersion == "GRPC" {
+					params.Matcher = &elbv2.Matcher{
+						GrpcCode: aws.String(m),
+					}
+				} else {
+					params.Matcher = &elbv2.Matcher{
+						HttpCode: aws.String(m),
+					}
 				}
 			}
 		}
@@ -416,10 +432,16 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			healthCheckProtocol := healthCheck["protocol"].(string)
-
+			protocolVersion := d.Get("protocol_version").(string)
 			if healthCheckProtocol != elbv2.ProtocolEnumTcp && !d.IsNewResource() {
-				params.Matcher = &elbv2.Matcher{
-					HttpCode: aws.String(healthCheck["matcher"].(string)),
+				if protocolVersion == "GRPC" {
+					params.Matcher = &elbv2.Matcher{
+						GrpcCode: aws.String(healthCheck["matcher"].(string)),
+					}
+				} else {
+					params.Matcher = &elbv2.Matcher{
+						HttpCode: aws.String(healthCheck["matcher"].(string)),
+					}
 				}
 				params.HealthCheckPath = aws.String(healthCheck["path"].(string))
 				params.HealthCheckIntervalSeconds = aws.Int64(int64(healthCheck["interval"].(int)))
@@ -644,6 +666,9 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 	}
 	if targetGroup.Matcher != nil && targetGroup.Matcher.HttpCode != nil {
 		healthCheck["matcher"] = aws.StringValue(targetGroup.Matcher.HttpCode)
+	}
+	if targetGroup.Matcher != nil && targetGroup.Matcher.GrpcCode != nil {
+		healthCheck["matcher"] = aws.StringValue(targetGroup.Matcher.GrpcCode)
 	}
 	if v, _ := d.Get("target_type").(string); v != elbv2.TargetTypeEnumLambda {
 		d.Set("vpc_id", targetGroup.VpcId)

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -404,7 +404,7 @@ func TestAccAWSLBTargetGroup_Protocol_Tls(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck(t *testing.T) {
 	var targetGroup1 elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -414,7 +414,7 @@ func TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_GRPC_ProtocolVersion(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_GRPC_ProtocolVersion(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &targetGroup1),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -402,6 +402,60 @@ func TestAccAWSLBTargetGroup_Protocol_Tls(t *testing.T) {
 	})
 }
 
+func TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck(t *testing.T) {
+	var targetGroup1 elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "aws_lb_target_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBTargetGroupConfig_GRPC_ProtocolVersion(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &targetGroup1),
+					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/Test.Check/healthcheck"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "0-99"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update(t *testing.T) {
+	var targetGroup1 elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lb_target_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBTargetGroupConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &targetGroup1),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_version", "HTTP1"),
+				),
+			},
+			{
+				Config: testAccAWSLBTargetGroupConfig_GRPC_ProtocolVersion(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &targetGroup1),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_version", "GRPC"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy(t *testing.T) {
 	var confBefore, confAfter elbv2.TargetGroup
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
@@ -952,6 +1006,7 @@ func TestAccAWSLBTargetGroup_defaults_application(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "protocol_version", "HTTP1"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "200"),
 					resource.TestCheckResourceAttr(resourceName, "slow_start", "0"),
@@ -1822,6 +1877,56 @@ resource "aws_lb_target_group" "test" {
     healthy_threshold   = 3
     unhealthy_threshold = 3
     matcher             = "200-299"
+  }
+
+  tags = {
+    Name = "TestAccAWSLBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test2" {
+  cidr_block = "10.10.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-lb-target-group-basic-2"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-lb-target-group-basic"
+  }
+}
+`, targetGroupName)
+}
+
+func testAccAWSLBTargetGroupConfig_GRPC_ProtocolVersion(targetGroupName string) string {
+	return fmt.Sprintf(`
+resource "aws_lb_target_group" "test" {
+  name             = "%s"
+  port             = 80
+  protocol         = "HTTP"
+  protocol_version = "GRPC"
+  vpc_id           = aws_vpc.test2.id
+
+  deregistration_delay = 200
+
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path                = "/Test.Check/healthcheck"
+    interval            = 60
+    port                = 8080
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "0-99"
   }
 
   tags = {

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -103,10 +103,11 @@ The underlying function is invoked when `target_type` is set to `lambda`.
 * `path` - (Required for HTTP/HTTPS ALB and HTTP NLB) The destination for the health check request. Applies to only HTTP/HTTPS.
 * `port` - (Optional) The port to use to connect with the target. Valid values are either ports 1-65535, or `traffic-port`. Defaults to `traffic-port`.
 * `protocol` - (Optional) The protocol to use to connect with the target. Defaults to `HTTP`. Not applicable when `target_type` is `lambda`.
+* `protocol_version` - (Optional) The protocol version. Defaults to `HTTP1`. Specify GRPC to send requests to targets using GRPC, HTTP2 to send requests to targets using HTTP/2, HTTP1 to send requests to targets using HTTP/1.1.
 * `timeout` - (Optional) The amount of time, in seconds, during which no response means a failed health check. For Application Load Balancers, the range is 2 to 120 seconds, and the default is 5 seconds for the `instance` target type and 30 seconds for the `lambda` target type. For Network Load Balancers, you cannot set a custom value, and the default is 10 seconds for TCP and HTTPS health checks and 6 seconds for HTTP health checks.
 * `healthy_threshold` - (Optional) The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3.
 * `unhealthy_threshold` - (Optional) The number of consecutive health check failures required before considering the target unhealthy . For Network Load Balancers, this value must be the same as the `healthy_threshold`. Defaults to 3.
-* `matcher` (Required for HTTP/HTTPS ALB) The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299"). Applies to Application Load Balancers only (HTTP/HTTPS), not Network Load Balancers (TCP).
+* `matcher` (Required for HTTP/HTTPS/GRPC ALB) The response codes to use when checking for a healthy responses from a target. You can specify multiple values (for example, "200,202" for HTTP(s) or "0,12" for GRPC) or a range of values (for example, "200-299" or "0-99"). Applies to Application Load Balancers only (HTTP/HTTPS/GRPC), not Network Load Balancers (TCP).
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBTargetGroup_ -timeout 120m
=== RUN   TestAccAWSLBTargetGroup_basic
=== PAUSE TestAccAWSLBTargetGroup_basic
=== RUN   TestAccAWSLBTargetGroup_basicUdp
=== PAUSE TestAccAWSLBTargetGroup_basicUdp
=== RUN   TestAccAWSLBTargetGroup_ProtocolVersion
=== PAUSE TestAccAWSLBTargetGroup_ProtocolVersion
=== RUN   TestAccAWSLBTargetGroup_withoutHealthcheck
=== PAUSE TestAccAWSLBTargetGroup_withoutHealthcheck
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== RUN   TestAccAWSLBTargetGroup_Protocol_Geneve
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Geneve
=== RUN   TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
=== RUN   TestAccAWSLBTargetGroup_Protocol_Tls
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Tls
=== RUN   TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck
=== PAUSE TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck
=== RUN   TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update
=== PAUSE TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== RUN   TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== RUN   TestAccAWSLBTargetGroup_BackwardsCompatibility
=== PAUSE TestAccAWSLBTargetGroup_BackwardsCompatibility
=== RUN   TestAccAWSLBTargetGroup_namePrefix
=== PAUSE TestAccAWSLBTargetGroup_namePrefix
=== RUN   TestAccAWSLBTargetGroup_generatedName
=== PAUSE TestAccAWSLBTargetGroup_generatedName
=== RUN   TestAccAWSLBTargetGroup_changeNameForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeNameForceNew
=== RUN   TestAccAWSLBTargetGroup_changeProtocolForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeProtocolForceNew
=== RUN   TestAccAWSLBTargetGroup_changePortForceNew
=== PAUSE TestAccAWSLBTargetGroup_changePortForceNew
=== RUN   TestAccAWSLBTargetGroup_changeVpcForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeVpcForceNew
=== RUN   TestAccAWSLBTargetGroup_tags
=== PAUSE TestAccAWSLBTargetGroup_tags
=== RUN   TestAccAWSLBTargetGroup_enableHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_enableHealthCheck
=== RUN   TestAccAWSLBTargetGroup_updateHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_updateHealthCheck
=== RUN   TestAccAWSLBTargetGroup_updateSticknessEnabled
=== PAUSE TestAccAWSLBTargetGroup_updateSticknessEnabled
=== RUN   TestAccAWSLBTargetGroup_defaults_application
=== PAUSE TestAccAWSLBTargetGroup_defaults_application
=== RUN   TestAccAWSLBTargetGroup_defaults_network
=== PAUSE TestAccAWSLBTargetGroup_defaults_network
=== RUN   TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessDefaultALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessDefaultALB
=== RUN   TestAccAWSLBTargetGroup_stickinessValidNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessValidNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessValidALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessValidALB
=== RUN   TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessInvalidALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessInvalidALB
=== CONT  TestAccAWSLBTargetGroup_basic
=== CONT  TestAccAWSLBTargetGroup_defaults_network
=== CONT  TestAccAWSLBTargetGroup_changePortForceNew
=== CONT  TestAccAWSLBTargetGroup_changeProtocolForceNew
=== CONT  TestAccAWSLBTargetGroup_defaults_application
=== CONT  TestAccAWSLBTargetGroup_updateSticknessEnabled
=== CONT  TestAccAWSLBTargetGroup_updateHealthCheck
=== CONT  TestAccAWSLBTargetGroup_enableHealthCheck
=== CONT  TestAccAWSLBTargetGroup_tags
=== CONT  TestAccAWSLBTargetGroup_changeVpcForceNew
=== CONT  TestAccAWSLBTargetGroup_stickinessValidNLB
=== CONT  TestAccAWSLBTargetGroup_stickinessValidALB
=== CONT  TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== CONT  TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== CONT  TestAccAWSLBTargetGroup_stickinessInvalidALB
=== CONT  TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== CONT  TestAccAWSLBTargetGroup_changeNameForceNew
=== CONT  TestAccAWSLBTargetGroup_Protocol_Tls
=== CONT  TestAccAWSLBTargetGroup_stickinessDefaultALB
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (22.55s)
=== CONT  TestAccAWSLBTargetGroup_generatedName
--- PASS: TestAccAWSLBTargetGroup_basic (24.78s)
=== CONT  TestAccAWSLBTargetGroup_ProtocolVersion
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (26.40s)
=== CONT  TestAccAWSLBTargetGroup_withoutHealthcheck
--- PASS: TestAccAWSLBTargetGroup_defaults_application (30.55s)
=== CONT  TestAccAWSLBTargetGroup_namePrefix
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (35.15s)
=== CONT  TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (13.94s)
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck (43.66s)
=== CONT  TestAccAWSLBTargetGroup_BackwardsCompatibility
--- PASS: TestAccAWSLBTargetGroup_defaults_network (44.16s)
=== CONT  TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update
--- PASS: TestAccAWSLBTargetGroup_generatedName (23.44s)
=== CONT  TestAccAWSLBTargetGroup_basicUdp
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (46.21s)
=== CONT  TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (48.72s)
=== CONT  TestAccAWSLBTargetGroup_Protocol_Geneve
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion (32.73s)
--- PASS: TestAccAWSLBTargetGroup_namePrefix (27.34s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (64.85s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (66.01s)
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (69.54s)
--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (28.69s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (74.12s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (74.13s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (77.05s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (79.57s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (45.36s)
--- PASS: TestAccAWSLBTargetGroup_basicUdp (36.05s)
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update (40.79s)
--- PASS: TestAccAWSLBTargetGroup_tags (86.03s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (46.81s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (88.51s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Geneve (47.66s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (99.87s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (108.36s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (64.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	111.026s
```
