### PR TITLE
resource/iam_policy_document: Preserve order of condition values

### DIFF
--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
@@ -69,7 +70,7 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 										Required: true,
 									},
 									"values": {
-										Type:     schema.TypeSet,
+										Type:     schema.TypeList,
 										Required: true,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
@@ -310,9 +311,8 @@ func dataSourceAwsIamPolicyDocumentMakeConditions(in []interface{}, version stri
 			Variable: item["variable"].(string),
 		}
 		out[i].Values, err = dataSourceAwsIamPolicyDocumentReplaceVarsInList(
-			iamPolicyDecodeConfigStringList(
-				item["values"].(*schema.Set).List(),
-			), version,
+			aws.StringValueSlice(expandStringList(item["values"].([]interface{}))),
+			version,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("error reading values: %s", err)

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -393,8 +393,8 @@ func testAccAWSIAMPolicyDocumentExpectedJSON() string {
       "Condition": {
         "StringLike": {
           "s3:prefix": [
-            "home/${aws:username}/",
-            "home/"
+            "home/",
+            "home/${aws:username}/"
           ]
         }
       }
@@ -560,8 +560,8 @@ func testAccAWSIAMPolicyDocumentSourceExpectedJSON() string {
       "Condition": {
         "StringLike": {
           "s3:prefix": [
-            "home/${aws:username}/",
-            "home/"
+            "home/",
+            "home/${aws:username}/"
           ]
         }
       }

--- a/aws/iam_policy_model.go
+++ b/aws/iam_policy_model.go
@@ -170,7 +170,7 @@ func (cs IAMPolicyStatementConditionSet) MarshalJSON() ([]byte, error) {
 			if _, ok := raw[c.Test][c.Variable]; !ok {
 				raw[c.Test][c.Variable] = make([]string, 0, len(i))
 			}
-			sort.Sort(sort.Reverse(sort.StringSlice(i)))
+			// order matters with values so not sorting here
 			raw[c.Test][c.Variable] = append(raw[c.Test][c.Variable].([]string), i...)
 		case string:
 			raw[c.Test][c.Variable] = i


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14365

These two snippets from IAM policy documents are NOT equivalent. In other words, the order of condition values matters. Currently, `aws_iam_policy_document` does not preserve order by using a Set to represent `values` and by sorting the strings during JSON marshalling.

### This:

```json
      "Condition": {
        "StringLike": {
          "s3:prefix": [
            "home/jos/",
            "home/"
          ]
        }
      }
```

### is NOT equivalent to this:

```json
      "Condition": {
        "StringLike": {
          "s3:prefix": [
            "home/",
            "home/jos/"
          ]
        }
      }
```

No new tests are needed since these existing tests were verifying the **wrong** order of values (they are corrected in this PR):

* TestAccAWSDataSourceIAMPolicyDocument_basic
* TestAccAWSDataSourceIAMPolicyDocument_source

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipals (1.19s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting (4.86s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (17.66s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_stringAndSlice (17.79s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (17.93s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (17.94s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipalsGov (17.98s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (18.03s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_overrideList (18.08s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceList (18.14s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (18.14s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (19.58s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_version20081017 (25.24s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (27.04s)
```

Output from acceptance testing (`us-west-2`):

```
--- SKIP: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipalsGov (0.77s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting (3.22s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (12.13s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (12.18s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_overrideList (12.71s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_stringAndSlice (12.72s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceList (12.76s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (12.88s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipals (12.93s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (12.96s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (13.17s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (13.18s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_version20081017 (17.60s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (18.88s)
```
