### PR TITLE
r/aws_backup_plan: 'advanced_backup_setting.backup_options' and 'advanced_backup_setting.resource_type' are both Required

### DIFF
--- a/.changelog/17692.txt
+++ b/.changelog/17692.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_backup_plan: `backup_options` and `resource_type` attributes in `advanced_backup_setting` configuration block are both required
+```

--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -126,12 +126,12 @@ func resourceAwsBackupPlan() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"backup_options": {
 							Type:     schema.TypeMap,
-							Optional: true,
+							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"resource_type": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"EC2",
 							}, false),
@@ -339,6 +339,12 @@ func expandBackupPlanAdvancedBackupSettings(vAdvancedBackupSettings *schema.Set)
 		}
 		if v, ok := mAdvancedBackupSetting["resource_type"].(string); ok && v != "" {
 			advancedBackupSetting.ResourceType = aws.String(v)
+		}
+
+		// https://github.com/hashicorp/terraform-plugin-sdk/issues/588
+		// Map in Set may add empty element. Ignore it.
+		if advancedBackupSetting.ResourceType == nil {
+			continue
 		}
 
 		advancedBackupSettings = append(advancedBackupSettings, advancedBackupSetting)

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -67,8 +67,8 @@ For **copy_action** the following attributes are supported:
 ### Advanced Backup Setting Arguments
 For `advanced_backup_setting` the following attibutes are supported:
 
-* `backup_options` - (Optional) Specifies the backup option for a selected resource. This option is only available for Windows VSS backup jobs. Set to `{ WindowsVSS = "enabled" }` to enable Windows VSS backup option and create a VSS Windows backup.
-* `resource_type` - (Optional) The type of AWS resource to be backed up. For VSS Windows backups, the only supported resource type is Amazon EC2. Valid values: `EC2`.
+* `backup_options` - (Required) Specifies the backup option for a selected resource. This option is only available for Windows VSS backup jobs. Set to `{ WindowsVSS = "enabled" }` to enable Windows VSS backup option and create a VSS Windows backup.
+* `resource_type` - (Required) The type of AWS resource to be backed up. For VSS Windows backups, the only supported resource type is Amazon EC2. Valid values: `EC2`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17667.
Relates: https://github.com/hashicorp/terraform-plugin-sdk/issues/588.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsBackupPlan_AdvancedBackupSetting'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsBackupPlan_AdvancedBackupSetting -timeout 120m
=== RUN   TestAccAwsBackupPlan_AdvancedBackupSetting
=== PAUSE TestAccAwsBackupPlan_AdvancedBackupSetting
=== CONT  TestAccAwsBackupPlan_AdvancedBackupSetting
--- PASS: TestAccAwsBackupPlan_AdvancedBackupSetting (27.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.930s
```
