### PR TITLE
[WIP] Adding content_sensitive argument to aws_s3_bucket_object

### DIFF
--- a/.changelog/18139.txt
+++ b/.changelog/18139.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_object: Argument `content_sensitive` to create objects with sensitive values. Will not be displayed in diffs.
+```

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -89,19 +89,26 @@ func resourceAwsS3BucketObject() *schema.Resource {
 			"source": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"content", "content_base64"},
+				ConflictsWith: []string{"content", "content_sensitive", "content_base64"},
 			},
 
 			"content": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"source", "content_base64"},
+				ConflictsWith: []string{"source", "content_sensitive", "content_base64"},
+			},
+
+			"content_sensitive": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"source", "content", "content_base64"},
 			},
 
 			"content_base64": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"source", "content"},
+				ConflictsWith: []string{"source", "content", "content_sensitive"},
 			},
 
 			"storage_class": {
@@ -205,6 +212,9 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 			}
 		}()
 	} else if v, ok := d.GetOk("content"); ok {
+		content := v.(string)
+		body = bytes.NewReader([]byte(content))
+	} else if v, ok := d.GetOk("content_sensitive"); ok {
 		content := v.(string)
 		body = bytes.NewReader([]byte(content))
 	} else if v, ok := d.GetOk("content_base64"); ok {
@@ -519,6 +529,7 @@ func hasS3BucketObjectContentChanges(d resourceDiffer) bool {
 		"content_language",
 		"content_type",
 		"content",
+		"content_sensitive",
 		"etag",
 		"kms_key_id",
 		"metadata",

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -193,6 +193,28 @@ func TestAccAWSS3BucketObject_content(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3BucketObject_contentSensitive(t *testing.T) {
+	var obj s3.GetObjectOutput
+	resourceName := "aws_s3_bucket_object.object"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccAWSS3BucketObjectConfigContentSensitive(rInt, "some_bucket_content"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
+					testAccCheckAWSS3BucketObjectBody(&obj, "some_bucket_content"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3BucketObject_etagEncryption(t *testing.T) {
 	var obj s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.object"
@@ -1474,6 +1496,20 @@ resource "aws_s3_bucket_object" "object" {
   bucket  = aws_s3_bucket.object_bucket.bucket
   key     = "test-key"
   content = %[2]q
+}
+`, randInt, content)
+}
+
+func testAccAWSS3BucketObjectConfigContentSensitive(randInt int, content string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket" {
+  bucket = "tf-object-test-bucket-%[1]d"
+}
+
+resource "aws_s3_bucket_object" "object" {
+  bucket  = aws_s3_bucket.object_bucket.bucket
+  key     = "test-key"
+  content_sensitive = %[2]q
 }
 `, randInt, content)
 }

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -111,15 +111,16 @@ resource "aws_s3_bucket_object" "examplebucket_object" {
 
 ## Argument Reference
 
--> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, and `content_base64` all expect already encoded/compressed bytes.
+-> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, `content_sensitive` and `content_base64` all expect already encoded/compressed bytes.
 
 The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
 * `key` - (Required) The name of the object once it is in the bucket.
-* `source` - (Optional, conflicts with `content` and `content_base64`) The path to a file that will be read and uploaded as raw bytes for the object content.
-* `content` - (Optional, conflicts with `source` and `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
-* `content_base64` - (Optional, conflicts with `source` and `content`) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for small content such as the result of the `gzipbase64` function with small text strings. For larger objects, use `source` to stream the content from a disk file.
+* `source` - (Optional, conflicts with `content`, `content_sensitive` and `content_base64`) The path to a file that will be read and uploaded as raw bytes for the object content.
+* `content` - (Optional, conflicts with `source`, `content_sensitive` and `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
+* `content_sensitive` - (Optional, conflicts with `source`, `content` and `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text. Will not be displayed in diffs.
+* `content_base64` - (Optional, conflicts with `source`, `content` and `content_sensitive`) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for small content such as the result of the `gzipbase64` function with small text strings. For larger objects, use `source` to stream the content from a disk file.
 * `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, and `bucket-owner-full-control`. Defaults to `private`.
 * `cache_control` - (Optional) Specifies caching behavior along the request/reply chain Read [w3c cache_control](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) for further details.
 * `content_disposition` - (Optional) Specifies presentational information for the object. Read [w3c content_disposition](http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) for further information.


### PR DESCRIPTION
Adding **content_sensitive** argument to Resource: aws_s3_bucket_object, so the content value will not be displayed in diffs.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
