### PR TITLE
New resource: aws_gamelift_game_server_group

### DIFF
--- a/aws/internal/service/gamelift/waiter/status.go
+++ b/aws/internal/service/gamelift/waiter/status.go
@@ -1,0 +1,33 @@
+package waiter
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func GameServerGroupState(conn *gamelift.GameLift, gameServerGroupID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := conn.DescribeGameServerGroup(&gamelift.DescribeGameServerGroupInput{
+			GameServerGroupName: aws.String(gameServerGroupID),
+		})
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if output == nil || output.GameServerGroup == nil {
+			return nil, "", nil
+		}
+
+		status := aws.StringValue(output.GameServerGroup.Status)
+
+		if status == gamelift.GameServerGroupStatusError {
+			return nil, status, errors.New(aws.StringValue(output.GameServerGroup.StatusReason))
+		}
+
+		return output.GameServerGroup, status, nil
+	}
+}

--- a/aws/internal/service/gamelift/waiter/waiter.go
+++ b/aws/internal/service/gamelift/waiter/waiter.go
@@ -1,0 +1,51 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func GameServerGroupActive(conn *gamelift.GameLift, gameServerGroupID string, timeout time.Duration) (*gamelift.GameServerGroup, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			gamelift.GameServerGroupStatusNew,
+			gamelift.GameServerGroupStatusActivating,
+		},
+		Target: []string{
+			gamelift.GameServerGroupStatusActive,
+		},
+		Refresh: GameServerGroupState(conn, gameServerGroupID),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*gamelift.GameServerGroup); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+func GameServerGroupDeleted(conn *gamelift.GameLift, gameServerGroupID string, timeout time.Duration) (*gamelift.GameServerGroup, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			gamelift.GameServerGroupStatusDeleteScheduled,
+			gamelift.GameServerGroupStatusDeleting,
+			gamelift.GameServerGroupStatusDeleted,
+		},
+		Target:  []string{},
+		Refresh: GameServerGroupState(conn, gameServerGroupID),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*gamelift.GameServerGroup); ok {
+		return v, err
+	}
+
+	return nil, err
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -688,6 +688,7 @@ func Provider() *schema.Provider {
 			"aws_gamelift_alias":                                      resourceAwsGameliftAlias(),
 			"aws_gamelift_build":                                      resourceAwsGameliftBuild(),
 			"aws_gamelift_fleet":                                      resourceAwsGameliftFleet(),
+			"aws_gamelift_game_server_group":                          resourceAwsGameliftGameServerGroup(),
 			"aws_gamelift_game_session_queue":                         resourceAwsGameliftGameSessionQueue(),
 			"aws_glacier_vault":                                       resourceAwsGlacierVault(),
 			"aws_glacier_vault_lock":                                  resourceAwsGlacierVaultLock(),

--- a/aws/resource_aws_gamelift_game_server_group.go
+++ b/aws/resource_aws_gamelift_game_server_group.go
@@ -1,0 +1,531 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/gamelift/waiter"
+)
+
+func resourceAwsGameliftGameServerGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGameliftGameServerGroupCreate,
+		Read:   resourceAwsGameliftGameServerGroupRead,
+		Update: resourceAwsGameliftGameServerGroupUpdate,
+		Delete: resourceAwsGameliftGameServerGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_scaling_group_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_scaling_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"estimated_instance_warmup": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"target_tracking_configuration": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"target_value": {
+										Type:         schema.TypeFloat,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.FloatAtLeast(0),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"balancing_strategy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(gamelift.BalancingStrategy_Values(), false),
+			},
+			"game_server_group_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 128),
+			},
+			"game_server_protection_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(gamelift.GameServerProtectionPolicy_Values(), false),
+			},
+			"instance_definition": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 2,
+				MaxItems: 20,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(gamelift.GameServerGroupInstanceType_Values(), false),
+						},
+						"weighted_capacity": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 3),
+						},
+					},
+				},
+			},
+			"launch_template": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							Computed:      true,
+							ForceNew:      true,
+							ConflictsWith: []string{"launch_template.0.name"},
+							ValidateFunc:  validateLaunchTemplateId,
+						},
+						"name": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							Computed:      true,
+							ForceNew:      true,
+							ConflictsWith: []string{"launch_template.0.id"},
+							ValidateFunc:  validateLaunchTemplateName,
+						},
+						"version": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 128),
+						},
+					},
+				},
+			},
+			"max_size": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"min_size": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"role_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+			"tags": tagsSchema(),
+			"vpc_subnets": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 20,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(15, 24),
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsGameliftGameServerGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	gameServerGroupName := d.Get("game_server_group_name").(string)
+
+	input := gamelift.CreateGameServerGroupInput{
+		GameServerGroupName: aws.String(gameServerGroupName),
+		InstanceDefinitions: expandGameliftInstanceDefinitions(d.Get("instance_definition").(*schema.Set).List()),
+		LaunchTemplate:      expandGameliftLaunchTemplateSpecification(d.Get("launch_template").([]interface{})[0].(map[string]interface{})),
+		MaxSize:             aws.Int64(int64(d.Get("max_size").(int))),
+		MinSize:             aws.Int64(int64(d.Get("min_size").(int))),
+		RoleArn:             aws.String(d.Get("role_arn").(string)),
+		Tags:                keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().GameliftTags(),
+	}
+
+	if v, ok := d.GetOk("auto_scaling_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.AutoScalingPolicy = expandGameliftGameServerGroupAutoScalingPolicy(v.([]interface{})[0].(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("balancing_strategy"); ok {
+		input.BalancingStrategy = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("game_server_protection_policy"); ok {
+		input.GameServerProtectionPolicy = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("vpc_subnets"); ok && v.(*schema.Set).Len() > 0 {
+		input.VpcSubnets = expandStringSet(v.(*schema.Set))
+	}
+
+	_, err := conn.CreateGameServerGroup(&input)
+
+	if err != nil {
+		return fmt.Errorf("error creating GameLift Game Server Group: %w", err)
+	}
+
+	d.SetId(gameServerGroupName)
+
+	if _, err := waiter.GameServerGroupActive(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return fmt.Errorf("error waiting for Gamelift Game Server Group (%s) to be active: %w", d.Id(), err)
+	}
+
+	return resourceAwsGameliftGameServerGroupRead(d, meta)
+}
+
+func resourceAwsGameliftGameServerGroupRead(d *schema.ResourceData, meta interface{}) error {
+	autoscalingconn := meta.(*AWSClient).autoscalingconn
+	gameliftconn := meta.(*AWSClient).gameliftconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	gameServerGroupName := d.Id()
+
+	describeGameServerGroupOutput, err := gameliftconn.DescribeGameServerGroup(&gamelift.DescribeGameServerGroupInput{
+		GameServerGroupName: aws.String(gameServerGroupName),
+	})
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
+		log.Printf("[WARN] Gamelift Game Server Group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Gamelift Game Server Group (%s): %w", d.Id(), err)
+	}
+
+	gameServerGroup := describeGameServerGroupOutput.GameServerGroup
+
+	// To view properties of automatically created Auto Scaling group users should access it directly:
+	// https://docs.aws.amazon.com/gamelift/latest/apireference/API_DescribeGameServerGroup.html
+	autoScalingGroupName := strings.Split(aws.StringValue(gameServerGroup.AutoScalingGroupArn), "/")[1]
+	autoScalingGroup, err := getAwsAutoscalingGroup(autoScalingGroupName, autoscalingconn)
+
+	if err != nil {
+		return err
+	}
+
+	if autoScalingGroup == nil {
+		return fmt.Errorf("error describing Auto Scaling Group (%s): not found", autoScalingGroupName)
+	}
+
+	describePoliciesOutput, err := autoscalingconn.DescribePolicies(&autoscaling.DescribePoliciesInput{
+		AutoScalingGroupName: aws.String(autoScalingGroupName),
+		PolicyNames:          []*string{aws.String(gameServerGroupName)},
+	})
+
+	if err != nil {
+		return fmt.Errorf("error describing Auto Scaling Group Policies (%s): %s", autoScalingGroupName, err)
+	}
+
+	arn := aws.StringValue(gameServerGroup.GameServerGroupArn)
+	d.Set("arn", arn)
+	d.Set("auto_scaling_group_arn", gameServerGroup.AutoScalingGroupArn)
+	d.Set("balancing_strategy", gameServerGroup.BalancingStrategy)
+	d.Set("game_server_group_name", gameServerGroupName)
+	d.Set("game_server_protection_policy", gameServerGroup.GameServerProtectionPolicy)
+	d.Set("max_size", autoScalingGroup.MaxSize)
+	d.Set("min_size", autoScalingGroup.MinSize)
+	d.Set("role_arn", gameServerGroup.RoleArn)
+
+	// d.Set("vpc_subnets", ...) is absent because Gamelift doesn't return its value in API
+	// and dynamically changes autoScalingGroup.VPCZoneIdentifier using its proprietary FleetIQ Spot Viability algorithm.
+
+	if len(describePoliciesOutput.ScalingPolicies) == 1 {
+		if err := d.Set("auto_scaling_policy", []interface{}{flattenGameliftGameServerGroupAutoScalingPolicy(describePoliciesOutput.ScalingPolicies[0])}); err != nil {
+			return fmt.Errorf("error setting auto_scaling_policy: %w", err)
+		}
+	} else {
+		d.Set("auto_scaling_policy", nil)
+	}
+
+	if err := d.Set("instance_definition", flattenGameliftInstanceDefinitions(gameServerGroup.InstanceDefinitions)); err != nil {
+		return fmt.Errorf("error setting instance_definition: %s", err)
+	}
+
+	if err := d.Set("launch_template", flattenLaunchTemplateSpecification(autoScalingGroup.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification)); err != nil {
+		return fmt.Errorf("error setting launch_template: %s", err)
+	}
+
+	tags, err := keyvaluetags.GameliftListTags(gameliftconn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Game Lift Game Server Group (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsGameliftGameServerGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	gameServerGroupName := d.Id()
+
+	if d.HasChanges("balancing_strategy", "game_server_protection_policy", "instance_definition", "role_arn") {
+		input := gamelift.UpdateGameServerGroupInput{
+			GameServerGroupName: aws.String(gameServerGroupName),
+			InstanceDefinitions: expandGameliftInstanceDefinitions(d.Get("instance_definition").(*schema.Set).List()),
+			RoleArn:             aws.String(d.Get("role_arn").(string)),
+		}
+
+		if v, ok := d.GetOk("balancing_strategy"); ok {
+			input.BalancingStrategy = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("game_server_protection_policy"); ok {
+			input.GameServerProtectionPolicy = aws.String(v.(string))
+		}
+
+		_, err := conn.UpdateGameServerGroup(&input)
+
+		if err != nil {
+			return fmt.Errorf("error updating GameLift Game Server Group (%s): %w", d.Id(), err)
+		}
+	}
+
+	arn := d.Get("arn").(string)
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.GameliftUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Game Lift Fleet (%s) tags: %s", arn, err)
+		}
+	}
+
+	return resourceAwsGameliftGameServerGroupRead(d, meta)
+}
+
+func resourceAwsGameliftGameServerGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	gameServerGroupName := d.Id()
+
+	_, err := conn.DeleteGameServerGroup(&gamelift.DeleteGameServerGroupInput{
+		GameServerGroupName: aws.String(gameServerGroupName),
+	})
+
+	if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Gamelift Game Server Group (%s): %w", d.Id(), err)
+	}
+
+	_, err = waiter.GameServerGroupDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+
+	if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error waiting for Gamelift Game Server Group (%s) deletion: %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandGameliftGameServerGroupAutoScalingPolicy(tfMap map[string]interface{}) *gamelift.GameServerGroupAutoScalingPolicy {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &gamelift.GameServerGroupAutoScalingPolicy{
+		TargetTrackingConfiguration: expandGameliftTargetTrackingConfiguration(tfMap["target_tracking_configuration"].([]interface{})[0].(map[string]interface{})),
+	}
+
+	if v, ok := tfMap["estimated_instance_warmup"].(int); ok && v != 0 {
+		apiObject.EstimatedInstanceWarmup = aws.Int64(int64(v))
+	}
+
+	return apiObject
+}
+
+func expandGameliftInstanceDefinition(tfMap map[string]interface{}) *gamelift.InstanceDefinition {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &gamelift.InstanceDefinition{
+		InstanceType: aws.String(tfMap["instance_type"].(string)),
+	}
+
+	if v, ok := tfMap["weighted_capacity"].(string); ok && v != "" {
+		apiObject.WeightedCapacity = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandGameliftInstanceDefinitions(tfList []interface{}) []*gamelift.InstanceDefinition {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*gamelift.InstanceDefinition
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandGameliftInstanceDefinition(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandGameliftLaunchTemplateSpecification(tfMap map[string]interface{}) *gamelift.LaunchTemplateSpecification {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &gamelift.LaunchTemplateSpecification{}
+
+	if v, ok := tfMap["id"].(string); ok && v != "" {
+		apiObject.LaunchTemplateId = aws.String(v)
+	}
+
+	if v, ok := tfMap["name"].(string); ok && v != "" {
+		apiObject.LaunchTemplateName = aws.String(v)
+	}
+
+	if v, ok := tfMap["version"].(string); ok && v != "" {
+		apiObject.Version = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandGameliftTargetTrackingConfiguration(tfMap map[string]interface{}) *gamelift.TargetTrackingConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &gamelift.TargetTrackingConfiguration{
+		TargetValue: aws.Float64(tfMap["target_value"].(float64)),
+	}
+
+	return apiObject
+}
+
+func flattenGameliftGameServerGroupAutoScalingPolicy(apiObject *autoscaling.ScalingPolicy) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"target_tracking_configuration": []interface{}{flattenGameliftTargetTrackingConfiguration(apiObject.TargetTrackingConfiguration)},
+	}
+
+	if v := apiObject.EstimatedInstanceWarmup; v != nil {
+		tfMap["estimated_instance_warmup"] = aws.Int64Value(v)
+	}
+
+	return tfMap
+}
+
+func flattenGameliftInstanceDefinition(apiObject *gamelift.InstanceDefinition) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"instance_type": aws.StringValue(apiObject.InstanceType),
+	}
+
+	if v := apiObject.WeightedCapacity; v != nil {
+		tfMap["weighted_capacity"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}
+
+func flattenGameliftInstanceDefinitions(apiObjects []*gamelift.InstanceDefinition) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenGameliftInstanceDefinition(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenGameliftTargetTrackingConfiguration(apiObject *autoscaling.TargetTrackingConfiguration) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"target_value": aws.Float64Value(apiObject.TargetValue),
+	}
+
+	return tfMap
+}

--- a/aws/resource_aws_gamelift_game_server_group_test.go
+++ b/aws/resource_aws_gamelift_game_server_group_test.go
@@ -1,0 +1,1238 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_gamelift_game_server_group", &resource.Sweeper{
+		Name: "aws_gamelift_game_server_group",
+		F:    testSweepGameliftGameServerGroups,
+	})
+}
+
+func testSweepGameliftGameServerGroups(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).gameliftconn
+	input := &gamelift.ListGameServerGroupsInput{}
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListGameServerGroupsPages(input, func(page *gamelift.ListGameServerGroupsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, gameServerGroup := range page.GameServerGroups {
+			id := aws.StringValue(gameServerGroup.GameServerGroupName)
+
+			input := &gamelift.DeleteGameServerGroupInput{
+				GameServerGroupName: gameServerGroup.GameServerGroupName,
+			}
+
+			log.Printf("[INFO] Deleting Gamelift Game Server Group: %s", id)
+			_, err := conn.DeleteGameServerGroup(input)
+
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Gamelift Game Server Group (%s): %w", id, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Gamelift Game Server Group sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil()
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Gamelift Game Server Groups: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func TestAccGameliftGameServerGroup_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "gamelift", fmt.Sprintf(`gameservergroup/%s`, rName)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "auto_scaling_group_arn", "autoscaling", regexp.MustCompile(`autoScalingGroup:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "balancing_strategy", gamelift.BalancingStrategySpotPreferred),
+					resource.TestCheckResourceAttr(resourceName, "game_server_protection_policy", gamelift.GameServerProtectionPolicyNoProtection),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.0.version", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_AutoScalingPolicy(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigAutoScalingPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.0.estimated_instance_warmup", "60"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.0.target_tracking_configuration.0.target_value", "77.7"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigAutoScalingPolicyEstimatedInstanceWarmup(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.0.estimated_instance_warmup", "66"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_policy.0.target_tracking_configuration.0.target_value", "77.7"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_BalancingStrategy(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigBalancingStrategy(rName, gamelift.BalancingStrategySpotOnly),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "balancing_strategy", gamelift.BalancingStrategySpotOnly),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_GameServerGroupName(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigGameServerGroupName(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "game_server_group_name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGameliftGameServerGroupConfigGameServerGroupName(rName, rName+"-new"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "game_server_group_name", rName+"-new"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_InstanceDefinition(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigInstanceDefinition(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "instance_definition.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGameliftGameServerGroupConfigInstanceDefinition(rName, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "instance_definition.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_InstanceDefinition_WeightedCapacity(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigInstanceDefinitionWeightedCapacity(rName, "1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "instance_definition.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "instance_definition.0.weighted_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_definition.1.weighted_capacity", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGameliftGameServerGroupConfigInstanceDefinitionWeightedCapacity(rName, "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "instance_definition.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "instance_definition.0.weighted_capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "instance_definition.1.weighted_capacity", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_LaunchTemplate_Id(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigLaunchTemplateId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", "aws_launch_template.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.0.version", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_LaunchTemplate_Name(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigLaunchTemplateName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", "aws_launch_template.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.0.version", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_LaunchTemplate_Version(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigLaunchTemplateVersion(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", "aws_launch_template.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.0.version", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_GameServerProtectionPolicy(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigGameServerProtectionPolicy(rName, gamelift.GameServerProtectionPolicyFullProtection),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "game_server_protection_policy", gamelift.GameServerProtectionPolicyFullProtection),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_MaxSize(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigMaxSize(rName, "1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "max_size", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGameliftGameServerGroupConfigMaxSize(rName, "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "max_size", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_MinSize(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigMinSize(rName, "1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "min_size", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGameliftGameServerGroupConfigMinSize(rName, "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "min_size", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_RoleArn(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigRoleArn(rName, "test1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckResourceAttrGlobalARN(resourceName, "role_arn", "iam", fmt.Sprintf(`role/%s-test1`, rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test1", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGameliftGameServerGroupConfigRoleArn(rName, "test2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					testAccCheckResourceAttrGlobalARN(resourceName, "role_arn", "iam", fmt.Sprintf(`role/%s-test2`, rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test2", "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_Tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigTags(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGameliftGameServerGroupConfigTags(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGameliftGameServerGroup_VpcSubnets(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_gamelift_game_server_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSGamelift(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGameliftGameServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGameliftGameServerGroupConfigVpcSubnets(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"vpc_subnets"},
+			},
+			{
+				Config: testAccGameliftGameServerGroupConfigVpcSubnets(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGameliftGameServerGroupExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGameliftGameServerGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_gamelift_game_server_group" {
+			continue
+		}
+
+		input := gamelift.DescribeGameServerGroupInput{
+			GameServerGroupName: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeGameServerGroup(&input)
+
+		if tfawserr.ErrCodeEquals(err, gamelift.ErrCodeNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if output != nil {
+			return fmt.Errorf("Gamelift Game Server Group (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckGameliftGameServerGroupExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource %s not found", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource %s has not set its id", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+		input := gamelift.DescribeGameServerGroupInput{
+			GameServerGroupName: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeGameServerGroup(&input)
+
+		if err != nil {
+			return fmt.Errorf("error reading Gamelift Game Server Group (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output == nil {
+			return fmt.Errorf("Gamelift Game Server Group (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccGameliftGameServerGroupIamConfig(rName string, name string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" %[2]q {
+  assume_role_policy = <<-EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": [
+              "autoscaling.amazonaws.com",
+              "gamelift.amazonaws.com"
+            ]
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
+    }
+  EOF
+
+  name = "%[1]s-%[2]s"
+}
+
+resource "aws_iam_role_policy_attachment" %[2]q {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/GameLiftGameServerGroupPolicy"
+  role = aws_iam_role.%[2]s.name
+}
+`, rName, name)
+}
+
+func testAccGameliftGameServerGroupLaunchTemplateConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  image_id = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  name = %[1]q
+}
+`, rName)
+}
+
+func testAccGameliftGameServerGroupInstanceTypeOfferingsConfig() string {
+	return `
+data "aws_ec2_instance_type_offerings" "available" {
+  filter {
+    name = "instance-type"
+    values = ["c5a.large", "c5a.2xlarge", "c5.large", "c5.2xlarge", "m4.large", "m4.2xlarge", "m5a.large", "m5a.2xlarge", "m5.large", "m5.2xlarge"]
+  }
+}
+`
+}
+
+func testAccGameliftGameServerGroupConfig(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccGameliftGameServerGroupConfigAutoScalingPolicy(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  auto_scaling_policy {
+    target_tracking_configuration {
+      target_value = 77.7
+    }
+  }
+
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccGameliftGameServerGroupConfigAutoScalingPolicyEstimatedInstanceWarmup(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  auto_scaling_policy {
+    estimated_instance_warmup = 66
+
+    target_tracking_configuration {
+      target_value = 77.7
+    }
+  }
+
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccGameliftGameServerGroupConfigBalancingStrategy(rName string, balancingStrategy string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  balancing_strategy = %[2]q
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, balancingStrategy))
+}
+
+func testAccGameliftGameServerGroupConfigGameServerGroupName(rName string, gameServerGroupName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, gameServerGroupName))
+}
+
+func testAccGameliftGameServerGroupConfigInstanceDefinition(rName string, count int) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+	for_each = slice(tolist(data.aws_ec2_instance_type_offerings.available.instance_types), 0, %[2]d)
+
+    content {
+      instance_type = instance_definition.value
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, count))
+}
+
+func testAccGameliftGameServerGroupConfigInstanceDefinitionWeightedCapacity(rName string, weightedCapacity string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+	for_each = slice(tolist(data.aws_ec2_instance_type_offerings.available.instance_types), 0, 2)
+
+    content {
+      instance_type = instance_definition.value
+      weighted_capacity = %[2]q
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, weightedCapacity))
+}
+func testAccGameliftGameServerGroupConfigLaunchTemplateId(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccGameliftGameServerGroupConfigLaunchTemplateName(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    name = aws_launch_template.test.name
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccGameliftGameServerGroupConfigLaunchTemplateVersion(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+    version = 1
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName))
+}
+
+func testAccGameliftGameServerGroupConfigMaxSize(rName string, maxSize string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = %[2]s
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, maxSize))
+}
+
+func testAccGameliftGameServerGroupConfigMinSize(rName string, minSize string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 2
+  min_size = %[2]s
+  role_arn = aws_iam_role.test.arn
+  
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, minSize))
+}
+
+func testAccGameliftGameServerGroupConfigTags(rName string, key string, value string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  tags = {
+    %[2]s = %[3]q
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, key, value))
+}
+
+func testAccGameliftGameServerGroupConfigGameServerProtectionPolicy(rName string, gameServerProtectionPolicy string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+  game_server_protection_policy = %[2]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+      instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, gameServerProtectionPolicy))
+}
+
+func testAccGameliftGameServerGroupConfigRoleArn(rName string, roleArn string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, roleArn),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+	  instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.%[2]s.arn
+
+  depends_on = [aws_iam_role_policy_attachment.%[2]s]
+}
+`, rName, roleArn))
+}
+
+func testAccGameliftGameServerGroupConfigVpcSubnets(rName string, count int) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccGameliftGameServerGroupIamConfig(rName, "test"),
+		testAccGameliftGameServerGroupInstanceTypeOfferingsConfig(),
+		testAccGameliftGameServerGroupLaunchTemplateConfig(rName),
+		fmt.Sprintf(`
+data "aws_vpc" "test" {
+  default = true
+}
+
+data "aws_subnet_ids" "test" {
+  vpc_id = data.aws_vpc.test.id
+}
+
+resource "aws_gamelift_game_server_group" "test" {
+  game_server_group_name = %[1]q
+
+  dynamic "instance_definition" {
+    for_each = data.aws_ec2_instance_type_offerings.available.instance_types
+
+    content {
+	  instance_type = instance_definition.key
+    }
+  }
+
+  launch_template {
+    id = aws_launch_template.test.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.test.arn
+  vpc_subnets = slice(tolist(data.aws_subnet_ids.test.ids), 0, %[2]d)
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, count))
+}

--- a/website/docs/r/gamelift_game_server_group.html.markdown
+++ b/website/docs/r/gamelift_game_server_group.html.markdown
@@ -1,0 +1,206 @@
+---
+subcategory: "Gamelift"
+layout: "aws"
+page_title: "AWS: aws_gamelift_game_server_group"
+description: |-
+Provides a Gamelift Game Server Group resource.
+---
+
+# Resource: aws_gamelift_game_server_group
+
+Provides an Gamelift Game Server Group resource.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "aws_gamelift_game_server_group" "example" {
+  game_server_group_name = "example"
+
+  instance_definition {
+    instance_type = "c5.large"
+  }
+
+  instance_definition {
+    instance_type = "c5a.large"
+  }
+
+  launch_template {
+    id = aws_launch_template.example.id
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.example.arn
+
+  depends_on = [
+    aws_iam_role_policy_attachment.example
+  ]
+}
+```
+
+Full usage:
+
+```hcl
+resource "aws_gamelift_game_server_group" "example" {
+  auto_scaling_policy {
+    estimated_instance_warmup = 60
+
+    target_tracking_configuration {
+      target_value = 75
+    }
+  }
+
+  balancing_strategy = "SPOT_ONLY"
+  game_server_group_name = "example"
+  game_server_protection_policy = "FULL_PROTECTION"
+
+  instance_definition {
+    instance_type = "c5.large"
+    weighted_capacity = "1"
+  }
+
+  instance_definition {
+    instance_type = "c5.2xlarge"
+    weighted_capacity = "2"
+  }
+
+  launch_template {
+    id = aws_launch_template.example.id
+    version = "1"
+  }
+
+  max_size = 1
+  min_size = 1
+  role_arn = aws_iam_role.example.arn
+
+  tags = {
+    Name = "example"
+  }
+
+  vpc_subnets = [
+    "subnet-12345678", 
+    "subnet-23456789"
+  ]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.example
+  ]
+}
+```
+
+### Example IAM Role for Gamelift Game Server Group
+```hcl
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "example" {
+  assume_role_policy = <<-EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": [
+              "autoscaling.amazonaws.com",
+              "gamelift.amazonaws.com"
+            ]
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
+    }
+  EOF
+
+  name = "gamelift-game-server-group-example"
+}
+
+resource "aws_iam_role_policy_attachment" "example" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/GameLiftGameServerGroupPolicy"
+  role = aws_iam_role.example.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `balancing_strategy` - (Optional) Indicates how GameLift FleetIQ balances the use of Spot Instances and On-Demand Instances. 
+  Valid values: `SPOT_ONLY`, `SPOT_PREFERRED`, `ON_DEMAND_ONLY`. Defaults to `SPOT_PREFERRED`.
+* `game_server_group_name` - (Required) Name of the game server group. 
+  This value is used to generate unique ARN identifiers for the EC2 Auto Scaling group and the GameLift FleetIQ game server group.
+* `game_server_protection_policy` - (Optional) Indicates whether instances in the game server group are protected from early termination. 
+  Unprotected instances that have active game servers running might be terminated during a scale-down event, 
+  causing players to be dropped from the game. 
+  Protected instances cannot be terminated while there are active game servers running except in the event 
+  of a forced game server group deletion.
+  Valid values: `NO_PROTECTION`, `FULL_PROTECTION`. Defaults to `NO_PROTECTION`.
+* `max_size` - (Required) The maximum number of instances allowed in the EC2 Auto Scaling group. 
+  During automatic scaling events, GameLift FleetIQ and EC2 do not scale up the group above this maximum.
+* `min_size` - (Required) The minimum number of instances allowed in the EC2 Auto Scaling group. 
+  During automatic scaling events, GameLift FleetIQ and EC2 do not scale down the group below this minimum.
+* `role_arn` - (Required) ARN for an IAM role that allows Amazon GameLift to access your EC2 Auto Scaling groups.
+* `tags` - (Optional) Key-value map of resource tags
+* `vpc_subnets` - (Optional) A list of VPC subnets to use with instances in the game server group.
+  By default, all GameLift FleetIQ-supported Availability Zones are used.
+
+### `auto_scaling_policy`
+Configuration settings to define a scaling policy for the Auto Scaling group that is optimized for game hosting.
+The scaling policy uses the metric `PercentUtilizedGameServers` to maintain a buffer of idle game servers that 
+can immediately accommodate new games and players.
+
+* `estimated_instance_warmup` - (Optional) Length of time, in seconds, it takes for a new instance to start 
+  new game server processes and register with GameLift FleetIQ.
+  Specifying a warm-up time can be useful, particularly with game servers that take a long time to start up, 
+  because it avoids prematurely starting new instances. Defaults to `60`.
+
+#### `target_tracking_configuration`
+Settings for a target-based scaling policy applied to Auto Scaling group.
+These settings are used to create a target-based policy that tracks the GameLift FleetIQ metric `PercentUtilizedGameServers` 
+and specifies a target value for the metric.
+
+* `target_value` - (Required) Desired value to use with a game server group target-based scaling policy.
+
+### `instance_definition`
+The EC2 instance types and sizes to use in the Auto Scaling group.
+The instance definitions must specify at least two different instance types that are supported by GameLift FleetIQ.
+
+* `instance_type` - (Required) An EC2 instance type.
+* `weighted_capacity` - (Optional) Instance weighting that indicates how much this instance type contributes 
+  to the total capacity of a game server group. 
+  Instance weights are used by GameLift FleetIQ to calculate the instance type's cost per unit hour and better identify 
+  the most cost-effective options.
+
+### `launch_template`
+The EC2 launch template that contains configuration settings and game server code to be deployed to all instances in the game server group. 
+You can specify the template using either the template name or ID.
+
+* `id` - (Optional) A unique identifier for an existing EC2 launch template.
+* `name` - (Optional) A readable identifier for an existing EC2 launch template.
+* `version` - (Optional) The version of the EC2 launch template to use. If none is set, the default is the first version created.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the Gamelift Game Server Group.
+* `arn` - The ARN of the Gamelift Game Server Group.
+* `auto_scaling_group_arn` - The ARN of the created EC2 Auto Scaling group.
+
+
+## Timeouts
+
+`aws_gamelift_game_server_group` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+* `create` - (Default `10 minutes`) How long to wait for the Gamelift Game Server Group to be created.
+* `delete` - (Default `30 minutes`) How long to wait for the Gamelift Game Server Group to be deleted.
+
+## Import
+
+Gamelift Game Server Group can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_gamelift_game_server_group.example example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Reference: #18002

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
# make testacc TESTARGS='-run=TestAccGameliftGameServerGroup'
=== RUN   TestAccGameliftGameServerGroup_basic
=== PAUSE TestAccGameliftGameServerGroup_basic
=== RUN   TestAccGameliftGameServerGroup_AutoScalingPolicy
=== PAUSE TestAccGameliftGameServerGroup_AutoScalingPolicy
=== RUN   TestAccGameliftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup
=== PAUSE TestAccGameliftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup
=== RUN   TestAccGameliftGameServerGroup_BalancingStrategy
=== PAUSE TestAccGameliftGameServerGroup_BalancingStrategy
=== RUN   TestAccGameliftGameServerGroup_GameServerGroupName
=== PAUSE TestAccGameliftGameServerGroup_GameServerGroupName
=== RUN   TestAccGameliftGameServerGroup_InstanceDefinition
=== PAUSE TestAccGameliftGameServerGroup_InstanceDefinition
=== RUN   TestAccGameliftGameServerGroup_InstanceDefinition_WeightedCapacity
=== PAUSE TestAccGameliftGameServerGroup_InstanceDefinition_WeightedCapacity
=== RUN   TestAccGameliftGameServerGroup_LaunchTemplate_Id
=== PAUSE TestAccGameliftGameServerGroup_LaunchTemplate_Id
=== RUN   TestAccGameliftGameServerGroup_LaunchTemplate_Name
=== PAUSE TestAccGameliftGameServerGroup_LaunchTemplate_Name
=== RUN   TestAccGameliftGameServerGroup_LaunchTemplate_Version
=== PAUSE TestAccGameliftGameServerGroup_LaunchTemplate_Version
=== RUN   TestAccGameliftGameServerGroup_GameServerProtectionPolicy
=== PAUSE TestAccGameliftGameServerGroup_GameServerProtectionPolicy
=== RUN   TestAccGameliftGameServerGroup_MaxSize
=== PAUSE TestAccGameliftGameServerGroup_MaxSize
=== RUN   TestAccGameliftGameServerGroup_MinSize
=== PAUSE TestAccGameliftGameServerGroup_MinSize
=== RUN   TestAccGameliftGameServerGroup_RoleArn
=== PAUSE TestAccGameliftGameServerGroup_RoleArn
=== RUN   TestAccGameliftGameServerGroup_Tags
=== PAUSE TestAccGameliftGameServerGroup_Tags
=== RUN   TestAccGameliftGameServerGroup_VpcSubnets
=== PAUSE TestAccGameliftGameServerGroup_VpcSubnets
=== CONT  TestAccGameliftGameServerGroup_basic
=== CONT  TestAccGameliftGameServerGroup_LaunchTemplate_Version
=== CONT  TestAccGameliftGameServerGroup_VpcSubnets
=== CONT  TestAccGameliftGameServerGroup_Tags
=== CONT  TestAccGameliftGameServerGroup_RoleArn
=== CONT  TestAccGameliftGameServerGroup_MinSize
=== CONT  TestAccGameliftGameServerGroup_InstanceDefinition
=== CONT  TestAccGameliftGameServerGroup_LaunchTemplate_Name
=== CONT  TestAccGameliftGameServerGroup_InstanceDefinition_WeightedCapacity
=== CONT  TestAccGameliftGameServerGroup_MaxSize
=== CONT  TestAccGameliftGameServerGroup_LaunchTemplate_Id
=== CONT  TestAccGameliftGameServerGroup_GameServerProtectionPolicy
=== CONT  TestAccGameliftGameServerGroup_BalancingStrategy
=== CONT  TestAccGameliftGameServerGroup_GameServerGroupName
=== CONT  TestAccGameliftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup
=== CONT  TestAccGameliftGameServerGroup_AutoScalingPolicy
--- PASS: TestAccGameliftGameServerGroup_basic (263.08s)
--- PASS: TestAccGameliftGameServerGroup_LaunchTemplate_Id (267.91s)
--- PASS: TestAccGameliftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup (269.90s)
--- PASS: TestAccGameliftGameServerGroup_Tags (292.55s)
--- PASS: TestAccGameliftGameServerGroup_GameServerProtectionPolicy (299.93s)
--- PASS: TestAccGameliftGameServerGroup_RoleArn (303.11s)
--- PASS: TestAccGameliftGameServerGroup_BalancingStrategy (305.06s)
--- PASS: TestAccGameliftGameServerGroup_LaunchTemplate_Name (305.07s)
--- PASS: TestAccGameliftGameServerGroup_LaunchTemplate_Version (320.22s)
--- PASS: TestAccGameliftGameServerGroup_AutoScalingPolicy (325.74s)
--- PASS: TestAccGameliftGameServerGroup_InstanceDefinition (367.12s)
--- PASS: TestAccGameliftGameServerGroup_InstanceDefinition_WeightedCapacity (376.41s)
--- PASS: TestAccGameliftGameServerGroup_MaxSize (524.09s)
--- PASS: TestAccGameliftGameServerGroup_MinSize (563.99s)
--- PASS: TestAccGameliftGameServerGroup_GameServerGroupName (579.16s)
--- PASS: TestAccGameliftGameServerGroup_VpcSubnets (585.84s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       585.881s
```
