### PR TITLE
add concurrent build limit to aws_codebuild_project

### DIFF
--- a/.changelog/18320.txt
+++ b/.changelog/18320.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codebuild_project: Add `concurrent_build_limit` argument to specify build concurrency.
+```

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -193,6 +193,11 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 					},
 				},
 			},
+			"concurrent_build_limit": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+			},
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -747,6 +752,10 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 		params.Cache = expandProjectCache(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("concurrent_build_limit"); ok {
+		params.ConcurrentBuildLimit = aws.Int64(int64(v.(int)))
+	}
+
 	if v, ok := d.GetOk("description"); ok {
 		params.Description = aws.String(v.(string))
 	}
@@ -1277,6 +1286,7 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("arn", project.Arn)
+	d.Set("concurrent_build_limit", project.ConcurrentBuildLimit)
 	d.Set("description", project.Description)
 	d.Set("encryption_key", project.EncryptionKey)
 	d.Set("name", project.Name)
@@ -1361,6 +1371,10 @@ func resourceAwsCodeBuildProjectUpdate(d *schema.ResourceData, meta interface{})
 				Type: aws.String("NO_CACHE"),
 			}
 		}
+	}
+
+	if d.HasChange("concurrent_build_limit") {
+		params.ConcurrentBuildLimit = aws.Int64(int64(d.Get("concurrent_build_limit").(int)))
 	}
 
 	if d.HasChange("description") {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -2220,6 +2220,7 @@ func TestAccAWSCodeBuildProject_ConcurrentBuildLimit(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
 		Providers:    testAccProviders,
+		ErrorCheck:   testAccErrorCheck(t, codebuild.EndpointsID),
 		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -233,6 +233,7 @@ The following arguments are optional:
 * `build_batch_config` - (Optional) Defines the batch build options for the project.
 * `build_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.
 * `cache` - (Optional) Configuration block. Detailed below.
+* `concurrent_build_limit` - (Optional) Specify a maximum number of concurrent builds for the project. The value specified must be greater than 0 and less than the account concurrent running builds limit.
 * `description` - (Optional) Short description of the project.
 * `encryption_key` - (Optional) AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build project's build output artifacts.
 * `logs_config` - (Optional) Configuration block. Detailed below.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17942 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
andy@andy-NUC8i7BEH:~/development/terraform-providers/terraform-provider-aws$ make testacc TESTARGS='-run=TestAccAWSCodeBuildProject_ConcurrentBuildLimit'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeBuildProject_ConcurrentBuildLimit -timeout 180m
=== RUN   TestAccAWSCodeBuildProject_ConcurrentBuildLimit
=== PAUSE TestAccAWSCodeBuildProject_ConcurrentBuildLimit
=== CONT  TestAccAWSCodeBuildProject_ConcurrentBuildLimit
--- PASS: TestAccAWSCodeBuildProject_ConcurrentBuildLimit (92.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       92.564s
```
