### PR TITLE
Make eks_node_group scaling_config.desired_size optional

### DIFF
--- a/.changelog/18340.txt
+++ b/.changelog/18340.txt
@@ -1,0 +1,3 @@
+```release-notes:enhancement
+resource/aws_eks_node_group: Changed `desired_size` to optional
+```

--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -1780,8 +1780,8 @@ resource "aws_eks_node_group" "test" {
   subnet_ids      = aws_subnet.test[*].id
 
   scaling_config {
-    max_size     = %[2]d
-    min_size     = %[3]d
+    max_size = %[2]d
+    min_size = %[3]d
   }
 
   depends_on = [

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -35,28 +35,6 @@ resource "aws_eks_node_group" "example" {
 }
 ```
 
-### Ignoring Changes to Desired Size
-
-You can utilize the generic Terraform resource [lifecycle configuration block](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html) with `ignore_changes` to create an EKS Node Group with an initial size of running instances, then ignore any changes to that count caused externally (e.g. Application Autoscaling).
-
-```terraform
-resource "aws_eks_node_group" "example" {
-  # ... other configurations ...
-
-  scaling_config {
-    # Example: Create EKS Node Group with 2 instances to start
-    desired_size = 2
-
-    # ... other configurations ...
-  }
-
-  # Optional: Allow external changes without Terraform plan difference
-  lifecycle {
-    ignore_changes = [scaling_config[0].desired_size]
-  }
-}
-```
-
 ### Example IAM Role for EKS Node Group
 
 ```terraform
@@ -150,7 +128,7 @@ The following arguments are optional:
 
 ### scaling_config Configuration Block
 
-* `desired_size` - (Required) Desired number of worker nodes.
+* `desired_size` - (Optional) Desired number of worker nodes.
 * `max_size` - (Required) Maximum number of worker nodes.
 * `min_size` - (Required) Minimum number of worker nodes.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18310

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

On the first run, several tests failed / timed out. I then re-run them individually and succeeded:
```
$ make testacc TESTARGS='-run=TestAccXXX'
=== CONT  TestAccAWSEksNodeGroup_ScalingConfig_MaxSize
    resource_aws_eks_node_group_test.go:629: Step 1/3 error: Error running apply: exit status 1

        Error: error waiting for EKS Node Group (tf-acc-test-1853196453753687279:tf-acc-test-1853196453753687279) creation: InternalFailure: Amazon EKS was unable to process your request. Please try again.. Resource IDs: []

          on terraform_plugin_test.tf line 142, in resource "aws_eks_node_group" "test":
         142: resource "aws_eks_node_group" "test" {


--- FAIL: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1526.13s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1702.71s)
--- PASS: TestAccAWSEksNodeGroup_disappears (1716.09s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1731.28s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Single (1741.60s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1772.10s)
--- PASS: TestAccAWSEksNodeGroup_CapacityType_Spot (1807.90s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1820.49s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1825.58s)
--- PASS: TestAccAWSEksNodeGroup_basic (1829.69s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1836.48s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1853.29s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_OmitDesiredSize (1866.31s)
--- PASS: TestAccAWSEksNodeGroup_AmiType (1981.43s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Id (2190.75s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Name (2385.75s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Version (2409.97s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Multiple (1061.35s)
```

Several tests failed on the first try. I re-run them individually and they succeeded. 
```
make testacc TESTARGS='-run=TestAccAWSEksNodeGroup_ScalingConfig_MaxSize'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksNodeGroup_ScalingConfig_MaxSize -timeout 180m
=== RUN   TestAccAWSEksNodeGroup_ScalingConfig_MaxSize
=== PAUSE TestAccAWSEksNodeGroup_ScalingConfig_MaxSize
=== CONT  TestAccAWSEksNodeGroup_ScalingConfig_MaxSize
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1113.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1120.357s

make testacc TESTARGS='-run=TestAccAWSEksNodeGroup_ForceUpdateVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksNodeGroup_ForceUpdateVersion -timeout 180m
=== RUN   TestAccAWSEksNodeGroup_ForceUpdateVersion
=== PAUSE TestAccAWSEksNodeGroup_ForceUpdateVersion
=== CONT  TestAccAWSEksNodeGroup_ForceUpdateVersion
--- PASS: TestAccAWSEksNodeGroup_ForceUpdateVersion (4455.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4461.307s

make testacc TESTARGS='-run=TestAccAWSEksNodeGroup_Version'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksNodeGroup_Version -timeout 180m
=== RUN   TestAccAWSEksNodeGroup_Version
=== PAUSE TestAccAWSEksNodeGroup_Version
=== CONT  TestAccAWSEksNodeGroup_Version
--- PASS: TestAccAWSEksNodeGroup_Version (4294.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4297.005s

make testacc TESTARGS='-run=TestAccAWSEksNodeGroup_ReleaseVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksNodeGroup_ReleaseVersion -timeout 180m
=== RUN   TestAccAWSEksNodeGroup_ReleaseVersion
=== PAUSE TestAccAWSEksNodeGroup_ReleaseVersion
=== CONT  TestAccAWSEksNodeGroup_ReleaseVersion
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (3566.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3569.051s
```