### PR TITLE
r/aws_dynamodb_table: update gsi provisioned throughput settings

### DIFF
--- a/.changelog/18215.txt
+++ b/.changelog/18215.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Update Global Secondary Index provisioned throughput settings on new changes
+```

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -543,6 +543,7 @@ func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 				continue
 			}
 
+			hasTableUpdate = true
 			input.GlobalSecondaryIndexUpdates = append(input.GlobalSecondaryIndexUpdates, gsiUpdate)
 		}
 	}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #9671

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDynamoDbTable_gsi'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDynamoDbTable_gsi -timeout 180m
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes_emptyPlan (44.95s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (61.57s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (190.39s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (522.81s)
```
