### PR TITLE
resourcegroupstaggingapi_resources - new data source

### DIFF
--- a/.changelog/17804.txt
+++ b/.changelog/17804.txt
@@ -1,3 +1,3 @@
-```release-note:data-source
+```release-note:new-data-source
 aws_resourcegroupstaggingapi_resources
 ```

--- a/.changelog/17804.txt
+++ b/.changelog/17804.txt
@@ -1,0 +1,3 @@
+```release-note:data-source
+aws_resourcegroupstaggingapi_resources
+```

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources.go
@@ -22,11 +22,18 @@ func dataSourceAwsResourceGroupsTaggingAPIResources() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"resource_arn_list": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"tag_filters"},
+			},
 			"resource_type_filters": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MaxItems: 100,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:          schema.TypeSet,
+				Optional:      true,
+				MaxItems:      100,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"resource_arn_list"},
 			},
 			"tag_filters": {
 				Type:     schema.TypeList,
@@ -97,6 +104,10 @@ func dataSourceAwsResourceGroupsTaggingAPIResourcesRead(d *schema.ResourceData, 
 
 	if v, ok := d.GetOk("exclude_compliant_resources"); ok {
 		input.ExcludeCompliantResources = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("resource_arn_list"); ok && v.(*schema.Set).Len() > 0 {
+		input.ResourceARNList = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("tag_filters"); ok {

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources.go
@@ -26,7 +26,7 @@ func dataSourceAwsResourceGroupsTaggingAPIResources() *schema.Resource {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"tag_filters"},
+				ConflictsWith: []string{"filter"},
 			},
 			"resource_type_filters": {
 				Type:          schema.TypeSet,
@@ -35,7 +35,7 @@ func dataSourceAwsResourceGroupsTaggingAPIResources() *schema.Resource {
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				ConflictsWith: []string{"resource_arn_list"},
 			},
-			"tag_filters": {
+			"filter": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 50,
@@ -110,7 +110,7 @@ func dataSourceAwsResourceGroupsTaggingAPIResourcesRead(d *schema.ResourceData, 
 		input.ResourceARNList = expandStringSet(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("tag_filters"); ok {
+	if v, ok := d.GetOk("filter"); ok {
 		input.TagFilters = expandAwsResourceGroupsTaggingAPITagFilters(v.([]interface{}))
 	}
 

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources.go
@@ -1,0 +1,182 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsResourceGroupsTaggingAPIResources() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsResourceGroupsTaggingAPIResourcesRead,
+
+		Schema: map[string]*schema.Schema{
+			"exclude_compliant_resources": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"include_compliance_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"resource_type_filters": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 100,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tag_filters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 50,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 20,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"resource_tag_mapping_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"compliance_details": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"compliance_status": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"keys_with_noncompliant_values": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"non_compliant_keys": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"tags": tagsSchemaComputed(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsResourceGroupsTaggingAPIResourcesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).resourcegroupstaggingapiconn
+
+	input := &resourcegroupstaggingapi.GetResourcesInput{}
+
+	if v, ok := d.GetOk("include_compliance_details"); ok {
+		input.IncludeComplianceDetails = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("exclude_compliant_resources"); ok {
+		input.ExcludeCompliantResources = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("tag_filters"); ok {
+		input.TagFilters = expandAwsResourceGroupsTaggingAPITagFilters(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("resource_type_filters"); ok && v.(*schema.Set).Len() > 0 {
+		input.ResourceTypeFilters = expandStringSet(v.(*schema.Set))
+	}
+
+	var taggings []*resourcegroupstaggingapi.ResourceTagMapping
+
+	err := conn.GetResourcesPages(input, func(page *resourcegroupstaggingapi.GetResourcesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		taggings = append(taggings, page.ResourceTagMappingList...)
+		return !lastPage
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(meta.(*AWSClient).partition)
+
+	if err := d.Set("resource_tag_mapping_list", flattenAwsResourceGroupsTaggingAPIResourcesTagMappingList(taggings)); err != nil {
+		return fmt.Errorf("error setting resource tag mapping list: %w", err)
+	}
+
+	return nil
+}
+
+func expandAwsResourceGroupsTaggingAPITagFilters(filters []interface{}) []*resourcegroupstaggingapi.TagFilter {
+	result := make([]*resourcegroupstaggingapi.TagFilter, len(filters))
+
+	for i, filter := range filters {
+		m := filter.(map[string]interface{})
+
+		result[i] = &resourcegroupstaggingapi.TagFilter{
+			Key: aws.String(m["key"].(string)),
+		}
+
+		if v, ok := m["values"]; ok && v.(*schema.Set).Len() > 0 {
+			result[i].Values = expandStringSet(v.(*schema.Set))
+		}
+	}
+
+	return result
+}
+
+func flattenAwsResourceGroupsTaggingAPIResourcesTagMappingList(list []*resourcegroupstaggingapi.ResourceTagMapping) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+
+	for _, i := range list {
+		l := map[string]interface{}{
+			"resource_arn": aws.StringValue(i.ResourceARN),
+			"tags":         keyvaluetags.ResourcegroupstaggingapiKeyValueTags(i.Tags).IgnoreAws().Map(),
+		}
+
+		if i.ComplianceDetails != nil {
+			l["compliance_details"] = flattenAwsResourceGroupsTaggingAPIComplianceDetails(i.ComplianceDetails)
+		}
+
+		result = append(result, l)
+	}
+
+	return result
+}
+
+func flattenAwsResourceGroupsTaggingAPIComplianceDetails(details *resourcegroupstaggingapi.ComplianceDetails) []map[string]interface{} {
+	if details == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"compliance_status":             aws.BoolValue(details.ComplianceStatus),
+		"keys_with_noncompliant_values": flattenStringSet(details.KeysWithNoncompliantValues),
+		"non_compliant_keys":            flattenStringSet(details.NoncompliantKeys),
+	}
+
+	return []map[string]interface{}{m}
+}

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources.go
@@ -26,7 +26,7 @@ func dataSourceAwsResourceGroupsTaggingAPIResources() *schema.Resource {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"filter"},
+				ConflictsWith: []string{"tag_filter"},
 			},
 			"resource_type_filters": {
 				Type:          schema.TypeSet,

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources.go
@@ -134,7 +134,7 @@ func dataSourceAwsResourceGroupsTaggingAPIResourcesRead(d *schema.ResourceData, 
 
 	d.SetId(meta.(*AWSClient).partition)
 
-	if err := d.Set("resource_tag_mapping_list", flattenAwsResourceGroupsTaggingAPIResourcesTagMappingList(taggings)); err != nil {
+	if err := d.Set("resource_tag_mapping_list", flattenAwsResourceGroupsTaggingAPIResourcesTagMappingList(taggings, meta)); err != nil {
 		return fmt.Errorf("error setting resource tag mapping list: %w", err)
 	}
 
@@ -159,13 +159,14 @@ func expandAwsResourceGroupsTaggingAPITagFilters(filters []interface{}) []*resou
 	return result
 }
 
-func flattenAwsResourceGroupsTaggingAPIResourcesTagMappingList(list []*resourcegroupstaggingapi.ResourceTagMapping) []map[string]interface{} {
+func flattenAwsResourceGroupsTaggingAPIResourcesTagMappingList(list []*resourcegroupstaggingapi.ResourceTagMapping, meta interface{}) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	for _, i := range list {
 		l := map[string]interface{}{
 			"resource_arn": aws.StringValue(i.ResourceARN),
-			"tags":         keyvaluetags.ResourcegroupstaggingapiKeyValueTags(i.Tags).IgnoreAws().Map(),
+			"tags":         keyvaluetags.ResourcegroupstaggingapiKeyValueTags(i.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map(),
 		}
 
 		if i.ComplianceDetails != nil {

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -12,8 +13,9 @@ func TestAccDataSourceAwsResourceGroupsTaggingAPIResources_basic(t *testing.T) {
 	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, resourcegroupstaggingapi.EndpointsID),
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsResourceGroupsTaggingAPIResourcesBasicConfig,
@@ -32,8 +34,9 @@ func TestAccDataSourceAwsResourceGroupsTaggingAPIResources_tag_key_filter(t *tes
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, resourcegroupstaggingapi.EndpointsID),
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsResourceGroupsTaggingAPIResourcesTagKeyFilterConfig(rName),
@@ -52,8 +55,9 @@ func TestAccDataSourceAwsResourceGroupsTaggingAPIResources_compliance(t *testing
 	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, resourcegroupstaggingapi.EndpointsID),
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsResourceGroupsTaggingAPIResourcesComplianceConfig,
@@ -73,8 +77,9 @@ func TestAccDataSourceAwsResourceGroupsTaggingAPIResources_resource_type_filters
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, resourcegroupstaggingapi.EndpointsID),
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsResourceGroupsTaggingAPIResourcesResourceTypeFiltersConfig(rName),
@@ -95,8 +100,9 @@ func TestAccDataSourceAwsResourceGroupsTaggingAPIResources_resource_arn_list(t *
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, resourcegroupstaggingapi.EndpointsID),
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsResourceGroupsTaggingAPIResourcesResourceARNListConfig(rName),

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
@@ -175,9 +175,3 @@ data "aws_resourcegroupstaggingapi_resources" "test" {
   exclude_compliant_resources = false
 }
 `
