### PR TITLE
tests: Add Common (semgrepable) ErrorCheck functionality

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1047,7 +1047,7 @@ func RegisterServiceErrorCheckFunc(endpointID string, f ServiceErrorCheckFunc) {
 	serviceErrorCheckFuncs[endpointID] = f
 }
 
-func testAccErrorCheckSkip(t *testing.T, endpointID string) resource.ErrorCheckFunc {
+func testAccErrorCheck(t *testing.T, endpointID string) resource.ErrorCheckFunc {
 	return func(err error) error {
 		if err == nil {
 			return err
@@ -1058,7 +1058,7 @@ func testAccErrorCheckSkip(t *testing.T, endpointID string) resource.ErrorCheckF
 			err = ef(err)
 		}
 
-		if testAccErrorCheck(err) {
+		if testAccErrorCheckCommon(err) {
 			t.Skipf("skipping test for %s/%s: %s", testAccGetPartition(), testAccGetRegion(), err.Error())
 		}
 
@@ -1066,7 +1066,7 @@ func testAccErrorCheckSkip(t *testing.T, endpointID string) resource.ErrorCheckF
 	}
 }
 
-func testAccErrorCheck(err error) bool {
+func testAccErrorCheckCommon(err error) bool {
 	if strings.Contains(err.Error(), "is not supported in this region") {
 		return true
 	}

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1067,15 +1067,11 @@ func testAccErrorCheck(t *testing.T, endpointID string) resource.ErrorCheckFunc 
 }
 
 func testAccErrorCheckCommon(err error) bool {
-	if strings.Contains(err.Error(), "is not supported in this region") {
+	if strings.Contains(err.Error(), "is not supported in this") {
 		return true
 	}
 
-	if strings.Contains(err.Error(), "is currently not supported in this region") {
-		return true
-	}
-
-	if strings.Contains(err.Error(), "is not supported in this partition") {
+	if strings.Contains(err.Error(), "is currently not supported") {
 		return true
 	}
 

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1058,7 +1058,7 @@ func testAccErrorCheckSkip(t *testing.T, endpointID string) resource.ErrorCheckF
 			err = ef(err)
 		}
 
-		if testAccErrorCheckSkipError(err) {
+		if testAccErrorCheck(err) {
 			t.Skipf("skipping test for %s/%s: %s", testAccGetPartition(), testAccGetRegion(), err.Error())
 		}
 
@@ -1066,7 +1066,7 @@ func testAccErrorCheckSkip(t *testing.T, endpointID string) resource.ErrorCheckF
 	}
 }
 
-func testAccErrorCheckSkipError(err error) bool {
+func testAccErrorCheck(err error) bool {
 	if strings.Contains(err.Error(), "is not supported in this region") {
 		return true
 	}

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1047,15 +1047,17 @@ func RegisterServiceErrorCheckFunc(endpointID string, f ServiceErrorCheckFunc) {
 	serviceErrorCheckFuncs[endpointID] = f
 }
 
-func testAccErrorCheck(t *testing.T, endpointID string) resource.ErrorCheckFunc {
+func testAccErrorCheck(t *testing.T, endpointIDs ...string) resource.ErrorCheckFunc {
 	return func(err error) error {
 		if err == nil {
 			return err
 		}
 
-		if f, ok := serviceErrorCheckFuncs[endpointID]; ok {
-			ef := f(t)
-			err = ef(err)
+		for _, endpointID := range endpointIDs {
+			if f, ok := serviceErrorCheckFuncs[endpointID]; ok {
+				ef := f(t)
+				err = ef(err)
+			}
 		}
 
 		if testAccErrorCheckCommon(err) {

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1044,6 +1044,12 @@ func RegisterServiceErrorCheckFunc(endpointID string, f ServiceErrorCheckFunc) {
 	if serviceErrorCheckFuncs == nil {
 		serviceErrorCheckFuncs = make(map[string]ServiceErrorCheckFunc)
 	}
+
+	if _, ok := serviceErrorCheckFuncs[endpointID]; ok {
+		// already registered
+		panic(fmt.Sprintf("Cannot re-register a service! ServiceErrorCheckFunc exists for %s", endpointID))
+	}
+
 	serviceErrorCheckFuncs[endpointID] = f
 }
 
@@ -1057,6 +1063,10 @@ func testAccErrorCheck(t *testing.T, endpointIDs ...string) resource.ErrorCheckF
 			if f, ok := serviceErrorCheckFuncs[endpointID]; ok {
 				ef := f(t)
 				err = ef(err)
+			}
+
+			if err == nil {
+				break
 			}
 		}
 

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1047,7 +1047,7 @@ func RegisterServiceErrorCheckFunc(endpointID string, f ServiceErrorCheckFunc) {
 
 	if _, ok := serviceErrorCheckFuncs[endpointID]; ok {
 		// already registered
-		panic(fmt.Sprintf("Cannot re-register a service! ServiceErrorCheckFunc exists for %s", endpointID))
+		panic(fmt.Sprintf("Cannot re-register a service! ServiceErrorCheckFunc exists for %s", endpointID)) //lintignore:R009
 	}
 
 	serviceErrorCheckFuncs[endpointID] = f

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func init() {
+	RegisterServiceErrorCheckFunc(route53.EndpointsID, testAccErrorCheckSkipRoute53)
+}
+
 func TestCleanRecordName(t *testing.T) {
 	cases := []struct {
 		Input, Output string
@@ -110,7 +114,7 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -137,7 +141,7 @@ func TestAccAWSRoute53Record_underscored(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -164,7 +168,7 @@ func TestAccAWSRoute53Record_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -187,7 +191,7 @@ func TestAccAWSRoute53Record_disappears_MultipleRecords(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -214,7 +218,7 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -256,7 +260,7 @@ func TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -283,7 +287,7 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:      testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"zone_id"}, // just for this test
 		Providers:       testAccProviders,
@@ -311,7 +315,7 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -339,7 +343,7 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -367,7 +371,7 @@ func TestAccAWSRoute53Record_dsSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -393,7 +397,7 @@ func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -420,7 +424,7 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -455,7 +459,7 @@ func TestAccAWSRoute53Record_failover(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -483,7 +487,7 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: "aws_route53_record.www-live",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -512,7 +516,7 @@ func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -546,7 +550,7 @@ func TestAccAWSRoute53Record_Alias_Elb(t *testing.T) {
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElb, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -574,7 +578,7 @@ func TestAccAWSRoute53Record_Alias_S3(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -601,7 +605,7 @@ func TestAccAWSRoute53Record_Alias_VpcEndpoint(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -633,7 +637,7 @@ func TestAccAWSRoute53Record_Alias_Uppercase(t *testing.T) {
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElbUppercase, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -660,7 +664,7 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -698,7 +702,7 @@ func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -727,7 +731,7 @@ func TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -760,7 +764,7 @@ func TestAccAWSRoute53Record_HealthCheckId_TypeChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -793,7 +797,7 @@ func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -821,7 +825,7 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -856,7 +860,7 @@ func TestAccAWSRoute53Record_NameChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -892,7 +896,7 @@ func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -927,7 +931,7 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -962,7 +966,7 @@ func TestAccAWSRoute53Record_empty(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -984,7 +988,7 @@ func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -1011,7 +1015,7 @@ func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -1052,7 +1056,7 @@ func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipRoute53(t),
+		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -1080,7 +1084,7 @@ func testAccErrorCheckSkipRoute53(t *testing.T) resource.ErrorCheckFunc {
 
 func testAccAWSRoute53RecordOverwriteExpectErrorCheck(t *testing.T) resource.ErrorCheckFunc {
 	return func(err error) error {
-		f := testAccErrorCheckSkipRoute53(t)
+		f := testAccErrorCheckSkip(t, route53.EndpointsID)
 		err = f(err)
 
 		if err == nil {

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -1079,6 +1079,7 @@ func testAccErrorCheckSkipRoute53(t *testing.T) resource.ErrorCheckFunc {
 	return testAccErrorCheckSkipMessagesContaining(t,
 		"Operations related to PublicDNS",
 		"Regional control plane current does not support",
+		"NoSuchHostedZone: The specified hosted zone",
 	)
 }
 

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -114,7 +114,7 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -141,7 +141,7 @@ func TestAccAWSRoute53Record_underscored(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -168,7 +168,7 @@ func TestAccAWSRoute53Record_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -191,7 +191,7 @@ func TestAccAWSRoute53Record_disappears_MultipleRecords(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -218,7 +218,7 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -260,7 +260,7 @@ func TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -287,7 +287,7 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:      testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"zone_id"}, // just for this test
 		Providers:       testAccProviders,
@@ -315,7 +315,7 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -343,7 +343,7 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -371,7 +371,7 @@ func TestAccAWSRoute53Record_dsSupport(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -397,7 +397,7 @@ func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -424,7 +424,7 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -459,7 +459,7 @@ func TestAccAWSRoute53Record_failover(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -487,7 +487,7 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: "aws_route53_record.www-live",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -516,7 +516,7 @@ func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -550,7 +550,7 @@ func TestAccAWSRoute53Record_Alias_Elb(t *testing.T) {
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElb, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -578,7 +578,7 @@ func TestAccAWSRoute53Record_Alias_S3(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -605,7 +605,7 @@ func TestAccAWSRoute53Record_Alias_VpcEndpoint(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -637,7 +637,7 @@ func TestAccAWSRoute53Record_Alias_Uppercase(t *testing.T) {
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElbUppercase, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -664,7 +664,7 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -702,7 +702,7 @@ func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -731,7 +731,7 @@ func TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -764,7 +764,7 @@ func TestAccAWSRoute53Record_HealthCheckId_TypeChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -797,7 +797,7 @@ func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -825,7 +825,7 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -860,7 +860,7 @@ func TestAccAWSRoute53Record_NameChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -896,7 +896,7 @@ func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -931,7 +931,7 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -966,7 +966,7 @@ func TestAccAWSRoute53Record_empty(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -988,7 +988,7 @@ func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
@@ -1015,7 +1015,7 @@ func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -1056,7 +1056,7 @@ func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkip(t, route53.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
@@ -1084,7 +1084,7 @@ func testAccErrorCheckSkipRoute53(t *testing.T) resource.ErrorCheckFunc {
 
 func testAccAWSRoute53RecordOverwriteExpectErrorCheck(t *testing.T) resource.ErrorCheckFunc {
 	return func(err error) error {
-		f := testAccErrorCheckSkip(t, route53.EndpointsID)
+		f := testAccErrorCheck(t, route53.EndpointsID)
 		err = f(err)
 
 		if err == nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17566
Fixes #16390

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSRoute53Record_Alias_VpcEndpoint (423.10s)
--- SKIP: TestAccAWSRoute53Record_Alias_Elb (20.22s)
--- SKIP: TestAccAWSRoute53Record_Alias_S3 (19.21s)
--- SKIP: TestAccAWSRoute53Record_Alias_Uppercase (22.64s)
--- SKIP: TestAccAWSRoute53Record_AliasChange (19.60s)
--- SKIP: TestAccAWSRoute53Record_allowOverwrite (10.72s)
--- SKIP: TestAccAWSRoute53Record_basic (11.17s)
--- SKIP: TestAccAWSRoute53Record_basic_fqdn (13.62s)
--- SKIP: TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID (33.44s)
--- SKIP: TestAccAWSRoute53Record_caaSupport (20.31s)
--- SKIP: TestAccAWSRoute53Record_disappears (36.86s)
--- SKIP: TestAccAWSRoute53Record_disappears_MultipleRecords (33.15s)
--- SKIP: TestAccAWSRoute53Record_doNotAllowOverwrite (11.80s)
--- SKIP: TestAccAWSRoute53Record_dsSupport (11.24s)
--- SKIP: TestAccAWSRoute53Record_empty (11.20s)
--- SKIP: TestAccAWSRoute53Record_failover (15.42s)
--- SKIP: TestAccAWSRoute53Record_generatesSuffix (11.53s)
--- SKIP: TestAccAWSRoute53Record_geolocation_basic (10.19s)
--- SKIP: TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange (21.36s)
--- SKIP: TestAccAWSRoute53Record_HealthCheckId_TypeChange (15.29s)
--- SKIP: TestAccAWSRoute53Record_latency_basic (62.97s)
--- SKIP: TestAccAWSRoute53Record_longTXTrecord (11.53s)
--- SKIP: TestAccAWSRoute53Record_multivalue_answer_basic (10.03s)
--- SKIP: TestAccAWSRoute53Record_NameChange (33.84s)
--- SKIP: TestAccAWSRoute53Record_SetIdentifierChange (11.58s)
--- SKIP: TestAccAWSRoute53Record_spfSupport (20.75s)
--- SKIP: TestAccAWSRoute53Record_txtSupport (14.06s)
--- SKIP: TestAccAWSRoute53Record_TypeChange (34.83s)
--- SKIP: TestAccAWSRoute53Record_underscored (30.38s)
--- SKIP: TestAccAWSRoute53Record_weighted_alias (42.74s)
--- SKIP: TestAccAWSRoute53Record_weighted_basic (11.65s)
--- SKIP: TestAccAWSRoute53Record_weighted_to_simple_basic (11.53s)
--- SKIP: TestAccAWSRoute53Record_wildcard (11.62s)
```

On commercial (`us-west-2`):
```
--- PASS: TestAccAWSRoute53Record_doNotAllowOverwrite (135.39s)
--- PASS: TestAccAWSRoute53Record_Alias_S3 (152.89s)
--- PASS: TestAccAWSRoute53Record_dsSupport (174.82s)
--- PASS: TestAccAWSRoute53Record_caaSupport (175.10s)
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (175.78s)
--- PASS: TestAccAWSRoute53Record_failover (178.10s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (179.49s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (182.96s)
--- PASS: TestAccAWSRoute53Record_latency_basic (183.92s)
--- PASS: TestAccAWSRoute53Record_empty (190.77s)
--- PASS: TestAccAWSRoute53Record_longTXTrecord (197.37s)
--- PASS: TestAccAWSRoute53Record_TypeChange (198.71s)
--- PASS: TestAccAWSRoute53Record_basic (207.94s)
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (221.32s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (221.76s)
--- PASS: TestAccAWSRoute53Record_wildcard (245.64s)
--- PASS: TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange (250.42s)
--- PASS: TestAccAWSRoute53Record_AliasChange (256.13s)
--- PASS: TestAccAWSRoute53Record_NameChange (282.15s)
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (162.23s)
--- PASS: TestAccAWSRoute53Record_HealthCheckId_TypeChange (305.46s)
--- PASS: TestAccAWSRoute53Record_spfSupport (131.32s)
--- PASS: TestAccAWSRoute53Record_Alias_Elb (125.85s)
--- PASS: TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID (146.32s)
--- PASS: TestAccAWSRoute53Record_disappears (135.23s)
--- PASS: TestAccAWSRoute53Record_txtSupport (156.31s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (161.19s)
--- PASS: TestAccAWSRoute53Record_underscored (147.12s)
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (179.77s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (182.45s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (191.86s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (317.13s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (461.22s)
```