### PR TITLE
Handle ObjectNotFoundException gracefully when deleting app autoscaling target

### DIFF
--- a/.changelog/18115.txt
+++ b/.changelog/18115.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appautoscaling_target: Ignore `ObjectNotFoundException` on deletion
+```

--- a/aws/resource_aws_appautoscaling_target.go
+++ b/aws/resource_aws_appautoscaling_target.go
@@ -154,6 +154,10 @@ func resourceAwsAppautoscalingTargetDelete(d *schema.ResourceData, meta interfac
 
 	_, err := conn.DeregisterScalableTarget(input)
 
+	if isAWSErr(err, applicationautoscaling.ErrCodeObjectNotFoundException, "") {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error deleting Application AutoScaling Target (%s): %w", d.Id(), err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18114

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
N/A. The existing test cases don't cover such a scenario and I'm not sure how to set the test up myself. I copied the fix for aws_appautoscaling_policy which itself doesn't appear to cover this scenario.