### PR TITLE
r/launch_template: add support for network-interface tag specification

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -589,6 +589,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 								ec2.ResourceTypeVolume,
 								ec2.ResourceTypeSpotInstancesRequest,
 								ec2.ResourceTypeElasticGpu,
+								ec2.ResourceTypeNetworkInterface,
 							}, false),
 						},
 						"tags": tagsSchema(),

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -405,7 +405,7 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "ram_disk_id"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tag_specifications.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "tag_specifications.#", "5"),
 				),
 			},
 			{
@@ -1540,6 +1540,14 @@ resource "aws_launch_template" "test" {
 
   tag_specifications {
     resource_type = "elastic-gpu"
+
+    tags = {
+      Name = "test"
+    }
+  }
+
+  tag_specifications {
+    resource_type = "network-interface"
 
     tags = {
       Name = "test"

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -335,11 +335,11 @@ For more information, see the documentation on [Nitro Enclaves](https://docs.aws
 
 ### Tag Specifications
 
-The tags to apply to the resources during launch. You can tag instances, volumes, elastic GPUs and spot instance requests. More information can be found in the [EC2 API documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html).
+The tags to apply to the resources during launch. You can tag instances, volumes, elastic GPUs, spot instance requests and network interfaces. More information can be found in the [EC2 API documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html).
 
 Each `tag_specifications` block supports the following:
 
-* `resource_type` - The type of resource to tag. Valid values are `instance`, `volume`, `elastic-gpu` and `spot-instances-request`.
+* `resource_type` - The type of resource to tag. Valid values are `instance`, `volume`, `elastic-gpu`, `spot-instances-request` and `network-interface`.
 * `tags` - A map of tags to assign to the resource.
 
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18029

Add support for `network-interface` resource types in `launch_template` tag specification blocks, as AWS now supports it during creation; even though documentation seems to be outdated both in [AWS User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html#create-launch-template-define-parameters) and in [AWS API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestLaunchTemplateData.html#API_RequestLaunchTemplateData_Contents).

Previously:
```console
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplate_data'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplate_data -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_data
    resource_aws_launch_template_test.go:381: Step 1/2 error: Error running pre-apply refresh: exit status 1

        Error: expected tag_specifications.0.resource_type to be one of [instance volume spot-instances-request elastic-gpu], got network-interface

          on terraform_plugin_test.tf line 89, in resource "aws_launch_template" "test":
          57:     resource_type = "network-interface"


--- FAIL: TestAccAWSLaunchTemplate_data (7.50s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	9.279s
FAIL
make: *** [testacc] Error 1
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplate_data'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplate_data -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (51.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	53.701s
...
```
