### PR TITLE
r/ssm_association - validations + wait for association argument + arn attribute

### DIFF
--- a/.changelog/17732.txt
+++ b/.changelog/17732.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_ssm_association: Add plan time validation to `association_name`, `document_version`, `schedule_expression`, `output_location.s3_bucket_name`, `output_location.s3_key_prefix`, `targets.key`, `targets.values`, `automation_target_parameter_name`
+```
+
+```release-note:enhancement
+resource/aws_ssm_association: Add `wait_for_success_timeout_seconds` argument
+```
+
+```release-note:enhancement
+resource/aws_ssm_association: Add `arn` attribute
+```

--- a/internal/service/ssm/association.go
+++ b/internal/service/ssm/association.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func ResourceAssociation() *schema.Resource {
@@ -28,6 +31,10 @@ func ResourceAssociation() *schema.Resource {
 		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"apply_only_at_cron_interval": {
 				Type:     schema.TypeBool,
 				Default:  false,
@@ -36,20 +43,26 @@ func ResourceAssociation() *schema.Resource {
 			"association_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(3, 128),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`), "must contain only alphanumeric, underscore, hyphen, or period characters"),
+				),
 			},
 			"association_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"instance_id": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:       schema.TypeString,
+				ForceNew:   true,
+				Optional:   true,
+				Deprecated: "use 'targets' argument instead. https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateAssociation.html#systemsmanager-CreateAssociation-request-InstanceId",
 			},
 			"document_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)$`), ""),
 			},
 			"max_concurrency": {
 				Type:         schema.TypeString,
@@ -73,8 +86,9 @@ func ResourceAssociation() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"schedule_expression": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 256),
 			},
 			"output_location": {
 				Type:     schema.TypeList,
@@ -83,12 +97,14 @@ func ResourceAssociation() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"s3_bucket_name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(3, 63),
 						},
 						"s3_key_prefix": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(0, 500),
 						},
 						"s3_region": {
 							Type:         schema.TypeString,
@@ -106,30 +122,31 @@ func ResourceAssociation() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 163),
 						},
 						"values": {
 							Type:     schema.TypeList,
 							Required: true,
+							MaxItems: 50,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
 			},
 			"compliance_severity": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ssm.ComplianceSeverityUnspecified,
-					ssm.ComplianceSeverityLow,
-					ssm.ComplianceSeverityMedium,
-					ssm.ComplianceSeverityHigh,
-					ssm.ComplianceSeverityCritical,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ssm.ComplianceSeverity_Values(), false),
 			},
 			"automation_target_parameter_name": {
-				Type:     schema.TypeString,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 50),
+			},
+			"wait_for_success_timeout_seconds": {
+				Type:     schema.TypeInt,
 				Optional: true,
 			},
 		},
@@ -169,8 +186,8 @@ func resourceAssociationCreate(d *schema.ResourceData, meta interface{}) error {
 		associationInput.Parameters = expandSSMDocumentParameters(v.(map[string]interface{}))
 	}
 
