### PR TITLE
d/aws_glue_catalog_database-database-naming-convention

### DIFF
--- a/.changelog/18320.txt
+++ b/.changelog/18320.txt
@@ -1,3 +1,0 @@
-```release-notes:enhancement
-resource/aws_glue_catalog_database: Add `glue catalog database` naming convention.
-```

--- a/.changelog/18320.txt
+++ b/.changelog/18320.txt
@@ -1,0 +1,3 @@
+```release-notes:enhancement
+resource/aws_glue_catalog_database: Add `glue catalog database` naming convention.
+```

--- a/website/docs/r/glue_catalog_database.html.markdown
+++ b/website/docs/r/glue_catalog_database.html.markdown
@@ -22,7 +22,7 @@ resource "aws_glue_catalog_database" "aws_glue_catalog_database" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the database.
+* `name` - (Required) The name of the database. The acceptable characters are lowercase letters, numbers, and the underscore character.
 * `catalog_id` - (Optional) ID of the Glue Catalog to create the database in. If omitted, this defaults to the AWS Account ID.
 * `description` - (Optional) Description of the database.
 * `location_uri` - (Optional) The location of the database (for example, an HDFS path).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

When using Athena with the AWS Glue Data Catalog, we can use AWS Glue to create databases and tables (schema) to be queried in Athena, or we can use Athena to create schema and then use them in AWS Glue and related services. 

Under the hood, Athena uses Presto to process DML statements and Hive to process the DDL statements that create and modify schema. With these technologies, there are a couple of conventions to follow so that Athena and AWS Glue work well together.

One of the conventions is that the the only acceptable characters for database names are lowercase letters, numbers, and the underscore character ([source](https://docs.aws.amazon.com/athena/latest/ug/glue-best-practices.html#schema-names)). Hence the PR.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
