### PR TITLE
r/waf_rule: catch referenced item exception when removing WAF rule; additional linting

### DIFF
--- a/.changelog/17876.txt
+++ b/.changelog/17876.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_waf_rule: Fix rule deletion when still referenced by a WebACL
+```

--- a/aws/resource_aws_waf_rule_test.go
+++ b/aws/resource_aws_waf_rule_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/waf/lister"
 )
@@ -45,6 +44,10 @@ func testSweepWafRules(region string) error {
 		}
 
 		for _, rule := range page.Rules {
+			if rule == nil {
+				continue
+			}
+
 			id := aws.StringValue(rule.RuleId)
 
 			r := resourceAwsWafRule()
@@ -166,7 +169,7 @@ func TestAccAWSWafRule_disappears(t *testing.T) {
 				Config: testAccAWSWafRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRuleExists(resourceName, &v),
-					testAccCheckAWSWafRuleDisappears(&v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsWafRule(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -179,7 +182,6 @@ func TestAccAWSWafRule_changePredicates(t *testing.T) {
 	var byteMatchSet waf.ByteMatchSet
 
 	var before, after waf.Rule
-	var idx int
 	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 	resourceName := "aws_waf_rule.wafrule"
 
@@ -195,7 +197,6 @@ func TestAccAWSWafRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRuleExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
-					computeWafRulePredicateWithIpSet(&ipset, false, "IPMatch", &idx),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "false",
 						"type":    "IPMatch",
@@ -209,7 +210,6 @@ func TestAccAWSWafRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRuleExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
-					computeWafRulePredicateWithByteMatchSet(&byteMatchSet, true, "ByteMatch", &idx),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "true",
 						"type":    "ByteMatch",
@@ -224,7 +224,6 @@ func TestAccAWSWafRule_geoMatchSetPredicate(t *testing.T) {
 	var geoMatchSet waf.GeoMatchSet
 
 	var v waf.Rule
-	var idx int
 	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 	resourceName := "aws_waf_rule.wafrule"
 
@@ -240,7 +239,6 @@ func TestAccAWSWafRule_geoMatchSetPredicate(t *testing.T) {
 					testAccCheckAWSWafRuleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
-					computeWafRulePredicateWithGeoMatchSet(&geoMatchSet, true, "GeoMatch", &idx),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "true",
 						"type":    "GeoMatch",
@@ -251,61 +249,29 @@ func TestAccAWSWafRule_geoMatchSetPredicate(t *testing.T) {
 	})
 }
 
-// computeWafRulePredicateWithIpSet calculates index
-// which isn't static because dataId is generated as part of the test
-func computeWafRulePredicateWithIpSet(ipSet *waf.IPSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		predicateResource := resourceAwsWafRule().Schema["predicates"].Elem.(*schema.Resource)
+// TestAccAWSWafRule_webACL validates the resource's
+// retry behavior when removed from a WebACL
+func TestAccAWSWafRule_webACL(t *testing.T) {
+	var rule waf.Rule
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_rule.test"
 
-		m := map[string]interface{}{
-			"data_id": *ipSet.IPSetId,
-			"negated": negated,
-			"type":    pType,
-		}
-
-		f := schema.HashResource(predicateResource)
-		*idx = f(m)
-
-		return nil
-	}
-}
-
-// computeWafRulePredicateWithByteMatchSet calculates index
-// which isn't static because dataId is generated as part of the test
-func computeWafRulePredicateWithByteMatchSet(set *waf.ByteMatchSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		predicateResource := resourceAwsWafRule().Schema["predicates"].Elem.(*schema.Resource)
-
-		m := map[string]interface{}{
-			"data_id": *set.ByteMatchSetId,
-			"negated": negated,
-			"type":    pType,
-		}
-
-		f := schema.HashResource(predicateResource)
-		*idx = f(m)
-
-		return nil
-	}
-}
-
-// computeWafRulePredicateWithGeoMatchSet calculates index
-// which isn't static because dataId is generated as part of the test
-func computeWafRulePredicateWithGeoMatchSet(set *waf.GeoMatchSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		predicateResource := resourceAwsWafRule().Schema["predicates"].Elem.(*schema.Resource)
-
-		m := map[string]interface{}{
-			"data_id": *set.GeoMatchSetId,
-			"negated": negated,
-			"type":    pType,
-		}
-
-		f := schema.HashResource(predicateResource)
-		*idx = f(m)
-
-		return nil
-	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRuleConfig_referencedByWebACL(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRuleExists(resourceName, &rule),
+				),
+			},
+			{
+				Config: testAccAWSWafWebAclConfig_noRules(rName),
+			},
+		},
+	})
 }
 
 func TestAccAWSWafRule_noPredicates(t *testing.T) {
@@ -383,49 +349,6 @@ func TestAccAWSWafRule_Tags(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSWafRuleDisappears(v *waf.Rule) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).wafconn
-
-		wr := newWafRetryer(conn)
-		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
-			req := &waf.UpdateRuleInput{
-				ChangeToken: token,
-				RuleId:      v.RuleId,
-			}
-
-			for _, Predicate := range v.Predicates {
-				Predicate := &waf.RuleUpdate{
-					Action: aws.String("DELETE"),
-					Predicate: &waf.Predicate{
-						Negated: Predicate.Negated,
-						Type:    Predicate.Type,
-						DataId:  Predicate.DataId,
-					},
-				}
-				req.Updates = append(req.Updates, Predicate)
-			}
-
-			return conn.UpdateRule(req)
-		})
-		if err != nil {
-			return fmt.Errorf("Error Updating WAF Rule: %s", err)
-		}
-
-		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
-			opts := &waf.DeleteRuleInput{
-				ChangeToken: token,
-				RuleId:      v.RuleId,
-			}
-			return conn.DeleteRule(opts)
-		})
-		if err != nil {
-			return fmt.Errorf("Error Deleting WAF Rule: %s", err)
-		}
-		return nil
-	}
-}
-
 func testAccCheckAWSWafRuleDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_waf_rule" {
@@ -438,20 +361,17 @@ func testAccCheckAWSWafRuleDestroy(s *terraform.State) error {
 				RuleId: aws.String(rs.Primary.ID),
 			})
 
-		if err == nil {
-			if *resp.Rule.RuleId == rs.Primary.ID {
-				return fmt.Errorf("WAF Rule %s still exists", rs.Primary.ID)
-			}
+		if tfawserr.ErrCodeEquals(err, waf.ErrCodeNonexistentItemException) {
+			continue
 		}
 
-		// Return nil if the Rule is already destroyed
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == waf.ErrCodeNonexistentItemException {
-				return nil
-			}
+		if err != nil {
+			return fmt.Errorf("error reading WAF Rule (%s): %w", rs.Primary.ID, err)
 		}
 
-		return err
+		if resp != nil && resp.Rule != nil {
+			return fmt.Errorf("WAF Rule (%s) still exists", rs.Primary.ID)
+		}
 	}
 
 	return nil
@@ -681,4 +601,59 @@ resource "aws_waf_rule" "wafrule" {
   }
 }
 `, rName, tag1Key, tag1Value, tag2Key, tag2Value)
