### PR TITLE
data-source/iam_policy_document: Keep empty conditions

### DIFF
--- a/.changelog/17752.txt
+++ b/.changelog/17752.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_iam_policy_document: Keep empty conditions
+data-source/aws_iam_policy_document: Keep empty conditions
 ```

--- a/.changelog/17752.txt
+++ b/.changelog/17752.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_policy_document: Keep empty conditions
+```

--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -311,7 +311,7 @@ func dataSourceAwsIamPolicyDocumentMakeConditions(in []interface{}, version stri
 			Variable: item["variable"].(string),
 		}
 		out[i].Values, err = dataSourceAwsIamPolicyDocumentReplaceVarsInList(
-			aws.StringValueSlice(expandStringList(item["values"].([]interface{}))),
+			aws.StringValueSlice(expandStringListKeepEmpty(item["values"].([]interface{}))),
 			version,
 		)
 		if err != nil {

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -312,6 +312,7 @@ data "aws_iam_policy_document" "test" {
       variable = "s3:prefix"
       values = [
         "home/",
+        "",
         "home/&{aws:username}/",
       ]
     }
@@ -394,6 +395,7 @@ func testAccAWSIAMPolicyDocumentExpectedJSON() string {
         "StringLike": {
           "s3:prefix": [
             "home/",
+            "",
             "home/${aws:username}/"
           ]
         }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -983,6 +983,16 @@ func expandStringList(configured []interface{}) []*string {
 	return vs
 }
 
+func expandStringListKeepEmpty(configured []interface{}) []*string {
+	vs := make([]*string, 0, len(configured))
+	for _, v := range configured {
+		if val, ok := v.(string); ok {
+			vs = append(vs, aws.String(val))
+		}
+	}
+	return vs
+}
+
 // Takes the result of flatmap.Expand for an array of int64
 // and returns a []*int64
 func expandInt64List(configured []interface{}) []*int64 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17711

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (11.88s)
```

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (8.57s)
```