### PR TITLE
docs: Add import of aws_default_

### DIFF
--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -3,41 +3,26 @@ subcategory: "VPC"
 layout: "aws"
 page_title: "AWS: aws_default_network_acl"
 description: |-
-  Manage the default Network ACL resource.
+  Manage a default network ACL.
 ---
 
 # Resource: aws_default_network_acl
 
-Provides a resource to manage the default AWS Network ACL. VPC Only.
+Provides a resource to manage a VPC's default network ACL. This resource can manage the default network ACL of the default or a non-default VPC.
 
-Each VPC created in AWS comes with a Default Network ACL that can be managed, but not
-destroyed. **This is an advanced resource**, and has special caveats to be aware
-of when using it. Please read this document in its entirety before using this
-resource.
+~> **NOTE:** This is an advanced resource with special caveats. Please read this document in its entirety before using this resource. The `aws_default_network_acl` behaves differently from normal resources. Terraform does not _create_ this resource but instead attempts to "adopt" it into management.
 
-The `aws_default_network_acl` behaves differently from normal resources, in that
-Terraform does not _create_ this resource, but instead attempts to "adopt" it
-into management. We can do this because each VPC created has a Default Network
-ACL that cannot be destroyed, and is created with a known set of default rules.
+Every VPC has a default network ACL that can be managed but not destroyed. When Terraform first adopts the Default Network ACL, it **immediately removes all rules in the ACL**. It then proceeds to create any rules specified in the configuration. This step is required so that only the rules specified in the configuration are created.
 
-When Terraform first adopts the Default Network ACL, it **immediately removes all
-rules in the ACL**. It then proceeds to create any rules specified in the
-configuration. This step is required so that only the rules specified in the
-configuration are created.
+This resource treats its inline rules as absolute; only the rules defined inline are created, and any additions/removals external to this resource will result in diffs being shown. For these reasons, this resource is incompatible with the `aws_network_acl_rule` resource.
 
-This resource treats its inline rules as absolute; only the rules defined
-inline are created, and any additions/removals external to this resource will
-result in diffs being shown. For these reasons, this resource is incompatible with the
-`aws_network_acl_rule` resource.
+For more information about Network ACLs, see the AWS Documentation on [Network ACLs][aws-network-acls].
 
-For more information about Network ACLs, see the AWS Documentation on
-[Network ACLs][aws-network-acls].
+## Example Usage
 
-## Basic Example Usage, with default rules
+### Basic Example
 
-The following config gives the Default Network ACL the same rules that AWS
-includes, but pulls the resource under management by Terraform. This means that
-any ACL rules added or changed will be detected as drift.
+The following config gives the Default Network ACL the same rules that AWS includes but pulls the resource under management by Terraform. This means that any ACL rules added or changed will be detected as drift.
 
 ```hcl
 resource "aws_vpc" "mainvpc" {
@@ -45,13 +30,13 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = aws_default_vpc.mainvpc.default_network_acl_id
+  default_network_acl_id = aws_vpc.mainvpc.default_network_acl_id
 
   ingress {
     protocol   = -1
     rule_no    = 100
     action     = "allow"
-    cidr_block = aws_default_vpc.mainvpc.cidr_block
+    cidr_block = aws_vpc.mainvpc.cidr_block
     from_port  = 0
     to_port    = 0
   }
@@ -67,10 +52,9 @@ resource "aws_default_network_acl" "default" {
 }
 ```
 
-## Example config to deny all Egress traffic, allowing Ingress
+### Example: Deny All Egress Traffic, Allow Ingress
 
-The following denies all Egress traffic by omitting any `egress` rules, while
-including the default `ingress` rule to allow all traffic.
+The following denies all Egress traffic by omitting any `egress` rules, while including the default `ingress` rule to allow all traffic.
 
 ```hcl
 resource "aws_vpc" "mainvpc" {
@@ -78,7 +62,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = aws_default_vpc.mainvpc.default_network_acl_id
+  default_network_acl_id = aws_vpc.mainvpc.default_network_acl_id
 
   ingress {
     protocol   = -1
@@ -91,11 +75,9 @@ resource "aws_default_network_acl" "default" {
 }
 ```
 
