### PR TITLE
Add CodeStar Connection data source

### DIFF
--- a/aws/data_source_aws_codestarconnections_connection.go
+++ b/aws/data_source_aws_codestarconnections_connection.go
@@ -1,0 +1,70 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/codestarconnections/finder"
+)
+
+func dataSourceAwsCodeStarConnectionsConnection() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCodeStarConnectionsConnectionRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"connection_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"provider_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsCodeStarConnectionsConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codestarconnectionsconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	arn := d.Get("arn").(string)
+
+	log.Printf("[DEBUG] Getting CodeStar Connection")
+	connection, err := finder.ConnectionByArn(conn, arn)
+	if err != nil {
+		return fmt.Errorf("error getting CodeStar Connection (%s): %w", arn, err)
+	}
+	log.Printf("[DEBUG] CodeStar Connection: %#v", connection)
+
+	d.SetId(arn)
+	d.Set("connection_status", connection.ConnectionStatus)
+	d.Set("name", connection.ConnectionName)
+	d.Set("provider_type", connection.ProviderType)
+
+	tags, err := keyvaluetags.CodestarconnectionsListTags(conn, arn)
+	if err != nil {
+		return fmt.Errorf("error listing tags for CodeStar Connection (%s): %w", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags for CodeStar Connection (%s): %w", arn, err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_codestarconnections_connection_test.go
+++ b/aws/data_source_aws_codestarconnections_connection_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/codestarconnections"
@@ -12,20 +11,23 @@ import (
 
 func TestAccDataSourceAwsCodeStarConnectionsConnection_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "data.aws_codestarconnections_connection.test"
+	dataSourceName := "data.aws_codestarconnections_connection.test"
+	resourceName := "aws_codestarconnections_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(codestarconnections.EndpointsID, t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(codestarconnections.EndpointsID, t) },
+		ErrorCheck: testAccErrorCheck(t, codestarconnections.EndpointsID),
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAWSCodeStarConnectionsConnectionConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccMatchResourceAttrRegionalARN(resourceName, "id", "codestar-connections", regexp.MustCompile("connection/.+")),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codestar-connections", regexp.MustCompile("connection/.+")),
-					resource.TestCheckResourceAttr(resourceName, "provider_type", codestarconnections.ProviderTypeBitbucket),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "connection_status", codestarconnections.ConnectionStatusPending),
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "provider_type", dataSourceName, "provider_type"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "connection_status", dataSourceName, "connection_status"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
 				),
 			},
 		},
@@ -34,18 +36,18 @@ func TestAccDataSourceAwsCodeStarConnectionsConnection_basic(t *testing.T) {
 
 func TestAccDataSourceAwsCodeStarConnectionsConnection_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "data.aws_codestarconnections_connection.test"
+	dataSourceName := "data.aws_codestarconnections_connection.test"
+	resourceName := "aws_codestarconnections_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(codestarconnections.EndpointsID, t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(codestarconnections.EndpointsID, t) },
+		ErrorCheck: testAccErrorCheck(t, codestarconnections.EndpointsID),
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAWSCodeStarConnectionsConnectionConfigTags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
 				),
 			},
 		},

--- a/aws/data_source_aws_codestarconnections_connection_test.go
+++ b/aws/data_source_aws_codestarconnections_connection_test.go
@@ -1,0 +1,84 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/codestarconnections"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceAwsCodeStarConnectionsConnection_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "data.aws_codestarconnections_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(codestarconnections.EndpointsID, t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSCodeStarConnectionsConnectionConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMatchResourceAttrRegionalARN(resourceName, "id", "codestar-connections", regexp.MustCompile("connection/.+")),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codestar-connections", regexp.MustCompile("connection/.+")),
+					resource.TestCheckResourceAttr(resourceName, "provider_type", codestarconnections.ProviderTypeBitbucket),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "connection_status", codestarconnections.ConnectionStatusPending),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsCodeStarConnectionsConnection_tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "data.aws_codestarconnections_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(codestarconnections.EndpointsID, t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSCodeStarConnectionsConnectionConfigTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSCodeStarConnectionsConnectionConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "Bitbucket"
+}
+
+data "aws_codestarconnections_connection" "test" {
+  arn = aws_codestarconnections_connection.test.arn
+}
+`, rName)
+}
+
+func testAccDataSourceAWSCodeStarConnectionsConnectionConfigTags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "Bitbucket"
+
+  tags = {
+    "key1" = "value1"
+    "key2" = "value2"
+  }
+}
+
+data "aws_codestarconnections_connection" "test" {
+  arn = aws_codestarconnections_connection.test.arn
+}
+`, rName)
+}

