### PR TITLE
Add preserve_client_ip attribute support in aws_lb_target_group resource

### DIFF
--- a/.changelog/17731.txt
+++ b/.changelog/17731.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lb_target_group: Add preserve_client_ip target attribute support
+```

--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -154,6 +154,11 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 				},
 			},
 
+			"preserve_client_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchemaComputed(),
 		},
 	}

--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -154,7 +154,7 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 				},
 			},
 
-			"preserve_client_id": {
+			"preserve_client_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -18,89 +18,14 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
 			"arn_suffix": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"port": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-
-			"protocol": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"protocol_version": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"vpc_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"deregistration_delay": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-
-			"slow_start": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-
-			"proxy_protocol_v2": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-
-			"lambda_multi_value_headers_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-
-			"load_balancing_algorithm_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"target_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"stickiness": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enabled": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"cookie_duration": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-					},
-				},
-			},
-
 			"health_check": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -110,42 +35,34 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
-
-						"interval": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-
-						"path": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-
-						"port": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-
-						"protocol": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-
-						"timeout": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-
 						"healthy_threshold": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-
+						"interval": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"matcher": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-
+						"path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"unhealthy_threshold": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -153,13 +70,72 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 					},
 				},
 			},
-
+			"lambda_multi_value_headers_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"load_balancing_algorithm_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"preserve_client_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protocol_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"proxy_protocol_v2": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"slow_start": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"stickiness": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cookie_duration": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"target_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tagsSchemaComputed(),
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestAccDataSourceAWSALBTargetGroup_basic(t *testing.T) {
-	lbName := fmt.Sprintf("testlb-%s", acctest.RandString(13))
-	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceNameArn := "data.aws_lb_target_group.alb_tg_test_with_arn"
 	resourceName := "data.aws_lb_target_group.alb_tg_test_with_name"
 
@@ -21,9 +20,9 @@ func TestAccDataSourceAWSALBTargetGroup_basic(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSLBTargetGroupConfigBasic(lbName, targetGroupName),
+				Config: testAccDataSourceAWSLBTargetGroupConfigBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceNameArn, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceNameArn, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceNameArn, "arn"),
 					resource.TestCheckResourceAttrSet(resourceNameArn, "arn_suffix"),
 					resource.TestCheckResourceAttr(resourceNameArn, "port", "8080"),
@@ -34,7 +33,7 @@ func TestAccDataSourceAWSALBTargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameArn, "deregistration_delay", "300"),
 					resource.TestCheckResourceAttr(resourceNameArn, "slow_start", "0"),
 					resource.TestCheckResourceAttr(resourceNameArn, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceNameArn, "tags.TestName", "TestAccDataSourceAWSALBTargetGroup_basic"),
+					resource.TestCheckResourceAttr(resourceNameArn, "tags.TestName", rName),
 					resource.TestCheckResourceAttr(resourceNameArn, "stickiness.#", "1"),
 					resource.TestCheckResourceAttr(resourceNameArn, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.path", "/health"),
@@ -45,7 +44,7 @@ func TestAccDataSourceAWSALBTargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.matcher", "200-299"),
 
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "arn_suffix"),
 					resource.TestCheckResourceAttr(resourceName, "port", "8080"),
@@ -55,7 +54,7 @@ func TestAccDataSourceAWSALBTargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "300"),
 					resource.TestCheckResourceAttr(resourceName, "slow_start", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.TestName", "TestAccDataSourceAWSALBTargetGroup_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health"),
@@ -72,8 +71,7 @@ func TestAccDataSourceAWSALBTargetGroup_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
-	lbName := fmt.Sprintf("testlb-%s", acctest.RandString(13))
-	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceNameArn := "data.aws_alb_target_group.alb_tg_test_with_arn"
 	resourceName := "data.aws_alb_target_group.alb_tg_test_with_name"
 
@@ -83,9 +81,9 @@ func TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSLBTargetGroupConfigBackwardsCompatibility(lbName, targetGroupName),
+				Config: testAccDataSourceAWSLBTargetGroupConfigBackwardsCompatibility(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceNameArn, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceNameArn, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceNameArn, "arn"),
 					resource.TestCheckResourceAttrSet(resourceNameArn, "arn_suffix"),
 					resource.TestCheckResourceAttr(resourceNameArn, "port", "8080"),
@@ -95,7 +93,7 @@ func TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameArn, "deregistration_delay", "300"),
 					resource.TestCheckResourceAttr(resourceNameArn, "slow_start", "0"),
 					resource.TestCheckResourceAttr(resourceNameArn, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceNameArn, "tags.TestName", "TestAccDataSourceAWSALBTargetGroup_basic"),
+					resource.TestCheckResourceAttr(resourceNameArn, "tags.TestName", rName),
 					resource.TestCheckResourceAttr(resourceNameArn, "stickiness.#", "1"),
 					resource.TestCheckResourceAttr(resourceNameArn, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.path", "/health"),
@@ -106,7 +104,7 @@ func TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.matcher", "200-299"),
 
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "arn_suffix"),
 					resource.TestCheckResourceAttr(resourceName, "port", "8080"),
@@ -115,7 +113,7 @@ func TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "300"),
 					resource.TestCheckResourceAttr(resourceName, "slow_start", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.TestName", "TestAccDataSourceAWSALBTargetGroup_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health"),
@@ -131,7 +129,7 @@ func TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAWSLBTargetGroupConfigBasic(lbName string, targetGroupName string) string {
+func testAccDataSourceAWSLBTargetGroupConfigBasic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_listener" "front_end" {
   load_balancer_arn = aws_lb.alb_test.id
@@ -145,7 +143,7 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -154,12 +152,12 @@ resource "aws_lb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -176,7 +174,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
@@ -198,7 +196,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-data-source-target-group-basic"
+    Name = %[1]q
   }
 }
 
@@ -210,7 +208,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-data-source-target-group-basic"
+    Name = %[1]q
   }
 }
 
@@ -234,7 +232,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
@@ -245,10 +243,10 @@ data "aws_lb_target_group" "alb_tg_test_with_arn" {
 data "aws_lb_target_group" "alb_tg_test_with_name" {
   name = aws_lb_target_group.test.name
 }
-`, lbName, targetGroupName)
+`, rName)
 }
 
-func testAccDataSourceAWSLBTargetGroupConfigBackwardsCompatibility(lbName string, targetGroupName string) string {
+func testAccDataSourceAWSLBTargetGroupConfigBackwardsCompatibility(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_listener" "front_end" {
   load_balancer_arn = aws_alb.alb_test.id
@@ -262,7 +260,7 @@ resource "aws_alb_listener" "front_end" {
 }
 
 resource "aws_alb" "alb_test" {
-  name            = "%s"
+  name            = %[1]q
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
   subnets         = aws_subnet.alb_test[*].id
@@ -271,12 +269,12 @@ resource "aws_alb" "alb_test" {
   enable_deletion_protection = false
 
   tags = {
-    TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 8080
   protocol = "HTTP"
   vpc_id   = aws_vpc.alb_test.id
@@ -293,7 +291,7 @@ resource "aws_alb_target_group" "test" {
   }
 
   tags = {
-    TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
@@ -315,7 +313,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-data-source-target-group-bc"
+    Name = %[1]q
   }
 }
 
@@ -327,7 +325,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-lb-data-source-target-group-bc"
+    Name = %[1]q
   }
 }
 
@@ -351,7 +349,7 @@ resource "aws_security_group" "alb_test" {
   }
 
   tags = {
-    TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
@@ -362,5 +360,5 @@ data "aws_alb_target_group" "alb_tg_test_with_arn" {
 data "aws_alb_target_group" "alb_tg_test_with_name" {
   name = aws_alb_target_group.test.name
 }
-`, lbName, targetGroupName)
+`, rName)
 }

--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -46,42 +46,43 @@ func TestALBTargetGroupCloudwatchSuffixFromARN(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_basic(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "slow_start", "0"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "target_type", "instance"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.enabled", "true"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "60"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8081"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTP"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "3"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "3"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "3"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200-299"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.TestName", "TestAccAWSALBTargetGroup_basic"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr(resourceName, "slow_start", "0"),
+					resource.TestCheckResourceAttr(resourceName, "target_type", "instance"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "60"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8081"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "3"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "3"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200-299"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName),
 				),
 			},
 		},
@@ -90,19 +91,21 @@ func TestAccAWSALBTargetGroup_basic(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_namePrefix(t *testing.T) {
 	var conf elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_namePrefix,
+				Config: testAccAWSALBTargetGroupConfig_namePrefix(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestMatchResourceAttr("aws_alb_target_group.test", "name", regexp.MustCompile("^tf-")),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^tf-")),
 				),
 			},
 		},
@@ -111,18 +114,20 @@ func TestAccAWSALBTargetGroup_namePrefix(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_generatedName(t *testing.T) {
 	var conf elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_generatedName,
+				Config: testAccAWSALBTargetGroupConfig_generatedName(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
 				),
 			},
 		},
@@ -131,28 +136,29 @@ func TestAccAWSALBTargetGroup_generatedName(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_changeNameForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
-	targetGroupNameBefore := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
-	targetGroupNameAfter := fmt.Sprintf("test-target-group-%s", acctest.RandString(4))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rNameAfter := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupNameBefore),
+				Config: testAccAWSALBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupNameBefore),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupNameAfter),
+				Config: testAccAWSALBTargetGroupConfig_basic(rNameAfter),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupNameAfter),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameAfter),
 				),
 			},
 		},
@@ -161,27 +167,28 @@ func TestAccAWSALBTargetGroup_changeNameForceNew(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_changeProtocolForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_updatedProtocol(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_updatedProtocol(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTP"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
 				),
 			},
 		},
@@ -190,27 +197,28 @@ func TestAccAWSALBTargetGroup_changeProtocolForceNew(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_changePortForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_updatedPort(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_updatedPort(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "442"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "port", "442"),
 				),
 			},
 		},
@@ -219,25 +227,26 @@ func TestAccAWSALBTargetGroup_changePortForceNew(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_changeVpcForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &before),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_updatedVpc(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_updatedVpc(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &after),
 				),
 			},
 		},
@@ -246,30 +255,31 @@ func TestAccAWSALBTargetGroup_changeVpcForceNew(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_tags(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.TestName", "TestAccAWSALBTargetGroup_basic"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_updateTags(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_updateTags(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.Environment", "Production"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.Type", "ALB Target Group"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Type", "ALB Target Group"),
 				),
 			},
 		},
@@ -278,61 +288,62 @@ func TestAccAWSALBTargetGroup_tags(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_updateHealthCheck(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "60"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8081"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTP"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "3"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "3"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "3"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200-299"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "60"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8081"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "3"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "3"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200-299"),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_updateHealthCheck(targetGroupName),
+				Config: testAccAWSALBTargetGroupConfig_updateHealthCheck(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200"),
 				),
 			},
 		},
@@ -341,84 +352,85 @@ func TestAccAWSALBTargetGroup_updateHealthCheck(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_updateSticknessEnabled(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_stickiness(targetGroupName, false, false),
+				Config: testAccAWSALBTargetGroupConfig_stickiness(rName, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200"),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_stickiness(targetGroupName, true, true),
+				Config: testAccAWSALBTargetGroupConfig_stickiness(rName, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.enabled", "true"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200"),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_stickiness(targetGroupName, true, false),
+				Config: testAccAWSALBTargetGroupConfig_stickiness(rName, true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.enabled", "false"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200"),
 				),
 			},
 		},
@@ -427,27 +439,28 @@ func TestAccAWSALBTargetGroup_updateSticknessEnabled(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_setAndUpdateSlowStart(t *testing.T) {
 	var before, after elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_updateSlowStart(targetGroupName, 30),
+				Config: testAccAWSALBTargetGroupConfig_updateSlowStart(rName, 30),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "slow_start", "30"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "slow_start", "30"),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_updateSlowStart(targetGroupName, 60),
+				Config: testAccAWSALBTargetGroupConfig_updateSlowStart(rName, 60),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "slow_start", "60"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "slow_start", "60"),
 				),
 			},
 		},
@@ -456,40 +469,41 @@ func TestAccAWSALBTargetGroup_setAndUpdateSlowStart(t *testing.T) {
 
 func TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_alb_target_group.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, false, ""),
+				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(rName, false, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "round_robin"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "load_balancing_algorithm_type", "round_robin"),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "round_robin"),
+				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(rName, true, "round_robin"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "round_robin"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "load_balancing_algorithm_type", "round_robin"),
 				),
 			},
 			{
-				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "least_outstanding_requests"),
+				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(rName, true, "least_outstanding_requests"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "least_outstanding_requests"),
+					testAccCheckAWSALBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "load_balancing_algorithm_type", "least_outstanding_requests"),
 				),
 			},
 		},
@@ -642,7 +656,7 @@ func TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled(t *testing.T) {
 }
 
 func TestAccAWSALBTargetGroup_missingPortProtocolVpc(t *testing.T) {
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -651,25 +665,25 @@ func TestAccAWSALBTargetGroup_missingPortProtocolVpc(t *testing.T) {
 		CheckDestroy: testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSALBTargetGroupConfig_missing_port(targetGroupName),
+				Config:      testAccAWSALBTargetGroupConfig_missing_port(rName),
 				ExpectError: regexp.MustCompile(`port should be set when target type is`),
 			},
 			{
-				Config:      testAccAWSALBTargetGroupConfig_missing_protocol(targetGroupName),
+				Config:      testAccAWSALBTargetGroupConfig_missing_protocol(rName),
 				ExpectError: regexp.MustCompile(`protocol should be set when target type is`),
 			},
 			{
-				Config:      testAccAWSALBTargetGroupConfig_missing_vpc(targetGroupName),
+				Config:      testAccAWSALBTargetGroupConfig_missing_vpc(rName),
 				ExpectError: regexp.MustCompile(`vpc_id should be set when target type is`),
 			},
 		},
 	})
 }
 
-func testAccAWSALBTargetGroupConfig_basic(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -693,7 +707,7 @@ resource "aws_alb_target_group" "test" {
   }
 
   tags = {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
@@ -701,15 +715,15 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-basic"
+    Name = %[1]q
   }
-}`, targetGroupName)
+}`, rName)
 }
 
-func testAccAWSALBTargetGroupConfig_updatedPort(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_updatedPort(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 442
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -733,7 +747,7 @@ resource "aws_alb_target_group" "test" {
   }
 
   tags = {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
@@ -741,15 +755,15 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-basic"
+    Name = %[1]q
   }
-}`, targetGroupName)
+}`, rName)
 }
 
-func testAccAWSALBTargetGroupConfig_updatedProtocol(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_updatedProtocol(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTP"
   vpc_id   = aws_vpc.test2.id
@@ -773,7 +787,7 @@ resource "aws_alb_target_group" "test" {
   }
 
   tags = {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
@@ -781,7 +795,7 @@ resource "aws_vpc" "test2" {
   cidr_block = "10.10.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-basic-2"
+    Name = "%[1]s-2"
   }
 }
 
@@ -789,15 +803,15 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-basic"
+    Name = %[1]q
   }
-}`, targetGroupName)
+}`, rName)
 }
 
-func testAccAWSALBTargetGroupConfig_updatedVpc(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_updatedVpc(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -821,7 +835,7 @@ resource "aws_alb_target_group" "test" {
   }
 
   tags = {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    TestName = %[1]q
   }
 }
 
@@ -829,15 +843,15 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-basic"
+    Name = %[1]q
   }
-}`, targetGroupName)
+}`, rName)
 }
 
-func testAccAWSALBTargetGroupConfig_updateTags(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_updateTags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -870,15 +884,15 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-basic"
+    Name = %[1]q
   }
-}`, targetGroupName)
+}`, rName)
 }
 
-func testAccAWSALBTargetGroupConfig_updateHealthCheck(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_updateHealthCheck(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -906,12 +920,12 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-basic"
+    Name = %[1]q
   }
-}`, targetGroupName)
+}`, rName)
 }
 
-func testAccAWSALBTargetGroupConfig_stickiness(targetGroupName string, addStickinessBlock bool, enabled bool) string {
+func testAccAWSALBTargetGroupConfig_stickiness(rName string, addStickinessBlock bool, enabled bool) string {
 	var stickinessBlock string
 
 	if addStickinessBlock {
@@ -925,14 +939,14 @@ func testAccAWSALBTargetGroupConfig_stickiness(targetGroupName string, addSticki
 
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
-  %s
+  %[2]s
 
   health_check {
     path                = "/health2"
@@ -950,12 +964,12 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-stickiness"
+    Name = %[1]q
   }
-}`, targetGroupName, stickinessBlock)
+}`, rName, stickinessBlock)
 }
 
-func testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName string, nonDefault bool, algoType string) string {
+func testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(rName string, nonDefault bool, algoType string) string {
 	var algoTypeParam string
 
 	if nonDefault {
@@ -964,33 +978,33 @@ func testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName strin
 
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
 
-  %s
+  %[2]s
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-load-balancing-algo"
+    Name = %[1]q
   }
-}`, targetGroupName, algoTypeParam)
+}`, rName, algoTypeParam)
 }
 
-func testAccAWSALBTargetGroupConfig_updateSlowStart(targetGroupName string, slowStartDuration int) string {
+func testAccAWSALBTargetGroupConfig_updateSlowStart(rName string, slowStartDuration int) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTP"
   vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
-  slow_start           = %d
+  slow_start           = %[2]d
 
   stickiness {
     type            = "lb_cookie"
@@ -1009,7 +1023,7 @@ resource "aws_alb_target_group" "test" {
   }
 
   tags = {
-    TestName = "TestAccAWSALBTargetGroup_SlowStart"
+    TestName = %[1]q
   }
 }
 
@@ -1017,12 +1031,13 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-alb-target-group-slowstart"
+    Name = %[1]q
   }
-}`, targetGroupName, slowStartDuration)
+}`, rName, slowStartDuration)
 }
 
-const testAccAWSALBTargetGroupConfig_namePrefix = `
+func testAccAWSALBTargetGroupConfig_namePrefix(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
   name_prefix = "tf-"
   port        = 80
@@ -1033,12 +1048,14 @@ resource "aws_alb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-alb-target-group-name-prefix"
+    Name = %[1]q
   }
 }
