### PR TITLE
r/aws_kinesis_analytics_application: Add 'start_application' attribute

### DIFF
--- a/.changelog/17784.txt
+++ b/.changelog/17784.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_kinesis_analytics_application: Add `start_application` attribute
 ```
+
+```release-note:enhancement
+resource/aws_kinesis_analytics_application: `starting_position_configuration` can be specified when starting an application
+```

--- a/.changelog/17784.txt
+++ b/.changelog/17784.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_kinesis_analytics_application: Add `start_application` attribute
+```

--- a/aws/internal/service/kinesisanalytics/finder/finder.go
+++ b/aws/internal/service/kinesisanalytics/finder/finder.go
@@ -35,9 +35,8 @@ func ApplicationDetail(conn *kinesisanalytics.KinesisAnalytics, input *kinesisan
 
 	if output == nil || output.ApplicationDetail == nil {
 		return nil, &resource.NotFoundError{
-			Message:      "Empty result",
-			LastRequest:  input,
-			LastResponse: output,
+			Message:     "Empty result",
+			LastRequest: input,
 		}
 	}
 

--- a/aws/internal/service/kinesisanalytics/finder/finder.go
+++ b/aws/internal/service/kinesisanalytics/finder/finder.go
@@ -3,17 +3,42 @@ package finder
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// ApplicationByName returns the application corresponding to the specified name.
-func ApplicationByName(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
+// ApplicationDetailByName returns the application corresponding to the specified name.
+// Returns NotFoundError if no application is found.
+func ApplicationDetailByName(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
 	input := &kinesisanalytics.DescribeApplicationInput{
 		ApplicationName: aws.String(name),
 	}
 
+	return ApplicationDetail(conn, input)
+}
+
+// ApplicationDetail returns the application details corresponding to the specified name.
+// Returns NotFoundError if no application is found.
+func ApplicationDetail(conn *kinesisanalytics.KinesisAnalytics, input *kinesisanalytics.DescribeApplicationInput) (*kinesisanalytics.ApplicationDetail, error) {
 	output, err := conn.DescribeApplication(input)
+
+	if tfawserr.ErrCodeEquals(err, kinesisanalytics.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return nil, err
+	}
+
+	if output == nil || output.ApplicationDetail == nil {
+		return nil, &resource.NotFoundError{
+			Message:      "Empty result",
+			LastRequest:  input,
+			LastResponse: output,
+		}
 	}
 
 	return output.ApplicationDetail, nil

--- a/aws/internal/service/kinesisanalytics/waiter/status.go
+++ b/aws/internal/service/kinesisanalytics/waiter/status.go
@@ -3,9 +3,9 @@ package waiter
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -13,12 +13,12 @@ const (
 	applicationStatusUnknown  = "Unknown"
 )
 
-// ApplicationStatus fetches the Application and its Status
+// ApplicationStatus fetches the ApplicationDetail and its Status
 func ApplicationStatus(conn *kinesisanalytics.KinesisAnalytics, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		application, err := finder.ApplicationByName(conn, name)
+		applicationDetail, err := finder.ApplicationDetailByName(conn, name)
 
-		if tfawserr.ErrCodeEquals(err, kinesisanalytics.ErrCodeResourceNotFoundException) {
+		if tfresource.NotFound(err) {
 			return nil, applicationStatusNotFound, nil
 		}
 
@@ -26,6 +26,6 @@ func ApplicationStatus(conn *kinesisanalytics.KinesisAnalytics, name string) res
 			return nil, applicationStatusUnknown, err
 		}
 
-		return application, aws.StringValue(application.ApplicationStatus), nil
+		return applicationDetail, aws.StringValue(applicationDetail.ApplicationStatus), nil
 	}
 }

--- a/aws/internal/service/kinesisanalytics/waiter/status.go
+++ b/aws/internal/service/kinesisanalytics/waiter/status.go
@@ -8,22 +8,17 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-const (
-	applicationStatusNotFound = "NotFound"
-	applicationStatusUnknown  = "Unknown"
-)
-
 // ApplicationStatus fetches the ApplicationDetail and its Status
 func ApplicationStatus(conn *kinesisanalytics.KinesisAnalytics, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		applicationDetail, err := finder.ApplicationDetailByName(conn, name)
 
 		if tfresource.NotFound(err) {
-			return nil, applicationStatusNotFound, nil
+			return nil, "", nil
 		}
 
 		if err != nil {
-			return nil, applicationStatusUnknown, err
+			return nil, "", err
 		}
 
 		return applicationDetail, aws.StringValue(applicationDetail.ApplicationStatus), nil

--- a/aws/internal/service/kinesisanalytics/waiter/waiter.go
+++ b/aws/internal/service/kinesisanalytics/waiter/waiter.go
@@ -11,17 +11,19 @@ import (
 )
 
 const (
-	ApplicationReadyTimeout   = 5 * time.Minute
-	ApplicationRunningTimeout = 5 * time.Minute
+	ApplicationDeletedTimeout = 5 * time.Minute
+	ApplicationStartedTimeout = 5 * time.Minute
+	ApplicationStoppedTimeout = 5 * time.Minute
+	ApplicationUpdatedTimeout = 5 * time.Minute
 )
 
 // ApplicationDeleted waits for an Application to return Deleted
-func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, name string, timeout time.Duration) (*kinesisanalytics.ApplicationDetail, error) {
+func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{kinesisanalytics.ApplicationStatusDeleting},
 		Target:  []string{},
 		Refresh: ApplicationStatus(conn, name),
-		Timeout: timeout,
+		Timeout: ApplicationDeletedTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -33,31 +35,49 @@ func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, name string, ti
 	return nil, err
 }
 
-// ApplicationReady waits for an Application to return Ready
-func ApplicationReady(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{kinesisanalytics.ApplicationStatusStopping},
-		Target:  []string{kinesisanalytics.ApplicationStatusReady},
-		Refresh: ApplicationStatus(conn, name),
-		Timeout: ApplicationReadyTimeout,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if v, ok := outputRaw.(*kinesisanalytics.ApplicationDetail); ok {
-		return v, err
-	}
-
-	return nil, err
-}
-
-// ApplicationRunning waits for an Application to return Running
-func ApplicationRunning(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
+// ApplicationStarted waits for an Application to start
+func ApplicationStarted(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{kinesisanalytics.ApplicationStatusStarting},
 		Target:  []string{kinesisanalytics.ApplicationStatusRunning},
 		Refresh: ApplicationStatus(conn, name),
-		Timeout: ApplicationRunningTimeout,
+		Timeout: ApplicationStartedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*kinesisanalytics.ApplicationDetail); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+// ApplicationStopped waits for an Application to stop
+func ApplicationStopped(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{kinesisanalytics.ApplicationStatusStopping},
+		Target:  []string{kinesisanalytics.ApplicationStatusReady},
+		Refresh: ApplicationStatus(conn, name),
+		Timeout: ApplicationStoppedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*kinesisanalytics.ApplicationDetail); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+// ApplicationUpdated waits for an Application to update
+func ApplicationUpdated(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{kinesisanalytics.ApplicationStatusUpdating},
+		Target:  []string{kinesisanalytics.ApplicationStatusReady, kinesisanalytics.ApplicationStatusRunning},
+		Refresh: ApplicationStatus(conn, name),
+		Timeout: ApplicationUpdatedTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/internal/service/kinesisanalytics/waiter/waiter.go
+++ b/aws/internal/service/kinesisanalytics/waiter/waiter.go
@@ -11,9 +11,12 @@ import (
 )
 
 // ApplicationDeleted waits for an Application to return Deleted
-func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, name string, timeout time.Duration) (*kinesisanalytics.ApplicationSummary, error) {
+func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, name string, timeout time.Duration) (*kinesisanalytics.ApplicationDetail, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{kinesisanalytics.ApplicationStatusRunning, kinesisanalytics.ApplicationStatusDeleting},
+		Pending: []string{
+			kinesisanalytics.ApplicationStatusRunning,
+			kinesisanalytics.ApplicationStatusDeleting,
+		},
 		Target:  []string{},
 		Refresh: ApplicationStatus(conn, name),
 		Timeout: timeout,
@@ -21,7 +24,7 @@ func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, name string, ti
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*kinesisanalytics.ApplicationSummary); ok {
+	if v, ok := outputRaw.(*kinesisanalytics.ApplicationDetail); ok {
 		return v, err
 	}
 

--- a/aws/internal/service/kinesisanalytics/waiter/waiter.go
+++ b/aws/internal/service/kinesisanalytics/waiter/waiter.go
@@ -10,35 +10,16 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-const (
-	ApplicationRunningTimeout = 5 * time.Minute
-)
-
 // ApplicationDeleted waits for an Application to return Deleted
 func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, name string, timeout time.Duration) (*kinesisanalytics.ApplicationDetail, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{kinesisanalytics.ApplicationStatusDeleting},
+		Pending: []string{
+			kinesisanalytics.ApplicationStatusRunning,
+			kinesisanalytics.ApplicationStatusDeleting,
+		},
 		Target:  []string{},
 		Refresh: ApplicationStatus(conn, name),
 		Timeout: timeout,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if v, ok := outputRaw.(*kinesisanalytics.ApplicationDetail); ok {
-		return v, err
-	}
-
-	return nil, err
-}
-
-// ApplicationRunning waits for an Application to return Running
-func ApplicationRunning(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{kinesisanalytics.ApplicationStatusStarting},
-		Target:  []string{kinesisanalytics.ApplicationStatusRunning},
-		Refresh: ApplicationStatus(conn, name),
-		Timeout: ApplicationRunningTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/internal/service/kinesisanalytics/waiter/waiter.go
+++ b/aws/internal/service/kinesisanalytics/waiter/waiter.go
@@ -10,16 +10,35 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
+const (
+	ApplicationRunningTimeout = 5 * time.Minute
+)
+
 // ApplicationDeleted waits for an Application to return Deleted
 func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, name string, timeout time.Duration) (*kinesisanalytics.ApplicationDetail, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			kinesisanalytics.ApplicationStatusRunning,
-			kinesisanalytics.ApplicationStatusDeleting,
-		},
+		Pending: []string{kinesisanalytics.ApplicationStatusDeleting},
 		Target:  []string{},
 		Refresh: ApplicationStatus(conn, name),
 		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*kinesisanalytics.ApplicationDetail); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+// ApplicationRunning waits for an Application to return Running
+func ApplicationRunning(conn *kinesisanalytics.KinesisAnalytics, name string) (*kinesisanalytics.ApplicationDetail, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{kinesisanalytics.ApplicationStatusStarting},
+		Target:  []string{kinesisanalytics.ApplicationStatusRunning},
+		Refresh: ApplicationStatus(conn, name),
+		Timeout: ApplicationRunningTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -432,7 +432,7 @@ func resourceAwsKinesisAnalyticsApplication() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"record_format_type": {
 										Type:         schema.TypeString,
-										Optional:     true,
+										Required:     true,
 										ValidateFunc: validation.StringInSlice(kinesisanalytics.RecordFormatType_Values(), false),
 									},
 								},

--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -788,6 +788,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 					return fmt.Errorf("error adding Kinesis Analytics Application (%s) CloudWatch logging option: %w", d.Id(), err)
 				}
 
+				if _, err := waiter.ApplicationUpdated(conn, applicationName); err != nil {
+					return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to update: %w", d.Id(), err)
+				}
+
 				currentApplicationVersionId += 1
 			} else if len(n.([]interface{})) == 0 {
 				// Delete existing CloudWatch logging options.
@@ -807,6 +811,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 
 				if err != nil {
 					return fmt.Errorf("error deleting Kinesis Analytics Application (%s) CloudWatch logging option: %w", d.Id(), err)
+				}
+
+				if _, err := waiter.ApplicationUpdated(conn, applicationName); err != nil {
+					return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to update: %w", d.Id(), err)
 				}
 
 				currentApplicationVersionId += 1
@@ -854,6 +862,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 					return fmt.Errorf("error adding Kinesis Analytics Application (%s) input: %w", d.Id(), err)
 				}
 
