### PR TITLE
r/aws_globalaccelerator_accelerator: Correctly update flow log attributes when enabled

### DIFF
--- a/.changelog/17739.txt
+++ b/.changelog/17739.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_globalaccelerator_accelerator: Allow update of flow log attribute for active flow logs
 ```
+
+```release-note:enhancement
+resource/aws_globalaccelerator_accelerator: Add plan time validation to `name`, `flow_logs_s3_bucket` and `flow_logs_s3_prefix` attributes
+```

--- a/.changelog/17739.txt
+++ b/.changelog/17739.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_globalaccelerator_accelerator: Allow update of flow log attribute for active flow logs
+```

--- a/aws/internal/service/globalaccelerator/arn.go
+++ b/aws/internal/service/globalaccelerator/arn.go
@@ -1,0 +1,73 @@
+package globalaccelerator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+const (
+	ARNSeparator = "/"
+	ARNService   = "globalaccelerator"
+)
+
+// EndpointGroupARNToListenerARN converts an endpoint group ARN to a listener ARN.
+// See https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglobalaccelerator.html#awsglobalaccelerator-resources-for-iam-policies.
+func EndpointGroupARNToListenerARN(inputARN string) (string, error) {
+	parsedARN, err := arn.Parse(inputARN)
+
+	if err != nil {
+		return "", fmt.Errorf("error parsing ARN (%s): %w", inputARN, err)
+	}
+
+	if actual, expected := parsedARN.Service, ARNService; actual != expected {
+		return "", fmt.Errorf("expected service %s in ARN (%s), got: %s", expected, inputARN, actual)
+	}
+
+	resourceParts := strings.Split(parsedARN.Resource, ARNSeparator)
+
+	if actual, expected := len(resourceParts), 6; actual < expected {
+		return "", fmt.Errorf("expected at least %d resource parts in ARN (%s), got: %d", expected, inputARN, actual)
+	}
+
+	outputARN := arn.ARN{
+		Partition: parsedARN.Partition,
+		Service:   parsedARN.Service,
+		Region:    parsedARN.Region,
+		AccountID: parsedARN.AccountID,
+		Resource:  strings.Join(resourceParts[0:4], ARNSeparator),
+	}.String()
+
+	return outputARN, nil
+}
+
+// ListenerOrEndpointGroupARNToAcceleratorARN converts a listener or endpoint group ARN to an accelerator ARN.
+// See https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglobalaccelerator.html#awsglobalaccelerator-resources-for-iam-policies.
+func ListenerOrEndpointGroupARNToAcceleratorARN(inputARN string) (string, error) {
+	parsedARN, err := arn.Parse(inputARN)
+
+	if err != nil {
+		return "", fmt.Errorf("error parsing ARN (%s): %w", inputARN, err)
+	}
+
+	if actual, expected := parsedARN.Service, ARNService; actual != expected {
+		return "", fmt.Errorf("expected service %s in ARN (%s), got: %s", expected, inputARN, actual)
+	}
+
+	resourceParts := strings.Split(parsedARN.Resource, ARNSeparator)
+
+	if actual, expected := len(resourceParts), 4; actual < expected {
+		return "", fmt.Errorf("expected at least %d resource parts in ARN (%s), got: %d", expected, inputARN, actual)
+	}
+
+	outputARN := arn.ARN{
+		Partition: parsedARN.Partition,
+		Service:   parsedARN.Service,
+		Region:    parsedARN.Region,
+		AccountID: parsedARN.AccountID,
+		Resource:  strings.Join(resourceParts[0:2], ARNSeparator),
+	}.String()
+
+	return outputARN, nil
+}

