### PR TITLE
tests/provider: Fix and enable AWS SDK Go pointer conversion linting (C resources)

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -57,7 +57,6 @@ rules:
         - aws/cloudfront_distribution_configuration_structure.go
         - aws/data_source_aws_route_table.go
         - aws/opsworks_layers.go
-        - aws/resource_aws_c*
         - aws/resource_aws_d*
         - aws/resource_aws_e*
         - aws/resource_aws_g*
@@ -94,7 +93,6 @@ rules:
         - aws/data_source_aws_route*
         - aws/ecs_task_definition_equivalency.go
         - aws/opsworks_layers.go
-        - aws/resource_aws_c*.go
         - aws/resource_aws_d*.go
         - aws/resource_aws_e*.go
         - aws/resource_aws_g*.go

--- a/aws/resource_aws_cloud9_environment_ec2.go
+++ b/aws/resource_aws_cloud9_environment_ec2.go
@@ -129,13 +129,13 @@ func resourceAwsCloud9EnvironmentEc2Create(d *schema.ResourceData, meta interfac
 				return 42, "", err
 			}
 
-			status := *out.Status
-			var sErr error
+			status := aws.StringValue(out.Status)
+
 			if status == cloud9.EnvironmentStatusError && out.Message != nil {
-				sErr = fmt.Errorf("Reason: %s", *out.Message)
+				return out, status, fmt.Errorf("Reason: %s", aws.StringValue(out.Message))
 			}
 
