### PR TITLE
r/aws_mq_configuration: add missing authentication_strategy

### DIFF
--- a/.changelog/18070.txt
+++ b/.changelog/18070.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_mq_configuration: Add missing `authentication_strategy` option to be able to add ldap authentication options
+```

--- a/.changelog/18070.txt
+++ b/.changelog/18070.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_mq_configuration: Add missing `authentication_strategy` option to be able to add ldap authentication options
+resource/aws_mq_configuration: Add `ldap` as an `authentication_strategy` and `RabbitMQ` as an `engine_type`
 ```

--- a/aws/resource_aws_mq_configuration.go
+++ b/aws/resource_aws_mq_configuration.go
@@ -42,6 +42,12 @@ func resourceAwsMqConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"authentication_strategy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(mq.AuthenticationStrategy_Values(), true),
+			},
 			"data": {
 				Type:             schema.TypeString,
 				Required:         true,
@@ -87,6 +93,9 @@ func resourceAwsMqConfigurationCreate(d *schema.ResourceData, meta interface{}) 
 		Name:          aws.String(d.Get("name").(string)),
 	}
 
+	if v, ok := d.GetOk("authentication_strategy"); ok {
+		input.AuthenticationStrategy = aws.String(v.(string))
+	}
 	if v, ok := d.GetOk("tags"); ok {
 		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().MqTags()
 	}
@@ -121,6 +130,7 @@ func resourceAwsMqConfigurationRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	d.Set("arn", out.Arn)
+	d.Set("authentication_strategy", out.AuthenticationStrategy)
 	d.Set("description", out.LatestRevision.Description)
 	d.Set("engine_type", out.EngineType)
 	d.Set("engine_version", out.EngineVersion)

--- a/aws/resource_aws_mq_configuration.go
+++ b/aws/resource_aws_mq_configuration.go
@@ -58,12 +58,10 @@ func resourceAwsMqConfiguration() *schema.Resource {
 				Optional: true,
 			},
 			"engine_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					mq.EngineTypeActivemq,
