### PR TITLE
Replaces `pattern-not-inside` directives in rules with `nosemgrep` comments in code

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -121,9 +121,7 @@ rules:
     paths:
       include:
         - aws/
-    patterns:
-      - pattern: schema.NewSet(schema.HashString, flattenStringList($APIOBJECT))
-      - pattern-not-inside: func flattenStringSet(list []*string) *schema.Set { ... }
+    pattern: schema.NewSet(schema.HashString, flattenStringList($APIOBJECT))
     severity: WARNING
     
   - id: helper-schema-Set-extraneous-expandStringList-with-List
@@ -139,7 +137,6 @@ rules:
             $LIST := $SET.List()
             ...
             expandStringList($LIST)
-      - pattern-not-inside: func expandStringSet(configured *schema.Set) []*string { ... }
     severity: WARNING
 
 
@@ -215,9 +212,7 @@ rules:
               var $CAST *resource.NotFoundError
               ...
               errors.As($ERR, &$CAST)
-          - pattern-not-inside: func NotFound(err error) bool { ... }
         - patterns:
           - pattern: |
               $X, $Y := $ERR.(*resource.NotFoundError)
-          - pattern-not-inside: func isResourceNotFoundError(err error) bool { ... }
     severity: WARNING

--- a/aws/internal/tfresource/errors.go
+++ b/aws/internal/tfresource/errors.go
@@ -10,7 +10,7 @@ import (
 // Specifically, NotFound returns true if the error or a wrapped error is of type
 // resource.NotFoundError.
 func NotFound(err error) bool {
-	var e *resource.NotFoundError
+	var e *resource.NotFoundError // nosemgrep: is-not-found-error
 	return errors.As(err, &e)
 }
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1013,7 +1013,7 @@ func expandFloat64Map(m map[string]interface{}) map[string]*float64 {
 
 // Takes the result of schema.Set of strings and returns a []*string
 func expandStringSet(configured *schema.Set) []*string {
-	return expandStringList(configured.List())
+	return expandStringList(configured.List()) // nosemgrep: helper-schema-Set-extraneous-expandStringList-with-List
 }
 
 // Takes the result of schema.Set of strings and returns a []*int64
@@ -1033,7 +1033,7 @@ func flattenStringList(list []*string) []interface{} {
 }
 
 func flattenStringSet(list []*string) *schema.Set {
-	return schema.NewSet(schema.HashString, flattenStringList(list))
+	return schema.NewSet(schema.HashString, flattenStringList(list)) // nosemgrep: helper-schema-Set-extraneous-NewSet-with-flattenStringList
 }
 
 // hashStringCaseInsensitive hashes strings in a case insensitive manner.

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 // Base64Encode encodes data if the input isn't already encoded using base64.StdEncoding.EncodeToString.
@@ -44,13 +44,11 @@ func jsonBytesEqual(b1, b2 []byte) bool {
 }
 
 func isResourceNotFoundError(err error) bool {
-	_, ok := err.(*resource.NotFoundError)
-	return ok
+	return tfresource.NotFound(err)
 }
 
 func isResourceTimeoutError(err error) bool {
-	timeoutErr, ok := err.(*resource.TimeoutError)
-	return ok && timeoutErr.LastError == nil
+	return tfresource.TimedOut(err)
 }
 
 func appendUniqueString(slice []string, elem string) []string {


### PR DESCRIPTION
Replaces `pattern-not-inside` directives in rules with `nosemgrep` comments in code. This separates the concerns of defining a rule from specific instances where the rule should be ignored.
