### PR TITLE
docs/resource/aws_storagegateway_stored_iscsi_volume: Fix incorrect resource type in import section

### DIFF
--- a/website/docs/r/storagegateway_stored_iscsi_volume.html.markdown
+++ b/website/docs/r/storagegateway_stored_iscsi_volume.html.markdown
@@ -75,5 +75,5 @@ In addition to all arguments above, the following attributes are exported:
 `aws_storagegateway_stored_iscsi_volume` can be imported by using the volume Amazon Resource Name (ARN), e.g.
 
 ```
-$ terraform import aws_storagegateway_cache.example arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12345678/volume/vol-12345678
+$ terraform import aws_storagegateway_stored_iscsi_volume.example arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12345678/volume/vol-12345678
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15842

Previously:

```
	* website/docs/r/storagegateway_stored_iscsi_volume.html.markdown: error checking file contents: import section code block text should contain resource name: aws_storagegateway_stored_iscsi_volume
```

Output from acceptance testing: N/A (documentation)