-			return out, status, sErr
+			return out, status, nil
 		},
 	}
 	_, err = stateConf.WaitForState()

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -50,9 +50,9 @@ func testSweepCloudFrontDistributions(region string) error {
 	}
 
 	for _, distributionSummary := range distributionSummaries {
-		distributionID := *distributionSummary.Id
+		distributionID := aws.StringValue(distributionSummary.Id)
 
-		if *distributionSummary.Enabled {
+		if aws.BoolValue(distributionSummary.Enabled) {
 			log.Printf("[WARN] Skipping deletion of enabled CloudFront Distribution: %s", distributionID)
 			continue
 		}

--- a/aws/resource_aws_cloudfront_origin_request_policy.go
+++ b/aws/resource_aws_cloudfront_origin_request_policy.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -154,11 +155,16 @@ func resourceAwsCloudFrontOriginRequestPolicyRead(d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading CloudFront Origin Request Policy (%s): %w", d.Id(), err)
 	}
+
+	if resp == nil || resp.OriginRequestPolicy == nil || resp.OriginRequestPolicy.OriginRequestPolicyConfig == nil {
+		return fmt.Errorf("error reading CloudFront Origin Request Policy (%s): empty response", d.Id())
+	}
+
 	d.Set("etag", aws.StringValue(resp.ETag))
 
-	originRequestPolicy := *resp.OriginRequestPolicy.OriginRequestPolicyConfig
+	originRequestPolicy := resp.OriginRequestPolicy.OriginRequestPolicyConfig
 	d.Set("comment", aws.StringValue(originRequestPolicy.Comment))
 	d.Set("name", aws.StringValue(originRequestPolicy.Name))
 	d.Set("cookies_config", flattenCloudFrontOriginRequestPolicyCookiesConfig(originRequestPolicy.CookiesConfig))

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -259,7 +259,7 @@ func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 	// you're looking for is not found. Instead, it's simply not in the list.
 	var trail *cloudtrail.Trail
 	for _, c := range resp.TrailList {
-		if d.Id() == *c.Name {
+		if d.Id() == aws.StringValue(c.Name) {
 			trail = c
 		}
 	}
@@ -566,8 +566,8 @@ func flattenAwsCloudTrailEventSelector(configured []*cloudtrail.EventSelector) [
 
 	for _, raw := range configured {
 		item := make(map[string]interface{})
-		item["read_write_type"] = *raw.ReadWriteType
-		item["include_management_events"] = *raw.IncludeManagementEvents
+		item["read_write_type"] = aws.StringValue(raw.ReadWriteType)
+		item["include_management_events"] = aws.BoolValue(raw.IncludeManagementEvents)
 		item["data_resource"] = flattenAwsCloudTrailEventSelectorDataResource(raw.DataResources)
 
 		eventSelectors = append(eventSelectors, item)
@@ -581,7 +581,7 @@ func flattenAwsCloudTrailEventSelectorDataResource(configured []*cloudtrail.Data
 
 	for _, raw := range configured {
 		item := make(map[string]interface{})
-		item["type"] = *raw.Type
+		item["type"] = aws.StringValue(raw.Type)
 		item["values"] = flattenStringList(raw.Values)
 
 		dataResources = append(dataResources, item)

--- a/aws/resource_aws_cloudwatch_log_destination.go
+++ b/aws/resource_aws_cloudwatch_log_destination.go
@@ -139,7 +139,7 @@ func lookupCloudWatchLogDestination(conn *cloudwatchlogs.CloudWatchLogs,
 	}
 
 	for _, destination := range resp.Destinations {
-		if *destination.DestinationName == name {
+		if aws.StringValue(destination.DestinationName) == name {
 			return destination, true, nil
 		}
 	}

--- a/aws/resource_aws_cloudwatch_log_metric_filter.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter.go
@@ -170,7 +170,7 @@ func lookupCloudWatchLogMetricFilter(conn *cloudwatchlogs.CloudWatchLogs,
 	}
 
 	for _, mf := range resp.MetricFilters {
-		if *mf.FilterName == name {
+		if aws.StringValue(mf.FilterName) == name {
 			return mf, nil
 		}
 	}

--- a/aws/resource_aws_cloudwatch_log_resource_policy.go
+++ b/aws/resource_aws_cloudwatch_log_resource_policy.go
@@ -104,7 +104,7 @@ func lookupCloudWatchLogResourcePolicy(conn *cloudwatchlogs.CloudWatchLogs,
 	}
 
 	for _, resourcePolicy := range resp.ResourcePolicies {
-		if *resourcePolicy.PolicyName == name {
+		if aws.StringValue(resourcePolicy.PolicyName) == name {
 			return resourcePolicy, true, nil
 		}
 	}

--- a/aws/resource_aws_cloudwatch_log_stream.go
+++ b/aws/resource_aws_cloudwatch_log_stream.go
@@ -149,7 +149,7 @@ func lookupCloudWatchLogStream(conn *cloudwatchlogs.CloudWatchLogs,
 	}
 
 	for _, ls := range resp.LogStreams {
-		if *ls.LogStreamName == name {
+		if aws.StringValue(ls.LogStreamName) == name {
 			return ls, true, nil
 		}
 	}

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -307,7 +307,7 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 	if err := d.Set("alarm_actions", flattenStringSet(resp.AlarmActions)); err != nil {
 		log.Printf("[WARN] Error setting Alarm Actions: %s", err)
 	}
-	arn := *resp.AlarmArn
+	arn := aws.StringValue(resp.AlarmArn)
 	d.Set("alarm_description", resp.AlarmDescription)
 	d.Set("alarm_name", resp.AlarmName)
 	d.Set("arn", arn)
@@ -578,7 +578,7 @@ func getAwsCloudWatchMetricAlarm(d *schema.ResourceData, meta interface{}) (*clo
 func flattenDimensions(dims []*cloudwatch.Dimension) map[string]interface{} {
 	flatDims := make(map[string]interface{})
 	for _, d := range dims {
-		flatDims[*d.Name] = *d.Value
+		flatDims[aws.StringValue(d.Name)] = aws.StringValue(d.Value)
 	}
 	return flatDims
 }

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -1107,14 +1107,14 @@ func ec2TagFiltersToMap(list []*codedeploy.EC2TagFilter) []map[string]interface{
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, tf := range list {
 		l := make(map[string]interface{})
-		if tf.Key != nil && *tf.Key != "" {
-			l["key"] = *tf.Key
+		if v := tf.Key; aws.StringValue(v) != "" {
+			l["key"] = aws.StringValue(v)
 		}
-		if tf.Value != nil && *tf.Value != "" {
-			l["value"] = *tf.Value
+		if v := tf.Value; aws.StringValue(v) != "" {
+			l["value"] = aws.StringValue(v)
 		}
-		if tf.Type != nil && *tf.Type != "" {
-			l["type"] = *tf.Type
+		if v := tf.Type; aws.StringValue(v) != "" {
+			l["type"] = aws.StringValue(v)
 		}
 		result = append(result, l)
 	}
@@ -1126,14 +1126,14 @@ func onPremisesTagFiltersToMap(list []*codedeploy.TagFilter) []map[string]string
 	result := make([]map[string]string, 0, len(list))
 	for _, tf := range list {
 		l := make(map[string]string)
-		if tf.Key != nil && *tf.Key != "" {
-			l["key"] = *tf.Key
+		if v := tf.Key; aws.StringValue(v) != "" {
+			l["key"] = aws.StringValue(v)
 		}
-		if tf.Value != nil && *tf.Value != "" {
-			l["value"] = *tf.Value
+		if v := tf.Value; aws.StringValue(v) != "" {
+			l["value"] = aws.StringValue(v)
 		}
-		if tf.Type != nil && *tf.Type != "" {
-			l["type"] = *tf.Type
+		if v := tf.Type; aws.StringValue(v) != "" {
+			l["type"] = aws.StringValue(v)
 		}
 		result = append(result, l)
 	}
@@ -1168,8 +1168,8 @@ func triggerConfigsToMap(list []*codedeploy.TriggerConfig) []map[string]interfac
 	for _, tc := range list {
 		item := make(map[string]interface{})
 		item["trigger_events"] = flattenStringSet(tc.TriggerEvents)
-		item["trigger_name"] = *tc.TriggerName
-		item["trigger_target_arn"] = *tc.TriggerTargetArn
+		item["trigger_name"] = aws.StringValue(tc.TriggerName)
+		item["trigger_target_arn"] = aws.StringValue(tc.TriggerTargetArn)
 		result = append(result, item)
 	}
 	return result
@@ -1184,7 +1184,7 @@ func autoRollbackConfigToMap(config *codedeploy.AutoRollbackConfiguration) []map
 	// otherwise empty configurations will be created
 	if config != nil && (*config.Enabled || len(config.Events) > 0) {
 		item := make(map[string]interface{})
-		item["enabled"] = *config.Enabled
+		item["enabled"] = aws.BoolValue(config.Enabled)
 		item["events"] = flattenStringSet(config.Events)
 		result = append(result, item)
 	}
@@ -1207,8 +1207,8 @@ func alarmConfigToMap(config *codedeploy.AlarmConfiguration) []map[string]interf
 
 		item := make(map[string]interface{})
 		item["alarms"] = flattenStringSet(names)
-		item["enabled"] = *config.Enabled
-		item["ignore_poll_alarm_failure"] = *config.IgnorePollAlarmFailure
+		item["enabled"] = aws.BoolValue(config.Enabled)
+		item["ignore_poll_alarm_failure"] = aws.BoolValue(config.IgnorePollAlarmFailure)
 
 		result = append(result, item)
 	}
@@ -1311,11 +1311,11 @@ func flattenDeploymentStyle(style *codedeploy.DeploymentStyle) []map[string]inte
 	}
 
 	item := make(map[string]interface{})
-	if style.DeploymentOption != nil {
-		item["deployment_option"] = *style.DeploymentOption
+	if v := style.DeploymentOption; v != nil {
+		item["deployment_option"] = aws.StringValue(v)
 	}
-	if style.DeploymentType != nil {
-		item["deployment_type"] = *style.DeploymentType
+	if v := style.DeploymentType; v != nil {
+		item["deployment_type"] = aws.StringValue(v)
 	}
 
 	result := make([]map[string]interface{}, 0, 1)
@@ -1351,11 +1351,11 @@ func flattenBlueGreenDeploymentConfig(config *codedeploy.BlueGreenDeploymentConf
 		a := make([]map[string]interface{}, 0)
 		deploymentReadyOption := make(map[string]interface{})
 
-		if config.DeploymentReadyOption.ActionOnTimeout != nil {
-			deploymentReadyOption["action_on_timeout"] = *config.DeploymentReadyOption.ActionOnTimeout
+		if v := config.DeploymentReadyOption.ActionOnTimeout; v != nil {
+			deploymentReadyOption["action_on_timeout"] = aws.StringValue(v)
 		}
-		if config.DeploymentReadyOption.WaitTimeInMinutes != nil {
-			deploymentReadyOption["wait_time_in_minutes"] = *config.DeploymentReadyOption.WaitTimeInMinutes
+		if v := config.DeploymentReadyOption.WaitTimeInMinutes; v != nil {
+			deploymentReadyOption["wait_time_in_minutes"] = aws.Int64Value(v)
 		}
 
 		m["deployment_ready_option"] = append(a, deploymentReadyOption)
@@ -1365,8 +1365,8 @@ func flattenBlueGreenDeploymentConfig(config *codedeploy.BlueGreenDeploymentConf
 		b := make([]map[string]interface{}, 0)
 		greenFleetProvisioningOption := make(map[string]interface{})
 
-		if config.GreenFleetProvisioningOption.Action != nil {
-			greenFleetProvisioningOption["action"] = *config.GreenFleetProvisioningOption.Action
+		if v := config.GreenFleetProvisioningOption.Action; v != nil {
+			greenFleetProvisioningOption["action"] = aws.StringValue(v)
 		}
 
 		m["green_fleet_provisioning_option"] = append(b, greenFleetProvisioningOption)
@@ -1376,11 +1376,11 @@ func flattenBlueGreenDeploymentConfig(config *codedeploy.BlueGreenDeploymentConf
 		c := make([]map[string]interface{}, 0)
 		blueInstanceTerminationOption := make(map[string]interface{})
 
-		if config.TerminateBlueInstancesOnDeploymentSuccess.Action != nil {
-			blueInstanceTerminationOption["action"] = *config.TerminateBlueInstancesOnDeploymentSuccess.Action
+		if v := config.TerminateBlueInstancesOnDeploymentSuccess.Action; v != nil {
+			blueInstanceTerminationOption["action"] = aws.StringValue(v)
 		}
-		if config.TerminateBlueInstancesOnDeploymentSuccess.TerminationWaitTimeInMinutes != nil {
-			blueInstanceTerminationOption["termination_wait_time_in_minutes"] = *config.TerminateBlueInstancesOnDeploymentSuccess.TerminationWaitTimeInMinutes
+		if v := config.TerminateBlueInstancesOnDeploymentSuccess.TerminationWaitTimeInMinutes; v != nil {
+			blueInstanceTerminationOption["termination_wait_time_in_minutes"] = aws.Int64Value(v)
 		}
 
 		m["terminate_blue_instances_on_deployment_success"] = append(c, blueInstanceTerminationOption)

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -348,7 +348,7 @@ func expandAwsCodePipelineActions(a []interface{}) []*codepipeline.ActionDeclara
 	for _, config := range a {
 		data := config.(map[string]interface{})
 
-		conf := expandAwsCodePipelineStageActionConfiguration(data["configuration"].(map[string]interface{}))
+		conf := stringMapToPointers(data["configuration"].(map[string]interface{}))
 
 		action := codepipeline.ActionDeclaration{
 			ActionTypeId: &codepipeline.ActionTypeId{
@@ -406,7 +406,7 @@ func flattenAwsCodePipelineStageActions(si int, actions []*codepipeline.ActionDe
 			"name":     aws.StringValue(action.Name),
 		}
 		if action.Configuration != nil {
-			config := flattenAwsCodePipelineStageActionConfiguration(action.Configuration)
+			config := aws.StringValueMap(action.Configuration)
 
 			actionProvider := aws.StringValue(action.ActionTypeId.Provider)
 			if actionProvider == CodePipelineProviderGitHub {
@@ -449,23 +449,6 @@ func flattenAwsCodePipelineStageActions(si int, actions []*codepipeline.ActionDe
 	return actionsList
 }
 
-func expandAwsCodePipelineStageActionConfiguration(config map[string]interface{}) map[string]*string {
-	m := map[string]*string{}
-	for k, v := range config {
-		s := v.(string)
-		m[k] = &s
-	}
-	return m
-}
-
-func flattenAwsCodePipelineStageActionConfiguration(config map[string]*string) map[string]string {
-	m := map[string]string{}
-	for k, v := range config {
-		m[k] = *v
-	}
-	return m
-}
-
 func expandAwsCodePipelineActionsOutputArtifacts(s []interface{}) []*codepipeline.OutputArtifact {
 	outputArtifacts := []*codepipeline.OutputArtifact{}
 	for _, artifact := range s {
@@ -482,7 +465,7 @@ func expandAwsCodePipelineActionsOutputArtifacts(s []interface{}) []*codepipelin
 func flattenAwsCodePipelineActionsOutputArtifacts(artifacts []*codepipeline.OutputArtifact) []string {
 	values := []string{}
 	for _, artifact := range artifacts {
-		values = append(values, *artifact.Name)
+		values = append(values, aws.StringValue(artifact.Name))
 	}
 	return values
 }
@@ -503,7 +486,7 @@ func expandAwsCodePipelineActionsInputArtifacts(s []interface{}) []*codepipeline
 func flattenAwsCodePipelineActionsInputArtifacts(artifacts []*codepipeline.InputArtifact) []string {
 	values := []string{}
 	for _, artifact := range artifacts {
-		values = append(values, *artifact.Name)
+		values = append(values, aws.StringValue(artifact.Name))
 	}
 	return values
 }

--- a/aws/resource_aws_config_remediation_configuration.go
+++ b/aws/resource_aws_config_remediation_configuration.go
@@ -119,11 +119,11 @@ func flattenRemediationConfigurationParameters(parameters map[string]*configserv
 	for key, value := range parameters {
 		item := make(map[string]interface{})
 		item["name"] = key
-		if value.ResourceValue != nil {
-			item["resource_value"] = *value.ResourceValue.Value
+		if v := value.ResourceValue; v != nil {
+			item["resource_value"] = aws.StringValue(v.Value)
 		}
-		if value.StaticValue != nil && len(value.StaticValue.Values) > 0 {
-			item["static_value"] = *value.StaticValue.Values[0]
+		if v := value.StaticValue; v != nil && len(v.Values) > 0 {
+			item["static_value"] = aws.StringValue(v.Values[0])
 		}
 
 		items = append(items, item)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12992

Previously:

```
aws/resource_aws_cloud9_environment_ec2.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
132:			status := *out.Status

aws/resource_aws_cloudfront_distribution_test.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
53:		distributionID := *distributionSummary.Id

aws/resource_aws_cloudfront_origin_request_policy.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
161:	originRequestPolicy := *resp.OriginRequestPolicy.OriginRequestPolicyConfig

aws/resource_aws_cloudtrail.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
569:		item["read_write_type"] = *raw.ReadWriteType
--------------------------------------------------------------------------------
570:		item["include_management_events"] = *raw.IncludeManagementEvents
--------------------------------------------------------------------------------
584:		item["type"] = *raw.Type
--------------------------------------------------------------------------------
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
262:		if d.Id() == *c.Name {

aws/resource_aws_cloudwatch_log_destination.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
142:		if *destination.DestinationName == name {

aws/resource_aws_cloudwatch_log_metric_filter.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
173:		if *mf.FilterName == name {

aws/resource_aws_cloudwatch_log_resource_policy.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
107:		if *resourcePolicy.PolicyName == name {

aws/resource_aws_cloudwatch_log_stream.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
152:		if *ls.LogStreamName == name {

aws/resource_aws_cloudwatch_metric_alarm.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
310:	arn := *resp.AlarmArn
--------------------------------------------------------------------------------
581:		flatDims[*d.Name] = *d.Value

aws/resource_aws_codedeploy_deployment_group.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
1111:			l["key"] = *tf.Key
--------------------------------------------------------------------------------
1114:			l["value"] = *tf.Value
--------------------------------------------------------------------------------
1117:			l["type"] = *tf.Type
--------------------------------------------------------------------------------
1130:			l["key"] = *tf.Key
--------------------------------------------------------------------------------
1133:			l["value"] = *tf.Value
--------------------------------------------------------------------------------
1136:			l["type"] = *tf.Type
--------------------------------------------------------------------------------
1171:		item["trigger_name"] = *tc.TriggerName
--------------------------------------------------------------------------------
1172:		item["trigger_target_arn"] = *tc.TriggerTargetArn
--------------------------------------------------------------------------------
1187:		item["enabled"] = *config.Enabled
--------------------------------------------------------------------------------
1210:		item["enabled"] = *config.Enabled
--------------------------------------------------------------------------------
1211:		item["ignore_poll_alarm_failure"] = *config.IgnorePollAlarmFailure
--------------------------------------------------------------------------------
1315:		item["deployment_option"] = *style.DeploymentOption
--------------------------------------------------------------------------------
1318:		item["deployment_type"] = *style.DeploymentType
--------------------------------------------------------------------------------
1355:			deploymentReadyOption["action_on_timeout"] = *config.DeploymentReadyOption.ActionOnTimeout
--------------------------------------------------------------------------------
1358:			deploymentReadyOption["wait_time_in_minutes"] = *config.DeploymentReadyOption.WaitTimeInMinutes
--------------------------------------------------------------------------------
1369:			greenFleetProvisioningOption["action"] = *config.GreenFleetProvisioningOption.Action
--------------------------------------------------------------------------------
1380:			blueInstanceTerminationOption["action"] = *config.TerminateBlueInstancesOnDeploymentSuccess.Action
--------------------------------------------------------------------------------
1383:			blueInstanceTerminationOption["termination_wait_time_in_minutes"] = *config.TerminateBlueInstancesOnDeploymentSuccess.TerminationWaitTimeInMinutes
--------------------------------------------------------------------------------
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
1110:		if tf.Key != nil && *tf.Key != "" {
--------------------------------------------------------------------------------
1113:		if tf.Value != nil && *tf.Value != "" {
--------------------------------------------------------------------------------
1116:		if tf.Type != nil && *tf.Type != "" {
--------------------------------------------------------------------------------
1129:		if tf.Key != nil && *tf.Key != "" {
--------------------------------------------------------------------------------
1132:		if tf.Value != nil && *tf.Value != "" {
--------------------------------------------------------------------------------
1135:		if tf.Type != nil && *tf.Type != "" {

aws/resource_aws_codepipeline.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
464:		m[k] = *v

aws/resource_aws_config_remediation_configuration.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
123:			item["resource_value"] = *value.ResourceValue.Value
--------------------------------------------------------------------------------
126:			item["static_value"] = *value.StaticValue.Values[0]
ran 15 rules on 2163 files: 40 findings
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloud9EnvironmentEc2_allFields (286.70s)
--- PASS: TestAccAWSCloud9EnvironmentEc2_basic (209.52s)
--- PASS: TestAccAWSCloud9EnvironmentEc2_disappears (170.86s)
--- PASS: TestAccAWSCloud9EnvironmentEc2_tags (232.19s)

--- PASS: TestAccAWSCloudFrontOriginRequestPolicy_basic (19.69s)
--- PASS: TestAccAWSCloudFrontOriginRequestPolicy_noneBehavior (22.64s)
--- PASS: TestAccAWSCloudFrontOriginRequestPolicy_update (37.49s)

--- FAIL: TestAccAWSCloudTrail_serial (656.14s)
    --- FAIL: TestAccAWSCloudTrail_serial/Trail (656.14s)
        --- FAIL: TestAccAWSCloudTrail_serial/Trail/basic (48.14s) # Account permissions
        --- FAIL: TestAccAWSCloudTrail_serial/Trail/enableLogging (46.70s) # Account permissions
        --- PASS: TestAccAWSCloudTrail_serial/Trail/cloudwatch (73.41s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/eventSelector (138.13s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/includeGlobalServiceEvents (35.63s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/insightSelector (35.46s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/isMultiRegion (91.64s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/kmsKey (35.12s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/logValidation (65.09s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/tags (86.69s)
        --- SKIP: TestAccAWSCloudTrail_serial/Trail/isOrganization (0.13s)

--- PASS: TestAccAWSCloudwatchLogDestination_basic (84.11s)
--- PASS: TestAccAWSCloudwatchLogDestination_disappears (88.96s)

--- PASS: TestAccAWSCloudWatchLogMetricFilter_basic (92.40s)

--- PASS: TestAccAWSCloudWatchLogResourcePolicy_basic (32.98s)

--- PASS: TestAccAWSCloudWatchLogStream_basic (21.49s)
--- PASS: TestAccAWSCloudWatchLogStream_disappears (20.86s)
--- PASS: TestAccAWSCloudWatchLogStream_disappears_LogGroup (20.50s)

--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (252.05s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic (26.06s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction (27.65s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (23.92s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm (17.54s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_disappears (18.25s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (42.33s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_expression (96.17s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_extendedStatistic (19.08s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_missingStatistic (5.29s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_tags (62.51s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_treatMissingData (42.33s)

--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (33.38s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (51.51s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (38.86s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (40.28s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (43.51s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (61.36s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (42.37s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (64.37s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (71.37s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (61.98s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (46.42s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (151.03s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (48.72s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (45.77s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (177.57s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (31.64s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (31.74s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (45.98s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (43.92s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (30.83s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (310.19s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (35.95s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (54.46s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (32.28s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (44.30s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (43.70s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (67.73s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (45.46s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (64.46s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (41.70s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (71.08s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (73.36s)

--- FAIL: TestAccAWSCodePipeline_multiregion_ConvertSingleRegion (83.25s) # https://github.com/hashicorp/terraform-provider-aws/issues/16706
--- PASS: TestAccAWSCodePipeline_basic (72.08s)
--- PASS: TestAccAWSCodePipeline_deployWithServiceRole (47.91s)
--- PASS: TestAccAWSCodePipeline_disappears (37.13s)
--- PASS: TestAccAWSCodePipeline_emptyStageArtifacts (43.65s)
--- PASS: TestAccAWSCodePipeline_multiregion_basic (46.08s)
--- PASS: TestAccAWSCodePipeline_multiregion_Update (73.72s)
--- PASS: TestAccAWSCodePipeline_tags (98.61s)
--- PASS: TestAccAWSCodePipeline_WithNamespace (49.41s)
--- SKIP: TestAccAWSCodePipeline_WithGitHubv1SourceAction (0.00s)

--- PASS: TestAccAWSConfig_serial (3698.82s)
    --- PASS: TestAccAWSConfig_serial/RemediationConfiguration (364.40s)
        --- PASS: TestAccAWSConfig_serial/RemediationConfiguration/basic (86.05s)
        --- PASS: TestAccAWSConfig_serial/RemediationConfiguration/disappears (83.00s)
        --- PASS: TestAccAWSConfig_serial/RemediationConfiguration/recreates (99.34s)
        --- PASS: TestAccAWSConfig_serial/RemediationConfiguration/updates (96.01s)
```
