### PR TITLE
r/aws_lakeformation_permissions: Fix bug where SELECT permissions are not properly read in from AWS

### DIFF
--- a/.changelog/18203.txt
+++ b/.changelog/18203.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_permissions: Properly serialize SELECT permission for `permissions` and `permissions_with_grant_option` fields
+```

--- a/aws/resource_aws_lakeformation_permissions.go
+++ b/aws/resource_aws_lakeformation_permissions.go
@@ -695,7 +695,7 @@ func flattenLakeFormationTableWithColumnsResource(apiObject *lakeformation.Table
 }
 
 func flattenLakeFormationPermissions(apiObjects []*lakeformation.PrincipalResourcePermissions) []string {
-	if apiObjects == nil || len(apiObjects) == 0 {
+	if apiObjects == nil {
 		return nil
 	}
 
@@ -711,7 +711,7 @@ func flattenLakeFormationPermissions(apiObjects []*lakeformation.PrincipalResour
 }
 
 func flattenLakeFormationGrantPermissions(apiObjects []*lakeformation.PrincipalResourcePermissions) []string {
-	if apiObjects == nil || len(apiObjects) == 0 {
+	if apiObjects == nil {
 		return nil
 	}
 

--- a/aws/resource_aws_lakeformation_permissions.go
+++ b/aws/resource_aws_lakeformation_permissions.go
@@ -430,24 +430,6 @@ func resourceAwsLakeFormationPermissionsCompareResource(in, out lakeformation.Re
 	return reflect.DeepEqual(in, out)
 }
 
-// The SELECT permission always appears on the Data permissions page of the Lake Formation console as a separate row
-func resourceAwsLakeFormationPermissionsCompareSelectSeparateRow(in, out lakeformation.Resource) bool {
-	if in.TableWithColumns == nil || in.TableWithColumns.ColumnNames == nil {
-		return false
-	}
-
-	if len(in.TableWithColumns.ColumnNames) > 0 {
-		return false
-	}
-
-	columnNames := make([]*string, 0)
-	columnNames = append(columnNames, aws.String("*"))
-
-	in.TableWithColumns.ColumnNames = columnNames
-
-	return reflect.DeepEqual(in, out)
-}
-
 // expandLakeFormationResourceType returns the Lake Formation resource type represented by the resource.
 // This is helpful in distinguishing between TABLE and TABLE_WITH_COLUMNS types when filtering ListPermission results.
 func expandLakeFormationResourceType(d *schema.ResourceData) string {

--- a/aws/resource_aws_lakeformation_permissions.go
+++ b/aws/resource_aws_lakeformation_permissions.go
@@ -332,8 +332,8 @@ func resourceAwsLakeFormationPermissionsRead(d *schema.ResourceData, meta interf
 	}
 
 	d.Set("principal", principalResourcePermissions[0].Principal.DataLakePrincipalIdentifier)
-	d.Set("permissions", flattenPermissions(principalResourcePermissions))
-	d.Set("permissions_with_grant_option", flattenGrantPermissions(principalResourcePermissions))
+	d.Set("permissions", flattenLakeFormationPermissions(principalResourcePermissions))
+	d.Set("permissions_with_grant_option", flattenLakeFormationGrantPermissions(principalResourcePermissions))
 
 	if principalResourcePermissions[0].Resource.Catalog != nil {
 		d.Set("catalog_resource", true)
@@ -694,26 +694,34 @@ func flattenLakeFormationTableWithColumnsResource(apiObject *lakeformation.Table
 	return tfMap
 }
 
-func flattenPermissions(principalResourcePermissions []*lakeformation.PrincipalResourcePermissions) []string {
-	permissions := make([]string, 0)
+func flattenLakeFormationPermissions(apiObjects []*lakeformation.PrincipalResourcePermissions) []string {
+	if apiObjects == nil || len(apiObjects) == 0 {
+		return nil
+	}
 
-	for _, resourcePermission := range principalResourcePermissions {
+	tfList := make([]string, 0)
+
+	for _, resourcePermission := range apiObjects {
 		for _, permission := range resourcePermission.Permissions {
-			permissions = append(permissions, aws.StringValue(permission))
+			tfList = append(tfList, aws.StringValue(permission))
 		}
 	}
 
-	return permissions
+	return tfList
 }
 
-func flattenGrantPermissions(principalResourcePermissions []*lakeformation.PrincipalResourcePermissions) []string {
-	grantPermissions := make([]string, 0)
+func flattenLakeFormationGrantPermissions(apiObjects []*lakeformation.PrincipalResourcePermissions) []string {
+	if apiObjects == nil || len(apiObjects) == 0 {
+		return nil
+	}
 
-	for _, resourcePermission := range principalResourcePermissions {
+	tfList := make([]string, 0)
+
+	for _, resourcePermission := range apiObjects {
 		for _, grantPermission := range resourcePermission.PermissionsWithGrantOption {
-			grantPermissions = append(grantPermissions, aws.StringValue(grantPermission))
+			tfList = append(tfList, aws.StringValue(grantPermission))
 		}
 	}
 
-	return grantPermissions
+	return tfList
 }

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -816,7 +816,7 @@ resource "aws_lakeformation_data_lake_settings" "test" {
 }
 
 resource "aws_lakeformation_permissions" "test" {
-  principal  = aws_iam_role.test.arn
+  principal = aws_iam_role.test.arn
 
   permissions                   = ["ALL", "ALTER", "DELETE", "DESCRIBE", "DROP", "INSERT", "SELECT"]
   permissions_with_grant_option = ["ALL", "ALTER", "DELETE", "DESCRIBE", "DROP", "INSERT", "SELECT"]

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -816,9 +816,9 @@ resource "aws_lakeformation_data_lake_settings" "test" {
 }
 
 resource "aws_lakeformation_permissions" "test" {
-  principal   = aws_iam_role.test.arn
+  principal  = aws_iam_role.test.arn
 
-  permissions 				    = ["ALL", "ALTER", "DELETE", "DESCRIBE", "DROP", "INSERT", "SELECT"]
+  permissions                   = ["ALL", "ALTER", "DELETE", "DESCRIBE", "DROP", "INSERT", "SELECT"]
   permissions_with_grant_option = ["ALL", "ALTER", "DELETE", "DESCRIBE", "DROP", "INSERT", "SELECT"]
 
   table {

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -207,6 +207,37 @@ func testAccAWSLakeFormationPermissions_tableWithColumnsAndTable(t *testing.T) {
 	})
 }
 
+func testAccAWSLakeFormationPermissions_selectPermissions(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lakeformation_permissions.test"
+	roleName := "aws_iam_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lakeformation.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLakeFormationPermissionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLakeFormationPermissionsConfig_selectPermissions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLakeFormationPermissionsExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "principal", roleName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "7"),
+				),
+			},
+			{
+				Config: testAccAWSLakeFormationPermissionsConfig_selectPermissions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLakeFormationPermissionsExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "principal", roleName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "7"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLakeFormationPermissionsDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).lakeformationconn
 
@@ -731,6 +762,74 @@ resource "aws_lakeformation_permissions" "test" {
     database_name = aws_glue_catalog_table.test.database_name
     name          = aws_glue_catalog_table.test.name
     column_names  = ["event", "timestamp"]
+  }
+}
+`, rName)
+}
+
+func testAccAWSLakeFormationPermissionsConfig_selectPermissions(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "glue.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+
+  storage_descriptor {
+    columns {
+      name = "event"
+      type = "string"
+    }
+    columns {
+      name = "timestamp"
+      type = "date"
+    }
+    columns {
+      name = "value"
+      type = "double"
+    }
+  }
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+  # this will result in multiple permissions for iam role
+  admins = [aws_iam_role.test.arn, data.aws_caller_identity.current.arn]
+}
+
+resource "aws_lakeformation_permissions" "test" {
+  permissions = ["ALL", "ALTER", "DELETE", "DESCRIBE", "DROP", "INSERT", "SELECT"]
+  principal   = aws_iam_role.test.arn
+
+  table {
+    database_name = aws_glue_catalog_table.test.database_name
+	wildcard	  = true
   }
 }
 `, rName)

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -223,16 +223,8 @@ func testAccAWSLakeFormationPermissions_selectPermissions(t *testing.T) {
 					testAccCheckAWSLakeFormationPermissionsExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "principal", roleName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "7"),
+					resource.TestCheckResourceAttr(resourceName, "permissions_with_grant_option.#", "7"),
 				),
-			},
-			{
-				Config: testAccAWSLakeFormationPermissionsConfig_selectPermissions(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLakeFormationPermissionsExists(resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "principal", roleName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.#", "7"),
-				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -824,12 +816,14 @@ resource "aws_lakeformation_data_lake_settings" "test" {
 }
 
 resource "aws_lakeformation_permissions" "test" {
-  permissions = ["ALL", "ALTER", "DELETE", "DESCRIBE", "DROP", "INSERT", "SELECT"]
   principal   = aws_iam_role.test.arn
+
+  permissions 				    = ["ALL", "ALTER", "DELETE", "DESCRIBE", "DROP", "INSERT", "SELECT"]
+  permissions_with_grant_option = ["ALL", "ALTER", "DELETE", "DESCRIBE", "DROP", "INSERT", "SELECT"]
 
   table {
     database_name = aws_glue_catalog_table.test.database_name
-	wildcard	  = true
+    name          = aws_glue_catalog_table.test.name
   }
 }
 `, rName)