+}
+
+func testAccAWSWafRuleConfig_referencedByWebACL(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_ipset" "test" {
+  name = %[1]q
+
+  ip_set_descriptors {
+    type  = "IPV4"
+    value = "192.0.7.0/24"
+  }
+}
+
+resource "aws_waf_rule" "test" {
+  metric_name = "testrulemetric"
+  name        = %[1]q
+
+  predicates {
+    data_id = aws_waf_ipset.test.id
+    negated = false
+    type    = "IPMatch"
+  }
+}
+
+resource "aws_waf_web_acl" "test" {
+  metric_name = "testwebaclmetric"
+  name        = %[1]q
+
+  default_action {
+    type = "ALLOW"
+  }
+
+  rules {
+    priority = 1
+    rule_id  = aws_waf_rule.test.id
+
+    action {
+      type = "BLOCK"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSWafWebAclConfig_noRules(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_web_acl" "test" {
+  metric_name = "testwebaclmetric"
+  name        = %[1]q
+
+  default_action {
+    type = "ALLOW"
+  }
+}
+`, rName)
 }

--- a/aws/resource_aws_waf_rule_test.go
+++ b/aws/resource_aws_waf_rule_test.go
@@ -505,7 +505,7 @@ func testAccPreCheckAWSWaf(t *testing.T) {
 func testAccAWSWafRuleConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+  name = %[1]q
 
   ip_set_descriptors {
     type  = "IPV4"
@@ -515,8 +515,8 @@ resource "aws_waf_ipset" "ipset" {
 
 resource "aws_waf_rule" "wafrule" {
   depends_on  = [aws_waf_ipset.ipset]
-  name        = "%s"
-  metric_name = "%s"
+  name        = %[1]q
+  metric_name = %[1]q
 
   predicates {
     data_id = aws_waf_ipset.ipset.id
@@ -524,13 +524,13 @@ resource "aws_waf_rule" "wafrule" {
     type    = "IPMatch"
   }
 }
-`, name, name, name)
+`, name)
 }
 
 func testAccAWSWafRuleConfigChangeName(name string) string {
 	return fmt.Sprintf(`
 resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+  name = %[1]q
 
   ip_set_descriptors {
     type  = "IPV4"
@@ -540,8 +540,8 @@ resource "aws_waf_ipset" "ipset" {
 
 resource "aws_waf_rule" "wafrule" {
   depends_on  = [aws_waf_ipset.ipset]
-  name        = "%s"
-  metric_name = "%s"
+  name        = %[1]q
+  metric_name = %[1]q
 
   predicates {
     data_id = aws_waf_ipset.ipset.id
@@ -549,13 +549,13 @@ resource "aws_waf_rule" "wafrule" {
     type    = "IPMatch"
   }
 }
-`, name, name, name)
+`, name)
 }
 
 func testAccAWSWafRuleConfig_changePredicates(name string) string {
 	return fmt.Sprintf(`
 resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+  name = %[1]q
 
   ip_set_descriptors {
     type  = "IPV4"
@@ -564,7 +564,7 @@ resource "aws_waf_ipset" "ipset" {
 }
 
 resource "aws_waf_byte_match_set" "set" {
-  name = "%s"
+  name = %[1]q
 
   byte_match_tuples {
     text_transformation   = "NONE"
@@ -579,8 +579,8 @@ resource "aws_waf_byte_match_set" "set" {
 }
 
 resource "aws_waf_rule" "wafrule" {
-  name        = "%s"
-  metric_name = "%s"
+  name        = %[1]q
+  metric_name = %[1]q
 
   predicates {
     data_id = aws_waf_byte_match_set.set.id
@@ -588,22 +588,22 @@ resource "aws_waf_rule" "wafrule" {
     type    = "ByteMatch"
   }
 }
-`, name, name, name, name)
+`, name)
 }
 
 func testAccAWSWafRuleConfig_noPredicates(name string) string {
 	return fmt.Sprintf(`
 resource "aws_waf_rule" "wafrule" {
-  name        = "%s"
-  metric_name = "%s"
+  name        = %[1]q
+  metric_name = %[1]q
 }
-`, name, name)
+`, name)
 }
 
 func testAccAWSWafRuleConfig_geoMatchSetPredicate(name string) string {
 	return fmt.Sprintf(`
 resource "aws_waf_geo_match_set" "geo_match_set" {
-  name = "%s"
+  name = %[1]q
 
   geo_match_constraint {
     type  = "Country"
@@ -612,8 +612,8 @@ resource "aws_waf_geo_match_set" "geo_match_set" {
 }
 
 resource "aws_waf_rule" "wafrule" {
-  name        = "%s"
-  metric_name = "%s"
+  name        = %[1]q
+  metric_name = %[1]q
 
   predicates {
     data_id = aws_waf_geo_match_set.geo_match_set.id
@@ -621,13 +621,13 @@ resource "aws_waf_rule" "wafrule" {
     type    = "GeoMatch"
   }
 }
-`, name, name, name)
+`, name)
 }
 
 func testAccAWSWafRuleConfigTags1(rName, tag1Key, tag1Value string) string {
 	return fmt.Sprintf(`
 resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+  name = %[1]q
 
   ip_set_descriptors {
     type  = "IPV4"
@@ -637,8 +637,8 @@ resource "aws_waf_ipset" "ipset" {
 
 resource "aws_waf_rule" "wafrule" {
   depends_on  = [aws_waf_ipset.ipset]
-  name        = "%s"
-  metric_name = "%s"
+  name        = %[1]q
+  metric_name = %[1]q
 
   predicates {
     data_id = aws_waf_ipset.ipset.id
@@ -650,13 +650,13 @@ resource "aws_waf_rule" "wafrule" {
     %q = %q
   }
 }
-`, rName, rName, rName, tag1Key, tag1Value)
+`, rName, tag1Key, tag1Value)
 }
 
 func testAccAWSWafRuleConfigTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
 resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+  name = %[1]q
 
   ip_set_descriptors {
     type  = "IPV4"
@@ -666,8 +666,8 @@ resource "aws_waf_ipset" "ipset" {
 
 resource "aws_waf_rule" "wafrule" {
   depends_on  = [aws_waf_ipset.ipset]
-  name        = "%s"
-  metric_name = "%s"
+  name        = %[1]q
+  metric_name = %[1]q
 
   predicates {
     data_id = aws_waf_ipset.ipset.id
@@ -680,5 +680,5 @@ resource "aws_waf_rule" "wafrule" {
     %q = %q
   }
 }
-`, rName, rName, rName, tag1Key, tag1Value, tag2Key, tag2Value)
+`, rName, tag1Key, tag1Value, tag2Key, tag2Value)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14957 
Relates #14601 
Relates https://github.com/hashicorp/terraform-provider-aws/issues/15945

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSWafWebAcl_disappears (14.62s)
--- PASS: TestAccAWSWafWebAcl_basic (32.22s)
--- PASS: TestAccAWSWafWebAcl_DefaultAction (38.11s)
--- PASS: TestAccAWSWafWebAcl_changeNameForceNew (42.26s)
--- PASS: TestAccAWSWafWebAcl_Rules (58.64s)
--- PASS: TestAccAWSWafWebAcl_Tags (66.27s)
--- PASS: TestAccAWSWafWebAcl_LoggingConfiguration (97.69s)

--- PASS: TestAccAWSWafRule_noPredicates (22.30s)
--- PASS: TestAccAWSWafRule_geoMatchSetPredicate (39.42s)
--- PASS: TestAccAWSWafRule_basic (45.11s)
--- PASS: TestAccAWSWafRule_disappears (45.55s)
--- PASS: TestAccAWSWafRule_webACL (57.04s)
--- PASS: TestAccAWSWafRule_Tags (58.97s)
--- PASS: TestAccAWSWafRule_changeNameForceNew (60.97s)
--- PASS: TestAccAWSWafRule_changePredicates (68.42s)
```

Sanity checking after test runs:
```bash
$ aws waf list-rules

{
    "Rules": []
}
```
```bash
$ aws waf list-web-acls

{
    "WebACLs": []
}
```