--- a/aws/internal/service/globalaccelerator/arn_test.go
+++ b/aws/internal/service/globalaccelerator/arn_test.go
@@ -1,0 +1,122 @@
+package globalaccelerator_test
+
+import (
+	"regexp"
+	"testing"
+
+	tfglobalaccelerator "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/globalaccelerator"
+)
+
+func TestEndpointGroupARNToListenerARN(t *testing.T) {
+	testCases := []struct {
+		TestName      string
+		InputARN      string
+		ExpectedError *regexp.Regexp
+		ExpectedARN   string
+	}{
+		{
+			TestName:      "empty ARN",
+			InputARN:      "",
+			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+		},
+		{
+			TestName:      "unparsable ARN",
+			InputARN:      "test",
+			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+		},
+		{
+			TestName:      "invalid ARN service",
+			InputARN:      "arn:aws:ec2::123456789012:accelerator/a-123/listener/l-456/endpoint-group/eg-789",
+			ExpectedError: regexp.MustCompile(`expected service globalaccelerator`),
+		},
+		{
+			TestName:      "invalid ARN resource parts",
+			InputARN:      "arn:aws:globalaccelerator::123456789012:accelerator/a-123/listener/l-456",
+			ExpectedError: regexp.MustCompile(`expected at least 6 resource parts`),
+		},
+		{
+			TestName:    "valid ARN",
+			InputARN:    "arn:aws:globalaccelerator::123456789012:accelerator/a-123/listener/l-456/endpoint-group/eg-789",
+			ExpectedARN: "arn:aws:globalaccelerator::123456789012:accelerator/a-123/listener/l-456",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := tfglobalaccelerator.EndpointGroupARNToListenerARN(testCase.InputARN)
+
+			if err == nil && testCase.ExpectedError != nil {
+				t.Fatalf("expected error %s, got no error", testCase.ExpectedError.String())
+			}
+
+			if err != nil && testCase.ExpectedError == nil {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if err != nil && !testCase.ExpectedError.MatchString(err.Error()) {
+				t.Fatalf("expected error %s, got: %s", testCase.ExpectedError.String(), err)
+			}
+
+			if got != testCase.ExpectedARN {
+				t.Errorf("got %s, expected %s", got, testCase.ExpectedARN)
+			}
+		})
+	}
+}
+
+func TestListenerOrEndpointGroupARNToAcceleratorARN(t *testing.T) {
+	testCases := []struct {
+		TestName      string
+		InputARN      string
+		ExpectedError *regexp.Regexp
+		ExpectedARN   string
+	}{
+		{
+			TestName:      "empty ARN",
+			InputARN:      "",
+			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+		},
+		{
+			TestName:      "unparsable ARN",
+			InputARN:      "test",
+			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+		},
+		{
+			TestName:      "invalid ARN service",
+			InputARN:      "arn:aws:ec2::123456789012:accelerator/a-123/listener/l-456",
+			ExpectedError: regexp.MustCompile(`expected service globalaccelerator`),
+		},
+		{
+			TestName:      "invalid ARN resource parts",
+			InputARN:      "arn:aws:globalaccelerator::123456789012:accelerator/a-123",
+			ExpectedError: regexp.MustCompile(`expected at least 4 resource parts`),
+		},
+		{
+			TestName:    "valid ARN",
+			InputARN:    "arn:aws:globalaccelerator::123456789012:accelerator/a-123/listener/l-456",
+			ExpectedARN: "arn:aws:globalaccelerator::123456789012:accelerator/a-123",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := tfglobalaccelerator.ListenerOrEndpointGroupARNToAcceleratorARN(testCase.InputARN)
+
+			if err == nil && testCase.ExpectedError != nil {
+				t.Fatalf("expected error %s, got no error", testCase.ExpectedError.String())
+			}
+
+			if err != nil && testCase.ExpectedError == nil {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if err != nil && !testCase.ExpectedError.MatchString(err.Error()) {
+				t.Fatalf("expected error %s, got: %s", testCase.ExpectedError.String(), err)
+			}
+
+			if got != testCase.ExpectedARN {
+				t.Errorf("got %s, expected %s", got, testCase.ExpectedARN)
+			}
+		})
+	}
+}

