### PR TITLE
Fix sfn logging_configuration example

### DIFF
--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -88,7 +88,7 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
 EOF
 
   logging_configuration {
-    log_destination        = aws_cloudwatch_log_group.log_group_for_sfn.arn
+    log_destination        = "${aws_cloudwatch_log_group.log_group_for_sfn.arn}:*"
     include_execution_data = true
     level                  = "ERROR"
   }
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 ### `logging_configuration` Configuration Block
 
-* `log_destination` - (Optional) Amazon Resource Name (ARN) of CloudWatch log group. Make sure the State Machine does have the right IAM Policies for Logging.
+* `log_destination` - (Optional) Amazon Resource Name (ARN) of CloudWatch log group. Make sure the State Machine does have the right IAM Policies for Logging. Log Group ARN must be provided with '*' qualifier.
 * `include_execution_data` - (Optional) Determines whether execution data is included in your log. When set to FALSE, data is excluded.
 * `level` - (Optional) Defines which category of execution history events are logged. Valid Values: ALL | ERROR | FATAL | OFF
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 ### `logging_configuration` Configuration Block
 
-* `log_destination` - (Optional) Amazon Resource Name (ARN) of CloudWatch log group. Make sure the State Machine does have the right IAM Policies for Logging. Log Group ARN must be provided with '*' qualifier.
+* `log_destination` - (Optional) Amazon Resource Name (ARN) of CloudWatch log group. Make sure the State Machine does have the right IAM Policies for Logging. The ARN must end with `:*`
 * `include_execution_data` - (Optional) Determines whether execution data is included in your log. When set to FALSE, data is excluded.
 * `level` - (Optional) Defines which category of execution history events are logged. Valid Values: ALL | ERROR | FATAL | OFF
 


### PR DESCRIPTION
`terraform apply` throws following error when `*` is not used with LogGroup ARN.
```
Error: InvalidLoggingConfiguration: Invalid Logging Configuration: Log Group ARN must be provided with '*' qualifier.
```
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Fixes #17682 
