### PR TITLE
Support AWS account IDs as valid lakeformation principals

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -667,6 +667,14 @@ func validatePrincipal(v interface{}, k string) (ws []string, errors []error) {
 		return ws, errors
 	}
 
+	// https://docs.aws.amazon.com/lake-formation/latest/dg/lf-permissions-reference.html
+	// Principal is an AWS account
+	// --principal DataLakePrincipalIdentifier=111122223333
+	wsAccount, errorsAccount := validateAwsAccountId(v, k)
+	if len(errorsAccount) == 0 {
+		return wsAccount, errorsAccount
+	}
+
 	wsARN, errorsARN := validateArn(v, k)
 	ws = append(ws, wsARN...)
 	errors = append(errors, errorsARN...)
@@ -674,6 +682,10 @@ func validatePrincipal(v interface{}, k string) (ws []string, errors []error) {
 	pattern := `\d{12}:(role|user)/`
 	if !regexp.MustCompile(pattern).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q doesn't look like a user or role: %q", k, value))
+	}
+
+	if len(errors) > 0 {
+		errors = append(errors, errorsAccount...)
 	}
 
 	return ws, errors

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -368,6 +368,7 @@ func TestValidatePrincipal(t *testing.T) {
 
 	validNames := []string{
 		"IAM_ALLOWED_PRINCIPALS", // Special principal
+		"123456789012",           //Account ID
 		"arn:aws-us-gov:iam::357342307427:role/tf-acc-test-3217321001347236965",          // lintignore:AWSAT005          // IAM Role
 		"arn:aws:iam::123456789012:user/David",                                           // lintignore:AWSAT005          // IAM User
 		"arn:aws-us-gov:iam:us-west-2:357342307427:role/tf-acc-test-3217321001347236965", // lintignore:AWSAT003,AWSAT005 // Non-global IAM Role?
@@ -383,7 +384,6 @@ func TestValidatePrincipal(t *testing.T) {
 	invalidNames := []string{
 		"IAM_NOT_ALLOWED_PRINCIPALS", // doesn't exist
 		"arn",
-		"123456789012",
 		"arn:aws",
 		"arn:aws:logs",            //lintignore:AWSAT005
 		"arn:aws:logs:region:*:*", //lintignore:AWSAT005

--- a/website/docs/r/lakeformation_permissions.html.markdown
+++ b/website/docs/r/lakeformation_permissions.html.markdown
@@ -46,7 +46,7 @@ resource "aws_lakeformation_permissions" "test" {
 The following arguments are required:
 
 * `permissions` – (Required) List of permissions granted to the principal. Valid values may include `ALL`, `ALTER`, `CREATE_DATABASE`, `CREATE_TABLE`, `DATA_LOCATION_ACCESS`, `DELETE`, `DESCRIBE`, `DROP`, `INSERT`, and `SELECT`. For details on each permission, see [Lake Formation Permissions Reference](https://docs.aws.amazon.com/lake-formation/latest/dg/lf-permissions-reference.html).
-* `principal` – (Required) Principal to be granted the permissions on the resource. Supported principals include IAM users and IAM roles.
+* `principal` – (Required) Principal to be granted the permissions on the resource. Supported principals include IAM users and IAM roles as well as AWS account IDs for cross-account permissions.
 
 One of the following is required:
 


### PR DESCRIPTION
Lake Formation permissions supports granting permissions on a account basis if resources are shared across accounts.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
