### PR TITLE
[WIP] Remove Artificial limit on service registries

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -327,7 +327,6 @@ func resourceAwsEcsService() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"container_name": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
ECS documentation accepts a list of service_registry objects with no specification in the docs that it is limited to a single entry. This may have been a bug when the support was first added based on comments on that [PR](https://github.com/hashicorp/terraform-provider-aws/pull/3906). Seems better to allow AWS to return an error if there is a problem rather than artificially limiting it in the provider.

[Docs on Service Definition](https://docs.aws.amazon.com/AmazonECS/latest/userguide/service_definition_parameters.html)
[Docs on Create Service API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html#ECS-CreateService-request-serviceRegistries)

Closes: #9573

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEcsService_withServiceRegistries'
run=TestAccAWSEcsService_withServiceRegistries'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEcsService_withServiceRegistries -timeout 120m
=== RUN   TestAccAWSEcsService_withServiceRegistries
=== PAUSE TestAccAWSEcsService_withServiceRegistries
=== RUN   TestAccAWSEcsService_withServiceRegistries_container
=== PAUSE TestAccAWSEcsService_withServiceRegistries_container
=== CONT  TestAccAWSEcsService_withServiceRegistries
=== CONT  TestAccAWSEcsService_withServiceRegistries_container
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (167.89s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (178.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       178.195s...
```
