### PR TITLE
F/destination_outpost_arn support in aws_ami_copy

### DIFF
--- a/.changelog/17735.txt
+++ b/.changelog/17735.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ami_copy: Add `destination_outpost_arn` argument
+```

--- a/aws/resource_aws_ami_copy.go
+++ b/aws/resource_aws_ami_copy.go
@@ -209,6 +209,11 @@ func resourceAwsAmiCopy() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"destination_outpost_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
 			"sriov_net_support": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -250,6 +255,10 @@ func resourceAwsAmiCopyCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("kms_key_id"); ok {
 		req.KmsKeyId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("destination_outpost_arn"); ok {
+		req.DestinationOutpostArn = aws.String(v.(string))
 	}
 
 	res, err := client.CopyImage(req)

--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -99,6 +99,7 @@ func TestAccAWSAMICopy_DestinationOutpost(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAMICopyDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -91,6 +91,28 @@ func TestAccAWSAMICopy_EnaSupport(t *testing.T) {
 	})
 }
 
+func TestAccAWSAMICopy_DestinationOutpost(t *testing.T) {
+	var image ec2.Image
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	outpostDataSourceName := "data.aws_outposts_outpost.test"
+	resourceName := "aws_ami_copy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAMICopyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAMICopyConfigDestOutpost(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAMICopyExists(resourceName, &image),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_outpost_arn", outpostDataSourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSAMICopy_tags(t *testing.T) {
 	var ami ec2.Image
 	resourceName := "aws_ami_copy.test"
@@ -364,6 +386,35 @@ resource "aws_ami_copy" "test" {
   name              = "%s-copy"
   source_ami_id     = aws_ami.test.id
   source_ami_region = data.aws_region.current.name
+}
+`, rName, rName)
+}
+
+func testAccAWSAMICopyConfigDestOutpost(rName string) string {
+	return testAccAWSAMICopyConfigBase(rName) + fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+resource "aws_ami" "test" {
+  ena_support         = true
+  name                = "%s-source"
+  virtualization_type = "hvm"
+  root_device_name    = "/dev/sda1"
+
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    snapshot_id = aws_ebs_snapshot.test.id
+  }
+}
+
+resource "aws_ami_copy" "test" {
+  name              = "%s-copy"
+  source_ami_id     = aws_ami.test.id
+  source_ami_region = data.aws_region.current.name
+  destination_outpost_arn = data.aws_outposts_outpost.test.arn
 }
 `, rName, rName)
 }

--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -411,9 +411,9 @@ resource "aws_ami" "test" {
 }
 
 resource "aws_ami_copy" "test" {
-  name              = "%s-copy"
-  source_ami_id     = aws_ami.test.id
-  source_ami_region = data.aws_region.current.name
+  name                    = "%s-copy"
+  source_ami_id           = aws_ami.test.id
+  source_ami_region       = data.aws_region.current.name
   destination_outpost_arn = data.aws_outposts_outpost.test.arn
 }
 `, rName, rName)

--- a/website/docs/r/ami_copy.html.markdown
+++ b/website/docs/r/ami_copy.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
   given by `source_ami_region`.
 * `source_ami_region` - (Required) The region from which the AMI will be copied. This may be the
   same as the AWS provider region in order to create a copy within the same region.
-* `destination_outpost_arn` - (Optional) The ARN of the Outpost to which to copy the AMI. 
+* `destination_outpost_arn` - (Optional) The ARN of the Outpost to which to copy the AMI.
   Only specify this parameter when copying an AMI from an AWS Region to an Outpost. The AMI must be in the Region of the destination Outpost.  
 * `encrypted` - (Optional) Specifies whether the destination snapshots of the copied image should be encrypted. Defaults to `false`
 * `kms_key_id` - (Optional) The full ARN of the KMS Key to use when encrypting the snapshots of an image during a copy operation. If not specified, then the default AWS KMS Key will be used

--- a/website/docs/r/ami_copy.html.markdown
+++ b/website/docs/r/ami_copy.html.markdown
@@ -44,6 +44,8 @@ The following arguments are supported:
   given by `source_ami_region`.
 * `source_ami_region` - (Required) The region from which the AMI will be copied. This may be the
   same as the AWS provider region in order to create a copy within the same region.
+* `destination_outpost_arn` - (Optional) The ARN of the Outpost to which to copy the AMI. 
+  Only specify this parameter when copying an AMI from an AWS Region to an Outpost. The AMI must be in the Region of the destination Outpost.  
 * `encrypted` - (Optional) Specifies whether the destination snapshots of the copied image should be encrypted. Defaults to `false`
 * `kms_key_id` - (Optional) The full ARN of the KMS Key to use when encrypting the snapshots of an image during a copy operation. If not specified, then the default AWS KMS Key will be used
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17490.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAMICopy_DestinationOutpost'
=== RUN   TestAccAWSAMICopy_DestinationOutpost
=== PAUSE TestAccAWSAMICopy_DestinationOutpost
=== CONT  TestAccAWSAMICopy_DestinationOutpost
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSAMICopy_DestinationOutpost (5.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	9.235s
...
```
