### PR TITLE
14324 - Fix kafka_versions being a required field

### DIFF
--- a/.changelog/17571.txt
+++ b/.changelog/17571.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_msk_configuration: `kafka_versions` argument is optional
+```

--- a/aws/resource_aws_msk_configuration.go
+++ b/aws/resource_aws_msk_configuration.go
@@ -32,7 +32,7 @@ func resourceAwsMskConfiguration() *schema.Resource {
 			},
 			"kafka_versions": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -59,13 +59,16 @@ func resourceAwsMskConfigurationCreate(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).kafkaconn
 
 	input := &kafka.CreateConfigurationInput{
-		KafkaVersions:    expandStringSet(d.Get("kafka_versions").(*schema.Set)),
 		Name:             aws.String(d.Get("name").(string)),
 		ServerProperties: []byte(d.Get("server_properties").(string)),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kafka_versions"); ok {
+		input.KafkaVersions = expandStringSet(v.(*schema.Set))
 	}
 
 	output, err := conn.CreateConfiguration(input)

--- a/aws/resource_aws_msk_configuration.go
+++ b/aws/resource_aws_msk_configuration.go
@@ -67,7 +67,7 @@ func resourceAwsMskConfigurationCreate(d *schema.ResourceData, meta interface{})
 		input.Description = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("kafka_versions"); ok {
+	if v, ok := d.GetOk("kafka_versions"); ok && v.(*schema.Set).Len() > 0 {
 		input.KafkaVersions = expandStringSet(v.(*schema.Set))
 	}
 

--- a/aws/resource_aws_msk_configuration_test.go
+++ b/aws/resource_aws_msk_configuration_test.go
@@ -91,7 +91,6 @@ func TestAccAWSMskConfiguration_basic(t *testing.T) {
 					testAccCheckMskConfigurationExists(resourceName, &configuration1),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "kafka", regexp.MustCompile(`configuration/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "kafka_versions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "1"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestMatchResourceAttr(resourceName, "server_properties", regexp.MustCompile(`auto.create.topics.enable = true`)),
