### PR TITLE
aws_ec2_carrier_gateway: Correct the ARN account id

### DIFF
--- a/aws/resource_aws_ec2_carrier_gateway.go
+++ b/aws/resource_aws_ec2_carrier_gateway.go
@@ -99,7 +99,7 @@ func resourceAwsEc2CarrierGatewayRead(d *schema.ResourceData, meta interface{}) 
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(carrierGateway.OwnerId),
 		Resource:  fmt.Sprintf("carrier-gateway/%s", d.Id()),
 	}.String()
 	d.Set("arn", arn)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16978

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2CarrierGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2CarrierGateway_ -timeout 120m
=== RUN   TestAccAWSEc2CarrierGateway_basic
=== PAUSE TestAccAWSEc2CarrierGateway_basic
=== RUN   TestAccAWSEc2CarrierGateway_disappears
=== PAUSE TestAccAWSEc2CarrierGateway_disappears
=== RUN   TestAccAWSEc2CarrierGateway_Tags
=== PAUSE TestAccAWSEc2CarrierGateway_Tags
=== CONT  TestAccAWSEc2CarrierGateway_basic
=== CONT  TestAccAWSEc2CarrierGateway_Tags
=== CONT  TestAccAWSEc2CarrierGateway_disappears
=== CONT  TestAccAWSEc2CarrierGateway_basic
    resource_aws_ec2_carrier_gateway_test.go:246: skipping since no Wavelength Zones are available
--- SKIP: TestAccAWSEc2CarrierGateway_basic (2.88s)
=== CONT  TestAccAWSEc2CarrierGateway_disappears
    resource_aws_ec2_carrier_gateway_test.go:246: skipping since no Wavelength Zones are available
--- SKIP: TestAccAWSEc2CarrierGateway_disappears (2.88s)
=== CONT  TestAccAWSEc2CarrierGateway_Tags
    resource_aws_ec2_carrier_gateway_test.go:246: skipping since no Wavelength Zones are available
--- SKIP: TestAccAWSEc2CarrierGateway_Tags (2.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.936s
```

I couldn't access the wavelength zone, so would anybody run the ACC tests instead? 