### PR TITLE
tests/lb: Remove deprecated type constraints

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1513,7 +1513,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1669,7 +1669,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1738,7 +1738,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -1805,7 +1805,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2194,7 +2194,7 @@ resource "aws_alb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2261,7 +2261,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2327,7 +2327,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2407,7 +2407,7 @@ output "lb_name" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2482,7 +2482,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2550,7 +2550,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2779,7 +2779,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {
@@ -2822,7 +2822,7 @@ resource "aws_lb" "lb_test" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 resource "aws_vpc" "alb_test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17920

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSLB_LoadBalancerType_Gateway (1.73s)
--- SKIP: TestAccAWSLB_ALB_outpost (2.02s)
--- SKIP: TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing (0.40s)
--- PASS: TestAccAWSLB_noSecurityGroup (191.72s)
--- PASS: TestAccAWSLB_generatedName (191.95s)
--- PASS: TestAccAWSLB_namePrefix (211.80s)
--- PASS: TestAccAWSLB_NLB_basic (224.51s)
--- PASS: TestAccAWSLB_IPv6SubnetMapping (226.08s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (229.51s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (236.40s)
--- PASS: TestAccAWSLB_ALB_basic (246.97s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (262.50s)
--- PASS: TestAccAWSLB_updatedSubnets (265.76s)
--- PASS: TestAccAWSLB_updatedIpAddressType (284.75s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields (302.02s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (324.76s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (325.83s)
--- PASS: TestAccAWSLB_tags (329.00s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (346.66s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (359.57s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (360.56s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (177.78s)
--- PASS: TestAccAWSLB_BackwardsCompatibility (178.39s)
--- PASS: TestAccAWSLB_ALB_AccessLogs (389.90s)
--- PASS: TestAccAWSLB_NLB_privateipv4address (219.19s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (468.31s)
```

Output from acceptance testing (`us-west-2`):

```
--- SKIP: TestAccAWSLB_ALB_outpost (1.41s)
--- PASS: TestAccAWSLB_noSecurityGroup (181.59s)
--- PASS: TestAccAWSLB_ALB_basic (189.85s)
--- PASS: TestAccAWSLB_namePrefix (190.49s)
--- PASS: TestAccAWSLB_BackwardsCompatibility (197.60s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (198.02s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (236.59s)
--- PASS: TestAccAWSLB_generatedName (243.54s)
--- PASS: TestAccAWSLB_NLB_privateipv4address (244.76s)
--- PASS: TestAccAWSLB_updatedIpAddressType (261.23s)
--- PASS: TestAccAWSLB_updatedSubnets (291.94s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields (303.12s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (305.66s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway (109.64s)
--- PASS: TestAccAWSLB_tags (309.86s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (311.02s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (312.94s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (336.34s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (339.34s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (372.56s)
--- PASS: TestAccAWSLB_ALB_AccessLogs (378.91s)
--- PASS: TestAccAWSLB_IPv6SubnetMapping (212.10s)
--- PASS: TestAccAWSLB_NLB_basic (214.43s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (433.14s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (272.46s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing (274.30s)
```