### PR TITLE
r/aws_lambda_event_source_mapping: Correct attribute updates

### DIFF
--- a/.changelog/17933.txt
+++ b/.changelog/17933.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_lambda_event_source_mapping: Fix update of `batch_size` for MSK event source mappings
+```
+
+```release-note:enhancement
+resource/aws_lambda_event_source_mapping: Don't incorrectly update unspecified `maximum_batching_window_in_seconds`, `maximum_record_age_in_seconds` and `maximum_retry_attempts` arguments from their default values
+```

--- a/aws/internal/service/lambda/finder/finder.go
+++ b/aws/internal/service/lambda/finder/finder.go
@@ -1,0 +1,45 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// EventSourceMappingConfigurationByID returns the event source mapping corresponding to the specified ID.
+// Returns NotFoundError if no event source mapping is found.
+func EventSourceMappingConfigurationByID(conn *lambda.Lambda, uuid string) (*lambda.EventSourceMappingConfiguration, error) {
+	input := &lambda.GetEventSourceMappingInput{
+		UUID: aws.String(uuid),
+	}
+
+	return EventSourceMappingConfiguration(conn, input)
+}
+
+// EventSourceMappingConfiguration returns the event source mapping corresponding to the specified input.
+// Returns NotFoundError if no event source mapping is found.
+func EventSourceMappingConfiguration(conn *lambda.Lambda, input *lambda.GetEventSourceMappingInput) (*lambda.EventSourceMappingConfiguration, error) {
+	output, err := conn.GetEventSourceMapping(input)
+
+	if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle any empty result.
+	if output == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}

--- a/aws/internal/service/lambda/waiter/status.go
+++ b/aws/internal/service/lambda/waiter/status.go
@@ -3,8 +3,9 @@ package waiter
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lambda/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -18,13 +19,9 @@ const (
 
 func EventSourceMappingState(conn *lambda.Lambda, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &lambda.GetEventSourceMappingInput{
-			UUID: aws.String(id),
-		}
+		eventSourceMappingConfiguration, err := finder.EventSourceMappingConfigurationByID(conn, id)
 
-		output, err := conn.GetEventSourceMapping(input)
-
-		if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceNotFoundException) {
+		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}
 
@@ -32,10 +29,6 @@ func EventSourceMappingState(conn *lambda.Lambda, id string) resource.StateRefre
 			return nil, "", err
 		}
 
-		if output == nil {
-			return nil, "", nil
-		}
-
-		return output, aws.StringValue(output.State), nil
+		return eventSourceMappingConfiguration, aws.StringValue(eventSourceMappingConfiguration.State), nil
 	}
 }

--- a/aws/internal/service/lambda/waiter/status.go
+++ b/aws/internal/service/lambda/waiter/status.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	EventSourceMappingStateCreating  = "Creating"
+	EventSourceMappingStateDeleting  = "Deleting"
 	EventSourceMappingStateDisabled  = "Disabled"
 	EventSourceMappingStateDisabling = "Disabling"
 	EventSourceMappingStateEnabled   = "Enabled"

--- a/aws/internal/service/lambda/waiter/waiter.go
+++ b/aws/internal/service/lambda/waiter/waiter.go
@@ -16,6 +16,8 @@ const (
 	LambdaFunctionPublishTimeout         = 5 * time.Minute
 	LambdaFunctionPutConcurrencyTimeout  = 1 * time.Minute
 	LambdaFunctionExtraThrottlingTimeout = 9 * time.Minute
+
+	EventSourceMappingPropagationTimeout = 5 * time.Minute
 )
 
 func EventSourceMappingCreate(conn *lambda.Lambda, id string) (*lambda.EventSourceMappingConfiguration, error) {

--- a/aws/internal/service/lambda/waiter/waiter.go
+++ b/aws/internal/service/lambda/waiter/waiter.go
@@ -10,6 +10,7 @@ import (
 const (
 	EventSourceMappingCreateTimeout      = 10 * time.Minute
 	EventSourceMappingUpdateTimeout      = 10 * time.Minute
+	EventSourceMappingDeleteTimeout      = 5 * time.Minute
 	LambdaFunctionCreateTimeout          = 5 * time.Minute
 	LambdaFunctionUpdateTimeout          = 5 * time.Minute
 	LambdaFunctionPublishTimeout         = 5 * time.Minute
@@ -30,6 +31,23 @@ func EventSourceMappingCreate(conn *lambda.Lambda, id string) (*lambda.EventSour
 		},
 		Refresh: EventSourceMappingState(conn, id),
 		Timeout: EventSourceMappingCreateTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*lambda.EventSourceMappingConfiguration); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func EventSourceMappingDelete(conn *lambda.Lambda, id string) (*lambda.EventSourceMappingConfiguration, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{EventSourceMappingStateDeleting},
+		Target:  []string{},
+		Refresh: EventSourceMappingState(conn, id),
+		Timeout: EventSourceMappingDeleteTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -457,5 +457,9 @@ func resourceAwsLambdaEventSourceMappingDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("error deleting Lambda Event Source Mapping (%s): %w", d.Id(), err)
 	}
 
+	if _, err := waiter.EventSourceMappingDelete(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for Lambda Event Source Mapping (%s) to delete: %w", d.Id(), err)
+	}
+
 	return nil
 }

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -911,7 +911,7 @@ func testAccCheckAwsLambdaEventSourceMappingExists(n string, v *lambda.EventSour
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Lambda Event Source Mapping is set")
+			return fmt.Errorf("no Lambda Event Source Mapping is set")
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).lambdaconn

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -734,7 +734,7 @@ func TestAccAWSLambdaEventSourceMapping_MSK(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, lambda.EndpointsID, "kafka"), //using kafka.EndpointsID will import kafka and make linters sad
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
 		Steps: []resource.TestStep{
@@ -892,7 +892,7 @@ func testAccCheckLambdaEventSourceMappingDestroy(s *terraform.State) error {
 		}
 
 		if err != nil {
-			return err
+			return fmt.Errorf("error reading Lambda Event Source Mapping (%s): %w", rs.Primary.ID, err)
 		}
 
 		return fmt.Errorf("Lambda Event Source Mapping %s still exists", rs.Primary.ID)
@@ -907,11 +907,11 @@ func testAccCheckAwsLambdaEventSourceMappingExists(n string, v *lambda.EventSour
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf(" Lambda Event Source Mapping resource not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("no Lambda Event Source Mapping is set")
+			return fmt.Errorf("no Lambda Event Source Mapping ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).lambdaconn

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -19,10 +19,18 @@ import (
 )
 
 func init() {
+	RegisterServiceErrorCheckFunc(lambda.EndpointsID, testAccErrorCheckSkipLambda)
+
 	resource.AddTestSweepers("aws_lambda_function", &resource.Sweeper{
 		Name: "aws_lambda_function",
 		F:    testSweepLambdaFunctions,
 	})
+}
+
+func testAccErrorCheckSkipLambda(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"InvalidParameterValueException: Unsupported source arn",
+	)
 }
 
 func testSweepLambdaFunctions(region string) error {

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Lambda"
 layout: "aws"
 page_title: "AWS: aws_lambda_event_source_mapping"
 description: |-
-  Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB and SQS
+  Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB, SQS and Managed Streaming for Apache Kafka (MSK).
 ---
 
 # Resource: aws_lambda_event_source_mapping
 
-Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB and SQS.
+Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB, SQS and Managed Streaming for Apache Kafka (MSK).
 
 For information about Lambda and how to use it, see [What is AWS Lambda?][1].
 For information about event source mappings, see [CreateEventSourceMapping][2] in the API docs.
@@ -35,7 +35,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 }
 ```
 