@@ -286,7 +285,6 @@ func testAccCheckMskConfigurationExists(resourceName string, configuration *kafk
 func testAccMskConfigurationConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
-  kafka_versions = ["2.1.0"]
   name           = %[1]q
 
   server_properties = <<PROPERTIES
@@ -301,7 +299,6 @@ func testAccMskConfigurationConfigDescription(rName, description string) string 
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
   description    = %[2]q
-  kafka_versions = ["2.1.0"]
   name           = %[1]q
 
   server_properties = <<PROPERTIES
@@ -327,7 +324,6 @@ PROPERTIES
 func testAccMskConfigurationConfigServerProperties(rName string, serverProperty string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
-  kafka_versions = ["2.1.0"]
   name           = %[1]q
 
   server_properties = <<PROPERTIES

--- a/aws/resource_aws_msk_configuration_test.go
+++ b/aws/resource_aws_msk_configuration_test.go
@@ -91,6 +91,7 @@ func TestAccAWSMskConfiguration_basic(t *testing.T) {
 					testAccCheckMskConfigurationExists(resourceName, &configuration1),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "kafka", regexp.MustCompile(`configuration/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "kafka_versions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "1"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestMatchResourceAttr(resourceName, "server_properties", regexp.MustCompile(`auto.create.topics.enable = true`)),
@@ -176,6 +177,8 @@ func TestAccAWSMskConfiguration_KafkaVersions(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMskConfigurationExists(resourceName, &configuration1),
 					resource.TestCheckResourceAttr(resourceName, "kafka_versions.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "kafka_versions.*", "2.6.0"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "kafka_versions.*", "2.7.0"),
 				),
 			},
 			{
@@ -311,7 +314,7 @@ PROPERTIES
 func testAccMskConfigurationConfigKafkaVersions(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
-  kafka_versions = ["1.1.1", "2.1.0"]
+  kafka_versions = ["2.6.0", "2.7.0"]
   name           = %[1]q
 
   server_properties = <<PROPERTIES

--- a/aws/resource_aws_msk_configuration_test.go
+++ b/aws/resource_aws_msk_configuration_test.go
@@ -285,7 +285,7 @@ func testAccCheckMskConfigurationExists(resourceName string, configuration *kafk
 func testAccMskConfigurationConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
-  name           = %[1]q
+  name = %[1]q
 
   server_properties = <<PROPERTIES
 auto.create.topics.enable = true
@@ -298,8 +298,8 @@ PROPERTIES
 func testAccMskConfigurationConfigDescription(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
-  description    = %[2]q
-  name           = %[1]q
+  description = %[2]q
+  name        = %[1]q
 
   server_properties = <<PROPERTIES
 auto.create.topics.enable = true
@@ -324,7 +324,7 @@ PROPERTIES
 func testAccMskConfigurationConfigServerProperties(rName string, serverProperty string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
-  name           = %[1]q
+  name = %[1]q
 
   server_properties = <<PROPERTIES
 %[2]s

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -420,8 +420,6 @@ github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/S
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320/go.mod h1:EiZBMaudVLy8fmjf9Npq1dq9RalhveqZG5w/yz3mHWs=
 github.com/hashicorp/go-getter v1.4.0/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
 github.com/hashicorp/go-getter v1.5.0/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
-github.com/hashicorp/go-getter v1.5.1 h1:lM9sM02nvEApQGFgkXxWbhfqtyN+AyhQmi+MaMdBDOI=
-github.com/hashicorp/go-getter v1.5.1/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-getter v1.5.2 h1:XDo8LiAcDisiqZdv0TKgz+HtX3WN7zA2JD1R1tjsabE=
 github.com/hashicorp/go-getter v1.5.2/go.mod h1:orNH3BTYLu/fIxGIdLjLoAJHWMDQ/UKQr5O4m3iBuoo=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -420,6 +420,8 @@ github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/S
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320/go.mod h1:EiZBMaudVLy8fmjf9Npq1dq9RalhveqZG5w/yz3mHWs=
 github.com/hashicorp/go-getter v1.4.0/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
 github.com/hashicorp/go-getter v1.5.0/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
+github.com/hashicorp/go-getter v1.5.1 h1:lM9sM02nvEApQGFgkXxWbhfqtyN+AyhQmi+MaMdBDOI=
+github.com/hashicorp/go-getter v1.5.1/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-getter v1.5.2 h1:XDo8LiAcDisiqZdv0TKgz+HtX3WN7zA2JD1R1tjsabE=
 github.com/hashicorp/go-getter v1.5.2/go.mod h1:orNH3BTYLu/fIxGIdLjLoAJHWMDQ/UKQr5O4m3iBuoo=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14324

Output from acceptance testing:
```
make testacc TESTARGS='-run=TestAccAWSMskConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMskConfiguration -timeout 120m
=== RUN   TestAccAWSMskConfigurationDataSource_Name
=== PAUSE TestAccAWSMskConfigurationDataSource_Name
=== RUN   TestAccAWSMskConfiguration_basic
=== PAUSE TestAccAWSMskConfiguration_basic
=== RUN   TestAccAWSMskConfiguration_disappears
=== PAUSE TestAccAWSMskConfiguration_disappears
=== RUN   TestAccAWSMskConfiguration_Description
=== PAUSE TestAccAWSMskConfiguration_Description
=== RUN   TestAccAWSMskConfiguration_KafkaVersions
=== PAUSE TestAccAWSMskConfiguration_KafkaVersions
=== RUN   TestAccAWSMskConfiguration_ServerProperties
=== PAUSE TestAccAWSMskConfiguration_ServerProperties
=== CONT  TestAccAWSMskConfigurationDataSource_Name
=== CONT  TestAccAWSMskConfiguration_KafkaVersions
=== CONT  TestAccAWSMskConfiguration_ServerProperties
=== CONT  TestAccAWSMskConfiguration_disappears
=== CONT  TestAccAWSMskConfiguration_Description
=== CONT  TestAccAWSMskConfiguration_basic
--- PASS: TestAccAWSMskConfiguration_KafkaVersions (42.42s)
--- PASS: TestAccAWSMskConfigurationDataSource_Name (42.77s)
--- PASS: TestAccAWSMskConfiguration_disappears (50.25s)
--- PASS: TestAccAWSMskConfiguration_basic (50.45s)
--- PASS: TestAccAWSMskConfiguration_Description (54.28s)
--- PASS: TestAccAWSMskConfiguration_ServerProperties (76.16s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       76.265s
```