### PR TITLE
aws_vpc: Correct the ARN account id

### DIFF
--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -194,7 +194,7 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(vpc.OwnerId),
 		Resource:  fmt.Sprintf("vpc/%s", d.Id()),
 	}.String()
 	d.Set("arn", arn)

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -272,7 +272,7 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(vpc.OwnerId),
 		Resource:  fmt.Sprintf("vpc/%s", d.Id()),
 	}.String()
 	d.Set("arn", arn)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -335,8 +335,6 @@ This functionality is only supported in the following resources:
     - [`aws_synthetics_canary` resource](/docs/providers/aws/r/synthetics_canary.html)
     - [`aws_vpc_endpoint_service` data source](/docs/providers/aws/d/vpc_endpoint_service.html)
     - [`aws_vpc_endpoint_service` resource](/docs/providers/aws/r/vpc_endpoint_service.html)
-    - [`aws_vpc` data source](/docs/providers/aws/d/vpc.html)
-    - [`aws_vpc` resource](/docs/providers/aws/r/vpc.html)
     - [`aws_vpn_connection` resource](/docs/providers/aws/r/vpn_connection.html)
     - [`aws_vpn_gateway` data source](/docs/providers/aws/d/vpn_gateway.html)
     - [`aws_vpn_gateway` resource](/docs/providers/aws/r/vpn_gateway.html)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16978

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSVpc_ -timeout 120m
=== RUN   TestAccAWSVpc_coreMismatchedDiffs
=== PAUSE TestAccAWSVpc_coreMismatchedDiffs
=== RUN   TestAccAWSVpc_basic
=== PAUSE TestAccAWSVpc_basic
=== RUN   TestAccAWSVpc_disappears
=== PAUSE TestAccAWSVpc_disappears
=== RUN   TestAccAWSVpc_ignoreTags
=== PAUSE TestAccAWSVpc_ignoreTags
=== RUN   TestAccAWSVpc_AssignGeneratedIpv6CidrBlock
=== PAUSE TestAccAWSVpc_AssignGeneratedIpv6CidrBlock
=== RUN   TestAccAWSVpc_Tenancy
=== PAUSE TestAccAWSVpc_Tenancy
=== RUN   TestAccAWSVpc_tags
=== PAUSE TestAccAWSVpc_tags
=== RUN   TestAccAWSVpc_update
=== PAUSE TestAccAWSVpc_update
=== RUN   TestAccAWSVpc_bothDnsOptionsSet
=== PAUSE TestAccAWSVpc_bothDnsOptionsSet
=== RUN   TestAccAWSVpc_DisabledDnsSupport
=== PAUSE TestAccAWSVpc_DisabledDnsSupport
=== RUN   TestAccAWSVpc_classiclinkOptionSet
=== PAUSE TestAccAWSVpc_classiclinkOptionSet
=== RUN   TestAccAWSVpc_classiclinkDnsSupportOptionSet
=== PAUSE TestAccAWSVpc_classiclinkDnsSupportOptionSet
=== CONT  TestAccAWSVpc_coreMismatchedDiffs
=== CONT  TestAccAWSVpc_update
=== CONT  TestAccAWSVpc_AssignGeneratedIpv6CidrBlock
--- PASS: TestAccAWSVpc_coreMismatchedDiffs (36.47s)
=== CONT  TestAccAWSVpc_tags
--- PASS: TestAccAWSVpc_update (73.99s)
=== CONT  TestAccAWSVpc_Tenancy
--- PASS: TestAccAWSVpc_AssignGeneratedIpv6CidrBlock (99.30s)
=== CONT  TestAccAWSVpc_classiclinkOptionSet
--- PASS: TestAccAWSVpc_tags (96.75s)
=== CONT  TestAccAWSVpc_classiclinkDnsSupportOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (42.29s)
=== CONT  TestAccAWSVpc_ignoreTags
--- PASS: TestAccAWSVpc_Tenancy (95.87s)
=== CONT  TestAccAWSVpc_DisabledDnsSupport
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (42.54s)
=== CONT  TestAccAWSVpc_bothDnsOptionsSet
--- PASS: TestAccAWSVpc_ignoreTags (68.20s)
=== CONT  TestAccAWSVpc_basic
--- PASS: TestAccAWSVpc_DisabledDnsSupport (51.79s)
=== CONT  TestAccAWSVpc_disappears
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (52.72s)
--- PASS: TestAccAWSVpc_basic (40.35s)
--- PASS: TestAccAWSVpc_disappears (29.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	252.910s

$ TF_ACC=1 go test ./aws -v -count 1 -parallel 1 -run=TestAccDataSourceAwsVpc_ -timeout 120m
=== RUN   TestAccDataSourceAwsVpc_basic
=== PAUSE TestAccDataSourceAwsVpc_basic
=== RUN   TestAccDataSourceAwsVpc_ipv6Associated
=== PAUSE TestAccDataSourceAwsVpc_ipv6Associated
=== RUN   TestAccDataSourceAwsVpc_multipleCidr
=== PAUSE TestAccDataSourceAwsVpc_multipleCidr
=== CONT  TestAccDataSourceAwsVpc_basic
--- PASS: TestAccDataSourceAwsVpc_basic (35.46s)
=== CONT  TestAccDataSourceAwsVpc_multipleCidr
--- PASS: TestAccDataSourceAwsVpc_multipleCidr (58.33s)
=== CONT  TestAccDataSourceAwsVpc_ipv6Associated
--- PASS: TestAccDataSourceAwsVpc_ipv6Associated (34.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	130.136s
```
Fix the VPC ARN account id to use the owner id.