### PR TITLE
Update aws_apigatewayv2_integration documentation for private integration

### DIFF
--- a/website/docs/r/apigatewayv2_integration.html.markdown
+++ b/website/docs/r/apigatewayv2_integration.html.markdown
@@ -63,13 +63,32 @@ resource "aws_apigatewayv2_integration" "example" {
 }
 ```
 
+### Private Integration
+
+```hcl
+resource "aws_apigatewayv2_integration" "example" {
+  api_id           = aws_apigatewayv2_api.example.id
+  credentials_arn  = aws_iam_role.example.arn
+  description      = "Example with a load balancer"
+  integration_type = "HTTP_PROXY"
+  integration_uri  = aws_lb_listener.example.arn
+
+  connection_type = "VPC_LINK"
+  connection_id   = aws_apigatewayv2_vpc_link.example.id
+
+  tls_config {
+    server_name_to_verify = "example.com"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `api_id` - (Required) The API identifier.
 * `integration_type` - (Required) The integration type of an integration.
-Valid values: `AWS` (supported only for WebSocket APIs), `AWS_PROXY`, `HTTP` (supported only for WebSocket APIs), `HTTP_PROXY`, `MOCK` (supported only for WebSocket APIs).
+Valid values: `AWS` (supported only for WebSocket APIs), `AWS_PROXY`, `HTTP` (supported only for WebSocket APIs), `HTTP_PROXY`, `MOCK` (supported only for WebSocket APIs). For an HTTP API private integration, use `HTTP_PROXY`.
 * `connection_id` - (Optional) The ID of the [VPC link](apigatewayv2_vpc_link.html) for a private integration. Supported only for HTTP APIs. Must be between 1 and 1024 characters in length.
 * `connection_type` - (Optional) The type of the network connection to the integration endpoint. Valid values: `INTERNET`, `VPC_LINK`. Default is `INTERNET`.
 * `content_handling_strategy` - (Optional) How to handle response payload content type conversions. Valid values: `CONVERT_TO_BINARY`, `CONVERT_TO_TEXT`. Supported only for WebSocket APIs.


### PR DESCRIPTION
- Adds use case on `integration_type` for HTTP_PROXY
- Adds an example for a pirvate integration with a load balancer listener

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
