### PR TITLE
Make snapshot_identifier computed

### DIFF
--- a/.changelog/18013.txt
+++ b/.changelog/18013.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_db_instance: Allow `snapshot_identifier` to be removed from configuration by making it `computed`
+resource/aws_db_instance: Allow `snapshot_identifier` to be removed from configuration without resource recreation
 ```

--- a/.changelog/18013.txt
+++ b/.changelog/18013.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Allow `snapshot_identifier` to be removed from configuration by making it `computed`
+```

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -414,6 +414,7 @@ func resourceAwsDbInstance() *schema.Resource {
 
 			"snapshot_identifier": {
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 				ForceNew: true,
 			},

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -2733,7 +2733,7 @@ func testAccCheckAWSDBInstanceNoSnapshot(s *terraform.State) error {
 
 func testAccCheckAWSDBInstanceNotRecreated(instance1, instance2 *rds.DBInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.TimeValue(instance1.InstanceCreateTime) != aws.TimeValue(instance2.InstanceCreateTime) {
+		if !aws.TimeValue(instance1.InstanceCreateTime).Equal(aws.TimeValue(instance2.InstanceCreateTime)) {
 			return fmt.Errorf("database instance was recreated. expected: %s, got: %s", instance1.InstanceCreateTime, instance2.InstanceCreateTime)
 		}
 		return nil

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -1176,6 +1176,34 @@ func TestAccAWSDBInstance_SnapshotIdentifier(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBInstance_SnapshotIdentifierRemoved(t *testing.T) {
+	var dbInstance1, dbInstance2 rds.DBInstance
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_SnapshotIdentifier(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance1),
+				),
+			},
+			{
+				Config: testAccAWSDBInstanceConfig_SnapshotIdentifierRemoved(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance2),
+					testAccCheckAWSDBInstanceNotRecreated(&dbInstance1, &dbInstance2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage(t *testing.T) {
 	var dbInstance, sourceDbInstance rds.DBInstance
 	var dbSnapshot rds.DBSnapshot
@@ -2701,6 +2729,15 @@ func testAccCheckAWSDBInstanceNoSnapshot(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckAWSDBInstanceNotRecreated(instance1, instance2 *rds.DBInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(instance1.InstanceCreateTime) != aws.TimeValue(instance2.InstanceCreateTime) {
+			return fmt.Errorf("database instance was recreated. expected: %s, got: %s", instance1.InstanceCreateTime, instance2.InstanceCreateTime)
+		}
+		return nil
+	}
 }
 
 func testAccCheckAWSDBInstanceExists(n string, v *rds.DBInstance) resource.TestCheckFunc {
@@ -6067,6 +6104,35 @@ resource "aws_db_instance" "test" {
   identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   snapshot_identifier = aws_db_snapshot.test.id
+  skip_final_snapshot = true
+}
+`, rName))
+}
+
+func testAccAWSDBInstanceConfig_SnapshotIdentifierRemoved(rName string) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
+resource "aws_db_instance" "source" {
+  allocated_storage   = 5
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = aws_db_instance.source.id
+  db_snapshot_identifier = %[1]q
+}
+
+resource "aws_db_instance" "test" {
+  allocated_storage   = 5
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  identifier          = %[1]q
+  instance_class      = aws_db_instance.source.instance_class
   skip_final_snapshot = true
 }
 `, rName))


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #467

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBInstance_SnapshotIdentifierRemoved -timeout 120m
=== RUN   TestAccAWSDBInstance_SnapshotIdentifierRemoved
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifierRemoved
=== CONT  TestAccAWSDBInstance_SnapshotIdentifierRemoved
--- PASS: TestAccAWSDBInstance_SnapshotIdentifierRemoved (1386.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1386.601s
```
