### PR TITLE
Support all valid operating systems in aws_gamelift_build

### DIFF
--- a/.changelog/17764.txt
+++ b/.changelog/17764.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_gamelift_build: Support all valid operating system values
+```

--- a/aws/resource_aws_gamelift_build.go
+++ b/aws/resource_aws_gamelift_build.go
@@ -27,13 +27,10 @@ func resourceAwsGameliftBuild() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 			"operating_system": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					gamelift.OperatingSystemAmazonLinux,
-					gamelift.OperatingSystemWindows2012,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(gamelift.OperatingSystem_Values(), false),
 			},
 			"storage_location": {
 				Type:     schema.TypeList,

--- a/website/docs/r/gamelift_build.html.markdown
+++ b/website/docs/r/gamelift_build.html.markdown
@@ -32,7 +32,7 @@ resource "aws_gamelift_build" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the build
-* `operating_system` - (Required) Operating system that the game server binaries are built to run on. e.g. `WINDOWS_2012` or `AMAZON_LINUX`.
+* `operating_system` - (Required) Operating system that the game server binaries are built to run on. e.g. `WINDOWS_2012`, `AMAZON_LINUX` or `AMAZON_LINUX_2`.
 * `storage_location` - (Required) Information indicating where your game build files are stored. See below.
 * `version` - (Optional) Version that is associated with this build.
 * `tags` - (Optional) Key-value map of resource tags


### PR DESCRIPTION
- Switched to use SDK provided values slice, as suggested in #14601
- Direct effect is that it adds support for AMAZON_LINUX_2 as a valid operating system for builds

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #17763
Relates #14601