--- a/aws/resource_aws_lakeformation_test.go
+++ b/aws/resource_aws_lakeformation_test.go
@@ -6,25 +6,26 @@ import (
 
 func TestAccAWSLakeFormation_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
-		"DataLakeSettings": {
-			"basic":            testAccAWSLakeFormationDataLakeSettings_basic,
-			"disappears":       testAccAWSLakeFormationDataLakeSettings_disappears,
-			"withoutCatalogId": testAccAWSLakeFormationDataLakeSettings_withoutCatalogId,
-			"dataSource":       testAccAWSLakeFormationDataLakeSettingsDataSource_basic,
-		},
+		// "DataLakeSettings": {
+		// 	"basic":            testAccAWSLakeFormationDataLakeSettings_basic,
+		// 	"disappears":       testAccAWSLakeFormationDataLakeSettings_disappears,
+		// 	"withoutCatalogId": testAccAWSLakeFormationDataLakeSettings_withoutCatalogId,
+		// 	"dataSource":       testAccAWSLakeFormationDataLakeSettingsDataSource_basic,
+		// },
 		"Permissions": {
-			"basic":                      testAccAWSLakeFormationPermissions_basic,
-			"dataLocation":               testAccAWSLakeFormationPermissions_dataLocation,
-			"database":                   testAccAWSLakeFormationPermissions_database,
-			"tableName":                  testAccAWSLakeFormationPermissions_table_name,
-			"tableWildcard":              testAccAWSLakeFormationPermissions_table_wildcard,
-			"tableWithColumns":           testAccAWSLakeFormationPermissions_tableWithColumns,
-			"tableWithColumnsAndTable":   testAccAWSLakeFormationPermissions_tableWithColumnsAndTable,
-			"basicDataSource":            testAccAWSLakeFormationPermissionsDataSource_basic,
-			"dataLocationDataSource":     testAccAWSLakeFormationPermissionsDataSource_dataLocation,
-			"databaseDataSource":         testAccAWSLakeFormationPermissionsDataSource_database,
-			"tableDataSource":            testAccAWSLakeFormationPermissionsDataSource_table,
-			"tableWithColumnsDataSource": testAccAWSLakeFormationPermissionsDataSource_tableWithColumns,
+			// "basic":                      testAccAWSLakeFormationPermissions_basic,
+			// "dataLocation":               testAccAWSLakeFormationPermissions_dataLocation,
+			// "database":                   testAccAWSLakeFormationPermissions_database,
+			// "tableName":                  testAccAWSLakeFormationPermissions_table_name,
+			// "tableWildcard":              testAccAWSLakeFormationPermissions_table_wildcard,
+			// "tableWithColumns":           testAccAWSLakeFormationPermissions_tableWithColumns,
+			// "tableWithColumnsAndTable":   testAccAWSLakeFormationPermissions_tableWithColumnsAndTable,
+			// "basicDataSource":            testAccAWSLakeFormationPermissionsDataSource_basic,
+			// "dataLocationDataSource":     testAccAWSLakeFormationPermissionsDataSource_dataLocation,
+			// "databaseDataSource":         testAccAWSLakeFormationPermissionsDataSource_database,
+			// "tableDataSource":            testAccAWSLakeFormationPermissionsDataSource_table,
+			// "tableWithColumnsDataSource": testAccAWSLakeFormationPermissionsDataSource_tableWithColumns,
+			"selectPermissions": testAccAWSLakeFormationPermissions_selectPermissions,
 		},
 	}
 

