### PR TITLE
provider: Convert and enforce most data sources to AWS Go SDK pointer conversion functions during assignment

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -48,7 +48,28 @@ rules:
           metavariable: '$Y'
           regex: '^"github.com/aws/aws-sdk-go/service/[^/]+"$'
     severity: WARNING
-  
+
+  - id: prefer-aws-go-sdk-pointer-conversion-assignment
+    languages: [go]
+    message: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
+    paths:
+      exclude:
+        - aws/cloudfront_distribution_configuration_structure.go
+        - aws/data_source_aws_route_table.go
+        - aws/opsworks_layers.go
+        - aws/resource*
+        - aws/structure.go
+        - aws/waf_helpers.go
+        - aws/internal/generators/
+        - aws/internal/keyvaluetags/
+        - awsproviderlint/vendor/
+      include:
+        - aws/
+    patterns:
+      - pattern: '$LHS = *$RHS'
+      - pattern-not: '*$LHS2 = *$RHS'
+    severity: WARNING
+
   - id: aws-go-sdk-pointer-conversion-ResourceData-SetId
     fix: d.SetId(aws.StringValue($VALUE))
     languages: [go]

--- a/aws/data_source_aws_cloudfront_origin_request_policy.go
+++ b/aws/data_source_aws_cloudfront_origin_request_policy.go
@@ -128,7 +128,11 @@ func dataSourceAwsCloudFrontOriginRequestPolicyRead(d *schema.ResourceData, meta
 		}
 		d.Set("etag", aws.StringValue(resp.ETag))
 
-		originRequestPolicy := *resp.OriginRequestPolicy.OriginRequestPolicyConfig
+		if resp == nil || resp.OriginRequestPolicy == nil || resp.OriginRequestPolicy.OriginRequestPolicyConfig == nil {
+			return nil
+		}
+
+		originRequestPolicy := resp.OriginRequestPolicy.OriginRequestPolicyConfig
 		d.Set("comment", aws.StringValue(originRequestPolicy.Comment))
 		d.Set("name", aws.StringValue(originRequestPolicy.Name))
 		d.Set("cookies_config", flattenCloudFrontOriginRequestPolicyCookiesConfig(originRequestPolicy.CookiesConfig))

