### PR TITLE
Increase Lambda function publish timeout

### DIFF
--- a/aws/internal/service/lambda/waiter/waiter.go
+++ b/aws/internal/service/lambda/waiter/waiter.go
@@ -12,7 +12,7 @@ const (
 	EventSourceMappingUpdateTimeout      = 10 * time.Minute
 	LambdaFunctionCreateTimeout          = 5 * time.Minute
 	LambdaFunctionUpdateTimeout          = 5 * time.Minute
-	LambdaFunctionPublishTimeout         = 2 * time.Minute
+	LambdaFunctionPublishTimeout         = 5 * time.Minute
 	LambdaFunctionPutConcurrencyTimeout  = 1 * time.Minute
 	LambdaFunctionExtraThrottlingTimeout = 9 * time.Minute
 )


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Publishing a Lambda function based on a large Docker image can take longer than 2 minutes. It's a bit more than 2 minutes for an image of ~ 2 GB. Lambda supports images with a size of up to 10 GB. I haven't tried if 5 minutes are really sufficient for the max image size.

Relates #17169