### PR TITLE
Ensure example resource lifecycle waiter code compiles

### DIFF
--- a/docs/contributing/retries-and-waiters.md
+++ b/docs/contributing/retries-and-waiters.md
@@ -359,7 +359,7 @@ function ExampleThingUpdate(d *schema.ResourceData, meta interface{}) error {
 	d.HasChange("attribute") {
 		// ... AWS Go SDK logic to update attribute ...
 
-		if err := waiter.ThingAttributeUpdated(conn, d.Id(), d.Get("attribute").(string)); err != nil {
+		if _, err := waiter.ThingAttributeUpdated(conn, d.Id(), d.Get("attribute").(string)); err != nil {
 			return fmt.Errorf("error waiting for Example Thing (%s) attribute update: %w", d.Id(), err)
 		}
 	}
@@ -466,7 +466,7 @@ func ThingDeleted(conn *example.Example, id string) (*example.Thing, error) {
 function ExampleThingCreate(d *schema.ResourceData, meta interface{}) error {
 	// ... AWS Go SDK logic to create resource ...
 
-	if err := waiter.ThingCreated(conn, d.Id()); err != nil {
+	if _, err := waiter.ThingCreated(conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for Example Thing (%s) creation: %w", d.Id(), err)
 	}
 
@@ -476,7 +476,7 @@ function ExampleThingCreate(d *schema.ResourceData, meta interface{}) error {
 function ExampleThingDelete(d *schema.ResourceData, meta interface{}) error {
 	// ... AWS Go SDK logic to delete resource ...
 
-	if err := waiter.ThingDeleted(conn, d.Id()); err != nil {
+	if _, err := waiter.ThingDeleted(conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for Example Thing (%s) deletion: %w", d.Id(), err)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Resource lifecycle waiters return 2 values, `*example.Thing` and `error`. Ensure that the calling code samples reflect this and compile after copy-and-paste.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```
