### PR TITLE
linter: Replace time.Time == time.Time with time.Equals()

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -221,3 +221,29 @@ rules:
               $X, $Y := $ERR.(*resource.NotFoundError)
           - pattern-not-inside: func isResourceNotFoundError(err error) bool { ... }
     severity: WARNING
+
+  - id: time-equality
+    languages: [go]
+    message: Use time.Equal() instead of ==
+    paths:
+      include:
+        - aws/
+    patterns:
+      - pattern-either:
+        - pattern: |
+            aws.TimeValue($X) == $Y
+        - pattern: |
+            aws.TimeValue($X) != $Y
+        - pattern: |
+            ($X : time.Time) == $Y
+        - pattern: |
+            ($X : time.Time) != $Y
+        - pattern: |
+            $X == aws.TimeValue($Y)
+        - pattern: |
+            $X != aws.TimeValue($Y)
+        - pattern: |
+            $X == ($Y : time.Time)
+        - pattern: |
+            $X != ($Y : time.Time)
+    severity: WARNING

--- a/aws/resource_aws_api_gateway_api_key_test.go
+++ b/aws/resource_aws_api_gateway_api_key_test.go
@@ -269,7 +269,7 @@ func testAccCheckAWSAPIGatewayApiKeyDestroy(s *terraform.State) error {
 
 func testAccCheckAWSAPIGatewayApiKeyNotRecreated(i, j *apigateway.ApiKey) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedDate) != aws.TimeValue(j.CreatedDate) {
+		if !aws.TimeValue(i.CreatedDate).Equal(aws.TimeValue(j.CreatedDate)) {
 			return fmt.Errorf("API Gateway API Key recreated")
 		}
 

--- a/aws/resource_aws_api_gateway_deployment_test.go
+++ b/aws/resource_aws_api_gateway_deployment_test.go
@@ -331,7 +331,7 @@ func testAccCheckAWSAPIGatewayDeploymentDestroy(s *terraform.State) error {
 
 func testAccCheckAWSAPIGatewayDeploymentNotRecreated(i, j *apigateway.Deployment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedDate) != aws.TimeValue(j.CreatedDate) {
+		if !aws.TimeValue(i.CreatedDate).Equal(aws.TimeValue(j.CreatedDate)) {
 			return fmt.Errorf("API Gateway Deployment recreated")
 		}
 
@@ -341,7 +341,7 @@ func testAccCheckAWSAPIGatewayDeploymentNotRecreated(i, j *apigateway.Deployment
 
 func testAccCheckAWSAPIGatewayDeploymentRecreated(i, j *apigateway.Deployment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedDate) == aws.TimeValue(j.CreatedDate) {
+		if aws.TimeValue(i.CreatedDate).Equal(aws.TimeValue(j.CreatedDate)) {
 			return fmt.Errorf("API Gateway Deployment not recreated")
 		}
 

--- a/aws/resource_aws_apigatewayv2_deployment_test.go
+++ b/aws/resource_aws_apigatewayv2_deployment_test.go
@@ -192,7 +192,7 @@ func testAccCheckAWSAPIGatewayV2DeploymentExists(n string, vApiId *string, v *ap
 
 func testAccCheckAWSAPIGatewayV2DeploymentNotRecreated(i, j *apigatewayv2.GetDeploymentOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedDate) != aws.TimeValue(j.CreatedDate) {
+		if !aws.TimeValue(i.CreatedDate).Equal(aws.TimeValue(j.CreatedDate)) {
 			return fmt.Errorf("API Gateway V2 Deployment recreated")
 		}
 
@@ -202,7 +202,7 @@ func testAccCheckAWSAPIGatewayV2DeploymentNotRecreated(i, j *apigatewayv2.GetDep
 
 func testAccCheckAWSAPIGatewayV2DeploymentRecreated(i, j *apigatewayv2.GetDeploymentOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedDate) == aws.TimeValue(j.CreatedDate) {
+		if aws.TimeValue(i.CreatedDate).Equal(aws.TimeValue(j.CreatedDate)) {
 			return fmt.Errorf("API Gateway V2 Deployment not recreated")
 		}
 

--- a/aws/resource_aws_codedeploy_app_test.go
+++ b/aws/resource_aws_codedeploy_app_test.go
@@ -220,7 +220,7 @@ func testAccCheckAWSCodeDeployAppExists(name string, application *codedeploy.App
 
 func testAccCheckAWSCodeDeployAppRecreated(i, j *codedeploy.ApplicationInfo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreateTime) == aws.TimeValue(j.CreateTime) {
+		if aws.TimeValue(i.CreateTime).Equal(aws.TimeValue(j.CreateTime)) {
 			return errors.New("CodeDeploy Application was not recreated")
 		}
 

--- a/aws/resource_aws_codedeploy_deployment_config_test.go
+++ b/aws/resource_aws_codedeploy_deployment_config_test.go
@@ -273,7 +273,7 @@ func testAccCheckAWSCodeDeployDeploymentConfigExists(name string, config *codede
 
 func testAccCheckAWSCodeDeployDeploymentConfigRecreated(i, j *codedeploy.DeploymentConfigInfo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreateTime) == aws.TimeValue(j.CreateTime) {
+		if aws.TimeValue(i.CreateTime).Equal(aws.TimeValue(j.CreateTime)) {
 			return errors.New("CodeDeploy Deployment Config was not recreated")
 		}
 

--- a/aws/resource_aws_datasync_agent_test.go
+++ b/aws/resource_aws_datasync_agent_test.go
@@ -275,7 +275,7 @@ func testAccCheckAWSDataSyncAgentDisappears(agent *datasync.DescribeAgentOutput)
 
 func testAccCheckAWSDataSyncAgentNotRecreated(i, j *datasync.DescribeAgentOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreationTime) != aws.TimeValue(j.CreationTime) {
+		if !aws.TimeValue(i.CreationTime).Equal(aws.TimeValue(j.CreationTime)) {
 			return errors.New("DataSync Agent was recreated")
 		}
 

--- a/aws/resource_aws_datasync_location_efs_test.go
+++ b/aws/resource_aws_datasync_location_efs_test.go
@@ -276,7 +276,7 @@ func testAccCheckAWSDataSyncLocationEfsDisappears(location *datasync.DescribeLoc
 
 func testAccCheckAWSDataSyncLocationEfsNotRecreated(i, j *datasync.DescribeLocationEfsOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreationTime) != aws.TimeValue(j.CreationTime) {
+		if !aws.TimeValue(i.CreationTime).Equal(aws.TimeValue(j.CreationTime)) {
 			return errors.New("DataSync Location EFS was recreated")
 		}
 

--- a/aws/resource_aws_datasync_location_nfs_test.go
+++ b/aws/resource_aws_datasync_location_nfs_test.go
@@ -306,7 +306,7 @@ func testAccCheckAWSDataSyncLocationNfsDisappears(location *datasync.DescribeLoc
 
 func testAccCheckAWSDataSyncLocationNfsNotRecreated(i, j *datasync.DescribeLocationNfsOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreationTime) != aws.TimeValue(j.CreationTime) {
+		if !aws.TimeValue(i.CreationTime).Equal(aws.TimeValue(j.CreationTime)) {
 			return errors.New("DataSync Location EFS was recreated")
 		}
 

--- a/aws/resource_aws_datasync_location_s3_test.go
+++ b/aws/resource_aws_datasync_location_s3_test.go
@@ -253,7 +253,7 @@ func testAccCheckAWSDataSyncLocationS3Disappears(location *datasync.DescribeLoca
 
 func testAccCheckAWSDataSyncLocationS3NotRecreated(i, j *datasync.DescribeLocationS3Output) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreationTime) != aws.TimeValue(j.CreationTime) {
+		if !aws.TimeValue(i.CreationTime).Equal(aws.TimeValue(j.CreationTime)) {
 			return errors.New("DataSync Location S3 was recreated")
 		}
 

--- a/aws/resource_aws_datasync_location_smb_test.go
+++ b/aws/resource_aws_datasync_location_smb_test.go
@@ -253,7 +253,7 @@ func testAccCheckAWSDataSyncLocationSmbDisappears(location *datasync.DescribeLoc
 
 func testAccCheckAWSDataSyncLocationSmbNotRecreated(i, j *datasync.DescribeLocationSmbOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreationTime) != aws.TimeValue(j.CreationTime) {
+		if !aws.TimeValue(i.CreationTime).Equal(aws.TimeValue(j.CreationTime)) {
 			return errors.New("DataSync Location SMB was recreated")
 		}
 

--- a/aws/resource_aws_docdb_cluster_test.go
+++ b/aws/resource_aws_docdb_cluster_test.go
@@ -537,7 +537,7 @@ func testAccCheckDocDBClusterExistsWithProvider(n string, v *docdb.DBCluster, pr
 
 func testAccCheckDocDBClusterRecreated(i, j *docdb.DBCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.ClusterCreateTime) == aws.TimeValue(j.ClusterCreateTime) {
+		if aws.TimeValue(i.ClusterCreateTime).Equal(aws.TimeValue(j.ClusterCreateTime)) {
 			return errors.New("DocDB Cluster was not recreated")
 		}
 

--- a/aws/resource_aws_ec2_fleet_test.go
+++ b/aws/resource_aws_ec2_fleet_test.go
@@ -1204,7 +1204,7 @@ func testAccCheckAWSEc2FleetDisappears(fleet *ec2.FleetData) resource.TestCheckF
 
 func testAccCheckAWSEc2FleetNotRecreated(i, j *ec2.FleetData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreateTime) != aws.TimeValue(j.CreateTime) {
+		if !aws.TimeValue(i.CreateTime).Equal(aws.TimeValue(j.CreateTime)) {
 			return errors.New("EC2 Fleet was recreated")
 		}
 
@@ -1214,7 +1214,7 @@ func testAccCheckAWSEc2FleetNotRecreated(i, j *ec2.FleetData) resource.TestCheck
 
 func testAccCheckAWSEc2FleetRecreated(i, j *ec2.FleetData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreateTime) == aws.TimeValue(j.CreateTime) {
+		if aws.TimeValue(i.CreateTime).Equal(aws.TimeValue(j.CreateTime)) {
 			return errors.New("EC2 Fleet was not recreated")
 		}
 

--- a/aws/resource_aws_ecr_repository_test.go
+++ b/aws/resource_aws_ecr_repository_test.go
@@ -370,7 +370,7 @@ func testAccCheckAWSEcrRepositoryRepositoryURL(resourceName, repositoryName stri
 
 func testAccCheckAWSEcrRepositoryRecreated(i, j *ecr.Repository) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedAt) == aws.TimeValue(j.CreatedAt) {
+		if aws.TimeValue(i.CreatedAt).Equal(aws.TimeValue(j.CreatedAt)) {
 			return fmt.Errorf("ECR repository was not recreated")
 		}
 
@@ -380,7 +380,7 @@ func testAccCheckAWSEcrRepositoryRecreated(i, j *ecr.Repository) resource.TestCh
 
 func testAccCheckAWSEcrRepositoryNotRecreated(i, j *ecr.Repository) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedAt) != aws.TimeValue(j.CreatedAt) {
+		if !aws.TimeValue(i.CreatedAt).Equal(aws.TimeValue(j.CreatedAt)) {
 			return fmt.Errorf("ECR repository was recreated")
 		}
 

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -1362,7 +1362,7 @@ func testAccCheckAWSEcsServiceDisappears(service *ecs.Service) resource.TestChec
 
 func testAccCheckAWSEcsServiceNotRecreated(i, j *ecs.Service) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedAt) != aws.TimeValue(j.CreatedAt) {
+		if !aws.TimeValue(i.CreatedAt).Equal(aws.TimeValue(j.CreatedAt)) {
 			return fmt.Errorf("ECS Service (%s) unexpectedly recreated", aws.StringValue(j.ServiceArn))
 		}
 

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -556,7 +556,7 @@ func testAccCheckAWSEksClusterDestroy(s *terraform.State) error {
 
 func testAccCheckAWSEksClusterRecreated(i, j *eks.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedAt) == aws.TimeValue(j.CreatedAt) {
+		if aws.TimeValue(i.CreatedAt).Equal(aws.TimeValue(j.CreatedAt)) {
 			return errors.New("EKS Cluster was not recreated")
 		}
 
@@ -566,7 +566,7 @@ func testAccCheckAWSEksClusterRecreated(i, j *eks.Cluster) resource.TestCheckFun
 
 func testAccCheckAWSEksClusterNotRecreated(i, j *eks.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedAt) != aws.TimeValue(j.CreatedAt) {
+		if !aws.TimeValue(i.CreatedAt).Equal(aws.TimeValue(j.CreatedAt)) {
 			return errors.New("EKS Cluster was recreated")
 		}
 

--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -869,7 +869,7 @@ func testAccCheckAWSEksNodeGroupDisappears(nodeGroup *eks.Nodegroup) resource.Te
 
 func testAccCheckAWSEksNodeGroupNotRecreated(i, j *eks.Nodegroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedAt) != aws.TimeValue(j.CreatedAt) {
+		if !aws.TimeValue(i.CreatedAt).Equal(aws.TimeValue(j.CreatedAt)) {
 			return fmt.Errorf("EKS Node Group (%s) was recreated", aws.StringValue(j.NodegroupName))
 		}
 
@@ -879,7 +879,7 @@ func testAccCheckAWSEksNodeGroupNotRecreated(i, j *eks.Nodegroup) resource.TestC
 
 func testAccCheckAWSEksNodeGroupRecreated(i, j *eks.Nodegroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreatedAt) == aws.TimeValue(j.CreatedAt) {
+		if aws.TimeValue(i.CreatedAt).Equal(aws.TimeValue(j.CreatedAt)) {
 			return fmt.Errorf("EKS Node Group (%s) was not recreated", aws.StringValue(j.NodegroupName))
 		}
 

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -767,7 +767,7 @@ func testAccCheckAWSElasticacheClusterReplicationGroupIDAttribute(cluster *elast
 
 func testAccCheckAWSElasticacheClusterNotRecreated(i, j *elasticache.CacheCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CacheClusterCreateTime) != aws.TimeValue(j.CacheClusterCreateTime) {
+		if !aws.TimeValue(i.CacheClusterCreateTime).Equal(aws.TimeValue(j.CacheClusterCreateTime)) {
 			return errors.New("ElastiCache Cluster was recreated")
 		}
 
@@ -777,7 +777,7 @@ func testAccCheckAWSElasticacheClusterNotRecreated(i, j *elasticache.CacheCluste
 
 func testAccCheckAWSElasticacheClusterRecreated(i, j *elasticache.CacheCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CacheClusterCreateTime) == aws.TimeValue(j.CacheClusterCreateTime) {
+		if aws.TimeValue(i.CacheClusterCreateTime).Equal(aws.TimeValue(j.CacheClusterCreateTime)) {
 			return errors.New("ElastiCache Cluster was not recreated")
 		}
 

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -1285,7 +1285,7 @@ func testAccCheckAWSESDomainNotRecreated(i, j *elasticsearch.ElasticsearchDomain
 			return err
 		}
 
-		if aws.TimeValue(iConfig.DomainConfig.ElasticsearchClusterConfig.Status.CreationDate) != aws.TimeValue(jConfig.DomainConfig.ElasticsearchClusterConfig.Status.CreationDate) {
+		if !aws.TimeValue(iConfig.DomainConfig.ElasticsearchClusterConfig.Status.CreationDate).Equal(aws.TimeValue(jConfig.DomainConfig.ElasticsearchClusterConfig.Status.CreationDate)) {
 			return fmt.Errorf("ES Domain was recreated")
 		}
 

--- a/aws/resource_aws_kms_external_key_test.go
+++ b/aws/resource_aws_kms_external_key_test.go
@@ -492,7 +492,7 @@ func testAccCheckAWSKmsExternalKeyDisappears(key *kms.KeyMetadata) resource.Test
 
 func testAccCheckAWSKmsExternalKeyNotRecreated(i, j *kms.KeyMetadata) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreationDate) != aws.TimeValue(j.CreationDate) {
+		if !aws.TimeValue(i.CreationDate).Equal(aws.TimeValue(j.CreationDate)) {
 			return fmt.Errorf("KMS External Key recreated")
 		}
 
@@ -502,7 +502,7 @@ func testAccCheckAWSKmsExternalKeyNotRecreated(i, j *kms.KeyMetadata) resource.T
 
 func testAccCheckAWSKmsExternalKeyRecreated(i, j *kms.KeyMetadata) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreationDate) == aws.TimeValue(j.CreationDate) {
+		if aws.TimeValue(i.CreationDate).Equal(aws.TimeValue(j.CreationDate)) {
 			return fmt.Errorf("KMS External Key not recreated")
 		}
 

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -2365,7 +2365,7 @@ func testAccCheckAWSClusterExistsWithProvider(n string, v *rds.DBCluster, provid
 
 func testAccCheckAWSClusterRecreated(i, j *rds.DBCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.ClusterCreateTime) == aws.TimeValue(j.ClusterCreateTime) {
+		if aws.TimeValue(i.ClusterCreateTime).Equal(aws.TimeValue(j.ClusterCreateTime)) {
 			return errors.New("RDS Cluster was not recreated")
 		}
 

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -369,7 +369,7 @@ func testAccCheckAWSSagemakerNotebookInstanceExists(n string, notebook *sagemake
 
 func testAccCheckAWSSagemakerNotebookInstanceNotRecreated(i, j *sagemaker.DescribeNotebookInstanceOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreationTime) != aws.TimeValue(j.CreationTime) {
+		if !aws.TimeValue(i.CreationTime).Equal(aws.TimeValue(j.CreationTime)) {
 			return errors.New("Sagemaker Notebook Instance was recreated")
 		}
 
@@ -379,7 +379,7 @@ func testAccCheckAWSSagemakerNotebookInstanceNotRecreated(i, j *sagemaker.Descri
 
 func testAccCheckAWSSagemakerNotebookInstanceRecreated(i, j *sagemaker.DescribeNotebookInstanceOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(i.CreationTime) == aws.TimeValue(j.CreationTime) {
+		if aws.TimeValue(i.CreationTime).Equal(aws.TimeValue(j.CreationTime)) {
 			return errors.New("Sagemaker Notebook Instance was not recreated")
 		}
 


### PR DESCRIPTION
[Go documentation](https://golang.org/pkg/time/#Time) recommends against using `==` for comparing `time.Time` values. Replace occurrences and add semgrep rule to detect future occurrences.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerNotebookInstance\|TestAccAWSElasticSearchDomain\|TestAccAWSDocDBCluster\|TestAccAWSEksCluster\|TestAccAWSCodeDeployDeploymentConfig\|TestAccAWSRDSCluster\|TestAccAWSEc2Fleet\|TestAccAWSDataSyncLocationSmb\|TestAccAWSEcrRepository\|TestAccAWSDataSyncAgent\|TestAccAWSAPIGatewayApiKey\|TestAccAWSAPIGatewayDeployment\|TestAccAWSKmsExternalKey\|TestAccAWSAPIGatewayV2Deployment\|TestAccAWSCodeDeployApp\|TestAccAWSDataSyncLocationEfs\|TestAccAWSEcsService\|TestAccAWSDataSyncLocationNfs\|TestAccAWSDataSyncLocationS3\|TestAccAWSEksNodeGroup\|TestAccAWSElasticacheCluster'

--- PASS: TestAccAWSEcrRepositoryDataSource_nonExistent (13.26s)
--- PASS: TestAccAWSAPIGatewayApiKey_disappears (43.63s)
--- PASS: TestAccAWSEksClusterAuthDataSource_basic (47.65s)
--- PASS: TestAccAWSEcrRepositoryDataSource_basic (48.23s)
--- PASS: TestAccAWSEcrRepositoryDataSource_encryption (50.19s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageName_EmptyString (50.74s)
--- PASS: TestAccAWSAPIGatewayApiKey_basic (58.35s)
--- PASS: TestAccAWSAPIGatewayApiKey_Value (59.83s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageDescription (89.84s)
--- PASS: TestAccAWSAPIGatewayApiKey_Description (95.11s)
--- PASS: TestAccAWSAPIGatewayV2Deployment_disappears (50.70s)
--- PASS: TestAccAWSAPIGatewayApiKey_Enabled (95.24s)
--- PASS: TestAccAWSCodeDeployApp_computePlatform_ECS (54.54s)
--- PASS: TestAccAWSAPIGatewayV2Deployment_basic (94.42s)
--- PASS: TestAccAWSCodeDeployApp_basic (60.87s)
--- PASS: TestAccAWSEcsServiceDataSource_basic (110.51s)
--- PASS: TestAccAWSCodeDeployApp_computePlatform_Lambda (52.53s)
--- PASS: TestAccAWSAPIGatewayApiKey_Tags (133.60s)
--- PASS: TestAccAWSCodeDeployApp_computePlatform (83.78s)
--- PASS: TestAccAWSCodeDeployDeploymentConfig_basic (47.70s)
--- PASS: TestAccAWSAPIGatewayDeployment_disappears_RestApi (140.23s)
--- PASS: TestAccAWSCodeDeployApp_name (86.14s)
--- PASS: TestAccAWSAPIGatewayDeployment_Description (151.86s)
--- PASS: TestAccAWSCodeDeployDeploymentConfig_hostCount (68.12s)
--- PASS: TestAccAWSCodeDeployDeploymentConfig_fleetPercent (68.52s)
--- PASS: TestAccAWSCodeDeployDeploymentConfig_trafficCanary (68.44s)
--- PASS: TestAccAWSCodeDeployDeploymentConfig_trafficLinear (61.86s)
--- PASS: TestAccAWSAPIGatewayDeployment_Triggers (172.27s)
--- PASS: TestAccAWSAPIGatewayV2Deployment_Triggers (128.06s)
--- PASS: TestAccAWSDataSyncLocationS3_basic (30.60s)
--- PASS: TestAccAWSDataSyncLocationS3_disappears (28.41s)
--- PASS: TestAccAWSDataSyncLocationS3_Tags (56.55s)
--- PASS: TestAccAWSAPIGatewayDeployment_Variables (255.54s)
--- PASS: TestAccAWSAPIGatewayDeployment_basic (258.28s)
--- PASS: TestAccAWSDataSyncLocationEfs_basic (135.30s)
--- PASS: TestAccAWSDataSyncLocationEfs_disappears (134.63s)
--- PASS: TestAccAWSDataSyncLocationEfs_Subdirectory (134.25s)
--- PASS: TestAccAWSDataSyncLocationEfs_Tags (180.71s)
--- PASS: TestAccAWSDataSyncLocationNfs_disappears (184.47s)
--- PASS: TestAccAWSDataSyncLocationNfs_basic (192.29s)
--- PASS: TestAccAWSDataSyncLocationNfs_Subdirectory (176.63s)
--- PASS: TestAccAWSDataSyncAgent_basic (236.10s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_basic (15.64s)
--- PASS: TestAccAWSDataSyncLocationSmb_basic (154.82s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_namePrefix (15.95s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_generatedName (17.37s)
--- PASS: TestAccAWSDataSyncAgent_disappears (251.85s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Description (16.59s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_disappears (13.90s)
--- PASS: TestAccAWSDataSyncLocationSmb_disappears (166.87s)
--- PASS: TestAccAWSDataSyncAgent_Tags (259.83s)
--- PASS: TestAccAWSDataSyncAgent_AgentName (263.73s)
--- PASS: TestAccAWSDocDBCluster_missingUserNameCausesError (7.84s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Parameter (29.32s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Tags (37.93s)
--- PASS: TestAccAWSDataSyncLocationNfs_AgentARNs_Multple (236.03s)
--- PASS: TestAccAWSDataSyncLocationNfs_Tags (243.35s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageName (430.27s)
--- PASS: TestAccAWSDataSyncLocationSmb_Tags (203.98s)
--- PASS: TestAccAWSEc2Fleet_basic (43.20s)
--- PASS: TestAccAWSDocDBCluster_basic (139.30s)
--- PASS: TestAccAWSEc2Fleet_disappears (39.84s)
--- PASS: TestAccAWSDocDBCluster_kmsKey (139.38s)
--- PASS: TestAccAWSDocDBCluster_encrypted (129.29s)
--- PASS: TestAccAWSDocDBCluster_generatedName (173.45s)
--- PASS: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (161.36s)
--- PASS: TestAccAWSDocDBClusterSnapshot_basic (184.36s)
--- SKIP: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_MaxPrice (0.00s)
--- PASS: TestAccAWSDocDBCluster_namePrefix (184.24s)
--- PASS: TestAccAWSDocDBCluster_updateTags (205.64s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateId (78.22s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateName (76.03s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_Version (77.59s)
--- PASS: TestAccAWSEc2Fleet_ExcessCapacityTerminationPolicy (107.58s)
--- PASS: TestAccAWSDocDBCluster_takeFinalSnapshot (254.89s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_AvailabilityZone (86.70s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_InstanceType (87.59s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority (87.67s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority_Multiple (86.59s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_SubnetId (87.52s)
--- PASS: TestAccAWSEc2Fleet_SpotOptions_CapacityRebalance (41.74s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity_Multiple (83.52s)
--- PASS: TestAccAWSDocDBCluster_backupsUpdate (283.61s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity (87.02s)
--- PASS: TestAccAWSEc2Fleet_OnDemandOptions_AllocationStrategy (85.29s)
--- PASS: TestAccAWSEc2Fleet_ReplaceUnhealthyInstances (81.72s)
--- PASS: TestAccAWSEc2Fleet_SpotOptions_AllocationStrategy (77.68s)
--- PASS: TestAccAWSDocDBCluster_Port (295.19s)
--- PASS: TestAccAWSEc2Fleet_SpotOptions_InstanceInterruptionBehavior (80.13s)
--- PASS: TestAccAWSEc2Fleet_SpotOptions_InstancePoolsToUseCount (80.48s)
--- PASS: TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_OnDemand (41.93s)
--- PASS: TestAccAWSEcrRepositoryPolicy_basic (22.09s)
--- PASS: TestAccAWSDocDBCluster_deleteProtection (293.07s)
--- FAIL: TestAccAWSEcrRepositoryPolicy_iam (26.06s)
--- PASS: TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_Spot (52.11s)
--- PASS: TestAccAWSEcrRepository_basic (31.71s)
--- PASS: TestAccAWSEcrRepository_immutability (31.27s)
--- PASS: TestAccAWSEc2Fleet_Tags (109.67s)
--- PASS: TestAccAWSEc2Fleet_Type (57.56s)
--- PASS: TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType (87.81s)
--- PASS: TestAccAWSEcrRepository_tags (47.34s)
--- PASS: TestAccAWSEcrRepository_encryption_kms (53.13s)
--- PASS: TestAccAWSEc2Fleet_TerminateInstancesWithExpiration (101.15s)
--- PASS: TestAccAWSEcrRepository_encryption_aes256 (62.66s)
--- PASS: TestAccAWSEcrRepository_image_scanning_configuration (73.97s)
--- PASS: TestAccAWSEcsService_disappears (76.37s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (80.92s)
--- PASS: TestAccAWSEcsService_withARN (102.91s)
--- PASS: TestAccAWSEcsService_basicImport (100.94s)
--- PASS: TestAccAWSEcsService_withIamRole (57.12s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (91.11s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_External (41.71s)
--- PASS: TestAccAWSEcsService_withMultipleCapacityProviderStrategies (133.87s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (69.29s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (57.76s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy_Type_Missing (1.88s)
--- PASS: TestAccAWSEksClusterDataSource_basic (905.73s)
--- PASS: TestAccAWSDocDBClusterInstance_kmsKey (639.90s)
--- PASS: TestAccAWSDocDBClusterInstance_namePrefix (643.86s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (140.97s)
--- PASS: TestAccAWSEcsService_withLbChanges (80.24s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (79.43s)
--- PASS: TestAccAWSEcsService_withCapacityProviderStrategy (186.12s)
--- PASS: TestAccAWSDocDBClusterInstance_basic (676.00s)
--- PASS: TestAccAWSDocDBClusterInstance_generatedName (665.20s)
--- PASS: TestAccAWSDocDBClusterInstance_az (683.58s)
--- PASS: TestAccAWSDocDBClusterInstance_disappears (651.89s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (78.33s)
--- PASS: TestAccAWSEcsService_withForceNewDeployment (92.76s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (51.68s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (80.88s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (62.41s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (102.44s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (80.24s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (239.48s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (108.42s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (241.54s)
--- PASS: TestAccAWSEcsService_ManagedTags (83.05s)
--- PASS: TestAccAWSEcsService_withAlb (217.54s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (158.72s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (160.86s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndWaitForSteadyState (164.32s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (163.43s)
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups (253.30s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndUpdateWaitForSteadyState (196.28s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (148.42s)
--- PASS: TestAccAWSEc2Fleet_TargetCapacitySpecification_TotalTargetCapacity (481.02s)
--- PASS: TestAccAWSEcsService_Tags (208.09s)
--- PASS: TestAccAWSEcsService_PropagateTags (206.12s)
--- PASS: TestAccAWSEc2Fleet_TemplateMultipleNetworkInterfaces (559.46s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig (767.52s)
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (858.33s)
--- PASS: TestAccAWSEksCluster_basic (909.13s)
--- PASS: TestAccAWSEksCluster_Tags (876.12s)
--- PASS: TestAccAWSEksCluster_Logging (954.50s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1055.67s)
--- PASS: TestAccAWSEksNodeGroup_CapacityType_Spot (1096.97s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Multiple (1048.19s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Single (1108.67s)
--- PASS: TestAccAWSEksNodeGroup_disappears (1225.40s)
--- PASS: TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs (1269.03s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1156.23s)
--- PASS: TestAccAWSEksNodeGroup_basic (1297.44s)
--- PASS: TestAccAWSEksNodeGroup_AmiType (1393.47s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1489.43s)
--- PASS: TestAccAWSEksCluster_NetworkConfig_ServiceIpv4Cidr (1487.70s)
--- SKIP: TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic (1.96s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Id (1498.43s)
--- PASS: TestAccAWSElasticacheCluster_Port_Redis_Default (548.31s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1058.00s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached (631.05s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis (640.04s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (630.46s)
--- PASS: TestAccAWSElasticacheCluster_Port (640.10s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (695.29s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Name (1528.38s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1359.58s)
--- PASS: TestAccAWSEksCluster_Version (2389.05s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (2386.09s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis (2.89s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1168.69s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1257.68s)
--- PASS: TestAccAWSElasticacheCluster_vpc (552.25s)
--- PASS: TestAccAWSElasticacheCluster_Memcached_FinalSnapshot (3.00s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1409.03s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1409.75s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (899.90s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (722.73s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached (622.89s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis (599.84s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Version (2059.51s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1204.71s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1192.50s)
--- PASS: TestAccAWSElasticacheCluster_Redis_FinalSnapshot (839.50s)
--- PASS: TestAccAWSElasticSearchDomain_basic (834.30s)
--- PASS: TestAccAWSElasticSearchDomain_duplicate (525.79s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached (1273.84s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis (1322.22s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached (1282.02s)
--- PASS: TestAccAWSElasticSearchDomainPolicy_basic (1077.07s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis (1393.06s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone (1356.90s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica (1376.04s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica (1384.73s)
--- PASS: TestAccAWSElasticSearchDomain_v23 (1234.68s)
--- PASS: TestAccAWSElasticSearchDomain_RequireHTTPS (1789.95s)
--- PASS: TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_Disabled (874.60s)
--- PASS: TestAccAWSElasticSearchDomain_vpc (1207.09s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (3762.93s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions_EsApplicationLogs (918.87s)
--- PASS: TestAccAWSElasticSearchDomain_complex (1554.40s)
--- PASS: TestAccAWSEksNodeGroup_ForceUpdateVersion (4864.25s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions_AuditLogs (1377.13s)
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (1747.16s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (668.96s)
--- PASS: TestAccAWSKmsExternalKey_basic (13.51s)
--- PASS: TestAccAWSKmsExternalKey_disappears (9.60s)
--- PASS: TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_IAM (1673.88s)
--- PASS: TestAccAWSKmsExternalKey_DeletionWindowInDays (23.36s)
--- FAIL: TestAccAWSKmsExternalKey_Description (18.95s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions_SearchSlowLogs (1549.33s)
--- PASS: TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_UserDB (1797.08s)
--- FAIL: TestAccAWSKmsExternalKey_Policy (23.39s)
--- FAIL: TestAccAWSKmsExternalKey_Tags (28.04s)
--- PASS: TestAccAWSKmsExternalKey_KeyMaterialBase64 (80.88s)
--- PASS: TestAccAWSElasticSearchDomain_tags (729.34s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key (951.17s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove (1603.49s)
--- PASS: TestAccAWSElasticSearchDomain_withDedicatedMaster (2676.89s)
--- PASS: TestAccAWSKmsExternalKey_Enabled (222.99s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions_IndexSlowLogs (1896.63s)
--- PASS: TestAccAWSElasticSearchDomain_NodeToNodeEncryption (903.51s)
--- PASS: TestAccAWSKmsExternalKey_ValidTo (214.13s)
--- PASS: TestAccAWSElasticSearchDomain_WithVolumeType_Missing (626.18s)
--- PASS: TestAccAWSElasticSearchDomain_policy (1461.75s)
--- PASS: TestAccAWSEksNodeGroup_Version (4710.58s)
--- PASS: TestAccAWSRDSClusterInstance_generatedName (656.91s)
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (727.86s)
--- PASS: TestAccAWSRDSClusterInstance_isAlreadyBeingDeleted (769.54s)
--- PASS: TestAccAWSRDSClusterInstance_az (793.17s)
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (745.83s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsUpdate (1952.76s)
--- PASS: TestAccAWSRDSClusterInstance_disappears (819.51s)
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (817.56s)
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (2966.47s)
--- PASS: TestAccAWSRDSClusterEndpoint_tags (1083.62s)
--- PASS: TestAccAWSRDSClusterEndpoint_basic (1124.01s)
--- PASS: TestAccAWSElasticSearchDomain_update (1902.63s)
--- PASS: TestAccAWSRDSClusterInstance_CopyTagsToSnapshot (768.58s)
--- PASS: TestAccAWSRDSCluster_basic (136.90s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2 (633.02s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1525.08s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1 (765.10s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql (694.15s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (137.61s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_RemovedToEnabled (857.53s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToDisabled (1041.95s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql_DefaultKeyToCustomKey (599.78s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (125.83s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1 (805.56s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (6.50s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (177.66s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToRemoved (970.71s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2 (754.11s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (140.41s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1_DefaultKeyToCustomKey (781.11s)
--- PASS: TestAccAWSRDSClusterInstance_CACertificateIdentifier (582.23s)
--- PASS: TestAccAWSRDSCluster_generatedName (136.49s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2_DefaultKeyToCustomKey (800.30s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql (756.05s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_Postgresql (117.93s)
--- PASS: TestAccAWSRDSCluster_kmsKey (118.53s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringInterval (1362.44s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (197.00s)
--- PASS: TestAccAWSRDSCluster_encrypted (136.84s)
--- PASS: TestAccAWSRDSCluster_Tags (210.79s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (201.82s)
--- PASS: TestAccAWSRDSCluster_iamAuth (115.91s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_MySQL (219.44s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (208.86s)
--- PASS: TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig (4704.36s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (166.94s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (198.19s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (239.81s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (170.66s)
--- PASS: TestAccAWSRDSCluster_PointInTimeRestore_EnabledCloudwatchLogsExports (422.29s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (186.35s)
--- PASS: TestAccAWSRDSCluster_PointInTimeRestore (442.37s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global (180.31s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add (184.44s)
--- PASS: TestAccAWSElasticSearchDomain_warm (4809.84s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned (160.76s)
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove (182.53s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update (196.08s)
--- PASS: TestAccAWSRDSCluster_EngineMode (453.64s)
--- PASS: TestAccAWSRDSCluster_Port (278.39s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity (268.04s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (468.15s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (329.84s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (406.03s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (416.24s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (391.98s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (435.86s)
--- PASS: TestAccAWSElasticSearchDomain_update_volume_type (3015.43s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_KmsKeyId (406.01s)
--- PASS: TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_basic (15.18s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (475.62s)
--- PASS: TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Update (23.34s)
--- PASS: TestAccAWSRDSCluster_AllowMajorVersionUpgrade (1340.58s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (405.11s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (375.96s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (581.87s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (375.05s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (434.67s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (415.04s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (377.17s)
--- PASS: TestAccAWSSagemakerNotebookInstance_basic (306.12s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (387.21s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (396.05s)
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (400.30s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1077.01s)
--- PASS: TestAccAWSSagemakerNotebookInstance_kms (317.16s)
--- PASS: TestAccAWSSagemakerNotebookInstance_tags (362.20s)
--- PASS: TestAccAWSSagemakerNotebookInstance_disappears (345.50s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (1521.75s)
--- PASS: TestAccAWSSagemakerNotebookInstance_update (647.47s)
--- PASS: TestAccAWSElasticSearchDomain_update_version (3536.68s)
--- PASS: TestAccAWSRDSCluster_ReplicationSourceIdentifier_KmsKeyId (1551.54s)
--- PASS: TestAccAWSSagemakerNotebookInstance_direct_internet_access (709.53s)
--- PASS: TestAccAWSSagemakerNotebookInstance_root_access (749.20s)
--- PASS: TestAccAWSSagemakerNotebookInstance_volumesize (1029.25s)
--- PASS: TestAccAWSSagemakerNotebookInstance_LifecycleConfigName (1068.95s)
--- PASS: TestAccAWSSagemakerNotebookInstance_default_code_repository_sagemakerRepo (1019.41s)
--- PASS: TestAccAWSSagemakerNotebookInstance_default_code_repository (1128.68s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_PrimarySecondaryClusters (1951.23s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_ReplicationSourceIdentifier (1949.53s)
--- PASS: TestAccAWSSagemakerNotebookInstance_additional_code_repositories (1490.28s)
```

The five test failures, 

* `TestAccAWSEcrRepositoryPolicy_iam`
* `TestAccAWSKmsExternalKey_Description`
* `TestAccAWSKmsExternalKey_Policy`
* `TestAccAWSKmsExternalKey_Tags`
* `TestAccAWSRDSCluster_s3Restore`

have existing intermittent or consistent failures