### PR TITLE
r/pinpoint_event_stream - retry on eventual consistency error

### DIFF
--- a/.changelog/18305.txt
+++ b/.changelog/18305.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_pinpoint_event_stream: Retry on eventual consistency error
+```
+
+```release-note:enhancement
+resource/aws_pinpoint_event_stream: Plan time validations for `destination_stream_arn` and `role_arn`
+```

--- a/aws/resource_aws_pinpoint_event_stream.go
+++ b/aws/resource_aws_pinpoint_event_stream.go
@@ -54,6 +54,7 @@ func resourceAwsPinpointEventStreamUpsert(d *schema.ResourceData, meta interface
 		WriteEventStream: params,
 	}
 
+	// Retry for IAM eventual consistency
 	_, err := retryOnAwsCode("BadRequestException", func() (interface{}, error) {
 		return conn.PutEventStream(&req)
 	})

--- a/aws/resource_aws_pinpoint_event_stream_test.go
+++ b/aws/resource_aws_pinpoint_event_stream_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccAWSPinpointEventStream_basic(t *testing.T) {
 	var stream pinpoint.EventStream
-	resourceName := "aws_pinpoint_event_stream.test_event_stream"
+	resourceName := "aws_pinpoint_event_stream.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rName2 := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -25,9 +25,12 @@ func TestAccAWSPinpointEventStream_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSPinpointEventStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSPinpointEventStreamConfig_basic(rName),
+				Config: testAccAWSPinpointEventStreamConfig_basic(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointEventStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttrPair(resourceName, "application_id", "aws_pinpoint_app.test", "application_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_stream_arn", "aws_kinesis_stream.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
 				),
 			},
 			{
@@ -36,10 +39,37 @@ func TestAccAWSPinpointEventStream_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSPinpointEventStreamConfig_basic(rName2),
+				Config: testAccAWSPinpointEventStreamConfig_basic(rName, rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointEventStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttrPair(resourceName, "application_id", "aws_pinpoint_app.test", "application_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_stream_arn", "aws_kinesis_stream.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSPinpointEventStream_disappears(t *testing.T) {
+	var stream pinpoint.EventStream
+	resourceName := "aws_pinpoint_event_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointEventStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointEventStreamConfig_basic(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointEventStreamExists(resourceName, &stream),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsPinpointEventStream(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -74,22 +104,24 @@ func testAccCheckAWSPinpointEventStreamExists(n string, stream *pinpoint.EventSt
 	}
 }
 
-func testAccAWSPinpointEventStreamConfig_basic(rName string) string {
+func testAccAWSPinpointEventStreamConfig_basic(rName, streamName string) string {
 	return fmt.Sprintf(`
-resource "aws_pinpoint_app" "test_app" {}
+resource "aws_pinpoint_app" "test" {}
 
-resource "aws_pinpoint_event_stream" "test_event_stream" {
-  application_id         = aws_pinpoint_app.test_app.application_id
-  destination_stream_arn = aws_kinesis_stream.test_stream.arn
-  role_arn               = aws_iam_role.test_role.arn
+resource "aws_pinpoint_event_stream" "test" {
+  application_id         = aws_pinpoint_app.test.application_id
+  destination_stream_arn = aws_kinesis_stream.test.arn
+  role_arn               = aws_iam_role.test.arn
 }
 
-resource "aws_kinesis_stream" "test_stream" {
-  name        = %[1]q
+resource "aws_kinesis_stream" "test" {
+  name        = %[2]q
   shard_count = 1
 }
 
-resource "aws_iam_role" "test_role" {
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -107,9 +139,9 @@ resource "aws_iam_role" "test_role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "test_role_policy" {
-  name = "test_policy"
-  role = aws_iam_role.test_role.id
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
 
   policy = <<EOF
 {
@@ -121,13 +153,13 @@ resource "aws_iam_role_policy" "test_role_policy" {
     ],
     "Effect": "Allow",
     "Resource": [
-      "*"
+      "${aws_kinesis_stream.test.arn}"
     ]
   }
 }
 EOF
 }
-`, rName)
+`, rName, streamName)
 }
 
 func testAccCheckAWSPinpointEventStreamDestroy(s *terraform.State) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15899

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSPinpointEventStream_'
--- PASS: TestAccAWSPinpointEventStream_disappears (92.02s)
--- PASS: TestAccAWSPinpointEventStream_basic (204.16s)
```
