### PR TITLE
Added locations and location_types to the output of aws_ec2_instance_type_offerings. #15272

### DIFF
--- a/aws/data_source_aws_ec2_instance_type_offerings.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings.go
@@ -20,6 +20,11 @@ func dataSourceAwsEc2InstanceTypeOfferings() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"locations": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"location_type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -28,6 +33,11 @@ func dataSourceAwsEc2InstanceTypeOfferings() *schema.Resource {
 					ec2.LocationTypeAvailabilityZoneId,
 					ec2.LocationTypeRegion,
 				}, false),
+			},
+			"location_types": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
@@ -47,6 +57,8 @@ func dataSourceAwsEc2InstanceTypeOfferingsRead(d *schema.ResourceData, meta inte
 	}
 
 	var instanceTypes []string
+	var locations []string
+	var locationTypes []string
 
 	for {
 		output, err := conn.DescribeInstanceTypeOfferings(input)
@@ -65,6 +77,8 @@ func dataSourceAwsEc2InstanceTypeOfferingsRead(d *schema.ResourceData, meta inte
 			}
 
 			instanceTypes = append(instanceTypes, aws.StringValue(instanceTypeOffering.InstanceType))
+			locations = append(locations, aws.StringValue(instanceTypeOffering.Location))
+			locationTypes = append(locationTypes, aws.StringValue(instanceTypeOffering.LocationType))
 		}
 
 		if aws.StringValue(output.NextToken) == "" {
@@ -76,6 +90,14 @@ func dataSourceAwsEc2InstanceTypeOfferingsRead(d *schema.ResourceData, meta inte
 
 	if err := d.Set("instance_types", instanceTypes); err != nil {
 		return fmt.Errorf("error setting instance_types: %w", err)
+	}
+
+	if err := d.Set("locations", locations); err != nil {
+		return fmt.Errorf("error setting locations: %w", err)
+	}
+
+	if err := d.Set("location_types", locationTypes); err != nil {
+		return fmt.Errorf("error setting location_types: %w", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)

--- a/aws/data_source_aws_ec2_instance_type_offerings_test.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings_test.go
@@ -57,6 +57,14 @@ func testAccCheckEc2InstanceTypeOfferingsInstanceTypes(dataSourceName string) re
 			return fmt.Errorf("expected at least one instance_types result, got none")
 		}
 
+		if v := rs.Primary.Attributes["locations.#"]; v == "0" {
+			return fmt.Errorf("expected at least one locations result, got none")
+		}
+
+		if v := rs.Primary.Attributes["location_types.#"]; v == "0" {
+			return fmt.Errorf("expected at least one location_types result, got none")
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15272 

Output from acceptance testing:

```bash
$ make testacc TESTARGS='-run=TestAccAWSEc2InstanceTypeOfferingsDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2InstanceTypeOfferingsDataSource_ -timeout 120m
=== RUN   TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter
=== PAUSE TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter
=== RUN   TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType
=== PAUSE TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType
=== CONT  TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter
=== CONT  TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType
--- PASS: TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter (22.55s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType (26.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       26.979s
```
