### PR TITLE
r/aws_globalaccelerator_accelerator: Correct name validation length

### DIFF
--- a/.changelog/17985.txt
+++ b/.changelog/17985.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_globalaccelerator_accelerator: Correct length for `name` attribute validation
+```

--- a/aws/resource_aws_globalaccelerator_accelerator.go
+++ b/aws/resource_aws_globalaccelerator_accelerator.go
@@ -43,7 +43,7 @@ func resourceAwsGlobalAcceleratorAccelerator() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 32),
+					validation.StringLenBetween(1, 255),
 					validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z-]+$`), "only alphanumeric characters and hyphens are allowed"),
 					validation.StringDoesNotMatch(regexp.MustCompile(`^-`), "cannot start with a hyphen"),
 					validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "cannot end with a hyphen"),

--- a/aws/resource_aws_globalaccelerator_listener.go
+++ b/aws/resource_aws_globalaccelerator_listener.go
@@ -41,21 +41,15 @@ func resourceAwsGlobalAcceleratorListener() *schema.Resource {
 				ForceNew: true,
 			},
 			"client_affinity": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  globalaccelerator.ClientAffinityNone,
-				ValidateFunc: validation.StringInSlice([]string{
-					globalaccelerator.ClientAffinityNone,
-					globalaccelerator.ClientAffinitySourceIp,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      globalaccelerator.ClientAffinityNone,
+				ValidateFunc: validation.StringInSlice(globalaccelerator.ClientAffinity_Values(), false),
 			},
 			"protocol": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					globalaccelerator.ProtocolTcp,
-					globalaccelerator.ProtocolUdp,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(globalaccelerator.Protocol_Values(), false),
 			},
 			"port_range": {
 				Type:     schema.TypeSet,
@@ -67,12 +61,12 @@ func resourceAwsGlobalAcceleratorListener() *schema.Resource {
 						"from_port": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(0, 65535),
+							ValidateFunc: validation.IsPortNumber,
 						},
 						"to_port": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(0, 65535),
+							ValidateFunc: validation.IsPortNumber,
 						},
 					},
 				},
@@ -97,7 +91,7 @@ func resourceAwsGlobalAcceleratorListenerCreate(d *schema.ResourceData, meta int
 
 	resp, err := conn.CreateListener(opts)
 	if err != nil {
-		return fmt.Errorf("Error creating Global Accelerator listener: %s", err)
+		return fmt.Errorf("error creating Global Accelerator listener: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.Listener.ListenerArn))
@@ -135,7 +129,7 @@ func resourceAwsGlobalAcceleratorListenerRead(d *schema.ResourceData, meta inter
 	d.Set("client_affinity", listener.ClientAffinity)
 	d.Set("protocol", listener.Protocol)
 	if err := d.Set("port_range", resourceAwsGlobalAcceleratorListenerFlattenPortRanges(listener.PortRanges)); err != nil {
-		return fmt.Errorf("error setting port_range: %s", err)
+		return fmt.Errorf("error setting port_range: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/17978.
Relates: #14601.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ ACCTEST_PARALLELISM=2 make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsGlobalAcceleratorListener_\|TestAccAwsGlobalAcceleratorAccelerator_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAwsGlobalAcceleratorListener_\|TestAccAwsGlobalAcceleratorAccelerator_ -timeout 120m
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_basic
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_basic
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_disappears
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_disappears
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_update
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_update
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_attributes
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_attributes
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_tags
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_tags
=== RUN   TestAccAwsGlobalAcceleratorListener_basic
=== PAUSE TestAccAwsGlobalAcceleratorListener_basic
=== RUN   TestAccAwsGlobalAcceleratorListener_disappears
=== PAUSE TestAccAwsGlobalAcceleratorListener_disappears
=== RUN   TestAccAwsGlobalAcceleratorListener_update
=== PAUSE TestAccAwsGlobalAcceleratorListener_update
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_basic
=== CONT  TestAccAwsGlobalAcceleratorListener_basic
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_basic (70.93s)
=== CONT  TestAccAwsGlobalAcceleratorListener_update
--- PASS: TestAccAwsGlobalAcceleratorListener_basic (113.72s)
=== CONT  TestAccAwsGlobalAcceleratorListener_disappears
--- PASS: TestAccAwsGlobalAcceleratorListener_update (180.45s)
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_attributes
--- PASS: TestAccAwsGlobalAcceleratorListener_disappears (151.63s)
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_tags
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_tags (98.71s)
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_update
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_disappears
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_update (144.97s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_attributes (280.63s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_disappears (64.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	573.286s
```
