### PR TITLE
Support ipv6_addresses for data_source_aws_instance

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -93,6 +93,11 @@ func dataSourceAwsInstance() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"ipv6_addresses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"iam_instance_profile": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -488,6 +493,14 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 				}
 				if err := d.Set("secondary_private_ips", secondaryIPs); err != nil {
 					return fmt.Errorf("error setting secondary_private_ips: %w", err)
+				}
+
+				Ipv6Addresses := make([]string, 0, len(ni.Ipv6Addresses))
+				for _, ip := range ni.Ipv6Addresses {
+					Ipv6Addresses = append(Ipv6Addresses, aws.StringValue(ip.Ipv6Address))
+				}
+				if err := d.Set("ipv6_addresses", Ipv6Addresses); err != nil {
+					return fmt.Errorf("error setting ipv6_addresses: %w", err)
 				}
 			}
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12785

The docs did not need to be updated because this attribute is already documented but does not exist: https://github.com/hashicorp/terraform/pull/14473

Output from acceptance testing:
```
--- PASS: TestAccAWSInstanceDataSource_blockDevices (64.90s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (79.73s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (85.27s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (87.17s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (88.19s)
--- PASS: TestAccAWSInstanceDataSource_gp3ThroughputDevice (89.10s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (89.68s)
--- PASS: TestAccAWSInstance_rootInstanceStore (111.77s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (111.91s)
--- PASS: TestAccAWSInstanceDataSource_VPC (113.69s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (119.74s)
--- PASS: TestAccAWSInstanceDataSource_blockDeviceTags (121.32s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (172.56s)
--- PASS: TestAccAWSInstanceDataSource_tags (206.27s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (206.79s)
--- PASS: TestAccAWSInstanceDataSource_basic (207.90s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (303.11s)
--- PASS: TestAccAWSInstanceDataSource_enclaveOptions (305.44s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (309.75s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (97.71s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (102.48s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (77.08s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (176.24s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (70.43s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (262.45s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (185.82s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (206.20s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (293.09s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (14.30s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidThroughputForVolumeType (14.70s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType (14.74s)
--- PASS: TestAccAWSInstance_basic (78.38s)
--- PASS: TestAccAWSInstance_GP3RootBlockDevice (79.34s)
--- PASS: TestAccAWSInstance_blockDevices (84.98s)
--- PASS: TestAccAWSInstance_disappears (85.35s)
--- PASS: TestAccAWSInstance_Empty_PrivateIP (85.87s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (86.01s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (96.55s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (96.96s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (97.49s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (102.96s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (103.19s)
--- PASS: TestAccAWSInstance_blockDeviceTags_ebsAndRoot (113.33s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (131.51s)
--- PASS: TestAccAWSInstance_blockDeviceTags_volumeTags (140.27s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (154.98s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (156.01s)
--- PASS: TestAccAWSInstance_blockDeviceTags_withAttachedVolume (175.99s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (216.41s)
--- PASS: TestAccAWSInstance_hibernation (229.83s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (109.14s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (111.91s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (152.97s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (97.42s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (97.66s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate (121.58s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs (322.23s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate (152.57s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (92.39s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (92.40s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (170.66s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs (351.77s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs (642.01s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (96.60s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (105.64s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (172.72s)
--- PASS: TestAccAWSInstance_atLeastOneOtherEbsVolume (202.93s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (175.90s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (116.07s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (146.35s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (100.53s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (114.23s)
--- PASS: TestAccAWSInstance_enclaveOptions (429.37s)
--- PASS: TestAccAWSInstance_dedicatedInstance (114.61s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (103.97s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (319.82s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (101.33s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (113.90s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (131.01s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (103.86s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (110.44s)
--- PASS: TestAccAWSInstance_disableApiTermination (140.43s)
--- PASS: TestAccAWSInstance_changeInstanceType (238.62s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (18.45s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (73.54s)
--- PASS: TestAccAWSInstance_keyPairCheck (93.09s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (93.73s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (113.22s)
--- PASS: TestAccAWSInstance_tags (122.04s)
--- PASS: TestAccAWSInstance_instanceProfileChange (206.83s)
--- PASS: TestAccAWSInstance_withIamInstanceProfilePath (214.89s)
--- PASS: TestAccAWSInstancesDataSource_instanceStateNames (312.94s)
--- PASS: TestAccAWSInstancesDataSource_basic (312.99s)
--- PASS: TestAccAWSInstancesDataSource_tags (334.49s)
--- PASS: TestAccAWSInstance_userDataBase64 (105.32s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (114.25s)
--- PASS: TestAccAWSInstance_metadataOptions (118.15s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (82.39s)
--- PASS: TestAccAWSInstance_hibernation (199.67s)
--- PASS: TestAccAWSInstance_privateIP (85.47s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (125.35s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (91.38s)
--- PASS: TestAccAWSInstance_placementGroup (105.78s)
--- PASS: TestAccAWSInstance_sourceDestCheck (146.78s)
--- PASS: TestAccAWSInstance_inEc2Classic (83.16s)

Tests were broken and I had to manually update an image type t2.large -> t2.2xlarge for these to pass:

--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (98.98s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (110.91s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (112.90s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyThroughput_Gp3 (115.71s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (98.34s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1 (118.68s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2 (109.21s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (70.70s)


```
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
