### PR TITLE
r/ssm_parameter - tag on create + validations

### DIFF
--- a/.changelog/17830.txt
+++ b/.changelog/17830.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ssm_parameter: Add plan time validation to `name`, `description` and `allowed_pattern`
+```
+
+```release-note:enhancement
+resource/aws_ssm_parameter: Tag on create
+```

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -32,13 +32,15 @@ func resourceAwsSsmParameter() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 2048),
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 			"tier": {
 				Type:     schema.TypeString,
@@ -50,13 +52,9 @@ func resourceAwsSsmParameter() *schema.Resource {
 				}, false),
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ssm.ParameterTypeString,
-					ssm.ParameterTypeStringList,
-					ssm.ParameterTypeSecureString,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(ssm.ParameterType_Values(), false),
 			},
 			"value": {
 				Type:      schema.TypeString,
@@ -87,8 +85,9 @@ func resourceAwsSsmParameter() *schema.Resource {
 				Optional: true,
 			},
 			"allowed_pattern": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 			"version": {
 				Type:     schema.TypeInt,
@@ -166,7 +165,7 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	}
 	describeResp, err := ssmconn.DescribeParameters(describeParamsInput)
 	if err != nil {
-		return fmt.Errorf("error describing SSM parameter: %s", err)
+		return fmt.Errorf("error describing SSM parameter: %w", err)
 	}
 
 	if describeResp == nil || len(describeResp.Parameters) == 0 || describeResp.Parameters[0] == nil {
@@ -188,11 +187,11 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	tags, err := keyvaluetags.SsmListTags(ssmconn, name, ssm.ResourceTypeForTaggingParameter)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for SSM Parameter (%s): %s", name, err)
+		return fmt.Errorf("error listing tags for SSM Parameter (%s): %w", name, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.Set("arn", param.ARN)
@@ -218,10 +217,11 @@ func resourceAwsSsmParameterDelete(d *schema.ResourceData, meta interface{}) err
 func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
-	log.Printf("[INFO] Creating SSM Parameter: %s", d.Get("name").(string))
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating SSM Parameter: %s", name)
 
 	paramInput := &ssm.PutParameterInput{
-		Name:           aws.String(d.Get("name").(string)),
+		Name:           aws.String(name),
 		Type:           aws.String(d.Get("type").(string)),
 		Tier:           aws.String(d.Get("tier").(string)),
 		Value:          aws.String(d.Get("value").(string)),
@@ -242,6 +242,10 @@ func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error 
 		paramInput.SetKeyId(keyID.(string))
 	}
 
+	if v, ok := d.GetOk("tags"); ok && d.IsNewResource() {
+		paramInput.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SsmTags()
+	}
+
 	log.Printf("[DEBUG] Waiting for SSM Parameter %v to be updated", d.Get("name"))
 	_, err := ssmconn.PutParameter(paramInput)
 
@@ -251,19 +255,18 @@ func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating SSM parameter: %s", err)
+		return fmt.Errorf("error creating SSM parameter: %w", err)
 	}
 
-	name := d.Get("name").(string)
-	if d.HasChange("tags") {
+	if !d.IsNewResource() && d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
 		if err := keyvaluetags.SsmUpdateTags(ssmconn, name, ssm.ResourceTypeForTaggingParameter, o, n); err != nil {
-			return fmt.Errorf("error updating SSM Parameter (%s) tags: %s", name, err)
+			return fmt.Errorf("error updating SSM Parameter (%s) tags: %w", name, err)
 		}
 	}
 
-	d.SetId(d.Get("name").(string))
+	d.SetId(name)
 
 	return resourceAwsSsmParameterRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17819

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMParameter_'
--- PASS: TestAccAWSSSMParameter_disappears (39.90s)
--- PASS: TestAccAWSSSMParameter_secure (62.44s)
--- PASS: TestAccAWSSSMParameter_basic (62.61s)
--- PASS: TestAccAWSSSMParameter_fullPath (63.02s)
--- PASS: TestAccAWSSSMParameter_DataType_AwsEc2Image (68.32s)
--- PASS: TestAccAWSSSMParameter_secure_with_key (77.85s)
--- PASS: TestAccAWSSSMParameter_updateDescription (90.66s)
--- PASS: TestAccAWSSSMParameter_overwrite (94.95s)
--- PASS: TestAccAWSSSMParameter_updateType (96.96s)
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (99.72s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (115.52s)
--- PASS: TestAccAWSSSMParameter_Tier (129.45s)
--- PASS: TestAccAWSSSMParameter_tags (131.75s)
```