--- a/aws/internal/service/globalaccelerator/arn_test.go
+++ b/aws/internal/service/globalaccelerator/arn_test.go
@@ -92,8 +92,13 @@ func TestListenerOrEndpointGroupARNToAcceleratorARN(t *testing.T) {
 			ExpectedError: regexp.MustCompile(`expected at least 4 resource parts`),
 		},
 		{
-			TestName:    "valid ARN",
+			TestName:    "valid listener ARN",
 			InputARN:    "arn:aws:globalaccelerator::123456789012:accelerator/a-123/listener/l-456",
+			ExpectedARN: "arn:aws:globalaccelerator::123456789012:accelerator/a-123",
+		},
+		{
+			TestName:    "valid endpoint group ARN",
+			InputARN:    "arn:aws:globalaccelerator::123456789012:accelerator/a-123/listener/l-456/endpoint-group/eg-789",
 			ExpectedARN: "arn:aws:globalaccelerator::123456789012:accelerator/a-123",
 		},
 	}

--- a/aws/internal/service/globalaccelerator/finder/finder.go
+++ b/aws/internal/service/globalaccelerator/finder/finder.go
@@ -14,6 +14,12 @@ func AcceleratorByARN(conn *globalaccelerator.GlobalAccelerator, arn string) (*g
 		AcceleratorArn: aws.String(arn),
 	}
 
