### PR TITLE
Add aws_cloudfront_monitoring_subscription resource

### DIFF
--- a/.changelog/18083.txt
+++ b/.changelog/18083.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_cloudfront_monitoring_subscription
+```

--- a/aws/internal/service/cloudfront/finder/finder.go
+++ b/aws/internal/service/cloudfront/finder/finder.go
@@ -54,3 +54,22 @@ func RealtimeLogConfigByARN(conn *cloudfront.CloudFront, arn string) (*cloudfron
 
 	return output.RealtimeLogConfig, nil
 }
+
+// MonitoringSubscriptionByDistributionId returns the monitoring subscription corresponding to the specified distribution id.
+// Returns nil if no subscription is found.
+func MonitoringSubscriptionByDistributionId(conn *cloudfront.CloudFront, id string) (*cloudfront.MonitoringSubscription, error) {
+	input := &cloudfront.GetMonitoringSubscriptionInput{
+		DistributionId: aws.String(id),
+	}
+
+	output, err := conn.GetMonitoringSubscription(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output.MonitoringSubscription, nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -547,6 +547,7 @@ func Provider() *schema.Provider {
 			"aws_cloudfront_distribution":                             resourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_function":                                 resourceAwsCloudFrontFunction(),
 			"aws_cloudfront_key_group":                                resourceAwsCloudFrontKeyGroup(),
+			"aws_cloudfront_monitoring_subscription":                  resourceAwsCloudFrontMonitoringSubscription(),
 			"aws_cloudfront_origin_access_identity":                   resourceAwsCloudFrontOriginAccessIdentity(),
 			"aws_cloudfront_origin_request_policy":                    resourceAwsCloudFrontOriginRequestPolicy(),
 			"aws_cloudfront_public_key":                               resourceAwsCloudFrontPublicKey(),

--- a/aws/resource_aws_cloudfront_monitoring_subscription.go
+++ b/aws/resource_aws_cloudfront_monitoring_subscription.go
@@ -1,0 +1,165 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudfront/finder"
+)
+
+func resourceAwsCloudFrontMonitoringSubscription() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudFrontMonitoringSubscriptionCreate,
+		Read:   resourceAwsCloudFrontMonitoringSubscriptionRead,
+		Delete: resourceAwsCloudFrontMonitoringSubscriptionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"distribution_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"monitoring_subscription": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"realtime_metrics_subscription_config": {
+							Type:     schema.TypeList,
+							Required: true,
+							ForceNew: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"realtime_metrics_subscription_status": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(cloudfront.RealtimeMetricsSubscriptionStatus_Values(), false),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsCloudFrontMonitoringSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	id := d.Get("distribution_id").(string)
+	input := &cloudfront.CreateMonitoringSubscriptionInput{
+		DistributionId:         aws.String(id),
+		MonitoringSubscription: expandCloudFrontMonitoringSubscription(d.Get("monitoring_subscription").([]interface{})),
+	}
+
+	log.Printf("[DEBUG] Creating CloudFront Monitoring Subscription: %s", input)
+	_, err := conn.CreateMonitoringSubscription(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating CloudFront Monitoring Subscription (%s): %w", id, err)
+	}
+
+	d.SetId(id)
+
+	return resourceAwsCloudFrontMonitoringSubscriptionRead(d, meta)
+}
+
+func resourceAwsCloudFrontMonitoringSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	subscription, err := finder.MonitoringSubscriptionByDistributionId(conn, d.Id())
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
+		log.Printf("[WARN] CloudFront Distribution (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading CloudFront Monitoring Subscription (%s): %w", d.Id(), err)
+	}
+
+	if subscription == nil {
+		if d.IsNewResource() {
+			return fmt.Errorf("error reading CloudFront Monitoring Subscription (%s): not found", d.Id())
+		}
+		log.Printf("[WARN] CloudFront Monitoring Subscription (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("distribution_id", d.Id())
+	if err := d.Set("monitoring_subscription", flattenCloudFrontMonitoringSubscription(subscription)); err != nil {
+		return fmt.Errorf("error setting monitoring_subscription: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsCloudFrontMonitoringSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+
+	log.Printf("[DEBUG] Deleting CloudFront Monitoring Subscription (%s)", d.Id())
+	_, err := conn.DeleteMonitoringSubscription(&cloudfront.DeleteMonitoringSubscriptionInput{
+		DistributionId: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, cloudfront.ErrCodeNoSuchDistribution) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting CloudFront Monitoring Subscription (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandCloudFrontMonitoringSubscription(vSubscription []interface{}) *cloudfront.MonitoringSubscription {
+	if len(vSubscription) == 0 || vSubscription[0] == nil {
+		return nil
+	}
+
+	mSubscription := vSubscription[0].(map[string]interface{})
+
+	return &cloudfront.MonitoringSubscription{
+		RealtimeMetricsSubscriptionConfig: expandCloudFrontRealtimeMetricsSubscriptionConfig(mSubscription["realtime_metrics_subscription_config"].([]interface{})),
+	}
+}
+
+func expandCloudFrontRealtimeMetricsSubscriptionConfig(vConfig []interface{}) *cloudfront.RealtimeMetricsSubscriptionConfig {
+	if len(vConfig) == 0 || vConfig[0] == nil {
+		return nil
+	}
+
+	mConfig := vConfig[0].(map[string]interface{})
+
+	return &cloudfront.RealtimeMetricsSubscriptionConfig{
+		RealtimeMetricsSubscriptionStatus: aws.String(mConfig["realtime_metrics_subscription_status"].(string)),
+	}
+}
+
+func flattenCloudFrontMonitoringSubscription(subscription *cloudfront.MonitoringSubscription) []interface{} {
+	return []interface{}{map[string]interface{}{"realtime_metrics_subscription_config": flattenCloudFrontRealtimeMetricsSubscriptionConfig(subscription.RealtimeMetricsSubscriptionConfig)}}
+}
+
+func flattenCloudFrontRealtimeMetricsSubscriptionConfig(config *cloudfront.RealtimeMetricsSubscriptionConfig) []interface{} {
+	return []interface{}{map[string]interface{}{"realtime_metrics_subscription_status": config.RealtimeMetricsSubscriptionStatus}}
+}

--- a/aws/resource_aws_cloudfront_monitoring_subscription_test.go
+++ b/aws/resource_aws_cloudfront_monitoring_subscription_test.go
@@ -78,7 +78,7 @@ func TestAccAWSCloudFrontMonitoringSubscription_basic(t *testing.T) {
 		CheckDestroy: testAccCheckCloudFrontMonitoringSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig(),
+				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig("Enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontMonitoringSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "distribution_id"),
@@ -106,7 +106,7 @@ func TestAccAWSCloudFrontMonitoringSubscription_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckCloudFrontMonitoringSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig(),
+				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig("Enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontMonitoringSubscriptionExists(resourceName, &v),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudFrontMonitoringSubscription(), resourceName),
@@ -117,7 +117,7 @@ func TestAccAWSCloudFrontMonitoringSubscription_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFrontMonitoringSubscription_RealtimeMetricsSubscriptionConfig(t *testing.T) {
+func TestAccAWSCloudFrontMonitoringSubscription_update(t *testing.T) {
 	var v cloudfront.MonitoringSubscription
 	resourceName := "aws_cloudfront_monitoring_subscription.test"
 
@@ -127,7 +127,7 @@ func TestAccAWSCloudFrontMonitoringSubscription_RealtimeMetricsSubscriptionConfi
 		CheckDestroy: testAccCheckCloudFrontMonitoringSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFrontMonitoringSubscriptionRealtimeMetricsSubscriptionConfigConfig("Enabled"),
+				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig("Enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontMonitoringSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "distribution_id"),
@@ -142,7 +142,7 @@ func TestAccAWSCloudFrontMonitoringSubscription_RealtimeMetricsSubscriptionConfi
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudFrontMonitoringSubscriptionRealtimeMetricsSubscriptionConfigConfig("Disabled"),
+				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig("Disabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontMonitoringSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "distribution_id"),
@@ -249,23 +249,7 @@ resource "aws_cloudfront_distribution" "test" {
 `
 }
 