-	if _, ok := d.GetOk("targets"); ok {
-		associationInput.Targets = expandTargets(d.Get("targets").([]interface{}))
+	if v, ok := d.GetOk("targets"); ok {
+		associationInput.Targets = expandTargets(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("output_location"); ok {
@@ -195,7 +212,7 @@ func resourceAssociationCreate(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.CreateAssociation(associationInput)
 	if err != nil {
-		return fmt.Errorf("Error creating SSM association: %s", err)
+		return fmt.Errorf("Error creating SSM association: %w", err)
 	}
 
 	if resp.AssociationDescription == nil {
@@ -203,7 +220,14 @@ func resourceAssociationCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(aws.StringValue(resp.AssociationDescription.AssociationId))
-	d.Set("association_id", resp.AssociationDescription.AssociationId)
+
+	if v, ok := d.GetOk("wait_for_success_timeout_seconds"); ok {
+		dur, _ := time.ParseDuration(fmt.Sprintf("%ds", v.(int)))
+		_, err = waitAssociationSuccess(conn, d.Id(), dur)
+		if err != nil {
+			return fmt.Errorf("error waiting for SSM Association (%s) to be Success: %w", d.Id(), err)
+		}
+	}
 
 	return resourceAssociationRead(d, meta)
 }
@@ -213,24 +237,24 @@ func resourceAssociationRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Reading SSM Association: %s", d.Id())
 
-	params := &ssm.DescribeAssociationInput{
-		AssociationId: aws.String(d.Id()),
-	}
-
-	resp, err := conn.DescribeAssociation(params)
-
+	association, err := FindAssociationById(conn, d.Id())
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, ssm.ErrCodeAssociationDoesNotExist, "") {
+		if !d.IsNewResource() && tfresource.NotFound(err) {
 			d.SetId("")
+			log.Printf("[WARN] Unable to find SSM Association (%s); removing from state", d.Id())
 			return nil
 		}
-		return fmt.Errorf("Error reading SSM association: %s", err)
-	}
-	if resp.AssociationDescription == nil {
-		return fmt.Errorf("AssociationDescription was nil")
+		return fmt.Errorf("error reading SSM Association (%s): %w", d.Id(), err)
 	}
 
-	association := resp.AssociationDescription
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "ssm",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("association/%s", aws.StringValue(association.AssociationId)),
+	}.String()
+	d.Set("arn", arn)
 	d.Set("apply_only_at_cron_interval", association.ApplyOnlyAtCronInterval)
 	d.Set("association_name", association.AssociationName)
 	d.Set("instance_id", association.InstanceId)
@@ -248,11 +272,11 @@ func resourceAssociationRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := d.Set("targets", flattenTargets(association.Targets)); err != nil {
-		return fmt.Errorf("Error setting targets error: %#v", err)
+		return fmt.Errorf("Error setting targets error: %w", err)
 	}
 
 	if err := d.Set("output_location", flattenAssociationOutoutLocation(association.OutputLocation)); err != nil {
-		return fmt.Errorf("Error setting output_location error: %#v", err)
+		return fmt.Errorf("Error setting output_location error: %w", err)
 	}
 
 	return nil
@@ -264,7 +288,7 @@ func resourceAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] SSM Association update: %s", d.Id())
 
 	associationInput := &ssm.UpdateAssociationInput{
-		AssociationId: aws.String(d.Get("association_id").(string)),
+		AssociationId: aws.String(d.Id()),
 	}
 
 	if v, ok := d.GetOk("apply_only_at_cron_interval"); ok {
@@ -326,13 +350,16 @@ func resourceAssociationDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting SSM Association: %s", d.Id())
 
 	params := &ssm.DeleteAssociationInput{
-		AssociationId: aws.String(d.Get("association_id").(string)),
+		AssociationId: aws.String(d.Id()),
 	}
 
 	_, err := conn.DeleteAssociation(params)
 
 	if err != nil {
-		return fmt.Errorf("Error deleting SSM association: %s", err)
+		if tfawserr.ErrCodeContains(err, ssm.ErrCodeAssociationDoesNotExist) {
+			return nil
+		}
+		return fmt.Errorf("Error deleting SSM association: %w", err)
 	}
 
 	return nil

--- a/internal/service/ssm/association_test.go
+++ b/internal/service/ssm/association_test.go
@@ -1257,7 +1257,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithOutPutLocationUpdateBucketNameConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "output_location" {
-  bucket        =  %[1]q
+  bucket        = %[1]q
   force_destroy = true
 }
 

--- a/internal/service/ssm/association_test.go
+++ b/internal/service/ssm/association_test.go
@@ -1262,7 +1262,7 @@ resource "aws_s3_bucket" "output_location" {
 }
 
 resource "aws_s3_bucket" "output_location_updated" {
-  bucket        =  "%[1]s-2"
+  bucket        = "%[1]s-2"
   force_destroy = true
 }
 

--- a/internal/service/ssm/association_test.go
+++ b/internal/service/ssm/association_test.go
@@ -2,21 +2,22 @@ package ssm_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfssm "github.com/hashicorp/terraform-provider-aws/internal/service/ssm"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccSSMAssociation_basic(t *testing.T) {
-	name := fmt.Sprintf("tf-acc-ssm-association-%s", sdkacctest.RandString(10))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -26,10 +27,20 @@ func TestAccSSMAssociation_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociationBasicConfig(name),
+				Config: testAccAssociationBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ssm", regexp.MustCompile(`association/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "apply_only_at_cron_interval", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "aws_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "output_location.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "InstanceIds"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "targets.0.values.0", "aws_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "document_version", "$DEFAULT"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 			{
@@ -63,8 +74,8 @@ func TestAccSSMAssociation_disappears(t *testing.T) {
 	})
 }
 
-func TestAccSSMAssociation_applyOnlyAtCronInterval(t *testing.T) {
-	name := sdkacctest.RandString(10)
+func TestAccSSMAssociation_disappears_document(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -74,7 +85,29 @@ func TestAccSSMAssociation_applyOnlyAtCronInterval(t *testing.T) {
 		CheckDestroy: testAccCheckAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociationBasicWithApplyOnlyAtCronIntervalConfig(name, true),
+				Config: testAccAssociationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAssociationExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfssm.ResourceDocument(), "aws_ssm_document.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSSMAssociation_applyOnlyAtCronInterval(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ssm_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ssm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssociationBasicWithApplyOnlyAtCronIntervalConfig(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "apply_only_at_cron_interval", "true"),
@@ -86,7 +119,7 @@ func TestAccSSMAssociation_applyOnlyAtCronInterval(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAssociationBasicWithApplyOnlyAtCronIntervalConfig(name, false),
+				Config: testAccAssociationBasicWithApplyOnlyAtCronIntervalConfig(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "apply_only_at_cron_interval", "false"),
@@ -97,7 +130,7 @@ func TestAccSSMAssociation_applyOnlyAtCronInterval(t *testing.T) {
 }
 
 func TestAccSSMAssociation_withTargets(t *testing.T) {
-	name := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 	oneTarget := `
 
@@ -127,15 +160,12 @@ targets {
 		CheckDestroy: testAccCheckAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociationBasicWithTargetsConfig(name, oneTarget),
+				Config: testAccAssociationBasicWithTargetsConfig(rName, oneTarget),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.#", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.0.values.0", "acceptanceTest"),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptanceTest"),
 				),
 			},
 			{
@@ -144,31 +174,23 @@ targets {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAssociationBasicWithTargetsConfig(name, twoTargets),
+				Config: testAccAssociationBasicWithTargetsConfig(rName, twoTargets),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.#", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.0.values.0", "acceptanceTest"),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.1.key", "tag:ExtraName"),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.1.values.0", "acceptanceTest"),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptanceTest"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:ExtraName"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptanceTest"),
 				),
 			},
 			{
-				Config: testAccAssociationBasicWithTargetsConfig(name, oneTarget),
+				Config: testAccAssociationBasicWithTargetsConfig(rName, oneTarget),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.#", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr(
-						resourceName, "targets.0.values.0", "acceptanceTest"),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptanceTest"),
 				),
 			},
 		},
@@ -176,7 +198,7 @@ targets {
 }
 
 func TestAccSSMAssociation_withParameters(t *testing.T) {
-	name := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -186,11 +208,10 @@ func TestAccSSMAssociation_withParameters(t *testing.T) {
 		CheckDestroy: testAccCheckAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociationBasicWithParametersConfig(name),
+				Config: testAccAssociationBasicWithParametersConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameters.Directory", "myWorkSpace"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Directory", "myWorkSpace"),
 				),
 			},
 			{
@@ -200,11 +221,10 @@ func TestAccSSMAssociation_withParameters(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"parameters"},
 			},
 			{
-				Config: testAccAssociationBasicWithParametersUpdatedConfig(name),
+				Config: testAccAssociationBasicWithParametersUpdatedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameters.Directory", "myWorkSpaceUpdated"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Directory", "myWorkSpaceUpdated"),
 				),
 			},
 		},
@@ -212,9 +232,9 @@ func TestAccSSMAssociation_withParameters(t *testing.T) {
 }
 
 func TestAccSSMAssociation_withAssociationName(t *testing.T) {
-	assocName1 := sdkacctest.RandString(10)
-	assocName2 := sdkacctest.RandString(10)
-	rName := sdkacctest.RandString(5)
+	assocName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	assocName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -227,8 +247,7 @@ func TestAccSSMAssociation_withAssociationName(t *testing.T) {
 				Config: testAccAssociationBasicWithAssociationNameConfig(rName, assocName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "association_name", assocName1),
+					resource.TestCheckResourceAttr(resourceName, "association_name", assocName1),
 				),
 			},
 			{
@@ -240,8 +259,7 @@ func TestAccSSMAssociation_withAssociationName(t *testing.T) {
 				Config: testAccAssociationBasicWithAssociationNameConfig(rName, assocName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "association_name", assocName2),
+					resource.TestCheckResourceAttr(resourceName, "association_name", assocName2),
 				),
 			},
 		},
@@ -249,8 +267,8 @@ func TestAccSSMAssociation_withAssociationName(t *testing.T) {
 }
 
 func TestAccSSMAssociation_withAssociationNameAndScheduleExpression(t *testing.T) {
-	assocName := sdkacctest.RandString(10)
-	rName := sdkacctest.RandString(5)
+	assocName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 	scheduleExpression1 := "cron(0 16 ? * TUE *)"
 	scheduleExpression2 := "cron(0 16 ? * WED *)"
@@ -287,7 +305,7 @@ func TestAccSSMAssociation_withAssociationNameAndScheduleExpression(t *testing.T
 }
 
 func TestAccSSMAssociation_withDocumentVersion(t *testing.T) {
-	name := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -297,11 +315,10 @@ func TestAccSSMAssociation_withDocumentVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociationBasicWithDocumentVersionConfig(name),
+				Config: testAccAssociationBasicWithDocumentVersionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "document_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "document_version", "1"),
 				),
 			},
 			{
@@ -314,7 +331,7 @@ func TestAccSSMAssociation_withDocumentVersion(t *testing.T) {
 }
 
 func TestAccSSMAssociation_withOutputLocation(t *testing.T) {
-	name := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -324,13 +341,11 @@ func TestAccSSMAssociation_withOutputLocation(t *testing.T) {
 		CheckDestroy: testAccCheckAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociationBasicWithOutPutLocationConfig(name),
+				Config: testAccAssociationBasicWithOutPutLocationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-%s", name)),
-					resource.TestCheckResourceAttr(
-						resourceName, "output_location.0.s3_key_prefix", "SSMAssociation"),
+					resource.TestCheckResourceAttrPair(resourceName, "output_location.0.s3_bucket_name", "aws_s3_bucket.output_location", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "output_location.0.s3_key_prefix", "SSMAssociation"),
 				),
 			},
 			{
@@ -339,23 +354,19 @@ func TestAccSSMAssociation_withOutputLocation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAssociationBasicWithOutPutLocationUpdateBucketNameConfig(name),
+				Config: testAccAssociationBasicWithOutPutLocationUpdateBucketNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
-					resource.TestCheckResourceAttr(
-						resourceName, "output_location.0.s3_key_prefix", "SSMAssociation"),
+					resource.TestCheckResourceAttrPair(resourceName, "output_location.0.s3_bucket_name", "aws_s3_bucket.output_location_updated", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "output_location.0.s3_key_prefix", "SSMAssociation"),
 				),
 			},
 			{
-				Config: testAccAssociationBasicWithOutPutLocationUpdateKeyPrefixConfig(name),
+				Config: testAccAssociationBasicWithOutPutLocationUpdateKeyPrefixConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
-					resource.TestCheckResourceAttr(
-						resourceName, "output_location.0.s3_key_prefix", "UpdatedAssociation"),
+					resource.TestCheckResourceAttrPair(resourceName, "output_location.0.s3_bucket_name", "aws_s3_bucket.output_location_updated", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "output_location.0.s3_key_prefix", "UpdatedAssociation"),
 				),
 			},
 		},
@@ -413,7 +424,7 @@ func TestAccSSMAssociation_withOutputLocation_s3Region(t *testing.T) {
 }
 
 func TestAccSSMAssociation_withAutomationTargetParamName(t *testing.T) {
-	name := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -423,11 +434,10 @@ func TestAccSSMAssociation_withAutomationTargetParamName(t *testing.T) {
 		CheckDestroy: testAccCheckAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociationBasicWithAutomationTargetParamNameConfig(name),
+				Config: testAccAssociationBasicWithAutomationTargetParamNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameters.Directory", "myWorkSpace"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Directory", "myWorkSpace"),
 				),
 			},
 			{
@@ -437,11 +447,10 @@ func TestAccSSMAssociation_withAutomationTargetParamName(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"parameters"},
 			},
 			{
-				Config: testAccAssociationBasicWithParametersUpdatedConfig(name),
+				Config: testAccAssociationBasicWithParametersUpdatedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameters.Directory", "myWorkSpaceUpdated"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Directory", "myWorkSpaceUpdated"),
 				),
 			},
 		},
@@ -449,7 +458,7 @@ func TestAccSSMAssociation_withAutomationTargetParamName(t *testing.T) {
 }
 
 func TestAccSSMAssociation_withScheduleExpression(t *testing.T) {
-	name := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -459,7 +468,7 @@ func TestAccSSMAssociation_withScheduleExpression(t *testing.T) {
 		CheckDestroy: testAccCheckAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociationBasicWithScheduleExpressionConfig(name),
+				Config: testAccAssociationBasicWithScheduleExpressionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "schedule_expression", "cron(0 16 ? * TUE *)"),
@@ -471,7 +480,7 @@ func TestAccSSMAssociation_withScheduleExpression(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAssociationBasicWithScheduleExpressionUpdatedConfig(name),
+				Config: testAccAssociationBasicWithScheduleExpressionUpdatedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "schedule_expression", "cron(0 16 ? * WED *)"),
@@ -482,8 +491,8 @@ func TestAccSSMAssociation_withScheduleExpression(t *testing.T) {
 }
 
 func TestAccSSMAssociation_withComplianceSeverity(t *testing.T) {
-	assocName := sdkacctest.RandString(10)
-	rName := sdkacctest.RandString(10)
+	assocName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	compSeverity1 := "HIGH"
 	compSeverity2 := "LOW"
 	resourceName := "aws_ssm_association.test"
@@ -498,10 +507,8 @@ func TestAccSSMAssociation_withComplianceSeverity(t *testing.T) {
 				Config: testAccAssociationBasicWithComplianceSeverityConfig(compSeverity1, rName, assocName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "association_name", assocName),
-					resource.TestCheckResourceAttr(
-						resourceName, "compliance_severity", compSeverity1),
+					resource.TestCheckResourceAttr(resourceName, "association_name", assocName),
+					resource.TestCheckResourceAttr(resourceName, "compliance_severity", compSeverity1),
 				),
 			},
 			{
@@ -513,10 +520,8 @@ func TestAccSSMAssociation_withComplianceSeverity(t *testing.T) {
 				Config: testAccAssociationBasicWithComplianceSeverityConfig(compSeverity2, rName, assocName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "association_name", assocName),
-					resource.TestCheckResourceAttr(
-						resourceName, "compliance_severity", compSeverity2),
+					resource.TestCheckResourceAttr(resourceName, "association_name", assocName),
+					resource.TestCheckResourceAttr(resourceName, "compliance_severity", compSeverity2),
 				),
 			},
 		},
@@ -524,7 +529,7 @@ func TestAccSSMAssociation_withComplianceSeverity(t *testing.T) {
 }
 
 func TestAccSSMAssociation_rateControl(t *testing.T) {
-	name := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -534,13 +539,11 @@ func TestAccSSMAssociation_rateControl(t *testing.T) {
 		CheckDestroy: testAccCheckAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociationRateControlConfig(name, "10%"),
+				Config: testAccAssociationRateControlConfig(rName, "10%"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "max_concurrency", "10%"),
-					resource.TestCheckResourceAttr(
-						resourceName, "max_errors", "10%"),
+					resource.TestCheckResourceAttr(resourceName, "max_concurrency", "10%"),
+					resource.TestCheckResourceAttr(resourceName, "max_errors", "10%"),
 				),
 			},
 			{
@@ -549,13 +552,11 @@ func TestAccSSMAssociation_rateControl(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAssociationRateControlConfig(name, "20%"),
+				Config: testAccAssociationRateControlConfig(rName, "20%"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssociationExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "max_concurrency", "20%"),
-					resource.TestCheckResourceAttr(
-						resourceName, "max_errors", "20%"),
+					resource.TestCheckResourceAttr(resourceName, "max_concurrency", "20%"),
+					resource.TestCheckResourceAttr(resourceName, "max_errors", "20%"),
 				),
 			},
 		},
@@ -575,14 +576,8 @@ func testAccCheckAssociationExists(n string) resource.TestCheckFunc {
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SSMConn
 
-		_, err := conn.DescribeAssociation(&ssm.DescribeAssociationInput{
-			AssociationId: aws.String(rs.Primary.Attributes["association_id"]),
-		})
-
+		_, err := tfssm.FindAssociationById(conn, rs.Primary.ID)
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, ssm.ErrCodeAssociationDoesNotExist, "") {
-				return nil
-			}
 			return err
 		}
 
@@ -598,19 +593,18 @@ func testAccCheckAssociationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		out, err := conn.DescribeAssociation(&ssm.DescribeAssociationInput{
-			AssociationId: aws.String(rs.Primary.Attributes["association_id"]),
-		})
+		assoc, err := tfssm.FindAssociationById(conn, rs.Primary.ID)
 
-		if err != nil {
-			if tfawserr.ErrMessageContains(err, ssm.ErrCodeAssociationDoesNotExist, "") {
-				continue
-			}
-			return err
+		if tfresource.NotFound(err) {
+			continue
 		}
 
-		if out != nil {
-			return fmt.Errorf("Expected AWS SSM Association to be gone, but was still found")
+		if err != nil {
+			return fmt.Errorf("error reading SSM Association (%s): %w", rs.Primary.ID, err)
+		}
+
+		if aws.StringValue(assoc.AssociationId) == rs.Primary.ID {
+			return fmt.Errorf("SSM Association %q still exists", rs.Primary.ID)
 		}
 	}
 
@@ -620,7 +614,7 @@ func testAccCheckAssociationDestroy(s *terraform.State) error {
 func testAccAssociationBasicWithApplyOnlyAtCronIntervalConfig(rName string, applyOnlyAtCronInterval bool) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -661,14 +655,14 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithAutomationTargetParamNameConfig(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), fmt.Sprintf(`
 resource "aws_iam_instance_profile" "ssm_profile" {
-  name = "ssm_profile-%[1]s"
+  name = %[1]q
   role = aws_iam_role.ssm_role.name
 }
 
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "ssm_role" {
-  name = "ssm_role-%[1]s"
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -690,7 +684,7 @@ EOF
 }
 
 resource "aws_ssm_document" "foo" {
-  name          = "test_document-%[1]s"
+  name          = %[1]q
   document_type = "Automation"
 
   content = <<DOC
@@ -773,7 +767,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithParametersUpdatedConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<-DOC
@@ -823,7 +817,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithParametersConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<-DOC
@@ -873,7 +867,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithTargetsConfig(rName, targetsStr string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -907,10 +901,6 @@ resource "aws_ssm_association" "test" {
 
 func testAccAssociationBasicConfig(rName string) string {
 	return fmt.Sprintf(`
-variable "name" {
-  default = "%s"
-}
-
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -934,7 +924,7 @@ resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = var.name
+    Name = %[1]q
   }
 }
 
@@ -945,7 +935,7 @@ resource "aws_subnet" "first" {
 }
 
 resource "aws_security_group" "test" {
-  name        = var.name
+  name        = %[1]q
   description = "foo"
   vpc_id      = aws_vpc.main.id
 
@@ -965,12 +955,12 @@ resource "aws_instance" "test" {
   subnet_id              = aws_subnet.first.id
 
   tags = {
-    Name = var.name
+    Name = %[1]q
   }
 }
 
 resource "aws_ssm_document" "test" {
-  name          = var.name
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -996,7 +986,7 @@ DOC
 }
 
 resource "aws_ssm_association" "test" {
-  name        = var.name
+  name        = %[1]q
   instance_id = aws_instance.test.id
 }
 `, rName)
@@ -1005,7 +995,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithDocumentVersionConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1031,7 +1021,7 @@ DOC
 }
 
 resource "aws_ssm_association" "test" {
-  name             = "test_document_association-%s"
+  name             = %[1]q
   document_version = aws_ssm_document.test.latest_version
 
   targets {
@@ -1039,13 +1029,13 @@ resource "aws_ssm_association" "test" {
     values = ["acceptanceTest"]
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccAssociationBasicWithScheduleExpressionConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1085,7 +1075,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithScheduleExpressionUpdatedConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1125,12 +1115,12 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithOutPutLocationConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "output_location" {
-  bucket        = "tf-acc-test-ssmoutput-%s"
+  bucket        = %[1]q
   force_destroy = true
 }
 
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1168,7 +1158,7 @@ resource "aws_ssm_association" "test" {
     s3_key_prefix  = "SSMAssociation"
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccAssociationWithOutputLocationS3RegionConfigBase(rName string) string {
@@ -1267,17 +1257,17 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithOutPutLocationUpdateBucketNameConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "output_location" {
-  bucket        = "tf-acc-test-ssmoutput-%s"
+  bucket        =  %[1]q
   force_destroy = true
 }
 
 resource "aws_s3_bucket" "output_location_updated" {
-  bucket        = "tf-acc-test-ssmoutput-updated-%s"
+  bucket        =  "%[1]s-2"
   force_destroy = true
 }
 
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1315,23 +1305,23 @@ resource "aws_ssm_association" "test" {
     s3_key_prefix  = "SSMAssociation"
   }
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccAssociationBasicWithOutPutLocationUpdateKeyPrefixConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "output_location" {
-  bucket        = "tf-acc-test-ssmoutput-%s"
+  bucket        = %[1]q
   force_destroy = true
 }
 
 resource "aws_s3_bucket" "output_location_updated" {
-  bucket        = "tf-acc-test-ssmoutput-updated-%s"
+  bucket        = "%[1]s-2"
   force_destroy = true
 }
 
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1369,13 +1359,13 @@ resource "aws_ssm_association" "test" {
     s3_key_prefix  = "UpdatedAssociation"
   }
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccAssociationBasicWithAssociationNameConfig(rName, assocName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1402,7 +1392,7 @@ DOC
 
 resource "aws_ssm_association" "test" {
   name             = aws_ssm_document.test.name
-  association_name = "%s"
+  association_name = %[2]q
 
   targets {
     key    = "tag:Name"
@@ -1415,7 +1405,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationWithAssociationNameAndScheduleExpressionConfig(rName, associationName, scheduleExpression string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1441,9 +1431,9 @@ DOC
 }
 
 resource "aws_ssm_association" "test" {
-  association_name    = %q
+  association_name    = %[2]q
   name                = aws_ssm_document.test.name
-  schedule_expression = %q
+  schedule_expression = %[3]q
 
   targets {
     key    = "tag:Name"
@@ -1456,7 +1446,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithComplianceSeverityConfig(compSeverity, rName, assocName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "test_document_association-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1483,8 +1473,8 @@ DOC
 
 resource "aws_ssm_association" "test" {
   name                = aws_ssm_document.test.name
-  association_name    = "%s"
-  compliance_severity = "%s"
+  association_name    = %[2]q
+  compliance_severity = %[3]q
 
   targets {
     key    = "tag:Name"
@@ -1497,7 +1487,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationRateControlConfig(rName, rate string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = "tf-test-ssm-document-%s"
+  name          = %[1]q
   document_type = "Command"
 
   content = <<DOC
@@ -1524,13 +1514,13 @@ DOC
 
 resource "aws_ssm_association" "test" {
   name            = aws_ssm_document.test.name
-  max_concurrency = "%s"
-  max_errors      = "%s"
+  max_concurrency = %[2]q
+  max_errors      = %[2]q
 
   targets {
     key    = "tag:Name"
     values = ["acceptanceTest"]
   }
 }
-`, rName, rate, rate)
+`, rName, rate)
 }

--- a/internal/service/ssm/association_test.go
+++ b/internal/service/ssm/association_test.go
@@ -767,7 +767,7 @@ resource "aws_ssm_association" "test" {
 func testAccAssociationBasicWithParametersUpdatedConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name          = %[1]q
+  name          = "%[1]s-2"
   document_type = "Command"
 
   content = <<-DOC

--- a/internal/service/ssm/find.go
+++ b/internal/service/ssm/find.go
@@ -5,7 +5,34 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
+
+func FindAssociationById(conn *ssm.SSM, id string) (*ssm.AssociationDescription, error) {
+	input := &ssm.DescribeAssociationInput{
+		AssociationId: aws.String(id),
+	}
+
+	output, err := conn.DescribeAssociation(input)
+	if tfawserr.ErrCodeContains(err, ssm.ErrCodeAssociationDoesNotExist) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.AssociationDescription == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.AssociationDescription, nil
+}
 
 // FindDocumentByName returns the Document corresponding to the specified name.
 func FindDocumentByName(conn *ssm.SSM, name string) (*ssm.DocumentDescription, error) {

--- a/internal/service/ssm/status.go
+++ b/internal/service/ssm/status.go
@@ -4,11 +4,28 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 const (
 	documentStatusUnknown = "Unknown"
 )
+
+func statusAssociation(conn *ssm.SSM, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindAssociationById(conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status.Name), nil
+	}
+}
 
 // statusDocument fetches the Document and its Status
 func statusDocument(conn *ssm.SSM, name string) resource.StateRefreshFunc {

--- a/internal/service/ssm/wait.go
+++ b/internal/service/ssm/wait.go
@@ -1,16 +1,39 @@
 package ssm
 
 import (
+	"errors"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 const (
 	documentDeleteTimeout = 2 * time.Minute
 	documentActiveTimeout = 2 * time.Minute
 )
+
+func waitAssociationSuccess(conn *ssm.SSM, id string, timeout time.Duration) (*ssm.AssociationDescription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ssm.AssociationStatusNamePending},
+		Target:  []string{ssm.AssociationStatusNameSuccess},
+		Refresh: statusAssociation(conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ssm.AssociationDescription); ok {
+		if statusName := aws.StringValue(output.Status.Name); statusName == ssm.AssociationStatusNameFailed {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.Status.Message)))
+		}
+		return output, err
+	}
+
+	return nil, err
+}
 
 // waitDocumentDeleted waits for an Document to return Deleted
 func waitDocumentDeleted(conn *ssm.SSM, name string) (*ssm.DocumentDescription, error) {

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -72,6 +72,7 @@ The following arguments are supported:
 * `max_concurrency` - (Optional) The maximum number of targets allowed to run the association at the same time. You can specify a number, for example 10, or a percentage of the target set, for example 10%.
 * `max_errors` - (Optional) The number of errors that are allowed before the system stops sending requests to run the association on additional targets. You can specify a number, for example 10, or a percentage of the target set, for example 10%.
 * `automation_target_parameter_name` - (Optional) Specify the target for the association. This target is required for associations that use an `Automation` document and target resources by using rate controls. This should be set to the SSM document `parameter` that will define how your automation will branch out.
+* `wait_for_success_timeout_seconds` - (Optional) The number of seconds to wait for the association status to be `Success`. If `Success` status is not reached within the given time, create opration will fail.
 
 Output Location (`output_location`) is an S3 bucket where you want to store the results of this association:
 
@@ -88,6 +89,7 @@ Targets specify what instance IDs or tags to apply the document to and has these
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the SSM association
 * `association_id` - The ID of the SSM association.
 * `instance_id` - The instance id that the SSM document was applied to.
 * `name` - The name of the SSM document to apply.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMAssociation_'
--- PASS: TestAccSSMAssociation_withDocumentVersion (52.79s)
--- PASS: TestAccSSMAssociation_applyOnlyAtCronInterval (85.90s)
--- PASS: TestAccSSMAssociation_withScheduleExpression (86.16s)
--- PASS: TestAccSSMAssociation_withAssociationNameAndScheduleExpression (86.24s)
--- PASS: TestAccSSMAssociation_withParameters (86.36s)
--- PASS: TestAccSSMAssociation_rateControl (86.36s)
--- PASS: TestAccSSMAssociation_withAssociationName (92.62s)
--- PASS: TestAccSSMAssociation_withComplianceSeverity (93.61s)
--- PASS: TestAccSSMAssociation_withTargets (117.98s)
--- PASS: TestAccSSMAssociation_disappears_document (157.77s)
--- PASS: TestAccSSMAssociation_disappears (166.70s)
--- PASS: TestAccSSMAssociation_basic (174.55s)
--- PASS: TestAccSSMAssociation_withOutputLocation_s3Region (188.80s)
--- PASS: TestAccSSMAssociation_withOutputLocation (200.40s)
--- PASS: TestAccSSMAssociation_withAutomationTargetParamName (110.68s)
```