-## Example config to deny all traffic to any Subnet in the Default Network ACL
+### Example: Deny All Traffic To Any Subnet In The Default Network ACL
 
-This config denies all traffic in the Default ACL. This can be useful if you
-want a locked down default to force all resources in the VPC to assign a
-non-default ACL.
+This config denies all traffic in the Default ACL. This can be useful if you want to lock down the VPC to force all resources to assign a non-default ACL.
 
 ```hcl
 resource "aws_vpc" "mainvpc" {
@@ -103,62 +85,19 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = aws_default_vpc.mainvpc.default_network_acl_id
+  default_network_acl_id = aws_vpc.mainvpc.default_network_acl_id
 
   # no rules defined, deny all traffic in this ACL
 }
 ```
 
-## Argument Reference
+### Managing Subnets In A Default Network ACL
 
-The following arguments are supported:
+Within a VPC, all Subnets must be associated with a Network ACL. In order to "delete" the association between a Subnet and a non-default Network ACL, the association is destroyed by replacing it with an association between the Subnet and the Default ACL instead.
 
-* `default_network_acl_id` - (Required) The Network ACL ID to manage. This
-attribute is exported from `aws_vpc`, or manually found via the AWS Console.
-* `subnet_ids` - (Optional) A list of Subnet IDs to apply the ACL to. See the
-notes below on managing Subnets in the Default Network ACL
-* `ingress` - (Optional) Specifies an ingress rule. Parameters defined below.
-* `egress` - (Optional) Specifies an egress rule. Parameters defined below.
-* `tags` - (Optional) A map of tags to assign to the resource.
+When managing the Default Network ACL, you cannot "remove" Subnets. Instead, they must be reassigned to another Network ACL, or the Subnet itself must be destroyed. Because of these requirements, removing the `subnet_ids` attribute from the configuration of a `aws_default_network_acl` resource may result in a reoccurring plan, until the Subnets are reassigned to another Network ACL or are destroyed.
 
-Both `egress` and `ingress` support the following keys:
-
-* `from_port` - (Required) The from port to match.
-* `to_port` - (Required) The to port to match.
-* `rule_no` - (Required) The rule number. Used for ordering.
-* `action` - (Required) The action to take.
-* `protocol` - (Required) The protocol to match. If using the -1 'all'
-protocol, you must specify a from and to port of 0.
-* `cidr_block` - (Optional) The CIDR block to match. This must be a
-valid network mask.
-* `ipv6_cidr_block` - (Optional) The IPv6 CIDR block.
-* `icmp_type` - (Optional) The ICMP type to be used. Default 0.
-* `icmp_code` - (Optional) The ICMP type code to be used. Default 0.
-
-~> Note: For more information on ICMP types and codes, see here: https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml
-
-### Managing Subnets in the Default Network ACL
-
-Within a VPC, all Subnets must be associated with a Network ACL. In order to
-"delete" the association between a Subnet and a non-default Network ACL, the
-association is destroyed by replacing it with an association between the Subnet
-and the Default ACL instead.
-
-When managing the Default Network ACL, you cannot "remove" Subnets.
-Instead, they must be reassigned to another Network ACL, or the Subnet itself must be
-destroyed. Because of these requirements, removing the `subnet_ids` attribute from the
-configuration of a `aws_default_network_acl` resource may result in a reoccurring
-plan, until the Subnets are reassigned to another Network ACL or are destroyed.
-
-Because Subnets are by default associated with the Default Network ACL, any
-non-explicit association will show up as a plan to remove the Subnet. For
-example: if you have a custom `aws_network_acl` with two subnets attached, and
-you remove the `aws_network_acl` resource, after successfully destroying this
-resource future plans will show a diff on the managed `aws_default_network_acl`,
-as those two Subnets have been orphaned by the now destroyed network acl and thus
-adopted by the Default Network ACL. In order to avoid a reoccurring plan, they
-will need to be reassigned, destroyed, or added to the `subnet_ids` attribute of
-the `aws_default_network_acl` entry.
+Because Subnets are by default associated with the Default Network ACL, any non-explicit association will show up as a plan to remove the Subnet. For example: if you have a custom `aws_network_acl` with two subnets attached, and you remove the `aws_network_acl` resource, after successfully destroying this resource future plans will show a diff on the managed `aws_default_network_acl`, as those two Subnets have been orphaned by the now destroyed network acl and thus adopted by the Default Network ACL. In order to avoid a reoccurring plan, they will need to be reassigned, destroyed, or added to the `subnet_ids` attribute of the `aws_default_network_acl` entry.
 
 As an alternative to the above, you can also specify the following lifecycle configuration in your `aws_default_network_acl` resource:
 