-func testAccAWSCloudFrontMonitoringSubscriptionConfig() string {
-	return composeConfig(
-		testAccAWSCloudFrontMonitoringSubscriptionConfigBase(),
-		`
-resource "aws_cloudfront_monitoring_subscription" "test" {
-  distribution_id = aws_cloudfront_distribution.test.id
-
-  monitoring_subscription {
-    realtime_metrics_subscription_config {
-      realtime_metrics_subscription_status = "Enabled"
-    }
-  }
-}
-`)
-}
-
-func testAccAWSCloudFrontMonitoringSubscriptionRealtimeMetricsSubscriptionConfigConfig(status string) string {
+func testAccAWSCloudFrontMonitoringSubscriptionConfig(status string) string {
 	return composeConfig(
 		testAccAWSCloudFrontMonitoringSubscriptionConfigBase(),
 		fmt.Sprintf(`
@@ -274,7 +258,7 @@ resource "aws_cloudfront_monitoring_subscription" "test" {
 
   monitoring_subscription {
     realtime_metrics_subscription_config {
-      realtime_metrics_subscription_status = %q
+      realtime_metrics_subscription_status = %[1]q
     }
   }
 }

--- a/aws/resource_aws_cloudfront_monitoring_subscription_test.go
+++ b/aws/resource_aws_cloudfront_monitoring_subscription_test.go
@@ -1,0 +1,282 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudfront/finder"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_cloudfront_monitoring_subscription", &resource.Sweeper{
+		Name: "aws_cloudfront_monitoring_subscription",
+		F:    testSweepCloudFrontMonitoringSubscriptions,
+	})
+}
+
+func testSweepCloudFrontMonitoringSubscriptions(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).cloudfrontconn
+	var sweeperErrs *multierror.Error
+
+	distributionSummaries := make([]*cloudfront.DistributionSummary, 0)
+
+	input := &cloudfront.ListDistributionsInput{}
+	err = conn.ListDistributionsPages(input, func(page *cloudfront.ListDistributionsOutput, lastPage bool) bool {
+		distributionSummaries = append(distributionSummaries, page.DistributionList.Items...)
+		return !lastPage
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping CloudFront Monitoring Subscriptions sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("error listing CloudFront Distributions: %s", err)
+	}
+
+	if len(distributionSummaries) == 0 {
+		log.Print("[DEBUG] No CloudFront Distributions found")
+		return nil
+	}
+
+	for _, distributionSummary := range distributionSummaries {
+
+		_, err := conn.GetMonitoringSubscription(&cloudfront.GetMonitoringSubscriptionInput{
+			DistributionId: distributionSummary.Id,
+		})
+		if err != nil {
+			return fmt.Errorf("error reading CloudFront Monitoring Subscription %s: %s", aws.StringValue(distributionSummary.Id), err)
+		}
+
+		_, err = conn.DeleteMonitoringSubscription(&cloudfront.DeleteMonitoringSubscriptionInput{
+			DistributionId: distributionSummary.Id,
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting CloudFront Monitoring Subscription %s: %s", aws.StringValue(distributionSummary.Id), err)
+		}
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func TestAccAWSCloudFrontMonitoringSubscription_basic(t *testing.T) {
+	var v cloudfront.MonitoringSubscription
+	resourceName := "aws_cloudfront_monitoring_subscription.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontMonitoringSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontMonitoringSubscriptionExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "distribution_id"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_subscription.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_subscription.0.realtime_metrics_subscription_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_subscription.0.realtime_metrics_subscription_config.0.realtime_metrics_subscription_status", "Enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontMonitoringSubscription_disappears(t *testing.T) {
+	var v cloudfront.MonitoringSubscription
+	resourceName := "aws_cloudfront_monitoring_subscription.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontMonitoringSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontMonitoringSubscriptionExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudFrontMonitoringSubscription(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontMonitoringSubscription_RealtimeMetricsSubscriptionConfig(t *testing.T) {
+	var v cloudfront.MonitoringSubscription
+	resourceName := "aws_cloudfront_monitoring_subscription.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontMonitoringSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontMonitoringSubscriptionRealtimeMetricsSubscriptionConfigConfig("Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontMonitoringSubscriptionExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "distribution_id"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_subscription.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_subscription.0.realtime_metrics_subscription_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_subscription.0.realtime_metrics_subscription_config.0.realtime_metrics_subscription_status", "Enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCloudFrontMonitoringSubscriptionRealtimeMetricsSubscriptionConfigConfig("Disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontMonitoringSubscriptionExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "distribution_id"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_subscription.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_subscription.0.realtime_metrics_subscription_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_subscription.0.realtime_metrics_subscription_config.0.realtime_metrics_subscription_status", "Disabled"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudFrontMonitoringSubscriptionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cloudfrontconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudfront_monitoring_subscription" {
+			continue
+		}
+
+		s, err := finder.MonitoringSubscriptionByDistributionId(conn, rs.Primary.ID)
+
+		if isAWSErr(err, cloudfront.ErrCodeNoSuchDistribution, "") {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if s != nil {
+			continue
+		}
+		return fmt.Errorf("CloudFront Monitoring Subscription still exists: %s", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckCloudFrontMonitoringSubscriptionExists(n string, v *cloudfront.MonitoringSubscription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No CloudFront Monitoring Subscription ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudfrontconn
+		out, err := finder.MonitoringSubscriptionByDistributionId(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*v = *out
+
+		return nil
+	}
+}
+
+func testAccAWSCloudFrontMonitoringSubscriptionConfigBase() string {
+	return `
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = true
+  retain_on_delete = false
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`
+}
+
+func testAccAWSCloudFrontMonitoringSubscriptionConfig() string {
+	return composeConfig(
+		testAccAWSCloudFrontMonitoringSubscriptionConfigBase(),
+		`
+resource "aws_cloudfront_monitoring_subscription" "test" {
+  distribution_id = aws_cloudfront_distribution.test.id
+
+  monitoring_subscription {
+    realtime_metrics_subscription_config {
+      realtime_metrics_subscription_status = "Enabled"
+    }
+  }
+}
+`)
+}
+
+func testAccAWSCloudFrontMonitoringSubscriptionRealtimeMetricsSubscriptionConfigConfig(status string) string {
+	return composeConfig(
+		testAccAWSCloudFrontMonitoringSubscriptionConfigBase(),
+		fmt.Sprintf(`
+resource "aws_cloudfront_monitoring_subscription" "test" {
+  distribution_id = aws_cloudfront_distribution.test.id
+
+  monitoring_subscription {
+    realtime_metrics_subscription_config {
+      realtime_metrics_subscription_status = %q
+    }
+  }
+}
+`, status))
+}

--- a/aws/resource_aws_cloudfront_monitoring_subscription_test.go
+++ b/aws/resource_aws_cloudfront_monitoring_subscription_test.go
@@ -76,6 +76,7 @@ func TestAccAWSCloudFrontMonitoringSubscription_basic(t *testing.T) {
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontMonitoringSubscriptionDestroy,
+		ErrorCheck:   testAccErrorCheck(t, cloudfront.EndpointsID),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig("Enabled"),
@@ -104,6 +105,7 @@ func TestAccAWSCloudFrontMonitoringSubscription_disappears(t *testing.T) {
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontMonitoringSubscriptionDestroy,
+		ErrorCheck:   testAccErrorCheck(t, cloudfront.EndpointsID),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig("Enabled"),
@@ -125,6 +127,7 @@ func TestAccAWSCloudFrontMonitoringSubscription_update(t *testing.T) {
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontMonitoringSubscriptionDestroy,
+		ErrorCheck:   testAccErrorCheck(t, cloudfront.EndpointsID),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCloudFrontMonitoringSubscriptionConfig("Enabled"),

--- a/website/docs/r/cloudfront_monitoring_subscription.html.markdown
+++ b/website/docs/r/cloudfront_monitoring_subscription.html.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_monitoring_subscription"
+description: |-
+  Provides a CloudFront monitoring subscription resource.
+---
+
+# Resource: aws_cloudfront_monitoring_subscription
+
+Provides a CloudFront real-time log configuration resource.
+
+## Example Usage
+
+```hcl
+resource "aws_cloudfront_monitoring_subscription" "example" {
+  distribution_id = aws_cloudfront_distribution.example.id
+
+  monitoring_subscription {
+    realtime_metrics_subscription_config {
+      realtime_metrics_subscription_status = "Enabled"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `distribution_id` - (Required) The ID of the distribution that you are enabling metrics for.
+* `monitoring_subscription` - (Required) A monitoring subscription. This structure contains information about whether additional CloudWatch metrics are enabled for a given CloudFront distribution.
+
+The `monitoring_subscription` object supports the following argument:
+
+* `realtime_metrics_subscription_config` - (Required) A subscription configuration for additional CloudWatch metrics.
+
+The `realtime_metrics_subscription_config` object supports the following argument:
+
+* `realtime_metrics_subscription_status` - (Required) A flag that indicates whether additional CloudWatch metrics are enabled for a given CloudFront distribution. Valid values are `Enabled` and `Disabled`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the CloudFront monitoring subscription, which corresponds to the `distribution_id`.
+
+## Import
+
+CloudFront monitoring subscription can be imported using the id, e.g.
+
+```
+$ terraform import aws_cloudfront_monitoring_subscription.example E3QYSUHO4VYRGB
+```

--- a/website/docs/r/cloudfront_monitoring_subscription.html.markdown
+++ b/website/docs/r/cloudfront_monitoring_subscription.html.markdown
@@ -12,7 +12,7 @@ Provides a CloudFront real-time log configuration resource.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "aws_cloudfront_monitoring_subscription" "example" {
   distribution_id = aws_cloudfront_distribution.example.id
 

--- a/website/docs/r/cloudfront_monitoring_subscription.html.markdown
+++ b/website/docs/r/cloudfront_monitoring_subscription.html.markdown
@@ -31,13 +31,13 @@ The following arguments are supported:
 * `distribution_id` - (Required) The ID of the distribution that you are enabling metrics for.
 * `monitoring_subscription` - (Required) A monitoring subscription. This structure contains information about whether additional CloudWatch metrics are enabled for a given CloudFront distribution.
 
-The `monitoring_subscription` object supports the following argument:
+### monitoring_subscription
 
-* `realtime_metrics_subscription_config` - (Required) A subscription configuration for additional CloudWatch metrics.
+* `realtime_metrics_subscription_config` - (Required) A subscription configuration for additional CloudWatch metrics. See below.
 
-The `realtime_metrics_subscription_config` object supports the following argument:
+### realtime_metrics_subscription_config
 
-* `realtime_metrics_subscription_status` - (Required) A flag that indicates whether additional CloudWatch metrics are enabled for a given CloudFront distribution. Valid values are `Enabled` and `Disabled`.
+* `realtime_metrics_subscription_status` - (Required) A flag that indicates whether additional CloudWatch metrics are enabled for a given CloudFront distribution. Valid values are `Enabled` and `Disabled`. See below.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/11577

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudFrontMonitoringSubscription_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontMonitoringSubscription_ -timeout 180m
=== RUN   TestAccAWSCloudFrontMonitoringSubscription_basic
=== PAUSE TestAccAWSCloudFrontMonitoringSubscription_basic
=== RUN   TestAccAWSCloudFrontMonitoringSubscription_disappears
=== PAUSE TestAccAWSCloudFrontMonitoringSubscription_disappears
=== RUN   TestAccAWSCloudFrontMonitoringSubscription_RealtimeMetricsSubscriptionConfig
=== PAUSE TestAccAWSCloudFrontMonitoringSubscription_RealtimeMetricsSubscriptionConfig
=== CONT  TestAccAWSCloudFrontMonitoringSubscription_basic
=== CONT  TestAccAWSCloudFrontMonitoringSubscription_RealtimeMetricsSubscriptionConfig
=== CONT  TestAccAWSCloudFrontMonitoringSubscription_disappears
--- PASS: TestAccAWSCloudFrontMonitoringSubscription_basic (390.68s)
--- PASS: TestAccAWSCloudFrontMonitoringSubscription_disappears (392.95s)
--- PASS: TestAccAWSCloudFrontMonitoringSubscription_RealtimeMetricsSubscriptionConfig (400.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	402.625s
```

Added `aws_cloudfront_monitoring_subscription` resource. Thank you for your review! 