### PR TITLE
Update provider development docs to include development overrides

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -56,7 +56,7 @@ $ make testacc
 
 With Terraform v0.14 and later, [development overrides for provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers) can be leveraged in order to use the provider built from source.
 
-To do this, populate a Terraform CLI configuration file can be created (in `~/.terraformrc` for all platforms other than Windows; in `terraform.rc` in the `%APPDATA%` directory when using Windows) with at least the following options:
+To do this, populate a Terraform CLI configuration file (`~/.terraformrc` for all platforms other than Windows; `terraform.rc` in the `%APPDATA%` directory when using Windows) with at least the following options:
 
 ```
 provider_installation {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -58,7 +58,7 @@ With Terraform v0.14 and later, [development overrides for provider developers](
 
 To do this, populate a Terraform CLI configuration file (`~/.terraformrc` for all platforms other than Windows; `terraform.rc` in the `%APPDATA%` directory when using Windows) with at least the following options:
 
-```
+```hcl
 provider_installation {
   dev_overrides {
     "hashicorp/aws" = "[REPLACE WITH GOPATH]/bin"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -54,7 +54,7 @@ $ make testacc
 
 ## Using the Provider
 
-With Terraform v0.14 and later, the [development overrides for provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers) can be leveraged in order to use the provider built from source. 
+With Terraform v0.14 and later, [development overrides for provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers) can be leveraged in order to use the provider built from source.
 
 To do this, populate a Terraform CLI configuration file can be created (in `~/.terraformrc` for all platforms other than Windows; in `terraform.rc` in the `%APPDATA%` directory when using Windows) with at least the following options:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -51,3 +51,18 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 ```sh
 $ make testacc
 ```
+
+## Using the Provider
+
+With Terraform v0.14 and later, the [development overrides for provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers) can be leveraged in order to use the provider built from source. 
+
+To do this, populate a Terraform CLI configuration file can be created (in `~/.terraformrc` for all platforms other than Windows; in `terraform.rc` in the `%APPDATA%` directory when using Windows) with at least the following options:
+
+```
+provider_installation {
+  dev_overrides {
+    "hashicorp/aws" = "[REPLACE WITH GOPATH]/bin/terraform-provider-aws"
+  }
+  direct {}
+}
+```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -61,7 +61,7 @@ To do this, populate a Terraform CLI configuration file can be created (in `~/.t
 ```
 provider_installation {
   dev_overrides {
-    "hashicorp/aws" = "[REPLACE WITH GOPATH]/bin/terraform-provider-aws"
+    "hashicorp/aws" = "[REPLACE WITH GOPATH]/bin"
   }
   direct {}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Documentation Updates for Provider Development

1. Document use of [development overrides for provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers) for using the Terraform Provider for AWS which was built from source.