+				if _, err := waiter.ApplicationUpdated(conn, applicationName); err != nil {
+					return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to update: %w", d.Id(), err)
+				}
+
 				currentApplicationVersionId += 1
 			} else if len(n.([]interface{})) == 0 {
 				// The existing input cannot be deleted.
@@ -887,6 +899,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 							return fmt.Errorf("error adding Kinesis Analytics Application (%s) input processing configuration: %w", d.Id(), err)
 						}
 
+						if _, err := waiter.ApplicationUpdated(conn, applicationName); err != nil {
+							return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to update: %w", d.Id(), err)
+						}
+
 						currentApplicationVersionId += 1
 					} else if len(n.([]interface{})) == 0 {
 						// Delete existing input processing configuration.
@@ -904,6 +920,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 
 						if err != nil {
 							return fmt.Errorf("error deleting Kinesis Analytics Application (%s) input processing configuration: %w", d.Id(), err)
+						}
+
+						if _, err := waiter.ApplicationUpdated(conn, applicationName); err != nil {
+							return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to update: %w", d.Id(), err)
 						}
 
 						currentApplicationVersionId += 1
@@ -962,6 +982,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 					return fmt.Errorf("error deleting Kinesis Analytics Application (%s) output: %w", d.Id(), err)
 				}
 
