### PR TITLE
data_source/aws_outposts_outpost and aws_outposts_outposts: add argument for owner_id

### DIFF
--- a/.changelog/17585.txt
+++ b/.changelog/17585.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_outposts_outpost: `owner_id` is now an optional argument 
+```
+
+```release-note:enhancement
+data-source/aws_outposts_outposts: Add `owner_id` argument
+```

--- a/aws/data_source_aws_outposts_outpost.go
+++ b/aws/data_source_aws_outposts_outpost.go
@@ -43,6 +43,7 @@ func dataSourceAwsOutpostsOutpost() *schema.Resource {
 			},
 			"owner_id": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 			"site_id": {
@@ -79,6 +80,10 @@ func dataSourceAwsOutpostsOutpostRead(d *schema.ResourceData, meta interface{}) 
 			}
 
 			if v, ok := d.GetOk("arn"); ok && v.(string) != aws.StringValue(outpost.OutpostArn) {
+				continue
+			}
+
+			if v, ok := d.GetOk("owner_id"); ok && v.(string) != aws.StringValue(outpost.OwnerId) {
 				continue
 			}
 

--- a/aws/data_source_aws_outposts_outpost_test.go
+++ b/aws/data_source_aws_outposts_outpost_test.go
@@ -20,13 +20,13 @@ func TestAccAWSOutpostsOutpostDataSource_Id(t *testing.T) {
 			{
 				Config: testAccAWSOutpostsOutpostDataSourceConfigId(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccMatchResourceAttrRegionalARN(dataSourceName, "arn", "outposts", regexp.MustCompile(`outpost/op-.+$`)),
+					testAccCheckResourceAttrRegionalARNIgnoreRegionAndAccount(dataSourceName, "arn", "outposts", regexp.MustCompile(`outpost/op-.+$`).String()),
 					resource.TestMatchResourceAttr(dataSourceName, "availability_zone", regexp.MustCompile(`^.+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "availability_zone_id", regexp.MustCompile(`^.+$`)),
 					resource.TestCheckResourceAttrSet(dataSourceName, "description"),
 					resource.TestMatchResourceAttr(dataSourceName, "id", regexp.MustCompile(`^op-.+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "name", regexp.MustCompile(`^.+$`)),
-					testAccCheckResourceAttrAccountID(dataSourceName, "owner_id"),
+					testAccMatchResourceAttrAccountID(dataSourceName, "owner_id"),
 				),
 			},
 		},
@@ -85,6 +85,31 @@ func TestAccAWSOutpostsOutpostDataSource_Arn(t *testing.T) {
 	})
 }
 
+func TestAccAWSOutpostsOutpostDataSource_OwnerId(t *testing.T) {
+	sourceDataSourceName := "data.aws_outposts_outpost.source"
+	dataSourceName := "data.aws_outposts_outpost.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSOutpostsOutpostDataSourceConfigOwnerId(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", sourceDataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone", sourceDataSourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_id", sourceDataSourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", sourceDataSourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", sourceDataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", sourceDataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "owner_id", sourceDataSourceName, "owner_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSOutpostsOutpostDataSourceConfigId() string {
 	return `
 data "aws_outposts_outposts" "test" {}
@@ -119,6 +144,20 @@ data "aws_outposts_outpost" "source" {
 
 data "aws_outposts_outpost" "test" {
   arn = data.aws_outposts_outpost.source.arn
+}
+`
+}
+
+func testAccAWSOutpostsOutpostDataSourceConfigOwnerId() string {
+	return `
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "source" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+data "aws_outposts_outpost" "test" {
+  owner_id = data.aws_outposts_outpost.source.owner_id
 }
 `
 }

--- a/aws/data_source_aws_outposts_outpost_test.go
+++ b/aws/data_source_aws_outposts_outpost_test.go
@@ -91,6 +91,7 @@ func TestAccAWSOutpostsOutpostDataSource_OwnerId(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, outposts.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{

--- a/aws/data_source_aws_outposts_outposts.go
+++ b/aws/data_source_aws_outposts_outposts.go
@@ -38,6 +38,11 @@ func dataSourceAwsOutpostsOutposts() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -68,6 +73,10 @@ func dataSourceAwsOutpostsOutpostsRead(d *schema.ResourceData, meta interface{})
 			}
 
 			if v, ok := d.GetOk("site_id"); ok && v.(string) != aws.StringValue(outpost.SiteId) {
+				continue
+			}
+
+			if v, ok := d.GetOk("owner_id"); ok && v.(string) != aws.StringValue(outpost.OwnerId) {
 				continue
 			}
 

--- a/website/docs/d/outposts_outpost.html.markdown
+++ b/website/docs/d/outposts_outpost.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 * `id` - (Optional) Identifier of the Outpost.
 * `name` - (Optional) Name of the Outpost.
 * `arn` - (Optional) Amazon Resource Name (ARN).
+* `owner_id` - (Optional) AWS Account identifier of the Outpost owner.
 
 ## Attribute Reference
 
@@ -33,5 +34,4 @@ In addition to all arguments above, the following attributes are exported:
 * `availability_zone` - Availability Zone name.
 * `availability_zone_id` - Availability Zone identifier.
 * `description` - Description.
-* `owner_id` - AWS Account identifier of the Outpost owner.
 * `site_id` - Site identifier.

--- a/website/docs/d/outposts_outposts.html.markdown
+++ b/website/docs/d/outposts_outposts.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 * `availability_zone` - (Optional) Availability Zone name.
 * `availability_zone_id` - (Optional) Availability Zone identifier.
 * `site_id` - (Optional) Site identifier.
+* `owner_id` - (Optional) AWS Account identifier of the Outpost owner.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17517

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
enhancement:

data_source/aws_outposts_outpost: Add support for `owner_id` argument

data_source/aws_outposts_outposts: Add support for `owner_id` argument
```

### Affected Resource(s)
- data_source: aws_outposts_outpost
- data_source: aws_outposts_outposts

### Terraform Configuration
```HCL
data "aws_outposts_outpost" "foo" {
  owner_id = "123456789012"
}

data "aws_outposts_outposts" "foo" {
  owner_id = "123456789012"
}

```
Output from acceptance testing for data_source/aws_outposts_outpost:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSOutpostsOutpostDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSOutpostsOutpostDataSource -timeout 120m
=== RUN   TestAccAWSOutpostsOutpostDataSource_Id
=== PAUSE TestAccAWSOutpostsOutpostDataSource_Id
=== RUN   TestAccAWSOutpostsOutpostDataSource_Name
=== PAUSE TestAccAWSOutpostsOutpostDataSource_Name
=== RUN   TestAccAWSOutpostsOutpostDataSource_Arn
=== PAUSE TestAccAWSOutpostsOutpostDataSource_Arn
=== RUN   TestAccAWSOutpostsOutpostDataSource_OwnerId
=== PAUSE TestAccAWSOutpostsOutpostDataSource_OwnerId
=== CONT  TestAccAWSOutpostsOutpostDataSource_Id
=== CONT  TestAccAWSOutpostsOutpostDataSource_OwnerId
=== CONT  TestAccAWSOutpostsOutpostDataSource_Arn
=== CONT  TestAccAWSOutpostsOutpostDataSource_Name
--- PASS: TestAccAWSOutpostsOutpostDataSource_Id (99.88s)
--- PASS: TestAccAWSOutpostsOutpostDataSource_Arn (100.06s)
--- PASS: TestAccAWSOutpostsOutpostDataSource_Name (102.92s)
--- PASS: TestAccAWSOutpostsOutpostDataSource_OwnerId (110.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       112.209s

...
```

Output from acceptance testing for data_source/aws_outposts_outposts:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSOutpostsOutpostsDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSOutpostsOutpostsDataSource -timeout 120m
=== RUN   TestAccAWSOutpostsOutpostsDataSource_basic
=== PAUSE TestAccAWSOutpostsOutpostsDataSource_basic
=== CONT  TestAccAWSOutpostsOutpostsDataSource_basic
--- PASS: TestAccAWSOutpostsOutpostsDataSource_basic (58.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       59.618s

...
```
