### PR TITLE
Allow forwarded_values to be empty

### DIFF
--- a/.changelog/18042.txt
+++ b/.changelog/18042.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_distribution: Allow `forwarded_values` to be set to empty when values were previously set
+```

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -80,7 +80,6 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
-							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"cookies": {
@@ -257,7 +256,6 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"forwarded_values": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Computed: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -364,6 +364,30 @@ func TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy(t *testing
 	})
 }
 
+func TestAccAWSCloudFrontDistribution_forwardedValuesToCachePolicy(t *testing.T) {
+	var distribution cloudfront.Distribution
+	resourceName := "aws_cloudfront_distribution.main"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontDistributionOrderedCacheBehavior,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
+				),
+			},
+			{
+				Config: testAccAWSCloudFrontDistributionOrderedCacheBehaviorCachePolicy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #17626

Output from acceptance testing:


```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontDistribution -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_disappears
=== PAUSE TestAccAWSCloudFrontDistribution_disappears
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
=== PAUSE TestAccAWSCloudFrontDistribution_S3Origin
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== PAUSE TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_customOrigin
=== RUN   TestAccAWSCloudFrontDistribution_originPolicyDefault
=== PAUSE TestAccAWSCloudFrontDistribution_originPolicyDefault
=== RUN   TestAccAWSCloudFrontDistribution_originPolicyOrdered
=== PAUSE TestAccAWSCloudFrontDistribution_originPolicyOrdered
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_multiOrigin
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
=== PAUSE TestAccAWSCloudFrontDistribution_HTTP11Config
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== PAUSE TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_RealtimeLogConfigArn
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_RealtimeLogConfigArn
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_RealtimeLogConfigArn
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_RealtimeLogConfigArn
=== RUN   TestAccAWSCloudFrontDistribution_Enabled
=== PAUSE TestAccAWSCloudFrontDistribution_Enabled
=== RUN   TestAccAWSCloudFrontDistribution_RetainOnDelete
=== PAUSE TestAccAWSCloudFrontDistribution_RetainOnDelete
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccAWSCloudFrontDistribution_WaitForDeployment
=== PAUSE TestAccAWSCloudFrontDistribution_WaitForDeployment
=== RUN   TestAccAWSCloudFrontDistribution_OriginGroups
=== PAUSE TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_disappears
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_RetainOnDelete
=== CONT  TestAccAWSCloudFrontDistribution_Enabled
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_WaitForDeployment
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_RealtimeLogConfigArn
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== CONT  TestAccAWSCloudFrontDistribution_originPolicyDefault
=== CONT  TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_RealtimeLogConfigArn
=== CONT  TestAccAWSCloudFrontDistribution_multiOrigin
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== CONT  TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== CONT  TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== CONT  TestAccAWSCloudFrontDistribution_originPolicyOrdered
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (197.60s)
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (203.33s)
=== CONT  TestAccAWSCloudFrontDistribution_HTTP11Config
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (203.81s)
=== CONT  TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_RealtimeLogConfigArn (207.79s)
=== CONT  TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
--- PASS: TestAccAWSCloudFrontDistribution_disappears (208.17s)
=== CONT  TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (210.27s)
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.65s)
=== CONT  TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_RealtimeLogConfigArn (215.03s)
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (0.73s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (219.32s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (235.34s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (288.60s)
--- PASS: TestAccAWSCloudFrontDistribution_originPolicyDefault (486.52s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy (486.58s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (489.05s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (489.74s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (489.98s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (490.33s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (493.50s)
--- PASS: TestAccAWSCloudFrontDistribution_originPolicyOrdered (494.57s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (494.94s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (495.96s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (679.66s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (473.93s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (473.78s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (470.32s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (484.08s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (665.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	869.535s

```
