### PR TITLE
r/ses_configuration_set - add reputation  and sending options 

### DIFF
--- a/.changelog/17608.txt
+++ b/.changelog/17608.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ses_configuration_set: Adds `reputation_metrics_enabled` and `sending_enabled` arguments and `last_fresh_start` attribute
+```

--- a/aws/resource_aws_ses_configuration_set.go
+++ b/aws/resource_aws_ses_configuration_set.go
@@ -215,11 +215,17 @@ func resourceAwsSesConfigurationSetDelete(d *schema.ResourceData, meta interface
 	conn := meta.(*AWSClient).sesconn
 
 	log.Printf("[DEBUG] SES Delete Configuration Rule Set: %s", d.Id())
-	_, err := conn.DeleteConfigurationSet(&ses.DeleteConfigurationSetInput{
+	input := &ses.DeleteConfigurationSetInput{
 		ConfigurationSetName: aws.String(d.Id()),
-	})
+	}
 
-	return err
+	if _, err := conn.DeleteConfigurationSet(input); err != nil {
+		if !isAWSErr(err, ses.ErrCodeConfigurationSetDoesNotExistException, "") {
+			return fmt.Errorf("error deleting SES Configuration Set (%s): %w", d.Id(), err)
+		}
+	}
+
+	return nil
 }
 
 func expandSesConfigurationSetDeliveryOptions(l []interface{}) *ses.DeliveryOptions {

--- a/aws/resource_aws_ses_configuration_set.go
+++ b/aws/resource_aws_ses_configuration_set.go
@@ -108,7 +108,7 @@ func resourceAwsSesConfigurationSetCreate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	if v := d.Get("sending_enabled"); v.(bool) == false {
+	if v := d.Get("sending_enabled"); !v.(bool) {
 		input := &ses.UpdateConfigurationSetSendingEnabledInput{
 			ConfigurationSetName: aws.String(configurationSetName),
 			Enabled:              aws.Bool(v.(bool)),

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -156,6 +156,7 @@ func TestAccAWSSESConfigurationSet_reputationMetricsEnabled(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
 		},
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESConfigurationSetDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -89,13 +89,100 @@ func TestAccAWSSESConfigurationSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "sending_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "last_fresh_start", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_fresh_start"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSESConfigurationSet_sendingEnabled(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ses_configuration_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESConfigurationSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSESConfigurationSetSendingConfig(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESConfigurationSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sending_enabled", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_fresh_start"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSESConfigurationSetSendingConfig(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESConfigurationSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sending_enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_fresh_start"),
+				),
+			},
+			{
+				Config: testAccAWSSESConfigurationSetSendingConfig(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESConfigurationSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sending_enabled", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_fresh_start"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSESConfigurationSet_reputationMetricsEnabled(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ses_configuration_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESConfigurationSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSESConfigurationSetReputationMetricsConfig(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESConfigurationSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSESConfigurationSetReputationMetricsConfig(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESConfigurationSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccAWSSESConfigurationSetReputationMetricsConfig(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESConfigurationSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "true"),
+				),
 			},
 		},
 	})
@@ -348,6 +435,24 @@ resource "aws_ses_configuration_set" "test" {
   name = %[1]q
 }
 `, rName)
+}
+
+func testAccAWSSESConfigurationSetSendingConfig(rName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_ses_configuration_set" "test" {
+  name            = %[1]q
+  sending_enabled = %[2]t
+}
+`, rName, enabled)
+}
+
+func testAccAWSSESConfigurationSetReputationMetricsConfig(rName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_ses_configuration_set" "test" {
+  name                       = %[1]q
+  reputation_metrics_enabled = %[2]t
+}
+`, rName, enabled)
 }
 
 func testAccAWSSESConfigurationSetDeliveryOptionsConfig(rName, tlsPolicy string) string {

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -110,6 +110,7 @@ func TestAccAWSSESConfigurationSet_sendingEnabled(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
 		},
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESConfigurationSetDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -87,6 +87,9 @@ func TestAccAWSSESConfigurationSet_basic(t *testing.T) {
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", ses.ServiceName, fmt.Sprintf("configuration-set/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sending_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "last_fresh_start", ""),
 				),
 			},
 			{

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -162,7 +162,7 @@ func TestAccAWSSESConfigurationSet_reputationMetricsEnabled(t *testing.T) {
 				Config: testAccAWSSESConfigurationSetReputationMetricsConfig(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESConfigurationSetExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "false"),
 				),
 			},
 			{
@@ -174,14 +174,14 @@ func TestAccAWSSESConfigurationSet_reputationMetricsEnabled(t *testing.T) {
 				Config: testAccAWSSESConfigurationSetReputationMetricsConfig(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESConfigurationSetExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "true"),
 				),
 			},
 			{
 				Config: testAccAWSSESConfigurationSetReputationMetricsConfig(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESConfigurationSetExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "reputation_metrics_enabled", "false"),
 				),
 			},
 		},

--- a/website/docs/r/ses_configuration_set.html.markdown
+++ b/website/docs/r/ses_configuration_set.html.markdown
@@ -39,6 +39,8 @@ The following argument is required:
 The following argument is optional:
 
 * `delivery_options` - (Optional) Configuration block. Detailed below.
+* `reputation_metrics_enabled` - (Optional) Whether or not Amazon SES publishes reputation metrics for the configuration set, such as bounce and complaint rates, to Amazon CloudWatch. The default value is `false`.
+* `sending_enabled` - (Optional) Whether email sending is enabled or disabled for the configuration set. The default value is `true`.
 
 ### delivery_options
 
@@ -50,6 +52,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - SES configuration set ARN.
 * `id` - SES configuration set name.
+* `last_fresh_start` - The date and time at which the reputation metrics for the configuration set were last reset. Resetting these metrics is known as a fresh start.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11747

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=-run=TestAccAWSSESConfigurationSet_'
--- PASS: TestAccAWSSESConfigurationSet_disappears (29.86s)
--- PASS: TestAccAWSSESConfigurationSet_emptyDeliveryOptions (39.73s)
--- PASS: TestAccAWSSESConfigurationSet_basic (40.14s)
--- PASS: TestAccAWSSESConfigurationSet_deliveryOptions (41.44s)
--- PASS: TestAccAWSSESConfigurationSet_sendingEnabled (86.97s)
--- PASS: TestAccAWSSESConfigurationSet_reputationMetricsEnabled (89.50s)
--- PASS: TestAccAWSSESConfigurationSet_update_emptyDeliveryOptions (90.77s)
--- PASS: TestAccAWSSESConfigurationSet_update_deliveryOptions (116.87s)
```