-### Managed Streaming for Kafka (MSK)
+### Managed Streaming for Apache Kafka (MSK)
 
 ```terraform
 resource "aws_lambda_event_source_mapping" "example" {
@@ -58,7 +58,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 ## Argument Reference
 
 * `batch_size` - (Optional) The largest number of records that Lambda will retrieve from your event source at the time of invocation. Defaults to `100` for DynamoDB, Kinesis and MSK, `10` for SQS.
-* `maximum_batching_window_in_seconds` - (Optional) The maximum amount of time to gather records before invoking the function, in seconds (between 0 and 300). Records will continue to buffer (or accumulate in the case of an SQS queue event source) until either `maximum_batching_window_in_seconds` expires or `batch_size` has been met. For streaming event sources, defaults to as soon as records are available in the stream. If the batch it reads from the stream/queue only has one record in it, Lambda only sends one record to the function.
+* `maximum_batching_window_in_seconds` - (Optional) The maximum amount of time to gather records before invoking the function, in seconds (between 0 and 300). Records will continue to buffer (or accumulate in the case of an SQS queue event source) until either `maximum_batching_window_in_seconds` expires or `batch_size` has been met. For streaming event sources, defaults to as soon as records are available in the stream. If the batch it reads from the stream/queue only has one record in it, Lambda only sends one record to the function. Only available for stream sources (DynamoDB and Kinesis) and SQS standard queues.
 * `event_source_arn` - (Required) The event source ARN - can be a Kinesis stream, DynamoDB stream, SQS queue or MSK cluster.
 * `enabled` - (Optional) Determines if the mapping will be enabled on creation. Defaults to `true`.
 * `function_name` - (Required) The name or the ARN of the Lambda function that will be subscribing to events.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17888.
Closes #15753.
Closes #14522.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLambdaEventSourceMapping_' ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSLambdaEventSourceMapping_ -timeout 120m
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_kinesis_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
=== PAUSE TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
=== RUN   TestAccAWSLambdaEventSourceMapping_sqs_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_sqs_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
=== PAUSE TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
=== RUN   TestAccAWSLambdaEventSourceMapping_SQSBatchWindow
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQSBatchWindow
=== RUN   TestAccAWSLambdaEventSourceMapping_disappears
=== PAUSE TestAccAWSLambdaEventSourceMapping_disappears
=== RUN   TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
=== PAUSE TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
=== RUN   TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp
=== PAUSE TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp
=== RUN   TestAccAWSLambdaEventSourceMapping_KinesisBatchWindow
=== PAUSE TestAccAWSLambdaEventSourceMapping_KinesisBatchWindow
=== RUN   TestAccAWSLambdaEventSourceMapping_ParallelizationFactor
=== PAUSE TestAccAWSLambdaEventSourceMapping_ParallelizationFactor
=== RUN   TestAccAWSLambdaEventSourceMapping_MaximumRetryAttempts
=== PAUSE TestAccAWSLambdaEventSourceMapping_MaximumRetryAttempts
=== RUN   TestAccAWSLambdaEventSourceMapping_MaximumRetryAttemptsZero
=== PAUSE TestAccAWSLambdaEventSourceMapping_MaximumRetryAttemptsZero
=== RUN   TestAccAWSLambdaEventSourceMapping_MaximumRecordAgeInSeconds
=== PAUSE TestAccAWSLambdaEventSourceMapping_MaximumRecordAgeInSeconds
=== RUN   TestAccAWSLambdaEventSourceMapping_BisectBatch
=== PAUSE TestAccAWSLambdaEventSourceMapping_BisectBatch
=== RUN   TestAccAWSLambdaEventSourceMapping_KinesisDestinationConfig
=== PAUSE TestAccAWSLambdaEventSourceMapping_KinesisDestinationConfig
=== RUN   TestAccAWSLambdaEventSourceMapping_MSK
=== PAUSE TestAccAWSLambdaEventSourceMapping_MSK
=== CONT  TestAccAWSLambdaEventSourceMapping_kinesis_basic
=== CONT  TestAccAWSLambdaEventSourceMapping_ParallelizationFactor
=== CONT  TestAccAWSLambdaEventSourceMapping_MSK
--- PASS: TestAccAWSLambdaEventSourceMapping_ParallelizationFactor (74.28s)
=== CONT  TestAccAWSLambdaEventSourceMapping_KinesisDestinationConfig
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_basic (80.01s)
=== CONT  TestAccAWSLambdaEventSourceMapping_BisectBatch
--- PASS: TestAccAWSLambdaEventSourceMapping_KinesisDestinationConfig (73.97s)
=== CONT  TestAccAWSLambdaEventSourceMapping_MaximumRecordAgeInSeconds
--- PASS: TestAccAWSLambdaEventSourceMapping_BisectBatch (71.95s)
=== CONT  TestAccAWSLambdaEventSourceMapping_MaximumRetryAttemptsZero
--- PASS: TestAccAWSLambdaEventSourceMapping_MaximumRecordAgeInSeconds (72.22s)
=== CONT  TestAccAWSLambdaEventSourceMapping_MaximumRetryAttempts
--- PASS: TestAccAWSLambdaEventSourceMapping_MaximumRetryAttemptsZero (85.38s)
=== CONT  TestAccAWSLambdaEventSourceMapping_disappears
--- PASS: TestAccAWSLambdaEventSourceMapping_MaximumRetryAttempts (71.67s)
=== CONT  TestAccAWSLambdaEventSourceMapping_KinesisBatchWindow
--- PASS: TestAccAWSLambdaEventSourceMapping_disappears (77.31s)
=== CONT  TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp
--- PASS: TestAccAWSLambdaEventSourceMapping_KinesisBatchWindow (71.84s)
=== CONT  TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
--- PASS: TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp (58.54s)
=== CONT  TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName (34.83s)
=== CONT  TestAccAWSLambdaEventSourceMapping_SQSBatchWindow
--- PASS: TestAccAWSLambdaEventSourceMapping_SQSBatchWindow (45.48s)
=== CONT  TestAccAWSLambdaEventSourceMapping_sqs_basic
--- PASS: TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected (103.07s)
=== CONT  TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize (70.70s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_basic (106.17s)
--- PASS: TestAccAWSLambdaEventSourceMapping_MSK (1812.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1812.846s
```