-`
+`, rName)
+}
 
-const testAccAWSALBTargetGroupConfig_generatedName = `
+func testAccAWSALBTargetGroupConfig_generatedName(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
   port     = 80
   protocol = "HTTP"
@@ -1057,17 +1074,18 @@ resource "aws_alb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-alb-target-group-generated-name"
+    Name = %[1]q
   }
 }
-`
+`, rName)
+}
 
-func testAccAWSALBTargetGroupConfig_lambda(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_lambda(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name        = "%s"
+  name        = %[1]q
   target_type = "lambda"
-}`, targetGroupName)
+}`, rName)
 }
 
 func testAccAWSALBTargetGroupConfig_lambdaMultiValueHeadersEnabled(rName string, lambdaMultiValueHadersEnabled bool) string {
@@ -1080,38 +1098,38 @@ resource "aws_alb_target_group" "test" {
 `, lambdaMultiValueHadersEnabled, rName)
 }
 
-func testAccAWSALBTargetGroupConfig_missing_port(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_missing_port(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-}`, targetGroupName)
+}`, rName)
 }
 
-func testAccAWSALBTargetGroupConfig_missing_protocol(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_missing_protocol(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name   = "%s"
+  name   = %[1]q
   port   = 443
   vpc_id = aws_vpc.test.id
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-}`, targetGroupName)
+}`, rName)
 }
 