--- a/aws/internal/service/codestarconnections/finder/finder.go
+++ b/aws/internal/service/codestarconnections/finder/finder.go
@@ -1,0 +1,22 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codestarconnections"
+)
+
+// ConnectionByArn returns the Connection corresponding to the specified Arn.
+func ConnectionByArn(conn *codestarconnections.CodeStarConnections, arn string) (*codestarconnections.Connection, error) {
+	output, err := conn.GetConnection(&codestarconnections.GetConnectionInput{
+		ConnectionArn: aws.String(arn),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Connection == nil {
+		return nil, nil
+	}
+
+	return output.Connection, nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -221,6 +221,7 @@ func Provider() *schema.Provider {
 			"aws_codeartifact_repository_endpoint":           dataSourceAwsCodeArtifactRepositoryEndpoint(),
 			"aws_cognito_user_pools":                         dataSourceAwsCognitoUserPools(),
 			"aws_codecommit_repository":                      dataSourceAwsCodeCommitRepository(),
+			"aws_codestarconnections_connection":             dataSourceAwsCodeStarConnectionsConnection(),
 			"aws_cur_report_definition":                      dataSourceAwsCurReportDefinition(),
 			"aws_db_cluster_snapshot":                        dataSourceAwsDbClusterSnapshot(),
 			"aws_db_event_categories":                        dataSourceAwsDbEventCategories(),

--- a/website/docs/d/codestarconnections_connection.html.markdown
+++ b/website/docs/d/codestarconnections_connection.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "CodeStar Connections"
+layout: "aws"
+page_title: "AWS: aws_codestarconnections_connection"
+description: |-
+  Provides details about CodeStar Connection
+---
+
+# Data Source: aws_codestarconnections_connection
+
+Provides details about CodeStar Connection.
+
+## Example Usage
+
+```hcl
+data "aws_codestarconnections_connection" "example" {
+  arn = aws_codestarconnections_connection.example.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `arn` - (Required) The CodeStar Connection ARN.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `connection_status` - The CodeStar Connection status. Possible values are `PENDING`, `AVAILABLE` and `ERROR`.
+* `id` - The CodeStar Connection ARN.
+* `name` - The name of the CodeStar Connection. The name is unique in the calling AWS account.
+* `provider_type` - The name of the external provider where your third-party code repository is configured. Possible values are `Bitbucket`, `GitHub`, or `GitHubEnterpriseServer`.
+* `tags` - Map of key-value resource tags to associate with the resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/15453

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsCodeStarConnectionsConnection_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsCodeStarConnectionsConnection_ -timeout 180m
=== RUN   TestAccDataSourceAwsCodeStarConnectionsConnection_basic
=== PAUSE TestAccDataSourceAwsCodeStarConnectionsConnection_basic
=== RUN   TestAccDataSourceAwsCodeStarConnectionsConnection_tags
=== PAUSE TestAccDataSourceAwsCodeStarConnectionsConnection_tags
=== CONT  TestAccDataSourceAwsCodeStarConnectionsConnection_basic
=== CONT  TestAccDataSourceAwsCodeStarConnectionsConnection_tags
--- PASS: TestAccDataSourceAwsCodeStarConnectionsConnection_basic (37.21s)
--- PASS: TestAccDataSourceAwsCodeStarConnectionsConnection_tags (37.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.177s
```

Added CodeStar Connection data source. Thank you for your review!