### PR TITLE
resource/aws_db_instance: add support for CoIP enabled argument

### DIFF
--- a/.changelog/17864.txt
+++ b/.changelog/17864.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Add `customer_owned_ip_enabled` argument
+```

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -7694,8 +7694,8 @@ resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
 }
 
 data "aws_rds_engine_version" "test" {
-  engine = "mysql"
-version = "8.0.17"
+  engine  = "mysql"
+  version = "8.0.17"
 }
 
 data "aws_rds_orderable_db_instance" "test" {
@@ -7705,23 +7705,23 @@ data "aws_rds_orderable_db_instance" "test" {
 }
 
 resource "aws_db_instance" "test" {
-  allocated_storage       = 10
-  backup_retention_period = 1
-  engine                  = data.aws_rds_orderable_db_instance.test.engine
-  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
-  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
-  name                    = "baz"
-  parameter_group_name    = "default.${data.aws_rds_engine_version.test.parameter_group_family}"
-  password                = "barbarbarbar"
-  skip_final_snapshot     = true
-  username                = "foo"
-  db_subnet_group_name = aws_db_subnet_group.foo.name
-storage_encrypted       = true
+  allocated_storage         = 20
+  backup_retention_period   = 1
+  engine                    = data.aws_rds_orderable_db_instance.test.engine
+  engine_version            = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class            = data.aws_rds_orderable_db_instance.test.instance_class
+  name                      = "baz"
+  parameter_group_name      = "default.${data.aws_rds_engine_version.test.parameter_group_family}"
+  password                  = "barbarbarbar"
+  skip_final_snapshot       = true
+  username                  = "foo"
+  db_subnet_group_name      = aws_db_subnet_group.foo.name
+  storage_encrypted         = true
   customer_owned_ip_enabled = %[2]t
 
   timeouts {
     create = "180m"
-	update = "180m"
+    update = "180m"
   }
 }
 `, rInt, coipEnabled)
@@ -7738,12 +7738,12 @@ resource "aws_db_instance" "restore" {
     source_db_instance_identifier = aws_db_instance.test.identifier
     use_latest_restorable_time    = true
   }
