### PR TITLE
resource_aws_ec2_traffic_mirror_session: Correct ARN

### DIFF
--- a/aws/resource_aws_ec2_traffic_mirror_session.go
+++ b/aws/resource_aws_ec2_traffic_mirror_session.go
@@ -35,6 +35,10 @@ func resourceAwsEc2TrafficMirrorSession() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"packet_length": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -217,14 +221,14 @@ func resourceAwsEc2TrafficMirrorSessionRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
+	d.Set("owner_id", session.OwnerId)
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(session.OwnerId),
 		Resource:  fmt.Sprintf("traffic-mirror-session/%s", d.Id()),
 	}.String()
-
 	d.Set("arn", arn)
 
 	return nil

--- a/aws/resource_aws_ec2_traffic_mirror_session_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_session_test.go
@@ -40,6 +40,7 @@ func TestAccAWSEc2TrafficMirrorSession_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "session_number", strconv.Itoa(session)),
 					resource.TestMatchResourceAttr(resourceName, "virtual_network_id", regexp.MustCompile(`\d+`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`traffic-mirror-session/tms-.+`)),
 				),
 			},

--- a/website/docs/r/ec2_traffic_mirror_session.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_session.html.markdown
@@ -52,6 +52,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the traffic mirror session.
 * `id` - The name of the session.
+* `owner_id` - The AWS account ID of the session owner.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16978

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2TrafficMirrorSession_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TrafficMirrorSession_basic -timeout 120m
=== RUN   TestAccAWSEc2TrafficMirrorSession_basic
=== PAUSE TestAccAWSEc2TrafficMirrorSession_basic
=== CONT  TestAccAWSEc2TrafficMirrorSession_basic
--- PASS: TestAccAWSEc2TrafficMirrorSession_basic (505.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	507.041s
```

Thank you for your review!