--- a/aws/resource_aws_lakeformation_test.go
+++ b/aws/resource_aws_lakeformation_test.go
@@ -13,19 +13,23 @@ func TestAccAWSLakeFormation_serial(t *testing.T) {
 			"dataSource":       testAccAWSLakeFormationDataLakeSettingsDataSource_basic,
 		},
 		"Permissions": {
-			"basic":                      testAccAWSLakeFormationPermissions_basic,
-			"dataLocation":               testAccAWSLakeFormationPermissions_dataLocation,
-			"database":                   testAccAWSLakeFormationPermissions_database,
-			"tableName":                  testAccAWSLakeFormationPermissions_table_name,
-			"tableWildcard":              testAccAWSLakeFormationPermissions_table_wildcard,
-			"tableWithColumns":           testAccAWSLakeFormationPermissions_tableWithColumns,
-			"tableWithColumnsAndTable":   testAccAWSLakeFormationPermissions_tableWithColumnsAndTable,
+			"basic":             testAccAWSLakeFormationPermissions_basic,
+			"dataLocation":      testAccAWSLakeFormationPermissions_dataLocation,
+			"database":          testAccAWSLakeFormationPermissions_database,
+			"selectPermissions": testAccAWSLakeFormationPermissions_selectPermissions,
+		},
+		"TablePermissions": {
+			"tableName":                testAccAWSLakeFormationPermissions_table_name,
+			"tableWildcard":            testAccAWSLakeFormationPermissions_table_wildcard,
+			"tableWithColumns":         testAccAWSLakeFormationPermissions_tableWithColumns,
+			"tableWithColumnsAndTable": testAccAWSLakeFormationPermissions_tableWithColumnsAndTable,
+		},
+		"DataSourcePermissions": {
 			"basicDataSource":            testAccAWSLakeFormationPermissionsDataSource_basic,
 			"dataLocationDataSource":     testAccAWSLakeFormationPermissionsDataSource_dataLocation,
 			"databaseDataSource":         testAccAWSLakeFormationPermissionsDataSource_database,
 			"tableDataSource":            testAccAWSLakeFormationPermissionsDataSource_table,
 			"tableWithColumnsDataSource": testAccAWSLakeFormationPermissionsDataSource_tableWithColumns,
-			"selectPermissions":          testAccAWSLakeFormationPermissions_selectPermissions,
 		},
 	}
 

