### PR TITLE
Add 'automatic' to config_remediations

### DIFF
--- a/aws/resource_aws_config_remediation_configuration.go
+++ b/aws/resource_aws_config_remediation_configuration.go
@@ -35,6 +35,11 @@ func resourceAwsConfigRemediationConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"automatic": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"config_rule_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -138,6 +143,12 @@ func resourceAwsConfigRemediationConfigurationPut(d *schema.ResourceData, meta i
 	name := d.Get("config_rule_name").(string)
 	remediationConfigurationInput := configservice.RemediationConfiguration{
 		ConfigRuleName: aws.String(name),
+	}
+
+	if v, ok := d.GetOk("automatic"); ok && v.(bool) {
+		remediationConfigurationInput.Automatic = aws.Bool(true)
+		remediationConfigurationInput.MaximumAutomaticAttempts = aws.Int64(5)
+		remediationConfigurationInput.RetryAttemptSeconds = aws.Int64(60)
 	}
 
 	if v, ok := d.GetOk("parameter"); ok {

--- a/aws/resource_aws_config_remediation_configuration_test.go
+++ b/aws/resource_aws_config_remediation_configuration_test.go
@@ -29,6 +29,7 @@ func testAccConfigRemediationConfiguration_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigRemediationConfigurationExists(resourceName, &rc),
 					resource.TestCheckResourceAttr(resourceName, "config_rule_name", expectedName),
+					resource.TestCheckResourceAttr(resourceName, "automatic", "true"),
 					resource.TestCheckResourceAttr(resourceName, "target_id", "AWS-EnableS3BucketEncryption"),
 					resource.TestCheckResourceAttr(resourceName, "target_type", "SSM_DOCUMENT"),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "3"),
@@ -193,6 +194,7 @@ resource "aws_config_remediation_configuration" "test" {
   config_rule_name = aws_config_config_rule.test.name
 
   resource_type  = "AWS::S3::Bucket"
+  automatic      = true
   target_id      = "AWS-EnableS3BucketEncryption"
   target_type    = "SSM_DOCUMENT"
   target_version = "1"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
