### PR TITLE
r/ses_receipt_rule - add `encoding` + tests

### DIFF
--- a/.changelog/17654.txt
+++ b/.changelog/17654.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ses_receipt_rule: Add `encoding` argument to `sns_action` configuration block.
+```

--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -285,6 +285,12 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"encoding": {
+							Type:         schema.TypeString,
+							Default:      ses.SNSActionEncodingUtf8,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(ses.SNSActionEncoding_Values(), false),
+						},
 						"topic_arn": {
 							Type:         schema.TypeString,
 							Required:     true,
@@ -300,6 +306,7 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 				Set: func(v interface{}) int {
 					var buf bytes.Buffer
 					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["encoding"].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m["topic_arn"].(string)))
 					buf.WriteString(fmt.Sprintf("%d-", m["position"].(int)))
 
@@ -560,6 +567,7 @@ func resourceAwsSesReceiptRuleRead(d *schema.ResourceData, meta interface{}) err
 		if element.SNSAction != nil {
 			snsAction := map[string]interface{}{
 				"topic_arn": aws.StringValue(element.SNSAction.TopicArn),
+				"encoding":  aws.StringValue(element.SNSAction.Encoding),
 				"position":  i + 1,
 			}
 
@@ -771,6 +779,7 @@ func buildReceiptRule(d *schema.ResourceData) *ses.ReceiptRule {
 
 			snsAction := &ses.SNSAction{
 				TopicArn: aws.String(elem["topic_arn"].(string)),
+				Encoding: aws.String(elem["encoding"].(string)),
 			}
 
 			actions[elem["position"].(int)] = &ses.ReceiptAction{

--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -188,7 +188,7 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 						"invocation_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Default:      ses.InvocationTypeEvent,
 							ValidateFunc: validation.StringInSlice(ses.InvocationType_Values(), false),
 						},
 

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -651,7 +651,7 @@ resource "aws_ses_receipt_rule" "test" {
 
   lambda_action {
     function_arn = aws_lambda_function.test.arn
-  	position     = 1
+    position     = 1
   }
 
   depends_on = [aws_lambda_permission.test]
@@ -676,11 +676,11 @@ resource "aws_ses_receipt_rule" "test" {
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
-  
+
   stop_action {
-  	topic_arn = aws_sns_topic.test.arn
+    topic_arn = aws_sns_topic.test.arn
     scope     = "RuleSet"
-  	position  = 1
+    position  = 1
   }
 }
 `, rName)

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -538,7 +538,7 @@ resource "aws_ses_receipt_rule" "test" {
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
-  
+
   bounce_action {
     message         = %[1]q
     sender          = "test@example.com"
@@ -566,10 +566,10 @@ resource "aws_ses_receipt_rule" "test" {
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
-  
+
   sns_action {
-  	topic_arn = aws_sns_topic.test.arn
-  	position  = 1
+    topic_arn = aws_sns_topic.test.arn
+    position  = 1
   }
 }
 `, rName)
@@ -592,11 +592,11 @@ resource "aws_ses_receipt_rule" "test" {
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
-  
+
   sns_action {
-  	topic_arn = aws_sns_topic.test.arn
+    topic_arn = aws_sns_topic.test.arn
     encoding  = "Base64"
-  	position  = 1
+    position  = 1
   }
 }
 `, rName)

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccAWSSESReceiptRule_basic(t *testing.T) {
+	var rule ses.ReceiptRule
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_receipt_rule.test"
 
@@ -29,7 +31,7 @@ func TestAccAWSSESReceiptRule_basic(t *testing.T) {
 			{
 				Config: testAccAWSSESReceiptRuleBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptRuleExists(resourceName),
+					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "rule_set_name", rName),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("receipt-rule-set/%s:receipt-rule/%s", rName, rName)),
@@ -57,6 +59,8 @@ func TestAccAWSSESReceiptRule_basic(t *testing.T) {
 }
 
 func TestAccAWSSESReceiptRule_s3Action(t *testing.T) {
+	var rule ses.ReceiptRule
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_receipt_rule.test"
 
@@ -73,7 +77,7 @@ func TestAccAWSSESReceiptRule_s3Action(t *testing.T) {
 			{
 				Config: testAccAWSSESReceiptRuleS3ActionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptRuleExists(resourceName),
+					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "s3_action.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "s3_action.*.bucket_name", "aws_s3_bucket.test", "id"),
@@ -89,6 +93,8 @@ func TestAccAWSSESReceiptRule_s3Action(t *testing.T) {
 }
 
 func TestAccAWSSESReceiptRule_snsAction(t *testing.T) {
+	var rule ses.ReceiptRule
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_receipt_rule.test"
 
@@ -104,7 +110,7 @@ func TestAccAWSSESReceiptRule_snsAction(t *testing.T) {
 			{
 				Config: testAccAWSSESReceiptRuleSNSActionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptRuleExists(resourceName),
+					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "sns_action.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "sns_action.*.topic_arn", "aws_sns_topic.test", "arn"),
 				),
@@ -119,6 +125,8 @@ func TestAccAWSSESReceiptRule_snsAction(t *testing.T) {
 }
 
 func TestAccAWSSESReceiptRule_stopAction(t *testing.T) {
+	var rule ses.ReceiptRule
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_receipt_rule.test"
 
@@ -134,7 +142,7 @@ func TestAccAWSSESReceiptRule_stopAction(t *testing.T) {
 			{
 				Config: testAccAWSSESReceiptRuleStopActionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptRuleExists(resourceName),
+					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "stop_action.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "stop_action.*", map[string]string{
 						"scope": "RuleSet",
@@ -152,6 +160,8 @@ func TestAccAWSSESReceiptRule_stopAction(t *testing.T) {
 }
 
 func TestAccAWSSESReceiptRule_order(t *testing.T) {
+	var rule ses.ReceiptRule
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_receipt_rule.test"
 
@@ -168,7 +178,9 @@ func TestAccAWSSESReceiptRule_order(t *testing.T) {
 			{
 				Config: testAccAWSSESReceiptRuleOrderConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptRuleOrder(resourceName),
+					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "name", "second"),
+					resource.TestCheckResourceAttrPair(resourceName, "after", "aws_ses_receipt_rule.test1", "name"),
 				),
 			},
 			{
@@ -181,6 +193,8 @@ func TestAccAWSSESReceiptRule_order(t *testing.T) {
 }
 
 func TestAccAWSSESReceiptRule_actions(t *testing.T) {
+	var rule ses.ReceiptRule
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_receipt_rule.test"
 
@@ -197,7 +211,17 @@ func TestAccAWSSESReceiptRule_actions(t *testing.T) {
 			{
 				Config: testAccAWSSESReceiptRuleActionsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptRuleActions(resourceName),
+					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "add_header_action.*", map[string]string{
+						"header_name":  "Added-By",
+						"header_value": "Terraform",
+						"position":     "2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "add_header_action.*", map[string]string{
+						"header_name":  "Another-Header",
+						"header_value": "First",
+						"position":     "1",
+					}),
 				),
 			},
 			{
@@ -210,6 +234,8 @@ func TestAccAWSSESReceiptRule_actions(t *testing.T) {
 }
 
 func TestAccAWSSESReceiptRule_disappears(t *testing.T) {
+	var rule ses.ReceiptRule
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_receipt_rule.test"
 
@@ -228,7 +254,7 @@ func TestAccAWSSESReceiptRule_disappears(t *testing.T) {
 			{
 				Config: testAccAWSSESReceiptRuleBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptRuleExists(resourceName),
+					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSesReceiptRuleSet(), ruleSetResourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -236,7 +262,7 @@ func TestAccAWSSESReceiptRule_disappears(t *testing.T) {
 			{
 				Config: testAccAWSSESReceiptRuleBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptRuleExists(resourceName),
+					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSesReceiptRule(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -275,7 +301,7 @@ func testAccCheckSESReceiptRuleDestroy(s *terraform.State) error {
 
 }
 
-func testAccCheckAwsSESReceiptRuleExists(n string) resource.TestCheckFunc {
+func testAccCheckAwsSESReceiptRuleExists(n string, rule *ses.ReceiptRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -293,26 +319,12 @@ func testAccCheckAwsSESReceiptRuleExists(n string) resource.TestCheckFunc {
 			RuleSetName: aws.String(rs.Primary.Attributes["rule_set_name"]),
 		}
 
-		_, err := conn.DescribeReceiptRule(params)
+		resp, err := conn.DescribeReceiptRule(params)
 		if err != nil {
 			return err
 		}
 
-		// if !aws.BoolValue(response.Rule.Enabled) {
-		// 	return fmt.Errorf("Enabled (%v) was not set to true", *response.Rule.Enabled)
-		// }
-
-		// if !reflect.DeepEqual(response.Rule.Recipients, []*string{aws.String("test@example.com")}) {
-		// 	return fmt.Errorf("Recipients (%v) was not set to [test@example.com]", response.Rule.Recipients)
-		// }
-
-		// if !aws.BoolValue(response.Rule.ScanEnabled) {
-		// 	return fmt.Errorf("ScanEnabled (%v) was not set to true", *response.Rule.ScanEnabled)
-		// }
-
-		// if aws.StringValue(response.Rule.TlsPolicy) != ses.TlsPolicyRequire {
-		// 	return fmt.Errorf("TLS Policy (%s) was not set to Require", *response.Rule.TlsPolicy)
-		// }
+		*rule = *resp.Rule
 
 		return nil
 	}
@@ -326,95 +338,6 @@ func testAccAwsSesReceiptRuleImportStateIdFunc(resourceName string) resource.Imp
 		}
 
 		return fmt.Sprintf("%s:%s", rs.Primary.Attributes["rule_set_name"], rs.Primary.Attributes["name"]), nil
-	}
-}
-
-func testAccCheckAwsSESReceiptRuleOrder(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("SES Receipt Rule not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("SES Receipt Rule name not set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).sesconn
-
-		params := &ses.DescribeReceiptRuleSetInput{
-			RuleSetName: aws.String(rs.Primary.Attributes["rule_set_name"]),
-		}
-
-		response, err := conn.DescribeReceiptRuleSet(params)
-		if err != nil {
-			return err
-		}
-
-		if len(response.Rules) != 2 {
-			return fmt.Errorf("Number of rules (%d) was not equal to 2", len(response.Rules))
-		} else if aws.StringValue(response.Rules[0].Name) != "first" ||
-			aws.StringValue(response.Rules[1].Name) != "second" {
-			return fmt.Errorf("Order of rules (%v) was incorrect", response.Rules)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAwsSESReceiptRuleActions(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("SES Receipt Rule not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("SES Receipt Rule name not set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).sesconn
-
-		params := &ses.DescribeReceiptRuleInput{
-			RuleName:    aws.String(rs.Primary.Attributes["name"]),
-			RuleSetName: aws.String(rs.Primary.Attributes["rule_set_name"]),
-		}
-
-		response, err := conn.DescribeReceiptRule(params)
-		if err != nil {
-			return err
-		}
-
-		actions := response.Rule.Actions
-
-		if len(actions) != 3 {
-			return fmt.Errorf("Number of rules (%d) was not equal to 3", len(actions))
-		}
-
-		addHeaderAction := actions[0].AddHeaderAction
-		if aws.StringValue(addHeaderAction.HeaderName) != "Another-Header" {
-			return fmt.Errorf("Header Name (%s) was not equal to Another-Header", *addHeaderAction.HeaderName)
-		}
-
-		if aws.StringValue(addHeaderAction.HeaderValue) != "First" {
-			return fmt.Errorf("Header Value (%s) was not equal to First", *addHeaderAction.HeaderValue)
-		}
-
-		secondAddHeaderAction := actions[1].AddHeaderAction
-		if aws.StringValue(secondAddHeaderAction.HeaderName) != "Added-By" {
-			return fmt.Errorf("Header Name (%s) was not equal to Added-By", *secondAddHeaderAction.HeaderName)
-		}
-
-		if aws.StringValue(secondAddHeaderAction.HeaderValue) != "Terraform" {
-			return fmt.Errorf("Header Value (%s) was not equal to Terraform", *secondAddHeaderAction.HeaderValue)
-		}
-
-		stopAction := actions[2].StopAction
-		if aws.StringValue(stopAction.Scope) != ses.StopScopeRuleSet {
-			return fmt.Errorf("Scope (%s) was not equal to RuleSet", *stopAction.Scope)
-		}
-
-		return nil
 	}
 }
 

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -107,6 +107,7 @@ func TestAccAWSSESReceiptRule_snsAction(t *testing.T) {
 			testAccPreCheckAWSSES(t)
 			testAccPreCheckSESReceiptRule(t)
 		},
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
 		Steps: []resource.TestStep{
@@ -143,6 +144,7 @@ func TestAccAWSSESReceiptRule_snsActionEncoding(t *testing.T) {
 			testAccPreCheckAWSSES(t)
 			testAccPreCheckSESReceiptRule(t)
 		},
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
 		Steps: []resource.TestStep{
@@ -179,6 +181,7 @@ func TestAccAWSSESReceiptRule_lambdaAction(t *testing.T) {
 			testAccPreCheckAWSSES(t)
 			testAccPreCheckSESReceiptRule(t)
 		},
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
 		Steps: []resource.TestStep{
@@ -215,6 +218,7 @@ func TestAccAWSSESReceiptRule_stopAction(t *testing.T) {
 			testAccPreCheckAWSSES(t)
 			testAccPreCheckSESReceiptRule(t)
 		},
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -95,43 +95,6 @@ func TestAccAWSSESReceiptRule_s3Action(t *testing.T) {
 	})
 }
 
-func TestAccAWSSESReceiptRule_bounceAction(t *testing.T) {
-	var rule ses.ReceiptRule
-
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_ses_receipt_rule.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckAWSSES(t)
-			testAccPreCheckSESReceiptRule(t)
-		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSESReceiptRuleBounceActionConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
-					resource.TestCheckResourceAttr(resourceName, "bounce_action.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "bounce_action.*", map[string]string{
-						"message":         rName,
-						"sender":          "test@example.com",
-						"smtp_reply_code": "2yz",
-						"position":        "1",
-					}),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccAwsSesReceiptRuleImportStateIdFunc(resourceName),
-			},
-		},
-	})
-}
-
 func TestAccAWSSESReceiptRule_snsAction(t *testing.T) {
 	var rule ses.ReceiptRule
 
@@ -520,30 +483,6 @@ resource "aws_ses_receipt_rule" "test" {
   s3_action {
     bucket_name = aws_s3_bucket.test.id
     position    = 1
-  }
-}
-`, rName)
-}
-
-func testAccAWSSESReceiptRuleBounceActionConfig(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_ses_receipt_rule_set" "test" {
-  rule_set_name = %[1]q
-}
-
-resource "aws_ses_receipt_rule" "test" {
-  name          = %[1]q
-  rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
-  recipients    = ["test@example.com"]
-  enabled       = true
-  scan_enabled  = true
-  tls_policy    = "Require"
-
-  bounce_action {
-    message         = %[1]q
-    sender          = "test@example.com"
-    smtp_reply_code = "2yz"
-    position        = 1
   }
 }
 `, rName)

--- a/website/docs/r/ses_receipt_rule.html.markdown
+++ b/website/docs/r/ses_receipt_rule.html.markdown
@@ -87,6 +87,7 @@ SNS actions support the following:
 
 * `topic_arn` - (Required) The ARN of an SNS topic to notify
 * `position` - (Required) The position of the action in the receipt rule
+* `encoding` - (Optional) The encoding to use for the email within the Amazon SNS notification. Default value is `UTF-8`.
 
 Stop actions support the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10855
Closes #8605

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSESReceiptRule_'
--- PASS: TestAccAWSSESReceiptRule_stopAction (188.97s)
--- PASS: TestAccAWSSESReceiptRule_basic (229.48s)
--- PASS: TestAccAWSSESReceiptRule_snsAction (267.54s)
--- PASS: TestAccAWSSESReceiptRule_snsActionEncoding (273.15s)
--- PASS: TestAccAWSSESReceiptRule_order (370.68s)
--- PASS: TestAccAWSSESReceiptRule_disappears (391.07s)
--- PASS: TestAccAWSSESReceiptRule_actions (415.14s)
--- PASS: TestAccAWSSESReceiptRule_lambdaAction (454.19s)
--- PASS: TestAccAWSSESReceiptRule_s3Action (548.22s)
```
