### PR TITLE
ami: Fix main branch

### DIFF
--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -242,10 +242,6 @@ func resourceAwsAmi() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"platform": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -46,18 +46,16 @@ func resourceAwsAmi() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"image_location": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
 			"architecture": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				Default:      ec2.ArchitectureValuesX8664,
 				ValidateFunc: validation.StringInSlice(ec2.ArchitectureValues_Values(), false),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -81,45 +79,38 @@ func resourceAwsAmi() *schema.Resource {
 							Default:  true,
 							ForceNew: true,
 						},
-
 						"device_name": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
-
 						"encrypted": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
 						},
-
 						"iops": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							ForceNew: true,
 						},
-
 						"snapshot_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
 						},
-
 						"throughput": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"volume_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"volume_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -153,7 +144,6 @@ func resourceAwsAmi() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-
 						"virtual_name": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -167,6 +157,24 @@ func resourceAwsAmi() *schema.Resource {
 					buf.WriteString(fmt.Sprintf("%s-", m["virtual_name"].(string)))
 					return hashcode.String(buf.String())
 				},
+			},
+			"hypervisor": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_location": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"image_owner_alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"kernel_id": {
 				Type:     schema.TypeString,
@@ -190,6 +198,18 @@ func resourceAwsAmi() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"platform_details": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"platform": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"ramdisk_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -211,44 +231,16 @@ func resourceAwsAmi() *schema.Resource {
 				Default:  "simple",
 			},
 			"tags": tagsSchema(),
+			"usage_operation": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"virtualization_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				Default:      ec2.VirtualizationTypeParavirtual,
 				ValidateFunc: validation.StringInSlice(ec2.VirtualizationType_Values(), false),
-			},
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"usage_operation": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"platform_details": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_owner_alias": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"hypervisor": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"platform": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"public": {
-				Type:     schema.TypeBool,
-				Computed: true,
 			},
 		},
 	}
@@ -258,14 +250,14 @@ func resourceAwsAmiCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AWSClient).ec2conn
 
 	req := &ec2.RegisterImageInput{
-		Name:               aws.String(d.Get("name").(string)),
-		Description:        aws.String(d.Get("description").(string)),
 		Architecture:       aws.String(d.Get("architecture").(string)),
+		Description:        aws.String(d.Get("description").(string)),
+		EnaSupport:         aws.Bool(d.Get("ena_support").(bool)),
 		ImageLocation:      aws.String(d.Get("image_location").(string)),
+		Name:               aws.String(d.Get("name").(string)),
 		RootDeviceName:     aws.String(d.Get("root_device_name").(string)),
 		SriovNetSupport:    aws.String(d.Get("sriov_net_support").(string)),
 		VirtualizationType: aws.String(d.Get("virtualization_type").(string)),
-		EnaSupport:         aws.Bool(d.Get("ena_support").(bool)),
 	}
 
 	if kernelId := d.Get("kernel_id").(string); kernelId != "" {
@@ -396,26 +388,25 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("AMI has become %s", state)
 	}
 
-	d.Set("name", image.Name)
-	d.Set("description", image.Description)
-	d.Set("image_location", image.ImageLocation)
 	d.Set("architecture", image.Architecture)
+	d.Set("description", image.Description)
+	d.Set("ena_support", image.EnaSupport)
+	d.Set("hypervisor", image.Hypervisor)
+	d.Set("image_location", image.ImageLocation)
+	d.Set("image_owner_alias", image.ImageOwnerAlias)
+	d.Set("image_type", image.ImageType)
 	d.Set("kernel_id", image.KernelId)
+	d.Set("name", image.Name)
 	d.Set("owner_id", image.OwnerId)
+	d.Set("platform_details", image.PlatformDetails)
+	d.Set("platform", image.Platform)
+	d.Set("public", image.Public)
 	d.Set("ramdisk_id", image.RamdiskId)
 	d.Set("root_device_name", image.RootDeviceName)
 	d.Set("root_snapshot_id", amiRootSnapshotId(image))
 	d.Set("sriov_net_support", image.SriovNetSupport)