+				if _, err := waiter.ApplicationUpdated(conn, applicationName); err != nil {
+					return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to update: %w", d.Id(), err)
+				}
+
 				currentApplicationVersionId += 1
 			}
 
@@ -981,6 +1005,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 
 				if err != nil {
 					return fmt.Errorf("error adding Kinesis Analytics Application (%s) output: %w", d.Id(), err)
+				}
+
+				if _, err := waiter.ApplicationUpdated(conn, applicationName); err != nil {
+					return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to update: %w", d.Id(), err)
 				}
 
 				currentApplicationVersionId += 1
@@ -1008,6 +1036,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 					return fmt.Errorf("error adding Kinesis Analytics Application (%s) reference data source: %w", d.Id(), err)
 				}
 
+				if _, err := waiter.ApplicationUpdated(conn, applicationName); err != nil {
+					return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to update: %w", d.Id(), err)
+				}
+
 				currentApplicationVersionId += 1
 			} else if len(n.([]interface{})) == 0 {
 				// Delete existing reference data source.
@@ -1027,6 +1059,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 
 				if err != nil {
 					return fmt.Errorf("error deleting Kinesis Analytics Application (%s) reference data source: %w", d.Id(), err)
+				}
+
+				if _, err := waiter.ApplicationUpdated(conn, applicationName); err != nil {
+					return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to update: %w", d.Id(), err)
 				}
 
 				currentApplicationVersionId += 1

--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -318,15 +318,12 @@ func resourceAwsKinesisAnalyticsApplication() *schema.Resource {
 
 						"starting_position_configuration": {
 							Type:     schema.TypeList,
-							Optional: true,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"starting_position": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										Computed:     true,
-										ValidateFunc: validation.StringInSlice(kinesisanalytics.InputStartingPosition_Values(), false),
+										Type:     schema.TypeString,
+										Computed: true,
 									},
 								},
 							},
@@ -592,10 +589,8 @@ func resourceAwsKinesisAnalyticsApplication() *schema.Resource {
 			},
 
 			"status": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(kinesisanalytics.ApplicationStatus_Values(), false),
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"tags": tagsSchema(),
@@ -654,14 +649,6 @@ func resourceAwsKinesisAnalyticsApplicationCreate(d *schema.ResourceData, meta i
 
 		if err != nil {
 			return fmt.Errorf("error adding Kinesis Analytics Application (%s) reference data source: %w", d.Id(), err)
-		}
-	}
-
-	if v, ok := d.GetOk("status"); ok && v.(string) == kinesisanalytics.ApplicationStatusRunning {
-		err := startKinesisAnalyticsApplication(d, conn)
-
-		if err != nil {
-			return err
 		}
 	}
 
@@ -1088,54 +1075,6 @@ func resourceAwsKinesisAnalyticsApplicationImport(d *schema.ResourceData, meta i
 	d.Set("name", parts[1])
 
 	return []*schema.ResourceData{d}, nil
-}
-
-func startKinesisAnalyticsApplication(d *schema.ResourceData, conn *kinesisanalytics.KinesisAnalytics) error {
-	if v, ok := d.GetOk("inputs"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
-
-		if v, ok := tfMap["starting_position_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			tfMap := v[0].(map[string]interface{})
-
-			if v, ok := tfMap["starting_position"].(string); ok && v != "" {
-				applicationName := d.Get("name").(string)
-
-				application, err := finder.ApplicationDetailByName(conn, applicationName)
-
-				if err != nil {
-					return err
-				}
-
-				if len(application.InputDescriptions) > 0 {
-					input := &kinesisanalytics.StartApplicationInput{
-						ApplicationName: aws.String(applicationName),
-						InputConfigurations: []*kinesisanalytics.InputConfiguration{{
-							Id: application.InputDescriptions[0].InputId,
-							InputStartingPositionConfiguration: &kinesisanalytics.InputStartingPositionConfiguration{
-								InputStartingPosition: aws.String(v),
-							},
-						}},
-					}
-
-					log.Printf("[DEBUG] Starting Kinesis Analytics Application (%s): %s", d.Id(), input)
-
-					_, err := conn.StartApplication(input)
-
-					if err != nil {
-						return fmt.Errorf("error starting Kinesis Analytics Application (%s): %w", d.Id(), err)
-					}
-
-					_, err = waiter.ApplicationRunning(conn, applicationName)
-
-					if err != nil {
-						return fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to start: %w", d.Id(), err)
-					}
-				}
-			}
-		}
-	}
-
-	return nil
 }
 
 func expandKinesisAnalyticsCloudWatchLoggingOptions(vCloudWatchLoggingOptions []interface{}) []*kinesisanalytics.CloudWatchLoggingOption {

--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -1242,11 +1242,6 @@ func kinesisAnalyticsStopApplication(conn *kinesisanalytics.KinesisAnalytics, ap
 		return nil
 	}
 
-	if status := aws.StringValue(application.ApplicationStatus); status != kinesisanalytics.ApplicationStatusRunning {
-		log.Printf("[DEBUG] Kinesis Analytics Application (%s) has status %s, ignoring stop application request", applicationARN, status)
-		return nil
-	}
-
 	input := &kinesisanalytics.StopApplicationInput{
 		ApplicationName: aws.String(applicationName),
 	}

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -1570,6 +1570,160 @@ func TestAccAWSKinesisAnalyticsApplication_StartApplication_OnCreate(t *testing.
 	})
 }
 
