### PR TITLE
tests/resource/aws_vpc_peering_connection: Remove ID-only refresh configuration

### DIFF
--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -93,11 +93,8 @@ func TestAccAWSVPCPeeringConnection_basic(t *testing.T) {
 	resourceName := "aws_vpc_peering_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"auto_accept"},
-
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
@@ -138,10 +135,8 @@ func TestAccAWSVPCPeeringConnection_plan(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshIgnore: []string{"auto_accept"},
-
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
@@ -166,11 +161,8 @@ func TestAccAWSVPCPeeringConnection_tags(t *testing.T) {
 	resourceName := "aws_vpc_peering_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"auto_accept"},
-
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
@@ -232,11 +224,8 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"auto_accept"},
-
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
@@ -392,10 +381,8 @@ func TestAccAWSVPCPeeringConnection_failedState(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandString(17))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshIgnore: []string{"auto_accept"},
-
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
@@ -534,7 +521,6 @@ func TestAccAWSVPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
 			testAccMultipleRegionPreCheck(t, 2)
 		},
 		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshIgnore:   []string{"auto_accept"},
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
@@ -557,10 +543,7 @@ func TestAccAWSVPCPeeringConnection_region(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"auto_accept"},
-
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
 		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
@@ -589,11 +572,8 @@ func TestAccAWSVPCPeeringConnection_accept(t *testing.T) {
 	resourceName := "aws_vpc_peering_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"auto_accept"},
-
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18348

Identifier only refresh testing is generally a legacy testing practice before full import testing was the normal convention. Certain functionality of `IDRefreshName` testing, such as alternate providers defined by the test configuration and `ProviderFactories`, is not compatible since there is no method to pass in the original configuration to prevent Terraform CLI errors such as:

```
=== CONT  TestAccAWSVPCPeeringConnection_region
    testing_new.go:214: Error running terraform refresh: exit status 1

        Error: Provider configuration not present

        To work with aws_vpc.peer (orphan) its original provider configuration at
        provider["registry.terraform.io/hashicorp/awsalternate"] is required, but it
        has been removed. This occurs when a provider configuration is removed while
        objects created by that provider still exist in the state. Re-add the provider
        configuration to destroy aws_vpc.peer (orphan), after which you can remove the
        provider configuration again.

--- FAIL: TestAccAWSVPCPeeringConnection_region (24.38s)
```

Import testing accepts a `Config`, which is how it does not have a similar issue. Will submit followup issue to fix the Go documentation in the Terraform Plugin SDK as this testing is not run by default and note this limitation. Will also submit followup issue to remove `IDRefreshIgnore` and `IDRefreshName` from all testing.

Output from acceptance testing:

```
--- PASS: TestAccAWSVPCPeeringConnection_peerRegionAutoAccept (13.29s)
--- PASS: TestAccAWSVPCPeeringConnection_failedState (14.70s)
--- PASS: TestAccAWSVPCPeeringConnection_plan (24.21s)
--- PASS: TestAccAWSVPCPeeringConnection_optionsNoAutoAccept (25.87s)
--- PASS: TestAccAWSVPCPeeringConnection_basic (27.94s)
--- PASS: TestAccAWSVPCPeeringConnection_region (30.92s)
--- PASS: TestAccAWSVPCPeeringConnection_options (60.28s)
--- PASS: TestAccAWSVPCPeeringConnection_accept (61.32s)
--- PASS: TestAccAWSVPCPeeringConnection_tags (62.79s)
```