### PR TITLE
aws_internet_gateway: Correct the ARN account id

### DIFF
--- a/aws/data_source_aws_internet_gateway.go
+++ b/aws/data_source_aws_internet_gateway.go
@@ -100,7 +100,7 @@ func dataSourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) 
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(igw.OwnerId),
 		Resource:  fmt.Sprintf("internet-gateway/%s", d.Id()),
 	}.String()
 

--- a/aws/resource_aws_internet_gateway.go
+++ b/aws/resource_aws_internet_gateway.go
@@ -123,7 +123,7 @@ func resourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) er
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(ig.OwnerId),
 		Resource:  fmt.Sprintf("internet-gateway/%s", d.Id()),
 	}.String()
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -301,8 +301,6 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
     - [`aws_guardduty_threatintelset` resource](/docs/providers/aws/r/guardduty_threatintelset.html)
     - [`aws_instance` data source](/docs/providers/aws/d/instance.html)
     - [`aws_instance` resource](/docs/providers/aws/r/instance.html)
-    - [`aws_internet_gateway` data source](/docs/providers/aws/d/internet_gateway.html)
-    - [`aws_internet_gateway` resource](/docs/providers/aws/r/internet_gateway.html)
     - [`aws_key_pair` resource](/docs/providers/aws/r/key_pair.html)
     - [`aws_launch_template` data source](/docs/providers/aws/d/launch_template.html)
     - [`aws_launch_template` resource](/docs/providers/aws/r/launch_template.html)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16978

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSInternetGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSInternetGateway_ -timeout 120m
=== RUN   TestAccAWSInternetGateway_basic
=== PAUSE TestAccAWSInternetGateway_basic
=== RUN   TestAccAWSInternetGateway_delete
=== PAUSE TestAccAWSInternetGateway_delete
=== RUN   TestAccAWSInternetGateway_tags
=== PAUSE TestAccAWSInternetGateway_tags
=== RUN   TestAccAWSInternetGateway_disappears
=== PAUSE TestAccAWSInternetGateway_disappears
=== CONT  TestAccAWSInternetGateway_basic
=== CONT  TestAccAWSInternetGateway_disappears
=== CONT  TestAccAWSInternetGateway_tags
=== CONT  TestAccAWSInternetGateway_delete
--- PASS: TestAccAWSInternetGateway_disappears (54.14s)
--- PASS: TestAccAWSInternetGateway_delete (89.57s)
--- PASS: TestAccAWSInternetGateway_basic (113.91s)
--- PASS: TestAccAWSInternetGateway_tags (135.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	137.543s

$ make testacc TESTARGS='-run=TestAccDataSourceAwsInternetGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsInternetGateway_ -timeout 120m
=== RUN   TestAccDataSourceAwsInternetGateway_typical
=== PAUSE TestAccDataSourceAwsInternetGateway_typical
=== CONT  TestAccDataSourceAwsInternetGateway_typical
--- PASS: TestAccDataSourceAwsInternetGateway_typical (51.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	53.865s
```

Thank you for your review!