-func testAccAWSALBTargetGroupConfig_missing_vpc(targetGroupName string) string {
+func testAccAWSALBTargetGroupConfig_missing_vpc(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
 }
-`, targetGroupName)
+`, rName)
 }

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -734,7 +734,7 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 		case "preserve_client_ip.enabled":
 			_, err := strconv.ParseBool(aws.StringValue(attr.Value))
 			if err != nil {
-				return fmt.Errorf("Error converting preserve_client_ip.enabled to bool: %s", aws.StringValue(attr.Value))
+				return fmt.Errorf("error converting preserve_client_ip.enabled to bool: %s", aws.StringValue(attr.Value))
 			}
 			d.Set("preserve_client_ip", aws.StringValue(attr.Value))
 		}

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -372,7 +372,7 @@ func resourceAwsLbTargetGroupRead(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*AWSClient).elbv2conn
 
 	resp, err := conn.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{
-		TargetGroupArns: []*string{aws.String(d.Id())},
+		TargetGroupArns: aws.StringSlice([]string{d.Id()}),
 	})
 	if err != nil {
 		if isAWSErr(err, elbv2.ErrCodeTargetGroupNotFoundException, "") {

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -38,12 +38,100 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"arn_suffix": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"deregistration_delay": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      300,
+				ValidateFunc: validation.IntBetween(0, 3600),
+			},
+			"health_check": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"healthy_threshold": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      3,
+							ValidateFunc: validation.IntBetween(2, 10),
+						},
+						"interval": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  30,
+						},
+						"matcher": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"path": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validateAwsLbTargetGroupHealthCheckPath,
+						},
+						"port": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Default:          "traffic-port",
+							ValidateFunc:     validateAwsLbTargetGroupHealthCheckPort,
+							DiffSuppressFunc: suppressIfTargetType(elbv2.TargetTypeEnumLambda),
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  elbv2.ProtocolEnumHttp,
+							StateFunc: func(v interface{}) string {
+								return strings.ToUpper(v.(string))
+							},
+							ValidateFunc: validation.StringInSlice([]string{
+								elbv2.ProtocolEnumHttp,
+								elbv2.ProtocolEnumHttps,
+								elbv2.ProtocolEnumTcp,
+							}, true),
+							DiffSuppressFunc: suppressIfTargetType(elbv2.TargetTypeEnumLambda),
+						},
+						"timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntBetween(2, 120),
+						},
+						"unhealthy_threshold": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      3,
+							ValidateFunc: validation.IntBetween(2, 10),
+						},
+					},
+				},
+			},
+			"lambda_multi_value_headers_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"load_balancing_algorithm_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"round_robin",
+					"least_outstanding_requests",
+				}, false),
+			},
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -59,21 +147,29 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				ConflictsWith: []string{"name"},
 				ValidateFunc:  validateLbTargetGroupNamePrefix,
 			},
-
 			"port": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(1, 65535),
 			},
-
+			"preserve_client_ip": {
+				// Use TypeString to allow an "unspecified" value,
+				// since TypeBool only has true/false with false default.
+				// The conversion from bare true/false values in
+				// configurations to TypeString value is currently safe.
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: suppressEquivalentTypeStringBoolean,
+				ValidateFunc:     validateTypeStringNullableBoolean,
+			},
 			"protocol": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(elbv2.ProtocolEnum_Values(), true),
 			},
-
 			"protocol_version": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -97,61 +193,17 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 					return true
 				},
 			},
-
-			"vpc_id": {
-				Type:     schema.TypeString,
+			"proxy_protocol_v2": {
+				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
+				Default:  false,
 			},
-
-			"deregistration_delay": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      300,
-				ValidateFunc: validation.IntBetween(0, 3600),
-			},
-
 			"slow_start": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      0,
 				ValidateFunc: validateSlowStart,
 			},
-
-			"proxy_protocol_v2": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
-			"lambda_multi_value_headers_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
-			"target_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  elbv2.TargetTypeEnumInstance,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					elbv2.TargetTypeEnumInstance,
-					elbv2.TargetTypeEnumIp,
-					elbv2.TargetTypeEnumLambda,
-				}, false),
-			},
-
-			"load_balancing_algorithm_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"round_robin",
-					"least_outstanding_requests",
-				}, false),
-			},
-
 			"stickiness": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -159,6 +211,19 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"cookie_duration": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      86400,
+							ValidateFunc: validation.IntBetween(0, 604800),
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								switch d.Get("protocol").(string) {
+								case elbv2.ProtocolEnumTcp, elbv2.ProtocolEnumUdp, elbv2.ProtocolEnumTcpUdp, elbv2.ProtocolEnumTls:
+									return true
+								}
+								return false
+							},
+						},
 						"enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -182,113 +247,26 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 								return false
 							},
 						},
-						"cookie_duration": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      86400,
-							ValidateFunc: validation.IntBetween(0, 604800),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								switch d.Get("protocol").(string) {
-								case elbv2.ProtocolEnumTcp, elbv2.ProtocolEnumUdp, elbv2.ProtocolEnumTcpUdp, elbv2.ProtocolEnumTls:
-									return true
-								}
-								return false
-							},
-						},
 					},
 				},
 			},
-
-			"health_check": {
-				Type:     schema.TypeList,
+			"target_type": {
+				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-
-						"interval": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  30,
-						},
-
-						"path": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validateAwsLbTargetGroupHealthCheckPath,
-						},
-
-						"port": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          "traffic-port",
-							ValidateFunc:     validateAwsLbTargetGroupHealthCheckPort,
-							DiffSuppressFunc: suppressIfTargetType(elbv2.TargetTypeEnumLambda),
-						},
-
-						"protocol": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  elbv2.ProtocolEnumHttp,
-							StateFunc: func(v interface{}) string {
-								return strings.ToUpper(v.(string))
-							},
-							ValidateFunc: validation.StringInSlice([]string{
-								elbv2.ProtocolEnumHttp,
-								elbv2.ProtocolEnumHttps,
-								elbv2.ProtocolEnumTcp,
-							}, true),
-							DiffSuppressFunc: suppressIfTargetType(elbv2.TargetTypeEnumLambda),
-						},
-
-						"timeout": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.IntBetween(2, 120),
-						},
-
-						"healthy_threshold": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      3,
-							ValidateFunc: validation.IntBetween(2, 10),
-						},
-
-						"matcher": {
-							Type:     schema.TypeString,
-							Computed: true,
-							Optional: true,
-						},
-
-						"unhealthy_threshold": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      3,
-							ValidateFunc: validation.IntBetween(2, 10),
-						},
-					},
-				},
-			},
-			"preserve_client_ip": {
-				// Use TypeString to allow an "unspecified" value,
-				// since TypeBool only has true/false with false default.
-				// The conversion from bare true/false values in
-				// configurations to TypeString value is currently safe.
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				DiffSuppressFunc: suppressEquivalentTypeStringBoolean,
-				ValidateFunc:     validateTypeStringNullableBoolean,
+				Default:  elbv2.TargetTypeEnumInstance,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					elbv2.TargetTypeEnumInstance,
+					elbv2.TargetTypeEnumIp,
+					elbv2.TargetTypeEnumLambda,
+				}, false),
 			},
 			"tags": tagsSchema(),
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -693,11 +671,11 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 
 	healthCheck := make(map[string]interface{})
 	healthCheck["enabled"] = aws.BoolValue(targetGroup.HealthCheckEnabled)
