### PR TITLE
[WIP] Add KMS encryption support in aws_iam_access_key resource

### DIFF
--- a/.changelog/17892.txt
+++ b/.changelog/17892.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iam_access_key: Add secret access key encryption with KMS (symmetric)
+```

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -71,6 +71,8 @@ The following arguments are supported:
 * `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a
   keybase username in the form `keybase:some_person_that_exists`, for use
   in the `encrypted_secret` output attribute.
+* `kms_key` - (Optional) KMS CMK key id, alias or ARN, for use in the `encrypted_secret` output attribute. Does nothing if `pgp_key` set.
+* `kms_context` - (Optional) KMS encryption context for symmetric encryption, same context should be provided to decrypt data later.
 * `status` - (Optional) The access key status to apply. Defaults to `Active`.
 Valid values are `Active` and `Inactive`.
 
@@ -94,4 +96,4 @@ IAM Access Keys can be imported using the identifier, e.g.
 $ terraform import aws_iam_access_key.example AKIA1234567890
 ```
 
-Resource attributes such as `encrypted_secret`, `key_fingerprint`, `pgp_key`, `secret`, and `ses_smtp_password_v4` are not available for imported resources as this information cannot be read from the IAM API.
+Resource attributes such as `encrypted_secret`, `key_fingerprint`, `pgp_key`, `kms_key`, `secret`, and `ses_smtp_password_v4` are not available for imported resources as this information cannot be read from the IAM API.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #11053.

**Need help**
1. How should I get KMS instance/mock in acceptance test? 
2. Should I move KMS-related code to `aws/internal/encryption`?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