+	return Accelerator(conn, input)
+}
+
+// Accelerator returns the accelerator corresponding to the specified input.
+// Returns NotFoundError if no accelerator is found.
+func Accelerator(conn *globalaccelerator.GlobalAccelerator, input *globalaccelerator.DescribeAcceleratorInput) (*globalaccelerator.Accelerator, error) {
 	output, err := conn.DescribeAccelerator(input)
 
 	if tfawserr.ErrCodeEquals(err, globalaccelerator.ErrCodeAcceleratorNotFoundException) {
@@ -37,13 +43,19 @@ func AcceleratorByARN(conn *globalaccelerator.GlobalAccelerator, arn string) (*g
 	return output.Accelerator, nil
 }
 
-// AcceleratorAttributesByARN returns the accelerator corresponding to the specified ARN.
+// AcceleratorAttributesByARN returns the accelerator attributes corresponding to the specified ARN.
 // Returns NotFoundError if no accelerator is found.
 func AcceleratorAttributesByARN(conn *globalaccelerator.GlobalAccelerator, arn string) (*globalaccelerator.AcceleratorAttributes, error) {
 	input := &globalaccelerator.DescribeAcceleratorAttributesInput{
 		AcceleratorArn: aws.String(arn),
 	}
 
+	return AcceleratorAttributes(conn, input)
+}
+
+// AcceleratorAttributes returns the accelerator attributes corresponding to the specified input.
+// Returns NotFoundError if no accelerator is found.
+func AcceleratorAttributes(conn *globalaccelerator.GlobalAccelerator, input *globalaccelerator.DescribeAcceleratorAttributesInput) (*globalaccelerator.AcceleratorAttributes, error) {
 	output, err := conn.DescribeAcceleratorAttributes(input)
 
 	if tfawserr.ErrCodeEquals(err, globalaccelerator.ErrCodeAcceleratorNotFoundException) {

--- a/aws/internal/service/globalaccelerator/finder/finder.go
+++ b/aws/internal/service/globalaccelerator/finder/finder.go
@@ -3,7 +3,69 @@ package finder
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/globalaccelerator"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
+
+// AcceleratorByARN returns the accelerator corresponding to the specified ARN.
+// Returns NotFoundError if no accelerator is found.
+func AcceleratorByARN(conn *globalaccelerator.GlobalAccelerator, arn string) (*globalaccelerator.Accelerator, error) {
+	input := &globalaccelerator.DescribeAcceleratorInput{
+		AcceleratorArn: aws.String(arn),
+	}
+
+	output, err := conn.DescribeAccelerator(input)
+
+	if tfawserr.ErrCodeEquals(err, globalaccelerator.ErrCodeAcceleratorNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Accelerator == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Accelerator, nil
+}
+
+// AcceleratorAttributesByARN returns the accelerator corresponding to the specified ARN.
+// Returns NotFoundError if no accelerator is found.
+func AcceleratorAttributesByARN(conn *globalaccelerator.GlobalAccelerator, arn string) (*globalaccelerator.AcceleratorAttributes, error) {
+	input := &globalaccelerator.DescribeAcceleratorAttributesInput{
+		AcceleratorArn: aws.String(arn),
+	}
+
+	output, err := conn.DescribeAcceleratorAttributes(input)
+
+	if tfawserr.ErrCodeEquals(err, globalaccelerator.ErrCodeAcceleratorNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.AcceleratorAttributes == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.AcceleratorAttributes, nil
+}
 
 // EndpointGroupByARN returns the endpoint group corresponding to the specified ARN.
 func EndpointGroupByARN(conn *globalaccelerator.GlobalAccelerator, arn string) (*globalaccelerator.EndpointGroup, error) {

--- a/aws/internal/service/globalaccelerator/waiter/status.go
+++ b/aws/internal/service/globalaccelerator/waiter/status.go
@@ -1,0 +1,26 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/globalaccelerator"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/globalaccelerator/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+// AcceleratorStatus fetches the Accelerator and its Status
+func AcceleratorStatus(conn *globalaccelerator.GlobalAccelerator, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		accelerator, err := finder.AcceleratorByARN(conn, arn)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return accelerator, aws.StringValue(accelerator.Status), nil
+	}
+}

--- a/aws/internal/service/globalaccelerator/waiter/waiter.go
+++ b/aws/internal/service/globalaccelerator/waiter/waiter.go
@@ -1,0 +1,26 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/globalaccelerator"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// AcceleratorDeployed waits for an Accelerator to return Deployed
+func AcceleratorDeployed(conn *globalaccelerator.GlobalAccelerator, arn string, timeout time.Duration) (*globalaccelerator.Accelerator, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{globalaccelerator.AcceleratorStatusInProgress},
+		Target:  []string{globalaccelerator.AcceleratorStatusDeployed},
+		Refresh: AcceleratorStatus(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*globalaccelerator.Accelerator); ok {
+		return v, err
+	}
+
+	return nil, err
+}

--- a/aws/resource_aws_globalaccelerator_accelerator.go
+++ b/aws/resource_aws_globalaccelerator_accelerator.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -29,8 +28,6 @@ func resourceAwsGlobalAcceleratorAccelerator() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-
-		CustomizeDiff: resourceAwsGlobalAcceleratorAcceleratorCustomizeDiff,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -427,24 +424,6 @@ func resourceAwsGlobalAcceleratorAcceleratorDelete(d *schema.ResourceData, meta 
 				return nil
 			}
 			return fmt.Errorf("Error deleting Global Accelerator accelerator: %s", err)
-		}
-	}
-
-	return nil
-}
-
-func resourceAwsGlobalAcceleratorAcceleratorCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-	if v, ok := diff.GetOk("attributes"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
-
-		if v, ok := tfMap["flow_logs_enabled"].(bool); ok && v {
-			if v, ok := tfMap["flow_logs_s3_bucket"].(string); !ok || v == "" {
-				return fmt.Errorf("'flow_logs_s3_bucket' must be set when 'flow_logs_enabled' is true")
-			}
-
-			if v, ok := tfMap["flow_logs_s3_prefix"].(string); !ok || v == "" {
-				return fmt.Errorf("'flow_logs_s3_prefix' must be set when 'flow_logs_enabled' is true")
-			}
 		}
 	}
 

--- a/aws/resource_aws_globalaccelerator_accelerator_test.go
+++ b/aws/resource_aws_globalaccelerator_accelerator_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-// TODO Use sweeper dependencies, not nested calls.
 func init() {
 	resource.AddTestSweepers("aws_globalaccelerator_accelerator", &resource.Sweeper{
 		Name: "aws_globalaccelerator_accelerator",

--- a/aws/resource_aws_globalaccelerator_accelerator_test.go
+++ b/aws/resource_aws_globalaccelerator_accelerator_test.go
@@ -172,7 +172,7 @@ func sweepGlobalAcceleratorEndpointGroups(conn *globalaccelerator.GlobalAccelera
 }
 
 func TestAccAwsGlobalAcceleratorAccelerator_basic(t *testing.T) {
-	resourceName := "aws_globalaccelerator_accelerator.example"
+	resourceName := "aws_globalaccelerator_accelerator.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	ipRegex := regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
 	dnsNameRegex := regexp.MustCompile(`^a[a-f0-9]{16}\.awsglobalaccelerator\.com$`)
@@ -183,7 +183,7 @@ func TestAccAwsGlobalAcceleratorAccelerator_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGlobalAcceleratorAcceleratorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlobalAcceleratorAccelerator_basic(rName, false),
+				Config: testAccGlobalAcceleratorAcceleratorConfig(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalAcceleratorAcceleratorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -212,7 +212,7 @@ func TestAccAwsGlobalAcceleratorAccelerator_basic(t *testing.T) {
 }
 
 func TestAccAwsGlobalAcceleratorAccelerator_update(t *testing.T) {
-	resourceName := "aws_globalaccelerator_accelerator.example"
+	resourceName := "aws_globalaccelerator_accelerator.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	newName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -222,7 +222,7 @@ func TestAccAwsGlobalAcceleratorAccelerator_update(t *testing.T) {
 		CheckDestroy: testAccCheckGlobalAcceleratorAcceleratorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlobalAcceleratorAccelerator_basic(rName, true),
+				Config: testAccGlobalAcceleratorAcceleratorConfig(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalAcceleratorAcceleratorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -230,7 +230,7 @@ func TestAccAwsGlobalAcceleratorAccelerator_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGlobalAcceleratorAccelerator_basic(newName, false),
+				Config: testAccGlobalAcceleratorAcceleratorConfig(newName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalAcceleratorAcceleratorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", newName),
@@ -247,8 +247,8 @@ func TestAccAwsGlobalAcceleratorAccelerator_update(t *testing.T) {
 }
 
 func TestAccAwsGlobalAcceleratorAccelerator_attributes(t *testing.T) {
-	resourceName := "aws_globalaccelerator_accelerator.example"
-	s3BucketResourceName := "aws_s3_bucket.example"
+	resourceName := "aws_globalaccelerator_accelerator.test"
+	s3BucketResourceName := "aws_s3_bucket.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -257,7 +257,7 @@ func TestAccAwsGlobalAcceleratorAccelerator_attributes(t *testing.T) {
 		CheckDestroy: testAccCheckGlobalAcceleratorAcceleratorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlobalAcceleratorAccelerator_attributes(rName),
+				Config: testAccGlobalAcceleratorAcceleratorConfigAttributes(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalAcceleratorAcceleratorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "attributes.#", "1"),
@@ -276,7 +276,7 @@ func TestAccAwsGlobalAcceleratorAccelerator_attributes(t *testing.T) {
 }
 
 func TestAccAwsGlobalAcceleratorAccelerator_tags(t *testing.T) {
-	resourceName := "aws_globalaccelerator_accelerator.example"
+	resourceName := "aws_globalaccelerator_accelerator.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -285,13 +285,12 @@ func TestAccAwsGlobalAcceleratorAccelerator_tags(t *testing.T) {
 		CheckDestroy: testAccCheckGlobalAcceleratorAcceleratorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlobalAcceleratorAccelerator_tags(rName, false, "foo", "var"),
+				Config: testAccGlobalAcceleratorAcceleratorConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalAcceleratorAcceleratorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "var"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
@@ -300,18 +299,20 @@ func TestAccAwsGlobalAcceleratorAccelerator_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccGlobalAcceleratorAccelerator_tags(rName, false, "foo", "var2"),
+				Config: testAccGlobalAcceleratorAcceleratorConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalAcceleratorAcceleratorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "var2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
-				Config: testAccGlobalAcceleratorAccelerator_basic(rName, false),
+				Config: testAccGlobalAcceleratorAcceleratorConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalAcceleratorAcceleratorExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},
@@ -380,48 +381,61 @@ func testAccCheckGlobalAcceleratorAcceleratorDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccGlobalAcceleratorAccelerator_basic(rName string, enabled bool) string {
+func testAccGlobalAcceleratorAcceleratorConfig(rName string, enabled bool) string {
 	return fmt.Sprintf(`
-resource "aws_globalaccelerator_accelerator" "example" {
-  name            = "%s"
+resource "aws_globalaccelerator_accelerator" "test" {
+  name            = %[1]q
   ip_address_type = "IPV4"
-  enabled         = %t
+  enabled         = %[2]t
 }
 `, rName, enabled)
 }
 
-func testAccGlobalAcceleratorAccelerator_attributes(rName string) string {
+func testAccGlobalAcceleratorAcceleratorConfigAttributes(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "example" {
-  bucket_prefix = "tf-test-globalaccelerator-"
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
 }
 
-resource "aws_globalaccelerator_accelerator" "example" {
-  name            = "%s"
+resource "aws_globalaccelerator_accelerator" "test" {
+  name            = %[1]q
   ip_address_type = "IPV4"
   enabled         = false
 
   attributes {
     flow_logs_enabled   = true
-    flow_logs_s3_bucket = aws_s3_bucket.example.bucket
+    flow_logs_s3_bucket = aws_s3_bucket.test.bucket
     flow_logs_s3_prefix = "flow-logs/"
   }
 }
 `, rName)
 }
 
-func testAccGlobalAcceleratorAccelerator_tags(rName string, enabled bool, tagKey string, tagValue string) string {
+func testAccGlobalAcceleratorAcceleratorConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_globalaccelerator_accelerator" "example" {
-  name            = "%s"
+resource "aws_globalaccelerator_accelerator" "test" {
+  name            = %[1]q
   ip_address_type = "IPV4"
-  enabled         = %t
+  enabled         = false
 
   tags = {
-    Name = "%[1]s"
-
-    %[3]s = "%[4]s"
+    %[2]q = %[3]q
   }
 }
-`, rName, enabled, tagKey, tagValue)
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccGlobalAcceleratorAcceleratorConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_globalaccelerator_accelerator" "test" {
+  name            = %[1]q
+  ip_address_type = "IPV4"
+  enabled         = false
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14185.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ ACCTEST_PARALLELISM=2 make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsGlobalAcceleratorEndpointGroup_\|TestAccAwsGlobalAcceleratorListener_\|TestAccAwsGlobalAcceleratorAccelerator_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAwsGlobalAcceleratorEndpointGroup_\|TestAccAwsGlobalAcceleratorListener_\|TestAccAwsGlobalAcceleratorAccelerator_ -timeout 120m
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_basic
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_basic
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_disappears
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_disappears
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_update
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_update
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_attributes
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_attributes
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_tags
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_tags
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_basic
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_basic
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_disappears
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_disappears
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_Update
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_Update
=== RUN   TestAccAwsGlobalAcceleratorListener_basic
=== PAUSE TestAccAwsGlobalAcceleratorListener_basic
=== RUN   TestAccAwsGlobalAcceleratorListener_disappears
=== PAUSE TestAccAwsGlobalAcceleratorListener_disappears
=== RUN   TestAccAwsGlobalAcceleratorListener_update
=== PAUSE TestAccAwsGlobalAcceleratorListener_update
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_basic
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_basic (71.14s)
=== CONT  TestAccAwsGlobalAcceleratorListener_update
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion (190.26s)
=== CONT  TestAccAwsGlobalAcceleratorListener_disappears
=== CONT  TestAccAwsGlobalAcceleratorListener_basic
--- PASS: TestAccAwsGlobalAcceleratorListener_update (158.63s)
--- PASS: TestAccAwsGlobalAcceleratorListener_disappears (120.03s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_Update
--- PASS: TestAccAwsGlobalAcceleratorListener_basic (184.09s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_Update (257.05s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol (187.01s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_basic
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_basic (174.95s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides (213.72s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint (664.05s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_disappears
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP (708.09s)
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_attributes
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_disappears (173.58s)
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_tags
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_tags (91.68s)
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_update
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_attributes (279.32s)
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_disappears
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_disappears (115.97s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_update (185.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1890.885s
```
