### PR TITLE
[WIP] Add FIFO topic support for aws_sns_topic data source

### DIFF
--- a/.changelog/18087.txt
+++ b/.changelog/18087.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sns_topic: Allow getting info for FIFO SNS topics with .fifo suffix in the name
+```

--- a/aws/data_source_aws_sns.go
+++ b/aws/data_source_aws_sns.go
@@ -18,7 +18,7 @@ func dataSourceAwsSnsTopic() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					validNamePattern := "^[A-Za-z0-9_-]+$"
+					validNamePattern := "^[A-Za-z0-9_-]+(\\.fifo)?$"
 					validName, nameMatchErr := regexp.MatchString(validNamePattern, value)
 					if !validName || nameMatchErr != nil {
 						errors = append(errors, fmt.Errorf(

--- a/aws/data_source_aws_sns_test.go
+++ b/aws/data_source_aws_sns_test.go
@@ -19,6 +19,12 @@ func TestAccDataSourceAwsSnsTopic_basic(t *testing.T) {
 					testAccDataSourceAwsSnsTopicCheck("data.aws_sns_topic.by_name"),
 				),
 			},
+			{
+				Config: testAccDataSourceAwsSnsTopicConfigFifo,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsSnsTopicCheckFifo("data.aws_sns_topic.by_name_fifo"),
+				),
+			},
 		},
 	})
 }
@@ -49,6 +55,36 @@ func testAccDataSourceAwsSnsTopicCheck(name string) resource.TestCheckFunc {
 	}
 }
 
+func testAccDataSourceAwsSnsTopicCheckFifo(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+		//snsTopicRs, ok := s.RootModule().Resources["aws_sns_topic.tf_test_fifo"]
+		//if !ok {
+		//	return fmt.Errorf("can't find aws_sns_topic.tf_test_fifo in state")
+		//}
+		//attr := rs.Primary.Attributes
+
+		//if attr["name"] != snsTopicRs.Primary.Attributes["name"] {
+		//	return fmt.Errorf(
+		//		"name is %s; want %s",
+		//		attr["name"],
+		//		snsTopicRs.Primary.Attributes["name"],
+		//	)
+		//}
+		if rs.Primary.Attributes["name"] != "tf_test.fifo" {
+			return fmt.Errorf(
+				"name is %s; want %s",
+				rs.Primary.Attributes["name"],
+				"tf_test.fifo")
+		}
+
+		return nil
+	}
+}
+
 const testAccDataSourceAwsSnsTopicConfig = `
 resource "aws_sns_topic" "tf_wrong1" {
   name = "wrong1"
@@ -62,17 +98,19 @@ resource "aws_sns_topic" "tf_wrong2" {
   name = "wrong2"
 }
 
-# Can't work until fifo support is added
-#resource "aws_sns_topic" "tf_test_with_dot" {
-#  name = "tf_test.fifo"
-#}
-
 data "aws_sns_topic" "by_name" {
   name = aws_sns_topic.tf_test.name
   depends_on = [aws_sns_topic.tf_test]
 }
+`
 
-data "aws_sns_topic" "by_name_with_dot" {
+const testAccDataSourceAwsSnsTopicConfigFifo = `
+# Can't work until fifo support is added
+#resource "aws_sns_topic" "tf_test_fifo" {
+#  name = "tf_test.fifo"
+#}
+
+data "aws_sns_topic" "by_name_fifo" {
   name = "tf_test.fifo"
 }
 `

--- a/aws/data_source_aws_sns_test.go
+++ b/aws/data_source_aws_sns_test.go
@@ -62,8 +62,17 @@ resource "aws_sns_topic" "tf_wrong2" {
   name = "wrong2"
 }
 
+# Can't work until fifo support is added
+#resource "aws_sns_topic" "tf_test_with_dot" {
+#  name = "tf_test.fifo"
+#}
+
 data "aws_sns_topic" "by_name" {
   name = aws_sns_topic.tf_test.name
   depends_on = [aws_sns_topic.tf_test]
+}
+
+data "aws_sns_topic" "by_name_with_dot" {
+  name = "tf_test.fifo"
 }
 `

--- a/aws/data_source_aws_sns_test.go
+++ b/aws/data_source_aws_sns_test.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/sns"
 	"log"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/aws/data_source_aws_sns_test.go
+++ b/aws/data_source_aws_sns_test.go
@@ -42,6 +42,7 @@ func TestAccDataSourceAwsSnsTopic_fifo(t *testing.T) {
 	})
 }
 
+// TODO: Replace this function with terraform config once FIFO SNS is supported
 func testAccDataSourceAwsSnsTopicCreateFifo() {
 	conn := testAccProvider.Meta().(*AWSClient).snsconn
 	params := &sns.CreateTopicInput{

--- a/aws/data_source_aws_sns_test.go
+++ b/aws/data_source_aws_sns_test.go
@@ -64,5 +64,6 @@ resource "aws_sns_topic" "tf_wrong2" {
 
 data "aws_sns_topic" "by_name" {
   name = aws_sns_topic.tf_test.name
+  depends_on = [aws_sns_topic.tf_test]
 }
 `

--- a/aws/data_source_aws_sns_test.go
+++ b/aws/data_source_aws_sns_test.go
@@ -19,6 +19,15 @@ func TestAccDataSourceAwsSnsTopic_basic(t *testing.T) {
 					testAccDataSourceAwsSnsTopicCheck("data.aws_sns_topic.by_name"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsSnsTopic_fifo(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsSnsTopicConfigFifo,
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsSnsTopic_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSnsTopic_ -timeout 180m
=== RUN   TestAccDataSourceAwsSnsTopic_basic
=== PAUSE TestAccDataSourceAwsSnsTopic_basic
=== RUN   TestAccDataSourceAwsSnsTopic_fifo
=== PAUSE TestAccDataSourceAwsSnsTopic_fifo
=== CONT  TestAccDataSourceAwsSnsTopic_basic
=== CONT  TestAccDataSourceAwsSnsTopic_fifo
--- PASS: TestAccDataSourceAwsSnsTopic_basic (50.79s)
--- PASS: TestAccDataSourceAwsSnsTopic_fifo (53.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       56.413s
```
