### PR TITLE
tests/provider: Fix and enable AWS SDK Go pointer conversion linting (A-B resources)

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -57,7 +57,20 @@ rules:
         - aws/cloudfront_distribution_configuration_structure.go
         - aws/data_source_aws_route_table.go
         - aws/opsworks_layers.go
-        - aws/resource*
+        - aws/resource_aws_c*
+        - aws/resource_aws_d*
+        - aws/resource_aws_e*
+        - aws/resource_aws_g*
+        - aws/resource_aws_i*
+        - aws/resource_aws_k*
+        - aws/resource_aws_l*
+        - aws/resource_aws_mq_broker.go
+        - aws/resource_aws_o*
+        - aws/resource_aws_r*
+        - aws/resource_aws_s*
+        - aws/resource_aws_transfer_ssh_key.go
+        - aws/resource_aws_vpc.go
+        - aws/resource_aws_w*
         - aws/structure.go
         - aws/waf_helpers.go
         - aws/internal/generators/
@@ -81,7 +94,22 @@ rules:
         - aws/data_source_aws_route*
         - aws/ecs_task_definition_equivalency.go
         - aws/opsworks_layers.go
-        - aws/resource*
+        - aws/resource_aws_c*.go
+        - aws/resource_aws_d*.go
+        - aws/resource_aws_e*.go
+        - aws/resource_aws_g*.go
+        - aws/resource_aws_i*.go
+        - aws/resource_aws_k*.go
+        - aws/resource_aws_l*.go
+        - aws/resource_aws_main_route_table_association.go
+        - aws/resource_aws_n*.go
+        - aws/resource_aws_o*.go
+        - aws/resource_aws_r*.go
+        - aws/resource_aws_s*.go
+        - aws/resource_aws_transfer_ssh_key.go
+        - aws/resource_aws_v*.go
+        - aws/resource_aws_w*
+        - aws/resource*_test.go
         - aws/structure.go
         - aws/internal/generators/
         - aws/internal/keyvaluetags/

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -383,7 +383,7 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
-		state = *image.State
+		state = aws.StringValue(image.State)
 	}
 
 	if state == ec2.ImageStateDeregistered {

--- a/aws/resource_aws_api_gateway_base_path_mapping.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping.go
@@ -167,7 +167,7 @@ func resourceAwsApiGatewayBasePathMappingRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error reading Gateway base path mapping: %s", err)
 	}
 
