### PR TITLE
tests/lblistenerrule: Remove deprecated type constraints

### DIFF
--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -1326,7 +1326,7 @@ resource "aws_lb_target_group" "test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -1476,7 +1476,7 @@ resource "aws_lb_target_group" "test2" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -1631,7 +1631,7 @@ resource "aws_lb_target_group" "test2" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -1770,7 +1770,7 @@ resource "aws_lb_target_group" "test2" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -1891,7 +1891,7 @@ resource "aws_alb_target_group" "test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -2004,7 +2004,7 @@ resource "aws_lb" "alb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -2117,7 +2117,7 @@ resource "aws_lb" "alb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -2238,7 +2238,7 @@ resource "aws_lb_target_group" "test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -2370,7 +2370,7 @@ resource "aws_lb_target_group" "test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -2475,7 +2475,7 @@ resource "aws_lb_target_group" "test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -2534,7 +2534,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccAWSLBListenerRuleConfig_priorityFirst(lbName, targetGroupName string) string {
-	return testAccAWSLBListenerRuleConfig_priorityBase(lbName, targetGroupName) + `
+	return composeConfig(testAccAWSLBListenerRuleConfig_priorityBase(lbName, targetGroupName), `
 resource "aws_lb_listener_rule" "first" {
   listener_arn = aws_lb_listener.front_end.arn
 
@@ -2567,11 +2567,11 @@ resource "aws_lb_listener_rule" "third" {
 
   depends_on = [aws_lb_listener_rule.first]
 }
-`
+`)
 }
 
 func testAccAWSLBListenerRuleConfig_priorityLast(lbName, targetGroupName string) string {
-	return testAccAWSLBListenerRuleConfig_priorityFirst(lbName, targetGroupName) + `
+	return composeConfig(testAccAWSLBListenerRuleConfig_priorityFirst(lbName, targetGroupName), `
 resource "aws_lb_listener_rule" "last" {
   listener_arn = aws_lb_listener.front_end.arn
 
@@ -2586,11 +2586,11 @@ resource "aws_lb_listener_rule" "last" {
     }
   }
 }
-`
+`)
 }
 
 func testAccAWSLBListenerRuleConfig_priorityStatic(lbName, targetGroupName string) string {
-	return testAccAWSLBListenerRuleConfig_priorityFirst(lbName, targetGroupName) + `
+	return composeConfig(testAccAWSLBListenerRuleConfig_priorityFirst(lbName, targetGroupName), `
 resource "aws_lb_listener_rule" "last" {
   listener_arn = aws_lb_listener.front_end.arn
   priority     = 7
@@ -2606,11 +2606,11 @@ resource "aws_lb_listener_rule" "last" {
     }
   }
 }
-`
+`)
 }
 
 func testAccAWSLBListenerRuleConfig_priorityParallelism(lbName, targetGroupName string) string {
-	return testAccAWSLBListenerRuleConfig_priorityStatic(lbName, targetGroupName) + `
+	return composeConfig(testAccAWSLBListenerRuleConfig_priorityStatic(lbName, targetGroupName), `
 resource "aws_lb_listener_rule" "parallelism" {
   count = 10
 
@@ -2627,11 +2627,11 @@ resource "aws_lb_listener_rule" "parallelism" {
     }
   }
 }
-`
+`)
 }
 
 func testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName string) string {
-	return testAccAWSLBListenerRuleConfig_priorityBase(lbName, targetGroupName) + `
+	return composeConfig(testAccAWSLBListenerRuleConfig_priorityBase(lbName, targetGroupName), `
 resource "aws_lb_listener_rule" "priority50000" {
   listener_arn = aws_lb_listener.front_end.arn
   priority     = 50000
@@ -2647,12 +2647,12 @@ resource "aws_lb_listener_rule" "priority50000" {
     }
   }
 }
-`
+`)
 }
 
 // priority out of range (1, 50000)
 func testAccAWSLBListenerRuleConfig_priority50001(lbName, targetGroupName string) string {
-	return testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName) + `
+	return composeConfig(testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName), `
 resource "aws_lb_listener_rule" "priority50001" {
   listener_arn = aws_lb_listener.front_end.arn
 
@@ -2667,11 +2667,11 @@ resource "aws_lb_listener_rule" "priority50001" {
     }
   }
 }
