### PR TITLE
Add StateFunc to store values in lower case

### DIFF
--- a/.changelog/17909.txt
+++ b/.changelog/17909.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:enhancement
 resource/aws_db_parameter_group: Store all values in lowercase to prevent unexpected diffs
 ```

--- a/.changelog/17909.txt
+++ b/.changelog/17909.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_parameter_group: Store all values in lowercase to prevent unexpected diffs
+```

--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -70,11 +70,17 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 						"value": {
 							Type:     schema.TypeString,
 							Required: true,
+							StateFunc: func(v interface{}) string {
+								return strings.ToLower(v.(string))
+							},
 						},
 						"apply_method": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "immediate",
+							StateFunc: func(v interface{}) string {
+								return strings.ToLower(v.(string))
+							},
+							Default: "immediate",
 						},
 					},
 				},

--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -166,6 +166,22 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBParameterGroup_caseWithMixedParameters(t *testing.T) {
+	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBParameterGroupConfigCaseWithMixedParameters(groupName),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 	var v rds.DBParameterGroup
 	resourceName := "aws_db_parameter_group.test"
@@ -286,7 +302,7 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "event_scheduler",
-						"value": "ON",
+						"value": "on",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "innodb_buffer_pool_dump_at_shutdown",
@@ -322,7 +338,7 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "log_output",
-						"value": "FILE",
+						"value": "file",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "max_allowed_packet",
@@ -346,7 +362,7 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "tx_isolation",
-						"value": "REPEATABLE-READ",
+						"value": "repeatable-read",
 					}),
 				),
 			},
@@ -465,7 +481,7 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "event_scheduler",
-						"value": "ON",
+						"value": "on",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "innodb_buffer_pool_dump_at_shutdown",
@@ -501,7 +517,7 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "log_output",
-						"value": "FILE",
+						"value": "file",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "max_allowed_packet",
@@ -525,7 +541,7 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						"name":  "tx_isolation",
-						"value": "REPEATABLE-READ",
+						"value": "repeatable-read",
 					}),
 				),
 			},
@@ -905,6 +921,51 @@ resource "aws_db_parameter_group" "test" {
   }
 }
 `, n)
+}
+
+func testAccAWSDBParameterGroupConfigCaseWithMixedParameters(n string) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
+resource "aws_db_parameter_group" "test" {
+  name   = %[1]q
+  family = "mysql5.6"
+
+  parameter {
+    name         = "character_set_server"
+    value        = "utf8mb4"
+    apply_method = "pending-reboot"
+  }
+  parameter {
+    name         = "innodb_large_prefix"
+    value        = 1
+    apply_method = "pending-reboot"
+  }
+  parameter {
+    name         = "innodb_file_format"
+    value        = "Barracuda"
+    apply_method = "pending-reboot"
+  }
+  parameter {
+    name         = "innodb_log_file_size"
+    value        = 2147483648
+    apply_method = "pending-reboot"
+  }
+  parameter {
+    name         = "sql_mode"
+    value        = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+    apply_method = "pending-reboot"
+  }
+  parameter {
+    name         = "innodb_log_buffer_size"
+    value        = 268435456
+    apply_method = "pending-reboot"
+  }
+  parameter {
+    name         = "max_allowed_packet"
+    value        = 268435456
+    apply_method = "pending-reboot"
+  }
+}
+`, n))
 }
 
 func testAccAWSDBParameterGroupConfigWithApplyMethod(n string) string {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #15583 

Output from acceptance testing:

```
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBParameterGroup_ -timeout 120m
=== RUN   TestAccAWSDBParameterGroup_basic
=== PAUSE TestAccAWSDBParameterGroup_basic
=== RUN   TestAccAWSDBParameterGroup_caseWithMixedParameters
=== PAUSE TestAccAWSDBParameterGroup_caseWithMixedParameters
=== RUN   TestAccAWSDBParameterGroup_limit
=== PAUSE TestAccAWSDBParameterGroup_limit
=== RUN   TestAccAWSDBParameterGroup_Disappears
=== PAUSE TestAccAWSDBParameterGroup_Disappears
=== RUN   TestAccAWSDBParameterGroup_namePrefix
=== PAUSE TestAccAWSDBParameterGroup_namePrefix
=== RUN   TestAccAWSDBParameterGroup_generatedName
=== PAUSE TestAccAWSDBParameterGroup_generatedName
=== RUN   TestAccAWSDBParameterGroup_withApplyMethod
=== PAUSE TestAccAWSDBParameterGroup_withApplyMethod
=== RUN   TestAccAWSDBParameterGroup_Only
=== PAUSE TestAccAWSDBParameterGroup_Only
=== RUN   TestAccAWSDBParameterGroup_MatchDefault
=== PAUSE TestAccAWSDBParameterGroup_MatchDefault
=== RUN   TestAccAWSDBParameterGroup_updateParameters
=== PAUSE TestAccAWSDBParameterGroup_updateParameters
=== CONT  TestAccAWSDBParameterGroup_basic
=== CONT  TestAccAWSDBParameterGroup_withApplyMethod
=== CONT  TestAccAWSDBParameterGroup_MatchDefault
=== CONT  TestAccAWSDBParameterGroup_Only
=== CONT  TestAccAWSDBParameterGroup_caseWithMixedParameters
=== CONT  TestAccAWSDBParameterGroup_updateParameters
=== CONT  TestAccAWSDBParameterGroup_namePrefix
=== CONT  TestAccAWSDBParameterGroup_limit
=== CONT  TestAccAWSDBParameterGroup_Disappears
=== CONT  TestAccAWSDBParameterGroup_generatedName
--- PASS: TestAccAWSDBParameterGroup_Disappears (12.86s)
--- PASS: TestAccAWSDBParameterGroup_generatedName (16.50s)
--- PASS: TestAccAWSDBParameterGroup_namePrefix (20.30s)
--- PASS: TestAccAWSDBParameterGroup_Only (23.25s)
--- PASS: TestAccAWSDBParameterGroup_MatchDefault (25.28s)
--- PASS: TestAccAWSDBParameterGroup_caseWithMixedParameters (27.35s)
--- PASS: TestAccAWSDBParameterGroup_withApplyMethod (29.02s)
--- PASS: TestAccAWSDBParameterGroup_updateParameters (42.27s)
--- PASS: TestAccAWSDBParameterGroup_basic (47.21s)
--- PASS: TestAccAWSDBParameterGroup_limit (50.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.358s
```