+	healthCheck["healthy_threshold"] = int(aws.Int64Value(targetGroup.HealthyThresholdCount))
 	healthCheck["interval"] = int(aws.Int64Value(targetGroup.HealthCheckIntervalSeconds))
 	healthCheck["port"] = aws.StringValue(targetGroup.HealthCheckPort)
 	healthCheck["protocol"] = aws.StringValue(targetGroup.HealthCheckProtocol)
 	healthCheck["timeout"] = int(aws.Int64Value(targetGroup.HealthCheckTimeoutSeconds))
-	healthCheck["healthy_threshold"] = int(aws.Int64Value(targetGroup.HealthyThresholdCount))
 	healthCheck["unhealthy_threshold"] = int(aws.Int64Value(targetGroup.UnhealthyThresholdCount))
 
 	if targetGroup.HealthCheckPath != nil {

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -1340,6 +1340,7 @@ func TestAccAWSLBTargetGroup_preserveClientIPValid(t *testing.T) {
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -27,7 +27,7 @@ func init() {
 func testSweepLBTargetGroups(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.(*AWSClient).elbv2conn
 
@@ -55,7 +55,7 @@ func testSweepLBTargetGroups(region string) error {
 			log.Printf("[WARN] Skipping LB Target Group sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error retrieving LB Target Groups: %s", err)
+		return fmt.Errorf("error retrieving LB Target Groups: %w", err)
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func TestLBTargetGroupCloudwatchSuffixFromARN(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_basic(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -104,11 +104,11 @@ func TestAccAWSLBTargetGroup_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "protocol_version", "HTTP1"),
@@ -130,7 +130,7 @@ func TestAccAWSLBTargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200-299"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSLBTargetGroup_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 		},
@@ -139,7 +139,7 @@ func TestAccAWSLBTargetGroup_basic(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_basicUdp(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -150,11 +150,11 @@ func TestAccAWSLBTargetGroup_basicUdp(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_basicUdp(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_basicUdp(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "514"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "UDP"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -162,7 +162,7 @@ func TestAccAWSLBTargetGroup_basicUdp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "514"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "TCP"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSLBTargetGroup_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 		},
@@ -171,7 +171,7 @@ func TestAccAWSLBTargetGroup_basicUdp(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_ProtocolVersion(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -182,11 +182,11 @@ func TestAccAWSLBTargetGroup_ProtocolVersion(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_ProtocolVersion(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_ProtocolVersion(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "protocol_version", "HTTP2"),
@@ -208,7 +208,7 @@ func TestAccAWSLBTargetGroup_ProtocolVersion(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200-299"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSLBTargetGroup_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 		},
@@ -217,7 +217,7 @@ func TestAccAWSLBTargetGroup_ProtocolVersion(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_withoutHealthcheck(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -228,11 +228,11 @@ func TestAccAWSLBTargetGroup_withoutHealthcheck(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_withoutHealthcheck(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_withoutHealthcheck(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "false"),
 				),
@@ -243,7 +243,7 @@ func TestAccAWSLBTargetGroup_withoutHealthcheck(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 	var targetGroup1, targetGroup2, targetGroup3 elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -254,11 +254,11 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_typeTCP(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_typeTCP(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &targetGroup1),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "8082"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "TCP"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -277,20 +277,20 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
 					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&targetGroup1, 3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAcc_networkLB_TargetGroup"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_typeTCPInvalidThreshold(targetGroupName),
+				Config:      testAccAWSLBTargetGroupConfig_typeTCPInvalidThreshold(rName),
 				ExpectError: regexp.MustCompile(`health_check\.healthy_threshold [0-9]+ and health_check\.unhealthy_threshold [0-9]+ must be the same for target_groups with TCP protocol`),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_typeTCPThresholdUpdated(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_typeTCPThresholdUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &targetGroup2),
 					testAccCheckAWSLBTargetGroupNotRecreated(&targetGroup1, &targetGroup2),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "8082"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "TCP"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -308,11 +308,11 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "5"),
 					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&targetGroup2, 5),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAcc_networkLB_TargetGroup"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_typeTCPIntervalUpdated(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_typeTCPIntervalUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &targetGroup3),
 					testAccCheckAWSLBTargetGroupRecreated(&targetGroup2, &targetGroup3),
@@ -357,7 +357,7 @@ func TestAccAWSLBTargetGroup_Protocol_Geneve(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol(t *testing.T) {
 	var targetGroup1, targetGroup2 elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -368,7 +368,7 @@ func TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_typeTCPIntervalUpdated(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_typeTCPIntervalUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &targetGroup1),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
@@ -376,7 +376,7 @@ func TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(targetGroupName, "/", 5),
+				Config: testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(rName, "/", 5),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &targetGroup2),
 					testAccCheckAWSLBTargetGroupRecreated(&targetGroup1, &targetGroup2),
@@ -468,7 +468,7 @@ func TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy(t *testing.T) {
 	var confBefore, confAfter elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -479,14 +479,14 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_typeTCP(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_typeTCP(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &confBefore),
 					resource.TestCheckResourceAttr(resourceName, "proxy_protocol_v2", "false"),
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_typeTCP_withProxyProtocol(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_typeTCP_withProxyProtocol(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &confAfter),
 					resource.TestCheckResourceAttr(resourceName, "proxy_protocol_v2", "true"),
@@ -498,8 +498,7 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
 	var confBefore, confAfter elbv2.TargetGroup
-	rString := acctest.RandString(8)
-	targetGroupName := fmt.Sprintf("test-tg-tcp-http-hc-%s", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -510,11 +509,11 @@ func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(targetGroupName, "/healthz", 2),
+				Config: testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(rName, "/healthz", 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &confBefore),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "8082"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "TCP"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -532,15 +531,15 @@ func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "2"),
 					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&confBefore, 2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAcc_networkLB_HTTPHealthCheck"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(targetGroupName, "/healthz2", 4),
+				Config: testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(rName, "/healthz2", 4),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &confAfter),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "8082"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "TCP"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -558,7 +557,7 @@ func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "4"),
 					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&confAfter, 4),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAcc_networkLB_HTTPHealthCheck"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 		},
@@ -567,7 +566,7 @@ func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -578,11 +577,11 @@ func TestAccAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfigBackwardsCompatibility(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfigBackwardsCompatibility(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -602,7 +601,7 @@ func TestAccAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200-299"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSLBTargetGroup_basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 		},
@@ -611,6 +610,7 @@ func TestAccAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_namePrefix(t *testing.T) {
 	var conf elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -621,7 +621,7 @@ func TestAccAWSLBTargetGroup_namePrefix(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_namePrefix,
+				Config: testAccAWSLBTargetGroupConfig_namePrefix(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^tf-")),
@@ -633,6 +633,7 @@ func TestAccAWSLBTargetGroup_namePrefix(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_generatedName(t *testing.T) {
 	var conf elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -643,7 +644,7 @@ func TestAccAWSLBTargetGroup_generatedName(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_generatedName,
+				Config: testAccAWSLBTargetGroupConfig_generatedName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 				),
@@ -654,8 +655,8 @@ func TestAccAWSLBTargetGroup_generatedName(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_changeNameForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
-	targetGroupNameBefore := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
-	targetGroupNameAfter := fmt.Sprintf("test-target-group-%s", acctest.RandString(4))
+	rNameBefore := acctest.RandomWithPrefix("tf-acc-test")
+	rNameAfter := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -666,17 +667,17 @@ func TestAccAWSLBTargetGroup_changeNameForceNew(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_basic(targetGroupNameBefore),
+				Config: testAccAWSLBTargetGroupConfig_basic(rNameBefore),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &before),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupNameBefore),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameBefore),
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_basic(targetGroupNameAfter),
+				Config: testAccAWSLBTargetGroupConfig_basic(rNameAfter),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &after),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupNameAfter),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameAfter),
 				),
 			},
 		},
@@ -685,7 +686,7 @@ func TestAccAWSLBTargetGroup_changeNameForceNew(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_changeProtocolForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -696,14 +697,14 @@ func TestAccAWSLBTargetGroup_changeProtocolForceNew(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_updatedProtocol(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_updatedProtocol(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
@@ -715,7 +716,7 @@ func TestAccAWSLBTargetGroup_changeProtocolForceNew(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_changePortForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -726,14 +727,14 @@ func TestAccAWSLBTargetGroup_changePortForceNew(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_updatedPort(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_updatedPort(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "port", "442"),
@@ -745,7 +746,7 @@ func TestAccAWSLBTargetGroup_changePortForceNew(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_changeVpcForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -756,13 +757,13 @@ func TestAccAWSLBTargetGroup_changeVpcForceNew(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &before),
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_updatedVpc(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_updatedVpc(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &after),
 				),
@@ -773,7 +774,7 @@ func TestAccAWSLBTargetGroup_changeVpcForceNew(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_tags(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -784,7 +785,7 @@ func TestAccAWSLBTargetGroup_tags(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfigTags1(targetGroupName, "key1", "value1"),
+				Config: testAccAWSLBTargetGroupConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -792,7 +793,7 @@ func TestAccAWSLBTargetGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfigTags2(targetGroupName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAWSLBTargetGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -801,7 +802,7 @@ func TestAccAWSLBTargetGroup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfigTags1(targetGroupName, "key2", "value2"),
+				Config: testAccAWSLBTargetGroupConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -814,7 +815,7 @@ func TestAccAWSLBTargetGroup_tags(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_enableHealthCheck(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -825,22 +826,22 @@ func TestAccAWSLBTargetGroup_enableHealthCheck(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_withoutHealthcheck(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_withoutHealthcheck(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "false"),
 					testAccCheckAWSLBTargetGroupHealthCheckEnabled(&conf, false),
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_enableHealthcheck(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_enableHealthcheck(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "true"),
 					testAccCheckAWSLBTargetGroupHealthCheckEnabled(&conf, true),
@@ -852,7 +853,7 @@ func TestAccAWSLBTargetGroup_enableHealthCheck(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_updateHealthCheck(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -863,11 +864,11 @@ func TestAccAWSLBTargetGroup_updateHealthCheck(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_basic(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -891,11 +892,11 @@ func TestAccAWSLBTargetGroup_updateHealthCheck(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_updateHealthCheck(targetGroupName),
+				Config: testAccAWSLBTargetGroupConfig_updateHealthCheck(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -925,7 +926,7 @@ func TestAccAWSLBTargetGroup_updateHealthCheck(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_updateSticknessEnabled(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -936,11 +937,11 @@ func TestAccAWSLBTargetGroup_updateSticknessEnabled(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickiness(targetGroupName, false, false),
+				Config: testAccAWSLBTargetGroupConfig_stickiness(rName, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -957,11 +958,11 @@ func TestAccAWSLBTargetGroup_updateSticknessEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickiness(targetGroupName, true, true),
+				Config: testAccAWSLBTargetGroupConfig_stickiness(rName, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -982,11 +983,11 @@ func TestAccAWSLBTargetGroup_updateSticknessEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickiness(targetGroupName, true, false),
+				Config: testAccAWSLBTargetGroupConfig_stickiness(rName, true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -1012,7 +1013,7 @@ func TestAccAWSLBTargetGroup_updateSticknessEnabled(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_defaults_application(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1023,11 +1024,11 @@ func TestAccAWSLBTargetGroup_defaults_application(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccALB_defaults(targetGroupName),
+				Config: testAccALB_defaults(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "protocol_version", "HTTP1"),
@@ -1042,7 +1043,7 @@ func TestAccAWSLBTargetGroup_defaults_application(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSLBTargetGroup_application_LB_defaults"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 		},
@@ -1051,7 +1052,7 @@ func TestAccAWSLBTargetGroup_defaults_application(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_defaults_network(t *testing.T) {
 	var conf elbv2.TargetGroup
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 	healthCheckInvalid1 := `
 path     = "/health"
@@ -1085,23 +1086,23 @@ protocol = "TCP"
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid1),
+				Config:      testAccNLB_defaults(rName, healthCheckInvalid1),
 				ExpectError: regexp.MustCompile("health_check.path is not supported for target_groups with TCP protocol"),
 			},
 			{
-				Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid2),
+				Config:      testAccNLB_defaults(rName, healthCheckInvalid2),
 				ExpectError: regexp.MustCompile("health_check.matcher is not supported for target_groups with TCP protocol"),
 			},
 			{
-				Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid3),
+				Config:      testAccNLB_defaults(rName, healthCheckInvalid3),
 				ExpectError: regexp.MustCompile("health_check.timeout is not supported for target_groups with TCP protocol"),
 			},
 			{
-				Config: testAccNLB_defaults(targetGroupName, healthCheckValid),
+				Config: testAccNLB_defaults(rName, healthCheckValid),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "name", targetGroupName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "TCP"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
@@ -1115,7 +1116,7 @@ protocol = "TCP"
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSLBTargetGroup_application_LB_defaults"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 		},
@@ -1124,6 +1125,7 @@ protocol = "TCP"
 
 func TestAccAWSLBTargetGroup_stickinessDefaultNLB(t *testing.T) {
 	var conf elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1134,7 +1136,7 @@ func TestAccAWSLBTargetGroup_stickinessDefaultNLB(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessDefault("TCP"),
+				Config: testAccAWSLBTargetGroupConfig_stickinessDefault(rName, "TCP"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1143,7 +1145,7 @@ func TestAccAWSLBTargetGroup_stickinessDefaultNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessDefault("UDP"),
+				Config: testAccAWSLBTargetGroupConfig_stickinessDefault(rName, "UDP"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1152,7 +1154,7 @@ func TestAccAWSLBTargetGroup_stickinessDefaultNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessDefault("TCP_UDP"),
+				Config: testAccAWSLBTargetGroupConfig_stickinessDefault(rName, "TCP_UDP"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1166,6 +1168,7 @@ func TestAccAWSLBTargetGroup_stickinessDefaultNLB(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_stickinessDefaultALB(t *testing.T) {
 	var conf elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1176,7 +1179,7 @@ func TestAccAWSLBTargetGroup_stickinessDefaultALB(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessDefault("HTTP"),
+				Config: testAccAWSLBTargetGroupConfig_stickinessDefault(rName, "HTTP"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1190,6 +1193,7 @@ func TestAccAWSLBTargetGroup_stickinessDefaultALB(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
 	var conf elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1200,7 +1204,7 @@ func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("TCP", "source_ip", false),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "TCP", "source_ip", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1210,7 +1214,7 @@ func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
 			},
 			{
 				// this test should be invalid but allowed to avoid breaking changes
-				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("TCP", "lb_cookie", false),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "TCP", "lb_cookie", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1218,7 +1222,7 @@ func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("TCP", "source_ip", true),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "TCP", "source_ip", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1227,7 +1231,7 @@ func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("UDP", "source_ip", true),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "UDP", "source_ip", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1236,7 +1240,7 @@ func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("TCP_UDP", "source_ip", true),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "TCP_UDP", "source_ip", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1250,6 +1254,7 @@ func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
 
 func TestAccAWSLBTargetGroup_stickinessValidALB(t *testing.T) {
 	var conf elbv2.TargetGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1260,7 +1265,7 @@ func TestAccAWSLBTargetGroup_stickinessValidALB(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("HTTP", "lb_cookie", true),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "HTTP", "lb_cookie", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1270,7 +1275,7 @@ func TestAccAWSLBTargetGroup_stickinessValidALB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("HTTPS", "lb_cookie", true),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "HTTPS", "lb_cookie", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1284,6 +1289,8 @@ func TestAccAWSLBTargetGroup_stickinessValidALB(t *testing.T) {
 }
 
 func TestAccAWSLBTargetGroup_stickinessInvalidNLB(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
@@ -1291,15 +1298,15 @@ func TestAccAWSLBTargetGroup_stickinessInvalidNLB(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("TCP", "lb_cookie", true),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "TCP", "lb_cookie", true),
 				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("UDP", "lb_cookie", true),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "UDP", "lb_cookie", true),
 				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("TCP_UDP", "lb_cookie", true),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "TCP_UDP", "lb_cookie", true),
 				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
 			},
 		},
@@ -1307,6 +1314,8 @@ func TestAccAWSLBTargetGroup_stickinessInvalidNLB(t *testing.T) {
 }
 
 func TestAccAWSLBTargetGroup_stickinessInvalidALB(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
@@ -1314,19 +1323,19 @@ func TestAccAWSLBTargetGroup_stickinessInvalidALB(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("HTTP", "source_ip", true),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "HTTP", "source_ip", true),
 				ExpectError: regexp.MustCompile("Stickiness type 'source_ip' is not supported for target groups with"),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("HTTPS", "source_ip", true),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "HTTPS", "source_ip", true),
 				ExpectError: regexp.MustCompile("Stickiness type 'source_ip' is not supported for target groups with"),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("TLS", "lb_cookie", true),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "TLS", "lb_cookie", true),
 				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
 			},
 			{
-				Config:             testAccAWSLBTargetGroupConfig_stickinessValidity("TCP_UDP", "lb_cookie", false),
+				Config:             testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "TCP_UDP", "lb_cookie", false),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
@@ -1337,7 +1346,8 @@ func TestAccAWSLBTargetGroup_stickinessInvalidALB(t *testing.T) {
 func TestAccAWSLBTargetGroup_preserveClientIPValid(t *testing.T) {
 	var conf elbv2.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
@@ -1345,14 +1355,14 @@ func TestAccAWSLBTargetGroup_preserveClientIPValid(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_preserveClientIP(targetGroupName, true),
+				Config: testAccAWSLBTargetGroupConfig_preserveClientIP(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "preserve_client_ip", "true"),
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_preserveClientIP(targetGroupName, false),
+				Config: testAccAWSLBTargetGroupConfig_preserveClientIP(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "preserve_client_ip", "false"),
@@ -1506,17 +1516,17 @@ func testAccCheckAWSLBTargetGroupDestroy(s *terraform.State) error {
 		if isAWSErr(err, elbv2.ErrCodeTargetGroupNotFoundException, "") {
 			return nil
 		} else {
-			return fmt.Errorf("Unexpected error checking ALB destroyed: %s", err)
+			return fmt.Errorf("unexpected error checking ALB destroyed: %w", err)
 		}
 	}
 
 	return nil
 }
 
-func testAccALB_defaults(name string) string {
+func testAccALB_defaults(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTP"
   vpc_id   = aws_vpc.test.id
@@ -1540,7 +1550,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_application_LB_defaults"
+    Name = %[1]q
   }
 }
 
@@ -1548,16 +1558,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-alb-defaults"
+    Name = %[1]q
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccNLB_defaults(name, healthCheckBlock string) string {
+func testAccNLB_defaults(rName, healthCheckBlock string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
@@ -1566,11 +1576,11 @@ resource "aws_lb_target_group" "test" {
   slow_start           = 0
 
   health_check {
-    %s
+    %[2]s
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_application_LB_defaults"
+    Name = %[1]q
   }
 }
 
@@ -1578,16 +1588,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-nlb-defaults"
+    Name = %[1]q
   }
 }
-`, name, healthCheckBlock)
+`, rName, healthCheckBlock)
 }
 
-func testAccAWSLBTargetGroupConfig_basic(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -1612,7 +1622,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_basic"
+    Name = %[1]q
   }
 }
 
@@ -1620,16 +1630,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-basic"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_ProtocolVersion(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_ProtocolVersion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name             = "%s"
+  name             = %[1]q
   port             = 443
   protocol         = "HTTPS"
   protocol_version = "HTTP2"
@@ -1655,7 +1665,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_basic"
+    Name = %[1]q
   }
 }
 
@@ -1663,10 +1673,10 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-basic"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
 func testAccAWSLBTargetGroupConfigProtocolGeneve(rName string) string {
@@ -1675,7 +1685,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.10.10.0/25"
 
   tags = {
-    Name = "tf-acc-test-lb-target-group"
+    Name = %[1]q
   }
 }
 
@@ -1693,7 +1703,7 @@ resource "aws_lb_target_group" "test" {
 `, rName)
 }
 
-func testAccAWSLBTargetGroupConfigTags1(targetGroupName, tagKey1, tagValue1 string) string {
+func testAccAWSLBTargetGroupConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name     = %[1]q
@@ -1732,10 +1742,10 @@ resource "aws_vpc" "test" {
     Name = %[1]q
   }
 }
-`, targetGroupName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1)
 }
 
-func testAccAWSLBTargetGroupConfigTags2(targetGroupName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccAWSLBTargetGroupConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name     = %[1]q
@@ -1775,13 +1785,13 @@ resource "aws_vpc" "test" {
     Name = %[1]q
   }
 }
-`, targetGroupName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAWSLBTargetGroupConfig_basicUdp(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_basicUdp(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 514
   protocol = "UDP"
   vpc_id   = aws_vpc.test.id
@@ -1792,7 +1802,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_basic"
+    Name = %[1]q
   }
 }
 
@@ -1800,25 +1810,25 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-basic"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_withoutHealthcheck(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_withoutHealthcheck(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name        = "%s"
+  name        = %[1]q
   target_type = "lambda"
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfigBackwardsCompatibility(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfigBackwardsCompatibility(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_alb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -1843,7 +1853,7 @@ resource "aws_alb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_basic"
+    Name = %[1]q
   }
 }
 
@@ -1851,16 +1861,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-bc"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_enableHealthcheck(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_enableHealthcheck(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name        = "%s"
+  name        = %[1]q
   target_type = "lambda"
 
   health_check {
@@ -1868,13 +1878,13 @@ resource "aws_lb_target_group" "test" {
     interval = 60
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_updatedPort(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_updatedPort(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 442
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -1898,7 +1908,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_basic"
+    Name = %[1]q
   }
 }
 
@@ -1906,16 +1916,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-basic"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_updatedProtocol(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_updatedProtocol(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTP"
   vpc_id   = aws_vpc.test2.id
@@ -1939,7 +1949,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_basic"
+    Name = %[1]q
   }
 }
 
@@ -1947,7 +1957,7 @@ resource "aws_vpc" "test2" {
   cidr_block = "10.10.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-basic-2"
+    Name = "%[1]s-2"
   }
 }
 
@@ -1955,16 +1965,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-basic"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_GRPC_ProtocolVersion(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_GRPC_ProtocolVersion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name             = "%s"
+  name             = %[1]q
   port             = 80
   protocol         = "HTTP"
   protocol_version = "GRPC"
@@ -1989,7 +1999,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_basic"
+    Name = %[1]q
   }
 }
 
@@ -1997,7 +2007,7 @@ resource "aws_vpc" "test2" {
   cidr_block = "10.10.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-basic-2"
+    Name = "%[1]s-2"
   }
 }
 
@@ -2005,16 +2015,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-basic"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_updatedVpc(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_updatedVpc(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -2038,7 +2048,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_basic"
+    Name = %[1]q
   }
 }
 
@@ -2046,16 +2056,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-updated-vpc"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_updateHealthCheck(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_updateHealthCheck(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
@@ -2083,24 +2093,24 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-update-health-check"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_Protocol_Tls(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_Protocol_Tls(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "tf-acc-test-lb-target-group-protocol-tls"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb_target_group" "test" {
-  name     = %q
+  name     = %[1]q
   port     = 443
   protocol = "TLS"
   vpc_id   = aws_vpc.test.id
@@ -2114,16 +2124,16 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "tf-acc-test-lb-target-group-protocol-tls"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_typeTCP(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_typeTCP(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 8082
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
@@ -2139,7 +2149,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAcc_networkLB_TargetGroup"
+    Name = %[1]q
   }
 }
 
@@ -2147,16 +2157,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-type-tcp"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_typeTCP_withProxyProtocol(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_typeTCP_withProxyProtocol(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 8082
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
@@ -2173,7 +2183,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAcc_networkLB_TargetGroup"
+    Name = %[1]q
   }
 }
 
@@ -2181,16 +2191,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-type-tcp"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_typeTCPInvalidThreshold(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_typeTCPInvalidThreshold(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 8082
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
@@ -2206,7 +2216,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAcc_networkLB_TargetGroup"
+    Name = %[1]q
   }
 }
 
@@ -2214,16 +2224,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-type-tcp"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_typeTCPThresholdUpdated(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_typeTCPThresholdUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 8082
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
@@ -2239,7 +2249,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAcc_networkLB_TargetGroup"
+    Name = %[1]q
   }
 }
 
@@ -2247,16 +2257,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-type-tcp-threshold-updated"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_typeTCPIntervalUpdated(targetGroupName string) string {
+func testAccAWSLBTargetGroupConfig_typeTCPIntervalUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 8082
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
@@ -2272,7 +2282,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAcc_networkLB_TargetGroup"
+    Name = %[1]q
   }
 }
 
@@ -2280,13 +2290,13 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-type-tcp-interval-updated"
+    Name = %[1]q
   }
 }
-`, targetGroupName)
+`, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(targetGroupName, path string, threshold int) string {
+func testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(rName, path string, threshold int) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name     = "%[1]s"
@@ -2306,7 +2316,7 @@ resource "aws_lb_target_group" "test" {
   }
 
   tags = {
-    Name = "TestAcc_networkLB_HTTPHealthCheck"
+    Name = %[1]q
   }
 }
 
@@ -2314,19 +2324,19 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-type-tcp-http-health-check"
+    Name = %[1]q
   }
 }
-`, targetGroupName, threshold, path)
+`, rName, threshold, path)
 }
 
-func testAccAWSLBTargetGroupConfig_stickiness(targetGroupName string, addStickinessBlock bool, enabled bool) string {
+func testAccAWSLBTargetGroupConfig_stickiness(rName string, addStickinessBlock bool, enabled bool) string {
 	var stickinessBlock string
 
 	if addStickinessBlock {
 		stickinessBlock = fmt.Sprintf(`
 stickiness {
-  enabled         = "%t"
+  enabled         = "%[1]t"
   type            = "lb_cookie"
   cookie_duration = 10000
 }
@@ -2335,14 +2345,14 @@ stickiness {
 
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
-  %s
+  %[2]s
 
   health_check {
     path                = "/health2"
@@ -2360,13 +2370,14 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-stickiness"
+    Name = %[1]q
   }
 }
-`, targetGroupName, stickinessBlock)
+`, rName, stickinessBlock)
 }
 
-const testAccAWSLBTargetGroupConfig_namePrefix = `
+func testAccAWSLBTargetGroupConfig_namePrefix(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name_prefix = "tf-"
   port        = 80
@@ -2378,12 +2389,14 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-name-prefix"
+    Name = %[1]q
   }
 }
-`
+`, rName)
+}
 
-const testAccAWSLBTargetGroupConfig_generatedName = `
+func testAccAWSLBTargetGroupConfig_generatedName(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   port     = 80
   protocol = "HTTP"
@@ -2394,41 +2407,42 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-generated-name"
+    Name = %[1]q
   }
 }
-`
-
-func testAccAWSLBTargetGroupConfig_stickinessDefault(protocol string) string {
-	return fmt.Sprintf(`
-resource "aws_lb_target_group" "test" {
-  name_prefix = "tf-"
-  port        = 25
-  protocol    = %q
-  vpc_id      = aws_vpc.test.id
+`, rName)
 }
 
+func testAccAWSLBTargetGroupConfig_stickinessDefault(rName, protocol string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "testAccAWSLBTargetGroupConfig_stickinessDefault"
+    Name = %[1]q
   }
 }
-`, protocol)
+
+resource "aws_lb_target_group" "test" {
+  name_prefix = "tf-"
+  port        = 25
+  protocol    = %[2]q
+  vpc_id      = aws_vpc.test.id
+}
+`, rName, protocol)
 }
 
-func testAccAWSLBTargetGroupConfig_stickinessValidity(protocol, stickyType string, enabled bool) string {
+func testAccAWSLBTargetGroupConfig_stickinessValidity(rName, protocol, stickyType string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name_prefix = "tf-"
   port        = 25
-  protocol    = %q
+  protocol    = %[1]q
   vpc_id      = aws_vpc.test.id
 
   stickiness {
-    type    = %q
-    enabled = %t
+    type    = %[2]q
+    enabled = %[3]t
   }
 }
 
@@ -2436,16 +2450,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "testAccAWSLBTargetGroupConfig_stickinessValidity"
+    Name = %[4]q
   }
 }
-`, protocol, stickyType, enabled)
+`, protocol, stickyType, enabled, rName)
 }
 
-func testAccAWSLBTargetGroupConfig_preserveClientIP(targetGroupName string, preserveClientIP bool) string {
+func testAccAWSLBTargetGroupConfig_preserveClientIP(rName string, preserveClientIP bool) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name     = "%s"
+  name     = %[1]q
   port     = 443
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
@@ -2453,10 +2467,10 @@ resource "aws_lb_target_group" "test" {
   deregistration_delay = 200
   slow_start           = 0
 
-  preserve_client_ip = %t
+  preserve_client_ip = %[2]t
 
   tags = {
-    Name = "TestAccAWSLBTargetGroup_basic"
+    Name = %[1]q
   }
 }
 
@@ -2464,7 +2478,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-basic"
+    Name = %[1]q
   }
-}`, targetGroupName, preserveClientIP)
+}`, rName, preserveClientIP)
 }

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -1334,6 +1334,33 @@ func TestAccAWSLBTargetGroup_stickinessInvalidALB(t *testing.T) {
 	})
 }
 
+func TestAccAWSLBTargetGroup_preserveClientIPValid(t *testing.T) {
+	var conf elbv2.TargetGroup
+	resourceName := "aws_lb_target_group.test"
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandString(10))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBTargetGroupConfig_preserveClientIP(targetGroupName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "preserve_client_ip", "true"),
+				),
+			},
+			{
+				Config: testAccAWSLBTargetGroupConfig_preserveClientIP(targetGroupName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "preserve_client_ip", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLBTargetGroupExists(n string, res *elbv2.TargetGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -2412,4 +2439,31 @@ resource "aws_vpc" "test" {
   }
 }
 `, protocol, stickyType, enabled)
+}
+
+func testAccAWSLBTargetGroupConfig_preserveClientIP(targetGroupName string, preserveClientIP bool) string {
+	return fmt.Sprintf(`
+resource "aws_lb_target_group" "test" {
+  name     = "%s"
+  port     = 443
+  protocol = "TCP"
+  vpc_id   = aws_vpc.test.id
+
+  deregistration_delay = 200
+  slow_start           = 0
+
+  preserve_client_ip = %t
+
+  tags = {
+    Name = "TestAccAWSLBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-lb-target-group-basic"
+  }
+}`, targetGroupName, preserveClientIP)
 }

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -58,66 +58,54 @@ resource "aws_lb_target_group" "lambda-example" {
 
 The following arguments are supported:
 
-* `name` - (Optional, Forces new resource) The name of the target group. If omitted, Terraform will assign a random, unique name.
-* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.
-
-* `port` - (Optional, Forces new resource) The port on which targets receive traffic, unless overridden when registering a specific target. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
-* `protocol` - (Optional, Forces new resource) The protocol to use for routing traffic to the targets. Should be one of `GENEVE`, `HTTP`, `HTTPS`, `TCP`, `TCP_UDP`, `TLS`, or `UDP`. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
-* `protocol_version` - (Optional, Forces new resource) Only applicable when `protocol` is `HTTP` or `HTTPS`. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1
-* `vpc_id` - (Optional, Forces new resource) The identifier of the VPC in which to create the target group. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
-* `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
-* `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.
+* `deregistration_delay` - (Optional) Amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
+* `health_check` - (Optional, Maximum of 1) Health Check configuration block. Detailed below.
+* `lambda_multi_value_headers_enabled` - (Optional) Whether the request and response headers exchanged between the load balancer and the Lambda function include arrays of values or strings. Only applies when `target_type` is `lambda`.
 * `load_balancing_algorithm_type` - (Optional) Determines how the load balancer selects targets when routing requests. Only applicable for Application Load Balancer Target Groups. The value is `round_robin` or `least_outstanding_requests`. The default is `round_robin`.
-* `lambda_multi_value_headers_enabled` - (Optional) Boolean whether the request and response headers exchanged between the load balancer and the Lambda function include arrays of values or strings. Only applies when `target_type` is `lambda`.
-* `proxy_protocol_v2` - (Optional) Boolean to enable / disable support for proxy protocol v2 on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#proxy-protocol) for more information.
-* `stickiness` - (Optional, Maximum of 1) A Stickiness block. Stickiness blocks are documented below.
-* `health_check` - (Optional, Maximum of 1) A Health Check block. Health Check blocks are documented below.
-* `target_type` - (Optional, Forces new resource) The type of target that you must specify when registering targets with this target group.
-The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address) or `lambda` (targets are specified by lambda arn).
-The default is `instance`. Note that you can't specify targets for a target group using both instance IDs and IP addresses.
-If the target type is `ip`, specify IP addresses from the subnets of the virtual private cloud (VPC) for the target group,
-the RFC 1918 range (10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16), and the RFC 6598 range (100.64.0.0/10).
-You can't specify publicly routable IP addresses.
-* `preserve_client_ip` - (Optional) Boolean to indicate whether client IP preservation is enabled or disabled. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#client-ip-preservation) for more information.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.
+* `name` - (Optional, Forces new resource) Name of the target group. If omitted, Terraform will assign a random, unique name.
+* `port` - (May be required, Forces new resource) Port on which targets receive traffic, unless overridden when registering a specific target. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
+* `preserve_client_ip` - (Optional) Whether client IP preservation is enabled. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#client-ip-preservation) for more information.
+* `protocol_version` - (Optional, Forces new resource) Only applicable when `protocol` is `HTTP` or `HTTPS`. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1
+* `protocol` - (May be required, Forces new resource) Protocol to use for routing traffic to the targets. Should be one of `GENEVE`, `HTTP`, `HTTPS`, `TCP`, `TCP_UDP`, `TLS`, or `UDP`. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
+* `proxy_protocol_v2` - (Optional) Whether to enable support for proxy protocol v2 on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#proxy-protocol) for more information. Default is `false`.
+* `slow_start` - (Optional) Amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.
+* `stickiness` - (Optional, Maximum of 1) Stickiness configuration block. Detailed below.
+* `tags` - (Optional) Map of tags to assign to the resource.
+* `target_type` - (May be required, Forces new resource) Type of target that you must specify when registering targets with this target group. The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address) or `lambda` (targets are specified by lambda arn). The default is `instance`. Note that you can't specify targets for a target group using both instance IDs and IP addresses. If the target type is `ip`, specify IP addresses from the subnets of the virtual private cloud (VPC) for the target group, the RFC 1918 range (10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16), and the RFC 6598 range (100.64.0.0/10). You can't specify publicly routable IP addresses.
+* `vpc_id` - (Optional, Forces new resource) Identifier of the VPC in which to create the target group. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 
-Stickiness Blocks (`stickiness`) support the following:
+### health_check
 
-* `type` - (Required) The type of sticky sessions. The only current possible values are `lb_cookie` for ALBs and `source_ip` for NLBs.
-* `cookie_duration` - (Optional) Only used when the type is `lb_cookie`. The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
-* `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`
+~> **Note:** The Health Check parameters you can set vary by the `protocol` of the Target Group. Many parameters cannot be set to custom values for `network` load balancers at this time. See http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html for a complete reference. Keep in mind, that health checks produce actual requests to the backend. The underlying function is invoked when `target_type` is set to `lambda`.
+
+* `enabled` - (Optional) Whether health checks are enabled. Defaults to `true`.
+* `healthy_threshold` - (Optional) Number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3.
+* `interval` - (Optional) Approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. For `lambda` target groups, it needs to be greater as the `timeout` of the underlying `lambda`. Default 30 seconds.
+* `matcher` (May be required) Response codes to use when checking for a healthy responses from a target. You can specify multiple values (for example, "200,202" for HTTP(s) or "0,12" for GRPC) or a range of values (for example, "200-299" or "0-99"). Required for HTTP/HTTPS/GRPC ALB. Only applies to Application Load Balancers (i.e., HTTP/HTTPS/GRPC) not Network Load Balancers (i.e., TCP).
+* `path` - (May be required) Destination for the health check request. Required for HTTP/HTTPS ALB and HTTP NLB. Only applies to HTTP/HTTPS.
+* `port` - (Optional) Port to use to connect with the target. Valid values are either ports 1-65535, or `traffic-port`. Defaults to `traffic-port`.
+* `protocol_version` - (Optional) Protocol version. Defaults to `HTTP1`. Specify GRPC to send requests to targets using GRPC, HTTP2 to send requests to targets using HTTP/2, HTTP1 to send requests to targets using HTTP/1.1.
+* `protocol` - (Optional) Protocol to use to connect with the target. Defaults to `HTTP`. Not applicable when `target_type` is `lambda`.
+* `timeout` - (Optional) Amount of time, in seconds, during which no response means a failed health check. For Application Load Balancers, the range is 2 to 120 seconds, and the default is 5 seconds for the `instance` target type and 30 seconds for the `lambda` target type. For Network Load Balancers, you cannot set a custom value, and the default is 10 seconds for TCP and HTTPS health checks and 6 seconds for HTTP health checks.
+* `unhealthy_threshold` - (Optional) Number of consecutive health check failures required before considering the target unhealthy. For Network Load Balancers, this value must be the same as the `healthy_threshold`. Defaults to 3.
+
+### stickiness
 
 ~> **NOTE:** Currently, an NLB (i.e., protocol of `HTTP` or `HTTPS`) can have an invalid `stickiness` block with `type` set to `lb_cookie` as long as `enabled` is set to `false`. However, please update your configurations to avoid errors in a future version of the provider: either remove the invalid `stickiness` block or set the `type` to `source_ip`.
 
-Health Check Blocks (`health_check`):
-
-~> **Note:** The Health Check parameters you can set vary by the `protocol` of
-the Target Group. Many parameters cannot be set to custom values for `network`
-load balancers at this time. See
-http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
-for a complete reference.
-Keep in mind, that health checks produce actual requests to the backend.
-The underlying function is invoked when `target_type` is set to `lambda`.
-
-* `enabled` - (Optional) Indicates whether  health checks are enabled. Defaults to true.
-* `interval` - (Optional) The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. For `lambda` target groups, it needs to be greater as the `timeout` of the underlying `lambda`. Default 30 seconds.
-* `path` - (Required for HTTP/HTTPS ALB and HTTP NLB) The destination for the health check request. Applies to only HTTP/HTTPS.
-* `port` - (Optional) The port to use to connect with the target. Valid values are either ports 1-65535, or `traffic-port`. Defaults to `traffic-port`.
-* `protocol` - (Optional) The protocol to use to connect with the target. Defaults to `HTTP`. Not applicable when `target_type` is `lambda`.
-* `protocol_version` - (Optional) The protocol version. Defaults to `HTTP1`. Specify GRPC to send requests to targets using GRPC, HTTP2 to send requests to targets using HTTP/2, HTTP1 to send requests to targets using HTTP/1.1.
-* `timeout` - (Optional) The amount of time, in seconds, during which no response means a failed health check. For Application Load Balancers, the range is 2 to 120 seconds, and the default is 5 seconds for the `instance` target type and 30 seconds for the `lambda` target type. For Network Load Balancers, you cannot set a custom value, and the default is 10 seconds for TCP and HTTPS health checks and 6 seconds for HTTP health checks.
-* `healthy_threshold` - (Optional) The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3.
-* `unhealthy_threshold` - (Optional) The number of consecutive health check failures required before considering the target unhealthy . For Network Load Balancers, this value must be the same as the `healthy_threshold`. Defaults to 3.
-* `matcher` (Required for HTTP/HTTPS/GRPC ALB) The response codes to use when checking for a healthy responses from a target. You can specify multiple values (for example, "200,202" for HTTP(s) or "0,12" for GRPC) or a range of values (for example, "200-299" or "0-99"). Applies to Application Load Balancers only (HTTP/HTTPS/GRPC), not Network Load Balancers (TCP).
+* `cookie_duration` - (Optional) Only used when the type is `lb_cookie`. The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
+* `enabled` - (Optional) Whether to enable `stickiness`. Default is `true`.
+* `type` - (Required) Type of sticky sessions. The only current possible values are `lb_cookie` for ALBs and `source_ip` for NLBs.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ARN of the Target Group (matches `arn`)
-* `arn` - The ARN of the Target Group (matches `id`)
-* `arn_suffix` - The ARN suffix for use with CloudWatch Metrics.
-* `name` - The name of the Target Group
+* `arn_suffix` - ARN suffix for use with CloudWatch Metrics.
+* `arn` - ARN of the Target Group (matches `id`).
+* `id` - ARN of the Target Group (matches `arn`).
+* `name` - Name of the Target Group.
 
 ## Import
 

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -78,6 +78,7 @@ The default is `instance`. Note that you can't specify targets for a target grou
 If the target type is `ip`, specify IP addresses from the subnets of the virtual private cloud (VPC) for the target group,
 the RFC 1918 range (10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16), and the RFC 6598 range (100.64.0.0/10).
 You can't specify publicly routable IP addresses.
+* `preserve_client_ip` - (Optional) Boolean to indicate whether client IP preservation is enabled or disabled. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#client-ip-preservation) for more information.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 Stickiness Blocks (`stickiness`) support the following:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17550

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜  terraform-provider-aws git:(f-aws_lb_target_group-add_attribute) make testacc TESTARGS='-run=TestAccAWSLBTargetGroup_preserveClientIPValid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBTargetGroup_preserveClientIPValid -timeout 120m
=== RUN   TestAccAWSLBTargetGroup_preserveClientIPValid
=== PAUSE TestAccAWSLBTargetGroup_preserveClientIPValid
=== CONT  TestAccAWSLBTargetGroup_preserveClientIPValid
--- PASS: TestAccAWSLBTargetGroup_preserveClientIPValid (174.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	175.617s

➜  terraform-provider-aws git:(f-aws_lb_target_group-add_attribute) ✗ make testacc TESTARGS='-run=TestAccDataSourceAWSALBTargetGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSALBTargetGroup -timeout 120m
=== RUN   TestAccDataSourceAWSALBTargetGroup_basic
=== PAUSE TestAccDataSourceAWSALBTargetGroup_basic
=== CONT  TestAccDataSourceAWSALBTargetGroup_basic
--- PASS: TestAccDataSourceAWSALBTargetGroup_basic (269.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	270.936s
➜  terraform-provider-aws git:(f-aws_lb_target_group-add_attribute) ✗ make testacc TESTARGS='-run=TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility -timeout 120m
=== RUN   TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility
=== PAUSE TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility
=== CONT  TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility (273.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	275.069s
```
