### PR TITLE
tests/aws_config_configuration_aggregator: update organization and switch tests

### DIFF
--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -93,7 +93,7 @@ func TestAccAWSConfigConfigurationAggregator_organization(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_config_configuration_aggregator.example"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSConfigConfigurationAggregatorDestroy,
@@ -122,7 +122,7 @@ func TestAccAWSConfigConfigurationAggregator_switch(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_config_configuration_aggregator.example"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSConfigConfigurationAggregatorDestroy,
@@ -279,10 +279,12 @@ data "aws_caller_identity" "current" {
 
 func testAccAWSConfigConfigurationAggregatorConfig_organization(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_organizations_organization" "test" {}
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = ["config.${data.aws_partition.current.dns_suffix}"]
+}
 
 resource "aws_config_configuration_aggregator" "example" {
-  depends_on = [aws_iam_role_policy_attachment.example]
+  depends_on = [aws_iam_role_policy_attachment.example, aws_organizations_organization.test]
 
   name = %[1]q
 

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -105,7 +105,7 @@ func TestAccAWSConfigConfigurationAggregator_organization(t *testing.T) {
 					testAccCheckAWSConfigConfigurationAggregatorName(resourceName, rName, &ca),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "organization_aggregation_source.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "organization_aggregation_source.0.role_arn", "aws_iam_role.r", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "organization_aggregation_source.0.role_arn", "aws_iam_role.example", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "organization_aggregation_source.0.all_regions", "true"),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17670 

### Notes
* also switched the `organization` and `switch` tests from being run with `ParallelTest` since we can only have at most 1 organization created at a time; often resulting in one of the two tests erroring with: `Error: Error creating organization: AlreadyInOrganizationException: The AWS account is already a member of an organization.`

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSConfigConfigurationAggregator_account (12.45s)
--- PASS: TestAccAWSConfigConfigurationAggregator_organization (18.02s)
--- PASS: TestAccAWSConfigConfigurationAggregator_tags (31.44s)
--- PASS: TestAccAWSConfigConfigurationAggregator_switch (23.60s)
```
