### PR TITLE
aws_vpc_dhcp_options: Correct the ARN account id

### DIFF
--- a/aws/data_source_aws_vpc_dhcp_options.go
+++ b/aws/data_source_aws_vpc_dhcp_options.go
@@ -138,7 +138,7 @@ func dataSourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) e
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(output.DhcpOptions[0].OwnerId),
 		Resource:  fmt.Sprintf("dhcp-options/%s", d.Id()),
 	}.String()
 

--- a/aws/resource_aws_vpc_dhcp_options.go
+++ b/aws/resource_aws_vpc_dhcp_options.go
@@ -195,7 +195,7 @@ func resourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) err
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(opts.OwnerId),
 		Resource:  fmt.Sprintf("dhcp-options/%s", d.Id()),
 	}.String()
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -328,8 +328,6 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
     - [`aws_ssm_parameter` data source](/docs/providers/aws/d/ssm_parameter.html)
     - [`aws_ssm_parameter` resource](/docs/providers/aws/r/ssm_parameter.html)
     - [`aws_synthetics_canary` resource](/docs/providers/aws/r/synthetics_canary.html)
-    - [`aws_vpc_dhcp_options` data source](/docs/providers/aws/d/vpc_dhcp_options.html)
-    - [`aws_vpc_dhcp_options` resource](/docs/providers/aws/r/vpc_dhcp_options.html)
     - [`aws_vpc_endpoint_service` data source](/docs/providers/aws/d/vpc_endpoint_service.html)
     - [`aws_vpc_endpoint_service` resource](/docs/providers/aws/r/vpc_endpoint_service.html)
     - [`aws_vpc_endpoint` data source](/docs/providers/aws/d/vpc_endpoint.html)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16978

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDHCPOptions_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDHCPOptions_ -timeout 120m
=== RUN   TestAccAWSDHCPOptions_basic
=== PAUSE TestAccAWSDHCPOptions_basic
=== RUN   TestAccAWSDHCPOptions_deleteOptions
=== PAUSE TestAccAWSDHCPOptions_deleteOptions
=== RUN   TestAccAWSDHCPOptions_tags
=== PAUSE TestAccAWSDHCPOptions_tags
=== RUN   TestAccAWSDHCPOptions_disappears
=== PAUSE TestAccAWSDHCPOptions_disappears
=== CONT  TestAccAWSDHCPOptions_basic
=== CONT  TestAccAWSDHCPOptions_disappears
=== CONT  TestAccAWSDHCPOptions_tags
=== CONT  TestAccAWSDHCPOptions_deleteOptions
--- PASS: TestAccAWSDHCPOptions_disappears (33.97s)
--- PASS: TestAccAWSDHCPOptions_deleteOptions (35.68s)
--- PASS: TestAccAWSDHCPOptions_basic (45.99s)
--- PASS: TestAccAWSDHCPOptions_tags (92.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	94.316s

$ make testacc TESTARGS='-run=TestAccDataSourceAwsVpcDhcpOptions_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsVpcDhcpOptions_ -timeout 120m
=== RUN   TestAccDataSourceAwsVpcDhcpOptions_basic
=== PAUSE TestAccDataSourceAwsVpcDhcpOptions_basic
=== RUN   TestAccDataSourceAwsVpcDhcpOptions_Filter
=== PAUSE TestAccDataSourceAwsVpcDhcpOptions_Filter
=== CONT  TestAccDataSourceAwsVpcDhcpOptions_basic
=== CONT  TestAccDataSourceAwsVpcDhcpOptions_Filter
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_basic (37.38s)
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_Filter (57.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.894s
```
