### PR TITLE
fix(aws_ses_reciept_rule): include period in name validation regex

### DIFF
--- a/.changelog/17627.txt
+++ b/.changelog/17627.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ses_receipt_rule: Fix name validation regex to include `.` (period)
+```

--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -37,7 +37,7 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 64),
-					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z_-]+$`), "must contain only alphanumeric, underscore, and hyphen characters"),
+					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z._-]+$`), "must contain only alphanumeric, period, underscore, and hyphen characters"),
 					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z]`), "must begin with a alphanumeric character"),
 					validation.StringMatch(regexp.MustCompile(`[0-9a-zA-Z]$`), "must end with a alphanumeric character"),
 				),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13960 (bug introduced due to mistake in official AWS docs, which has also been reported)
Closes #17602

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSESReceiptRule_'
==> Checking that code complies with gofmt requirements...TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSESReceiptRule_ -timeout 120m=== RUN   TestAccAWSSESReceiptRule_basic
=== PAUSE TestAccAWSSESReceiptRule_basic
=== RUN   TestAccAWSSESReceiptRule_s3Action
=== PAUSE TestAccAWSSESReceiptRule_s3Action
=== RUN   TestAccAWSSESReceiptRule_order
=== PAUSE TestAccAWSSESReceiptRule_order
=== RUN   TestAccAWSSESReceiptRule_actions
=== PAUSE TestAccAWSSESReceiptRule_actions
=== RUN   TestAccAWSSESReceiptRule_disappears
=== PAUSE TestAccAWSSESReceiptRule_disappears
=== CONT  TestAccAWSSESReceiptRule_basic
=== CONT  TestAccAWSSESReceiptRule_actions
=== CONT  TestAccAWSSESReceiptRule_order
=== CONT  TestAccAWSSESReceiptRule_disappears
=== CONT  TestAccAWSSESReceiptRule_s3Action
--- PASS: TestAccAWSSESReceiptRule_actions (16.47s)
--- PASS: TestAccAWSSESReceiptRule_basic (16.48s)
--- PASS: TestAccAWSSESReceiptRule_order (16.73s)
--- PASS: TestAccAWSSESReceiptRule_s3Action (19.08s)
--- PASS: TestAccAWSSESReceiptRule_disappears (22.37s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       22.477s
...
```