-  skip_final_snapshot = true
+  skip_final_snapshot       = true
   customer_owned_ip_enabled = %[2]t
 
   timeouts {
     create = "180m"
-	update = "180m"
+    update = "180m"
   }
 }
 `, acctest.RandInt(), targetCoipEnabled))
@@ -7758,16 +7758,16 @@ resource "aws_db_snapshot" "test" {
 
 resource "aws_db_instance" "target" {
   customer_owned_ip_enabled = %[2]t
-  db_subnet_group_name = aws_db_subnet_group.foo.name
-storage_encrypted       = true
-  identifier                          = %[1]q
-  instance_class                      = aws_db_instance.test.instance_class
-  snapshot_identifier                 = aws_db_snapshot.test.id
-  skip_final_snapshot                 = true
+  db_subnet_group_name      = aws_db_subnet_group.foo.name
+  storage_encrypted         = true
+  identifier                = %[1]q
+  instance_class            = aws_db_instance.test.instance_class
+  snapshot_identifier       = aws_db_snapshot.test.id
+  skip_final_snapshot       = true
 
   timeouts {
     create = "180m"
-	update = "180m"
+    update = "180m"
   }
 }
 `, rName, targetCoipEnabled))

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -3359,6 +3359,175 @@ func TestAccAWSDBInstance_NoNationalCharacterSet_Oracle(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAWSDBInstance_CoipEnabled(t *testing.T) {
+	var v rds.DBInstance
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_Outpost_CoipEnabled(rName, true, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(resourceName, &v),
+					testAccCheckAWSDBInstanceAttributes(&v),
+					resource.TestCheckResourceAttr(
+						resourceName, "customer_owned_ip_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_CoipEnabled_DisabledToEnabled(t *testing.T) {
+	var dbInstance rds.DBInstance
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_Outpost_CoipEnabled(rName, false, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"skip_final_snapshot",
+					"final_snapshot_identifier",
+				},
+			},
+			{
+				Config: testAccAWSDBInstanceConfig_Outpost_CoipEnabled(rName, true, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_CoipEnabled_EnabledToDisabled(t *testing.T) {
+	var dbInstance rds.DBInstance
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_Outpost_CoipEnabled(rName, true, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"skip_final_snapshot",
+					"final_snapshot_identifier",
+				},
+			},
+			{
+				Config: testAccAWSDBInstanceConfig_Outpost_CoipEnabled(rName, false, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_CoipEnabled_RestoreToPointInTime(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	sourceName := "aws_db_instance.test"
+	resourceName := "aws_db_instance.restore"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_CoipEnabled_RestorePointInTime(rName, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceName, &sourceDbInstance),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"delete_automated_backups",
+					"final_snapshot_identifier",
+					"latest_restorable_time", // dynamic value of a DBInstance
+					"password",
+					"restore_to_point_in_time",
+					"skip_final_snapshot",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_CoipEnabled_SnapshotIdentifier(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	var dbSnapshot rds.DBSnapshot
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	sourceDbResourceName := "aws_db_instance.test"
+	snapshotResourceName := "aws_db_snapshot.test"
+	resourceName := "aws_db_instance.restore"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_CoipEnabled_SnapshotIdentifier(rName, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceDbResourceName, &sourceDbInstance),
+					testAccCheckDbSnapshotExists(snapshotResourceName, &dbSnapshot),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "customer_owned_ip_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSDBInstanceConfig_orderableClass(engine, version, license string) string {
 	return fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "test" {
@@ -7477,4 +7646,129 @@ resource "aws_db_instance" "test" {
   delete_automated_backups = false
 }
 `, rName))
+}
+
+func testAccAWSDBInstanceConfig_Outpost_CoipEnabled(rInt int, coipEnabled bool) string {
+	return fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+resource "aws_vpc" "foo" {
+  cidr_block = "10.128.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-db-instance-coip-%[1]d"
+  }
+}
+
+resource "aws_subnet" "foo" {
+  cidr_block        = "10.128.1.0/24"
+  availability_zone = data.aws_outposts_outpost.test.availability_zone
+  vpc_id            = aws_vpc.foo.id
+  outpost_arn       = data.aws_outposts_outpost.test.arn
+
+  tags = {
+    Name = "tf-acc-db-instance-coip-%[1]d"
+  }
+}
+
+resource "aws_db_subnet_group" "foo" {
+  name       = "foo-db-subnet-group-%[1]d"
+  subnet_ids = [aws_subnet.foo.id]
+
+  tags = {
+    Name = "tf-dbsubnet-group-coip-%[1]d"
+  }
+}
+
+data "aws_ec2_local_gateway_route_table" "test" {
+  outpost_arn = data.aws_outposts_outpost.test.arn
+}
+
+resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.test.id
+  vpc_id                       = aws_vpc.foo.id
+}
+
+data "aws_rds_engine_version" "test" {
+  engine = "mysql"
+version = "8.0.17"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.test.engine
+  engine_version             = data.aws_rds_engine_version.test.version
+  preferred_instance_classes = ["db.m5.large", "db.m5.xlarge", "db.r5.large"]
+}
+
+resource "aws_db_instance" "test" {
+  allocated_storage       = 10
+  backup_retention_period = 1
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
+  name                    = "baz"
+  parameter_group_name    = "default.${data.aws_rds_engine_version.test.parameter_group_family}"
+  password                = "barbarbarbar"
+  skip_final_snapshot     = true
+  username                = "foo"
+  db_subnet_group_name = aws_db_subnet_group.foo.name
+storage_encrypted       = true
+  customer_owned_ip_enabled = %[2]t
+
+  timeouts {
+    create = "180m"
+	update = "180m"
+  }
+}
+`, rInt, coipEnabled)
+}
+
+func testAccAWSDBInstanceConfig_CoipEnabled_RestorePointInTime(sourceCoipEnabled bool, targetCoipEnabled bool) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_Outpost_CoipEnabled(acctest.RandInt(), sourceCoipEnabled),
+		fmt.Sprintf(`
+resource "aws_db_instance" "restore" {
+  identifier     = "tf-acc-test-point-in-time-restore-%[1]d"
+  instance_class = aws_db_instance.test.instance_class
+  restore_to_point_in_time {
+    source_db_instance_identifier = aws_db_instance.test.identifier
+    use_latest_restorable_time    = true
+  }
+  skip_final_snapshot = true
+  customer_owned_ip_enabled = %[2]t
+
+  timeouts {
+    create = "180m"
+	update = "180m"
+  }
+}
+`, acctest.RandInt(), targetCoipEnabled))
+}
+
+func testAccAWSDBInstanceConfig_CoipEnabled_SnapshotIdentifier(rName string, sourceCoipEnabled bool, targetCoipEnabled bool) string {
+	return composeConfig(testAccAWSDBInstanceConfig_Outpost_CoipEnabled(acctest.RandInt(), sourceCoipEnabled), fmt.Sprintf(`
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = aws_db_instance.test.id
+  db_snapshot_identifier = %[1]q
+}
+
+resource "aws_db_instance" "target" {
+  customer_owned_ip_enabled = %[2]t
+  db_subnet_group_name = aws_db_subnet_group.foo.name
+storage_encrypted       = true
+  identifier                          = %[1]q
+  instance_class                      = aws_db_instance.test.instance_class
+  snapshot_identifier                 = aws_db_snapshot.test.id
+  skip_final_snapshot                 = true
+
+  timeouts {
+    create = "180m"
+	update = "180m"
+  }
+}
+`, rName, targetCoipEnabled))
 }

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -207,6 +207,7 @@ for more information.
 is provided) Username for the master DB user.
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to
 associate.
+* `customer_owned_ip_enabled` - (Optional) Indicates whether to enable a customer-owned IP address (CoIP) for an RDS on Outposts DB instance. See [CoIP for RDS on Outposts](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html#rds-on-outposts.coip) for more information.
 
 ~> **NOTE:** Removing the `replicate_source_db` attribute from an existing RDS
 Replicate database managed by Terraform will promote the database to a fully


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17165

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
enhancement:

resource/aws_db_instance: Add support for `customer_owned_ip_enabled` argument

```

### Affected Resource(s)
- resource: aws_db_instance

### Terraform Configuration
```HCL
resource "aws_db_instance" "foo" {
  customer_owned_ip_enabled = true
  allocated_storage         = 20
  engine                    = "mysql"
  engine_version            = "8.0.17"
  instance_class            = "db.m5.large"
  name                      = "foo"
  parameter_group_name      = "default.mysql8.0"
  password                  = "foobarbaz"
  username                  = "foo"
  db_subnet_group_name      = "foo-db-subnet-group"
  storage_encrypted         = true
}

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDBInstance_CoipEnabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSDBInstance_CoipEnabled -timeout 120m
=== RUN   TestAccAWSDBInstance_CoipEnabled
=== PAUSE TestAccAWSDBInstance_CoipEnabled
=== RUN   TestAccAWSDBInstance_CoipEnabled_DisabledToEnabled
=== PAUSE TestAccAWSDBInstance_CoipEnabled_DisabledToEnabled
=== RUN   TestAccAWSDBInstance_CoipEnabled_EnabledToDisabled
=== PAUSE TestAccAWSDBInstance_CoipEnabled_EnabledToDisabled
=== RUN   TestAccAWSDBInstance_CoipEnabled_RestoreToPointInTime
=== PAUSE TestAccAWSDBInstance_CoipEnabled_RestoreToPointInTime
=== RUN   TestAccAWSDBInstance_CoipEnabled_SnapshotIdentifier
=== PAUSE TestAccAWSDBInstance_CoipEnabled_SnapshotIdentifier
=== CONT  TestAccAWSDBInstance_CoipEnabled
=== CONT  TestAccAWSDBInstance_CoipEnabled_RestoreToPointInTime
=== CONT  TestAccAWSDBInstance_CoipEnabled_SnapshotIdentifier
=== CONT  TestAccAWSDBInstance_CoipEnabled_EnabledToDisabled
--- PASS: TestAccAWSDBInstance_CoipEnabled (550.70s)
--- PASS: TestAccAWSDBInstance_CoipEnabled_EnabledToDisabled (659.79s)
=== CONT  TestAccAWSDBInstance_CoipEnabled_DisabledToEnabled
--- PASS: TestAccAWSDBInstance_CoipEnabled_RestoreToPointInTime (1628.76s)
--- PASS: TestAccAWSDBInstance_CoipEnabled_SnapshotIdentifier (1852.34s)
--- PASS: TestAccAWSDBInstance_CoipEnabled_DisabledToEnabled (794.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       2006.422s

...
```
