### PR TITLE
r/synthetics_canary - fix canary update

### DIFF
--- a/.changelog/17704.txt
+++ b/.changelog/17704.txt
@@ -1,4 +1,3 @@
 ```release-note:bug
-`````
 resource/aws_synthetics_canary: Fix Canary Update when in running state
 ```

--- a/.changelog/17704.txt
+++ b/.changelog/17704.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_synthetics_canary: Fix Canary Update when in running state
+```

--- a/.changelog/17704.txt
+++ b/.changelog/17704.txt
@@ -1,3 +1,4 @@
-```release-note:enhancement
+```release-note:bug
+`````
 resource/aws_synthetics_canary: Fix Canary Update when in running state
 ```

--- a/aws/resource_aws_synthetics_canary_test.go
+++ b/aws/resource_aws_synthetics_canary_test.go
@@ -223,6 +223,7 @@ func TestAccAWSSyntheticsCanary_startCanary(t *testing.T) {
 					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf3),
 					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_started"),
+					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_stopped"),
 					testAccCheckAwsSyntheticsCanaryIsStartedAfter(&conf2, &conf3),
 				),
 			},
@@ -246,6 +247,7 @@ func TestAccAWSSyntheticsCanary_startCanary_codeChanges(t *testing.T) {
 				Config: testAccAWSSyntheticsCanaryStartCanaryConfig(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf1),
+					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_started"),
 				),
@@ -260,6 +262,7 @@ func TestAccAWSSyntheticsCanary_startCanary_codeChanges(t *testing.T) {
 				Config: testAccAWSSyntheticsCanaryStartCanaryZipUpdatedConfig(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf2),
+					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_started"),
 					testAccCheckAwsSyntheticsCanaryIsStartedAfter(&conf1, &conf2),

--- a/aws/resource_aws_synthetics_canary_test.go
+++ b/aws/resource_aws_synthetics_canary_test.go
@@ -265,6 +265,7 @@ func TestAccAWSSyntheticsCanary_startCanary_codeChanges(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_started"),
+					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_stopped"),
 					testAccCheckAwsSyntheticsCanaryIsStartedAfter(&conf1, &conf2),
 				),
 			},

--- a/aws/resource_aws_synthetics_canary_test.go
+++ b/aws/resource_aws_synthetics_canary_test.go
@@ -108,6 +108,7 @@ func TestAccAWSSyntheticsCanary_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "artifact_s3_location", fmt.Sprintf("%s/", rName)),
 					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.created"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 				),
 			},
 			{
@@ -139,6 +140,7 @@ func TestAccAWSSyntheticsCanary_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.created"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_modified"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					testAccCheckAwsSyntheticsCanaryIsUpdated(&conf1, &conf2),
 				),
 			},
@@ -222,6 +224,45 @@ func TestAccAWSSyntheticsCanary_startCanary(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_started"),
 					testAccCheckAwsSyntheticsCanaryIsStartedAfter(&conf2, &conf3),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSyntheticsCanary_startCanary_codeChanges(t *testing.T) {
+	var conf1, conf2 synthetics.Canary
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	resourceName := "aws_synthetics_canary.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSyntheticsCanaryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSyntheticsCanaryStartCanaryConfig(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf1),
+					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_started"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zip_file", "start_canary"},
+			},
+			{
+				Config: testAccAWSSyntheticsCanaryStartCanaryZipUpdatedConfig(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf2),
+					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_started"),
+					testAccCheckAwsSyntheticsCanaryIsStartedAfter(&conf1, &conf2),
 				),
 			},
 		},
@@ -821,6 +862,24 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
+  start_canary         = %[2]t
+  runtime_version      = "syn-1.0"
+
+  schedule {
+    expression = "rate(0 minute)"
+  }
+}
+`, rName, state))
+}
+
+func testAccAWSSyntheticsCanaryStartCanaryZipUpdatedConfig(rName string, state bool) string {
+	return composeConfig(testAccAWSSyntheticsCanaryConfigBase(rName), fmt.Sprintf(`
+resource "aws_synthetics_canary" "test" {
+  name                 = %[1]q
+  artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/"
+  execution_role_arn   = aws_iam_role.test.arn
+  handler              = "exports.handler"
+  zip_file             = "test-fixtures/lambdatest_modified.zip"
   start_canary         = %[2]t
   runtime_version      = "syn-1.0"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17642

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSyntheticsCanary_'
--- PASS: TestAccAWSSyntheticsCanary_disappears (102.15s)
--- PASS: TestAccAWSSyntheticsCanary_s3 (114.20s)
--- PASS: TestAccAWSSyntheticsCanary_basic (164.13s)
--- PASS: TestAccAWSSyntheticsCanary_runtimeVersion (172.09s)
--- PASS: TestAccAWSSyntheticsCanary_startCanary_codeChanges (175.97s)
--- PASS: TestAccAWSSyntheticsCanary_tags (206.14s)
--- PASS: TestAccAWSSyntheticsCanary_runConfig (211.43s)
--- PASS: TestAccAWSSyntheticsCanary_runConfigTracing (217.31s)
--- PASS: TestAccAWSSyntheticsCanary_startCanary (228.48s)
--- PASS: TestAccAWSSyntheticsCanary_vpc (778.07s)
```
