### PR TITLE
docs/provider: Remove other examples code block languages

### DIFF
--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -12,10 +12,37 @@ Manages a revision of an ECS task definition to be used in `aws_ecs_service`.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "aws_ecs_task_definition" "service" {
-  family                = "service"
-  container_definitions = file("task-definitions/service.json")
+  family = "service"
+  container_definitions = jsonencode([
+    {
+      name      = "first"
+      image     = "service-first"
+      cpu       = 10
+      memory    = 512
+      essential = true
+      portMappings = [
+        {
+          containerPort = 80
+          hostPort      = 80
+        }
+      ]
+    },
+    {
+      name      = "second"
+      image     = "service-second"
+      cpu       = 10
+      memory    = 256
+      essential = true
+      portMappings = [
+        {
+          containerPort = 443
+          hostPort      = 443
+        }
+      ]
+    }
+  ])
 
   volume {
     name      = "service-storage"
@@ -27,42 +54,6 @@ resource "aws_ecs_task_definition" "service" {
     expression = "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]"
   }
 }
-```
-
-The referenced `task-definitions/service.json` file contains a valid JSON document,
-which is shown below, and its content is going to be passed directly into the
-`container_definitions` attribute as a string. Please note that this example
-contains only a small subset of the available parameters.
-
-```json
-[
-  {
-    "name": "first",
-    "image": "service-first",
-    "cpu": 10,
-    "memory": 512,
-    "essential": true,
-    "portMappings": [
-      {
-        "containerPort": 80,
-        "hostPort": 80
-      }
-    ]
-  },
-  {
-    "name": "second",
-    "image": "service-second",
-    "cpu": 10,
-    "memory": 256,
-    "essential": true,
-    "portMappings": [
-      {
-        "containerPort": 443,
-        "hostPort": 443
-      }
-    ]
-  }
-]
 ```
 
 ### With AppMesh Proxy

--- a/website/docs/r/load_balancer_backend_server_policy.html.markdown
+++ b/website/docs/r/load_balancer_backend_server_policy.html.markdown
@@ -36,6 +36,8 @@ resource "aws_load_balancer_policy" "wu-tang-ca-pubkey-policy" {
   policy_name        = "wu-tang-ca-pubkey-policy"
   policy_type_name   = "PublicKeyPolicyType"
 
+  # The public key of a CA certificate file can be extracted with:
+  # $ cat wu-tang-ca.pem | openssl x509 -pubkey -noout | grep -v '\-\-\-\-' | tr -d '\n' > wu-tang-pubkey
   policy_attribute {
     name  = "PublicKey"
     value = file("wu-tang-pubkey")
@@ -62,14 +64,6 @@ resource "aws_load_balancer_backend_server_policy" "wu-tang-backend-auth-policie
   ]
 }
 ```
-
-Where the file `pubkey` in the current directory contains only the _public key_ of the certificate.
-
-```shell
-cat wu-tang-ca.pem | openssl x509 -pubkey -noout | grep -v '\-\-\-\-' | tr -d '\n' > wu-tang-pubkey
-```
-
-This example shows how to enable backend authentication for an ELB as well as customize the TLS settings.
 
 ## Argument Reference
 

--- a/website/docs/r/load_balancer_policy.html.markdown
+++ b/website/docs/r/load_balancer_policy.html.markdown
@@ -35,6 +35,8 @@ resource "aws_load_balancer_policy" "wu-tang-ca-pubkey-policy" {
   policy_name        = "wu-tang-ca-pubkey-policy"
   policy_type_name   = "PublicKeyPolicyType"
 
+  # The public key of a CA certificate file can be extracted with:
+  # $ cat wu-tang-ca.pem | openssl x509 -pubkey -noout | grep -v '\-\-\-\-' | tr -d '\n' > wu-tang-pubkey
   policy_attribute {
     name  = "PublicKey"
     value = file("wu-tang-pubkey")
@@ -97,14 +99,6 @@ resource "aws_load_balancer_listener_policy" "wu-tang-listener-policies-443" {
   ]
 }
 ```
-
-Where the file `pubkey` in the current directory contains only the _public key_ of the certificate.
-
-```shell
-cat wu-tang-ca.pem | openssl x509 -pubkey -noout | grep -v '\-\-\-\-' | tr -d '\n' > wu-tang-pubkey
-```
-
-This example shows how to enable backend authentication for an ELB as well as customize the TLS settings.
 
 ## Argument Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15842

Previously:

```
	* website/docs/r/ecs_task_definition.html.markdown: error checking file contents: example section code block language (json) should be: ```terraform
	* website/docs/r/load_balancer_backend_server_policy.html.markdown: error checking file contents: example section code block language (shell) should be: ```terraform
	* website/docs/r/load_balancer_policy.html.markdown: error checking file contents: example section code block language (shell) should be: ```terraform
```

The resource documentation examples sections are designated for Terraform configurations and in the future these files will only be generated from resource/attribute descriptions and configuration files.

For these in particular:

* Disallow json as a code block languange as it could allow Terraform JSON configuration files to be shown, where Terraform HCL configuration files are the norm. Instead, use jsonencode() function to show the container definitions inline.
* Move shell commands to code comments (or alteratively could be added to the relevant attribute description, but in this case it seems clearer to denote via comment the exact situation).

Output from acceptance testing: N/A (documentation)
