### PR TITLE
fix: cloudwatch_event_archive retention type on creation bug #16067

### DIFF
--- a/.changelog/17754.txt
+++ b/.changelog/17754.txt
@@ -1,0 +1,3 @@
+``release-note:bug
+resource/aws_cloudwatch_event_archive: Fix retention_days type conversion on creation
+```

--- a/aws/resource_aws_cloudwatch_event_archive.go
+++ b/aws/resource_aws_cloudwatch_event_archive.go
@@ -92,6 +92,12 @@ func resourceAwsCloudWatchEventArchiveRead(d *schema.ResourceData, meta interfac
 
 	out, err := conn.DescribeArchive(input)
 
+	if isAWSErr(err, events.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] CloudWatch Events archive (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error reading CloudWatch Events archive: %w", err)
 	}

--- a/aws/resource_aws_cloudwatch_event_archive.go
+++ b/aws/resource_aws_cloudwatch_event_archive.go
@@ -166,8 +166,7 @@ func buildCreateArchiveInputStruct(d *schema.ResourceData) (*events.CreateArchiv
 	}
 
 	if v, ok := d.GetOk("retention_days"); ok {
-		retentionInDays := int64(v.(int))
-		input.RetentionDays = aws.Int64(retentionInDays)
+		input.RetentionDays = aws.Int64(int64(v.(int)))
 	}
 
 	return &input, nil
@@ -191,8 +190,7 @@ func buildUpdateArchiveInputStruct(d *schema.ResourceData) (*events.UpdateArchiv
 	}
 
 	if v, ok := d.GetOk("retention_days"); ok {
-		retentionInDays := int64(v.(int))
-		input.RetentionDays = aws.Int64(retentionInDays)
+		input.RetentionDays = aws.Int64(int64(v.(int)))
 	}
 
 	return &input, nil

--- a/aws/resource_aws_cloudwatch_event_archive.go
+++ b/aws/resource_aws_cloudwatch_event_archive.go
@@ -166,7 +166,8 @@ func buildCreateArchiveInputStruct(d *schema.ResourceData) (*events.CreateArchiv
 	}
 
 	if v, ok := d.GetOk("retention_days"); ok {
-		input.RetentionDays = aws.Int64(v.(int64))
+		retentionInDays := int64(v.(int))
+		input.RetentionDays = aws.Int64(retentionInDays)
 	}
 
 	return &input, nil
@@ -196,5 +197,3 @@ func buildUpdateArchiveInputStruct(d *schema.ResourceData) (*events.UpdateArchiv
 
 	return &input, nil
 }
-
-// create a datasource

--- a/aws/resource_aws_cloudwatch_event_archive_test.go
+++ b/aws/resource_aws_cloudwatch_event_archive_test.go
@@ -143,7 +143,7 @@ func TestAccAWSCloudWatchEventArchive_disappears(t *testing.T) {
 				Config: testAccAWSCloudWatchEventArchiveConfig(archiveName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventArchiveExists(resourceName, &v),
-					//testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchEventArchive(), resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchEventArchive(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_cloudwatch_event_archive_test.go
+++ b/aws/resource_aws_cloudwatch_event_archive_test.go
@@ -70,7 +70,7 @@ func testSweepCloudWatchEventArchives(region string) error {
 	return nil
 }
 
-func TestAccAWSCloudWatchArchive_basic(t *testing.T) {
+func TestAccAWSCloudWatchEventArchive_basic(t *testing.T) {
 	var v1 events.DescribeArchiveOutput
 	archiveName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudwatch_event_archive.test"
@@ -78,12 +78,12 @@ func TestAccAWSCloudWatchArchive_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchArchiveDestroy,
+		CheckDestroy: testAccCheckAWSCloudWatchEventArchiveDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudWatchArchiveConfig(archiveName),
+				Config: testAccAWSCloudWatchEventArchiveConfig(archiveName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchArchiveExists(resourceName, &v1),
+					testAccCheckCloudWatchEventArchiveExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", archiveName),
 					resource.TestCheckResourceAttr(resourceName, "retention_days", "0"),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "events", fmt.Sprintf("archive/%s", archiveName)),
@@ -100,7 +100,7 @@ func TestAccAWSCloudWatchArchive_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudWatchArchive_update(t *testing.T) {
+func TestAccAWSCloudWatchEventArchive_update(t *testing.T) {
 	var v1 events.DescribeArchiveOutput
 	resourceName := "aws_cloudwatch_event_archive.test"
 	archiveName := acctest.RandomWithPrefix("tf-acc-test")
@@ -108,18 +108,18 @@ func TestAccAWSCloudWatchArchive_update(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchArchiveDestroy,
+		CheckDestroy: testAccCheckAWSCloudWatchEventArchiveDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudWatchArchiveConfig(archiveName),
+				Config: testAccAWSCloudWatchEventArchiveConfig(archiveName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchArchiveExists(resourceName, &v1),
+					testAccCheckCloudWatchEventArchiveExists(resourceName, &v1),
 				),
 			},
 			{
-				Config: testAccAWSCloudWatchArchiveConfig_updateAttributes(archiveName),
+				Config: testAccAWSCloudWatchEventArchiveConfig_updateAttributes(archiveName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchArchiveExists(resourceName, &v1),
+					testAccCheckCloudWatchEventArchiveExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "retention_days", "7"),
 					testAccCheckResourceAttrEquivalentJSON(resourceName, "event_pattern", "{\"source\":[\"company.team.service\"]}"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test"),
@@ -137,13 +137,13 @@ func TestAccAWSCloudWatchEventArchive_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchEventBusDestroy,
+		CheckDestroy: testAccCheckAWSCloudWatchEventArchiveDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudWatchArchiveConfig(archiveName),
+				Config: testAccAWSCloudWatchEventArchiveConfig(archiveName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchArchiveExists(resourceName, &v),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchEventArchive(), resourceName),
+					testAccCheckCloudWatchEventArchiveExists(resourceName, &v),
+					//testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchEventArchive(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -151,7 +151,7 @@ func TestAccAWSCloudWatchEventArchive_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSCloudWatchArchiveDestroy(s *terraform.State) error {
+func testAccCheckAWSCloudWatchEventArchiveDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn
 
 	for _, rs := range s.RootModule().Resources {
@@ -173,7 +173,7 @@ func testAccCheckAWSCloudWatchArchiveDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudWatchArchiveExists(n string, v *events.DescribeArchiveOutput) resource.TestCheckFunc {
+func testAccCheckCloudWatchEventArchiveExists(n string, v *events.DescribeArchiveOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -200,7 +200,7 @@ func testAccCheckCloudWatchArchiveExists(n string, v *events.DescribeArchiveOutp
 	}
 }
 
-func TestAccAWSCloudWatchArchive_retentionSetOnCreation(t *testing.T) {
+func TestAccAWSCloudWatchEventArchive_retentionSetOnCreation(t *testing.T) {
 	var v1 events.DescribeArchiveOutput
 	archiveName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudwatch_event_archive.test"
@@ -208,12 +208,12 @@ func TestAccAWSCloudWatchArchive_retentionSetOnCreation(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchArchiveDestroy,
+		CheckDestroy: testAccCheckAWSCloudWatchEventArchiveDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudWatchArchiveConfig_retentionOnCreation(archiveName),
+				Config: testAccAWSCloudWatchEventArchiveConfig_retentionOnCreation(archiveName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchArchiveExists(resourceName, &v1),
+					testAccCheckCloudWatchEventArchiveExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", archiveName),
 					resource.TestCheckResourceAttr(resourceName, "retention_days", "1"),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "events", fmt.Sprintf("archive/%s", archiveName)),
@@ -230,7 +230,7 @@ func TestAccAWSCloudWatchArchive_retentionSetOnCreation(t *testing.T) {
 	})
 }
 
-func testAccAWSCloudWatchArchiveConfig(name string) string {
+func testAccAWSCloudWatchEventArchiveConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
   name = %[1]q
@@ -243,7 +243,7 @@ resource "aws_cloudwatch_event_archive" "test" {
 `, name)
 }
 
