### PR TITLE
d - Add delete/destroy warning to aws_db_option_group resource page

### DIFF
--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -97,3 +97,13 @@ DB Option groups can be imported using the `name`, e.g.
 ```
 $ terraform import aws_db_option_group.bar mysql-option-group
 ```
+
+~> **WARNING:** You can perform a destroy on a `db_option_group`, as long as it is not associated with any Amazon RDS resource. An option group can be associated with a DB instance, a manual DB snapshot, or an automated DB snapshot.
+
+If you try to delete an option group that is associated with an Amazon RDS resource, an error similar to the following is returned:
+
+```
+An error occurred (InvalidOptionGroupStateFault) when calling the DeleteOptionGroup operation: The option group 'optionGroupName' cannot be deleted because it is in use.
+```
+
+More information about this can be found [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html#USER_WorkingWithOptionGroups.Delete).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
- **First PR**
[Documentation Update to the Website]
Added a delete/destroy warning to the [`aws_db_option_group`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_option_group) resource page - to educate and satisfy user suggestions in issue [#4597](https://github.com/hashicorp/terraform-provider-aws/issues/4597).

Did my best to follow the contribution guidelines. Feedback is welcome. Thanks!