### PR TITLE
tests/cloudhsmv2: Remove deprecated type constraints

### DIFF
--- a/aws/data_source_aws_cloudhsm2_cluster_test.go
+++ b/aws/data_source_aws_cloudhsm2_cluster_test.go
@@ -12,7 +12,7 @@ func TestAccDataSourceCloudHsmV2Cluster_basic(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_cluster.cluster"
 	dataSourceName := "data.aws_cloudhsm_v2_cluster.default"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -31,7 +31,7 @@ func TestAccDataSourceCloudHsmV2Cluster_basic(t *testing.T) {
 	})
 }
 
-var testAccCheckCloudHsmV2ClusterDataSourceConfig = testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+var testAccCheckCloudHsmV2ClusterDataSourceConfig = composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = list(string)
@@ -69,4 +69,4 @@ resource "aws_cloudhsm_v2_cluster" "cluster" {
 data "aws_cloudhsm_v2_cluster" "default" {
   cluster_id = aws_cloudhsm_v2_cluster.cluster.cluster_id
 }
-`, acctest.RandInt())
+`, acctest.RandInt()))

--- a/aws/data_source_aws_cloudhsm2_cluster_test.go
+++ b/aws/data_source_aws_cloudhsm2_cluster_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceCloudHsmV2Cluster_basic(t *testing.T) {
 var testAccCheckCloudHsmV2ClusterDataSourceConfig = testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "cloudhsm_v2_test_vpc" {

--- a/aws/resource_aws_cloudhsm2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm2_cluster_test.go
@@ -160,7 +160,7 @@ func testAccAWSCloudHsmV2ClusterConfigBase() string {
 	return `
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {

--- a/aws/resource_aws_cloudhsm2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm2_cluster_test.go
@@ -195,16 +195,16 @@ resource "aws_subnet" "cloudhsm_v2_test_subnets" {
 }
 
 func testAccAWSCloudHsmV2ClusterConfig() string {
-	return testAccAWSCloudHsmV2ClusterConfigBase() + `
+	return composeConfig(testAccAWSCloudHsmV2ClusterConfigBase(), `
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type   = "hsm1.medium"
   subnet_ids = [aws_subnet.cloudhsm_v2_test_subnets.*.id[0], aws_subnet.cloudhsm_v2_test_subnets.*.id[1]]
 }
-`
+`)
 }
 
 func testAccAWSCloudHsmV2ClusterConfigTags1(tagKey1, tagValue1 string) string {
-	return testAccAWSCloudHsmV2ClusterConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAWSCloudHsmV2ClusterConfigBase(), fmt.Sprintf(`
 resource "aws_cloudhsm_v2_cluster" "test" {
   hsm_type   = "hsm1.medium"
   subnet_ids = [aws_subnet.cloudhsm_v2_test_subnets.*.id[0], aws_subnet.cloudhsm_v2_test_subnets.*.id[1]]
@@ -213,11 +213,11 @@ resource "aws_cloudhsm_v2_cluster" "test" {
     %[1]q = %[2]q
   }
 }
-`, tagKey1, tagValue1)
+`, tagKey1, tagValue1))
 }
 
 func testAccAWSCloudHsmV2ClusterConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAWSCloudHsmV2ClusterConfigBase() + fmt.Sprintf(`
+	return composeConfig(testAccAWSCloudHsmV2ClusterConfigBase(), fmt.Sprintf(`
 resource "aws_cloudhsm_v2_cluster" "test" {
   hsm_type   = "hsm1.medium"
   subnet_ids = [aws_subnet.cloudhsm_v2_test_subnets.*.id[0], aws_subnet.cloudhsm_v2_test_subnets.*.id[1]]
@@ -227,7 +227,7 @@ resource "aws_cloudhsm_v2_cluster" "test" {
     %[3]q = %[4]q
   }
 }
-`, tagKey1, tagValue1, tagKey2, tagValue2)
+`, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccCheckAWSCloudHsmV2ClusterDestroy(s *terraform.State) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17920

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccDataSourceCloudHsmV2Cluster_basic (282.13s)
--- PASS: TestAccAWSCloudHsmV2Cluster_basic (281.88s)
--- PASS: TestAccAWSCloudHsmV2Cluster_Tags (320.42s)
```

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccDataSourceCloudHsmV2Cluster_basic (247.83s)
--- PASS: TestAccAWSCloudHsmV2Cluster_basic (279.64s)
--- PASS: TestAccAWSCloudHsmV2Cluster_Tags (354.01s)
```
