### PR TITLE
tests/provider: Use string matching in testAccErrorCheckCommon() and catch all InvalidAction

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1110,6 +1110,9 @@ func testAccErrorCheck(t *testing.T, endpointIDs ...string) resource.ErrorCheckF
 	}
 }
 
+// NOTE: This function cannot use the standard tfawserr helpers
+// as it is receiving error strings from the SDK testing framework,
+// not actual error types from the resource logic.
 func testAccErrorCheckCommon(err error) bool {
 	if strings.Contains(err.Error(), "is not supported in this") {
 		return true
@@ -1119,19 +1122,19 @@ func testAccErrorCheckCommon(err error) bool {
 		return true
 	}
 
-	if tfawserr.ErrCodeEquals(err, "UnknownOperationException") {
+	if strings.Contains(err.Error(), "InvalidAction") {
 		return true
 	}
 
-	if tfawserr.ErrCodeEquals(err, "UnsupportedOperation") {
+	if strings.Contains(err.Error(), "Unknown operation") {
 		return true
 	}
 
-	if tfawserr.ErrMessageContains(err, "InvalidInputException", "Unknown operation") {
+	if strings.Contains(err.Error(), "UnknownOperationException") {
 		return true
 	}
 
-	if tfawserr.ErrMessageContains(err, "InvalidAction", "Unavailable Operation") {
+	if strings.Contains(err.Error(), "UnsupportedOperation") {
 		return true
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/17566

Previously in AWS GovCloud (US):

```
=== CONT  TestAccAwsEc2ClientVpn_serial/NetworkAssociation_multipleSubnets
    resource_aws_ec2_client_vpn_network_association_test.go:144: Step 1/3 error: Error running apply: exit status 1

        Error: Error creating Client VPN endpoint: InvalidAction: The action CreateClientVpnEndpoint is not valid for this web service.
        	status code: 400, request id: 387e7807-e2b8-4314-9aa8-6cf2e33a0ded

          on terraform_plugin_test.tf line 61, in resource "aws_ec2_client_vpn_endpoint" "test":
          61: resource "aws_ec2_client_vpn_endpoint" "test" {

=== CONT  TestAccAwsEc2ClientVpn_serial/NetworkAssociation_securityGroups
    resource_aws_ec2_client_vpn_network_association_test.go:211: Step 1/3 error: Error running apply: exit status 1

        Error: Error creating Client VPN endpoint: InvalidAction: The action CreateClientVpnEndpoint is not valid for this web service.
        	status code: 400, request id: ad7a3b32-b650-4683-a7e0-945481550c6d

          on terraform_plugin_test.tf line 57, in resource "aws_ec2_client_vpn_endpoint" "test":
          57: resource "aws_ec2_client_vpn_endpoint" "test" {

=== CONT  TestAccAwsEc2ClientVpn_serial/NetworkAssociation_disappears
    resource_aws_ec2_client_vpn_network_association_test.go:186: Step 1/1 error: Error running apply: exit status 1

        Error: Error creating Client VPN endpoint: InvalidAction: The action CreateClientVpnEndpoint is not valid for this web service.
        	status code: 400, request id: feed7ccb-95a7-411f-b633-da58e8340392

          on terraform_plugin_test.tf line 56, in resource "aws_ec2_client_vpn_endpoint" "test":
          56: resource "aws_ec2_client_vpn_endpoint" "test" {

=== CONT  TestAccAwsEc2ClientVpn_serial/NetworkAssociation_basic
    resource_aws_ec2_client_vpn_network_association_test.go:105: Step 1/2 error: Error running apply: exit status 1

        Error: Error creating Client VPN endpoint: InvalidAction: The action CreateClientVpnEndpoint is not valid for this web service.
        	status code: 400, request id: 3f31766a-9288-4e46-9f35-6d7922e938ac

          on terraform_plugin_test.tf line 56, in resource "aws_ec2_client_vpn_endpoint" "test":
          56: resource "aws_ec2_client_vpn_endpoint" "test" {

--- FAIL: TestAccAwsEc2ClientVpn_serial (0.54s)
    --- FAIL: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_securityGroups (32.03s)
    --- FAIL: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_multipleSubnets (32.06s)
    --- FAIL: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_disappears (31.96s)
    --- FAIL: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_basic (33.01s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAwsEc2ClientVpn_serial (0.41s)
    --- SKIP: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_disappears (30.61s)
    --- SKIP: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_securityGroups (31.10s)
    --- SKIP: TestAccAwsEc2ClientVpn_serial/NetworkAssociation_basic (31.01s)
```