--- a/aws/resource_aws_lakeformation_test.go
+++ b/aws/resource_aws_lakeformation_test.go
@@ -6,26 +6,26 @@ import (
 
 func TestAccAWSLakeFormation_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
-		// "DataLakeSettings": {
-		// 	"basic":            testAccAWSLakeFormationDataLakeSettings_basic,
-		// 	"disappears":       testAccAWSLakeFormationDataLakeSettings_disappears,
-		// 	"withoutCatalogId": testAccAWSLakeFormationDataLakeSettings_withoutCatalogId,
-		// 	"dataSource":       testAccAWSLakeFormationDataLakeSettingsDataSource_basic,
-		// },
+		"DataLakeSettings": {
+			"basic":            testAccAWSLakeFormationDataLakeSettings_basic,
+			"disappears":       testAccAWSLakeFormationDataLakeSettings_disappears,
+			"withoutCatalogId": testAccAWSLakeFormationDataLakeSettings_withoutCatalogId,
+			"dataSource":       testAccAWSLakeFormationDataLakeSettingsDataSource_basic,
+		},
 		"Permissions": {
-			// "basic":                      testAccAWSLakeFormationPermissions_basic,
-			// "dataLocation":               testAccAWSLakeFormationPermissions_dataLocation,
-			// "database":                   testAccAWSLakeFormationPermissions_database,
-			// "tableName":                  testAccAWSLakeFormationPermissions_table_name,
-			// "tableWildcard":              testAccAWSLakeFormationPermissions_table_wildcard,
-			// "tableWithColumns":           testAccAWSLakeFormationPermissions_tableWithColumns,
-			// "tableWithColumnsAndTable":   testAccAWSLakeFormationPermissions_tableWithColumnsAndTable,
-			// "basicDataSource":            testAccAWSLakeFormationPermissionsDataSource_basic,
-			// "dataLocationDataSource":     testAccAWSLakeFormationPermissionsDataSource_dataLocation,
-			// "databaseDataSource":         testAccAWSLakeFormationPermissionsDataSource_database,
-			// "tableDataSource":            testAccAWSLakeFormationPermissionsDataSource_table,
-			// "tableWithColumnsDataSource": testAccAWSLakeFormationPermissionsDataSource_tableWithColumns,
-			"selectPermissions": testAccAWSLakeFormationPermissions_selectPermissions,
+			"basic":                      testAccAWSLakeFormationPermissions_basic,
+			"dataLocation":               testAccAWSLakeFormationPermissions_dataLocation,
+			"database":                   testAccAWSLakeFormationPermissions_database,
+			"tableName":                  testAccAWSLakeFormationPermissions_table_name,
+			"tableWildcard":              testAccAWSLakeFormationPermissions_table_wildcard,
+			"tableWithColumns":           testAccAWSLakeFormationPermissions_tableWithColumns,
+			"tableWithColumnsAndTable":   testAccAWSLakeFormationPermissions_tableWithColumnsAndTable,
+			"basicDataSource":            testAccAWSLakeFormationPermissionsDataSource_basic,
+			"dataLocationDataSource":     testAccAWSLakeFormationPermissionsDataSource_dataLocation,
+			"databaseDataSource":         testAccAWSLakeFormationPermissionsDataSource_database,
+			"tableDataSource":            testAccAWSLakeFormationPermissionsDataSource_table,
+			"tableWithColumnsDataSource": testAccAWSLakeFormationPermissionsDataSource_tableWithColumns,
+			"selectPermissions":          testAccAWSLakeFormationPermissions_selectPermissions,
 		},
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #17299 

Output from acceptance testing:

=== RUN   TestAccAWSLakeFormation_serial
=== RUN   TestAccAWSLakeFormation_serial/Permissions
=== RUN   TestAccAWSLakeFormation_serial/Permissions/selectPermissions
--- PASS: TestAccAWSLakeFormation_serial (38.65s)
    --- PASS: TestAccAWSLakeFormation_serial/Permissions (38.65s)
        --- PASS: TestAccAWSLakeFormation_serial/Permissions/selectPermissions (38.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       43.488s

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run= TestAccAWSLakeFormation_serial'

...
```