-`
+`)
 }
 
 func testAccAWSLBListenerRuleConfig_priorityInUse(lbName, targetGroupName string) string {
-	return testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName) + `
+	return composeConfig(testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName), `
 resource "aws_lb_listener_rule" "priority50000_in_use" {
   listener_arn = aws_lb_listener.front_end.arn
   priority     = 50000
@@ -2687,7 +2687,7 @@ resource "aws_lb_listener_rule" "priority50000_in_use" {
     }
   }
 }
-`
+`)
 }
 
 func testAccAWSLBListenerRuleConfig_cognito(rName, key, certificate string) string {
@@ -2775,7 +2775,7 @@ resource "aws_lb_target_group" "test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -2942,7 +2942,7 @@ resource "aws_lb_target_group" "test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {
@@ -3287,7 +3287,7 @@ resource "aws_lb" "alb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 data "aws_availability_zones" "available" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17920

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader_invalid (4.24s)
--- PASS: TestAccAWSLBListenerRule_conditionAttributesCount (35.16s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (182.81s)
--- FAIL: TestAccAWSLBListenerRule_cognito (194.06s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader (192.10s)
--- PASS: TestAccAWSLBListenerRule_basic (197.77s)
--- PASS: TestAccAWSLBListenerRule_conditionQueryString (200.66s)
--- PASS: TestAccAWSLBListenerRule_Action_Order (203.55s)
--- PASS: TestAccAWSLBListenerRule_conditionHostHeader (204.16s)
--- PASS: TestAccAWSLBListenerRule_conditionPathPattern (204.72s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpRequestMethod (206.58s)
--- PASS: TestAccAWSLBListenerRule_oidc (207.22s)
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (209.13s)
--- PASS: TestAccAWSLBListenerRule_updateFixedResponse (230.48s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (243.80s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMixed (253.42s)
--- PASS: TestAccAWSLBListenerRule_BackwardsCompatibility (235.62s)
--- PASS: TestAccAWSLBListenerRule_conditionSourceIp (294.67s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMultiple (295.30s)
--- PASS: TestAccAWSLBListenerRule_conditionMultiple (301.84s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (332.98s)
--- PASS: TestAccAWSLBListenerRule_redirect (176.03s)
--- PASS: TestAccAWSLBListenerRule_forwardWeighted (233.10s)
--- PASS: TestAccAWSLBListenerRule_priority (446.34s)
```

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader_invalid (4.09s)
--- PASS: TestAccAWSLBListenerRule_conditionAttributesCount (22.39s)
--- PASS: TestAccAWSLBListenerRule_conditionQueryString (182.12s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpRequestMethod (183.32s)
--- PASS: TestAccAWSLBListenerRule_redirect (184.68s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader (186.73s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (189.68s)
--- PASS: TestAccAWSLBListenerRule_conditionMultiple (192.44s)
--- PASS: TestAccAWSLBListenerRule_basic (194.54s)
--- PASS: TestAccAWSLBListenerRule_BackwardsCompatibility (195.08s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMultiple (204.30s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (207.77s)
--- PASS: TestAccAWSLBListenerRule_updateFixedResponse (216.77s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (224.27s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMixed (228.96s)
--- PASS: TestAccAWSLBListenerRule_conditionPathPattern (233.38s)
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (211.76s)
--- PASS: TestAccAWSLBListenerRule_cognito (237.65s)
--- PASS: TestAccAWSLBListenerRule_conditionHostHeader (238.09s)
--- PASS: TestAccAWSLBListenerRule_conditionSourceIp (240.59s)
--- PASS: TestAccAWSLBListenerRule_oidc (253.29s)
--- PASS: TestAccAWSLBListenerRule_Action_Order (179.54s)
--- PASS: TestAccAWSLBListenerRule_priority (379.60s)
--- PASS: TestAccAWSLBListenerRule_forwardWeighted (228.37s)
```