### PR TITLE
provider: Refactoring for Go 1.16 ioutil package deprecation

### DIFF
--- a/aws/data_source_aws_ip_ranges.go
+++ b/aws/data_source_aws_ip_ranges.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"sort"
 	"strconv"
@@ -89,7 +89,7 @@ func dataSourceAwsIPRangesRead(d *schema.ResourceData, meta interface{}) error {
 
 	defer res.Body.Close()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		return fmt.Errorf("Error reading response body from (%s): %w", url, err)

--- a/aws/internal/generators/listpages/main.go
+++ b/aws/internal/generators/listpages/main.go
@@ -9,7 +9,6 @@ import (
 	"go/ast"
 	"go/format"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -72,7 +71,7 @@ func main() {
 
 	src := g.format()
 
-	err := ioutil.WriteFile(outputName, src, 0644)
+	err := os.WriteFile(outputName, src, 0644)
 	if err != nil {
 		log.Fatalf("error writing output: %s", err)
 	}

--- a/aws/internal/service/eks/token/token.go
+++ b/aws/internal/service/eks/token/token.go
@@ -10,6 +10,7 @@ With the following modifications:
  - Hard copy and use local Canonicalize implementation instead of "sigs.k8s.io/aws-iam-authenticator/pkg/arn"
  - Fix staticcheck reports
  - Ignore errorlint reports
+ - Refactor deprecated io/ioutil in Go 1.16
 */
 
 /*
@@ -34,7 +35,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -316,7 +317,7 @@ func (v tokenVerifier) Verify(token string) (*Identity, error) {
 	}
 	defer response.Body.Close()
 
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, NewSTSError(fmt.Sprintf("error reading HTTP result: %v", err))
 	}

--- a/aws/internal/service/eks/token/token_test.go
+++ b/aws/internal/service/eks/token/token_test.go
@@ -6,6 +6,7 @@ With the following modifications:
 
  - Fix staticcheck reports
  - Ignore errorlint reports
+ - Refactor deprecated io/ioutil in Go 1.16
 */
 
 package token
@@ -17,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -69,7 +69,7 @@ func toToken(url string) string {
 func newVerifier(statusCode int, body string, err error) Verifier {
 	var rc io.ReadCloser
 	if body != "" {
-		rc = ioutil.NopCloser(bytes.NewReader([]byte(body)))
+		rc = io.NopCloser(bytes.NewReader([]byte(body)))
 	}
 	return tokenVerifier{
 		client: &http.Client{

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -1868,7 +1868,7 @@ func readHttpJson(url string, target interface{}) error {
 }
 
 func readLocalJson(localFile string, target interface{}) error {
-	file, e := ioutil.ReadFile(localFile)
+	file, e := os.ReadFile(localFile)
 	if e != nil {
 		log.Printf("[ERROR] %s", e)
 		return e

--- a/aws/resource_aws_iam_user_test.go
+++ b/aws/resource_aws_iam_user_test.go
@@ -2,8 +2,8 @@ package aws
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -765,7 +765,7 @@ func testAccCheckAWSUserCreatesMFADevice(getUserOutput *iam.GetUserOutput) resou
 func testAccCheckAWSUserUploadsSSHKey(getUserOutput *iam.GetUserOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		sshKey, err := ioutil.ReadFile("./test-fixtures/public-ssh-key.pub")
+		sshKey, err := os.ReadFile("./test-fixtures/public-ssh-key.pub")
 		if err != nil {
 			return fmt.Errorf("error reading SSH fixture: %s", err)
 		}
@@ -790,7 +790,7 @@ func testAccCheckAWSUserUploadSigningCertificate(getUserOutput *iam.GetUserOutpu
 	return func(s *terraform.State) error {
 		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
 
-		signingCertificate, err := ioutil.ReadFile("./test-fixtures/iam-ssl-unix-line-endings.pem")
+		signingCertificate, err := os.ReadFile("./test-fixtures/iam-ssl-unix-line-endings.pem")
 		if err != nil {
 			return fmt.Errorf("error reading signing certificate fixture: %s", err)
 		}

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"regexp"
 	"time"
 
@@ -1223,7 +1223,7 @@ func loadFileContent(v string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	fileContent, err := ioutil.ReadFile(filename)
+	fileContent, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"archive/zip"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -1895,7 +1894,7 @@ func testAccCreateZipFromFiles(files map[string]string, zipFile *os.File) error 
 			return err
 		}
 
-		fileContent, err := ioutil.ReadFile(source)
+		fileContent, err := os.ReadFile(source)
 		if err != nil {
 			return err
 		}
@@ -1915,7 +1914,7 @@ func testAccCreateZipFromFiles(files map[string]string, zipFile *os.File) error 
 }
 
 func createTempFile(prefix string) (string, *os.File, error) {
-	f, err := ioutil.TempFile(os.TempDir(), prefix)
+	f, err := os.CreateTemp(os.TempDir(), prefix)
 	if err != nil {
 		return "", nil, err
 	}

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"reflect"
@@ -343,7 +343,7 @@ func TestAccAWSS3BucketObject_updateSameFile(t *testing.T) {
 	defer os.Remove(filename)
 
 	rewriteFile := func(*terraform.State) error {
-		if err := ioutil.WriteFile(filename, []byte(changingData), 0644); err != nil {
+		if err := os.WriteFile(filename, []byte(changingData), 0644); err != nil {
 			os.Remove(filename)
 			t.Fatal(err)
 		}
@@ -1266,7 +1266,7 @@ func testAccCheckAWSS3BucketObjectExists(n string, obj *s3.GetObjectOutput) reso
 
 func testAccCheckAWSS3BucketObjectBody(obj *s3.GetObjectOutput, want string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		body, err := ioutil.ReadAll(obj.Body)
+		body, err := io.ReadAll(obj.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read body: %s", err)
 		}
@@ -1367,13 +1367,13 @@ func testAccCheckAWSS3BucketObjectSSE(n, expectedSSE string) resource.TestCheckF
 }
 
 func testAccAWSS3BucketObjectCreateTempFile(t *testing.T, data string) string {
-	tmpFile, err := ioutil.TempFile("", "tf-acc-s3-obj")
+	tmpFile, err := os.CreateTemp("", "tf-acc-s3-obj")
 	if err != nil {
 		t.Fatal(err)
 	}
 	filename := tmpFile.Name()
 
-	err = ioutil.WriteFile(filename, []byte(data), 0644)
+	err = os.WriteFile(filename, []byte(data), 0644)
 	if err != nil {
 		os.Remove(filename)
 		t.Fatal(err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://golang.org/doc/go1.16#ioutil
Closes #17685

> The io/ioutil package has turned out to be a poorly defined and hard to understand collection of things. All functionality provided by the package has been moved to other packages. The io/ioutil package remains and will continue to work as before, but we encourage new code to use the new definitions in the io and os packages. Here is a list of the new locations of the names exported by io/ioutil:
>
> Discard => io.Discard
> NopCloser => io.NopCloser
> ReadAll => io.ReadAll
> ReadDir => os.ReadDir (note: returns a slice of os.DirEntry rather than a slice of fs.FileInfo)
> ReadFile => os.ReadFile
> TempDir => os.MkdirTemp
> TempFile => os.CreateTemp
> WriteFile => os.WriteFile

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSEksClusterAuthDataSource_basic (22.94s)
--- PASS: TestAccAWSEMRCluster_additionalInfo (397.35s)
--- PASS: TestAccAWSEMRCluster_basic (417.79s)
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (1219.90s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (712.72s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy (554.33s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice (1053.30s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount (502.10s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType (930.50s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Name (874.76s)
--- PASS: TestAccAWSEMRCluster_custom_ami_id (561.57s)
--- PASS: TestAccAWSEMRCluster_disappears (411.63s)
--- PASS: TestAccAWSEMRCluster_ebs_config (468.45s)
--- PASS: TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups (855.75s)
--- PASS: TestAccAWSEMRCluster_instance_fleet (541.93s)
--- PASS: TestAccAWSEMRCluster_instance_fleet_master_only (456.74s)
--- PASS: TestAccAWSEMRCluster_keepJob (427.24s)
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (419.55s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice (982.40s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount (1108.12s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType (796.95s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Name (824.90s)
--- PASS: TestAccAWSEMRCluster_root_volume_size (858.33s)
--- PASS: TestAccAWSEMRCluster_s3Logging (530.64s)
--- PASS: TestAccAWSEMRCluster_security_config (488.98s)
--- PASS: TestAccAWSEMRCluster_Step_Basic (418.55s)
--- PASS: TestAccAWSEMRCluster_step_concurrency_level (468.54s)
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (867.38s)
--- PASS: TestAccAWSEMRCluster_Step_Multiple (429.61s)
--- PASS: TestAccAWSEMRCluster_tags (778.27s)
--- PASS: TestAccAWSEMRCluster_terminationProtected (466.76s)
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (681.14s)

--- PASS: TestAccAWSIPRanges_basic (8.32s)
--- PASS: TestAccAWSIPRanges_Url (8.11s)

--- PASS: TestAccAWSLambdaFunction_basic (834.98s)
--- PASS: TestAccAWSLambdaFunction_codeSigningConfig (1041.09s)
--- PASS: TestAccAWSLambdaFunction_concurrency (61.96s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (833.61s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (723.36s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (825.62s)
--- PASS: TestAccAWSLambdaFunction_disablePublish (1030.44s)
--- PASS: TestAccAWSLambdaFunction_disappears (987.71s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (248.82s)
--- PASS: TestAccAWSLambdaFunction_enablePublish (1061.19s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (1032.39s)
--- PASS: TestAccAWSLambdaFunction_Environment_Variables_NoValue (829.61s)
--- PASS: TestAccAWSLambdaFunction_envVariables (897.91s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (15.36s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (2800.62s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (375.38s)
--- PASS: TestAccAWSLambdaFunction_Layers (382.02s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (409.94s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (1230.66s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (273.09s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (1054.40s)
--- PASS: TestAccAWSLambdaFunction_runtimes (488.91s)
--- PASS: TestAccAWSLambdaFunction_s3 (58.10s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (101.92s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (100.67s)
--- PASS: TestAccAWSLambdaFunction_tags (136.46s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (403.51s)
--- PASS: TestAccAWSLambdaFunction_UnpublishedCodeUpdate (865.58s)
--- PASS: TestAccAWSLambdaFunction_versioned (80.38s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (1180.44s)
--- PASS: TestAccAWSLambdaFunction_VPC (404.37s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (897.65s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (746.66s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (288.91s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (2372.42s)
--- SKIP: TestAccAWSLambdaFunction_imageConfig (0.00s)

--- PASS: TestAccAWSS3BucketObject_acl (118.19s)
--- PASS: TestAccAWSS3BucketObject_content (34.71s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (46.29s)
--- PASS: TestAccAWSS3BucketObject_defaultBucketSSE (52.28s)
--- PASS: TestAccAWSS3BucketObject_empty (46.48s)
--- PASS: TestAccAWSS3BucketObject_etagEncryption (34.17s)
--- PASS: TestAccAWSS3BucketObject_ignoreTags (86.02s)
--- PASS: TestAccAWSS3BucketObject_kms (47.67s)
--- PASS: TestAccAWSS3BucketObject_metadata (116.27s)
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (8.51s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (109.88s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (86.04s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (75.78s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (133.43s)
--- PASS: TestAccAWSS3BucketObject_source (44.71s)
--- PASS: TestAccAWSS3BucketObject_sse (43.06s)
--- PASS: TestAccAWSS3BucketObject_storageClass (107.25s)
--- PASS: TestAccAWSS3BucketObject_tags (120.07s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingMultipleSlashes (147.00s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSingleSlash (118.44s)
--- PASS: TestAccAWSS3BucketObject_tagsMultipleSlashes (129.75s)
--- PASS: TestAccAWSS3BucketObject_updates (86.05s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (56.79s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (55.94s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (54.03s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (47.14s)
--- SKIP: TestAccAWSS3BucketObject_NonVersioned (0.70s)

--- PASS: TestAccAWSUser_basic (18.29s)
--- PASS: TestAccAWSUser_disappears (7.90s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (11.06s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (19.05s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (11.01s)
--- PASS: TestAccAWSUser_ForceDestroy_SigningCertificate (11.95s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (10.68s)
--- PASS: TestAccAWSUser_nameChange (16.99s)
--- PASS: TestAccAWSUser_pathChange (17.62s)
--- PASS: TestAccAWSUser_permissionsBoundary (39.55s)
--- PASS: TestAccAWSUser_tags (17.68s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSEksClusterAuthDataSource_basic (28.16s)

--- FAIL: TestAccAWSEMRCluster_bootstrap_ordering (264.97s) # https://github.com/hashicorp/terraform-provider-aws/issues/15608
--- FAIL: TestAccAWSEMRCluster_instance_fleet (309.15s) # https://github.com/hashicorp/terraform-provider-aws/issues/15608
--- FAIL: TestAccAWSEMRCluster_instance_fleet_master_only (291.43s) # https://github.com/hashicorp/terraform-provider-aws/issues/15608
--- PASS: TestAccAWSEMRCluster_additionalInfo (425.04s)
--- PASS: TestAccAWSEMRCluster_basic (356.09s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (370.54s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy (563.88s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice (867.74s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount (497.50s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType (826.05s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Name (759.99s)
--- PASS: TestAccAWSEMRCluster_custom_ami_id (434.39s)
--- PASS: TestAccAWSEMRCluster_disappears (478.53s)
--- PASS: TestAccAWSEMRCluster_ebs_config (458.88s)
--- PASS: TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups (759.17s)
--- PASS: TestAccAWSEMRCluster_keepJob (362.22s)
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (387.79s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice (715.21s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount (1181.25s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType (725.58s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Name (796.99s)
--- PASS: TestAccAWSEMRCluster_root_volume_size (729.93s)
--- PASS: TestAccAWSEMRCluster_s3Logging (518.49s)
--- PASS: TestAccAWSEMRCluster_security_config (453.30s)
--- PASS: TestAccAWSEMRCluster_Step_Basic (387.80s)
--- PASS: TestAccAWSEMRCluster_step_concurrency_level (424.42s)
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (865.86s)
--- PASS: TestAccAWSEMRCluster_Step_Multiple (395.99s)
--- PASS: TestAccAWSEMRCluster_tags (708.44s)
--- PASS: TestAccAWSEMRCluster_terminationProtected (356.26s)
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (675.16s)

--- PASS: TestAccAWSIPRanges_basic (12.75s)
--- PASS: TestAccAWSIPRanges_Url (12.92s)

--- PASS: TestAccAWSLambdaFunction_basic (68.18s)
--- PASS: TestAccAWSLambdaFunction_concurrency (107.17s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (156.84s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (131.64s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (132.90s)
--- PASS: TestAccAWSLambdaFunction_disablePublish (157.57s)
--- PASS: TestAccAWSLambdaFunction_disappears (70.26s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (143.29s)
--- PASS: TestAccAWSLambdaFunction_enablePublish (151.67s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (133.97s)
--- PASS: TestAccAWSLambdaFunction_Environment_Variables_NoValue (75.02s)
--- PASS: TestAccAWSLambdaFunction_envVariables (193.79s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (35.54s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (827.55s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (156.53s)
--- PASS: TestAccAWSLambdaFunction_Layers (155.57s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (214.20s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (523.98s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (529.79s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (109.03s)
--- PASS: TestAccAWSLambdaFunction_runtimes (580.88s)
--- PASS: TestAccAWSLambdaFunction_s3 (35.21s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (60.72s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (61.89s)
--- PASS: TestAccAWSLambdaFunction_tags (199.60s)
--- PASS: TestAccAWSLambdaFunction_UnpublishedCodeUpdate (97.62s)
--- PASS: TestAccAWSLambdaFunction_versioned (111.62s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (205.20s)
--- PASS: TestAccAWSLambdaFunction_VPC (386.34s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (553.55s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (256.43s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (383.17s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (1930.81s)
--- SKIP: TestAccAWSLambdaFunction_codeSigningConfig (0.75s)
--- SKIP: TestAccAWSLambdaFunction_imageConfig (0.00s)

--- PASS: TestAccAWSS3BucketObject_acl (78.44s)
--- PASS: TestAccAWSS3BucketObject_content (47.36s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (47.06s)
--- PASS: TestAccAWSS3BucketObject_defaultBucketSSE (40.35s)
--- PASS: TestAccAWSS3BucketObject_empty (47.45s)
--- PASS: TestAccAWSS3BucketObject_etagEncryption (47.13s)
--- PASS: TestAccAWSS3BucketObject_ignoreTags (69.26s)
--- PASS: TestAccAWSS3BucketObject_kms (31.34s)
--- PASS: TestAccAWSS3BucketObject_metadata (113.98s)
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (2.18s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (115.61s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (77.40s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (114.51s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (139.11s)
--- PASS: TestAccAWSS3BucketObject_source (47.21s)
--- PASS: TestAccAWSS3BucketObject_sse (29.40s)
--- PASS: TestAccAWSS3BucketObject_storageClass (161.13s)
--- PASS: TestAccAWSS3BucketObject_tags (158.09s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingMultipleSlashes (162.01s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSingleSlash (162.35s)
--- PASS: TestAccAWSS3BucketObject_tagsMultipleSlashes (161.07s)
--- PASS: TestAccAWSS3BucketObject_updates (93.23s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (52.71s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (52.29s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (56.95s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (46.56s)
--- SKIP: TestAccAWSS3BucketObject_NonVersioned (1.58s)

--- PASS: TestAccAWSUser_basic (30.14s)
--- PASS: TestAccAWSUser_disappears (11.79s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (19.10s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (18.86s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (19.94s)
--- PASS: TestAccAWSUser_ForceDestroy_SigningCertificate (20.78s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (19.72s)
--- PASS: TestAccAWSUser_nameChange (28.31s)
--- PASS: TestAccAWSUser_pathChange (48.94s)
--- PASS: TestAccAWSUser_permissionsBoundary (100.25s)
--- PASS: TestAccAWSUser_tags (68.49s)
```
