### PR TITLE
r/pinpoint_sms_channel - fix no setting params on update

### DIFF
--- a/.changelog/18281.txt
+++ b/.changelog/18281.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_pinpoint_sms_channel: Set all params on update
+```

--- a/aws/resource_aws_pinpoint_sms_channel.go
+++ b/aws/resource_aws_pinpoint_sms_channel.go
@@ -55,16 +55,16 @@ func resourceAwsPinpointSMSChannelUpsert(d *schema.ResourceData, meta interface{
 
 	applicationId := d.Get("application_id").(string)
 
-	params := &pinpoint.SMSChannelRequest{}
-
-	params.Enabled = aws.Bool(d.Get("enabled").(bool))
-
-	if d.HasChange("sender_id") {
-		params.SenderId = aws.String(d.Get("sender_id").(string))
+	params := &pinpoint.SMSChannelRequest{
+		Enabled: aws.Bool(d.Get("enabled").(bool)),
 	}
 
-	if d.HasChange("short_code") {
-		params.ShortCode = aws.String(d.Get("short_code").(string))
+	if v, ok := d.GetOk("sender_id"); ok {
+		params.SenderId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("short_code"); ok {
+		params.ShortCode = aws.String(v.(string))
 	}
 
 	req := pinpoint.UpdateSmsChannelInput{
@@ -74,7 +74,7 @@ func resourceAwsPinpointSMSChannelUpsert(d *schema.ResourceData, meta interface{
 
 	_, err := conn.UpdateSmsChannel(&req)
 	if err != nil {
-		return fmt.Errorf("error putting Pinpoint SMS Channel for application %s: %s", applicationId, err)
+		return fmt.Errorf("error putting Pinpoint SMS Channel for application %s: %w", applicationId, err)
 	}
 
 	d.SetId(applicationId)
@@ -97,15 +97,16 @@ func resourceAwsPinpointSMSChannelRead(d *schema.ResourceData, meta interface{})
 			return nil
 		}
 
-		return fmt.Errorf("error getting Pinpoint SMS Channel for application %s: %s", d.Id(), err)
+		return fmt.Errorf("error getting Pinpoint SMS Channel for application %s: %w", d.Id(), err)
 	}
 
-	d.Set("application_id", output.SMSChannelResponse.ApplicationId)
-	d.Set("enabled", output.SMSChannelResponse.Enabled)
-	d.Set("sender_id", output.SMSChannelResponse.SenderId)
-	d.Set("short_code", output.SMSChannelResponse.ShortCode)
-	d.Set("promotional_messages_per_second", aws.Int64Value(output.SMSChannelResponse.PromotionalMessagesPerSecond))
-	d.Set("transactional_messages_per_second", aws.Int64Value(output.SMSChannelResponse.TransactionalMessagesPerSecond))
+	res := output.SMSChannelResponse
+	d.Set("application_id", res.ApplicationId)
+	d.Set("enabled", res.Enabled)
+	d.Set("sender_id", res.SenderId)
+	d.Set("short_code", res.ShortCode)
+	d.Set("promotional_messages_per_second", aws.Int64Value(res.PromotionalMessagesPerSecond))
+	d.Set("transactional_messages_per_second", aws.Int64Value(res.TransactionalMessagesPerSecond))
 	return nil
 }
 
@@ -122,7 +123,7 @@ func resourceAwsPinpointSMSChannelDelete(d *schema.ResourceData, meta interface{
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Pinpoint SMS Channel for application %s: %s", d.Id(), err)
+		return fmt.Errorf("error deleting Pinpoint SMS Channel for application %s: %w", d.Id(), err)
 	}
 	return nil
 }

--- a/aws/resource_aws_pinpoint_sms_channel_test.go
+++ b/aws/resource_aws_pinpoint_sms_channel_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccAWSPinpointSMSChannel_basic(t *testing.T) {
 	var channel pinpoint.SMSChannelResponse
-	resourceName := "aws_pinpoint_sms_channel.test_sms_channel"
+	resourceName := "aws_pinpoint_sms_channel.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
@@ -55,7 +55,7 @@ func TestAccAWSPinpointSMSChannel_basic(t *testing.T) {
 
 func TestAccAWSPinpointSMSChannel_full(t *testing.T) {
 	var channel pinpoint.SMSChannelResponse
-	resourceName := "aws_pinpoint_sms_channel.test_sms_channel"
+	resourceName := "aws_pinpoint_sms_channel.test"
 	senderId := "1234"
 	shortCode := "5678"
 	newShortCode := "7890"
@@ -107,6 +107,29 @@ func TestAccAWSPinpointSMSChannel_full(t *testing.T) {
 	})
 }
 
+func TestAccAWSPinpointSMSChannel_disappears(t *testing.T) {
+	var channel pinpoint.SMSChannelResponse
+	resourceName := "aws_pinpoint_sms_channel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointSMSChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointSMSChannelConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointSMSChannelExists(resourceName, &channel),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsPinpointSMSChannel(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSPinpointSMSChannelExists(n string, channel *pinpoint.SMSChannelResponse) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -139,7 +162,7 @@ func testAccCheckAWSPinpointSMSChannelExists(n string, channel *pinpoint.SMSChan
 const testAccAWSPinpointSMSChannelConfig_basic = `
 resource "aws_pinpoint_app" "test_app" {}
 
-resource "aws_pinpoint_sms_channel" "test_sms_channel" {
+resource "aws_pinpoint_sms_channel" "test" {
   application_id = aws_pinpoint_app.test_app.application_id
 }
 `
@@ -148,7 +171,7 @@ func testAccAWSPinpointSMSChannelConfig_full(senderId, shortCode string) string 
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 
-resource "aws_pinpoint_sms_channel" "test_sms_channel" {
+resource "aws_pinpoint_sms_channel" "test" {
   application_id = aws_pinpoint_app.test_app.application_id
   enabled        = "false"
   sender_id      = "%s"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11853

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSPinpointSMSChannel_'
--- PASS: TestAccAWSPinpointSMSChannel_disappears (34.04s)
--- PASS: TestAccAWSPinpointSMSChannel_basic (76.71s)
--- PASS: TestAccAWSPinpointSMSChannel_full (77.54s)
```
