### PR TITLE
tests/shield: Remove deprecated type constraints

### DIFF
--- a/aws/resource_aws_shield_protection_test.go
+++ b/aws/resource_aws_shield_protection_test.go
@@ -300,7 +300,7 @@ data "aws_availability_zones" "available" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 variable "name" {
@@ -370,7 +370,7 @@ data "aws_availability_zones" "available" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }
 
 variable "name" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17920 

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSShieldProtection_Alb (1.29s)
--- SKIP: TestAccAWSShieldProtection_Elb (1.29s)
```

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSShieldProtection_Elb (42.29s)
--- PASS: TestAccAWSShieldProtection_Alb (172.87s)
```