### PR TITLE
b/resource_aws_rds_cluster: RDS cluster port change to happen in-place

### DIFF
--- a/.changelog/18081.txt
+++ b/.changelog/18081.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Changing the database port number is now updated in-place.
+```

--- a/.changelog/18081.txt
+++ b/.changelog/18081.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-resource/aws_rds_cluster: Changing the database port number is now updated in-place.
+```release-note:enhancement
+resource/aws_rds_cluster: Database port is updated in-place
 ```

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -353,7 +353,6 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 
 			// apply_immediately is used to determine when the update modifications
@@ -1151,6 +1150,11 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		} else {
 			req.VpcSecurityGroupIds = []*string{}
 		}
+		requestUpdate = true
+	}
+
+	if d.HasChange("port") {
+		req.Port = aws.Int64(int64(d.Get("port").(int)))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -4044,10 +4044,11 @@ resource "aws_db_cluster_snapshot" "test" {
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier      = %[1]q
-  preferred_backup_window = %[2]q
-  skip_final_snapshot     = true
-  snapshot_identifier     = aws_db_cluster_snapshot.test.id
+  cluster_identifier           = %[1]q
+  preferred_backup_window      = %[2]q
+  preferred_maintenance_window = "sun:09:00-sun:09:30"
+  skip_final_snapshot          = true
+  snapshot_identifier          = aws_db_cluster_snapshot.test.id
 }
 `, rName, preferredBackupWindow)
 }

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func init() {
+	RegisterServiceErrorCheckFunc(rds.EndpointsID, testAccErrorCheckSkipRDS)
+
 	resource.AddTestSweepers("aws_rds_cluster", &resource.Sweeper{
 		Name: "aws_rds_cluster",
 		F:    testSweepRdsClusters,
@@ -25,6 +27,16 @@ func init() {
 			"aws_db_instance",
 		},
 	})
+}
+
+func testAccErrorCheckSkipRDS(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"engine mode serverless you requested is currently unavailable",
+		"engine mode multimaster you requested is currently unavailable",
+		"requested engine version was not found or does not support parallelquery functionality",
+		"Backtrack is not enabled for the aurora engine",
+		"Read replica DB clusters are not available in this region for engine aurora",
+	)
 }
 
 func testSweepRdsClusters(region string) error {

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -1525,7 +1525,6 @@ func TestAccAWSRDSCluster_Port(t *testing.T) {
 				Config: testAccAWSClusterConfig_Port(rInt, 2345),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster2),
-					testAccCheckAWSClusterRecreated(&dbCluster1, &dbCluster2),
 					resource.TestCheckResourceAttr(resourceName, "port", "2345"),
 				),
 			},


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #18061

### Problem
When changing the RDS cluster port, currently this causes a recreate. This should be an in-place change.

### Fix 
- removes ForceNew from Port in schema
- requests cluster update if port config has changed
- modifies the particular test method to no longer check for ClusterRecreated.

### Testing
Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccAWSRDSCluster_Port'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRDSCluster_Port -timeout 180m
=== RUN   TestAccAWSRDSCluster_Port
=== PAUSE TestAccAWSRDSCluster_Port
=== CONT  TestAccAWSRDSCluster_Port
--- PASS: TestAccAWSRDSCluster_Port (284.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	289.250s
```
Output from my test env:
```
$ terraform apply

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/aws in /Users/dougb/dev/Go/src/github.com/scratch/aurora-test/terraform/tf-provider

aws_vpc.demo_vpc: Refreshing state... [id=vpc-093705f903f600b11]
aws_subnet.public[0]: Refreshing state... [id=subnet-004c69ce044e18d39]
aws_subnet.public[1]: Refreshing state... [id=subnet-0691d19de97719833]
aws_db_subnet_group.aurora_subnet_group: Refreshing state... [id=aurora_db_subnet_group]
aws_rds_cluster.default: Refreshing state... [id=aurora-cluster-demo]
aws_rds_cluster_instance.cluster_instances: Refreshing state... [id=aurora-cluster-demo]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_rds_cluster.default will be updated in-place
  ~ resource "aws_rds_cluster" "default" {
        id                                  = "aurora-cluster-demo"
      ~ port                                = 3306 -> 2000
        tags                                = {}
        # (30 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_rds_cluster.default: Modifying... [id=aurora-cluster-demo]
aws_rds_cluster.default: Still modifying... [id=aurora-cluster-demo, 10s elapsed]
aws_rds_cluster.default: Still modifying... [id=aurora-cluster-demo, 20s elapsed]
aws_rds_cluster.default: Still modifying... [id=aurora-cluster-demo, 30s elapsed]
aws_rds_cluster.default: Modifications complete after 32s [id=aurora-cluster-demo]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
$
```
Note: this is my first commit to this repo, and first time understanding the aws provider internals. Extra checks on my work appreciated. 🙂