### PR TITLE
resource/aws_imagebuilder_image_pipeline: Testing and documentation updates for schedule_expression API change

### DIFF
--- a/aws/resource_aws_imagebuilder_image_pipeline_test.go
+++ b/aws/resource_aws_imagebuilder_image_pipeline_test.go
@@ -415,11 +415,11 @@ func TestAccAwsImageBuilderImagePipeline_Schedule_ScheduleExpression(t *testing.
 		CheckDestroy: testAccCheckAwsImageBuilderImagePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsImageBuilderImagePipelineConfigScheduleScheduleExpression(rName, "cron(1 0 * * *)"),
+				Config: testAccAwsImageBuilderImagePipelineConfigScheduleScheduleExpression(rName, "cron(1 0 * * ? *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsImageBuilderImagePipelineExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "schedule.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_expression", "cron(1 0 * * *)"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_expression", "cron(1 0 * * ? *)"),
 				),
 			},
 			{
@@ -428,11 +428,11 @@ func TestAccAwsImageBuilderImagePipeline_Schedule_ScheduleExpression(t *testing.
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAwsImageBuilderImagePipelineConfigScheduleScheduleExpression(rName, "cron(2 0 * * *)"),
+				Config: testAccAwsImageBuilderImagePipelineConfigScheduleScheduleExpression(rName, "cron(2 0 * * ? *)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsImageBuilderImagePipelineExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "schedule.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_expression", "cron(2 0 * * *)"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_expression", "cron(2 0 * * ? *)"),
 				),
 			},
 		},
@@ -808,7 +808,7 @@ resource "aws_imagebuilder_image_pipeline" "test" {
 
   schedule {
     pipeline_execution_start_condition = %[2]q
-    schedule_expression                = "cron(0 0 * * *)"
+    schedule_expression                = "cron(0 0 * * ? *)"
   }
 }
 `, rName, pipelineExecutionStartCondition))

--- a/website/docs/r/imagebuilder_image_pipeline.html.markdown
+++ b/website/docs/r/imagebuilder_image_pipeline.html.markdown
@@ -19,7 +19,7 @@ resource "aws_imagebuilder_image_pipeline" "example" {
   name                             = "example"
 
   schedule {
-    schedule_expression = "cron(0 0 * * *)"
+    schedule_expression = "cron(0 0 * * ? *)"
   }
 }
 ```
@@ -53,7 +53,7 @@ The following arguments are optional:
 
 The following arguments are required:
 
-* `schedule_expression` - (Required) Cron expression of how often the pipeline start condition is evaluated. For example, `cron(0 0 * * *)` is evaluated every day at midnight UTC.
+* `schedule_expression` - (Required) Cron expression of how often the pipeline start condition is evaluated. For example, `cron(0 0 * * ? *)` is evaluated every day at midnight UTC. Configurations using the five field syntax that was previously accepted by the API, such as `cron(0 0 * * *)`, must be updated to the six field syntax. For more information, see the [Image Builder User Guide](https://docs.aws.amazon.com/imagebuilder/latest/userguide/cron-expressions.html).
 
 The following arguments are optional:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17396
Closes #17665

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAwsImageBuilderImagePipeline_Schedule_PipelineExecutionStartCondition (40.77s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Schedule_ScheduleExpression (42.15s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAwsImageBuilderImagePipeline_Schedule_ScheduleExpression (52.66s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Schedule_PipelineExecutionStartCondition (53.89s)
```
