### PR TITLE
workflow/firewatch: DryRun configuration to detect issues gaining reactions over a threshold

### DIFF
--- a/.github/workflows/firewatch.yml
+++ b/.github/workflows/firewatch.yml
@@ -1,0 +1,25 @@
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+name: Firewatch
+jobs:
+  FirewatchJob:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Firewatch
+      uses: breathingdust/firewatch@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        alert_threshold: 10
+        issue_age_months: 3
+        slack_token: 1
+        slack_channel: 1
+    - name: UploadArtifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: firewatch
+        path: firewatch.data
+        if-no-files-found: error
+        retention-days: 1


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This adds a dry-run configuration for a prototype tool which will alert provider maintainers to any recently created issue which receives reactions over a specified threshold. This will only add results to logs, any reporting is disabled until reasonable thresholds can be determined.