@@ -172,26 +111,52 @@ resource "aws_default_network_acl" "default" {
 }
 ```
 
-### Removing `aws_default_network_acl` from your configuration
+### Removing `aws_default_network_acl` From Your Configuration
 
-Each AWS VPC comes with a Default Network ACL that cannot be deleted. The `aws_default_network_acl`
-allows you to manage this Network ACL, but Terraform cannot destroy it. Removing
-this resource from your configuration will remove it from your statefile and
-management, **but will not destroy the Network ACL.** All Subnets associations
-and ingress or egress rules will be left as they are at the time of removal. You
-can resume managing them via the AWS Console.
+Each AWS VPC comes with a Default Network ACL that cannot be deleted. The `aws_default_network_acl` allows you to manage this Network ACL, but Terraform cannot destroy it. Removing this resource from your configuration will remove it from your statefile and management, **but will not destroy the Network ACL.** All Subnets associations and ingress or egress rules will be left as they are at the time of removal. You can resume managing them via the AWS Console.
+
+## Argument Reference
+
+The following arguments are required:
+
+* `default_network_acl_id` - (Required) Network ACL ID to manage. This attribute is exported from `aws_vpc`, or manually found via the AWS Console.
+
+The following arguments are optional:
+
+* `egress` - (Optional) Configuration block for an egress rule. Detailed below.
+* `ingress` - (Optional) Configuration block for an ingress rule. Detailed below.
+* `subnet_ids` - (Optional) List of Subnet IDs to apply the ACL to. See the notes below on managing Subnets in the Default Network ACL
+* `tags` - (Optional) Map of tags to assign to the resource.
+
+### egress and ingress
+
+Both the `egress` and `ingress` configuration blocks have the same arguments.
+
+The following arguments are required:
+
+* `action` - (Required) The action to take.
+* `from_port` - (Required) The from port to match.
+* `protocol` - (Required) The protocol to match. If using the -1 'all' protocol, you must specify a from and to port of 0.
+* `rule_no` - (Required) The rule number. Used for ordering.
+* `to_port` - (Required) The to port to match.
+
+The following arguments are optional:
+
+* `cidr_block` - (Optional) The CIDR block to match. This must be a valid network mask.
+* `icmp_code` - (Optional) The ICMP type code to be used. Default 0.
+* `icmp_type` - (Optional) The ICMP type to be used. Default 0.
+* `ipv6_cidr_block` - (Optional) The IPv6 CIDR block.
+
+-> For more information on ICMP types and codes, see [Internet Control Message Protocol (ICMP) Parameters](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml).
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the Default Network ACL
-* `arn` - The ARN of the Default Network ACL
-* `vpc_id` -  The ID of the associated VPC
-* `ingress` - Set of ingress rules
-* `egress` - Set of egress rules
-* `subnet_ids` – IDs of associated Subnets
-* `owner_id` - The ID of the AWS account that owns the Default Network ACL
+* `arn` - ARN of the Default Network ACL
+* `id` - ID of the Default Network ACL
+* `owner_id` - ID of the AWS account that owns the Default Network ACL
+* `vpc_id` -  ID of the associated VPC
 
 [aws-network-acls]: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ACLs.html
 

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -45,13 +45,13 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = aws_vpc.mainvpc.default_network_acl_id
+  default_network_acl_id = aws_default_vpc.mainvpc.default_network_acl_id
 
   ingress {
     protocol   = -1
     rule_no    = 100
     action     = "allow"
-    cidr_block = aws_vpc.mainvpc.cidr_block
+    cidr_block = aws_default_vpc.mainvpc.cidr_block
     from_port  = 0
     to_port    = 0
   }
@@ -78,13 +78,13 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = aws_vpc.mainvpc.default_network_acl_id
+  default_network_acl_id = aws_default_vpc.mainvpc.default_network_acl_id
 
   ingress {
     protocol   = -1
     rule_no    = 100
     action     = "allow"
-    cidr_block = aws_vpc.mainvpc.cidr_block
+    cidr_block = aws_default_vpc.mainvpc.cidr_block
     from_port  = 0
     to_port    = 0
   }
@@ -103,7 +103,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = aws_vpc.mainvpc.default_network_acl_id
+  default_network_acl_id = aws_default_vpc.mainvpc.default_network_acl_id
 
   # no rules defined, deny all traffic in this ACL
 }

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -44,7 +44,7 @@ a conflict of rule settings and will overwrite routes.
 
 ```hcl
 resource "aws_default_route_table" "r" {
-  default_route_table_id = aws_vpc.foo.default_route_table_id
+  default_route_table_id = aws_default_vpc.foo.default_route_table_id
 
   route {
     # ...

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -3,48 +3,24 @@ subcategory: "VPC"
 layout: "aws"
 page_title: "AWS: aws_default_route_table"
 description: |-
-  Provides a resource to manage a Default VPC Routing Table.
+  Provides a resource to manage a default route table of a VPC.
 ---
 
 # Resource: aws_default_route_table
 
-Provides a resource to manage a Default VPC Routing Table.
+Provides a resource to manage a default route table of a VPC. This resource can manage the default route table of the default or a non-default VPC.
 
-Each VPC created in AWS comes with a Default Route Table that can be managed, but not
-destroyed. **This is an advanced resource**, and has special caveats to be aware
-of when using it. Please read this document in its entirety before using this
-resource. It is recommended you **do not** use both `aws_default_route_table` to
-manage the default route table **and** use the `aws_main_route_table_association`,
-due to possible conflict in routes.
+~> **NOTE:** This is an advanced resource with special caveats. Please read this document in its entirety before using this resource. The `aws_default_route_table` resource behaves differently from normal resources. Terraform does not _create_ this resource but instead attempts to "adopt" it into management. **Do not** use both `aws_default_route_table` to manage a default route table **and** `aws_main_route_table_association` with the same VPC due to possible route conflicts.
 
-The `aws_default_route_table` behaves differently from normal resources, in that
-Terraform does not _create_ this resource, but instead attempts to "adopt" it
-into management. We can do this because each VPC created has a Default Route
-Table that cannot be destroyed, and is created with a single route.
+Every VPC has a default route table that can be managed but not destroyed. When Terraform first adopts a default route table, it **immediately removes all defined routes**. It then proceeds to create any routes specified in the configuration. This step is required so that only the routes specified in the configuration exist in the default route table.
 
-When Terraform first adopts the Default Route Table, it **immediately removes all
-defined routes**. It then proceeds to create any routes specified in the
-configuration. This step is required so that only the routes specified in the
-configuration present in the Default Route Table.
+For more information, see the Amazon VPC User Guide on [Route Tables](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html). For information about managing normal route tables in Terraform, see [`aws_route_table`](/docs/providers/aws/r/route_table.html).
 
-For more information about Route Tables, see the AWS Documentation on
-[Route Tables][aws-route-tables].
-
-For more information about managing normal Route Tables in Terraform, see our
-documentation on [aws_route_table][tf-route-tables].
-
-~> **NOTE on Route Tables and Routes:** Terraform currently
-provides both a standalone [Route resource](route.html) and a Route Table resource with routes
-defined in-line. At this time you cannot use a Route Table with in-line routes
-in conjunction with any Route resources. Doing so will cause
-a conflict of rule settings and will overwrite routes.
-
-
-## Example usage with tags
+## Example Usage
 
 ```hcl
 resource "aws_default_route_table" "r" {
-  default_route_table_id = aws_default_vpc.foo.default_route_table_id
+  default_route_table_id = aws_vpc.foo.default_route_table_id
 
   route {
     # ...
@@ -58,15 +34,19 @@ resource "aws_default_route_table" "r" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `default_route_table_id` - (Required) The ID of the Default Routing Table.
-* `route` - (Optional) A list of route objects. Their keys are documented below.
-  This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
-* `tags` - (Optional) A map of tags to assign to the resource.
-* `propagating_vgws` - (Optional) A list of virtual gateways for propagation.
+* `default_route_table_id` - (Required) ID of the default route table.
 
-### route Argument Reference
+The following arguments are optional:
+
+* `propagating_vgws` - (Optional) List of virtual gateways for propagation.
+* `route` - (Optional) Configuration block of routes. Detailed below.
+* `tags` - (Optional) Map of tags to assign to the resource.
+
+### route
+
+This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
 
 One of the following destination arguments must be supplied:
 
@@ -90,12 +70,13 @@ Note that the default route, mapping the VPC's CIDR block to "local", is created
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the routing table
-* `owner_id` - The ID of the AWS account that owns the route table
+* `id` - ID of the route table.
+* `owner_id` - ID of the AWS account that owns the route table.
+* `vpc_id` - ID of the VPC.
 
 ## Import
 
-Default VPC Routing tables can be imported using the `vpc_id`, e.g.
+Default VPC route tables can be imported using the `vpc_id`, e.g.
 
 ```
 $ terraform import aws_default_route_table.example vpc-33cc44dd

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -149,3 +149,11 @@ In addition to all arguments above, the following attributes are exported:
 * `description` - The description of the security group
 
 [aws-default-security-groups]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#default-security-group
+
+## Import
+
+Security Groups can be imported using the `security group id`, e.g.
+
+```
+$ terraform import aws_default_security_group.default_sg sg-903004f8
+```

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -3,42 +3,26 @@ subcategory: "VPC"
 layout: "aws"
 page_title: "AWS: aws_default_security_group"
 description: |-
-  Manage the default Security Group resource.
+  Manage a default security group resource.
 ---
 
 # Resource: aws_default_security_group
 
-Provides a resource to manage the default AWS Security Group.
+Provides a resource to manage a default security group. This resource can manage the default security group of the default or a non-default VPC.
 
-For EC2 Classic accounts, each region comes with a Default Security Group.
-Additionally, each VPC created in AWS comes with a Default Security Group that can be managed, but not
-destroyed. **This is an advanced resource**, and has special caveats to be aware
-of when using it. Please read this document in its entirety before using this
-resource.
+~> **NOTE:** This is an advanced resource with special caveats. Please read this document in its entirety before using this resource. The `aws_default_security_group` resource behaves differently from normal resources. Terraform does not _create_ this resource but instead attempts to "adopt" it into management.
 
-The `aws_default_security_group` behaves differently from normal resources, in that
-Terraform does not _create_ this resource, but instead "adopts" it
-into management. We can do this because these default security groups cannot be
-destroyed, and are created with a known set of default ingress/egress rules.
+For EC2 Classic accounts, each region comes with a default security group. Additionally, each VPC created in AWS comes with a default security group that can be managed but not destroyed.
 
-When Terraform first adopts the Default Security Group, it **immediately removes all
-ingress and egress rules in the Security Group**. It then proceeds to create any rules specified in the
-configuration. This step is required so that only the rules specified in the
-configuration are created.
+When Terraform first adopts the default security group, it **immediately removes all ingress and egress rules in the Security Group**. It then creates any rules specified in the configuration. This way only the rules specified in the configuration are created.
 
-This resource treats its inline rules as absolute; only the rules defined
-inline are created, and any additions/removals external to this resource will
-result in diff shown. For these reasons, this resource is incompatible with the
-`aws_security_group_rule` resource.
+This resource treats its inline rules as absolute; only the rules defined inline are created, and any additions/removals external to this resource will result in diff shown. For these reasons, this resource is incompatible with the `aws_security_group_rule` resource.
 
-For more information about Default Security Groups, see the AWS Documentation on
-[Default Security Groups][aws-default-security-groups].
+For more information about default security groups, see the AWS documentation on [Default Security Groups][aws-default-security-groups]. To manage normal security groups, see the [`aws_security_group`](/docs/providers/aws/r/security_group.html) resource.
 
-## Basic Example Usage, with default rules
+## Example Usage
 
-The following config gives the Default Security Group the same rules that AWS
-provides by default, but pulls the resource under management by Terraform. This means that
-any ingress or egress rules added or changed will be detected as drift.
+The following config gives the default security group the same rules that AWS provides by default but under management by Terraform. This means that any ingress or egress rules added or changed will be detected as drift.
 
 ```hcl
 resource "aws_vpc" "mainvpc" {
@@ -46,7 +30,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = aws_default_vpc.mainvpc.id
+  vpc_id = aws_vpc.mainvpc.id
 
   ingress {
     protocol  = -1
@@ -64,10 +48,9 @@ resource "aws_default_security_group" "default" {
 }
 ```
 
-## Example config to deny all Egress traffic, allowing Ingress
+### Example Config To Deny All Egress Traffic, Allowing Ingress
 
-The following denies all Egress traffic by omitting any `egress` rules, while
-including the default `ingress` rule to allow all traffic.
+The following denies all Egress traffic by omitting any `egress` rules, while including the default `ingress` rule to allow all traffic.
 
 ```hcl
 resource "aws_vpc" "mainvpc" {
@@ -75,7 +58,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = aws_default_vpc.mainvpc.id
+  vpc_id = aws_vpc.mainvpc.id
 
   ingress {
     protocol  = -1
@@ -86,67 +69,42 @@ resource "aws_default_security_group" "default" {
 }
 ```
 
+### Removing `aws_default_security_group` From Your Configuration
+
+Removing this resource from your configuration will remove it from your statefile and management, but will not destroy the Security Group. All ingress or egress rules will be left as they are at the time of removal. You can resume managing them via the AWS Console.
+
 ## Argument Reference
 
-The arguments of an `aws_default_security_group` differ slightly from `aws_security_group`
-resources. Namely, the `name` argument is computed, and the `name_prefix` attribute
-removed. The following arguments are still supported:
+The following arguments are optional:
 
-* `ingress` - (Optional) Can be specified multiple times for each ingress rule. Each ingress block supports fields documented [below](#ingress-blocks).
-* `egress` - (Optional, VPC only) Can be specified multiple times for each egress rule. Each egress block supports fields documented [below](#egress-blocks).
-* `vpc_id` - (Optional, Forces new resource) The VPC ID. **Note that changing the `vpc_id` will _not_ restore any default security group rules that were modified, added, or removed.** It will be left in its current state
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `egress` - (Optional, VPC only) Configuration block. Detailed below.
+* `ingress` - (Optional) Configuration block. Detailed below.
+* `tags` - (Optional) Map of tags to assign to the resource.
+* `vpc_id` - (Optional, Forces new resource) VPC ID. **Note that changing the `vpc_id` will _not_ restore any default security group rules that were modified, added, or removed.** It will be left in its current state.
 
-### `ingress` Block
+### egress and ingress
 
-* `cidr_blocks` - (Optional) List of CIDR blocks.
-* `description` - (Optional) Description of this ingress rule.
-* `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp" or "icmpv6")
-* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
-* `prefix_list_ids` - (Optional) List of prefix list IDs.
-* `protocol` - (Required) The protocol. If you select a protocol of "-1" (semantically equivalent to `"all"`, which is not a valid value here), you must specify a "from_port" and "to_port" equal to 0. If not icmp, icmpv6, tcp, udp, or "-1" use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
-* `security_groups` - (Optional) List of security group Group Names if using EC2-Classic, or Group IDs if using a VPC.
-* `self` - (Optional) If true, the security group itself will be added as a source to this ingress rule.
-* `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
-
-### `egress` Block
+Both the `egress` and `ingress` configuration blocks have the same arguments.
 
 * `cidr_blocks` - (Optional) List of CIDR blocks.
-* `description` - (Optional) Description of this egress rule.
-* `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp")
+* `description` - (Optional) Description of this rule.
+* `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp`)
 * `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
 * `prefix_list_ids` - (Optional) List of prefix list IDs (for allowing access to VPC endpoints)
-* `protocol` - (Required) The protocol. If you select a protocol of "-1" (semantically equivalent to `"all"`, which is not a valid value here), you must specify a "from_port" and "to_port" equal to 0. If not icmp, tcp, udp, or "-1" use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
+* `protocol` - (Required) Protocol. If you select a protocol of "-1" (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to `0`. If not `icmp`, `tcp`, `udp`, or `-1` use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
 * `security_groups` - (Optional) List of security group Group Names if using EC2-Classic, or Group IDs if using a VPC.
-* `self` - (Optional) If true, the security group itself will be added as a source to this egress rule.
-* `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
-
-
-## Usage
-
-With the exceptions mentioned above, `aws_default_security_group` should
-identical behavior to `aws_security_group`. Please consult [AWS_SECURITY_GROUP](/docs/providers/aws/r/security_group.html)
-for further usage documentation.
-
-### Removing `aws_default_security_group` from your configuration
-
-Each AWS VPC (or region, if using EC2 Classic) comes with a Default Security
-Group that cannot be deleted. The `aws_default_security_group` allows you to
-manage this Security Group, but Terraform cannot destroy it. Removing this resource
-from your configuration will remove it from your statefile and management, but
-will not destroy the Security Group. All ingress or egress rules will be left as
-they are at the time of removal. You can resume managing them via the AWS Console.
+* `self` - (Optional) Whether the security group itself will be added as a source to this egress rule.
+* `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the security group
-* `arn` - The ARN of the security group
-* `vpc_id` - The VPC ID.
-* `owner_id` - The owner ID.
-* `name` - The name of the security group
-* `description` - The description of the security group
+* `arn` - ARN of the security group.
+* `description` - Description of the security group.
+* `id` - ID of the security group.
+* `name` - Name of the security group.
+* `owner_id` - Owner ID.
 
 [aws-default-security-groups]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#default-security-group
 

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -46,7 +46,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = aws_vpc.mainvpc.id
+  vpc_id = aws_default_vpc.mainvpc.id
 
   ingress {
     protocol  = -1
@@ -75,7 +75,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = aws_vpc.mainvpc.id
+  vpc_id = aws_default_vpc.mainvpc.id
 
   ingress {
     protocol  = -1

--- a/website/docs/r/default_subnet.html.markdown
+++ b/website/docs/r/default_subnet.html.markdown
@@ -60,3 +60,11 @@ In addition to all arguments above, the following attributes are exported:
 * `ipv6_association_id` - The association ID for the IPv6 CIDR block.
 * `ipv6_cidr_block` - The IPv6 CIDR block.
 * `owner_id` - The ID of the AWS account that owns the subnet.
+
+## Import
+
+Subnets can be imported using the `subnet id`, e.g.
+
+```
+$ terraform import aws_default_subnet.public_subnet subnet-9d4a7b6c
+```

--- a/website/docs/r/default_subnet.html.markdown
+++ b/website/docs/r/default_subnet.html.markdown
@@ -8,16 +8,13 @@ description: |-
 
 # Resource: aws_default_subnet
 
-Provides a resource to manage a [default AWS VPC subnet](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html#default-vpc-basics)
-in the current region.
+Provides a resource to manage a [default AWS VPC subnet](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html#default-vpc-basics) in the current region.
 
-The `aws_default_subnet` behaves differently from normal resources, in that
-Terraform does not _create_ this resource, but instead "adopts" it
-into management.
+The `aws_default_subnet` behaves differently from normal resources, in that Terraform does not _create_ this resource but instead "adopts" it into management.
+
+The `aws_default_subnet` resource allows you to manage a region's default VPC subnet but Terraform cannot destroy it. Removing this resource from your configuration will remove it from your statefile and Terraform management.
 
 ## Example Usage
-
-Basic usage with tags:
 
 ```hcl
 resource "aws_default_subnet" "default_az1" {
@@ -31,35 +28,28 @@ resource "aws_default_subnet" "default_az1" {
 
 ## Argument Reference
 
-The arguments of an `aws_default_subnet` differ from `aws_subnet` resources.
-Namely, the `availability_zone` argument is required and the `availability_zone_id`, `vpc_id`, `cidr_block`, `ipv6_cidr_block`,
-and `assign_ipv6_address_on_creation` arguments are computed.
-The following arguments are still supported:
+The following argument is required:
 
-* `map_public_ip_on_launch` -  (Optional) Specify true to indicate
-    that instances launched into the subnet should be assigned
-    a public IP address.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `availability_zone`- (Required) AZ for the subnet.
 
-### Removing `aws_default_subnet` from your configuration
+The following arguments are optional:
 
-The `aws_default_subnet` resource allows you to manage a region's default VPC subnet,
-but Terraform cannot destroy it. Removing this resource from your configuration
-will remove it from your statefile and management, but will not destroy the subnet.
-You can resume managing the subnet via the AWS Console.
+* `map_public_ip_on_launch` - (Optional) Whether instances launched into the subnet should be assigned a public IP address.
+* `tags` - (Optional) Map of tags to assign to the resource.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the subnet
-* `availability_zone`- The AZ for the subnet.
-* `availability_zone_id`- The AZ ID of the subnet.
-* `cidr_block` - The CIDR block for the subnet.
-* `vpc_id` - The VPC ID.
-* `ipv6_association_id` - The association ID for the IPv6 CIDR block.
-* `ipv6_cidr_block` - The IPv6 CIDR block.
-* `owner_id` - The ID of the AWS account that owns the subnet.
+* `arn` - ARN for the subnet.
+* `assign_ipv6_address_on_creation` - Whether IPv6 addresses are assigned on creation.
+* `availability_zone_id`- AZ ID of the subnet.
+* `cidr_block` - CIDR block for the subnet.
+* `id` - ID of the subnet
+* `ipv6_association_id` - Association ID for the IPv6 CIDR block.
+* `ipv6_cidr_block` - IPv6 CIDR block.
+* `owner_id` - ID of the AWS account that owns the subnet.
+* `vpc_id` - VPC ID.
 
 ## Import
 

--- a/website/docs/r/default_vpc_dhcp_options.html.markdown
+++ b/website/docs/r/default_vpc_dhcp_options.html.markdown
@@ -55,3 +55,11 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the DHCP Options Set.
 * `arn` - The ARN of the DHCP Options Set.
 * `owner_id` - The ID of the AWS account that owns the DHCP options set.
+
+## Import
+
+VPC DHCP Options can be imported using the `dhcp options id`, e.g.
+
+```
+$ terraform import aws_default_vpc_dhcp_options.default_options dopt-d9070ebb
+```


### PR DESCRIPTION
Hi there,

Added some usage for `terraform import` in aws_default_XXX.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
