### PR TITLE
service/lightsail: New data source: aws_lighstail_domain, Added Tags support for resource_aws_lightsail_domain

### DIFF
--- a/aws/data_source_aws_lightsail_domain.go
+++ b/aws/data_source_aws_lightsail_domain.go
@@ -48,10 +48,12 @@ func dataSourceAwsLightsailDomainRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	d.Set("arn", resp.Domain.Arn)
-	d.Set("domain_name", resp.Domain.Name)
+	domain := resp.Domain
+
+	d.Set("arn", domain.Arn)
+	d.Set("domain_name", domain.Name)
 	d.SetId(d.Get("domain_name").(string))
-	if err := d.Set("tags", keyvaluetags.LightsailKeyValueTags(resp.Domain.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+	if err := d.Set("tags", keyvaluetags.LightsailKeyValueTags(domain.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/data_source_aws_lightsail_domain.go
+++ b/aws/data_source_aws_lightsail_domain.go
@@ -42,8 +42,7 @@ func dataSourceAwsLightsailDomainRead(d *schema.ResourceData, meta interface{}) 
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() == "NotFoundException" {
 				log.Printf("[WARN] Lightsail Domain (%s) not found, removing from state", d.Get("domain_name"))
-				d.SetId("")
-				return nil
+				return fmt.Errorf("no matching Lightsail Domain found")
 			}
 			return err
 		}

--- a/aws/data_source_aws_lightsail_domain.go
+++ b/aws/data_source_aws_lightsail_domain.go
@@ -19,7 +19,6 @@ func dataSourceAwsLightsailDomain() *schema.Resource {
 			"domain_name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_lightsail_domain.go
+++ b/aws/data_source_aws_lightsail_domain.go
@@ -1,0 +1,61 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsLightsailDomain() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsLightsailDomainRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func dataSourceAwsLightsailDomainRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	})
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				log.Printf("[WARN] Lightsail Domain (%s) not found, removing from state", d.Get("domain_name"))
+				d.SetId("")
+				return nil
+			}
+			return err
+		}
+		return err
+	}
+
+	d.Set("arn", resp.Domain.Arn)
+	d.Set("domain_name", resp.Domain.Name)
+	d.SetId(d.Get("domain_name").(string))
+	if err := d.Set("tags", keyvaluetags.LightsailKeyValueTags(resp.Domain.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_lightsail_domain_test.go
+++ b/aws/data_source_aws_lightsail_domain_test.go
@@ -1,130 +1,49 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/lightsail"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccDataSourceAWSLightsailDomain_basic(t *testing.T) {
+func TestAccAWSLightsailDomainDataSource_DomainName(t *testing.T) {
 	var domain lightsail.Domain
-	lightsailDomainName := fmt.Sprintf("tf-data-test-lightsail-%s.com", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test.com")
 	resourceName := "aws_lightsail_domain.test"
 	dataSourceName := "data.aws_lightsail_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckLightsailDomain(t) },
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccDataSourceCheckAWSLightsailDomainDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckLightsailDomain(t) },
+		CheckDestroy: testAccCheckAWSLightsailDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSLightsailDomainConfig_basic(lightsailDomainName),
+				Config: testAccAWSLightsailDomainDataSourceConfigDomainName(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "domain_name", dataSourceName, "domain_name"),
 					testAccCheckAWSLightsailDomainExists(resourceName, &domain),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name", dataSourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDataSourceAWSLightsailDomain_disappears(t *testing.T) {
-	var domain lightsail.Domain
-	lightsailDomainName := fmt.Sprintf("tf-data-test-lightsail-%s.com", acctest.RandString(5))
-	resourceName := "aws_lightsail_domain.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckLightsailDomain(t) },
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccDataSourceCheckAWSLightsailDomainDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLightsailDomainConfig_basic(lightsailDomainName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccDataSourceCheckAWSLightsailDomainExists(resourceName, &domain),
-					testAccCheckResourceDisappears(testAccProviderLightsailDomain, resourceAwsLightsailDomain(), resourceName),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func testAccDataSourceCheckAWSLightsailDomainExists(n string, domain *lightsail.Domain) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return errors.New("No Lightsail Domain ID is set")
-		}
-
-		conn := testAccProviderLightsailDomain.Meta().(*AWSClient).lightsailconn
-
-		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
-			DomainName: aws.String(rs.Primary.ID),
-		})
-
-		if err != nil {
-			return err
-		}
-
-		if resp == nil || resp.Domain == nil {
-			return fmt.Errorf("Domain (%s) not found", rs.Primary.ID)
-		}
-		*domain = *resp.Domain
-		return nil
-	}
-}
-
-func testAccDataSourceCheckAWSLightsailDomainDestroy(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_lightsail_domain" {
-			continue
-		}
-
-		conn := testAccProviderLightsailDomain.Meta().(*AWSClient).lightsailconn
-
-		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
-			DomainName: aws.String(rs.Primary.ID),
-		})
-
-		if err == nil {
-			if resp.Domain != nil {
-				return fmt.Errorf("Lightsail Domain %q still exists", rs.Primary.ID)
-			}
-		}
-
-		// Verify the error
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "NotFoundException" {
-				return nil
-			}
-		}
-		return err
-	}
-
-	return nil
-}
-
-func testAccDataSourceAWSLightsailDomainConfig_basic(lightsailDomainName string) string {
+func testAccAWSLightsailDomainDataSourceConfigDomainName(rName string) string {
 	return composeConfig(
 		testAccLightsailDomainRegionProviderConfig(),
 		fmt.Sprintf(`
 resource "aws_lightsail_domain" "test" {
   domain_name = "%s"
+  tags = {
+    "key1" = "value1"
+    "key2" = "value2"
+  }
 }
 data "aws_lightsail_domain" "test" {
   domain_name = aws_lightsail_domain.test.domain_name
 }
-`, lightsailDomainName))
+`, rName))
 }

--- a/aws/data_source_aws_lightsail_domain_test.go
+++ b/aws/data_source_aws_lightsail_domain_test.go
@@ -8,14 +8,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAwsLightsailDomainDataSource_domain_name(t *testing.T) {
+func TestAccDataSourceAwsLightsailDomainDataSource(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_lightsail_domain.test"
 	dataSourceName := "data.aws_lightsail_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Providers:         testAccProviders,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSLightsailDomainDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsLightsailDomainDomainName(rInt),

--- a/aws/data_source_aws_lightsail_domain_test.go
+++ b/aws/data_source_aws_lightsail_domain_test.go
@@ -1,41 +1,130 @@
 package aws
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccDataSourceAwsLightsailDomainDataSource(t *testing.T) {
-	rInt := acctest.RandInt()
+func TestAccDataSourceAWSLightsailDomain_basic(t *testing.T) {
+	var domain lightsail.Domain
+	lightsailDomainName := fmt.Sprintf("tf-data-test-lightsail-%s.com", acctest.RandString(5))
 	resourceName := "aws_lightsail_domain.test"
 	dataSourceName := "data.aws_lightsail_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		Providers:         testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckLightsailDomain(t) },
 		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccCheckAWSLightsailDomainDestroy,
+		CheckDestroy:      testAccDataSourceCheckAWSLightsailDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsLightsailDomainDomainName(rInt),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccDataSourceAWSLightsailDomainConfig_basic(lightsailDomainName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "domain_name", dataSourceName, "domain_name"),
+					testAccCheckAWSLightsailDomainExists(resourceName, &domain),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsLightsailDomainDomainName(rInt int) string {
-	return fmt.Sprintf(`
+func TestAccDataSourceAWSLightsailDomain_disappears(t *testing.T) {
+	var domain lightsail.Domain
+	lightsailDomainName := fmt.Sprintf("tf-data-test-lightsail-%s.com", acctest.RandString(5))
+	resourceName := "aws_lightsail_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckLightsailDomain(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccDataSourceCheckAWSLightsailDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailDomainConfig_basic(lightsailDomainName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDataSourceCheckAWSLightsailDomainExists(resourceName, &domain),
+					testAccCheckResourceDisappears(testAccProviderLightsailDomain, resourceAwsLightsailDomain(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccDataSourceCheckAWSLightsailDomainExists(n string, domain *lightsail.Domain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Lightsail Domain ID is set")
+		}
+
+		conn := testAccProviderLightsailDomain.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+			DomainName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || resp.Domain == nil {
+			return fmt.Errorf("Domain (%s) not found", rs.Primary.ID)
+		}
+		*domain = *resp.Domain
+		return nil
+	}
+}
+
+func testAccDataSourceCheckAWSLightsailDomainDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lightsail_domain" {
+			continue
+		}
+
+		conn := testAccProviderLightsailDomain.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+			DomainName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if resp.Domain != nil {
+				return fmt.Errorf("Lightsail Domain %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				return nil
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func testAccDataSourceAWSLightsailDomainConfig_basic(lightsailDomainName string) string {
+	return composeConfig(
+		testAccLightsailDomainRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_lightsail_domain" "test" {
-  domain_name = "terraformtestacchz-%[1]d.com."
+  domain_name = "%s"
 }
 data "aws_lightsail_domain" "test" {
   domain_name = aws_lightsail_domain.test.domain_name
 }
-`, rInt)
+`, lightsailDomainName))
 }

--- a/aws/data_source_aws_lightsail_domain_test.go
+++ b/aws/data_source_aws_lightsail_domain_test.go
@@ -1,0 +1,39 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAwsLightsailDomainDataSource_domain_name(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_lightsail_domain.test"
+	dataSourceName := "data.aws_lightsail_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsLightsailDomainDomainName(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name", dataSourceName, "domain_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsLightsailDomainDomainName(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_lightsail_domain" "test" {
+  domain_name = "terraformtestacchz-%[1]d.com."
+}
+data "aws_lightsail_domain" "test" {
+  domain_name = aws_lightsail_domain.test.domain_name
+}
+`, rInt)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -305,6 +305,7 @@ func Provider() *schema.Provider {
 			"aws_lex_bot":                                    dataSourceAwsLexBot(),
 			"aws_lex_intent":                                 dataSourceAwsLexIntent(),
 			"aws_lex_slot_type":                              dataSourceAwsLexSlotType(),
+			"aws_lightsail_domain":                           dataSourceAwsLightsailDomain(),
 			"aws_mq_broker":                                  dataSourceAwsMqBroker(),
 			"aws_msk_cluster":                                dataSourceAwsMskCluster(),
 			"aws_msk_configuration":                          dataSourceAwsMskConfiguration(),

--- a/aws/resource_aws_lightsail_domain_test.go
+++ b/aws/resource_aws_lightsail_domain_test.go
@@ -38,7 +38,7 @@ func TestAccAWSLightsailDomain_serial(t *testing.T) {
 
 func testAccAWSLightsailDomain_basic(t *testing.T) {
 	var domain lightsail.Domain
-	rName := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test.com")
 	resourceName := "aws_lightsail_domain.test"
 
 	resource.Test(t, resource.TestCase{
@@ -58,7 +58,7 @@ func testAccAWSLightsailDomain_basic(t *testing.T) {
 
 func testAccAWSLightsailDomain_disappears(t *testing.T) {
 	var domain lightsail.Domain
-	rName := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test.com")
 	resourceName := "aws_lightsail_domain.test"
 
 	resource.Test(t, resource.TestCase{
@@ -108,8 +108,8 @@ func testAccCheckAWSLightsailDomainExists(n string, domain *lightsail.Domain) re
 
 func testAccAWSLightsailDomain_DomainName(t *testing.T) {
 	var domain1, domain2 lightsail.Domain
-	rName := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(5))
-	rName2 := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test.com")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test.com")
 	resourceName := "aws_lightsail_domain.test"
 
 	resource.Test(t, resource.TestCase{
@@ -134,7 +134,7 @@ func testAccAWSLightsailDomain_DomainName(t *testing.T) {
 
 func testAccAWSLightsailDomain_Tags(t *testing.T) {
 	var domain1, domain2, domain3 lightsail.Domain
-	rName := fmt.Sprintf("tf-acc-test-%s.com", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test.com")
 	resourceName := "aws_lightsail_domain.test"
 
 	resource.Test(t, resource.TestCase{

--- a/website/docs/d/lightsail_domain.html.markdown
+++ b/website/docs/d/lightsail_domain.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "Lightsail"
+layout: "aws"
+page_title: "AWS: aws_lightsail_domain"
+description: |-
+  Provides details about a Lightsail Domain
+---
+
+# Data Source: aws_lightsail_domain
+
+Provides details about a Lightsail Domain for the specified domain (e.g., example.com).
+
+~> **Note:** Lightsail is currently only supported in a limited number of AWS Regions, please see ["Regions and Availability Zones in Amazon Lightsail"](https://lightsail.aws.amazon.com/ls/docs/overview/article/understanding-regions-and-availability-zones-in-amazon-lightsail) for more details
+
+## Example Usage, getting details of a domain
+
+```hcl
+data "aws_lightsail_domain" "domain_test" {
+  domain_name = "mydomain.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required) The name of the Lightsail domain to manage
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name used for this domain
+* `arn` - The ARN of the Lightsail domain
+* `tags` - A map of tags assigned to the resource.

--- a/website/docs/r/lightsail_domain.html.markdown
+++ b/website/docs/r/lightsail_domain.html.markdown
@@ -21,6 +21,9 @@ this parameter to manage the DNS records for that domain.
 ```hcl
 resource "aws_lightsail_domain" "domain_test" {
   domain_name = "mydomain.com"
+  tags = {
+    foo = "bar"
+  }
 }
 ```
 
@@ -36,3 +39,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name used for this domain
 * `arn` - The ARN of the Lightsail domain
+* `tags` - A map of tags assigned to the resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for CHANGELOG:

```release-note:new-data-source
aws_lightsail_domain
```
```release-note:enhancement
resource/aws_lightsail_domain: Add support for tags
```
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLightsailDomain'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLightsailDomain -timeout 120m
=== RUN   TestAccAWSLightsailDomainDataSource_DomainName
=== PAUSE TestAccAWSLightsailDomainDataSource_DomainName
=== RUN   TestAccAWSLightsailDomain_serial
=== RUN   TestAccAWSLightsailDomain_serial/Domain
=== RUN   TestAccAWSLightsailDomain_serial/Domain/basic
=== RUN   TestAccAWSLightsailDomain_serial/Domain/disappears
=== RUN   TestAccAWSLightsailDomain_serial/Domain/DomainName
=== RUN   TestAccAWSLightsailDomain_serial/Domain/Tags
--- PASS: TestAccAWSLightsailDomain_serial (414.56s)
    --- PASS: TestAccAWSLightsailDomain_serial/Domain (414.56s)
        --- PASS: TestAccAWSLightsailDomain_serial/Domain/basic (68.18s)
        --- PASS: TestAccAWSLightsailDomain_serial/Domain/disappears (54.77s)
        --- PASS: TestAccAWSLightsailDomain_serial/Domain/DomainName (112.88s)
        --- PASS: TestAccAWSLightsailDomain_serial/Domain/Tags (178.73s)
=== CONT  TestAccAWSLightsailDomainDataSource_DomainName
--- PASS: TestAccAWSLightsailDomainDataSource_DomainName (66.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       484.517s

...
```

This PR:

- Adds Lightsail domain data source (tested locally with make build)
- Updates Lightsail domain resource to support tags
- Convert Lightail domain to serialized tests to avoid hitting the limit of 3 resources
- Added tests to Lightsail domain resource for tags