-
-const testAccDataSourceAwsResourceGroupsTaggingAPIResourcesResourceTypeConfig = `
-data "aws_resourcegroupstaggingapi_resources" "test" {
-  resource_type_filters = ["ec2:instance"]
-}
-`

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
@@ -132,7 +132,7 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 data "aws_resourcegroupstaggingapi_resources" "test" {
-  filter {
+  tag_filter {
     key = "Key"
   }
 

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceAwsResourceGroupsTaggingAPIResources_basic(t *testing.T) {
+	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsResourceGroupsTaggingAPIResourcesBasicConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "resource_tag_mapping_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "resource_tag_mapping_list.0.resource_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsResourceGroupsTaggingAPIResources_tag_key_filter(t *testing.T) {
+	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
+	resourceName := "aws_lambda_function.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsResourceGroupsTaggingAPIResourcesTagKeyFilterConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "resource_tag_mapping_list.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "resource_tag_mapping_list.*", map[string]string{
+						"tags.Key": rName,
+					}),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "resource_tag_mapping_list.*.resource_arn", resourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsResourceGroupsTaggingAPIResources_compliance(t *testing.T) {
+	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsResourceGroupsTaggingAPIResourcesComplianceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "resource_tag_mapping_list.0.compliance_details.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "resource_tag_mapping_list.0.compliance_details.0.compliance_status", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "resource_tag_mapping_list.0.resource_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsResourceGroupsTaggingAPIResources_resource_type_filters(t *testing.T) {
+	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
+	resourceName := "aws_lambda_function.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsResourceGroupsTaggingAPIResourcesResourceTypeFiltersConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "resource_tag_mapping_list.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "resource_tag_mapping_list.*", map[string]string{
+						"tags.Key": rName,
+					}),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "resource_tag_mapping_list.*.resource_arn", resourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsResourceGroupsTaggingAPIResourcesBasicConfig = `
+data "aws_resourcegroupstaggingapi_resources" "test" {}
+`
+
+func testAccDataSourceAwsResourceGroupsTaggingAPIResourcesTagKeyFilterConfig(rName string) string {
+	return testAccDataSourceAWSLambdaFunctionConfigBase(rName) + fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  handler       = "exports.example"
+  role          = aws_iam_role.lambda.arn
+  runtime       = "nodejs12.x"
+
+  tags = {
+    Key = %[1]q
+  }
+}
+
+data "aws_resourcegroupstaggingapi_resources" "test" {
+  tag_filters {
+    key = "Key"
+  }
+
+  depends_on = [aws_lambda_function.test]
+}
+`, rName)
+}
+
+func testAccDataSourceAwsResourceGroupsTaggingAPIResourcesResourceTypeFiltersConfig(rName string) string {
+	return testAccDataSourceAWSLambdaFunctionConfigBase(rName) + fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  handler       = "exports.example"
+  role          = aws_iam_role.lambda.arn
+  runtime       = "nodejs12.x"
+}
+
+data "aws_resourcegroupstaggingapi_resources" "test" {
+  resource_type_filters = ["lambda"]
+
+  depends_on = [aws_lambda_function.test]
+}
+`, rName)
+}
+
+const testAccDataSourceAwsResourceGroupsTaggingAPIResourcesComplianceConfig = `
+data "aws_resourcegroupstaggingapi_resources" "test" {
+  include_compliance_details  = true
+  exclude_compliant_resources = false
+}
+`
+
+const testAccDataSourceAwsResourceGroupsTaggingAPIResourcesResourceTypeConfig = `
+data "aws_resourcegroupstaggingapi_resources" "test" {
+  resource_type_filters = ["ec2:instance"]
+}
+`

--- a/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
+++ b/aws/data_source_aws_resourcegroupstaggingapi_resources_test.go
@@ -126,7 +126,7 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 data "aws_resourcegroupstaggingapi_resources" "test" {
-  tag_filters {
+  filter {
     key = "Key"
   }
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -360,6 +360,7 @@ func Provider() *schema.Provider {
 			"aws_redshift_service_account":                   dataSourceAwsRedshiftServiceAccount(),
 			"aws_region":                                     dataSourceAwsRegion(),
 			"aws_regions":                                    dataSourceAwsRegions(),
+			"aws_resourcegroupstaggingapi_resources":         dataSourceAwsResourceGroupsTaggingAPIResources(),
 			"aws_route":                                      dataSourceAwsRoute(),
 			"aws_route_table":                                dataSourceAwsRouteTable(),
 			"aws_route_tables":                               dataSourceAwsRouteTables(),

--- a/infrastructure/repository/labels-service.tf
+++ b/infrastructure/repository/labels-service.tf
@@ -161,6 +161,7 @@ variable "service_labels" {
     "rds",
     "redshift",
     "resourcegroups",
+    "resourcegroupstaggingapi",
     "robomaker",
     "route53",
     "route53domains",

--- a/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `exclude_compliant_resources` - (Optional) Specifies whether to exclude resources that are compliant with the tag policy. You can use this parameter only if the `include_compliance_details` argument is also set to `true`.
 * `include_compliance_details` - (Optional) Specifies whether to include details regarding the compliance with the effective tag policy.
 * `tag_filters` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See [Tag Filters](#tag-filters) below. Conflicts with `resource_arn_list`.
-* `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of ec2 returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
+* `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of `ec2` returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
 * `resource_arn_list` - (Optional) Specifies a list of ARNs of resources for which you want to retrieve tag data. Conflicts with `tag_filters`.
 
 ### Tag Filters
@@ -71,5 +71,4 @@ A `resource_tag_mapping_list` block supports the following attributes:
 * `resource_arn` - The ARN of the resource.
 * `compliance_details` - Information that shows whether a resource is compliant with the effective tag policy, including details on any noncompliant tag keys. Documented below.
 * `tags` - tags assigned to the resource.
-
 

--- a/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
@@ -44,15 +44,9 @@ The following arguments are supported:
 
 * `exclude_compliant_resources` - (Optional) Specifies whether to exclude resources that are compliant with the tag policy. You can use this parameter only if the `include_compliance_details` argument is also set to `true`.
 * `include_compliance_details` - (Optional) Specifies whether to include details regarding the compliance with the effective tag policy.
-<<<<<<< HEAD
-* `tag_filters` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See [Tag Filters](#tag-filters) below. Conflicts with `resource_arn_list`.
-* `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of `ec2` returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
-* `resource_arn_list` - (Optional) Specifies a list of ARNs of resources for which you want to retrieve tag data. Conflicts with `tag_filters`.
-=======
 * `filter` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See [Filter](#filter) below. Conflicts with `resource_arn_list`.
-* `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of ec2 returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
+* `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of `ec2` returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
 * `resource_arn_list` - (Optional) Specifies a list of ARNs of resources for which you want to retrieve tag data. Conflicts with `filter`.
->>>>>>> a6eed3340 (docs)
 
 ### Filter
 

--- a/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
@@ -14,13 +14,13 @@ Provides details about resource tagging.
 
 ### Get All Resource Tag Mappings
 
-```hcl
+```terraform
 data "aws_resourcegroupstaggingapi_resources" "test" {}
 ```
 
 ### Filter By Tag Key and Value
 
-```hcl
+```terraform
 data "aws_resourcegroupstaggingapi_resources" "test" {
   filter {
     key    = "tag-key"
@@ -31,7 +31,7 @@ data "aws_resourcegroupstaggingapi_resources" "test" {
 
 ### Filter By Resource Type
 
-```hcl
+```terraform
 data "aws_resourcegroupstaggingapi_resources" "test" {
   resource_type_filter = ["ec2:instance"]
 }

--- a/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
@@ -22,7 +22,7 @@ data "aws_resourcegroupstaggingapi_resources" "test" {}
 
 ```hcl
 data "aws_resourcegroupstaggingapi_resources" "test" {
-  tag_filters {
+  filter {
     key    = "tag-key"
     values = ["tag-value-1", "tag-value-2"]
   }
@@ -50,10 +50,10 @@ The following arguments are supported:
 
 ### Tag Filters
 
-A `tag_filters` block supports the following arguments:
+A `filter` block supports the following arguments:
 
-If you do specify `tag_filters`, the response returns only those resources that are currently associated with the specified tag.
-If you don't specify a `tag_filters`, the response includes all resources that were ever associated with tags. Resources that currently don't have associated tags are shown with an empty tag set.
+If you do specify `filter`, the response returns only those resources that are currently associated with the specified tag.
+If you don't specify a `filter`, the response includes all resources that were ever associated with tags. Resources that currently don't have associated tags are shown with an empty tag set.
 
 * `key` - (Required) One part of a key-value pair that makes up a tag.
 * `values` - (Optional) The optional part of a key-value pair that make up a tag.

--- a/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
@@ -62,12 +62,10 @@ If you don't specify a `tag_filter`, the response includes all resources that we
 
 In addition to all arguments above, the following attributes are exported:
 
-* `resource_tag_mapping_list` - A [Resource Tag Mapping List](#resource-tag-mapping-list)`resource_tag_mapping_list` block. documented below.
-
-### Resource Tag Mapping List
-
-A `resource_tag_mapping_list` block supports the following attributes:
-
-* `resource_arn` - The ARN of the resource.
-* `compliance_details` - Information that shows whether a resource is compliant with the effective tag policy, including details on any noncompliant tag keys. Documented below.
-* `tags` - tags assigned to the resource.
+* `resource_tag_mapping_list` - List of objects matching the search criteria.
+    * `compliance_details` - List of objects with information that shows whether a resource is compliant with the effective tag policy, including details on any noncompliant tag keys.
+        * `compliance_status` - Whether the resource is compliant.
+        * `keys_with_noncompliant_values ` - Set of tag keys with non-compliant tag values.
+        * `non_compliant_keys ` - Set of non-compliant tag keys.
+    * `resource_arn` - ARN of the resource.
+    * `tags` - Map of tags assigned to the resource.

--- a/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "Resource Groups Tagging API"
+layout: "aws"
+page_title: "AWS: aws_resourcegroupstaggingapi_resources"
+description: |-
+  Provides details about resource tagging.
+---
+
+# Data Source: aws_resourcegroupstaggingapi_resources
+
+Provides details about resource tagging.
+
+## Example Usage
+
+### Get All Resource Tag Mappings
+
+```hcl
+data "aws_resourcegroupstaggingapi_resources" "test" {}
+```
+
+### Filter By Tag Key and Value
+
+```hcl
+data "aws_resourcegroupstaggingapi_resources" "test" {
+  tag_filters {
+    key    = "tag-key"
+    values = ["tag-value-1", "tag-value-2"]
+  }
+}
+```
+
+### Filter By Resource Type
+
+```hcl
+data "aws_resourcegroupstaggingapi_resources" "test" {
+  resource_type_filter = ["ec2:instance"]
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `exclude_compliant_resources` - (Optional) Specifies whether to exclude resources that are compliant with the tag policy. You can use this parameter only if the `include_compliance_details` argument is also set to `true`.
+* `include_compliance_details` - (Optional) Specifies whether to include details regarding the compliance with the effective tag policy.
+* `tag_filters` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See (Tag Filters)[#tag-filters] below. Conflicts with `resource_arn_list`.
+* `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of ec2 returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
+* `resource_arn_list` - (Optional) Specifies a list of ARNs of resources for which you want to retrieve tag data. Conflicts with `tag_filters`.
+
+### Tag Filters
+
+A `tag_filters` block supports the following arguments:
+
+If you do specify `tag_filters`, the response returns only those resources that are currently associated with the specified tag.
+If you don't specify a `tag_filters`, the response includes all resources that were ever associated with tags. Resources that currently don't have associated tags are shown with an empty tag set.
+
+* `key` - (Required) One part of a key-value pair that makes up a tag.
+* `values` - (Optional) The optional part of a key-value pair that make up a tag. 
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `resource_tag_mapping_list` - A [Resource Tag Mapping List](#resource-tag-mapping-list)`resource_tag_mapping_list` block. documented below.
+
+### Resource Tag Mapping List
+
+A `resource_tag_mapping_list` block supports the following attributes:
+
+* `resource_arn` - The ARN of the resource.
+* `compliance_details` - Information that shows whether a resource is compliant with the effective tag policy, including details on any noncompliant tag keys. Documented below.
+* `tags` - tags assigned to the resource.
+
+

--- a/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
@@ -22,7 +22,7 @@ data "aws_resourcegroupstaggingapi_resources" "test" {}
 
 ```terraform
 data "aws_resourcegroupstaggingapi_resources" "test" {
-  filter {
+  tag_filter {
     key    = "tag-key"
     values = ["tag-value-1", "tag-value-2"]
   }
@@ -44,16 +44,16 @@ The following arguments are supported:
 
 * `exclude_compliant_resources` - (Optional) Specifies whether to exclude resources that are compliant with the tag policy. You can use this parameter only if the `include_compliance_details` argument is also set to `true`.
 * `include_compliance_details` - (Optional) Specifies whether to include details regarding the compliance with the effective tag policy.
-* `filter` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See [Filter](#filter) below. Conflicts with `resource_arn_list`.
+* `tag_filter` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See [Tag Filter](#tag-filter) below. Conflicts with `resource_arn_list`.
 * `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of `ec2` returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
 * `resource_arn_list` - (Optional) Specifies a list of ARNs of resources for which you want to retrieve tag data. Conflicts with `filter`.
 
-### Filter
+### Tag Filter
 
-A `filter` block supports the following arguments:
+A `tag_filter` block supports the following arguments:
 
-If you do specify `filter`, the response returns only those resources that are currently associated with the specified tag.
-If you don't specify a `filter`, the response includes all resources that were ever associated with tags. Resources that currently don't have associated tags are shown with an empty tag set.
+If you do specify `tag_filter`, the response returns only those resources that are currently associated with the specified tag.
+If you don't specify a `tag_filter`, the response includes all resources that were ever associated with tags. Resources that currently don't have associated tags are shown with an empty tag set.
 
 * `key` - (Required) One part of a key-value pair that makes up a tag.
 * `values` - (Optional) The optional part of a key-value pair that make up a tag.
@@ -71,4 +71,3 @@ A `resource_tag_mapping_list` block supports the following attributes:
 * `resource_arn` - The ARN of the resource.
 * `compliance_details` - Information that shows whether a resource is compliant with the effective tag policy, including details on any noncompliant tag keys. Documented below.
 * `tags` - tags assigned to the resource.
-

--- a/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `exclude_compliant_resources` - (Optional) Specifies whether to exclude resources that are compliant with the tag policy. You can use this parameter only if the `include_compliance_details` argument is also set to `true`.
 * `include_compliance_details` - (Optional) Specifies whether to include details regarding the compliance with the effective tag policy.
-* `tag_filters` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See (Tag Filters)[#tag-filters] below. Conflicts with `resource_arn_list`.
+* `tag_filters` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See [Tag Filters](#tag-filters) below. Conflicts with `resource_arn_list`.
 * `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of ec2 returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
 * `resource_arn_list` - (Optional) Specifies a list of ARNs of resources for which you want to retrieve tag data. Conflicts with `tag_filters`.
 
@@ -56,7 +56,7 @@ If you do specify `tag_filters`, the response returns only those resources that 
 If you don't specify a `tag_filters`, the response includes all resources that were ever associated with tags. Resources that currently don't have associated tags are shown with an empty tag set.
 
 * `key` - (Required) One part of a key-value pair that makes up a tag.
-* `values` - (Optional) The optional part of a key-value pair that make up a tag. 
+* `values` - (Optional) The optional part of a key-value pair that make up a tag.
 
 ## Attributes Reference
 

--- a/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
+++ b/website/docs/d/resourcegroupstaggingapi_resources.html.markdown
@@ -44,11 +44,17 @@ The following arguments are supported:
 
 * `exclude_compliant_resources` - (Optional) Specifies whether to exclude resources that are compliant with the tag policy. You can use this parameter only if the `include_compliance_details` argument is also set to `true`.
 * `include_compliance_details` - (Optional) Specifies whether to include details regarding the compliance with the effective tag policy.
+<<<<<<< HEAD
 * `tag_filters` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See [Tag Filters](#tag-filters) below. Conflicts with `resource_arn_list`.
 * `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of `ec2` returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
 * `resource_arn_list` - (Optional) Specifies a list of ARNs of resources for which you want to retrieve tag data. Conflicts with `tag_filters`.
+=======
+* `filter` - (Optional) Specifies a list of Tag Filters (keys and values) to restrict the output to only those resources that have the specified tag and, if included, the specified value. See [Filter](#filter) below. Conflicts with `resource_arn_list`.
+* `resource_type_filter` - (Optional) The constraints on the resources that you want returned. The format of each resource type is `service:resourceType`. For example, specifying a resource type of ec2 returns all Amazon EC2 resources (which includes EC2 instances). Specifying a resource type of `ec2:instance` returns only EC2 instances.
+* `resource_arn_list` - (Optional) Specifies a list of ARNs of resources for which you want to retrieve tag data. Conflicts with `filter`.
+>>>>>>> a6eed3340 (docs)
 
-### Tag Filters
+### Filter
 
 A `filter` block supports the following arguments:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17705

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsResourceGroupsTaggingAPIResources_'
--- PASS: TestAccDataSourceAwsResourceGroupsTaggingAPIResources_basic (26.83s)
--- PASS: TestAccDataSourceAwsResourceGroupsTaggingAPIResources_compliance (27.22s)
--- PASS: TestAccDataSourceAwsResourceGroupsTaggingAPIResources_resource_type_filters (33.55s)
--- PASS: TestAccDataSourceAwsResourceGroupsTaggingAPIResources_tag_key_filter (66.65s)
--- PASS: TestAccDataSourceAwsResourceGroupsTaggingAPIResources_resource_arn_list (98.83s)
```