-	d.Set("virtualization_type", image.VirtualizationType)
-	d.Set("ena_support", image.EnaSupport)
 	d.Set("usage_operation", image.UsageOperation)
-	d.Set("platform_details", image.PlatformDetails)
-	d.Set("hypervisor", image.Hypervisor)
-	d.Set("image_type", image.ImageType)
-	d.Set("owner_id", image.OwnerId)
-	d.Set("public", image.Public)
-	d.Set("image_owner_alias", image.ImageOwnerAlias)
-	d.Set("platform", image.Platform)
+	d.Set("virtualization_type", image.VirtualizationType)
 
 	imageArn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,

--- a/aws/resource_aws_ami_copy.go
+++ b/aws/resource_aws_ami_copy.go
@@ -26,6 +26,10 @@ func resourceAwsAmiCopy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -91,6 +95,16 @@ func resourceAwsAmiCopy() *schema.Resource {
 					return hashcode.String(buf.String())
 				},
 			},
+			"ena_support": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"encrypted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
 			"ephemeral_block_device": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -117,17 +131,19 @@ func resourceAwsAmiCopy() *schema.Resource {
 					return hashcode.String(buf.String())
 				},
 			},
-			"ena_support": {
-				Type:     schema.TypeBool,
+			"hypervisor": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"encrypted": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-			},
 			"image_location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_owner_alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -157,6 +173,18 @@ func resourceAwsAmiCopy() *schema.Resource {
 			},
 			"owner_id": {
 				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"platform": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"platform_details": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public": {
+				Type:     schema.TypeBool,
 				Computed: true,
 			},
 			"ramdisk_id": {
@@ -190,36 +218,8 @@ func resourceAwsAmiCopy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"usage_operation": {
 				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"platform_details": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_owner_alias": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"hypervisor": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"platform": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"public": {
-				Type:     schema.TypeBool,
 				Computed: true,
 			},
 		},
@@ -236,11 +236,11 @@ func resourceAwsAmiCopyCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AWSClient).ec2conn
 
 	req := &ec2.CopyImageInput{
-		Name:          aws.String(d.Get("name").(string)),
 		Description:   aws.String(d.Get("description").(string)),
+		Encrypted:     aws.Bool(d.Get("encrypted").(bool)),
+		Name:          aws.String(d.Get("name").(string)),
 		SourceImageId: aws.String(d.Get("source_ami_id").(string)),
 		SourceRegion:  aws.String(d.Get("source_ami_region").(string)),
-		Encrypted:     aws.Bool(d.Get("encrypted").(bool)),
 	}
 
 	if v, ok := d.GetOk("kms_key_id"); ok {

--- a/aws/resource_aws_ami_copy.go
+++ b/aws/resource_aws_ami_copy.go
@@ -214,10 +214,6 @@ func resourceAwsAmiCopy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"platform": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/resource_aws_ami_from_instance.go
+++ b/aws/resource_aws_ami_from_instance.go
@@ -223,9 +223,9 @@ func resourceAwsAmiFromInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	client := meta.(*AWSClient).ec2conn
 
 	req := &ec2.CreateImageInput{
-		Name:        aws.String(d.Get("name").(string)),
 		Description: aws.String(d.Get("description").(string)),
 		InstanceId:  aws.String(d.Get("source_instance_id").(string)),
+		Name:        aws.String(d.Get("name").(string)),
 		NoReboot:    aws.Bool(d.Get("snapshot_without_reboot").(bool)),
 	}
 

--- a/aws/resource_aws_ami_from_instance.go
+++ b/aws/resource_aws_ami_from_instance.go
@@ -201,10 +201,6 @@ func resourceAwsAmiFromInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"platform": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/resource_aws_ami_from_instance.go
+++ b/aws/resource_aws_ami_from_instance.go
@@ -26,6 +26,10 @@ func resourceAwsAmiFromInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -121,7 +125,19 @@ func resourceAwsAmiFromInstance() *schema.Resource {
 					return hashcode.String(buf.String())
 				},
 			},
