### PR TITLE
r/ses_receipt_rule_set - add `arn` attribute

### DIFF
--- a/.changelog/17611.txt
+++ b/.changelog/17611.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/ses_receipt_rule_set: Add `arn` attribute
+```
+
+```release-note:enhancement
+resource/ses_receipt_rule_set: Add `plan time validation to `name`
+```

--- a/.changelog/17611.txt
+++ b/.changelog/17611.txt
@@ -3,5 +3,5 @@ resource/ses_receipt_rule_set: Add `arn` attribute
 ```
 
 ```release-note:enhancement
-resource/ses_receipt_rule_set: Add `plan time validation to `name`
+resource/ses_receipt_rule_set: Add plan time validation to `name`
 ```

--- a/aws/resource_aws_ses_receipt_rule_set.go
+++ b/aws/resource_aws_ses_receipt_rule_set.go
@@ -46,7 +46,7 @@ func resourceAwsSesReceiptRuleSetCreate(d *schema.ResourceData, meta interface{}
 
 	_, err := conn.CreateReceiptRuleSet(createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating SES rule set: %w", err)
+		return fmt.Errorf("error creating SES rule set: %w", err)
 	}
 
 	d.SetId(ruleSetName)

--- a/aws/resource_aws_ses_receipt_rule_set.go
+++ b/aws/resource_aws_ses_receipt_rule_set.go
@@ -5,8 +5,10 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsSesReceiptRuleSet() *schema.Resource {
@@ -19,10 +21,15 @@ func resourceAwsSesReceiptRuleSet() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"rule_set_name": {
+			"arn": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Computed: true,
+			},
+			"rule_set_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
 			},
 		},
 	}
@@ -39,7 +46,7 @@ func resourceAwsSesReceiptRuleSetCreate(d *schema.ResourceData, meta interface{}
 
 	_, err := conn.CreateReceiptRuleSet(createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating SES rule set: %s", err)
+		return fmt.Errorf("Error creating SES rule set: %w", err)
 	}
 
 	d.SetId(ruleSetName)
@@ -54,7 +61,7 @@ func resourceAwsSesReceiptRuleSetRead(d *schema.ResourceData, meta interface{}) 
 		RuleSetName: aws.String(d.Id()),
 	}
 
-	_, err := conn.DescribeReceiptRuleSet(input)
+	resp, err := conn.DescribeReceiptRuleSet(input)
 
 	if isAWSErr(err, ses.ErrCodeRuleSetDoesNotExistException, "") {
 		log.Printf("[WARN] SES Receipt Rule Set (%s) not found, removing from state", d.Id())
@@ -63,10 +70,25 @@ func resourceAwsSesReceiptRuleSetRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if err != nil {
-		return fmt.Errorf("error describing SES Receipt Rule Set (%s): %s", d.Id(), err)
+		return fmt.Errorf("error describing SES Receipt Rule Set (%s): %w", d.Id(), err)
 	}
 
-	d.Set("rule_set_name", d.Id())
+	if resp.Metadata == nil {
+		log.Print("[WARN] No Receipt Rule Set found")
+		d.SetId("")
+		return nil
+	}
+
+	name := aws.StringValue(resp.Metadata.Name)
+	d.Set("rule_set_name", name)
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ses",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("receipt-rule-set/%s", name),
+	}.String()
+	d.Set("arn", arn)
 
 	return nil
 }
@@ -75,9 +97,12 @@ func resourceAwsSesReceiptRuleSetDelete(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).sesconn
 
 	log.Printf("[DEBUG] SES Delete Receipt Rule Set: %s", d.Id())
-	_, err := conn.DeleteReceiptRuleSet(&ses.DeleteReceiptRuleSetInput{
+	input := &ses.DeleteReceiptRuleSetInput{
 		RuleSetName: aws.String(d.Id()),
-	})
+	}
+	if _, err := conn.DeleteReceiptRuleSet(input); err != nil {
+		return fmt.Errorf("error deleting SES Receipt Rule Set (%s): %w", d.Id(), err)
+	}
 
-	return err
+	return nil
 }

--- a/aws/resource_aws_ses_receipt_rule_set_test.go
+++ b/aws/resource_aws_ses_receipt_rule_set_test.go
@@ -94,6 +94,7 @@ func TestAccAWSSESReceiptRuleSet_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESReceiptRuleSetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "rule_set_name", rName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("receipt-rule-set/%s", rName)),
 				),
 			},
 			{

--- a/website/docs/r/ses_receipt_rule_set.html.markdown
+++ b/website/docs/r/ses_receipt_rule_set.html.markdown
@@ -24,6 +24,13 @@ The following arguments are supported:
 
 * `rule_set_name` - (Required) The name of the rule set
 
+## Attributes Reference
+
+In addition to the arguments, which are exported, the following attributes are exported:
+
+* `id` - The SES receipt rule set name.
+* `arn` - The SES receipt rule set ARN.
+
 ## Import
 
 SES receipt rule sets can be imported using the rule set name.

--- a/website/docs/r/ses_receipt_rule_set.html.markdown
+++ b/website/docs/r/ses_receipt_rule_set.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_ses_receipt_rule_set
 
-Provides an SES receipt rule set resource
+Provides an SES receipt rule set resource.
 
 ## Example Usage
 
@@ -22,14 +22,14 @@ resource "aws_ses_receipt_rule_set" "main" {
 
 The following arguments are supported:
 
-* `rule_set_name` - (Required) The name of the rule set
+* `rule_set_name` - (Required) Name of the rule set.
 
 ## Attributes Reference
 
 In addition to the arguments, which are exported, the following attributes are exported:
 
-* `id` - The SES receipt rule set name.
-* `arn` - The SES receipt rule set ARN.
+* `arn` - SES receipt rule set ARN.
+* `id` - SES receipt rule set name.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSESReceiptRuleSet_'
--- PASS: TestAccAWSSESReceiptRuleSet_disappears (27.97s)
--- PASS: TestAccAWSSESReceiptRuleSet_basic (38.07s)
```
