### PR TITLE
r/aws_ebs_volume: Only specify throughput on update for gp3 volumes

### DIFF
--- a/.changelog/17646.txt
+++ b/.changelog/17646.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ebs_volume: Only specify throughput on update for `gp3` volumes
+```

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -182,7 +182,8 @@ func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 
 		// "If no throughput value is specified, the existing value is retained."
 		// Not currently correct, so always specify any non-zero throughput value.
-		if v := d.Get("throughput").(int); v > 0 {
+		// Throughput is valid only for gp3 volumes.
+		if v := d.Get("throughput").(int); v > 0 && d.Get("type").(string) == ec2.VolumeTypeGp3 {
 			params.Throughput = aws.Int64(int64(v))
 		}
 

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -66,12 +66,21 @@ func testSweepEbsVolumes(region string) error {
 	return nil
 }
 
+// testAccErrorCheckSkipEBSVolume skips EBS volume tests that have error messages indicating unsupported features
+func testAccErrorCheckSkipEBSVolume(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"specified zone does not support multi-attach-enabled volumes",
+		"Unsupported volume type",
+	)
+}
+
 func TestAccAWSEBSVolume_basic(t *testing.T) {
 	var v ec2.Volume
 	resourceName := "aws_ebs_volume.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -107,6 +116,7 @@ func TestAccAWSEBSVolume_updateAttachedEbsVolume(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -142,6 +152,7 @@ func TestAccAWSEBSVolume_updateSize(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -177,6 +188,7 @@ func TestAccAWSEBSVolume_updateType(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -212,6 +224,7 @@ func TestAccAWSEBSVolume_updateIops_Io1(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -247,6 +260,7 @@ func TestAccAWSEBSVolume_updateIops_Io2(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -285,6 +299,7 @@ func TestAccAWSEBSVolume_kmsKey(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -313,6 +328,7 @@ func TestAccAWSEBSVolume_NoIops(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipEBSVolume(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
@@ -337,6 +353,7 @@ func TestAccAWSEBSVolume_InvalidIopsForType(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipEBSVolume(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
@@ -352,6 +369,7 @@ func TestAccAWSEBSVolume_InvalidThroughputForType(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipEBSVolume(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
@@ -369,6 +387,7 @@ func TestAccAWSEBSVolume_withTags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -397,6 +416,7 @@ func TestAccAWSEBSVolume_multiAttach(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -425,6 +445,7 @@ func TestAccAWSEBSVolume_outpost(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -452,6 +473,7 @@ func TestAccAWSEBSVolume_gp3_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -490,6 +512,7 @@ func TestAccAWSEBSVolume_gp3_iops(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -546,6 +569,7 @@ func TestAccAWSEBSVolume_gp3_throughput(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -602,6 +626,7 @@ func TestAccAWSEBSVolume_gp3_to_gp2(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -659,6 +684,7 @@ func TestAccAWSEBSVolume_snapshotID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -698,6 +724,7 @@ func TestAccAWSEBSVolume_snapshotIDAndSize(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheckSkipEBSVolume(t),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVolumeDestroy,
@@ -735,6 +762,7 @@ func TestAccAWSEBSVolume_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipEBSVolume(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17644.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEBSVolume_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEBSVolume_ -timeout 120m
=== RUN   TestAccAWSEBSVolume_basic
=== PAUSE TestAccAWSEBSVolume_basic
=== RUN   TestAccAWSEBSVolume_updateAttachedEbsVolume
=== PAUSE TestAccAWSEBSVolume_updateAttachedEbsVolume
=== RUN   TestAccAWSEBSVolume_updateSize
=== PAUSE TestAccAWSEBSVolume_updateSize
=== RUN   TestAccAWSEBSVolume_updateType
=== PAUSE TestAccAWSEBSVolume_updateType
=== RUN   TestAccAWSEBSVolume_updateIops_Io1
=== PAUSE TestAccAWSEBSVolume_updateIops_Io1
=== RUN   TestAccAWSEBSVolume_updateIops_Io2
=== PAUSE TestAccAWSEBSVolume_updateIops_Io2
=== RUN   TestAccAWSEBSVolume_kmsKey
=== PAUSE TestAccAWSEBSVolume_kmsKey
=== RUN   TestAccAWSEBSVolume_NoIops
=== PAUSE TestAccAWSEBSVolume_NoIops
=== RUN   TestAccAWSEBSVolume_InvalidIopsForType
=== PAUSE TestAccAWSEBSVolume_InvalidIopsForType
=== RUN   TestAccAWSEBSVolume_InvalidThroughputForType
=== PAUSE TestAccAWSEBSVolume_InvalidThroughputForType
=== RUN   TestAccAWSEBSVolume_withTags
=== PAUSE TestAccAWSEBSVolume_withTags
=== RUN   TestAccAWSEBSVolume_multiAttach
=== PAUSE TestAccAWSEBSVolume_multiAttach
=== RUN   TestAccAWSEBSVolume_outpost
=== PAUSE TestAccAWSEBSVolume_outpost
=== RUN   TestAccAWSEBSVolume_gp3_basic
=== PAUSE TestAccAWSEBSVolume_gp3_basic
=== RUN   TestAccAWSEBSVolume_gp3_iops
=== PAUSE TestAccAWSEBSVolume_gp3_iops
=== RUN   TestAccAWSEBSVolume_gp3_throughput
=== PAUSE TestAccAWSEBSVolume_gp3_throughput
=== RUN   TestAccAWSEBSVolume_gp3_to_gp2
=== PAUSE TestAccAWSEBSVolume_gp3_to_gp2
=== RUN   TestAccAWSEBSVolume_snapshotID
=== PAUSE TestAccAWSEBSVolume_snapshotID
=== RUN   TestAccAWSEBSVolume_snapshotIDAndSize
=== PAUSE TestAccAWSEBSVolume_snapshotIDAndSize
=== RUN   TestAccAWSEBSVolume_disappears
=== PAUSE TestAccAWSEBSVolume_disappears
=== CONT  TestAccAWSEBSVolume_basic
=== CONT  TestAccAWSEBSVolume_disappears
=== CONT  TestAccAWSEBSVolume_snapshotIDAndSize
=== CONT  TestAccAWSEBSVolume_snapshotID
=== CONT  TestAccAWSEBSVolume_gp3_to_gp2
=== CONT  TestAccAWSEBSVolume_gp3_throughput
=== CONT  TestAccAWSEBSVolume_gp3_iops
=== CONT  TestAccAWSEBSVolume_gp3_basic
=== CONT  TestAccAWSEBSVolume_outpost
=== CONT  TestAccAWSEBSVolume_multiAttach
=== CONT  TestAccAWSEBSVolume_withTags
=== CONT  TestAccAWSEBSVolume_InvalidThroughputForType
=== CONT  TestAccAWSEBSVolume_InvalidIopsForType
=== CONT  TestAccAWSEBSVolume_NoIops
=== CONT  TestAccAWSEBSVolume_kmsKey
=== CONT  TestAccAWSEBSVolume_updateIops_Io2
=== CONT  TestAccAWSEBSVolume_updateIops_Io1
=== CONT  TestAccAWSEBSVolume_updateType
=== CONT  TestAccAWSEBSVolume_updateSize
=== CONT  TestAccAWSEBSVolume_updateAttachedEbsVolume
=== CONT  TestAccAWSEBSVolume_outpost
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSEBSVolume_outpost (1.29s)
--- PASS: TestAccAWSEBSVolume_InvalidIopsForType (25.31s)
--- PASS: TestAccAWSEBSVolume_InvalidThroughputForType (25.46s)
--- PASS: TestAccAWSEBSVolume_disappears (64.80s)
--- PASS: TestAccAWSEBSVolume_NoIops (74.88s)
--- PASS: TestAccAWSEBSVolume_basic (75.05s)
--- PASS: TestAccAWSEBSVolume_gp3_basic (81.10s)
--- PASS: TestAccAWSEBSVolume_withTags (81.35s)
--- PASS: TestAccAWSEBSVolume_multiAttach (81.90s)
--- PASS: TestAccAWSEBSVolume_kmsKey (82.81s)
--- PASS: TestAccAWSEBSVolume_snapshotID (89.43s)
--- PASS: TestAccAWSEBSVolume_snapshotIDAndSize (93.87s)
--- PASS: TestAccAWSEBSVolume_updateIops_Io1 (110.84s)
--- PASS: TestAccAWSEBSVolume_gp3_throughput (116.39s)
--- PASS: TestAccAWSEBSVolume_gp3_to_gp2 (116.82s)
--- PASS: TestAccAWSEBSVolume_updateSize (118.95s)
--- PASS: TestAccAWSEBSVolume_updateType (119.42s)
--- PASS: TestAccAWSEBSVolume_gp3_iops (119.51s)
--- PASS: TestAccAWSEBSVolume_updateIops_Io2 (119.88s)
--- PASS: TestAccAWSEBSVolume_updateAttachedEbsVolume (216.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	216.236s
```
