### PR TITLE
aws_route_table: Add arn attribute

### DIFF
--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -114,6 +114,11 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 
 			"tags": tagsSchema(),
 
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -37,6 +37,7 @@ func TestAccAWSDefaultRouteTable_basic(t *testing.T) {
 				Config: testAccDefaultRouteTableConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -97,6 +98,7 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -116,6 +118,7 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					// The route block from the previous step should still be
@@ -131,6 +134,7 @@ func TestAccAWSDefaultRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					// This config uses attribute syntax to set zero routes
@@ -164,6 +168,7 @@ func TestAccAWSDefaultRouteTable_swap(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -157,6 +157,7 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -236,6 +237,7 @@ func TestAccAWSRouteTable_IPv4_To_InternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "2"),
@@ -250,6 +252,7 @@ func TestAccAWSRouteTable_IPv4_To_InternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "2"),
@@ -286,6 +289,7 @@ func TestAccAWSRouteTable_IPv4_To_Instance(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -321,6 +325,7 @@ func TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -442,6 +447,7 @@ func TestAccAWSRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "2"),
@@ -461,6 +467,7 @@ func TestAccAWSRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "2"),
@@ -480,6 +487,7 @@ func TestAccAWSRouteTable_Route_ConfigMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -513,6 +521,7 @@ func TestAccAWSRouteTable_IPv4_To_TransitGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -547,6 +556,7 @@ func TestAccAWSRouteTable_IPv4_To_VpcEndpoint(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -581,6 +591,7 @@ func TestAccAWSRouteTable_IPv4_To_LocalGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -615,6 +626,7 @@ func TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -649,6 +661,7 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "propagating_vgws.*", vgwResourceName1, "id"),
@@ -662,6 +675,7 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "propagating_vgws.*", vgwResourceName2, "id"),
@@ -733,6 +747,7 @@ func TestAccAWSRouteTable_IPv4_To_NatGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -768,6 +783,7 @@ func TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
@@ -800,6 +816,7 @@ func TestAccAWSRouteTable_VpcMultipleCidrs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -831,6 +848,7 @@ func TestAccAWSRouteTable_VpcClassicLink(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -868,6 +886,7 @@ func TestAccAWSRouteTable_GatewayVpcEndpoint(t *testing.T) {
 					// Refresh the route table once the VPC endpoint route is present.
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
@@ -911,6 +930,7 @@ func TestAccAWSRouteTable_MultipleRoutes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 5),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "3"),
@@ -929,6 +949,7 @@ func TestAccAWSRouteTable_MultipleRoutes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 5),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "3"),
@@ -947,6 +968,7 @@ func TestAccAWSRouteTable_MultipleRoutes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 5),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`route-table/rtb-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "propagating_vgws.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "route.#", "3"),

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -89,6 +89,7 @@ In addition to all arguments above, the following attributes are exported:
 attribute once the route resource is created.
 
 * `id` - The ID of the routing table.
+* `arn` - ARN of the route table.
 * `owner_id` - The ID of the AWS account that owns the route table.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 10 -run=TestAccAWSRouteTable_\|TestAccAWSDefaultRouteTable_ -timeout 120m
=== RUN   TestAccAWSDefaultRouteTable_basic
=== PAUSE TestAccAWSDefaultRouteTable_basic
=== RUN   TestAccAWSDefaultRouteTable_disappears_Vpc
=== PAUSE TestAccAWSDefaultRouteTable_disappears_Vpc
=== RUN   TestAccAWSDefaultRouteTable_Route_ConfigMode
=== PAUSE TestAccAWSDefaultRouteTable_Route_ConfigMode
=== RUN   TestAccAWSDefaultRouteTable_swap
=== PAUSE TestAccAWSDefaultRouteTable_swap
=== RUN   TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway
=== PAUSE TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway
=== RUN   TestAccAWSDefaultRouteTable_IPv4_To_VpcEndpoint
=== PAUSE TestAccAWSDefaultRouteTable_IPv4_To_VpcEndpoint
=== RUN   TestAccAWSDefaultRouteTable_VpcEndpointAssociation
=== PAUSE TestAccAWSDefaultRouteTable_VpcEndpointAssociation
=== RUN   TestAccAWSDefaultRouteTable_tags
=== PAUSE TestAccAWSDefaultRouteTable_tags
=== RUN   TestAccAWSDefaultRouteTable_ConditionalCidrBlock
=== PAUSE TestAccAWSDefaultRouteTable_ConditionalCidrBlock
=== RUN   TestAccAWSRouteTable_basic
=== PAUSE TestAccAWSRouteTable_basic
=== RUN   TestAccAWSRouteTable_disappears
=== PAUSE TestAccAWSRouteTable_disappears
=== RUN   TestAccAWSRouteTable_disappears_SubnetAssociation
=== PAUSE TestAccAWSRouteTable_disappears_SubnetAssociation
=== RUN   TestAccAWSRouteTable_IPv4_To_InternetGateway
=== PAUSE TestAccAWSRouteTable_IPv4_To_InternetGateway
=== RUN   TestAccAWSRouteTable_IPv4_To_Instance
=== PAUSE TestAccAWSRouteTable_IPv4_To_Instance
=== RUN   TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway
=== PAUSE TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway
=== RUN   TestAccAWSRouteTable_tags
=== PAUSE TestAccAWSRouteTable_tags
=== RUN   TestAccAWSRouteTable_RequireRouteDestination
=== PAUSE TestAccAWSRouteTable_RequireRouteDestination
=== RUN   TestAccAWSRouteTable_RequireRouteTarget
=== PAUSE TestAccAWSRouteTable_RequireRouteTarget
=== RUN   TestAccAWSRouteTable_Route_ConfigMode
=== PAUSE TestAccAWSRouteTable_Route_ConfigMode
=== RUN   TestAccAWSRouteTable_IPv4_To_TransitGateway
=== PAUSE TestAccAWSRouteTable_IPv4_To_TransitGateway
=== RUN   TestAccAWSRouteTable_IPv4_To_VpcEndpoint
=== PAUSE TestAccAWSRouteTable_IPv4_To_VpcEndpoint
=== RUN   TestAccAWSRouteTable_IPv4_To_LocalGateway
=== PAUSE TestAccAWSRouteTable_IPv4_To_LocalGateway
=== RUN   TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection
=== PAUSE TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
=== PAUSE TestAccAWSRouteTable_vgwRoutePropagation
=== RUN   TestAccAWSRouteTable_ConditionalCidrBlock
=== PAUSE TestAccAWSRouteTable_ConditionalCidrBlock
=== RUN   TestAccAWSRouteTable_IPv4_To_NatGateway
=== PAUSE TestAccAWSRouteTable_IPv4_To_NatGateway
=== RUN   TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached
=== PAUSE TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached
=== RUN   TestAccAWSRouteTable_VpcMultipleCidrs
=== PAUSE TestAccAWSRouteTable_VpcMultipleCidrs
=== RUN   TestAccAWSRouteTable_VpcClassicLink
=== PAUSE TestAccAWSRouteTable_VpcClassicLink
=== RUN   TestAccAWSRouteTable_GatewayVpcEndpoint
=== PAUSE TestAccAWSRouteTable_GatewayVpcEndpoint
=== RUN   TestAccAWSRouteTable_MultipleRoutes
=== PAUSE TestAccAWSRouteTable_MultipleRoutes
=== CONT  TestAccAWSDefaultRouteTable_basic
=== CONT  TestAccAWSRouteTable_RequireRouteDestination
=== CONT  TestAccAWSDefaultRouteTable_ConditionalCidrBlock
=== CONT  TestAccAWSRouteTable_MultipleRoutes
=== CONT  TestAccAWSRouteTable_disappears
=== CONT  TestAccAWSRouteTable_tags
=== CONT  TestAccAWSRouteTable_disappears_SubnetAssociation
=== CONT  TestAccAWSRouteTable_IPv4_To_InternetGateway
=== CONT  TestAccAWSRouteTable_GatewayVpcEndpoint
=== CONT  TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway
--- PASS: TestAccAWSRouteTable_disappears (55.46s)
=== CONT  TestAccAWSRouteTable_VpcClassicLink
--- PASS: TestAccAWSRouteTable_disappears_SubnetAssociation (57.35s)
=== CONT  TestAccAWSRouteTable_VpcMultipleCidrs
--- PASS: TestAccAWSRouteTable_GatewayVpcEndpoint (78.09s)
=== CONT  TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached
--- PASS: TestAccAWSDefaultRouteTable_basic (101.85s)
=== CONT  TestAccAWSRouteTable_IPv4_To_NatGateway
--- PASS: TestAccAWSRouteTable_VpcClassicLink (65.07s)
=== CONT  TestAccAWSRouteTable_ConditionalCidrBlock
--- PASS: TestAccAWSDefaultRouteTable_ConditionalCidrBlock (121.07s)
=== CONT  TestAccAWSRouteTable_vgwRoutePropagation
--- PASS: TestAccAWSRouteTable_IPv4_To_InternetGateway (122.87s)
=== CONT  TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection
--- PASS: TestAccAWSRouteTable_VpcMultipleCidrs (75.99s)
=== CONT  TestAccAWSRouteTable_IPv4_To_LocalGateway
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSRouteTable_IPv4_To_LocalGateway (0.29s)
=== CONT  TestAccAWSRouteTable_IPv4_To_VpcEndpoint
--- PASS: TestAccAWSRouteTable_tags (162.18s)
=== CONT  TestAccAWSRouteTable_IPv4_To_TransitGateway
--- PASS: TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached (92.71s)
=== CONT  TestAccAWSRouteTable_Route_ConfigMode
--- PASS: TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection (53.91s)
=== CONT  TestAccAWSRouteTable_RequireRouteTarget
--- PASS: TestAccAWSRouteTable_RequireRouteTarget (24.44s)
=== CONT  TestAccAWSDefaultRouteTable_VpcEndpointAssociation
--- PASS: TestAccAWSRouteTable_ConditionalCidrBlock (94.25s)
=== CONT  TestAccAWSDefaultRouteTable_tags
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (112.83s)
=== CONT  TestAccAWSRouteTable_basic
--- PASS: TestAccAWSRouteTable_MultipleRoutes (260.17s)
=== CONT  TestAccAWSDefaultRouteTable_swap
--- PASS: TestAccAWSDefaultRouteTable_VpcEndpointAssociation (63.56s)
=== CONT  TestAccAWSDefaultRouteTable_disappears_Vpc
--- PASS: TestAccAWSRouteTable_basic (56.72s)
=== CONT  TestAccAWSDefaultRouteTable_IPv4_To_VpcEndpoint
--- PASS: TestAccAWSDefaultRouteTable_disappears_Vpc (36.81s)
=== CONT  TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (136.54s)
=== CONT  TestAccAWSRouteTable_IPv4_To_Instance
--- PASS: TestAccAWSDefaultRouteTable_tags (97.22s)
=== CONT  TestAccAWSDefaultRouteTable_Route_ConfigMode
--- PASS: TestAccAWSRouteTable_RequireRouteDestination (356.86s)
--- PASS: TestAccAWSDefaultRouteTable_IPv4_To_TransitGateway (362.81s)
--- PASS: TestAccAWSRouteTable_IPv4_To_NatGateway (265.29s)
--- PASS: TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway (77.40s)
--- PASS: TestAccAWSDefaultRouteTable_swap (145.93s)
=== CONT  TestAccAWSDefaultRouteTable_Route_ConfigMode
    resource_aws_default_route_table_test.go:90: Step 4/4 error: Check failed: Check 2/8 error: Route Table has incorrect number of routes (Expected=1, Actual=2)
--- PASS: TestAccAWSRouteTable_IPv4_To_Instance (117.21s)
--- FAIL: TestAccAWSDefaultRouteTable_Route_ConfigMode (117.06s)
--- PASS: TestAccAWSRouteTable_IPv4_To_VpcEndpoint (374.54s)
--- PASS: TestAccAWSRouteTable_IPv4_To_TransitGateway (359.86s)
--- PASS: TestAccAWSDefaultRouteTable_IPv4_To_VpcEndpoint (404.97s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	697.474s
FAIL
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 10 -run=TestAccAWSDefaultRouteTable_Route_ConfigMode -timeout 120m
=== RUN   TestAccAWSDefaultRouteTable_Route_ConfigMode
=== PAUSE TestAccAWSDefaultRouteTable_Route_ConfigMode
=== CONT  TestAccAWSDefaultRouteTable_Route_ConfigMode
--- PASS: TestAccAWSDefaultRouteTable_Route_ConfigMode (126.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	127.965s
```
