### PR TITLE
[Proof of Concept] provider: default tags implementation

### DIFF
--- a/.changelog/17941.txt
+++ b/.changelog/17941.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Add `default_tags` argument (in public preview, see note above)
+```

--- a/aws/config.go
+++ b/aws/config.go
@@ -191,9 +191,10 @@ type Config struct {
 	AllowedAccountIds   []string
 	ForbiddenAccountIds []string
 
-	Endpoints        map[string]string
-	IgnoreTagsConfig *keyvaluetags.IgnoreConfig
-	Insecure         bool
+	DefaultTagsConfig *keyvaluetags.DefaultConfig
+	Endpoints         map[string]string
+	IgnoreTagsConfig  *keyvaluetags.IgnoreConfig
+	Insecure          bool
 
 	SkipCredsValidation     bool
 	SkipGetEC2Platforms     bool
@@ -249,6 +250,7 @@ type AWSClient struct {
 	datapipelineconn                    *datapipeline.DataPipeline
 	datasyncconn                        *datasync.DataSync
 	daxconn                             *dax.DAX
+	DefaultTagsConfig                   *keyvaluetags.DefaultConfig
 	devicefarmconn                      *devicefarm.DeviceFarm
 	dlmconn                             *dlm.DLM
 	dmsconn                             *databasemigrationservice.DatabaseMigrationService
@@ -492,6 +494,7 @@ func (c *Config) Client() (interface{}, error) {
 		datapipelineconn:                    datapipeline.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["datapipeline"])})),
 		datasyncconn:                        datasync.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["datasync"])})),
 		daxconn:                             dax.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["dax"])})),
+		DefaultTagsConfig:                   c.DefaultTagsConfig,
 		devicefarmconn:                      devicefarm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["devicefarm"])})),
 		dlmconn:                             dlm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["dlm"])})),
 		dmsconn:                             databasemigrationservice.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["dms"])})),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -89,6 +89,23 @@ func Provider() *schema.Provider {
 				Set:           schema.HashString,
 			},
 
+			"default_tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Configuration block with settings to default resource tags across all resources.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tags": {
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "Resource tags to default across all resources",
+						},
+					},
+				},
+			},
+
 			"endpoints": endpointsSchema(),
 
 			"ignore_tags": {
@@ -1337,6 +1354,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		Token:                   d.Get("token").(string),
 		Region:                  d.Get("region").(string),
 		CredsFilename:           d.Get("shared_credentials_file").(string),
+		DefaultTagsConfig:       expandProviderDefaultTags(d.Get("default_tags").([]interface{})),
 		Endpoints:               make(map[string]string),
 		MaxRetries:              d.Get("max_retries").(int),
 		IgnoreTagsConfig:        expandProviderIgnoreTags(d.Get("ignore_tags").([]interface{})),
@@ -1520,6 +1538,20 @@ func endpointsSchema() *schema.Schema {
 			Schema: endpointsAttributes,
 		},
 	}
+}
+
+func expandProviderDefaultTags(l []interface{}) *keyvaluetags.DefaultConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	defaultConfig := &keyvaluetags.DefaultConfig{}
+	m := l[0].(map[string]interface{})
+
+	if v, ok := m["tags"].(map[string]interface{}); ok {
+		defaultConfig.Tags = keyvaluetags.New(v)
+	}
+	return defaultConfig
 }
 
 func expandProviderIgnoreTags(l []interface{}) *keyvaluetags.IgnoreConfig {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17826 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccProvider_DefaultTags_Tags_One (5.33s)
--- PASS: TestAccProvider_DefaultTags_Tags_Multiple (5.34s)
--- PASS: TestAccProvider_DefaultTags_Tags_None (5.39s)
--- PASS: TestAccProvider_DefaultTags_EmptyConfigurationBlock (5.46s)

--- PASS: TestAccAWSProvider_Region_AwsChina (11.31s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (11.65s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (11.73s)
--- PASS: TestAccAWSProvider_Region_AwsC2S (11.75s)
--- PASS: TestAccAWSProvider_Region_AwsSC2S (12.66s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (13.84s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (13.84s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (13.84s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (13.96s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (14.06s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (14.18s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (14.20s)
--- PASS: TestAccAWSProvider_Endpoints (14.31s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (16.85s)
```
