### PR TITLE
provider: Convert and enforce most data sources to AWS Go SDK pointer conversion functions during conditionals

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -70,6 +70,41 @@ rules:
       - pattern-not: '*$LHS2 = *$RHS'
     severity: WARNING
 
+  - id: prefer-aws-go-sdk-pointer-conversion-conditional
+    languages: [go]
+    message: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
+    paths:
+      exclude:
+        - aws/cloudfront_distribution_configuration_structure.go
+        - aws/cloudfront_distribution_configuration_structure_test.go
+        - aws/config.go
+        - aws/data_source_aws_route*
+        - aws/ecs_task_definition_equivalency.go
+        - aws/opsworks_layers.go
+        - aws/resource*
+        - aws/structure.go
+        - aws/internal/generators/
+        - aws/internal/keyvaluetags/
+        - aws/internal/naming/
+        - awsproviderlint/vendor/
+      include:
+        - aws/
+    patterns:
+      - pattern-either:
+        - pattern: '$LHS == *$RHS'
+        - pattern: '$LHS != *$RHS'
+        - pattern: '$LHS > *$RHS'
+        - pattern: '$LHS < *$RHS'
+        - pattern: '$LHS >= *$RHS'
+        - pattern: '$LHS <= *$RHS'
+        - pattern: '*$LHS == $RHS'
+        - pattern: '*$LHS != $RHS'
+        - pattern: '*$LHS > $RHS'
+        - pattern: '*$LHS < $RHS'
+        - pattern: '*$LHS >= $RHS'
+        - pattern: '*$LHS <= $RHS'
+    severity: WARNING
+
   - id: aws-go-sdk-pointer-conversion-ResourceData-SetId
     fix: d.SetId(aws.StringValue($VALUE))
     languages: [go]

