### PR TITLE
aws_ec2_traffic_mirror_target: Correct arn

### DIFF
--- a/aws/resource_aws_ec2_traffic_mirror_target.go
+++ b/aws/resource_aws_ec2_traffic_mirror_target.go
@@ -21,6 +21,10 @@ func resourceAwsEc2TrafficMirrorTarget() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -45,11 +49,11 @@ func resourceAwsEc2TrafficMirrorTarget() *schema.Resource {
 				},
 				ValidateFunc: validateArn,
 			},
-			"tags": tagsSchema(),
-			"arn": {
+			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -133,11 +137,13 @@ func resourceAwsEc2TrafficMirrorTargetRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
+	d.Set("owner_id", target.OwnerId)
+
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Service:   ec2.ServiceName,
 		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: aws.StringValue(target.OwnerId),
 		Resource:  fmt.Sprintf("traffic-mirror-target/%s", d.Id()),
 	}.String()
 

--- a/aws/resource_aws_ec2_traffic_mirror_target_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_target_test.go
@@ -30,6 +30,7 @@ func TestAccAWSEc2TrafficMirrorTarget_nlb(t *testing.T) {
 				Config: testAccTrafficMirrorTargetConfigNlb(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TrafficMirrorTargetExists(resourceName, &v),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`traffic-mirror-target/tmt-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrPair(resourceName, "network_load_balancer_arn", "aws_lb.lb", "arn"),

--- a/website/docs/r/ec2_traffic_mirror_target.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_target.html.markdown
@@ -44,6 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the Traffic Mirror target.
 * `arn` - The ARN of the traffic mirror target.
+* `owner_id` - The ID of the AWS account that owns the traffic mirror target.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16978

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2TrafficMirrorTarget_nlb'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TrafficMirrorTarget_nlb -timeout 120m
=== RUN   TestAccAWSEc2TrafficMirrorTarget_nlb
=== PAUSE TestAccAWSEc2TrafficMirrorTarget_nlb
=== CONT  TestAccAWSEc2TrafficMirrorTarget_nlb
--- PASS: TestAccAWSEc2TrafficMirrorTarget_nlb (505.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	507.174s
```

Thank you for your review! 👍 