### PR TITLE
aws_vpc_endpoint: Correct the ARN account id

### DIFF
--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -163,7 +163,7 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(vpce.OwnerId),
 		Resource:  fmt.Sprintf("vpc-endpoint/%s", d.Id()),
 	}.String()
 	d.Set("arn", arn)

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -228,7 +228,7 @@ func resourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(vpce.OwnerId),
 		Resource:  fmt.Sprintf("vpc-endpoint/%s", d.Id()),
 	}.String()
 	d.Set("arn", arn)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -333,8 +333,6 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
     - [`aws_vpc_dhcp_options` resource](/docs/providers/aws/r/vpc_dhcp_options.html)
     - [`aws_vpc_endpoint_service` data source](/docs/providers/aws/d/vpc_endpoint_service.html)
     - [`aws_vpc_endpoint_service` resource](/docs/providers/aws/r/vpc_endpoint_service.html)
-    - [`aws_vpc_endpoint` data source](/docs/providers/aws/d/vpc_endpoint.html)
-    - [`aws_vpc_endpoint` resource](/docs/providers/aws/r/vpc_endpoint.html)
     - [`aws_vpc` data source](/docs/providers/aws/d/vpc.html)
     - [`aws_vpc` resource](/docs/providers/aws/r/vpc.html)
     - [`aws_vpn_connection` resource](/docs/providers/aws/r/vpn_connection.html)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16978

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccAWSVpcEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSVpcEndpoint_ -timeout 120m
=== RUN   TestAccAWSVpcEndpoint_gatewayBasic
=== PAUSE TestAccAWSVpcEndpoint_gatewayBasic
=== RUN   TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy
=== PAUSE TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy
=== RUN   TestAccAWSVpcEndpoint_gatewayPolicy
=== PAUSE TestAccAWSVpcEndpoint_gatewayPolicy
=== RUN   TestAccAWSVpcEndpoint_interfaceBasic
=== PAUSE TestAccAWSVpcEndpoint_interfaceBasic
=== RUN   TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
=== PAUSE TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
=== RUN   TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== PAUSE TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== RUN   TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== PAUSE TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== RUN   TestAccAWSVpcEndpoint_disappears
=== PAUSE TestAccAWSVpcEndpoint_disappears
=== RUN   TestAccAWSVpcEndpoint_tags
=== PAUSE TestAccAWSVpcEndpoint_tags
=== RUN   TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer
=== PAUSE TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer
=== CONT  TestAccAWSVpcEndpoint_gatewayBasic
=== CONT  TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== CONT  TestAccAWSVpcEndpoint_disappears
=== CONT  TestAccAWSVpcEndpoint_tags
=== CONT  TestAccAWSVpcEndpoint_interfaceBasic
=== CONT  TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
=== CONT  TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy
=== CONT  TestAccAWSVpcEndpoint_gatewayPolicy
=== CONT  TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer
=== CONT  TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate
--- PASS: TestAccAWSVpcEndpoint_disappears (63.21s)
--- PASS: TestAccAWSVpcEndpoint_gatewayBasic (69.60s)
--- PASS: TestAccAWSVpcEndpoint_gatewayPolicy (109.79s)
--- PASS: TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy (116.83s)
--- PASS: TestAccAWSVpcEndpoint_interfaceBasic (137.92s)
--- PASS: TestAccAWSVpcEndpoint_tags (138.56s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate (262.77s)
--- PASS: TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup (430.43s)
--- PASS: TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer (443.34s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate (479.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	481.158s

$ make testacc TESTARGS='-run=TestAccDataSourceAwsVpcEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsVpcEndpoint_ -timeout 120m
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayBasic
=== PAUSE TestAccDataSourceAwsVpcEndpoint_gatewayBasic
=== RUN   TestAccDataSourceAwsVpcEndpoint_byId
=== PAUSE TestAccDataSourceAwsVpcEndpoint_byId
=== RUN   TestAccDataSourceAwsVpcEndpoint_byFilter
=== PAUSE TestAccDataSourceAwsVpcEndpoint_byFilter
=== RUN   TestAccDataSourceAwsVpcEndpoint_byTags
=== PAUSE TestAccDataSourceAwsVpcEndpoint_byTags
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags
=== PAUSE TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags
=== RUN   TestAccDataSourceAwsVpcEndpoint_interface
=== PAUSE TestAccDataSourceAwsVpcEndpoint_interface
=== CONT  TestAccDataSourceAwsVpcEndpoint_gatewayBasic
=== CONT  TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags
=== CONT  TestAccDataSourceAwsVpcEndpoint_interface
=== CONT  TestAccDataSourceAwsVpcEndpoint_byFilter
=== CONT  TestAccDataSourceAwsVpcEndpoint_byId
=== CONT  TestAccDataSourceAwsVpcEndpoint_byTags
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayBasic (59.30s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byTags (59.32s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (59.41s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byFilter (59.86s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags (65.59s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_interface (194.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	196.836s
```

Thank you for your review!