### PR TITLE
Update aws_s3_bucket_notification for SNS example

### DIFF
--- a/aws/resource_aws_s3_bucket_notification_test.go
+++ b/aws/resource_aws_s3_bucket_notification_test.go
@@ -481,9 +481,7 @@ resource "aws_sns_topic" "topic" {
     {
       "Sid": "",
       "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
+      "Principal": { "Service": "s3.${data.aws_partition.current.dns_suffix}" },
       "Action": "SNS:Publish",
       "Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
       "Condition": {
@@ -586,6 +584,8 @@ resource "aws_s3_bucket_notification" "notification" {
 
 func testAccAWSS3BucketNotificationConfigLambdaFunction(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "iam_for_lambda" {
   name = %[1]q
 
@@ -596,7 +596,7 @@ resource "aws_iam_role" "iam_for_lambda" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "lambda.amazonaws.com"
+        "Service": "lambda.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -610,7 +610,7 @@ resource "aws_lambda_permission" "allow_bucket" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.func.arn
-  principal     = "s3.amazonaws.com"
+  principal     = "s3.${data.aws_partition.current.dns_suffix}"
   source_arn    = aws_s3_bucket.bucket.arn
 }
 
@@ -648,6 +648,8 @@ resource "aws_s3_bucket_notification" "notification" {
 
 func testAccAWSS3BucketNotificationConfigLambdaFunctionLambdaFunctionArnAlias(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
 {
@@ -656,7 +658,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "lambda.amazonaws.com"
+        "Service": "lambda.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow"
     }
@@ -684,7 +686,7 @@ resource "aws_lambda_alias" "test" {
 resource "aws_lambda_permission" "test" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.test.arn
-  principal     = "s3.amazonaws.com"
+  principal     = "s3.${data.aws_partition.current.dns_suffix}"
   qualifier     = aws_lambda_alias.test.name
   source_arn    = aws_s3_bucket.test.arn
   statement_id  = "AllowExecutionFromS3Bucket"
@@ -722,7 +724,7 @@ resource "aws_sns_topic" "topic" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "Service": "s3.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "SNS:Publish",
       "Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",

--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -25,7 +25,7 @@ resource "aws_sns_topic" "topic" {
     "Version":"2012-10-17",
     "Statement":[{
         "Effect": "Allow",
-        "Principal": {"AWS":"*"},
+        "Principal": { "Service": "s3.amazonaws.com" },
         "Action": "SNS:Publish",
         "Resource": "arn:aws:sns:*:*:s3-event-notification-topic",
         "Condition":{


### PR DESCRIPTION
Example for `aws_s3_bucket_notification` resource is failing due to policy misconfiguration. After this update everything  works ok.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
