### PR TITLE
r/db_instance: update plan-time validation for snapshot_identifier/name/username

### DIFF
--- a/.changelog/17755.txt
+++ b/.changelog/17755.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fix conflicting argument validation error
+```

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -4575,6 +4575,8 @@ resource "aws_db_instance" "mysql_restore" {
 
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   allocated_storage       = 20
+  username                = "root"
+  password                = "password"
   engine                  = data.aws_rds_orderable_db_instance.test.engine
   engine_version          = "5.6.41"
   backup_retention_period = 0


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17712, closes #17722
Relates #17037, #17156

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1192.86s)
```

### Notes
* changes here revert those originally introduced (https://github.com/hashicorp/terraform-provider-aws/pull/17156) to address #17037 
