### PR TITLE
darwin/arm64 is now ignored by goreleaser0.157+ if go<1.6

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,8 +23,6 @@ builds:
     ignore:
       - goarch: '386'
         goos: darwin
-      - goarch: arm64
-        goos: darwin
     ldflags:
       - -s -w -X version.ProviderVersion={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

goreleaser v0.157.0 ignores darwin/arm64 if `go<1.6` - https://github.com/goreleaser/goreleaser/releases/tag/v0.157.0, https://github.com/goreleaser/goreleaser/pull/2069