+			"hypervisor": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"image_location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_owner_alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -144,6 +160,18 @@ func resourceAwsAmiFromInstance() *schema.Resource {
 			},
 			"owner_id": {
 				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"platform": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"platform_details": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public": {
+				Type:     schema.TypeBool,
 				Computed: true,
 			},
 			"ramdisk_id": {
@@ -173,40 +201,12 @@ func resourceAwsAmiFromInstance() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tagsSchema(),
-			"virtualization_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"usage_operation": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"platform_details": {
+			"virtualization_type": {
 				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_owner_alias": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"hypervisor": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"platform": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"public": {
-				Type:     schema.TypeBool,
 				Computed: true,
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes Go errors introduced in #17178

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccDataSourceAwsAmiIds_basic (20.48s)
--- PASS: TestAccAWSAmiDataSource_instanceStore (25.04s)
--- PASS: TestAccAWSAmiDataSource_natInstance (25.04s)
--- PASS: TestAccAWSAmiDataSource_windowsInstance (25.34s)
--- PASS: TestAccAWSAmiDataSource_localNameFilter (26.63s)
--- PASS: TestAccDataSourceAwsAmiIds_sorted (40.93s)
--- PASS: TestAccAWSAMI_Gp3BlockDevice (49.62s)
--- PASS: TestAccAWSAMI_disappears (64.54s)
--- PASS: TestAccAWSAmiDataSource_Gp3BlockDevice (65.66s)
--- PASS: TestAccAWSAMI_basic (67.83s)
--- PASS: TestAccAWSAMI_EphemeralBlockDevices (67.86s)
--- PASS: TestAccAWSAMI_description (81.72s)
--- PASS: TestAccAWSAMI_tags (95.43s)
--- PASS: TestAccAWSAMIFromInstance_basic (261.02s)
--- PASS: TestAccAWSAMIFromInstance_tags (358.53s)
--- PASS: TestAccAWSAMICopy_EnaSupport (388.66s)
--- PASS: TestAccAWSAMICopy_basic (388.70s)
--- PASS: TestAccAWSAMICopy_Description (393.34s)
--- PASS: TestAccAWSAMICopy_tags (408.69s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccDataSourceAwsAmiIds_basic (21.13s)
--- PASS: TestAccAWSAmiDataSource_instanceStore (22.66s)
--- PASS: TestAccAWSAmiDataSource_windowsInstance (25.56s)
--- PASS: TestAccAWSAmiDataSource_natInstance (25.60s)
--- PASS: TestAccAWSAmiDataSource_localNameFilter (26.20s)
--- PASS: TestAccDataSourceAwsAmiIds_sorted (42.12s)
--- PASS: TestAccAWSAMI_Gp3BlockDevice (48.54s)
--- PASS: TestAccAWSAMI_disappears (59.22s)
--- PASS: TestAccAWSAmiDataSource_Gp3BlockDevice (63.03s)
--- PASS: TestAccAWSAMI_EphemeralBlockDevices (64.58s)
--- PASS: TestAccAWSAMI_basic (65.34s)
--- PASS: TestAccAWSAMI_description (77.76s)
--- PASS: TestAccAWSAMI_tags (88.58s)
--- PASS: TestAccAWSAMIFromInstance_basic (282.82s)
--- PASS: TestAccAWSAMIFromInstance_tags (306.00s)
--- PASS: TestAccAWSAMICopy_basic (377.52s)
--- PASS: TestAccAWSAMICopy_EnaSupport (377.75s)
--- PASS: TestAccAWSAMICopy_Description (390.21s)
--- PASS: TestAccAWSAMICopy_tags (403.49s)
```
