### PR TITLE
Reapply changes to avoid destroying instance on user_data updates

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -511,7 +511,6 @@ func resourceAwsInstance() *schema.Resource {
 			"user_data": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"user_data_base64"},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// Sometimes the EC2 API responds with the equivalent, empty SHA1 sum
@@ -535,7 +534,6 @@ func resourceAwsInstance() *schema.Resource {
 			"user_data_base64": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"user_data"},
 				ValidateFunc: func(v interface{}, name string) (warns []string, errs []error) {
 					s := v.(string)
@@ -1009,7 +1007,11 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+	shouldStopInstanceForUpdate := false
 	conn := meta.(*AWSClient).ec2conn
+	newAttributes := &ec2.ModifyInstanceAttributeInput{
+		InstanceId: aws.String(d.Id()),
+	}
 
 	if d.HasChange("tags") && !d.IsNewResource() {
 		o, n := d.GetChange("tags")
@@ -1230,74 +1232,34 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if d.HasChange("user_data") && !d.IsNewResource() {
+		log.Printf("[INFO] Modifying user data %s", d.Id())
+
+		newAttributes.UserData = &ec2.BlobAttributeValue{
+			Value: []byte(d.Get("user_data").(string)),
+		}
+		shouldStopInstanceForUpdate = true
+	}
+
+	if d.HasChange("user_data_base64") && !d.IsNewResource() {
+		log.Printf("[INFO] Modifying user data %s", d.Id())
+
+		userData, err := base64.URLEncoding.DecodeString(d.Get("user_data_base64").(string))
+		if err != nil {
+			return err
+		}
+		newAttributes.UserData = &ec2.BlobAttributeValue{
+			Value: userData,
+		}
+		shouldStopInstanceForUpdate = true
+	}
+
 	if d.HasChange("instance_type") && !d.IsNewResource() {
-		log.Printf("[INFO] Stopping Instance %q for instance_type change", d.Id())
-		_, err := conn.StopInstances(&ec2.StopInstancesInput{
-			InstanceIds: []*string{aws.String(d.Id())},
-		})
-		if err != nil {
-			return fmt.Errorf("error stopping instance (%s): %s", d.Id(), err)
+		newAttributes.InstanceId = aws.String(d.Id())
+		newAttributes.InstanceType = &ec2.AttributeValue{
+			Value: aws.String(d.Get("instance_type").(string)),
 		}
-
-		if err := waitForInstanceStopping(conn, d.Id(), 10*time.Minute); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] Modifying instance type %s", d.Id())
-		_, err = conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
-			InstanceId: aws.String(d.Id()),
-			InstanceType: &ec2.AttributeValue{
-				Value: aws.String(d.Get("instance_type").(string)),
-			},
-		})
-		if err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] Starting Instance %q after instance_type change", d.Id())
-
-		input := &ec2.StartInstancesInput{
-			InstanceIds: []*string{aws.String(d.Id())},
-		}
-
-		// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16433
-		err = resource.Retry(waiter.InstanceAttributePropagationTimeout, func() *resource.RetryError {
-			_, err := conn.StartInstances(input)
-
-			if tfawserr.ErrMessageContains(err, tfec2.ErrCodeInvalidParameterValue, "LaunchPlan instance type does not match attribute value") {
-				return resource.RetryableError(err)
-			}
-
-			if err != nil {
-				return resource.NonRetryableError(err)
-			}
-
-			return nil
-		})
-
-		if tfresource.TimedOut(err) {
-			_, err = conn.StartInstances(input)
-		}
-
-		if err != nil {
-			return fmt.Errorf("error starting EC2 Instance (%s): %w", d.Id(), err)
-		}
-
-		stateConf := &resource.StateChangeConf{
-			Pending:    []string{ec2.InstanceStateNamePending, ec2.InstanceStateNameStopped},
-			Target:     []string{ec2.InstanceStateNameRunning},
-			Refresh:    InstanceStateRefreshFunc(conn, d.Id(), []string{ec2.InstanceStateNameTerminated}),
-			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			Delay:      10 * time.Second,
-			MinTimeout: 3 * time.Second,
-		}
-
-		_, err = stateConf.WaitForState()
-		if err != nil {
-			return fmt.Errorf(
-				"Error waiting for instance (%s) to become ready: %s",
-				d.Id(), err)
-		}
+		shouldStopInstanceForUpdate = true
 	}
 
 	if d.HasChange("disable_api_termination") && !d.IsNewResource() {
@@ -1510,10 +1472,84 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if shouldStopInstanceForUpdate {
+		err := shutdownUpdate(d, conn, newAttributes)
+		if err != nil {
+			return err
+		}
+	}
+
 	// TODO(mitchellh): wait for the attributes we modified to
 	// persist the change...
 
 	return resourceAwsInstanceRead(d, meta)
+}
+
+func shutdownUpdate(d *schema.ResourceData, conn *ec2.EC2, newInstanceAttribute *ec2.ModifyInstanceAttributeInput) error {
+
+	log.Printf("[INFO] Stopping Instance %q for instance_type change", d.Id())
+	_, err := conn.StopInstances(&ec2.StopInstancesInput{
+		InstanceIds: []*string{aws.String(d.Id())},
+	})
+	if err != nil {
+		return fmt.Errorf("error starting EC2 Instance (%s): %w", d.Id(), err)
+	}
+
+	if err := waitForInstanceStopping(conn, d.Id(), 10*time.Minute); err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Modifying user data %s", d.Id())
+	_, err = conn.ModifyInstanceAttribute(newInstanceAttribute)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Starting Instance %q after instance_type change", d.Id())
+
+	input := &ec2.StartInstancesInput{
+		InstanceIds: []*string{aws.String(d.Id())},
+	}
+
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16433
+	err = resource.Retry(waiter.InstanceAttributePropagationTimeout, func() *resource.RetryError {
+		_, err := conn.StartInstances(input)
+
+		if tfawserr.ErrMessageContains(err, tfec2.ErrCodeInvalidParameterValue, "LaunchPlan instance type does not match attribute value") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.StartInstances(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error starting EC2 Instance (%s): %w", d.Id(), err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{ec2.InstanceStateNamePending, ec2.InstanceStateNameStopped},
+		Target:     []string{ec2.InstanceStateNameRunning},
+		Refresh:    InstanceStateRefreshFunc(conn, d.Id(), []string{ec2.InstanceStateNameTerminated}),
+		Timeout:    d.Timeout(schema.TimeoutUpdate),
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for instance (%s) to become ready: %s",
+			d.Id(), err)
+	}
+	return nil
 }
 
 func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -384,6 +384,41 @@ func TestAccAWSInstance_RootBlockDevice_KmsKeyArn(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstance_userDataChange(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfigWithUserDataBase64(rName, "hello world"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "aGVsbG8gd29ybGQ="),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"user_data"},
+			},
+			{
+				Config: testAccInstanceConfigWithUserDataBase64(rName, "new world"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "bmV3IHdvcmxk"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_userDataBase64(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
@@ -396,7 +431,7 @@ func TestAccAWSInstance_userDataBase64(t *testing.T) {
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithUserDataBase64(rName),
+				Config: testAccInstanceConfigWithUserDataBase64(rName, "hello world"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "aGVsbG8gd29ybGQ="),
@@ -3621,7 +3656,7 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfigWithUserDataBase64(rName string) string {
+func testAccInstanceConfigWithUserDataBase64(rName string, userData string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAwsInstanceVpcConfig(rName, false),
@@ -3631,9 +3666,9 @@ resource "aws_instance" "test" {
   subnet_id = aws_subnet.test.id
 
   instance_type    = "t2.small"
-  user_data_base64 = base64encode("hello world")
+  user_data_base64 = base64encode("%s")
 }
-`)
+`, userData)
 }
 
 func testAccInstanceConfigWithSmallInstanceType(rName string) string {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

Reapplying changes from https://github.com/hashicorp/terraform-provider-aws/pull/16011

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
