### PR TITLE
tests/provider: Temporarily disable darwin/arm64 builds for CI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,8 @@ builds:
     ignore:
       - goarch: '386'
         goos: darwin
+      - goarch: arm64
+        goos: darwin
     ldflags:
       - -s -w -X version.ProviderVersion={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/goreleaser/goreleaser/releases/tag/v0.156.2
Reference: https://github.com/goreleaser/goreleaser/pull/2069
Reference: https://github.com/hashicorp/terraform-provider-aws/pull/17655

This will likely be removed immediately after today's release and is just to prevent extraneous CI failures in the meantime.

Output from acceptance testing: N/A (CI configuration)