-func testAccAWSCloudWatchArchiveConfig_updateAttributes(name string) string {
+func testAccAWSCloudWatchEventArchiveConfig_updateAttributes(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
   name = %[1]q
@@ -263,7 +263,7 @@ PATTERN
 `, name)
 }
 
-func testAccAWSCloudWatchArchiveConfig_retentionOnCreation(name string) string {
+func testAccAWSCloudWatchEventArchiveConfig_retentionOnCreation(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
   name = %[1]q

--- a/aws/resource_aws_cloudwatch_event_archive_test.go
+++ b/aws/resource_aws_cloudwatch_event_archive_test.go
@@ -140,7 +140,7 @@ func TestAccAWSCloudWatchEventArchive_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudWatchEventBusDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudWatchEventBusConfig(archiveName),
+				Config: testAccAWSCloudWatchArchiveConfig(archiveName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchArchiveExists(resourceName, &v),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchEventArchive(), resourceName),

--- a/aws/resource_aws_cloudwatch_event_archive_test.go
+++ b/aws/resource_aws_cloudwatch_event_archive_test.go
@@ -272,7 +272,7 @@ resource "aws_cloudwatch_event_bus" "test" {
 resource "aws_cloudwatch_event_archive" "test" {
   name             = %[1]q
   event_source_arn = aws_cloudwatch_event_bus.test.arn
-retention_days     = 1
+  retention_days   = 1
 }
 `, name)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This is a bugfix for the new `cloudwatch_event_archive` resource that when `retention_days` is set on Creation it panics due to an incorrect type (Schema Behaviour [TypeInt] vs SDK expects [Int64]) - Updating `retention_days` after creation was working as expected, though.

New test has been added to cover `retention_days` set on creation.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16067

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchArchive'      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchArchive -timeout 120m
=== RUN   TestAccAWSCloudWatchArchive_basic
=== PAUSE TestAccAWSCloudWatchArchive_basic
=== RUN   TestAccAWSCloudWatchArchive_update
=== PAUSE TestAccAWSCloudWatchArchive_update
=== RUN   TestAccAWSCloudWatchArchive_retentionSetOnCreation
=== PAUSE TestAccAWSCloudWatchArchive_retentionSetOnCreation
=== CONT  TestAccAWSCloudWatchArchive_basic
=== CONT  TestAccAWSCloudWatchArchive_retentionSetOnCreation
=== CONT  TestAccAWSCloudWatchArchive_update
--- PASS: TestAccAWSCloudWatchArchive_basic (31.12s)
--- PASS: TestAccAWSCloudWatchArchive_retentionSetOnCreation (31.16s)
--- PASS: TestAccAWSCloudWatchArchive_update (47.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       50.163s


...
```
