### PR TITLE
Add "storage-optimization" to Neptune cluster instance create/update pending states

### DIFF
--- a/.changelog/17901.txt
+++ b/.changelog/17901.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_neptune_cluster_instance: Add "storage-optimization" to Neptune cluster instance create/update pending states
+```

--- a/aws/resource_aws_neptune_cluster_instance.go
+++ b/aws/resource_aws_neptune_cluster_instance.go
@@ -491,6 +491,7 @@ var resourceAwsNeptuneClusterInstanceCreateUpdatePendingStates = []string{
 	"upgrading",
 	"configuring-log-exports",
 	"configuring-enhanced-monitoring",
+	"storage-optimization",
 }
 
 var resourceAwsNeptuneClusterInstanceDeletePendingStates = []string{


### PR DESCRIPTION
I've found when a Neptune instance is resized I now get the following
error:

     Error: unexpected state 'storage-optimization', wanted target 'available'. last error: %!s(<nil>)

This is very similar to https://github.com/hashicorp/terraform-provider-aws/pull/15284

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