-	mappingBasePath := *mapping.BasePath
+	mappingBasePath := aws.StringValue(mapping.BasePath)
 
 	if mappingBasePath == emptyBasePathMappingValue {
 		mappingBasePath = ""

--- a/aws/resource_aws_api_gateway_documentation_part.go
+++ b/aws/resource_aws_api_gateway_documentation_part.go
@@ -200,18 +200,25 @@ func flattenApiGatewayDocumentationPartLocation(l *apigateway.DocumentationPartL
 	}
 
 	m := make(map[string]interface{})
-	m["type"] = *l.Type
-	if l.Method != nil {
-		m["method"] = *l.Method
+
+	if v := l.Method; v != nil {
+		m["method"] = aws.StringValue(v)
 	}
-	if l.Name != nil {
-		m["name"] = *l.Name
+
+	if v := l.Name; v != nil {
+		m["name"] = aws.StringValue(v)
 	}
-	if l.Path != nil {
-		m["path"] = *l.Path
+
+	if v := l.Path; v != nil {
+		m["path"] = aws.StringValue(v)
 	}
-	if l.StatusCode != nil {
-		m["status_code"] = *l.StatusCode
+
+	if v := l.StatusCode; v != nil {
+		m["status_code"] = aws.StringValue(v)
+	}
+
+	if v := l.Type; v != nil {
+		m["type"] = aws.StringValue(v)
 	}
 
 	return []interface{}{m}

--- a/aws/resource_aws_api_gateway_stage.go
+++ b/aws/resource_aws_api_gateway_stage.go
@@ -169,7 +169,7 @@ func resourceAwsApiGatewayStageCreate(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(fmt.Sprintf("ags-%s-%s", d.Get("rest_api_id").(string), d.Get("stage_name").(string)))
 
-	if waitForCache && *out.CacheClusterStatus != apigateway.CacheClusterStatusNotAvailable {
+	if waitForCache && out != nil && aws.StringValue(out.CacheClusterStatus) != apigateway.CacheClusterStatusNotAvailable {
 		stateConf := &resource.StateChangeConf{
 			Pending: []string{
 				apigateway.CacheClusterStatusCreateInProgress,
@@ -229,7 +229,7 @@ func resourceAwsApiGatewayStageRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("client_certificate_id", stage.ClientCertificateId)
 
-	if stage.CacheClusterStatus != nil && *stage.CacheClusterStatus == apigateway.CacheClusterStatusDeleteInProgress {
+	if aws.StringValue(stage.CacheClusterStatus) == apigateway.CacheClusterStatusDeleteInProgress {
 		d.Set("cache_cluster_enabled", false)
 		d.Set("cache_cluster_size", nil)
 	} else {
@@ -379,7 +379,7 @@ func resourceAwsApiGatewayStageUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Updating API Gateway Stage failed: %s", err)
 	}
 
-	if waitForCache && *out.CacheClusterStatus != apigateway.CacheClusterStatusNotAvailable {
+	if waitForCache && out != nil && aws.StringValue(out.CacheClusterStatus) != apigateway.CacheClusterStatusNotAvailable {
 		stateConf := &resource.StateChangeConf{
 			Pending: []string{
 				apigateway.CacheClusterStatusCreateInProgress,

--- a/aws/resource_aws_app_cookie_stickiness_policy.go
+++ b/aws/resource_aws_app_cookie_stickiness_policy.go
@@ -132,7 +132,7 @@ func resourceAwsAppCookieStickinessPolicyRead(d *schema.ResourceData, meta inter
 	// cookie expiration, in these descriptions.
 	policyDesc := getResp.PolicyDescriptions[0]
 	cookieAttr := policyDesc.PolicyAttributeDescriptions[0]
-	if *cookieAttr.AttributeName != "CookieName" {
+	if aws.StringValue(cookieAttr.AttributeName) != "CookieName" {
 		return fmt.Errorf("Unable to find cookie Name.")
 	}
 
@@ -168,12 +168,12 @@ func resourceAwsELBSticknessPolicyAssigned(policyName, lbName, lbPort string, el
 	lb := describeResp.LoadBalancerDescriptions[0]
 	assigned := false
 	for _, listener := range lb.ListenerDescriptions {
-		if lbPort != strconv.Itoa(int(*listener.Listener.LoadBalancerPort)) {
+		if listener == nil || listener.Listener == nil || lbPort != strconv.Itoa(int(aws.Int64Value(listener.Listener.LoadBalancerPort))) {
 			continue
 		}
 
 		for _, name := range listener.PolicyNames {
-			if policyName == *name {
+			if policyName == aws.StringValue(name) {
 				assigned = true
 				break
 			}

--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -705,22 +705,29 @@ func flattenTargetTrackingScalingPolicyConfiguration(cfg *applicationautoscaling
 	}
 
 	m := make(map[string]interface{})
-	m["target_value"] = *cfg.TargetValue
 
-	if cfg.DisableScaleIn != nil {
-		m["disable_scale_in"] = *cfg.DisableScaleIn
+	if v := cfg.CustomizedMetricSpecification; v != nil {
+		m["customized_metric_specification"] = flattenCustomizedMetricSpecification(v)
 	}
-	if cfg.ScaleInCooldown != nil {
-		m["scale_in_cooldown"] = *cfg.ScaleInCooldown
+
+	if v := cfg.DisableScaleIn; v != nil {
+		m["disable_scale_in"] = aws.BoolValue(v)
 	}
-	if cfg.ScaleOutCooldown != nil {
-		m["scale_out_cooldown"] = *cfg.ScaleOutCooldown
+
+	if v := cfg.PredefinedMetricSpecification; v != nil {
+		m["predefined_metric_specification"] = flattenPredefinedMetricSpecification(v)
 	}
-	if cfg.CustomizedMetricSpecification != nil {
-		m["customized_metric_specification"] = flattenCustomizedMetricSpecification(cfg.CustomizedMetricSpecification)
+
+	if v := cfg.ScaleInCooldown; v != nil {
+		m["scale_in_cooldown"] = aws.Int64Value(v)
 	}
-	if cfg.PredefinedMetricSpecification != nil {
-		m["predefined_metric_specification"] = flattenPredefinedMetricSpecification(cfg.PredefinedMetricSpecification)
+
+	if v := cfg.ScaleOutCooldown; v != nil {
+		m["scale_out_cooldown"] = aws.Int64Value(v)
+	}
+
+	if v := cfg.TargetValue; v != nil {
+		m["target_value"] = aws.Float64Value(v)
 	}
 
 	return []interface{}{m}
@@ -731,29 +738,49 @@ func flattenCustomizedMetricSpecification(cfg *applicationautoscaling.Customized
 		return []interface{}{}
 	}
 
-	m := map[string]interface{}{
-		"metric_name": *cfg.MetricName,
-		"namespace":   *cfg.Namespace,
-		"statistic":   *cfg.Statistic,
-	}
+	m := map[string]interface{}{}
 
-	if len(cfg.Dimensions) > 0 {
+	if v := cfg.Dimensions; len(v) > 0 {
 		m["dimensions"] = flattenMetricDimensions(cfg.Dimensions)
 	}
 
-	if cfg.Unit != nil {
-		m["unit"] = *cfg.Unit
+	if v := cfg.MetricName; v != nil {
+		m["metric_name"] = aws.StringValue(v)
 	}
+
+	if v := cfg.Namespace; v != nil {
+		m["namespace"] = aws.StringValue(v)
+	}
+
+	if v := cfg.Statistic; v != nil {
+		m["statistic"] = aws.StringValue(v)
+	}
+
+	if v := cfg.Unit; v != nil {
+		m["unit"] = aws.StringValue(v)
+	}
+
 	return []interface{}{m}
 }
 
 func flattenMetricDimensions(ds []*applicationautoscaling.MetricDimension) []interface{} {
 	l := make([]interface{}, len(ds))
 	for i, d := range ds {
-		l[i] = map[string]interface{}{
-			"name":  *d.Name,
-			"value": *d.Value,
+		if ds == nil {
+			continue
 		}
+
+		m := map[string]interface{}{}
+
+		if v := d.Name; v != nil {
+			m["name"] = aws.StringValue(v)
+		}
+
+		if v := d.Value; v != nil {
+			m["value"] = aws.StringValue(v)
+		}
+
+		l[i] = m
 	}
 	return l
 }
@@ -762,11 +789,16 @@ func flattenPredefinedMetricSpecification(cfg *applicationautoscaling.Predefined
 	if cfg == nil {
 		return []interface{}{}
 	}
-	m := map[string]interface{}{
-		"predefined_metric_type": *cfg.PredefinedMetricType,
+
+	m := map[string]interface{}{}
+
+	if v := cfg.PredefinedMetricType; v != nil {
+		m["predefined_metric_type"] = aws.StringValue(v)
 	}
-	if cfg.ResourceLabel != nil {
-		m["resource_label"] = *cfg.ResourceLabel
+
+	if v := cfg.ResourceLabel; v != nil {
+		m["resource_label"] = aws.StringValue(v)
 	}
+
 	return []interface{}{m}
 }

--- a/aws/resource_aws_appautoscaling_target.go
+++ b/aws/resource_aws_appautoscaling_target.go
@@ -191,7 +191,11 @@ func getAwsAppautoscalingTarget(resourceId, namespace, dimension string,
 	}
 
 	for idx, tgt := range describeTargets.ScalableTargets {
-		if *tgt.ResourceId == resourceId && *tgt.ScalableDimension == dimension {
+		if tgt == nil {
+			continue
+		}
+
+		if aws.StringValue(tgt.ResourceId) == resourceId && aws.StringValue(tgt.ScalableDimension) == dimension {
 			return describeTargets.ScalableTargets[idx], nil
 		}
 	}

--- a/aws/resource_aws_appsync_resolver.go
+++ b/aws/resource_aws_appsync_resolver.go
@@ -316,7 +316,7 @@ func flattenAppsyncCachingConfig(c *appsync.CachingConfig) []interface{} {
 		return nil
 	}
 
-	if len(c.CachingKeys) == 0 && *(c.Ttl) == 0 {
+	if len(c.CachingKeys) == 0 && aws.Int64Value(c.Ttl) == 0 {
 		return nil
 	}
 

--- a/aws/resource_aws_athena_database.go
+++ b/aws/resource_aws_athena_database.go
@@ -177,7 +177,11 @@ func executeAndExpectMatchingRow(qeid string, dbName string, conn *athena.Athena
 	}
 	for _, row := range rs.Rows {
 		for _, datum := range row.Data {
-			if *datum.VarCharValue == dbName {
+			if datum == nil {
+				continue
+			}
+
+			if aws.StringValue(datum.VarCharValue) == dbName {
 				return nil
 			}
 		}
@@ -229,12 +233,18 @@ func queryExecutionStateRefreshFunc(qeid string, conn *athena.Athena) resource.S
 		if err != nil {
 			return nil, "failed", err
 		}
-		status := out.QueryExecution.Status
-		if *status.State == athena.QueryExecutionStateFailed &&
-			status.StateChangeReason != nil {
-			err = fmt.Errorf("reason: %s", *status.StateChangeReason)
+
+		if out == nil || out.QueryExecution == nil || out.QueryExecution.Status == nil {
+			return nil, "", nil
 		}
-		return out, *out.QueryExecution.Status.State, err
+
+		status := out.QueryExecution.Status
+
+		if aws.StringValue(status.State) == athena.QueryExecutionStateFailed && status.StateChangeReason != nil {
+			err = fmt.Errorf("reason: %s", aws.StringValue(status.StateChangeReason))
+		}
+
+		return out, aws.StringValue(out.QueryExecution.Status.State), err
 	}
 }
 
@@ -242,7 +252,7 @@ func flattenAthenaResultSet(rs *athena.ResultSet) string {
 	ss := make([]string, 0)
 	for _, row := range rs.Rows {
 		for _, datum := range row.Data {
-			ss = append(ss, *datum.VarCharValue)
+			ss = append(ss, aws.StringValue(datum.VarCharValue))
 		}
 	}
 	return strings.Join(ss, "\n")

--- a/aws/resource_aws_autoscaling_attachment.go
+++ b/aws/resource_aws_autoscaling_attachment.go
@@ -93,7 +93,7 @@ func resourceAwsAutoscalingAttachmentRead(d *schema.ResourceData, meta interface
 	if v, ok := d.GetOk("elb"); ok {
 		found := false
 		for _, i := range asg.LoadBalancerNames {
-			if v.(string) == *i {
+			if v.(string) == aws.StringValue(i) {
 				d.Set("elb", v.(string))
 				found = true
 				break
@@ -109,7 +109,7 @@ func resourceAwsAutoscalingAttachmentRead(d *schema.ResourceData, meta interface
 	if v, ok := d.GetOk("alb_target_group_arn"); ok {
 		found := false
 		for _, i := range asg.TargetGroupARNs {
-			if v.(string) == *i {
+			if v.(string) == aws.StringValue(i) {
 				d.Set("alb_target_group_arn", v.(string))
 				found = true
 				break

--- a/aws/resource_aws_autoscaling_lifecycle_hook.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook.go
@@ -195,7 +195,11 @@ func getAwsAutoscalingLifecycleHook(d *schema.ResourceData, meta interface{}) (*
 	// find lifecycle hooks
 	name := d.Get("name")
 	for idx, sp := range resp.LifecycleHooks {
-		if *sp.LifecycleHookName == name {
+		if sp == nil {
+			continue
+		}
+
+		if aws.StringValue(sp.LifecycleHookName) == name {
 			return resp.LifecycleHooks[idx], nil
 		}
 	}

--- a/aws/resource_aws_autoscaling_notification.go
+++ b/aws/resource_aws_autoscaling_notification.go
@@ -83,9 +83,13 @@ func resourceAwsAutoscalingNotificationRead(d *schema.ResourceData, meta interfa
 		}
 
 		for _, n := range resp.NotificationConfigurations {
-			if *n.TopicARN == topic {
-				gRaw[*n.AutoScalingGroupName] = true
-				nRaw[*n.NotificationType] = true
+			if n == nil {
+				continue
+			}
+
+			if aws.StringValue(n.TopicARN) == topic {
+				gRaw[aws.StringValue(n.AutoScalingGroupName)] = true
+				nRaw[aws.StringValue(n.NotificationType)] = true
 			}
 		}
 		return true // return false to stop paging

--- a/aws/resource_aws_autoscaling_policy.go
+++ b/aws/resource_aws_autoscaling_policy.go
@@ -404,7 +404,11 @@ func getAwsAutoscalingPolicy(d *schema.ResourceData, meta interface{}) (*autosca
 	// find scaling policy
 	name := d.Get("name")
 	for idx, sp := range resp.ScalingPolicies {
-		if *sp.PolicyName == name {
+		if sp == nil {
+			continue
+		}
+
+		if aws.StringValue(sp.PolicyName) == name {
 			return resp.ScalingPolicies[idx], nil
 		}
 	}
@@ -484,31 +488,31 @@ func flattenTargetTrackingConfiguration(config *autoscaling.TargetTrackingConfig
 	}
 
 	result := map[string]interface{}{}
-	result["disable_scale_in"] = *config.DisableScaleIn
-	result["target_value"] = *config.TargetValue
+	result["disable_scale_in"] = aws.BoolValue(config.DisableScaleIn)
+	result["target_value"] = aws.Float64Value(config.TargetValue)
 	if config.PredefinedMetricSpecification != nil {
 		spec := map[string]interface{}{}
-		spec["predefined_metric_type"] = *config.PredefinedMetricSpecification.PredefinedMetricType
+		spec["predefined_metric_type"] = aws.StringValue(config.PredefinedMetricSpecification.PredefinedMetricType)
 		if config.PredefinedMetricSpecification.ResourceLabel != nil {
-			spec["resource_label"] = *config.PredefinedMetricSpecification.ResourceLabel
+			spec["resource_label"] = aws.StringValue(config.PredefinedMetricSpecification.ResourceLabel)
 		}
 		result["predefined_metric_specification"] = []map[string]interface{}{spec}
 	}
 	if config.CustomizedMetricSpecification != nil {
 		spec := map[string]interface{}{}
-		spec["metric_name"] = *config.CustomizedMetricSpecification.MetricName
-		spec["namespace"] = *config.CustomizedMetricSpecification.Namespace
-		spec["statistic"] = *config.CustomizedMetricSpecification.Statistic
+		spec["metric_name"] = aws.StringValue(config.CustomizedMetricSpecification.MetricName)
+		spec["namespace"] = aws.StringValue(config.CustomizedMetricSpecification.Namespace)
+		spec["statistic"] = aws.StringValue(config.CustomizedMetricSpecification.Statistic)
 		if config.CustomizedMetricSpecification.Unit != nil {
-			spec["unit"] = *config.CustomizedMetricSpecification.Unit
+			spec["unit"] = aws.StringValue(config.CustomizedMetricSpecification.Unit)
 		}
 		if config.CustomizedMetricSpecification.Dimensions != nil {
 			dimSpec := make([]interface{}, len(config.CustomizedMetricSpecification.Dimensions))
 			for i := range dimSpec {
 				dim := map[string]interface{}{}
 				rawDim := config.CustomizedMetricSpecification.Dimensions[i]
-				dim["name"] = *rawDim.Name
-				dim["value"] = *rawDim.Value
+				dim["name"] = aws.StringValue(rawDim.Name)
+				dim["value"] = aws.StringValue(rawDim.Value)
 				dimSpec[i] = dim
 			}
 			spec["metric_dimension"] = dimSpec

--- a/aws/resource_aws_autoscaling_schedule.go
+++ b/aws/resource_aws_autoscaling_schedule.go
@@ -236,7 +236,7 @@ func resourceAwsASGScheduledActionRetrieve(d *schema.ResourceData, meta interfac
 	}
 
 	if len(actions.ScheduledUpdateGroupActions) != 1 ||
-		*actions.ScheduledUpdateGroupActions[0].ScheduledActionName != d.Id() {
+		aws.StringValue(actions.ScheduledUpdateGroupActions[0].ScheduledActionName) != d.Id() {
 		return nil, false, nil
 	}
 

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -236,7 +236,7 @@ func getJobDefinition(conn *batch.Batch, arn string) (*batch.JobDefinition, erro
 	case numJobDefinitions == 0:
 		return nil, nil
 	case numJobDefinitions == 1:
-		if *resp.JobDefinitions[0].Status == "ACTIVE" {
+		if aws.StringValue(resp.JobDefinitions[0].Status) == "ACTIVE" {
 			return resp.JobDefinitions[0], nil
 		}
 		return nil, nil

--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -91,7 +91,7 @@ func resourceAwsBatchJobQueueCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error waiting for JobQueue state to be \"VALID\": %s", err)
 	}
 
-	arn := *out.JobQueueArn
+	arn := aws.StringValue(out.JobQueueArn)
 	log.Printf("[DEBUG] JobQueue created: %s", arn)
 	d.SetId(arn)
 

--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -513,7 +513,7 @@ func testAccAWSBudgetsBudgetNotificationConfigUpdate() budgets.Notification {
 
 func testAccAWSBudgetsBudgetConfig_WithAccountID(budgetConfig budgets.Budget, accountID, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -529,12 +529,12 @@ resource "aws_budgets_budget" "test" {
     "%s" = "%s"
   }
 }
-`, accountID, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, timePeriodStart, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
+`, accountID, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
 }
 
 func testAccAWSBudgetsBudgetConfig_PrefixDefaults(budgetConfig budgets.Budget, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -549,13 +549,13 @@ resource "aws_budgets_budget" "test" {
     "%s" = "%s"
   }
 }
-`, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, timePeriodStart, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
+`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
 }
 
 func testAccAWSBudgetsBudgetConfig_Prefix(budgetConfig budgets.Budget, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
 	timePeriodEnd := budgetConfig.TimePeriod.End.Format("2006-01-02_15:04")
-	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -578,11 +578,11 @@ resource "aws_budgets_budget" "test" {
     "%s" = "%s"
   }
 }
-`, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, *budgetConfig.CostTypes.IncludeTax, *budgetConfig.CostTypes.IncludeSubscription, *budgetConfig.CostTypes.UseBlended, timePeriodStart, timePeriodEnd, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
+`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), aws.BoolValue(budgetConfig.CostTypes.IncludeTax), aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription), aws.BoolValue(budgetConfig.CostTypes.UseBlended), timePeriodStart, timePeriodEnd, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
 }
 func testAccAWSBudgetsBudgetConfig_BasicDefaults(budgetConfig budgets.Budget, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
-	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -597,13 +597,13 @@ resource "aws_budgets_budget" "test" {
     "%s" = "%s"
   }
 }
-`, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, timePeriodStart, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
+`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), timePeriodStart, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
 }
 
 func testAccAWSBudgetsBudgetConfig_Basic(budgetConfig budgets.Budget, costFilterKey string) string {
 	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
 	timePeriodEnd := budgetConfig.TimePeriod.End.Format("2006-01-02_15:04")
-	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+	costFilterValue := aws.StringValue(budgetConfig.CostFilters[costFilterKey][0])
 
 	return fmt.Sprintf(`
 resource "aws_budgets_budget" "test" {
@@ -626,7 +626,7 @@ resource "aws_budgets_budget" "test" {
     "%s" = "%s"
   }
 }
-`, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, *budgetConfig.CostTypes.IncludeTax, *budgetConfig.CostTypes.IncludeSubscription, *budgetConfig.CostTypes.UseBlended, timePeriodStart, timePeriodEnd, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
+`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), aws.BoolValue(budgetConfig.CostTypes.IncludeTax), aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription), aws.BoolValue(budgetConfig.CostTypes.UseBlended), timePeriodStart, timePeriodEnd, aws.StringValue(budgetConfig.TimeUnit), costFilterKey, costFilterValue)
 }
 
 func testAccAWSBudgetsBudgetConfigWithNotification_Basic(budgetConfig budgets.Budget, notifications []budgets.Notification, emails []string, topics []string) string {
@@ -659,7 +659,7 @@ resource "aws_budgets_budget" "test" {
   time_unit         = "%s"
     %s
 }
-`, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, *budgetConfig.CostTypes.IncludeTax, *budgetConfig.CostTypes.IncludeSubscription, *budgetConfig.CostTypes.UseBlended, timePeriodStart, timePeriodEnd, *budgetConfig.TimeUnit, strings.Join(notificationStrings, "\n"))
+`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), aws.BoolValue(budgetConfig.CostTypes.IncludeTax), aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription), aws.BoolValue(budgetConfig.CostTypes.UseBlended), timePeriodStart, timePeriodEnd, aws.StringValue(budgetConfig.TimeUnit), strings.Join(notificationStrings, "\n"))
 
 }
 
@@ -683,5 +683,5 @@ notification {
   subscriber_sns_topic_arns  = [%s]
   comparison_operator        = "%s"
 }
-`, *notification.Threshold, *notification.ThresholdType, *notification.NotificationType, strings.Join(quotedEMails, ","), strings.Join(quotedTopics, ","), *notification.ComparisonOperator)
+`, aws.Float64Value(notification.Threshold), aws.StringValue(notification.ThresholdType), aws.StringValue(notification.NotificationType), strings.Join(quotedEMails, ","), strings.Join(quotedTopics, ","), aws.StringValue(notification.ComparisonOperator))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12992

The path matching in semgrep is quite limited, so unfortunately the exclude list is temporarily long until existing reports are fixed up. This does have the benefit of enabling the checking for some additional files beyond resources a and b though.

Previously:

```
aws/resource_aws_ami.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
386:		state = *image.State

aws/resource_aws_api_gateway_base_path_mapping.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
170:	mappingBasePath := *mapping.BasePath

aws/resource_aws_api_gateway_documentation_part.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
203:	m["type"] = *l.Type
--------------------------------------------------------------------------------
205:		m["method"] = *l.Method
--------------------------------------------------------------------------------
208:		m["name"] = *l.Name
--------------------------------------------------------------------------------
211:		m["path"] = *l.Path
--------------------------------------------------------------------------------
214:		m["status_code"] = *l.StatusCode

aws/resource_aws_api_gateway_integration.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
179:	if *connectionType == apigateway.ConnectionTypeVpcLink {

aws/resource_aws_api_gateway_stage.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
172:	if waitForCache && *out.CacheClusterStatus != apigateway.CacheClusterStatusNotAvailable {
--------------------------------------------------------------------------------
232:	if stage.CacheClusterStatus != nil && *stage.CacheClusterStatus == apigateway.CacheClusterStatusDeleteInProgress {
--------------------------------------------------------------------------------
382:	if waitForCache && *out.CacheClusterStatus != apigateway.CacheClusterStatusNotAvailable {

aws/resource_aws_app_cookie_stickiness_policy.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
135:	if *cookieAttr.AttributeName != "CookieName" {
--------------------------------------------------------------------------------
176:			if policyName == *name {

aws/resource_aws_appautoscaling_policy.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
708:	m["target_value"] = *cfg.TargetValue
--------------------------------------------------------------------------------
711:		m["disable_scale_in"] = *cfg.DisableScaleIn
--------------------------------------------------------------------------------
714:		m["scale_in_cooldown"] = *cfg.ScaleInCooldown
--------------------------------------------------------------------------------
717:		m["scale_out_cooldown"] = *cfg.ScaleOutCooldown
--------------------------------------------------------------------------------
745:		m["unit"] = *cfg.Unit
--------------------------------------------------------------------------------
769:		m["resource_label"] = *cfg.ResourceLabel

aws/resource_aws_appautoscaling_target.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
194:		if *tgt.ResourceId == resourceId && *tgt.ScalableDimension == dimension {
--------------------------------------------------------------------------------
194:		if *tgt.ResourceId == resourceId && *tgt.ScalableDimension == dimension {

aws/resource_aws_appsync_resolver.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
319:	if len(c.CachingKeys) == 0 && *(c.Ttl) == 0 {

aws/resource_aws_athena_database.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
180:			if *datum.VarCharValue == dbName {
--------------------------------------------------------------------------------
233:		if *status.State == athena.QueryExecutionStateFailed &&

aws/resource_aws_autoscaling_attachment.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
96:			if v.(string) == *i {
--------------------------------------------------------------------------------
112:			if v.(string) == *i {

aws/resource_aws_autoscaling_group.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
1584:			lbInstanceStates[*lbName][*is.InstanceId] = *is.State
--------------------------------------------------------------------------------
1613:			targetInstanceStates[*targetGroupARN][*desc.Target.Id] = *desc.TargetHealth.State
--------------------------------------------------------------------------------
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
1307:	if len(g.Instances) > 0 || *g.DesiredCapacity > 0 {
--------------------------------------------------------------------------------
1391:		if *asc.AutoScalingGroupName == asgName {

aws/resource_aws_autoscaling_lifecycle_hook.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
198:		if *sp.LifecycleHookName == name {

aws/resource_aws_autoscaling_notification.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
86:			if *n.TopicARN == topic {

aws/resource_aws_autoscaling_policy.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
487:	result["disable_scale_in"] = *config.DisableScaleIn
--------------------------------------------------------------------------------
488:	result["target_value"] = *config.TargetValue
--------------------------------------------------------------------------------
491:		spec["predefined_metric_type"] = *config.PredefinedMetricSpecification.PredefinedMetricType
--------------------------------------------------------------------------------
493:			spec["resource_label"] = *config.PredefinedMetricSpecification.ResourceLabel
--------------------------------------------------------------------------------
499:		spec["metric_name"] = *config.CustomizedMetricSpecification.MetricName
--------------------------------------------------------------------------------
500:		spec["namespace"] = *config.CustomizedMetricSpecification.Namespace
--------------------------------------------------------------------------------
501:		spec["statistic"] = *config.CustomizedMetricSpecification.Statistic
--------------------------------------------------------------------------------
503:			spec["unit"] = *config.CustomizedMetricSpecification.Unit
--------------------------------------------------------------------------------
510:				dim["name"] = *rawDim.Name
--------------------------------------------------------------------------------
511:				dim["value"] = *rawDim.Value
--------------------------------------------------------------------------------
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
407:		if *sp.PolicyName == name {

aws/resource_aws_autoscaling_schedule.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
239:		*actions.ScheduledUpdateGroupActions[0].ScheduledActionName != d.Id() {

aws/resource_aws_batch_job_definition.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
239:		if *resp.JobDefinitions[0].Status == "ACTIVE" {

aws/resource_aws_batch_job_queue.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
94:	arn := *out.JobQueueArn

aws/resource_aws_budgets_budget_test.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
516:	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
--------------------------------------------------------------------------------
537:	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
--------------------------------------------------------------------------------
558:	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
--------------------------------------------------------------------------------
585:	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
--------------------------------------------------------------------------------
606:	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAMI_disappears (42.05s)
--- PASS: TestAccAWSAMI_basic (45.35s)
--- PASS: TestAccAWSAMI_description (58.66s)
--- PASS: TestAccAWSAMI_Gp3BlockDevice (60.55s)
--- PASS: TestAccAWSAMI_EphemeralBlockDevices (60.56s)
--- PASS: TestAccAWSAMI_tags (72.08s)

--- PASS: TestAccAWSAPIGatewayBasePathMapping_basic (79.61s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_disappears (85.78s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_updates (137.34s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty (162.17s)

--- PASS: TestAccAWSAPIGatewayDocumentationPart_disappears (17.88s)
--- PASS: TestAccAWSAPIGatewayDocumentationPart_method (57.48s)
--- PASS: TestAccAWSAPIGatewayDocumentationPart_basic (81.28s)
--- PASS: TestAccAWSAPIGatewayDocumentationPart_responseHeader (144.04s)

--- PASS: TestAccAWSAPIGatewayIntegration_cache_key_parameters (29.83s)
--- PASS: TestAccAWSAPIGatewayIntegration_contentHandling (63.05s)
--- PASS: TestAccAWSAPIGatewayIntegration_basic (92.39s)
--- PASS: TestAccAWSAPIGatewayIntegration_TlsConfig_InsecureSkipVerification (120.65s)
--- PASS: TestAccAWSAPIGatewayIntegration_disappears (267.23s)
--- PASS: TestAccAWSAPIGatewayIntegration_integrationType (689.99s)

--- PASS: TestAccAWSAPIGatewayStage_disappears_ReferencingDeployment (53.04s)
--- PASS: TestAccAWSAPIGatewayStage_disappears (90.60s)
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings (425.17s)
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings_kinesis (484.94s)
--- PASS: TestAccAWSAPIGatewayStage_basic (716.29s)

--- PASS: TestAccAWSAppCookieStickinessPolicy_disappears_ELB (22.35s)
--- PASS: TestAccAWSAppCookieStickinessPolicy_disappears (24.07s)
--- PASS: TestAccAWSAppCookieStickinessPolicy_basic (45.25s)

--- PASS: TestAccAWSAppautoScalingPolicy_dynamodb_table (36.85s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName (38.45s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource (41.02s)
--- PASS: TestAccAWSAppautoScalingPolicy_dynamodb_index (44.74s)
--- PASS: TestAccAWSAppautoScalingPolicy_disappears (83.02s)
--- PASS: TestAccAWSAppautoScalingPolicy_basic (86.04s)
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (86.95s)
--- PASS: TestAccAWSAppautoScalingPolicy_scaleOutAndIn (89.54s)
--- PASS: TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew (97.35s)

--- PASS: TestAccAWSAppautoScalingTarget_multipleTargets (26.50s)
--- PASS: TestAccAWSAppautoScalingTarget_optionalRoleArn (27.17s)
--- PASS: TestAccAWSAppautoScalingTarget_basic (55.16s)
--- PASS: TestAccAWSAppautoScalingTarget_spotFleetRequest (73.87s)
--- PASS: TestAccAWSAppautoScalingTarget_disappears (86.80s)
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (1607.58s)

--- PASS: TestAccAwsAppsyncResolver_CachingConfig (22.06s)
--- PASS: TestAccAwsAppsyncResolver_basic (24.35s)
--- PASS: TestAccAwsAppsyncResolver_disappears (25.39s)
--- PASS: TestAccAwsAppsyncResolver_PipelineConfig (28.28s)
--- PASS: TestAccAwsAppsyncResolver_multipleResolvers (29.17s)
--- PASS: TestAccAwsAppsyncResolver_ResponseTemplate (32.16s)
--- PASS: TestAccAwsAppsyncResolver_RequestTemplate (36.21s)
--- PASS: TestAccAwsAppsyncResolver_DataSource (38.43s)

--- PASS: TestAccAWSASGNotification_basic (163.55s)
--- PASS: TestAccAWSASGNotification_Pagination (209.09s)
--- PASS: TestAccAWSASGNotification_update (267.50s)

--- PASS: TestAccAWSAthenaDatabase_basic (62.24s)
--- PASS: TestAccAWSAthenaDatabase_destroyFailsIfTablesExist (74.13s)
--- PASS: TestAccAWSAthenaDatabase_encryption (62.78s)
--- PASS: TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds (60.06s)
--- PASS: TestAccAWSAthenaDatabase_nameCantHaveUppercase (0.89s)
--- PASS: TestAccAWSAthenaDatabase_nameStartsWithUnderscore (55.47s)

--- PASS: TestAccAWSAutoscalingAttachment_albTargetGroup (212.13s)
--- PASS: TestAccAWSAutoscalingAttachment_elb (199.26s)

--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (201.41s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (320.35s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (38.57s)
--- PASS: TestAccAWSAutoScalingGroup_basic (289.78s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (60.48s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (143.25s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (294.41s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Basic (214.22s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Start (336.67s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Triggers (199.75s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (57.70s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (71.11s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (212.00s)
--- PASS: TestAccAWSAutoScalingGroup_launchTempPartitionNum (77.11s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (494.74s)
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (93.55s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (36.47s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_CapacityRebalance (64.39s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (69.23s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (101.46s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (61.91s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (46.71s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (64.41s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (102.21s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity (82.98s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (70.74s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (89.77s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (57.79s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType_With_LaunchTemplateSpecification (62.46s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (145.44s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (41.24s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (39.17s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (290.76s)
--- PASS: TestAccAWSAutoScalingGroup_tags (307.64s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (239.15s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (130.55s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (103.76s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (320.59s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (510.78s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (107.06s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (151.02s)

--- PASS: TestAccAWSAutoscalingLifecycleHook_basic (163.19s)
--- PASS: TestAccAWSAutoscalingLifecycleHook_omitDefaultResult (152.17s)

--- PASS: TestAccAWSAutoscalingPolicy_basic (159.49s)
--- PASS: TestAccAWSAutoscalingPolicy_disappears (54.90s)
--- PASS: TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment (65.16s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Custom (61.68s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Predefined (62.63s)
--- PASS: TestAccAWSAutoscalingPolicy_zerovalue (64.20s)

--- PASS: TestAccAWSAutoscalingSchedule_basic (161.88s)
--- PASS: TestAccAWSAutoscalingSchedule_disappears (145.38s)
--- PASS: TestAccAWSAutoscalingSchedule_negativeOne (143.80s)
--- PASS: TestAccAWSAutoscalingSchedule_recurrence (214.82s)
--- PASS: TestAccAWSAutoscalingSchedule_zeroValues (173.62s)

--- PASS: TestAccAWSBatchJobDefinition_basic (16.64s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (16.53s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (35.57s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (26.91s)

--- PASS: TestAccAWSBatchJobQueue_basic (162.85s)
--- PASS: TestAccAWSBatchJobQueue_ComputeEnvironments_ExternalOrderUpdate (132.15s)
--- PASS: TestAccAWSBatchJobQueue_disappears (113.08s)
--- PASS: TestAccAWSBatchJobQueue_Priority (147.46s)
--- PASS: TestAccAWSBatchJobQueue_State (138.84s)
--- PASS: TestAccAWSBatchJobQueue_Tags (151.88s)

--- PASS: TestAccAWSBudgetsBudget_basic (38.97s)
--- PASS: TestAccAWSBudgetsBudget_disappears (15.59s)
--- PASS: TestAccAWSBudgetsBudget_notification (97.30s)
--- PASS: TestAccAWSBudgetsBudget_prefix (36.26s)
```