--- a/aws/data_source_aws_cloudfront_origin_request_policy.go
+++ b/aws/data_source_aws_cloudfront_origin_request_policy.go
@@ -126,11 +126,12 @@ func dataSourceAwsCloudFrontOriginRequestPolicyRead(d *schema.ResourceData, meta
 		if err != nil {
 			return fmt.Errorf("Unable to retrieve origin request policy with ID %s: %w", d.Id(), err)
 		}
-		d.Set("etag", aws.StringValue(resp.ETag))
 
 		if resp == nil || resp.OriginRequestPolicy == nil || resp.OriginRequestPolicy.OriginRequestPolicyConfig == nil {
 			return nil
 		}
+
+		d.Set("etag", aws.StringValue(resp.ETag))
 
 		originRequestPolicy := resp.OriginRequestPolicy.OriginRequestPolicyConfig
 		d.Set("comment", aws.StringValue(originRequestPolicy.Comment))

--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -230,14 +230,14 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	if len(resp.DBInstances) < 1 {
+	if resp == nil || len(resp.DBInstances) < 1 || resp.DBInstances[0] == nil {
 		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
 	}
 	if len(resp.DBInstances) > 1 {
 		return fmt.Errorf("Your query returned more than one result. Please try a more specific search criteria.")
 	}
 
-	dbInstance := *resp.DBInstances[0]
+	dbInstance := resp.DBInstances[0]
 
 	d.SetId(d.Get("db_instance_identifier").(string))
 

--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -122,8 +122,8 @@ type volumeSort []*ec2.Volume
 func (a volumeSort) Len() int      { return len(a) }
 func (a volumeSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a volumeSort) Less(i, j int) bool {
-	itime := *a[i].CreateTime
-	jtime := *a[j].CreateTime
+	itime := aws.TimeValue(a[i].CreateTime)
+	jtime := aws.TimeValue(a[j].CreateTime)
 	return itime.Unix() < jtime.Unix()
 }
 

--- a/aws/data_source_aws_ec2_managed_prefix_list.go
+++ b/aws/data_source_aws_ec2_managed_prefix_list.go
@@ -93,7 +93,7 @@ func dataSourceAwsEc2ManagedPrefixListRead(ctx context.Context, d *schema.Resour
 		return diag.Errorf("error describing EC2 Managed Prefix Lists: %s", err)
 	}
 
-	if len(out.PrefixLists) < 1 {
+	if out == nil || len(out.PrefixLists) < 1 || out.PrefixLists[0] == nil {
 		return diag.Errorf("no managed prefix lists matched the given criteria")
 	}
 
@@ -101,7 +101,7 @@ func dataSourceAwsEc2ManagedPrefixListRead(ctx context.Context, d *schema.Resour
 		return diag.Errorf("more than 1 prefix list matched the given criteria")
 	}
 
-	pl := *out.PrefixLists[0]
+	pl := out.PrefixLists[0]
 
 	d.SetId(aws.StringValue(pl.PrefixListId))
 	d.Set("name", pl.PrefixListName)

--- a/aws/data_source_aws_ecs_container_definition.go
+++ b/aws/data_source_aws_ecs_container_definition.go
@@ -72,10 +72,14 @@ func dataSourceAwsEcsContainerDefinitionRead(d *schema.ResourceData, meta interf
 	desc, err := conn.DescribeTaskDefinition(params)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading ECS Task Definition: %w", err)
 	}
 
-	taskDefinition := *desc.TaskDefinition
+	if desc == nil || desc.TaskDefinition == nil {
+		return fmt.Errorf("error reading ECS Task Definition: empty response")
+	}
+
+	taskDefinition := desc.TaskDefinition
 	for _, def := range taskDefinition.ContainerDefinitions {
 		if aws.StringValue(def.Name) != d.Get("container_name").(string) {
 			continue

--- a/aws/data_source_aws_ecs_task_definition.go
+++ b/aws/data_source_aws_ecs_task_definition.go
@@ -56,7 +56,11 @@ func dataSourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Failed getting task definition %q: %w", d.Get("task_definition").(string), err)
 	}
 
-	taskDefinition := *desc.TaskDefinition
+	if desc == nil || desc.TaskDefinition == nil {
+		return fmt.Errorf("error reading ECS Task Definition: empty response")
+	}
+
+	taskDefinition := desc.TaskDefinition
 
 	d.SetId(aws.StringValue(taskDefinition.TaskDefinitionArn))
 	d.Set("family", aws.StringValue(taskDefinition.Family))

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -136,16 +136,16 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("network_interface_id", eip.NetworkInterfaceId)
 	d.Set("network_interface_owner_id", eip.NetworkInterfaceOwnerId)
 
-	region := *conn.Config.Region
+	region := aws.StringValue(conn.Config.Region)
 
 	d.Set("private_ip", eip.PrivateIpAddress)
 	if eip.PrivateIpAddress != nil {
-		d.Set("private_dns", fmt.Sprintf("ip-%s.%s", resourceAwsEc2DashIP(*eip.PrivateIpAddress), resourceAwsEc2RegionalPrivateDnsSuffix(region)))
+		d.Set("private_dns", fmt.Sprintf("ip-%s.%s", resourceAwsEc2DashIP(aws.StringValue(eip.PrivateIpAddress)), resourceAwsEc2RegionalPrivateDnsSuffix(region)))
 	}
 
 	d.Set("public_ip", eip.PublicIp)
 	if eip.PublicIp != nil {
-		d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s", resourceAwsEc2DashIP(*eip.PublicIp), resourceAwsEc2RegionalPublicDnsSuffix(region))))
+		d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s", resourceAwsEc2DashIP(aws.StringValue(eip.PublicIp)), resourceAwsEc2RegionalPublicDnsSuffix(region))))
 	}
 	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
 	d.Set("carrier_ip", eip.CarrierIp)

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -501,8 +501,8 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 		d.Set("source_dest_check", instance.SourceDestCheck)
 	}
 
-	if instance.Monitoring != nil && instance.Monitoring.State != nil {
-		monitoringState := *instance.Monitoring.State
+	if instance.Monitoring != nil {
+		monitoringState := aws.StringValue(instance.Monitoring.State)
 		d.Set("monitoring", monitoringState == "enabled" || monitoringState == "pending")
 	}
 

--- a/aws/data_source_aws_prefix_list.go
+++ b/aws/data_source_aws_prefix_list.go
@@ -65,12 +65,7 @@ func dataSourceAwsPrefixListRead(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(aws.StringValue(pl.PrefixListId))
 	d.Set("name", pl.PrefixListName)
-
-	cidrs := make([]string, len(pl.Cidrs))
-	for i, v := range pl.Cidrs {
-		cidrs[i] = *v
-	}
-	d.Set("cidr_blocks", cidrs)
+	d.Set("cidr_blocks", aws.StringValueSlice(pl.Cidrs))
 
 	return nil
 }

--- a/aws/data_source_aws_redshift_cluster.go
+++ b/aws/data_source_aws_redshift_cluster.go
@@ -185,11 +185,11 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error describing Redshift Cluster: %s, error: %w", cluster, err)
 	}
 
-	if resp.Clusters == nil || len(resp.Clusters) == 0 {
+	if resp.Clusters == nil || len(resp.Clusters) == 0 || resp.Clusters[0] == nil {
 		return fmt.Errorf("Error describing Redshift Cluster: %s, cluster information not found", cluster)
 	}
 
-	rsc := *resp.Clusters[0]
+	rsc := resp.Clusters[0]
 
 	d.SetId(cluster)
 	d.Set("allow_version_upgrade", rsc.AllowVersionUpgrade)

--- a/aws/data_source_aws_route53_resolver_rule.go
+++ b/aws/data_source_aws_route53_resolver_rule.go
@@ -120,8 +120,7 @@ func dataSourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface
 	}
 
 	d.SetId(aws.StringValue(rule.Id))
-	arn := *rule.Arn
-	d.Set("arn", arn)
+	d.Set("arn", rule.Arn)
 	// To be consistent with other AWS services that do not accept a trailing period,
 	// we remove the suffix from the Domain Name returned from the API
 	d.Set("domain_name", trimTrailingPeriod(aws.StringValue(rule.DomainName)))
@@ -134,6 +133,7 @@ func dataSourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface
 	d.Set("share_status", shareStatus)
 	// https://github.com/hashicorp/terraform-provider-aws/issues/10211
 	if shareStatus != route53resolver.ShareStatusSharedWithMe {
+		arn := aws.StringValue(rule.Arn)
 		tags, err := keyvaluetags.Route53resolverListTags(conn, arn)
 
 		if err != nil {

--- a/aws/data_source_aws_s3_bucket_object.go
+++ b/aws/data_source_aws_s3_bucket_object.go
@@ -216,7 +216,7 @@ func dataSourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) e
 		if out.ContentType == nil {
 			contentType = "<EMPTY>"
 		} else {
-			contentType = *out.ContentType
+			contentType = aws.StringValue(out.ContentType)
 		}
 
 		log.Printf("[INFO] Ignoring body of S3 object %s with Content-Type %q", uniqueId, contentType)

--- a/aws/data_source_aws_ssm_patch_baseline.go
+++ b/aws/data_source_aws_ssm_patch_baseline.go
@@ -97,7 +97,7 @@ func dataAwsSsmPatchBaselineRead(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if len(filteredBaselines) < 1 {
+	if len(filteredBaselines) < 1 || filteredBaselines[0] == nil {
 		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
 	}
 
@@ -105,7 +105,7 @@ func dataAwsSsmPatchBaselineRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Your query returned more than one result. Please try a more specific search criteria")
 	}
 
-	baseline := *filteredBaselines[0]
+	baseline := filteredBaselines[0]
 
 	d.SetId(aws.StringValue(baseline.BaselineId))
 	d.Set("name", baseline.BaselineName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12992

This work is being done in chunks to reduce review burden. Avoiding `aws_route_table` data source due to large pull request pending review.

Previously:

```
aws/data_source_aws_cloudfront_origin_request_policy.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
131:		originRequestPolicy := *resp.OriginRequestPolicy.OriginRequestPolicyConfig

aws/data_source_aws_db_instance.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
240:	dbInstance := *resp.DBInstances[0]

aws/data_source_aws_ebs_volume.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
125:	itime := *a[i].CreateTime
--------------------------------------------------------------------------------
126:	jtime := *a[j].CreateTime

aws/data_source_aws_ec2_managed_prefix_list.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
104:	pl := *out.PrefixLists[0]

aws/data_source_aws_ecs_container_definition.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
78:	taskDefinition := *desc.TaskDefinition

aws/data_source_aws_ecs_task_definition.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
59:	taskDefinition := *desc.TaskDefinition

aws/data_source_aws_eip.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
139:	region := *conn.Config.Region

aws/data_source_aws_instance.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
505:		monitoringState := *instance.Monitoring.State

aws/data_source_aws_mq_broker.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
214:			nextToken = *out.NextToken

aws/data_source_aws_prefix_list.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
71:		cidrs[i] = *v

aws/data_source_aws_redshift_cluster.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
192:	rsc := *resp.Clusters[0]

aws/data_source_aws_route53_resolver_rule.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
123:	arn := *rule.Arn

aws/data_source_aws_s3_bucket_object.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
219:			contentType = *out.ContentType

aws/data_source_aws_ssm_patch_baseline.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
108:	baseline := *filteredBaselines[0]
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFrontDataSourceOriginRequestPolicy_basic (14.90s)

--- PASS: TestAccAWSDataSourceRedshiftCluster_basic (338.01s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_logging (461.02s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_vpc (1007.17s)

--- PASS: TestAccAWSDbInstanceDataSource_basic (541.75s)
--- PASS: TestAccAWSDbInstanceDataSource_ec2Classic (428.74s)

--- PASS: TestAccAWSEbsVolumeDataSource_basic (26.76s)
--- PASS: TestAccAWSEbsVolumeDataSource_multipleFilters (28.34s)

--- PASS: TestAccAWSEcsDataSource_ecsCluster (25.22s)
--- PASS: TestAccAWSEcsDataSource_ecsClusterContainerInsights (27.43s)
--- PASS: TestAccAWSEcsDataSource_ecsContainerDefinition (85.07s)
--- PASS: TestAccAWSEcsDataSource_ecsTaskDefinition (14.90s)

--- PASS: TestAccAWSInstanceDataSource_AzUserData (87.68s)
--- PASS: TestAccAWSInstanceDataSource_basic (107.50s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (117.28s)
--- PASS: TestAccAWSInstanceDataSource_blockDeviceTags (72.21s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (99.16s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (109.93s)
--- PASS: TestAccAWSInstanceDataSource_enclaveOptions (129.58s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (174.55s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (207.17s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (176.78s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (188.74s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (116.35s)
--- PASS: TestAccAWSInstanceDataSource_gp3ThroughputDevice (138.11s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (95.12s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (126.18s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (106.32s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (105.60s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (99.53s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (116.08s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (97.97s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (100.32s)
--- PASS: TestAccAWSInstanceDataSource_tags (104.63s)
--- PASS: TestAccAWSInstanceDataSource_VPC (128.18s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (104.24s)

--- FAIL: TestAccAWSRoute53ResolverRuleDataSource_SharedByMe (245.06s) # https://github.com/hashicorp/terraform-provider-aws/issues/17748
--- FAIL: TestAccAWSRoute53ResolverRuleDataSource_SharedWithMe (244.80s) # https://github.com/hashicorp/terraform-provider-aws/issues/17748
--- PASS: TestAccAWSRoute53ResolverRuleDataSource_basic (39.01s)
--- PASS: TestAccAWSRoute53ResolverRuleDataSource_ResolverEndpointIdWithTags (245.76s)

--- PASS: TestAccAWSSsmPatchBaselineDataSource_existingBaseline (12.32s)
--- PASS: TestAccAWSSsmPatchBaselineDataSource_newBaseline (13.36s)

--- PASS: TestAccDataSourceAwsEc2ManagedPrefixList_basic (21.32s)
--- PASS: TestAccDataSourceAwsEc2ManagedPrefixList_filter (21.14s)
--- PASS: TestAccDataSourceAwsEc2ManagedPrefixList_matchesTooMany (2.87s)

--- PASS: TestAccDataSourceAWSEIP_CarrierIP (23.38s)
--- PASS: TestAccDataSourceAWSEIP_Filter (15.90s)
--- PASS: TestAccDataSourceAWSEIP_Id (15.69s)
--- PASS: TestAccDataSourceAWSEIP_Instance (136.26s)
--- PASS: TestAccDataSourceAWSEIP_NetworkInterface (75.80s)
--- PASS: TestAccDataSourceAWSEIP_PublicIP_EC2Classic (8.65s)
--- PASS: TestAccDataSourceAWSEIP_PublicIP_VPC (13.56s)
--- PASS: TestAccDataSourceAWSEIP_Tags (18.22s)
--- SKIP: TestAccDataSourceAWSEIP_CustomerOwnedIpv4Pool (1.43s)

--- PASS: TestAccDataSourceAWSMqBroker_basic (1171.78s)

--- PASS: TestAccDataSourceAwsPrefixList_basic (15.86s)
--- PASS: TestAccDataSourceAwsPrefixList_filter (15.64s)
--- PASS: TestAccDataSourceAwsPrefixList_nameDoesNotOverrideFilter (2.38s)

--- PASS: TestAccDataSourceAWSS3BucketObject_allParams (31.42s)
--- PASS: TestAccDataSourceAWSS3BucketObject_basic (30.11s)
--- PASS: TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint (31.43s)
--- PASS: TestAccDataSourceAWSS3BucketObject_kmsEncrypted (31.19s)
--- PASS: TestAccDataSourceAWSS3BucketObject_LeadingSlash (53.90s)
--- PASS: TestAccDataSourceAWSS3BucketObject_MultipleSlashes (52.83s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff (31.63s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn (33.57s)
--- PASS: TestAccDataSourceAWSS3BucketObject_readableBody (31.01s)
--- PASS: TestAccDataSourceAWSS3BucketObject_SingleSlashAsKey (28.06s)
```