### PR TITLE
tests/provider: Add missing ErrorCheck to TestCase

### DIFF
--- a/aws/resource_aws_iam_group_policy_test.go
+++ b/aws/resource_aws_iam_group_policy_test.go
@@ -87,6 +87,7 @@ func TestAccAWSIAMGroupPolicy_namePrefix(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName: "aws_iam_group_policy.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMGroupPolicyDestroy,
@@ -127,6 +128,7 @@ func TestAccAWSIAMGroupPolicy_generatedName(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName: "aws_iam_group_policy.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMGroupPolicyDestroy,

--- a/aws/resource_aws_iam_instance_profile_test.go
+++ b/aws/resource_aws_iam_instance_profile_test.go
@@ -74,7 +74,7 @@ func TestAccAWSIAMInstanceProfile_namePrefix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		ErrorCheck:      testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"name_prefix"},
 		Providers:       testAccProviders,

--- a/aws/resource_aws_iam_instance_profile_test.go
+++ b/aws/resource_aws_iam_instance_profile_test.go
@@ -74,6 +74,7 @@ func TestAccAWSIAMInstanceProfile_namePrefix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"name_prefix"},
 		Providers:       testAccProviders,

--- a/aws/resource_aws_iam_role_policy_test.go
+++ b/aws/resource_aws_iam_role_policy_test.go
@@ -101,6 +101,7 @@ func TestAccAWSIAMRolePolicy_namePrefix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMRolePolicyDestroy,
@@ -146,6 +147,7 @@ func TestAccAWSIAMRolePolicy_generatedName(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMRolePolicyDestroy,

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -221,7 +221,7 @@ func TestAccAWSIAMRole_namePrefix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		ErrorCheck:      testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"name_prefix"},
 		Providers:       testAccProviders,

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -221,6 +221,7 @@ func TestAccAWSIAMRole_namePrefix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"name_prefix"},
 		Providers:       testAccProviders,

