### PR TITLE
No update of associate_public_ip_address in a stopped state.

### DIFF
--- a/.changelog/17693.txt
+++ b/.changelog/17693.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Stopped instances retain associate_public_ip_address setting
+```

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -883,7 +883,11 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("source_dest_check", primaryNetworkInterface.SourceDestCheck)
 		}
 
-		d.Set("associate_public_ip_address", primaryNetworkInterface.Association != nil)
+		if aws.StringValue(instance.State.Name) != ec2.InstanceStateNameStopped {
+			d.Set("associate_public_ip_address", primaryNetworkInterface.Association != nil)
+		} else {
+			log.Printf("[INFO] Cannot determine associate_public_ip_address in stopped state")
+		}
 
 		for _, address := range primaryNetworkInterface.PrivateIpAddresses {
 			if !aws.BoolValue(address.Primary) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #761
Closes #10047

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (70.08s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (75.87s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (75.99s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (80.44s)
--- PASS: TestAccAWSInstanceDataSource_blockDeviceTags (90.36s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (91.33s)
--- PASS: TestAccAWSInstanceDataSource_tags (99.35s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (99.91s)
--- PASS: TestAccAWSInstanceDataSource_basic (101.21s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (103.32s)
--- PASS: TestAccAWSInstance_rootInstanceStore (105.63s)
--- PASS: TestAccAWSInstanceDataSource_gp3ThroughputDevice (106.16s)
--- PASS: TestAccAWSInstanceDataSource_VPC (106.44s)
--- PASS: TestAccAWSInstanceDataSource_enclaveOptions (107.92s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (109.12s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (109.61s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (148.48s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (159.58s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (323.02s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (65.77s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (107.33s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (104.28s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (176.57s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (101.47s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (72.04s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (346.39s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (181.54s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType (12.58s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (13.54s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidThroughputForVolumeType (13.94s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (71.85s)
--- PASS: TestAccAWSInstance_disappears (73.36s)
--- PASS: TestAccAWSInstance_GP3RootBlockDevice (79.50s)
--- PASS: TestAccAWSInstance_blockDevices (79.50s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (81.34s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (91.62s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (105.18s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (106.54s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (115.04s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1 (117.52s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyThroughput_Gp3 (117.66s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (117.73s)
--- PASS: TestAccAWSInstance_Empty_PrivateIP (120.17s)
--- PASS: TestAccAWSInstance_blockDeviceTags_ebsAndRoot (120.96s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (131.82s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2 (131.85s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (136.01s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (145.99s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (146.49s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (150.69s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (164.58s)
--- PASS: TestAccAWSInstance_blockDeviceTags_withAttachedVolume (165.05s)
--- PASS: TestAccAWSInstance_blockDeviceTags_volumeTags (169.04s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (187.43s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (200.04s)
--- PASS: TestAccAWSInstance_basic (200.32s)
--- PASS: TestAccAWSInstance_hibernation (200.49s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (97.65s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (148.21s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate (91.28s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs (321.41s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs (323.21s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (180.67s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate (144.79s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (111.08s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (130.09s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (162.27s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (97.38s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (110.91s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs (592.35s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (124.14s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (130.91s)
--- PASS: TestAccAWSInstance_atLeastOneOtherEbsVolume (198.61s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (111.17s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (132.70s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (110.98s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (333.46s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (122.29s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (89.04s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (122.47s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (202.34s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (114.70s)
--- PASS: TestAccAWSInstance_changeInstanceType (159.48s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (114.40s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (103.02s)
--- PASS: TestAccAWSInstance_dedicatedInstance (138.18s)
--- PASS: TestAccAWSInstance_disableApiTermination (148.88s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (147.22s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (145.72s)
--- PASS: TestAccAWSInstance_enclaveOptions (441.62s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (16.93s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (94.66s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (115.94s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (116.70s)
--- PASS: TestAccAWSInstance_tags (120.40s)
--- PASS: TestAccAWSInstance_keyPairCheck (204.50s)
--- PASS: TestAccAWSInstance_instanceProfileChange (213.87s)
--- PASS: TestAccAWSInstancesDataSource_instanceStateNames (304.06s)
--- PASS: TestAccAWSInstancesDataSource_basic (313.61s)
--- PASS: TestAccAWSInstancesDataSource_tags (345.53s)
--- PASS: TestAccAWSInstance_userDataBase64 (96.27s)
--- PASS: TestAccAWSInstance_metadataOptions (149.43s)
--- PASS: TestAccAWSInstance_hibernation (163.14s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (82.45s)
--- PASS: TestAccAWSInstance_privateIP (84.44s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (238.90s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (81.89s)
--- PASS: TestAccAWSInstance_sourceDestCheck (145.92s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (239.12s)
--- PASS: TestAccAWSInstance_placementGroup (330.62s)
--- PASS: TestAccAWSInstance_inEc2Classic (226.92s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (186.36s)
```
