### PR TITLE
resource/securityhub_organization_admin_account: retry on ResourceConflictException during creation

### DIFF
--- a/.changelog/18341.txt
+++ b/.changelog/18341.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_securityhub_organization_admin_account: Retry on `ResourceConflictException` error during creation
+```

--- a/aws/resource_aws_securityhub_organization_admin_account.go
+++ b/aws/resource_aws_securityhub_organization_admin_account.go
@@ -7,11 +7,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/securityhub"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/securityhub/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/securityhub/waiter"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsSecurityHubOrganizationAdminAccount() *schema.Resource {
@@ -44,21 +42,7 @@ func resourceAwsSecurityHubOrganizationAdminAccountCreate(d *schema.ResourceData
 		AdminAccountId: aws.String(adminAccountID),
 	}
 
-	err := resource.Retry(waiter.AdminAccountEnabledTimeout, func() *resource.RetryError {
-		_, err := conn.EnableOrganizationAdminAccount(input)
-
-		if err != nil {
-			if tfawserr.ErrCodeEquals(err, securityhub.ErrCodeResourceConflictException) {
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		_, err = conn.EnableOrganizationAdminAccount(input)
-	}
+	_, err := conn.EnableOrganizationAdminAccount(input)
 
 	if err != nil {
 		return fmt.Errorf("error enabling Security Hub Organization Admin Account (%s): %w", adminAccountID, err)

--- a/aws/resource_aws_securityhub_organization_admin_account.go
+++ b/aws/resource_aws_securityhub_organization_admin_account.go
@@ -7,9 +7,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/securityhub"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/securityhub/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/securityhub/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsSecurityHubOrganizationAdminAccount() *schema.Resource {
@@ -42,7 +44,21 @@ func resourceAwsSecurityHubOrganizationAdminAccountCreate(d *schema.ResourceData
 		AdminAccountId: aws.String(adminAccountID),
 	}
 
-	_, err := conn.EnableOrganizationAdminAccount(input)
+	err := resource.Retry(waiter.AdminAccountEnabledTimeout, func() *resource.RetryError {
+		_, err := conn.EnableOrganizationAdminAccount(input)
+
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, securityhub.ErrCodeResourceConflictException) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.EnableOrganizationAdminAccount(input)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error enabling Security Hub Organization Admin Account (%s): %w", adminAccountID, err)

--- a/aws/resource_aws_securityhub_test.go
+++ b/aws/resource_aws_securityhub_test.go
@@ -23,8 +23,9 @@ func TestAccAWSSecurityHub_serial(t *testing.T) {
 			"basic": testAccAWSSecurityHubInviteAccepter_basic,
 		},
 		"OrganizationAdminAccount": {
-			"basic":      testAccAwsSecurityHubOrganizationAdminAccount_basic,
-			"disappears": testAccAwsSecurityHubOrganizationAdminAccount_disappears,
+			"basic":       testAccAwsSecurityHubOrganizationAdminAccount_basic,
+			"disappears":  testAccAwsSecurityHubOrganizationAdminAccount_disappears,
+			"MultiRegion": testAccAwsSecurityHubOrganizationAdminAccount_MultiRegion,
 		},
 		"ProductSubscription": {
 			"basic": testAccAWSSecurityHubProductSubscription_basic,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17996

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSSecurityHub_serial (24.00s)
    --- PASS: TestAccAWSSecurityHub_serial/ActionTarget (74.20s)
        --- PASS: TestAccAWSSecurityHub_serial/ActionTarget/Description (25.29s)
        --- PASS: TestAccAWSSecurityHub_serial/ActionTarget/Name (22.85s)
        --- PASS: TestAccAWSSecurityHub_serial/ActionTarget/basic (14.31s)
        --- PASS: TestAccAWSSecurityHub_serial/ActionTarget/disappears (11.75s)
    --- PASS: TestAccAWSSecurityHub_serial/ProductSubscription (29.38s)
        --- PASS: TestAccAWSSecurityHub_serial/ProductSubscription/basic (29.38s)
    --- PASS: TestAccAWSSecurityHub_serial/StandardsSubscription (21.00s)
        --- PASS: TestAccAWSSecurityHub_serial/StandardsSubscription/basic (21.00s)
    --- PASS: TestAccAWSSecurityHub_serial/Member (30.99s)
        --- PASS: TestAccAWSSecurityHub_serial/Member/basic (15.88s)
        --- PASS: TestAccAWSSecurityHub_serial/Member/invite (15.11s)
    --- PASS: TestAccAWSSecurityHub_serial/OrganizationAdminAccount (59.09s)
        --- PASS: TestAccAWSSecurityHub_serial/OrganizationAdminAccount/basic (20.76s)
        --- PASS: TestAccAWSSecurityHub_serial/OrganizationAdminAccount/disappears (17.17s)
        --- PASS: TestAccAWSSecurityHub_serial/OrganizationAdminAccount/MultiRegion (21.17s)
```

### Notes
* improvement on retry behavior is not readily apparent when testing with 3 regions, but when testing with a terraform configuration outside of the test framework, (sporadic) errors previously thrown when creating 4+ resources with alternate regions are now appropriately caught, resulting in successful creations
