### PR TITLE
Fixed typo for sample IAM policy in aws_s3_bucket_policy document

### DIFF
--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -38,7 +38,7 @@ resource "aws_s3_bucket_policy" "b" {
           "${aws_s3_bucket.b.arn}/*",
         ]
         Condition = {
-          IPAddress = {
+          IpAddress = {
             "aws:SourceIp" = "8.8.8.8/32"
           }
         }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17805

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
