### PR TITLE
r/glue_partition - add nil check for `schema_reference`

### DIFF
--- a/.changelog/17702.txt
+++ b/.changelog/17702.txt
@@ -1,5 +1,5 @@
 ```release-note:bug
-resource/aws_glue_partition: Add nil check for `schema_reference`
+resource/aws_glue_catalog_table: Add nil check for `schema_reference`
 ```
 
 ```release-note:enhancement

--- a/.changelog/17702.txt
+++ b/.changelog/17702.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_glue_partition: Add nil check for `schema_reference`
+```
+
+```release-note:enhancement
+resource/aws_glue_partition: Add plan time validation for `partition_values`
+```

--- a/.changelog/17702.txt
+++ b/.changelog/17702.txt
@@ -1,5 +1,5 @@
 ```release-note:bug
-resource/aws_glue_catalog_table: Add nil check for `schema_reference`
+resource/aws_glue_catalog_table: Prevent `schema_reference` attribute error
 ```
 
 ```release-note:enhancement

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -755,8 +755,11 @@ func flattenGlueStorageDescriptor(s *glue.StorageDescriptor) []map[string]interf
 	storageDescriptor["sort_columns"] = flattenGlueOrders(s.SortColumns)
 	storageDescriptor["parameters"] = aws.StringValueMap(s.Parameters)
 	storageDescriptor["skewed_info"] = flattenGlueSkewedInfo(s.SkewedInfo)
-	storageDescriptor["schema_reference"] = flattenGlueTableSchemaReference(s.SchemaReference)
 	storageDescriptor["stored_as_sub_directories"] = aws.BoolValue(s.StoredAsSubDirectories)
+
+	if s.SchemaReference != nil {
+		storageDescriptor["schema_reference"] = flattenGlueTableSchemaReference(s.SchemaReference)
+	}
 
 	storageDescriptors[0] = storageDescriptor
 

--- a/aws/resource_aws_glue_partition.go
+++ b/aws/resource_aws_glue_partition.go
@@ -46,7 +46,10 @@ func resourceAwsGluePartition() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(1, 1024),
+				},
 			},
 			"storage_descriptor": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -137,6 +137,28 @@ func TestAccAWSGluePartition_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSGluePartition_disappears_table(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	parValue := acctest.RandString(10)
+	resourceName := "aws_glue_partition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGluePartitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGluePartitionBasicConfig(rName, parValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGluePartitionExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsGlueCatalogTable(), "aws_glue_catalog_table.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckGluePartitionDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).glueconn
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17679

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGluePartition_'
--- PASS: TestAccAWSGluePartition_disappears (42.79s)
--- PASS: TestAccAWSGluePartition_basic (46.65s)
--- PASS: TestAccAWSGluePartition_multipleValues (49.25s)
--- PASS: TestAccAWSGluePartition_parameters (117.59s)
--- PASS: TestAccAWSGluePartition_disappears_table (41.50s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSGlueCatalogTable'
--- PASS: TestAccAWSGlueCatalogTable_disappears_database (32.62s)
--- PASS: TestAccAWSGlueCatalogTable_disappears (39.25s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock (42.82s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock (43.48s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock (43.54s)
--- PASS: TestAccAWSGlueCatalogTable_columnParameters (43.88s)
--- PASS: TestAccAWSGlueCatalogTable_partitionIndexesMultiple (46.30s)
--- PASS: TestAccAWSGlueCatalogTable_full (47.73s)
--- PASS: TestAccAWSGlueCatalogTable_partitionIndexesSingle (48.69s)
--- PASS: TestAccAWSGlueCatalogTable_basic (50.23s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_schemaReference (62.31s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_schemaReferenceArn (63.68s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_UpdateValues (77.36s)
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (77.54s)
--- PASS: TestAccAWSGlueCatalogTable_update_replaceValues (79.08s)
```