--- a/aws/data_source_aws_ami_ids.go
+++ b/aws/data_source_aws_ami_ids.go
@@ -82,13 +82,14 @@ func dataSourceAwsAmiIdsRead(d *schema.ResourceData, meta interface{}) error {
 			// Check for a very rare case where the response would include no
 			// image name. No name means nothing to attempt a match against,
 			// therefore we are skipping such image.
-			if image.Name == nil || *image.Name == "" {
+			name := aws.StringValue(image.Name)
+			if name == "" {
 				log.Printf("[WARN] Unable to find AMI name to match against "+
 					"for image ID %q owned by %q, nothing to do.",
-					*image.ImageId, *image.OwnerId)
+					aws.StringValue(image.ImageId), aws.StringValue(image.OwnerId))
 				continue
 			}
-			if r.MatchString(*image.Name) {
+			if r.MatchString(name) {
 				filteredImages = append(filteredImages, image)
 			}
 		}

--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -148,7 +148,7 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 
 	err = conn.GetResourcesPages(resourceParams, func(page *apigateway.GetResourcesOutput, lastPage bool) bool {
 		for _, item := range page.Items {
-			if *item.Path == "/" {
+			if aws.StringValue(item.Path) == "/" {
 				d.Set("root_resource_id", item.Id)
 				return false
 			}

--- a/aws/data_source_aws_cloudfront_cache_policy.go
+++ b/aws/data_source_aws_cloudfront_cache_policy.go
@@ -173,7 +173,7 @@ func dataSourceAwsCloudFrontCachePolicyFindByName(d *schema.ResourceData, conn *
 	}
 
 	for _, policySummary := range resp.CachePolicyList.Items {
-		if *policySummary.CachePolicy.CachePolicyConfig.Name == d.Get("name").(string) {
+		if aws.StringValue(policySummary.CachePolicy.CachePolicyConfig.Name) == d.Get("name").(string) {
 			cachePolicy = policySummary.CachePolicy
 			break
 		}

--- a/aws/data_source_aws_cloudfront_origin_request_policy.go
+++ b/aws/data_source_aws_cloudfront_origin_request_policy.go
@@ -153,7 +153,7 @@ func dataSourceAwsCloudFrontOriginRequestPolicyFindByName(d *schema.ResourceData
 	}
 
 	for _, policySummary := range resp.OriginRequestPolicyList.Items {
-		if *policySummary.OriginRequestPolicy.OriginRequestPolicyConfig.Name == d.Get("name").(string) {
+		if aws.StringValue(policySummary.OriginRequestPolicy.OriginRequestPolicyConfig.Name) == d.Get("name").(string) {
 			originRequestPolicy = policySummary.OriginRequestPolicy
 			break
 		}

--- a/aws/data_source_aws_ebs_default_kms_key_test.go
+++ b/aws/data_source_aws_ebs_default_kms_key_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -44,8 +45,8 @@ func testAccCheckDataSourceAwsEBSDefaultKmsKey(n string) resource.TestCheckFunc 
 
 		attr := rs.Primary.Attributes["key_arn"]
 
-		if attr != *actual.KmsKeyId {
-			return fmt.Errorf("EBS default KMS key is not the expected value (%v)", actual.KmsKeyId)
+		if attr != aws.StringValue(actual.KmsKeyId) {
+			return fmt.Errorf("EBS default KMS key is not the expected value (%s)", aws.StringValue(actual.KmsKeyId))
 		}
 
 		return nil

--- a/aws/data_source_aws_ebs_encryption_by_default_test.go
+++ b/aws/data_source_aws_ebs_encryption_by_default_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -45,8 +46,8 @@ func testAccCheckDataSourceAwsEBSEncryptionByDefault(n string) resource.TestChec
 
 		attr, _ := strconv.ParseBool(rs.Primary.Attributes["enabled"])
 
-		if attr != *actual.EbsEncryptionByDefault {
-			return fmt.Errorf("EBS encryption by default is not in expected state (%t)", *actual.EbsEncryptionByDefault)
+		if attr != aws.BoolValue(actual.EbsEncryptionByDefault) {
+			return fmt.Errorf("EBS encryption by default is not in expected state (%t)", aws.BoolValue(actual.EbsEncryptionByDefault))
 		}
 
 		return nil

--- a/aws/data_source_aws_elasticache_cluster.go
+++ b/aws/data_source_aws_elasticache_cluster.go
@@ -187,7 +187,7 @@ func dataSourceAwsElastiCacheClusterRead(d *schema.ResourceData, meta interface{
 	d.Set("availability_zone", cluster.PreferredAvailabilityZone)
 
 	if cluster.NotificationConfiguration != nil {
-		if *cluster.NotificationConfiguration.TopicStatus == "active" {
+		if aws.StringValue(cluster.NotificationConfiguration.TopicStatus) == "active" {
 			d.Set("notification_topic_arn", cluster.NotificationConfiguration.TopicArn)
 		}
 	}

--- a/aws/data_source_aws_iam_server_certificate_test.go
+++ b/aws/data_source_aws_iam_server_certificate_test.go
@@ -29,7 +29,7 @@ func TestResourceSortByExpirationDate(t *testing.T) {
 		},
 	}
 	sort.Sort(certificateByExpiration(certs))
-	if *certs[0].ServerCertificateName != "latest" {
+	if aws.StringValue(certs[0].ServerCertificateName) != "latest" {
 		t.Fatalf("Expected first item to be %q, but was %q", "latest", *certs[0].ServerCertificateName)
 	}
 }

--- a/aws/data_source_aws_kms_alias.go
+++ b/aws/data_source_aws_kms_alias.go
@@ -43,7 +43,7 @@ func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading KMS Alias: %s", params)
 	err := conn.ListAliasesPages(params, func(page *kms.ListAliasesOutput, lastPage bool) bool {
 		for _, entity := range page.Aliases {
-			if *entity.AliasName == target {
+			if aws.StringValue(entity.AliasName) == target {
 				alias = entity
 				return false
 			}

--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -283,7 +283,7 @@ func dataSourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("no listener exists for load balancer: %s", lbArn)
 	}
 	for _, listener := range resp.Listeners {
-		if *listener.Port == int64(port.(int)) {
+		if aws.Int64Value(listener.Port) == int64(port.(int)) {
 			//log.Printf("[DEBUG] get listener arn for %s:%s: %s", lbArn, port, *listener.Port)
 			d.SetId(aws.StringValue(listener.ListenerArn))
 			return resourceAwsLbListenerRead(d, meta)

--- a/aws/data_source_aws_nat_gateway.go
+++ b/aws/data_source_aws_nat_gateway.go
@@ -130,7 +130,7 @@ func dataSourceAwsNatGatewayRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	for _, address := range ngw.NatGatewayAddresses {
-		if *address.AllocationId != "" {
+		if aws.StringValue(address.AllocationId) != "" {
 			d.Set("allocation_id", address.AllocationId)
 			d.Set("network_interface_id", address.NetworkInterfaceId)
 			d.Set("private_ip", address.PrivateIp)

--- a/aws/data_source_aws_sfn_state_machine.go
+++ b/aws/data_source_aws_sfn_state_machine.go
@@ -52,8 +52,8 @@ func dataSourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) 
 
 	err := conn.ListStateMachinesPages(params, func(page *sfn.ListStateMachinesOutput, lastPage bool) bool {
 		for _, sm := range page.StateMachines {
-			if *sm.Name == target {
-				arns = append(arns, *sm.StateMachineArn)
+			if aws.StringValue(sm.Name) == target {
+				arns = append(arns, aws.StringValue(sm.StateMachineArn))
 			}
 		}
 		return true

--- a/aws/data_source_aws_ssm_patch_baseline.go
+++ b/aws/data_source_aws_ssm_patch_baseline.go
@@ -82,7 +82,7 @@ func dataAwsSsmPatchBaselineRead(d *schema.ResourceData, meta interface{}) error
 	var filteredBaselines []*ssm.PatchBaselineIdentity
 	if v, ok := d.GetOk("operating_system"); ok {
 		for _, baseline := range resp.BaselineIdentities {
-			if v.(string) == *baseline.OperatingSystem {
+			if v.(string) == aws.StringValue(baseline.OperatingSystem) {
 				filteredBaselines = append(filteredBaselines, baseline)
 			}
 		}

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -175,7 +175,7 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("default_for_az", subnet.DefaultForAz)
 
 	for _, a := range subnet.Ipv6CidrBlockAssociationSet {
-		if *a.Ipv6CidrBlockState.State == "associated" { //we can only ever have 1 IPv6 block associated at once
+		if a.Ipv6CidrBlockState != nil && aws.StringValue(a.Ipv6CidrBlockState.State) == ec2.VpcCidrBlockStateCodeAssociated { //we can only ever have 1 IPv6 block associated at once
 			d.Set("ipv6_cidr_block_association_id", a.AssociationId)
 			d.Set("ipv6_cidr_block", a.Ipv6CidrBlock)
 		}

--- a/aws/data_source_aws_workspaces_image_test.go
+++ b/aws/data_source_aws_workspaces_image_test.go
@@ -64,10 +64,10 @@ func testAccCheckWorkspacesImageExists(n string, image *workspaces.WorkspaceImag
 		if err != nil {
 			return fmt.Errorf("Failed describe workspaces images: %w", err)
 		}
-		if len(resp.Images) == 0 {
+		if resp == nil || len(resp.Images) == 0 || resp.Images[0] == nil {
 			return fmt.Errorf("Workspace image %s was not found", rs.Primary.ID)
 		}
-		if *resp.Images[0].ImageId != rs.Primary.ID {
+		if aws.StringValue(resp.Images[0].ImageId) != rs.Primary.ID {
 			return fmt.Errorf("Workspace image ID mismatch - existing: %q, state: %q", *resp.Images[0].ImageId, rs.Primary.ID)
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12992

This work is being done in chunks to reduce review burden. Avoiding `aws_route` and `aws_route_table` data sources due to large pull requests pending review.

Previously:

```
aws/data_source_aws_acm_certificate.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
86:			if *cert.DomainName == target {
--------------------------------------------------------------------------------
128:				if *certificate.Type == *certType {
--------------------------------------------------------------------------------
188:	if *i.Status != *j.Status {
--------------------------------------------------------------------------------
192:	if *i.Status == acm.CertificateStatusIssued {

aws/data_source_aws_ami_ids.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
85:			if image.Name == nil || *image.Name == "" {

aws/data_source_aws_api_gateway_rest_api.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
151:			if *item.Path == "/" {

aws/data_source_aws_cloudfront_cache_policy.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
176:		if *policySummary.CachePolicy.CachePolicyConfig.Name == d.Get("name").(string) {

aws/data_source_aws_cloudfront_origin_request_policy.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
151:		if *policySummary.OriginRequestPolicy.OriginRequestPolicyConfig.Name == d.Get("name").(string) {

aws/data_source_aws_ebs_default_kms_key_test.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
47:		if attr != *actual.KmsKeyId {

aws/data_source_aws_ebs_encryption_by_default_test.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
48:		if attr != *actual.EbsEncryptionByDefault {

aws/data_source_aws_elasticache_cluster.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
190:		if *cluster.NotificationConfiguration.TopicStatus == "active" {

aws/data_source_aws_iam_server_certificate_test.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
32:	if *certs[0].ServerCertificateName != "latest" {

aws/data_source_aws_instance.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
391:			if instance.State != nil && *instance.State.Name != "terminated" {
--------------------------------------------------------------------------------
478:			if *ni.Attachment.DeviceIndex == 0 {
--------------------------------------------------------------------------------
500:	if instance.SubnetId != nil && *instance.SubnetId != "" {

aws/data_source_aws_kms_alias.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
46:			if *entity.AliasName == target {

aws/data_source_aws_lb_listener.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
286:		if *listener.Port == int64(port.(int)) {

aws/data_source_aws_nat_gateway.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
133:		if *address.AllocationId != "" {

aws/data_source_aws_sfn_state_machine.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
55:			if *sm.Name == target {

aws/data_source_aws_ssm_patch_baseline.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
85:			if v.(string) == *baseline.OperatingSystem {

aws/data_source_aws_subnet.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
178:		if *a.Ipv6CidrBlockState.State == "associated" { //we can only ever have 1 IPv6 block associated at once

aws/data_source_aws_workspaces_image_test.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
70:		if *resp.Images[0].ImageId != rs.Primary.ID {
```

Output from acceptance testing:

```
--- FAIL: TestAccAWSAcmCertificateDataSource_multipleIssued (2.76s) # https://github.com/hashicorp/terraform-provider-aws/issues/17404
--- FAIL: TestAccAWSAcmCertificateDataSource_singleIssued (9.02s) # https://github.com/hashicorp/terraform-provider-aws/issues/17404
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (22.58s)
--- PASS: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (14.61s)

--- PASS: TestAccAWSCloudFrontDataSourceCachePolicy_basic (20.71s)

--- PASS: TestAccAWSCloudFrontDataSourceOriginRequestPolicy_basic (18.62s)

--- PASS: TestAccAWSDataElasticacheCluster_basic (690.01s)

--- PASS: TestAccAWSInstanceDataSource_AzUserData (89.39s)
--- PASS: TestAccAWSInstanceDataSource_basic (105.68s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (109.08s)
--- PASS: TestAccAWSInstanceDataSource_blockDeviceTags (111.04s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (92.40s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (111.12s)
--- PASS: TestAccAWSInstanceDataSource_enclaveOptions (119.23s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (169.44s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (200.88s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (178.11s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (174.80s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (100.39s)
--- PASS: TestAccAWSInstanceDataSource_gp3ThroughputDevice (87.80s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (89.11s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (130.64s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (82.19s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (92.96s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (135.66s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (90.25s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (93.10s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (103.29s)
--- PASS: TestAccAWSInstanceDataSource_tags (98.98s)
--- PASS: TestAccAWSInstanceDataSource_VPC (109.26s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (105.95s)

--- PASS: TestAccAWSSsmPatchBaselineDataSource_existingBaseline (19.45s)
--- PASS: TestAccAWSSsmPatchBaselineDataSource_newBaseline (22.38s)

--- PASS: TestAccDataSourceAwsAmiIds_basic (16.91s)
--- PASS: TestAccDataSourceAwsAmiIds_sorted (37.67s)

--- PASS: TestAccDataSourceAwsApiGatewayRestApi_basic (16.62s)
--- PASS: TestAccDataSourceAwsApiGatewayRestApi_EndpointConfiguration_VpcEndpointIds (200.16s)

--- PASS: TestAccDataSourceAwsEBSDefaultKmsKey_basic (19.55s)

--- PASS: TestAccDataSourceAwsEBSEncryptionByDefault_basic (10.56s)

--- PASS: TestAccDataSourceAwsKmsAlias_AwsService (12.84s)
--- PASS: TestAccDataSourceAwsKmsAlias_CMK (19.43s)

--- PASS: TestAccDataSourceAWSLBListener_BackwardsCompatibility (196.24s)
--- PASS: TestAccDataSourceAWSLBListener_basic (186.19s)
--- PASS: TestAccDataSourceAWSLBListener_DefaultAction_Forward (183.04s)
--- PASS: TestAccDataSourceAWSLBListener_https (187.24s)

--- PASS: TestAccDataSourceAwsNatGateway_basic (208.03s)

--- PASS: TestAccDataSourceAwsSfnStateMachine_basic (49.83s)

--- PASS: TestAccDataSourceAwsSubnet_basic (34.58s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock (58.30s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter (85.44s)

--- SKIP: TestAccDataSourceAwsWorkspacesImage_basic (0.76s)
```