-				}, true),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(mq.EngineType_Values(), true),
 			},
 			"engine_version": {
 				Type:     schema.TypeString,
@@ -134,8 +132,8 @@ func resourceAwsMqConfigurationRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("description", out.LatestRevision.Description)
 	d.Set("engine_type", out.EngineType)
 	d.Set("engine_version", out.EngineVersion)
-	d.Set("name", out.Name)
 	d.Set("latest_revision", out.LatestRevision.Revision)
+	d.Set("name", out.Name)
 
 	rOut, err := conn.DescribeConfigurationRevision(&mq.DescribeConfigurationRevisionInput{
 		ConfigurationId:       aws.String(d.Id()),

--- a/aws/resource_aws_mq_configuration_test.go
+++ b/aws/resource_aws_mq_configuration_test.go
@@ -204,10 +204,10 @@ func testAccCheckAwsMqConfigurationExists(name string) resource.TestCheckFunc {
 func testAccMqConfigurationConfig(configurationName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
-  description    = "TfAccTest MQ Configuration"
-  name           = "%s"
-  engine_type    = "ActiveMQ"
-  engine_version = "5.15.0"
+  description             = "TfAccTest MQ Configuration"
+  name                    = "%s"
+  engine_type             = "ActiveMQ"
+  engine_version          = "5.15.0"
   authentication_strategy = "simple"
 
   data = <<DATA
@@ -274,10 +274,10 @@ DATA
 func testAccMqConfigurationWithLdapDataConfig(configurationName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
-  description    = "TfAccTest MQ Configuration"
-  name           = "%s"
-  engine_type    = "ActiveMQ"
-  engine_version = "5.15.0"
+  description             = "TfAccTest MQ Configuration"
+  name                    = "%s"
+  engine_type             = "ActiveMQ"
+  engine_version          = "5.15.0"
   authentication_strategy = "ldap"
 
   data = <<DATA

--- a/aws/resource_aws_mq_configuration_test.go
+++ b/aws/resource_aws_mq_configuration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccAWSMqConfiguration_basic(t *testing.T) {
-	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,7 +23,7 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqConfigurationConfig(configurationName),
+				Config: testAccMqConfigurationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqConfigurationExists(resourceName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexp.MustCompile(`configuration:+.`)),
@@ -32,7 +32,7 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
-					resource.TestCheckResourceAttr(resourceName, "name", configurationName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 			{
@@ -41,7 +41,7 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMqConfigurationConfig_descriptionUpdated(configurationName),
+				Config: testAccMqConfigurationConfig_descriptionUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqConfigurationExists(resourceName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexp.MustCompile(`configuration:+.`)),
@@ -49,7 +49,7 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "3"),
-					resource.TestCheckResourceAttr(resourceName, "name", configurationName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 		},
@@ -57,7 +57,7 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 }
 
 func TestAccAWSMqConfiguration_withData(t *testing.T) {
-	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -67,7 +67,7 @@ func TestAccAWSMqConfiguration_withData(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqConfigurationWithDataConfig(configurationName),
+				Config: testAccMqConfigurationWithDataConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqConfigurationExists(resourceName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexp.MustCompile(`configuration:+.`)),
@@ -75,7 +75,7 @@ func TestAccAWSMqConfiguration_withData(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
-					resource.TestCheckResourceAttr(resourceName, "name", configurationName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 			{
@@ -88,7 +88,7 @@ func TestAccAWSMqConfiguration_withData(t *testing.T) {
 }
 
 func TestAccAWSMqConfiguration_withLdapData(t *testing.T) {
-	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -98,7 +98,7 @@ func TestAccAWSMqConfiguration_withLdapData(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqConfigurationWithLdapDataConfig(configurationName),
+				Config: testAccMqConfigurationWithLdapDataConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqConfigurationExists(resourceName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexp.MustCompile(`configuration:+.`)),
@@ -107,7 +107,7 @@ func TestAccAWSMqConfiguration_withLdapData(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
-					resource.TestCheckResourceAttr(resourceName, "name", configurationName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 			{
@@ -120,7 +120,7 @@ func TestAccAWSMqConfiguration_withLdapData(t *testing.T) {
 }
 
 func TestAccAWSMqConfiguration_updateTags(t *testing.T) {
-	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -130,7 +130,7 @@ func TestAccAWSMqConfiguration_updateTags(t *testing.T) {
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMqConfigurationConfig_updateTags1(configurationName),
+				Config: testAccMqConfigurationConfig_updateTags1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -143,7 +143,7 @@ func TestAccAWSMqConfiguration_updateTags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMqConfigurationConfig_updateTags2(configurationName),
+				Config: testAccMqConfigurationConfig_updateTags2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -152,7 +152,7 @@ func TestAccAWSMqConfiguration_updateTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMqConfigurationConfig_updateTags3(configurationName),
+				Config: testAccMqConfigurationConfig_updateTags3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -202,11 +202,11 @@ func testAccCheckAwsMqConfigurationExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccMqConfigurationConfig(configurationName string) string {
+func testAccMqConfigurationConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description             = "TfAccTest MQ Configuration"
-  name                    = "%s"
+  name                    = %[1]q
   engine_type             = "ActiveMQ"
   engine_version          = "5.15.0"
   authentication_strategy = "simple"
@@ -217,14 +217,14 @@ resource "aws_mq_configuration" "test" {
 </broker>
 DATA
 }
-`, configurationName)
+`, rName)
 }
 
-func testAccMqConfigurationConfig_descriptionUpdated(configurationName string) string {
+func testAccMqConfigurationConfig_descriptionUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description    = "TfAccTest MQ Configuration Updated"
-  name           = "%s"
+  name           = %[1]q
   engine_type    = "ActiveMQ"
   engine_version = "5.15.0"
 
@@ -234,14 +234,14 @@ resource "aws_mq_configuration" "test" {
 </broker>
 DATA
 }
-`, configurationName)
+`, rName)
 }
 
-func testAccMqConfigurationWithDataConfig(configurationName string) string {
+func testAccMqConfigurationWithDataConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description    = "TfAccTest MQ Configuration"
-  name           = "%s"
+  name           = %[1]q
   engine_type    = "ActiveMQ"
   engine_version = "5.15.0"
 
@@ -269,14 +269,14 @@ resource "aws_mq_configuration" "test" {
 </broker>
 DATA
 }
-`, configurationName)
+`, rName)
 }
 
-func testAccMqConfigurationWithLdapDataConfig(configurationName string) string {
+func testAccMqConfigurationWithLdapDataConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description             = "TfAccTest MQ Configuration"
-  name                    = "%s"
+  name                    = %[1]q
   engine_type             = "ActiveMQ"
   engine_version          = "5.15.0"
   authentication_strategy = "ldap"
@@ -297,14 +297,14 @@ resource "aws_mq_configuration" "test" {
 </broker>
 DATA
 }
-`, configurationName)
+`, rName)
 }
 
-func testAccMqConfigurationConfig_updateTags1(configurationName string) string {
+func testAccMqConfigurationConfig_updateTags1(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description    = "TfAccTest MQ Configuration"
-  name           = "%s"
+  name           = %[1]q
   engine_type    = "ActiveMQ"
   engine_version = "5.15.0"
 
@@ -318,14 +318,14 @@ DATA
     env = "test"
   }
 }
-`, configurationName)
+`, rName)
 }
 
-func testAccMqConfigurationConfig_updateTags2(configurationName string) string {
+func testAccMqConfigurationConfig_updateTags2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description    = "TfAccTest MQ Configuration"
-  name           = "%s"
+  name           = %[1]q
   engine_type    = "ActiveMQ"
   engine_version = "5.15.0"
 
@@ -340,14 +340,14 @@ DATA
     role = "test-role"
   }
 }
-`, configurationName)
+`, rName)
 }
 
-func testAccMqConfigurationConfig_updateTags3(configurationName string) string {
+func testAccMqConfigurationConfig_updateTags3(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_mq_configuration" "test" {
   description    = "TfAccTest MQ Configuration"
-  name           = "%s"
+  name           = %[1]q
   engine_type    = "ActiveMQ"
   engine_version = "5.15.0"
 
@@ -361,5 +361,5 @@ DATA
     role = "test-role"
   }
 }
-`, configurationName)
+`, rName)
 }

--- a/aws/resource_aws_mq_configuration_test.go
+++ b/aws/resource_aws_mq_configuration_test.go
@@ -17,7 +17,11 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
@@ -61,7 +65,11 @@ func TestAccAWSMqConfiguration_withData(t *testing.T) {
 	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
@@ -92,7 +100,11 @@ func TestAccAWSMqConfiguration_withLdapData(t *testing.T) {
 	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
@@ -124,7 +136,11 @@ func TestAccAWSMqConfiguration_updateTags(t *testing.T) {
 	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
 		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,

--- a/aws/resource_aws_mq_configuration_test.go
+++ b/aws/resource_aws_mq_configuration_test.go
@@ -93,6 +93,7 @@ func TestAccAWSMqConfiguration_withLdapData(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
+		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
 		Steps: []resource.TestStep{

--- a/website/docs/r/mq_configuration.html.markdown
+++ b/website/docs/r/mq_configuration.html.markdown
@@ -36,25 +36,26 @@ DATA
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `data` - (Required) The broker configuration in XML format.
-  See [official docs](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-broker-configuration-parameters.html)
-  for supported parameters and format of the XML.
-* `description` - (Optional) The description of the configuration.
-* `engine_type` - (Required) The type of broker engine.
-* `engine_version` - (Required) The version of the broker engine.
-* `name` - (Required) The name of the configuration
-* `authentication_strategy` - (Optional) The authentication strategy associated with the configuration. Valid values are `simple` and `ldap`. `ldap` is not supported for `engine_type` `RabbitMQ`.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `data` - (Required) Broker configuration in XML format. See [official docs](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-broker-configuration-parameters.html) for supported parameters and format of the XML.
+* `engine_type` - (Required) Type of broker engine. Valid values are `ActiveMQ` and `RabbitMQ`.
+* `engine_version` - (Required) Version of the broker engine.
+* `name` - (Required) Name of the configuration.
+
+The following arguments are optional:
+
+* `authentication_strategy` - (Optional) Authentication strategy associated with the configuration. Valid values are `simple` and `ldap`. `ldap` is not supported for `engine_type` `RabbitMQ`.
+* `description` - (Optional) Description of the configuration.
+* `tags` - (Optional) Map of tags to assign to the resource.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The unique ID that Amazon MQ generates for the configuration.
-* `arn` - The ARN of the configuration.
-* `latest_revision` - The latest revision of the configuration.
+* `arn` - ARN of the configuration.
+* `id` - Unique ID that Amazon MQ generates for the configuration.
+* `latest_revision` - Latest revision of the configuration.
 
 ## Import
 

--- a/website/docs/r/mq_configuration.html.markdown
+++ b/website/docs/r/mq_configuration.html.markdown
@@ -45,6 +45,7 @@ The following arguments are supported:
 * `engine_type` - (Required) The type of broker engine.
 * `engine_version` - (Required) The version of the broker engine.
 * `name` - (Required) The name of the configuration
+* `authentication_strategy` - (Optional) The authentication strategy associated with the configuration. Valid values are `simple` and `ldap`. `ldap` is not supported for `engine_type` `RabbitMQ`.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
When creating an ActiveMQ instance with authentication_strategy=ldap,
then the corresponding configuration has to contain the same option
as well for the user to be able to include a cachedLDAPAuthorizationMap
element in the broker xml configuration. If the option is not provided
when creating the configuration, the default strategy "simple" is
assumed and AWS automatically removes the cachedLDAPAuthorizationMap
element.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--- Relates OR Closes #0000 --->

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSMqConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMqConfiguration -timeout 180m
=== RUN   TestAccAWSMqConfiguration_basic
=== PAUSE TestAccAWSMqConfiguration_basic
=== RUN   TestAccAWSMqConfiguration_withData
=== PAUSE TestAccAWSMqConfiguration_withData
=== RUN   TestAccAWSMqConfiguration_withLdapData
=== PAUSE TestAccAWSMqConfiguration_withLdapData
=== RUN   TestAccAWSMqConfiguration_updateTags
=== PAUSE TestAccAWSMqConfiguration_updateTags
=== CONT  TestAccAWSMqConfiguration_basic
=== CONT  TestAccAWSMqConfiguration_withData
=== CONT  TestAccAWSMqConfiguration_updateTags
=== CONT  TestAccAWSMqConfiguration_withLdapData
--- PASS: TestAccAWSMqConfiguration_withLdapData (33.69s)
--- PASS: TestAccAWSMqConfiguration_withData (36.95s)
--- PASS: TestAccAWSMqConfiguration_basic (59.69s)
--- PASS: TestAccAWSMqConfiguration_updateTags (79.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	85.756s
```