### PR TITLE
Fix AWS DB Proxy target example to use correct name from default TG attribute

### DIFF
--- a/website/docs/r/db_proxy_target.html.markdown
+++ b/website/docs/r/db_proxy_target.html.markdown
@@ -51,7 +51,7 @@ resource "aws_db_proxy_default_target_group" "example" {
 resource "aws_db_proxy_target" "example" {
   db_instance_identifier = aws_db_instance.example.id
   db_proxy_name          = aws_db_proxy.example.name
-  target_group_name      = aws_db_proxy_default_target_group.example.db_proxy_name
+  target_group_name      = aws_db_proxy_default_target_group.example.name
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

The example was using a bad output attribute from the default target group and when followed would lead to errors like:

```
Error: error registering RDS DB Proxy ($db_proxy_name/$db_proxy_target_group_name) Target: DBProxyTargetGroupNotFoundFault: Requested resource not found - TargetGroup: $db_proxy_target_group_name
```

We can see in the [docs for the aws_db_proxy_default_target_group
 resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy_default_target_group), that `db_proxy_name` is not a valid attribute.

I wasn't sure if a changelog entry was necessary for small updates to documentation examples but if needed, just let me know.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
