### PR TITLE
tests/provider: Fix and enable AWS SDK Go pointer conversion linting (T-W resources)

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -68,9 +68,6 @@ rules:
         - aws/resource_aws_o*
         - aws/resource_aws_r*
         - aws/resource_aws_s*
-        - aws/resource_aws_transfer_ssh_key.go
-        - aws/resource_aws_vpc.go
-        - aws/resource_aws_w*
         - aws/structure.go
         - aws/waf_helpers.go
         - aws/internal/generators/
@@ -106,9 +103,6 @@ rules:
         - aws/resource_aws_o*.go
         - aws/resource_aws_r*.go
         - aws/resource_aws_s*.go
-        - aws/resource_aws_transfer_ssh_key.go
-        - aws/resource_aws_v*.go
-        - aws/resource_aws_w*
         - aws/resource*_test.go
         - aws/structure.go
         - aws/internal/generators/

--- a/aws/resource_aws_transfer_ssh_key.go
+++ b/aws/resource_aws_transfer_ssh_key.go
@@ -97,8 +97,8 @@ func resourceAwsTransferSshKeyRead(d *schema.ResourceData, meta interface{}) err
 
 	var body string
 	for _, s := range resp.User.SshPublicKeys {
-		if sshKeyID == *s.SshPublicKeyId {
-			body = *s.SshPublicKeyBody
+		if sshKeyID == aws.StringValue(s.SshPublicKeyId) {
+			body = aws.StringValue(s.SshPublicKeyBody)
 		}
 	}
 

--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -176,8 +176,8 @@ func volumeAttachmentStateRefreshFunc(conn *ec2.EC2, name, volumeID, instanceID 
 		if len(resp.Volumes) > 0 {
 			v := resp.Volumes[0]
 			for _, a := range v.Attachments {
-				if a.InstanceId != nil && *a.InstanceId == instanceID {
-					return a, *a.State, nil
+				if aws.StringValue(a.InstanceId) == instanceID {
+					return a, aws.StringValue(a.State), nil
 				}
 			}
 		}
@@ -212,7 +212,7 @@ func resourceAwsVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error reading EC2 volume %s for instance: %s: %#v", d.Get("volume_id").(string), d.Get("instance_id").(string), err)
 	}
 
-	if len(vols.Volumes) == 0 || *vols.Volumes[0].State == ec2.VolumeStateAvailable {
+	if len(vols.Volumes) == 0 || aws.StringValue(vols.Volumes[0].State) == ec2.VolumeStateAvailable {
 		log.Printf("[DEBUG] Volume Attachment (%s) not found, removing from state", d.Id())
 		d.SetId("")
 	}

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -334,9 +334,9 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		classiclink_enabled := false
 		for _, v := range respClassiclink.Vpcs {
-			if *v.VpcId == vpcid {
+			if aws.StringValue(v.VpcId) == vpcid {
 				if v.ClassicLinkEnabled != nil {
-					classiclink_enabled = *v.ClassicLinkEnabled
+					classiclink_enabled = aws.BoolValue(v.ClassicLinkEnabled)
 				}
 				break
 			}
@@ -359,9 +359,9 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		classiclinkdns_enabled := false
 		for _, v := range respClassiclinkDnsSupport.Vpcs {
-			if *v.VpcId == vpcid {
+			if aws.StringValue(v.VpcId) == vpcid {
 				if v.ClassicLinkDnsSupported != nil {
-					classiclinkdns_enabled = *v.ClassicLinkDnsSupported
+					classiclinkdns_enabled = aws.BoolValue(v.ClassicLinkDnsSupported)
 				}
 				break
 			}

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -143,7 +143,7 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Account ID %s, VPC PeerConn Requester %s, Accepter %s",
 		client.accountid, *pc.RequesterVpcInfo.OwnerId, *pc.AccepterVpcInfo.OwnerId)
 
-	if (client.accountid == *pc.AccepterVpcInfo.OwnerId) && (client.accountid != *pc.RequesterVpcInfo.OwnerId) {
+	if (client.accountid == aws.StringValue(pc.AccepterVpcInfo.OwnerId)) && (client.accountid != aws.StringValue(pc.RequesterVpcInfo.OwnerId)) {
 		// We're the accepter
 		d.Set("peer_owner_id", pc.RequesterVpcInfo.OwnerId)
 		d.Set("peer_vpc_id", pc.RequesterVpcInfo.VpcId)

--- a/aws/resource_aws_vpn_connection_route.go
+++ b/aws/resource_aws_vpn_connection_route.go
@@ -155,7 +155,7 @@ func findConnectionRoute(conn *ec2.EC2, cidrBlock, vpnConnectionId string) (*ec2
 	vpnConnection := resp.VpnConnections[0]
 
 	for _, r := range vpnConnection.Routes {
-		if *r.DestinationCidrBlock == cidrBlock && *r.State != "deleted" {
+		if aws.StringValue(r.DestinationCidrBlock) == cidrBlock && aws.StringValue(r.State) != "deleted" {
 			return r, nil
 		}
 	}

--- a/aws/resource_aws_vpn_gateway_route_propagation.go
+++ b/aws/resource_aws_vpn_gateway_route_propagation.go
@@ -87,7 +87,7 @@ func resourceAwsVpnGatewayRoutePropagationRead(d *schema.ResourceData, meta inte
 	rt := rtRaw.(*ec2.RouteTable)
 	exists := false
 	for _, vgw := range rt.PropagatingVgws {
-		if *vgw.GatewayId == gwID {
+		if aws.StringValue(vgw.GatewayId) == gwID {
 			exists = true
 		}
 	}

--- a/aws/resource_aws_waf_sql_injection_match_set.go
+++ b/aws/resource_aws_waf_sql_injection_match_set.go
@@ -176,7 +176,7 @@ func flattenWafSqlInjectionMatchTuples(ts []*waf.SqlInjectionMatchTuple) []inter
 	out := make([]interface{}, len(ts))
 	for i, t := range ts {
 		m := make(map[string]interface{})
-		m["text_transformation"] = *t.TextTransformation
+		m["text_transformation"] = aws.StringValue(t.TextTransformation)
 		m["field_to_match"] = flattenFieldToMatch(t.FieldToMatch)
 		out[i] = m
 	}

--- a/aws/resource_aws_wafregional_rule.go
+++ b/aws/resource_aws_wafregional_rule.go
@@ -225,9 +225,9 @@ func flattenWafPredicates(ts []*waf.Predicate) []interface{} {
 	out := make([]interface{}, len(ts))
 	for i, p := range ts {
 		m := make(map[string]interface{})
-		m["negated"] = *p.Negated
-		m["type"] = *p.Type
-		m["data_id"] = *p.DataId
+		m["negated"] = aws.BoolValue(p.Negated)
+		m["type"] = aws.StringValue(p.Type)
+		m["data_id"] = aws.StringValue(p.DataId)
 		out[i] = m
 	}
 	return out

--- a/aws/resource_aws_workspaces_ip_group.go
+++ b/aws/resource_aws_workspaces_ip_group.go
@@ -212,12 +212,16 @@ func expandIpGroupRules(rules []interface{}) []*workspaces.IpRuleItem {
 func flattenIpGroupRules(rules []*workspaces.IpRuleItem) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(rules))
 	for _, rule := range rules {
-		r := map[string]interface{}{
-			"source": *rule.IpRule,
+		r := map[string]interface{}{}
+
+		if v := rule.IpRule; v != nil {
+			r["source"] = aws.StringValue(v)
 		}
-		if rule.RuleDesc != nil {
-			r["description"] = *rule.RuleDesc
+
+		if v := rule.RuleDesc; v != nil {
+			r["description"] = aws.StringValue(rule.RuleDesc)
 		}
+
 		result = append(result, r)
 	}
 	return result


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12992

Previously:

```
aws/resource_aws_transfer_ssh_key.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
101:			body = *s.SshPublicKeyBody
--------------------------------------------------------------------------------
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
100:		if sshKeyID == *s.SshPublicKeyId {

aws/resource_aws_volume_attachment.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
179:				if a.InstanceId != nil && *a.InstanceId == instanceID {
--------------------------------------------------------------------------------
215:	if len(vols.Volumes) == 0 || *vols.Volumes[0].State == ec2.VolumeStateAvailable {

aws/resource_aws_vpc.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
339:					classiclink_enabled = *v.ClassicLinkEnabled
--------------------------------------------------------------------------------
364:					classiclinkdns_enabled = *v.ClassicLinkDnsSupported
--------------------------------------------------------------------------------
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
337:			if *v.VpcId == vpcid {
--------------------------------------------------------------------------------
362:			if *v.VpcId == vpcid {

aws/resource_aws_vpc_peering_connection.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
146:	if (client.accountid == *pc.AccepterVpcInfo.OwnerId) && (client.accountid != *pc.RequesterVpcInfo.OwnerId) {
--------------------------------------------------------------------------------
146:	if (client.accountid == *pc.AccepterVpcInfo.OwnerId) && (client.accountid != *pc.RequesterVpcInfo.OwnerId) {

aws/resource_aws_vpn_connection_route.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
158:		if *r.DestinationCidrBlock == cidrBlock && *r.State != "deleted" {
--------------------------------------------------------------------------------
158:		if *r.DestinationCidrBlock == cidrBlock && *r.State != "deleted" {

aws/resource_aws_vpn_gateway_route_propagation.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-conditional: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
90:		if *vgw.GatewayId == gwID {

aws/resource_aws_waf_sql_injection_match_set.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
179:		m["text_transformation"] = *t.TextTransformation

aws/resource_aws_wafregional_rule.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
228:		m["negated"] = *p.Negated
--------------------------------------------------------------------------------
229:		m["type"] = *p.Type
--------------------------------------------------------------------------------
230:		m["data_id"] = *p.DataId

aws/resource_aws_workspaces_ip_group.go
severity:warning rule:prefer-aws-go-sdk-pointer-conversion-assignment: Prefer AWS Go SDK pointer conversion functions for dereferencing during assignment, e.g. aws.StringValue()
219:			r["description"] = *rule.RuleDesc
ran 15 rules on 2163 files: 18 findings
```

Output from acceptance testing:

```
--- PASS: TestAccAWSTransferSshKey_basic (172.65s)

--- PASS: TestAccAWSVolumeAttachment_attachStopped (379.45s)
--- PASS: TestAccAWSVolumeAttachment_basic (137.33s)
--- PASS: TestAccAWSVolumeAttachment_disappears (127.64s)
--- PASS: TestAccAWSVolumeAttachment_skipDestroy (106.70s)
--- PASS: TestAccAWSVolumeAttachment_update (117.94s)

--- PASS: TestAccAWSVpc_AssignGeneratedIpv6CidrBlock (96.85s)
--- PASS: TestAccAWSVpc_basic (35.87s)
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (45.41s)
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (39.09s)
--- PASS: TestAccAWSVpc_classiclinkOptionSet (38.76s)
--- PASS: TestAccAWSVpc_coreMismatchedDiffs (30.39s)
--- PASS: TestAccAWSVpc_defaultAndIgnoreTags (69.04s)
--- PASS: TestAccAWSVpc_defaultTags_providerAndResource_duplicateTag (5.12s)
--- PASS: TestAccAWSVpc_defaultTags_providerAndResource_nonOverlappingTag (74.60s)
--- PASS: TestAccAWSVpc_defaultTags_providerAndResource_overlappingTag (77.40s)
--- PASS: TestAccAWSVpc_defaultTags_providerOnly (74.67s)
--- PASS: TestAccAWSVpc_defaultTags_updateToProviderOnly (53.56s)
--- PASS: TestAccAWSVpc_defaultTags_updateToResourceOnly (54.07s)
--- PASS: TestAccAWSVpc_DisabledDnsSupport (44.39s)
--- PASS: TestAccAWSVpc_disappears (21.95s)
--- PASS: TestAccAWSVpc_ignoreTags (69.04s)
--- PASS: TestAccAWSVpc_tags (79.06s)
--- PASS: TestAccAWSVpc_Tenancy (77.06s)
--- PASS: TestAccAWSVpc_update (58.54s)

--- FAIL: TestAccAWSVPCPeeringConnection_region (39.86s) # https://github.com/hashicorp/terraform-provider-aws/issues/18348
--- PASS: TestAccAWSVPCPeeringConnection_accept (81.01s)
--- PASS: TestAccAWSVPCPeeringConnection_basic (43.58s)
--- PASS: TestAccAWSVPCPeeringConnection_failedState (18.09s)
--- PASS: TestAccAWSVPCPeeringConnection_options (78.71s)
--- PASS: TestAccAWSVPCPeeringConnection_optionsNoAutoAccept (30.00s)
--- PASS: TestAccAWSVPCPeeringConnection_peerRegionAutoAccept (16.39s)
--- PASS: TestAccAWSVPCPeeringConnection_plan (31.03s)
--- PASS: TestAccAWSVPCPeeringConnection_tags (85.86s)

--- PASS: TestAccAWSVpnConnectionRoute_basic (457.75s)

--- PASS: TestAccAWSVPNGatewayRoutePropagation_basic (55.88s)

--- PASS: TestAccAWSWafRegionalRule_basic (61.65s)
--- PASS: TestAccAWSWafRegionalRule_changeNameForceNew (107.77s)
--- PASS: TestAccAWSWafRegionalRule_changePredicates (103.24s)
--- PASS: TestAccAWSWafRegionalRule_disappears (64.90s)
--- PASS: TestAccAWSWafRegionalRule_noPredicates (44.78s)
--- PASS: TestAccAWSWafRegionalRule_tags (97.70s)

--- PASS: TestAccAWSWafSqlInjectionMatchSet_basic (21.90s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew (38.62s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeTuples (35.26s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_disappears (16.76s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_noTuples (20.81s)

--- FAIL: TestAccAwsWorkspacesIpGroup_MultipleDirectories (612.05s) # https://github.com/hashicorp/terraform-provider-aws/issues/18352
--- PASS: TestAccAwsWorkspacesIpGroup_basic (44.84s)
--- PASS: TestAccAwsWorkspacesIpGroup_disappears (24.70s)
--- PASS: TestAccAwsWorkspacesIpGroup_tags (69.57s)
```
