### PR TITLE
Use getOkExists to retrieve associate_public_ip_address as false.

### DIFF
--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -361,7 +361,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		createLaunchConfigurationOpts.PlacementTenancy = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("associate_public_ip_address"); ok {
+	if v, ok := d.GetOkExists("associate_public_ip_address"); ok {
 		createLaunchConfigurationOpts.AssociatePublicIpAddress = aws.Bool(v.(bool))
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1484
Closes #13137

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (18.80s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (19.62s)
--- PASS: TestAccAWSLaunchConfiguration_metadataOptions (20.64s)
--- PASS: TestAccAWSLaunchConfiguration_userData (32.96s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_ebsNoDevice (17.50s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (18.93s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (22.92s)
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (18.72s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (21.64s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (36.04s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (38.92s)
--- PASS: TestAccAWSLaunchConfiguration_withInstanceStoreAMI (27.35s)
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (33.31s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_VolumeSize (53.46s)
--- PASS: TestAccAWSLaunchConfiguration_basic (38.47s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears (359.20s)
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (23.36s)
```
