### PR TITLE
tests/provider: Fix and enable linting for immediate dereference after AWS SDK Go pointer conversion

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -115,6 +115,22 @@ rules:
     pattern: 'd.SetId(*$VALUE)'
     severity: WARNING
 
+  - id: aws-go-sdk-pointer-conversion-immediate-dereference
+    fix: $VALUE
+    languages: [go]
+    message: Using AWS Go SDK pointer conversion, e.g. aws.String(), with immediate dereferencing is extraneous
+    paths:
+      include:
+        - aws/
+    patterns:
+      - pattern-either:
+        - pattern: '*aws.Bool($VALUE)'
+        - pattern: '*aws.Float64($VALUE)'
+        - pattern: '*aws.Int64($VALUE)'
+        - pattern: '*aws.String($VALUE)'
+        - pattern: '*aws.Time($VALUE)'
+    severity: WARNING
+
   - id: helper-schema-Set-extraneous-NewSet-with-flattenStringList
     languages: [go]
     message: Prefer `flattenStringSet()` function for casting a list of string pointers to a set

--- a/aws/resource_aws_cur_report_definition.go
+++ b/aws/resource_aws_cur_report_definition.go
@@ -172,7 +172,7 @@ func resourceAwsCurReportDefinitionCreate(d *schema.ResourceData, meta interface
 func resourceAwsCurReportDefinitionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).costandusagereportconn
 
-	reportName := *aws.String(d.Id())
+	reportName := d.Id()
 
 	matchingReportDefinition, err := describeCurReportDefinition(conn, reportName)
 	if err != nil {

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -434,7 +434,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 				ebs.Iops = aws.Int64(int64(v))
 			}
 
-			if *aws.String(bd["device_name"].(string)) == *rootDeviceName {
+			if bd["device_name"].(string) == aws.StringValue(rootDeviceName) {
 				return fmt.Errorf("Root device (%s) declared as an 'ebs_block_device'.  Use 'root_block_device' keyword.", *rootDeviceName)
 			}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12992

This is akin to `*&var`, which is flagged by the Go toolchain.

Previously:

```
aws/resource_aws_cur_report_definition.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
175:	reportName := *aws.String(d.Id())
```

```
aws/resource_aws_cur_report_definition.go
severity:warning rule:aws-go-sdk-pointer-conversion-immediate-dereference: Using AWS Go SDK pointer conversion, e.g. aws.String(), with immediate dereferencing is extraneous
175:	reportName := *aws.String(d.Id())
autofix: d.Id()

aws/resource_aws_launch_configuration.go
severity:warning rule:aws-go-sdk-pointer-conversion-immediate-dereference: Using AWS Go SDK pointer conversion, e.g. aws.String(), with immediate dereferencing is extraneous
437:			if *aws.String(bd["device_name"].(string)) == *rootDeviceName {
autofix: bd["device_name"].(string)
```

Output from acceptance testing:

```
--- PASS: TestAccAwsCurReportDefinition_athena (37.90s)
--- PASS: TestAccAwsCurReportDefinition_basic (38.73s)
--- PASS: TestAccAwsCurReportDefinition_overwrite (38.85s)
--- PASS: TestAccAwsCurReportDefinition_parquet (38.70s)
--- PASS: TestAccAwsCurReportDefinition_refresh (40.36s)
--- PASS: TestAccAwsCurReportDefinition_textOrCsv (39.09s)

--- PASS: TestAccAWSLaunchConfiguration_basic (52.19s)
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (35.06s)
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (43.59s)
--- PASS: TestAccAWSLaunchConfiguration_metadataOptions (30.25s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears (388.12s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_VolumeSize (55.15s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (55.24s)
--- PASS: TestAccAWSLaunchConfiguration_userData (52.19s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (33.31s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (36.93s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (43.40s)
--- PASS: TestAccAWSLaunchConfiguration_withInstanceStoreAMI (29.75s)
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (31.12s)
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (46.41s)
```