+func TestAccAWSKinesisAnalyticsApplication_StartApplication_OnUpdate(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRole1ResourceName := "aws_iam_role.test.0"
+	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigStartApplication(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.name", "COLUMN_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.sql_type", "INTEGER"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "start_application", "false"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_application"},
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigStartApplication(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.name", "COLUMN_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.sql_type", "INTEGER"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", "NOW"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "start_application", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigStartApplication(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.name", "COLUMN_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.sql_type", "INTEGER"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", "NOW"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "start_application", "false"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKinesisAnalyticsApplicationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).kinesisanalyticsconn
 
@@ -2271,7 +2425,7 @@ resource "aws_kinesis_analytics_application" "test" {
     }
 
     starting_position_configuration {
-      starting_position = "NOW"
+      starting_position = (%[2]t ? "NOW" : null)
     }
   }
 

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -501,6 +501,8 @@ func TestAccAWSKinesisAnalyticsApplication_Input_Add(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
@@ -565,6 +567,8 @@ func TestAccAWSKinesisAnalyticsApplication_Input_Update(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
@@ -609,6 +613,8 @@ func TestAccAWSKinesisAnalyticsApplication_Input_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.resource_arn", streamsResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
@@ -672,6 +678,8 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add(t *t
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
@@ -716,6 +724,8 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add(t *t
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
@@ -782,6 +792,8 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete(t
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
@@ -823,6 +835,8 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete(t
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
@@ -891,6 +905,8 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update(t
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
@@ -935,6 +951,8 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update(t
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
@@ -1007,6 +1025,8 @@ func TestAccAWSKinesisAnalyticsApplication_Multiple_Update(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
 						"name":                        "OUTPUT_1",
@@ -1062,6 +1082,8 @@ func TestAccAWSKinesisAnalyticsApplication_Multiple_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.resource_arn", streamsResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
 						"name":                        "OUTPUT_2",
@@ -1477,6 +1499,72 @@ func TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update(t *testing
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisAnalyticsApplication_StartApplication_OnCreate(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRole1ResourceName := "aws_iam_role.test.0"
+	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigStartApplication(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.name", "COLUMN_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.sql_type", "INTEGER"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", "NOW"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "start_application", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_application"},
 			},
 		},
 	})
@@ -2148,6 +2236,48 @@ resource "aws_kinesis_analytics_application" "test" {
   }
 }
 `, rName))
+}
+
+func testAccKinesisAnalyticsApplicationConfigStartApplication(rName string, start bool) string {
+	return composeConfig(
+		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
+		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
+		fmt.Sprintf(`
+resource "aws_kinesis_analytics_application" "test" {
+  name = %[1]q
+
+  inputs {
+    name_prefix = "NAME_PREFIX_1"
+
+    schema {
+      record_columns {
+        name     = "COLUMN_1"
+        sql_type = "INTEGER"
+      }
+
+      record_format {
+        mapping_parameters {
+          csv {
+            record_column_delimiter = ","
+            record_row_delimiter    = "|"
+          }
+        }
+      }
+    }
+
+    kinesis_firehose {
+      resource_arn = aws_kinesis_firehose_delivery_stream.test.arn
+      role_arn     = aws_iam_role.test[0].arn
+    }
+
+    starting_position_configuration {
+      starting_position = "NOW"
+    }
+  }
+
+  start_application = %[2]t
+}
+`, rName, start))
 }
 
 func testAccKinesisAnalyticsApplicationConfigTags1(rName, tagKey1, tagValue1 string) string {

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/lister"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func init() {
@@ -42,7 +43,7 @@ func testSweepKinesisAnalyticsApplications(region string) error {
 			arn := aws.StringValue(applicationSummary.ApplicationARN)
 			name := aws.StringValue(applicationSummary.ApplicationName)
 
-			application, err := finder.ApplicationByName(conn, name)
+			application, err := finder.ApplicationDetailByName(conn, name)
 
 			if tfawserr.ErrMessageContains(err, kinesisanalytics.ErrCodeUnsupportedOperationException, "was created/updated by kinesisanalyticsv2 SDK") {
 				continue
@@ -1489,8 +1490,8 @@ func testAccCheckKinesisAnalyticsApplicationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := finder.ApplicationByName(conn, rs.Primary.Attributes["name"])
-		if isAWSErr(err, kinesisanalytics.ErrCodeResourceNotFoundException, "") {
+		_, err := finder.ApplicationDetailByName(conn, rs.Primary.Attributes["name"])
+		if tfresource.NotFound(err) {
 			continue
 		}
 		if err != nil {
@@ -1515,7 +1516,7 @@ func testAccCheckKinesisAnalyticsApplicationExists(n string, v *kinesisanalytics
 
 		conn := testAccProvider.Meta().(*AWSClient).kinesisanalyticsconn
 
-		application, err := finder.ApplicationByName(conn, rs.Primary.Attributes["name"])
+		application, err := finder.ApplicationDetailByName(conn, rs.Primary.Attributes["name"])
 		if err != nil {
 			return err
 		}

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"testing"
 	"time"
 
@@ -109,6 +110,7 @@ func TestAccAWSKinesisAnalyticsApplication_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -216,6 +218,7 @@ func TestAccAWSKinesisAnalyticsApplication_Code_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -235,6 +238,7 @@ func TestAccAWSKinesisAnalyticsApplication_Code_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -275,6 +279,7 @@ func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add(t *testi
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -296,6 +301,7 @@ func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add(t *testi
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -338,6 +344,7 @@ func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete(t *te
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -357,6 +364,7 @@ func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete(t *te
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -401,6 +409,7 @@ func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update(t *te
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -422,6 +431,7 @@ func TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update(t *te
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -462,6 +472,7 @@ func TestAccAWSKinesisAnalyticsApplication_Input_Add(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -505,6 +516,7 @@ func TestAccAWSKinesisAnalyticsApplication_Input_Add(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -571,6 +583,7 @@ func TestAccAWSKinesisAnalyticsApplication_Input_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -617,6 +630,7 @@ func TestAccAWSKinesisAnalyticsApplication_Input_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -682,6 +696,7 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add(t *t
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -728,6 +743,7 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add(t *t
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "3"), // Add input processing configuration + update input.
@@ -796,6 +812,7 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete(t
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -839,6 +856,7 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete(t
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "3"), // Delete input processing configuration + update input.
@@ -909,6 +927,7 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update(t
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -955,6 +974,7 @@ func TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update(t
 					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", ""),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -987,7 +1007,7 @@ func TestAccAWSKinesisAnalyticsApplication_Multiple_Update(t *testing.T) {
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKinesisAnalyticsApplicationConfigMultiple(rName),
+				Config: testAccKinesisAnalyticsApplicationConfigMultiple(rName, "", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
@@ -1046,7 +1066,7 @@ func TestAccAWSKinesisAnalyticsApplication_Multiple_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKinesisAnalyticsApplicationConfigMultipleUpdated(rName),
+				Config: testAccKinesisAnalyticsApplicationConfigMultipleUpdated(rName, "", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
@@ -1179,6 +1199,7 @@ func TestAccAWSKinesisAnalyticsApplication_Output_Update(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -1218,6 +1239,7 @@ func TestAccAWSKinesisAnalyticsApplication_Output_Update(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.lambda.0.resource_arn", lambdaResourceName, "arn"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.lambda.0.role_arn", iamRole1ResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "4"), // 1 * output deletion + 2 * output addition.
@@ -1242,6 +1264,7 @@ func TestAccAWSKinesisAnalyticsApplication_Output_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "6"), // 2 * output deletion.
@@ -1277,6 +1300,7 @@ func TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add(t *testing.T)
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -1314,6 +1338,7 @@ func TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add(t *testing.T)
 					resource.TestCheckResourceAttrPair(resourceName, "reference_data_sources.0.s3.0.role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.table_name", "TABLE-1"),
 					resource.TestCheckResourceAttrSet(resourceName, "reference_data_sources.0.id"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -1372,6 +1397,7 @@ func TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete(t *testing
 					resource.TestCheckResourceAttrPair(resourceName, "reference_data_sources.0.s3.0.role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.table_name", "TABLE-1"),
 					resource.TestCheckResourceAttrSet(resourceName, "reference_data_sources.0.id"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -1391,6 +1417,7 @@ func TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete(t *testing
 					resource.TestCheckResourceAttr(resourceName, "inputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outputs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "3"),
@@ -1450,6 +1477,7 @@ func TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update(t *testing
 					resource.TestCheckResourceAttrPair(resourceName, "reference_data_sources.0.s3.0.role_arn", iamRole1ResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.table_name", "TABLE-1"),
 					resource.TestCheckResourceAttrSet(resourceName, "reference_data_sources.0.id"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -1490,6 +1518,7 @@ func TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update(t *testing
 					resource.TestCheckResourceAttrPair(resourceName, "reference_data_sources.0.s3.0.role_arn", iamRole2ResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.table_name", "TABLE-2"),
 					resource.TestCheckResourceAttrSet(resourceName, "reference_data_sources.0.id"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_application"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", "3"),
@@ -1724,6 +1753,180 @@ func TestAccAWSKinesisAnalyticsApplication_StartApplication_OnUpdate(t *testing.
 	})
 }
 
+func TestAccAWSKinesisAnalyticsApplication_StartApplication_Update(t *testing.T) {
+	var v kinesisanalytics.ApplicationDetail
+	resourceName := "aws_kinesis_analytics_application.test"
+	iamRole1ResourceName := "aws_iam_role.test.0"
+	iamRole2ResourceName := "aws_iam_role.test.1"
+	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test"
+	lambdaResourceName := "aws_lambda_function.test.0"
+	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	streamsResourceName := "aws_kinesis_stream.test"
+	s3BucketResourceName := "aws_s3_bucket.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigMultiple(rName, "true", "LAST_STOPPED_POINT"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.log_stream_arn", cloudWatchLogStreamResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_logging_options.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.name", "COLUMN_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.sql_type", "INTEGER"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.0.lambda.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.resource_arn", lambdaResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.processing_configuration.0.lambda.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_firehose.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", "LAST_STOPPED_POINT"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"name":                        "OUTPUT_1",
+						"schema.#":                    "1",
+						"schema.0.record_format_type": "CSV",
+						"kinesis_firehose.#":          "1",
+						"kinesis_stream.#":            "0",
+						"lambda.#":                    "0",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_firehose.0.resource_arn", firehoseResourceName, "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_firehose.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "start_application", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisAnalyticsApplicationConfigMultipleUpdated(rName, "true", "LAST_STOPPED_POINT"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kinesisanalytics", fmt.Sprintf("application/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_logging_options.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "code", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "create_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_update_timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.stream_names.#", "42"),
+					resource.TestCheckResourceAttrSet(resourceName, "inputs.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.mapping", "MAPPING-2"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.name", "COLUMN_2"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.0.sql_type", "VARCHAR(8)"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.1.mapping", "MAPPING-3"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.1.name", "COLUMN_3"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_columns.1.sql_type", "DOUBLE"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_encoding", "UTF-8"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.mapping_parameters.0.json.0.record_row_path", "$path.to.record"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.schema.0.record_format.0.record_format_type", "JSON"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.name_prefix", "NAME_PREFIX_2"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.parallelism.0.count", "42"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.processing_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_firehose.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.kinesis_stream.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.resource_arn", streamsResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "inputs.0.kinesis_stream.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inputs.0.starting_position_configuration.0.starting_position", "LAST_STOPPED_POINT"),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"name":                        "OUTPUT_2",
+						"schema.#":                    "1",
+						"schema.0.record_format_type": "JSON",
+						"kinesis_firehose.#":          "0",
+						"kinesis_stream.#":            "1",
+						"lambda.#":                    "0",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_stream.0.resource_arn", streamsResourceName, "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.kinesis_stream.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"name":                        "OUTPUT_3",
+						"schema.#":                    "1",
+						"schema.0.record_format_type": "CSV",
+						"kinesis_firehose.#":          "0",
+						"kinesis_stream.#":            "0",
+						"lambda.#":                    "1",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.lambda.0.resource_arn", lambdaResourceName, "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "outputs.*.lambda.0.role_arn", iamRole1ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_columns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_columns.0.name", "COLUMN_1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_columns.0.sql_type", "INTEGER"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_encoding", ""),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.0.csv.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_column_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.0.csv.0.record_row_delimiter", "|"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.mapping_parameters.0.json.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.schema.0.record_format.0.record_format_type", "CSV"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.s3.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "reference_data_sources.0.s3.0.bucket_arn", s3BucketResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.s3.0.file_key", "KEY-1"),
+					resource.TestCheckResourceAttrPair(resourceName, "reference_data_sources.0.s3.0.role_arn", iamRole2ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "reference_data_sources.0.table_name", "TABLE-1"),
+					resource.TestCheckResourceAttrSet(resourceName, "reference_data_sources.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "start_application", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "Value3"),
+					resource.TestCheckResourceAttr(resourceName, "version", "8"), // Delete CloudWatch logging options + add reference data source + delete input processing configuration+ update application + delete output + 2 * add output.
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_application"},
+			},
+		},
+	})
+}
+
 func testAccCheckKinesisAnalyticsApplicationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).kinesisanalyticsconn
 
@@ -1733,9 +1936,11 @@ func testAccCheckKinesisAnalyticsApplicationDestroy(s *terraform.State) error {
 		}
 
 		_, err := finder.ApplicationDetailByName(conn, rs.Primary.Attributes["name"])
+
 		if tfresource.NotFound(err) {
 			continue
 		}
+
 		if err != nil {
 			return err
 		}
@@ -1759,6 +1964,7 @@ func testAccCheckKinesisAnalyticsApplicationExists(n string, v *kinesisanalytics
 		conn := testAccProvider.Meta().(*AWSClient).kinesisanalyticsconn
 
 		application, err := finder.ApplicationDetailByName(conn, rs.Primary.Attributes["name"])
+
 		if err != nil {
 			return err
 		}
@@ -2064,7 +2270,16 @@ resource "aws_kinesis_analytics_application" "test" {
 `, rName, lambdaIndex))
 }
 
-func testAccKinesisAnalyticsApplicationConfigMultiple(rName string) string {
+func testAccKinesisAnalyticsApplicationConfigMultiple(rName, startApplication, startingPosition string) string {
+	if startApplication == "" {
+		startApplication = "null"
+	}
+	if startingPosition == "" {
+		startingPosition = "null"
+	} else {
+		startingPosition = strconv.Quote(startingPosition)
+	}
+
 	return composeConfig(
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
@@ -2116,6 +2331,10 @@ resource "aws_kinesis_analytics_application" "test" {
       resource_arn = aws_kinesis_firehose_delivery_stream.test.arn
       role_arn     = aws_iam_role.test[0].arn
     }
+
+    starting_position_configuration {
+      starting_position = %[3]s
+    }
   }
 
   outputs {
@@ -2134,11 +2353,22 @@ resource "aws_kinesis_analytics_application" "test" {
   tags = {
     Key1 = "Value1"
   }
+
+  start_application = %[2]s
 }
-`, rName))
+`, rName, startApplication, startingPosition))
 }
 
-func testAccKinesisAnalyticsApplicationConfigMultipleUpdated(rName string) string {
+func testAccKinesisAnalyticsApplicationConfigMultipleUpdated(rName, startApplication, startingPosition string) string {
+	if startApplication == "" {
+		startApplication = "null"
+	}
+	if startingPosition == "" {
+		startingPosition = "null"
+	} else {
+		startingPosition = strconv.Quote(startingPosition)
+	}
+
 	return composeConfig(
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
@@ -2180,6 +2410,10 @@ resource "aws_kinesis_analytics_application" "test" {
     kinesis_stream {
       resource_arn = aws_kinesis_stream.test.arn
       role_arn     = aws_iam_role.test[1].arn
+    }
+
+    starting_position_configuration {
+      starting_position = %[3]s
     }
   }
 
@@ -2239,8 +2473,10 @@ resource "aws_kinesis_analytics_application" "test" {
     Key2 = "Value2"
     Key3 = "Value3"
   }
+
+  start_application = %[2]s
 }
-`, rName))
+`, rName, startApplication, startingPosition))
 }
 
 func testAccKinesisAnalyticsApplicationOutput(rName string) string {

--- a/website/docs/r/kinesis_analytics_application.html.markdown
+++ b/website/docs/r/kinesis_analytics_application.html.markdown
@@ -100,6 +100,8 @@ See [Kinesis Stream](#kinesis-stream) below for more details.
 See [Parallelism](#parallelism) below for more details.
 * `processing_configuration` - (Optional) The Processing Configuration to transform records as they are received from the stream.
 See [Processing Configuration](#processing-configuration) below for more details.
+* `starting_position_configuration` (Optional) The point at which the application starts processing records from the streaming source.
+See [Starting Position Configuration](#starting-position-configuration) below for more details.
 
 ### Outputs
 
@@ -187,6 +189,14 @@ The `lambda` block supports the following:
 
 * `resource_arn` - (Required) The ARN of the Lambda function.
 * `role_arn` - (Required) The ARN of the IAM Role used to access the Lambda function.
+
+#### Starting Position Configuration
+
+The point at which the application reads from the streaming source.
+
+The `starting_position_configuration` block supports the following:
+
+* `starting_position` - (Optional) The starting position on the stream. Valid values: `LAST_STOPPED_POINT`, `NOW`, `TRIM_HORIZON`.
 
 #### Record Columns
 

--- a/website/docs/r/kinesis_analytics_application.html.markdown
+++ b/website/docs/r/kinesis_analytics_application.html.markdown
@@ -72,8 +72,7 @@ See [CloudWatch Logging Options](#cloudwatch-logging-options) below for more det
 * `outputs` - (Optional) Output destination configuration of the application. See [Outputs](#outputs) below for more details.
 * `reference_data_sources` - (Optional) An S3 Reference Data Source for the application.
 See [Reference Data Sources](#reference-data-sources) below for more details.
-* `status` - (Optional) The status of the application. Set to `RUNNING` to start an application or `READY` to stop a running application.
-* `tags` - (Optional) Key-value map of tags for the Kinesis Analytics Application.
+* `tags` - Key-value map of tags for the Kinesis Analytics Application.
 
 ### CloudWatch Logging Options
 
@@ -100,9 +99,6 @@ See [Kinesis Stream](#kinesis-stream) below for more details.
 See [Parallelism](#parallelism) below for more details.
 * `processing_configuration` - (Optional) The Processing Configuration to transform records as they are received from the stream.
 See [Processing Configuration](#processing-configuration) below for more details.
-* `starting_position_configuration` - (Optional) The point at which the application reads from the streaming source.
-See [Starting Position Configuration](#starting-position-configuration) below for more details.
-This attribute is required to start the application.
 
 ### Outputs
 
@@ -191,14 +187,6 @@ The `lambda` block supports the following:
 * `resource_arn` - (Required) The ARN of the Lambda function.
 * `role_arn` - (Required) The ARN of the IAM Role used to access the Lambda function.
 
-#### Starting Position Configuration
-
-Describes the point at which the application reads from the streaming source.
-
-The `starting_position_configuration` block supports the following:
-
-* `starting_position` - (Optional) The starting position on the stream. Can be `NOW`, `TRIM_HORIZON` or `LAST_STOPPED_POINT`.
-
 #### Record Columns
 
 The Column mapping of each data element in the streaming source to the corresponding column in the in-application stream.
@@ -265,6 +253,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of the Kinesis Analytics Appliation.
 * `create_timestamp` - The Timestamp when the application version was created.
 * `last_update_timestamp` - The Timestamp when the application was last updated.
+* `status` - The Status of the application.
 * `version` - The Version of the application.
 
 [1]: https://docs.aws.amazon.com/kinesisanalytics/latest/dev/what-is.html

--- a/website/docs/r/kinesis_analytics_application.html.markdown
+++ b/website/docs/r/kinesis_analytics_application.html.markdown
@@ -192,6 +192,8 @@ The `lambda` block supports the following:
 
 #### Starting Position Configuration
 
+~> **NOTE**: To modify an application's starting position, first stop the application by setting `start_application = false`, then update `starting_position` and set `start_application = true`.
+
 The point at which the application reads from the streaming source.
 
 The `starting_position_configuration` block supports the following:

--- a/website/docs/r/kinesis_analytics_application.html.markdown
+++ b/website/docs/r/kinesis_analytics_application.html.markdown
@@ -72,6 +72,7 @@ See [CloudWatch Logging Options](#cloudwatch-logging-options) below for more det
 * `outputs` - (Optional) Output destination configuration of the application. See [Outputs](#outputs) below for more details.
 * `reference_data_sources` - (Optional) An S3 Reference Data Source for the application.
 See [Reference Data Sources](#reference-data-sources) below for more details.
+* `start_application` - (Optional) Whether to start or stop the Kinesis Analytics Application.
 * `tags` - Key-value map of tags for the Kinesis Analytics Application.
 
 ### CloudWatch Logging Options

--- a/website/docs/r/kinesis_analytics_application.html.markdown
+++ b/website/docs/r/kinesis_analytics_application.html.markdown
@@ -72,7 +72,8 @@ See [CloudWatch Logging Options](#cloudwatch-logging-options) below for more det
 * `outputs` - (Optional) Output destination configuration of the application. See [Outputs](#outputs) below for more details.
 * `reference_data_sources` - (Optional) An S3 Reference Data Source for the application.
 See [Reference Data Sources](#reference-data-sources) below for more details.
-* `start_application` - (Optional) Whether to start or stop the Kinesis Analytics Application.
+* `start_application` - (Optional) Whether to start or stop the Kinesis Analytics Application. To start an application, an input with a defined `starting_position` must be configured.
+To modify an application's starting position, first stop the application by setting `start_application = false`, then update `starting_position` and set `start_application = true`.
 * `tags` - Key-value map of tags for the Kinesis Analytics Application.
 
 ### CloudWatch Logging Options
@@ -192,13 +193,11 @@ The `lambda` block supports the following:
 
 #### Starting Position Configuration
 
-~> **NOTE**: To modify an application's starting position, first stop the application by setting `start_application = false`, then update `starting_position` and set `start_application = true`.
-
 The point at which the application reads from the streaming source.
 
 The `starting_position_configuration` block supports the following:
 
-* `starting_position` - (Optional) The starting position on the stream. Valid values: `LAST_STOPPED_POINT`, `NOW`, `TRIM_HORIZON`.
+* `starting_position` - (Required) The starting position on the stream. Valid values: `LAST_STOPPED_POINT`, `NOW`, `TRIM_HORIZON`.
 
 #### Record Columns
 

--- a/website/docs/r/kinesis_analytics_application.html.markdown
+++ b/website/docs/r/kinesis_analytics_application.html.markdown
@@ -72,7 +72,8 @@ See [CloudWatch Logging Options](#cloudwatch-logging-options) below for more det
 * `outputs` - (Optional) Output destination configuration of the application. See [Outputs](#outputs) below for more details.
 * `reference_data_sources` - (Optional) An S3 Reference Data Source for the application.
 See [Reference Data Sources](#reference-data-sources) below for more details.
-* `tags` - Key-value map of tags for the Kinesis Analytics Application.
+* `status` - (Optional) The status of the application. Set to `RUNNING` to start an application or `READY` to stop a running application.
+* `tags` - (Optional) Key-value map of tags for the Kinesis Analytics Application.
 
 ### CloudWatch Logging Options
 
@@ -99,6 +100,9 @@ See [Kinesis Stream](#kinesis-stream) below for more details.
 See [Parallelism](#parallelism) below for more details.
 * `processing_configuration` - (Optional) The Processing Configuration to transform records as they are received from the stream.
 See [Processing Configuration](#processing-configuration) below for more details.
+* `starting_position_configuration` - (Optional) The point at which the application reads from the streaming source.
+See [Starting Position Configuration](#starting-position-configuration) below for more details.
+This attribute is required to start the application.
 
 ### Outputs
 
@@ -187,6 +191,14 @@ The `lambda` block supports the following:
 * `resource_arn` - (Required) The ARN of the Lambda function.
 * `role_arn` - (Required) The ARN of the IAM Role used to access the Lambda function.
 
+#### Starting Position Configuration
+
+Describes the point at which the application reads from the streaming source.
+
+The `starting_position_configuration` block supports the following:
+
+* `starting_position` - (Optional) The starting position on the stream. Can be `NOW`, `TRIM_HORIZON` or `LAST_STOPPED_POINT`.
+
 #### Record Columns
 
 The Column mapping of each data element in the streaming source to the corresponding column in the in-application stream.
@@ -253,7 +265,6 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of the Kinesis Analytics Appliation.
 * `create_timestamp` - The Timestamp when the application version was created.
 * `last_update_timestamp` - The Timestamp when the application was last updated.
-* `status` - The Status of the application.
 * `version` - The Version of the application.
 
 [1]: https://docs.aws.amazon.com/kinesisanalytics/latest/dev/what-is.html


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7383.

Inspired by the [`aws_synthetics_canary` `start_canary` attribute](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/synthetics_canary#start_canary).

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSKinesisAnalyticsApplication_' ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSKinesisAnalyticsApplication_ -timeout 120m
=== RUN   TestAccAWSKinesisAnalyticsApplication_basic
=== PAUSE TestAccAWSKinesisAnalyticsApplication_basic
=== RUN   TestAccAWSKinesisAnalyticsApplication_disappears
=== PAUSE TestAccAWSKinesisAnalyticsApplication_disappears
=== RUN   TestAccAWSKinesisAnalyticsApplication_Tags
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Tags
=== RUN   TestAccAWSKinesisAnalyticsApplication_Code_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Code_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete
=== PAUSE TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete
=== RUN   TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_Input_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Input_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_Input_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Input_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete
=== PAUSE TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete
=== RUN   TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_Multiple_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Multiple_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_Output_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Output_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete
=== PAUSE TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete
=== RUN   TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update
=== RUN   TestAccAWSKinesisAnalyticsApplication_StartApplication_OnCreate
=== PAUSE TestAccAWSKinesisAnalyticsApplication_StartApplication_OnCreate
=== RUN   TestAccAWSKinesisAnalyticsApplication_StartApplication_OnUpdate
=== PAUSE TestAccAWSKinesisAnalyticsApplication_StartApplication_OnUpdate
=== RUN   TestAccAWSKinesisAnalyticsApplication_StartApplication_Update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_StartApplication_Update
=== CONT  TestAccAWSKinesisAnalyticsApplication_basic
=== CONT  TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update
=== CONT  TestAccAWSKinesisAnalyticsApplication_StartApplication_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (16.32s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_StartApplication_OnUpdate
--- PASS: TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Update (99.93s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_StartApplication_OnCreate
--- PASS: TestAccAWSKinesisAnalyticsApplication_StartApplication_OnUpdate (163.21s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Update (48.88s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete
--- PASS: TestAccAWSKinesisAnalyticsApplication_StartApplication_OnCreate (147.62s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add
--- PASS: TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Delete (41.52s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Output_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_ReferenceDataSource_Add (37.80s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Multiple_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_StartApplication_Update (377.13s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_Multiple_Update (122.81s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete
--- PASS: TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Update (40.96s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add
--- PASS: TestAccAWSKinesisAnalyticsApplication_Output_Update (165.73s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Input_Update
=== CONT  TestAccAWSKinesisAnalyticsApplication_Input_Add
--- PASS: TestAccAWSKinesisAnalyticsApplication_Input_Update (97.37s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Delete (127.42s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Code_Update
--- PASS: TestAccAWSKinesisAnalyticsApplication_InputProcessingConfiguration_Add (117.93s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete
--- PASS: TestAccAWSKinesisAnalyticsApplication_Code_Update (26.41s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add
--- PASS: TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Delete (40.00s)
=== CONT  TestAccAWSKinesisAnalyticsApplication_Tags
=== CONT  TestAccAWSKinesisAnalyticsApplication_disappears
--- PASS: TestAccAWSKinesisAnalyticsApplication_CloudWatchLoggingOptions_Add (41.22s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Tags (34.84s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_disappears (24.64s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Input_Add (104.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	637.969s
```