--- a/aws/resource_aws_iam_user_policy_test.go
+++ b/aws/resource_aws_iam_user_policy_test.go
@@ -95,6 +95,7 @@ func TestAccAWSIAMUserPolicy_namePrefix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName: policyResourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMUserPolicyDestroy,
@@ -137,6 +138,7 @@ func TestAccAWSIAMUserPolicy_generatedName(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
 		IDRefreshName: policyResourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMUserPolicyDestroy,

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -240,6 +240,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckEc2ClassicOrHasDefaultVpcWithDefaultSubnets(t)
 		},
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -269,6 +270,7 @@ func TestAccAWSInstance_atLeastOneOtherEbsVolume(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -398,6 +400,7 @@ func TestAccAWSInstance_userDataBase64(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -442,6 +445,7 @@ func TestAccAWSInstance_GP2IopsDevice(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"ephemeral_block_device", "user_data"},
 		Providers:       testAccProviders,
@@ -533,6 +537,7 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"ephemeral_block_device"},
 		Providers:       testAccProviders,
@@ -609,6 +614,7 @@ func TestAccAWSInstance_rootInstanceStore(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -663,6 +669,7 @@ func TestAccAWSInstance_noAMIEphemeralDevices(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"ephemeral_block_device"},
 		Providers:       testAccProviders,
@@ -719,6 +726,7 @@ func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -778,6 +786,7 @@ func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -812,6 +821,7 @@ func TestAccAWSInstance_dedicatedInstance(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"associate_public_ip_address"},
 		Providers:       testAccProviders,
@@ -842,6 +852,7 @@ func TestAccAWSInstance_outpost(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"associate_public_ip_address"},
 		Providers:       testAccProviders,
@@ -870,6 +881,7 @@ func TestAccAWSInstance_placementGroup(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"associate_public_ip_address"},
 		Providers:       testAccProviders,
@@ -969,6 +981,7 @@ func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"associate_public_ip_address"},
 		Providers:       testAccProviders,
@@ -996,6 +1009,7 @@ func TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -1033,6 +1047,7 @@ func TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -1264,6 +1279,7 @@ func TestAccAWSInstance_instanceProfileChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -1320,6 +1336,7 @@ func TestAccAWSInstance_withIamInstanceProfile(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -1384,6 +1401,7 @@ func TestAccAWSInstance_privateIP(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -1421,6 +1439,7 @@ func TestAccAWSInstance_associatePublicIPAndPrivateIP(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"associate_public_ip_address"},
 		Providers:       testAccProviders,
@@ -1461,6 +1480,7 @@ func TestAccAWSInstance_Empty_PrivateIP(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -1503,6 +1523,7 @@ func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"source_dest_check"},
 		Providers:       testAccProviders,
@@ -1563,6 +1584,7 @@ func TestAccAWSInstance_forceNewAndTagsDrift(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -3326,6 +3348,7 @@ func TestAccAWSInstance_metadataOptions(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
@@ -3923,6 +3946,7 @@ func TestAccAWSInstance_GP3RootBlockDevice(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"ephemeral_block_device", "user_data"},
 		Providers:       testAccProviders,

--- a/aws/resource_aws_internet_gateway_test.go
+++ b/aws/resource_aws_internet_gateway_test.go
@@ -142,6 +142,7 @@ func TestAccAWSInternetGateway_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInternetGatewayDestroy,
@@ -188,6 +189,7 @@ func TestAccAWSInternetGateway_delete(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInternetGatewayDestroy,
@@ -212,6 +214,7 @@ func TestAccAWSInternetGateway_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInternetGatewayDestroy,

--- a/aws/resource_aws_key_pair_test.go
+++ b/aws/resource_aws_key_pair_test.go
@@ -169,6 +169,7 @@ func TestAccAWSKeyPair_namePrefix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"key_name_prefix"},
 		Providers:       testAccProviders,

--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -62,6 +62,7 @@ func TestAccAWSNatGateway_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckNatGatewayDestroy,

--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -309,6 +309,7 @@ func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -351,6 +352,7 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -385,6 +387,7 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_update(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -440,6 +443,7 @@ func TestAccAWSNetworkAcl_CaseSensitivityNoChanges(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -465,6 +469,7 @@ func TestAccAWSNetworkAcl_OnlyEgressRules(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -493,6 +498,7 @@ func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -538,6 +544,7 @@ func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -586,6 +593,7 @@ func TestAccAWSNetworkAcl_SubnetsDelete(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -622,6 +630,7 @@ func TestAccAWSNetworkAcl_ipv6Rules(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -678,6 +687,7 @@ func TestAccAWSNetworkAcl_ipv6VpcRules(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
@@ -708,6 +718,7 @@ func TestAccAWSNetworkAcl_espProtocol(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,

--- a/aws/resource_aws_network_interface_attachment_test.go
+++ b/aws/resource_aws_network_interface_attachment_test.go
@@ -15,6 +15,7 @@ func TestAccAWSNetworkInterfaceAttachment_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: "aws_network_interface.bar",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -73,6 +73,7 @@ func TestAccAWSENI_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,
@@ -107,6 +108,7 @@ func TestAccAWSENI_ipv6(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,
@@ -154,6 +156,7 @@ func TestAccAWSENI_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,
@@ -199,6 +202,7 @@ func TestAccAWSENI_ipv6_count(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,
@@ -268,6 +272,7 @@ func TestAccAWSENI_updatedDescription(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,
@@ -301,6 +306,7 @@ func TestAccAWSENI_attached(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,
@@ -329,6 +335,7 @@ func TestAccAWSENI_ignoreExternalAttachment(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,
@@ -357,6 +364,7 @@ func TestAccAWSENI_sourceDestCheck(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,
@@ -397,6 +405,7 @@ func TestAccAWSENI_computedIPs(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSENIDestroy,

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -227,6 +227,7 @@ func TestAccAWSOpsWorksStack_classicEndpoints(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccRegionPreCheck(t, "us-west-2") }, //lintignore:AWSAT003
+		ErrorCheck:   testAccErrorCheck(t, opsworks.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -230,6 +230,7 @@ func TestAccAWSRouteTable_IPv4_To_InternetGateway(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
@@ -280,6 +281,7 @@ func TestAccAWSRouteTable_IPv4_To_Instance(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
@@ -315,6 +317,7 @@ func TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
@@ -353,6 +356,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
@@ -397,6 +401,7 @@ func TestAccAWSRouteTable_RequireRouteDestination(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
@@ -415,6 +420,7 @@ func TestAccAWSRouteTable_RequireRouteTarget(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
@@ -734,6 +740,7 @@ func TestAccAWSRouteTable_IPv4_To_NatGateway(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
@@ -769,6 +776,7 @@ func TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
@@ -912,6 +920,7 @@ func TestAccAWSRouteTable_MultipleRoutes(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -685,6 +685,7 @@ func TestAccAWSSecurityGroup_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
@@ -1057,6 +1058,7 @@ func TestAccAWSSecurityGroup_ipv6(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
@@ -1237,6 +1239,7 @@ func TestAccAWSSecurityGroup_self(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
@@ -1272,6 +1275,7 @@ func TestAccAWSSecurityGroup_vpc(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
@@ -1316,6 +1320,7 @@ func TestAccAWSSecurityGroup_vpcNegOneIngress(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
@@ -1353,6 +1358,7 @@ func TestAccAWSSecurityGroup_vpcProtoNumIngress(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
@@ -1389,6 +1395,7 @@ func TestAccAWSSecurityGroup_multiIngress(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
@@ -1415,6 +1422,7 @@ func TestAccAWSSecurityGroup_change(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
@@ -1448,6 +1456,7 @@ func TestAccAWSSecurityGroup_ruleDescription(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
@@ -1560,6 +1569,7 @@ func TestAccAWSSecurityGroup_defaultEgressVPC(t *testing.T) {
 	// VPC
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -129,6 +129,7 @@ func TestAccAWSSubnet_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckSubnetDestroy,
@@ -166,6 +167,7 @@ func TestAccAWSSubnet_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckSubnetDestroy,
@@ -210,6 +212,7 @@ func TestAccAWSSubnet_defaultTags_providerOnly(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
@@ -267,6 +270,7 @@ func TestAccAWSSubnet_defaultTags_updateToProviderOnly(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
@@ -309,6 +313,7 @@ func TestAccAWSSubnet_defaultTags_updateToResourceOnly(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
@@ -351,6 +356,7 @@ func TestAccAWSSubnet_defaultTags_providerAndResource_nonOverlappingTag(t *testi
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
@@ -415,6 +421,7 @@ func TestAccAWSSubnet_defaultTags_providerAndResource_overlappingTag(t *testing.
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
@@ -473,6 +480,7 @@ func TestAccAWSSubnet_defaultTags_providerAndResource_duplicateTag(t *testing.T)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
@@ -496,6 +504,7 @@ func TestAccAWSSubnet_defaultAndIgnoreTags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
@@ -562,6 +571,7 @@ func TestAccAWSSubnet_ipv6(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckSubnetDestroy,
@@ -602,6 +612,7 @@ func TestAccAWSSubnet_enableIpv6(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckSubnetDestroy,
@@ -645,6 +656,7 @@ func TestAccAWSSubnet_availabilityZoneId(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckSubnetDestroy,
@@ -788,6 +800,7 @@ func TestAccAWSSubnet_outpost(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckSubnetDestroy,

--- a/aws/resource_aws_vpc_endpoint_connection_notification_test.go
+++ b/aws/resource_aws_vpc_endpoint_connection_notification_test.go
@@ -18,6 +18,7 @@ func TestAccAWSVpcEndpointConnectionNotification_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVpcEndpointConnectionNotificationDestroy,

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -480,6 +480,7 @@ func TestAccAWSVpcEndpoint_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVpcEndpointDestroy,

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -94,6 +94,7 @@ func TestAccAWSVPCPeeringConnection_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"auto_accept"},
 
@@ -138,6 +139,7 @@ func TestAccAWSVPCPeeringConnection_plan(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshIgnore: []string{"auto_accept"},
 
 		Providers:    testAccProviders,
@@ -165,6 +167,7 @@ func TestAccAWSVPCPeeringConnection_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"auto_accept"},
 
@@ -230,6 +233,7 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"auto_accept"},
 
@@ -389,6 +393,7 @@ func TestAccAWSVPCPeeringConnection_failedState(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshIgnore: []string{"auto_accept"},
 
 		Providers:    testAccProviders,
@@ -528,6 +533,7 @@ func TestAccAWSVPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
 		},
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshIgnore:   []string{"auto_accept"},
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
@@ -551,6 +557,7 @@ func TestAccAWSVPCPeeringConnection_region(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
 		},
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"auto_accept"},
 
@@ -583,6 +590,7 @@ func TestAccAWSVPCPeeringConnection_accept(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
+		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"auto_accept"},
 

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -168,6 +168,7 @@ func TestAccAWSVpc_defaultTags_providerOnly(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
@@ -224,6 +225,7 @@ func TestAccAWSVpc_defaultTags_updateToProviderOnly(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
@@ -265,6 +267,7 @@ func TestAccAWSVpc_defaultTags_updateToResourceOnly(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
@@ -306,6 +309,7 @@ func TestAccAWSVpc_defaultTags_providerAndResource_nonOverlappingTag(t *testing.
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
@@ -369,6 +373,7 @@ func TestAccAWSVpc_defaultTags_providerAndResource_overlappingTag(t *testing.T) 
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
@@ -426,6 +431,7 @@ func TestAccAWSVpc_defaultTags_providerAndResource_duplicateTag(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
@@ -448,6 +454,7 @@ func TestAccAWSVpc_defaultAndIgnoreTags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -99,6 +99,7 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccAwsVpnConnectionDestroy,
@@ -208,6 +209,7 @@ func TestAccAWSVpnConnection_tunnelOptions(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccAwsVpnConnectionDestroy,
@@ -316,6 +318,7 @@ func TestAccAWSVpnConnection_withoutStaticRoutes(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccAwsVpnConnectionDestroy,
@@ -344,6 +347,7 @@ func TestAccAWSVpnConnection_withEnableAcceleration(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccAwsVpnConnectionDestroy,
@@ -371,6 +375,7 @@ func TestAccAWSVpnConnection_withIpv6(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccAwsVpnConnectionDestroy,
@@ -397,6 +402,7 @@ func TestAccAWSVpnConnection_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccAwsVpnConnectionDestroy,

--- a/aws/resource_aws_vpn_gateway_route_propagation_test.go
+++ b/aws/resource_aws_vpn_gateway_route_propagation_test.go
@@ -15,6 +15,7 @@ func TestAccAWSVPNGatewayRoutePropagation_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: "aws_vpn_gateway_route_propagation.foo",
 		Providers:     testAccProviders,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -109,6 +109,7 @@ func TestAccAWSVpnGateway_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVpnGatewayDestroy,
@@ -256,6 +257,7 @@ func TestAccAWSVpnGateway_reattach(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVpnGatewayDestroy,
@@ -320,6 +322,7 @@ func TestAccAWSVpnGateway_delete(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVpnGatewayDestroy,
@@ -348,6 +351,7 @@ func TestAccAWSVpnGateway_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVpnGatewayDestroy,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/18175

Previously:

```
aws/resource_aws_iam_group_policy_test.go:88:36: XAT001: missing ErrorCheck
aws/resource_aws_iam_group_policy_test.go:128:36: XAT001: missing ErrorCheck
aws/resource_aws_iam_instance_profile_test.go:75:36: XAT001: missing ErrorCheck
aws/resource_aws_iam_role_policy_test.go:102:36: XAT001: missing ErrorCheck
aws/resource_aws_iam_role_policy_test.go:147:36: XAT001: missing ErrorCheck
aws/resource_aws_iam_role_test.go:222:36: XAT001: missing ErrorCheck
aws/resource_aws_iam_user_policy_test.go:96:36: XAT001: missing ErrorCheck
aws/resource_aws_iam_user_policy_test.go:138:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:237:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:270:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:399:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:443:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:534:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:610:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:664:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:720:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:779:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:813:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:843:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:871:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:970:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:997:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:1034:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:1265:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:1321:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:1385:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:1422:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:1462:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:1504:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:1564:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:3327:36: XAT001: missing ErrorCheck
aws/resource_aws_instance_test.go:3924:36: XAT001: missing ErrorCheck
aws/resource_aws_internet_gateway_test.go:143:36: XAT001: missing ErrorCheck
aws/resource_aws_internet_gateway_test.go:189:36: XAT001: missing ErrorCheck
aws/resource_aws_internet_gateway_test.go:213:36: XAT001: missing ErrorCheck
aws/resource_aws_key_pair_test.go:170:36: XAT001: missing ErrorCheck
aws/resource_aws_nat_gateway_test.go:63:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:310:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:352:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:386:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:441:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:466:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:494:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:539:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:587:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:623:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:679:36: XAT001: missing ErrorCheck
aws/resource_aws_network_acl_test.go:709:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_attachment_test.go:16:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_test.go:74:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_test.go:108:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_test.go:155:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_test.go:200:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_test.go:269:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_test.go:302:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_test.go:330:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_test.go:358:36: XAT001: missing ErrorCheck
aws/resource_aws_network_interface_test.go:398:36: XAT001: missing ErrorCheck
aws/resource_aws_opsworks_stack_test.go:228:36: XAT001: missing ErrorCheck
aws/resource_aws_route_table_test.go:231:36: XAT001: missing ErrorCheck
aws/resource_aws_route_table_test.go:281:36: XAT001: missing ErrorCheck
aws/resource_aws_route_table_test.go:316:36: XAT001: missing ErrorCheck
aws/resource_aws_route_table_test.go:354:36: XAT001: missing ErrorCheck
aws/resource_aws_route_table_test.go:398:36: XAT001: missing ErrorCheck
aws/resource_aws_route_table_test.go:416:36: XAT001: missing ErrorCheck
aws/resource_aws_route_table_test.go:735:36: XAT001: missing ErrorCheck
aws/resource_aws_route_table_test.go:770:36: XAT001: missing ErrorCheck
aws/resource_aws_route_table_test.go:913:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:686:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:1058:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:1238:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:1273:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:1317:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:1354:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:1390:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:1416:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:1449:36: XAT001: missing ErrorCheck
aws/resource_aws_security_group_test.go:1561:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:130:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:167:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:211:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:268:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:310:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:352:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:416:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:474:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:497:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:563:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:603:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:646:36: XAT001: missing ErrorCheck
aws/resource_aws_subnet_test.go:789:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_endpoint_connection_notification_test.go:19:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_endpoint_test.go:481:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_peering_connection_test.go:95:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_peering_connection_test.go:139:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_peering_connection_test.go:166:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_peering_connection_test.go:231:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_peering_connection_test.go:390:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_peering_connection_test.go:526:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_peering_connection_test.go:549:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_peering_connection_test.go:584:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_test.go:169:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_test.go:225:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_test.go:266:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_test.go:307:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_test.go:370:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_test.go:427:36: XAT001: missing ErrorCheck
aws/resource_aws_vpc_test.go:449:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_connection_test.go:100:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_connection_test.go:209:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_connection_test.go:317:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_connection_test.go:345:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_connection_test.go:372:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_connection_test.go:398:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_gateway_route_propagation_test.go:16:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_gateway_test.go:110:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_gateway_test.go:257:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_gateway_test.go:321:36: XAT001: missing ErrorCheck
aws/resource_aws_vpn_gateway_test.go:349:36: XAT001: missing ErrorCheck
```
