### PR TITLE
Modernise aws_db_instance doc example

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -40,15 +40,15 @@ about [DB Instance Class Types](https://docs.aws.amazon.com/AmazonRDS/latest/Use
 
 ```hcl
 resource "aws_db_instance" "default" {
-  allocated_storage    = 20
-  storage_type         = "gp2"
+  allocated_storage    = 10
   engine               = "mysql"
   engine_version       = "5.7"
-  instance_class       = "db.t2.micro"
+  instance_class       = "db.t3.micro"
   name                 = "mydb"
   username             = "foo"
   password             = "foobarbaz"
   parameter_group_name = "default.mysql5.7"
+  skip_final_snapshot  = true
 }
 ```
 


### PR DESCRIPTION
Make life easier for people who copy and paste this example:

* Add `skip_final_snapshot`, so it can be immediately destroyed
* Remove `storage_type` (`gp2` is the default now)
* Reduce `allocated_storage` to the minimum allowed, so the instance creates faster
* Migrate `instance_class` to t3 family

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->