### PR TITLE
Add Semgrep rule to warn on calling 'd.SetId()' in a resource create or delete function

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -650,7 +650,7 @@ rules:
     severity: ERROR
     fix: "aws.Int64($X)"
 
-- id: calling-SetId-with-empty-string-in-resource-create
+  - id: calling-SetId-with-empty-string-in-resource-create
     languages: [go]
     message: Do not call `d.SetId("")` inside a resource create function
     paths:
@@ -667,9 +667,9 @@ rules:
           regex: "^resource\\w*(Create|Put|Set|Upsert|Enable)$"
     severity: WARNING
 
-  - id: calling-SetId-in-resource-update-or-delete
+  - id: calling-SetId-in-resource-delete
     languages: [go]
-    message: Do not call `d.SetId(...)` inside a resource update or delete function
+    message: Do not call `d.SetId(...)` inside a resource delete function
     paths:
       include:
         - internal/service/
@@ -681,5 +681,5 @@ rules:
           }
       - metavariable-regex:
           metavariable: "$FUNC"
-          regex: "^resource\\w*(Update|Delete|Disable)$"
+          regex: "^resource\\w*(Delete|Disable)$"
     severity: WARNING

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -649,3 +649,37 @@ rules:
           regex: (\d+)
     severity: ERROR
     fix: "aws.Int64($X)"
+
+- id: calling-SetId-with-empty-string-in-resource-create
+    languages: [go]
+    message: Do not call `d.SetId("")` inside a resource create function
+    paths:
+      include:
+        - internal/service/
+    patterns:
+      - pattern: |
+          func $FUNC(...) {
+            ...
+            d.SetId("")
+          }
+      - metavariable-regex:
+          metavariable: "$FUNC"
+          regex: "^resource\\w*(Create|Put|Set|Upsert|Enable)$"
+    severity: WARNING
+
+  - id: calling-SetId-in-resource-update-or-delete
+    languages: [go]
+    message: Do not call `d.SetId(...)` inside a resource update or delete function
+    paths:
+      include:
+        - internal/service/
+    patterns:
+      - pattern: |
+          func $FUNC(...) {
+            ...
+            d.SetId(...)
+          }
+      - metavariable-regex:
+          metavariable: "$FUNC"
+          regex: "^resource\\w*(Update|Delete|Disable)$"
+    severity: WARNING

--- a/internal/service/ec2/fleet.go
+++ b/internal/service/ec2/fleet.go
@@ -340,24 +340,24 @@ func resourceFleetCreate(d *schema.ResourceData, meta interface{}) error {
 		OnDemandOptions:                  expandEc2OnDemandOptionsRequest(d.Get("on_demand_options").([]interface{})),
 		ReplaceUnhealthyInstances:        aws.Bool(d.Get("replace_unhealthy_instances").(bool)),
 		SpotOptions:                      expandEc2SpotOptionsRequest(d.Get("spot_options").([]interface{})),
+		TagSpecifications:                ec2TagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeFleet),
 		TargetCapacitySpecification:      expandEc2TargetCapacitySpecificationRequest(d.Get("target_capacity_specification").([]interface{})),
 		TerminateInstancesWithExpiration: aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
-		TagSpecifications:                ec2TagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeFleet),
 		Type:                             aws.String(d.Get("type").(string)),
 	}
 
 	if d.Get("type").(string) != ec2.FleetTypeMaintain {
 		if input.SpotOptions.MaintenanceStrategies != nil {
 			log.Printf("[WARN] EC2 Fleet (%s) has an invalid configuration and can not be created. Capacity Rebalance maintenance strategies can only be specified for fleets of type maintain.", input)
-			d.SetId("")
 			return nil
 		}
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Fleet: %s", input)
 	output, err := conn.CreateFleet(input)
+
 	if err != nil {
-		return fmt.Errorf("error creating EC2 Fleet: %s", err)
+		return fmt.Errorf("error creating EC2 Fleet: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.FleetId))

--- a/internal/service/ec2/spot_fleet_request.go
+++ b/internal/service/ec2/spot_fleet_request.go
@@ -982,7 +982,6 @@ func resourceSpotFleetRequestCreate(d *schema.ResourceData, meta interface{}) er
 	if d.Get("fleet_type").(string) != ec2.FleetTypeMaintain {
 		if spotFleetConfig.SpotMaintenanceStrategies != nil {
 			log.Printf("[WARN] Spot Fleet (%s) has an invalid configuration and can not be requested. Capacity Rebalance maintenance strategies can only be specified for spot fleets of type maintain.", spotFleetConfig)
-			d.SetId("")
 			return nil
 		}
 	}
@@ -1048,19 +1047,19 @@ func resourceSpotFleetRequestCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2.html#type-RequestSpotFleetInput
-	spotFleetOpts := &ec2.RequestSpotFleetInput{
+	input := &ec2.RequestSpotFleetInput{
 		SpotFleetRequestConfig: spotFleetConfig,
 		DryRun:                 aws.Bool(false),
 	}
 
-	log.Printf("[DEBUG] Requesting spot fleet with these opts: %+v", spotFleetOpts)
+	log.Printf("[DEBUG] Creating Spot Fleet Request: %s", input)
 
 	// Since IAM is eventually consistent, we retry creation as a newly created role may not
 	// take effect immediately, resulting in an InvalidSpotFleetRequestConfig error
-	var resp *ec2.RequestSpotFleetOutput
+	var output *ec2.RequestSpotFleetOutput
 	err := resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
 		var err error
-		resp, err = conn.RequestSpotFleet(spotFleetOpts)
+		output, err = conn.RequestSpotFleet(input)
 
 		if tfawserr.ErrMessageContains(err, "InvalidSpotFleetRequestConfig", "Parameter: SpotFleetRequestConfig.IamFleetRole is invalid") {
 			return resource.RetryableError(err)
@@ -1078,14 +1077,14 @@ func resourceSpotFleetRequestCreate(d *schema.ResourceData, meta interface{}) er
 	})
 
 	if tfresource.TimedOut(err) {
-		resp, err = conn.RequestSpotFleet(spotFleetOpts)
+		output, err = conn.RequestSpotFleet(input)
 	}
 
 	if err != nil {
 		return fmt.Errorf("Error requesting spot fleet: %w", err)
 	}
 
-	d.SetId(aws.StringValue(resp.SpotFleetRequestId))
+	d.SetId(aws.StringValue(output.SpotFleetRequestId))
 
 	log.Printf("[INFO] Spot Fleet Request ID: %s", d.Id())
 	log.Println("[INFO] Waiting for Spot Fleet Request to be active")

--- a/internal/service/sns/topic_subscription.go
+++ b/internal/service/sns/topic_subscription.go
@@ -240,7 +240,6 @@ func resourceTopicSubscriptionDelete(d *schema.ResourceData, meta interface{}) e
 	})
 
 	if tfawserr.ErrMessageContains(err, sns.ErrCodeInvalidParameterException, "Cannot unsubscribe a subscription that is pending confirmation") {
-		log.Printf("[WARN] Removing unconfirmed SNS Topic Subscription (%s) from Terraform state but failed to remove it from AWS!", d.Id())
 		return nil
 	}
 

--- a/internal/service/wafregional/regex_match_set.go
+++ b/internal/service/wafregional/regex_match_set.go
@@ -143,13 +143,13 @@ func resourceRegexMatchSetDelete(d *schema.ResourceData, meta interface{}) error
 	region := meta.(*conns.AWSClient).Region
 
 	err := DeleteRegexMatchSetResource(conn, region, "global", d.Id(), getRegexMatchTuplesFromResourceData(d))
+
 	if tfawserr.ErrCodeEquals(err, wafregional.ErrCodeWAFNonexistentItemException) {
-		log.Printf("[WARN] WAF Regional Regex Match Set (%s) not found, removing from state", d.Id())
-		d.SetId("")
 		return nil
 	}
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting WAF Regional Regex Match Set (%s): %w", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12796.
Relates #18382.
Relates #18390.

Warns if `d.SetId("")` is called in a resource's `Create` function or `d.SetId(...)` is called in a resource's `Delete` function.

```console
% make testacc TESTS=TestAccCloudFormationStack_basic PKG=cloudformation
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudformation/... -v -count 1 -parallel 20 -run='TestAccCloudFormationStack_basic'  -timeout 180m
=== RUN   TestAccCloudFormationStack_basic
=== PAUSE TestAccCloudFormationStack_basic
=== CONT  TestAccCloudFormationStack_basic
--- PASS: TestAccCloudFormationStack_basic (58.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	62.549s
% make testacc TESTS=TestAccEC2Fleet_basic PKG=ec2                      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Fleet_basic'  -timeout 180m
=== RUN   TestAccEC2Fleet_basic
=== PAUSE TestAccEC2Fleet_basic
=== CONT  TestAccEC2Fleet_basic
--- PASS: TestAccEC2Fleet_basic (58.07s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	65.831s
% make testacc TESTS=TestAccEC2SpotFleetRequest_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2SpotFleetRequest_basic'  -timeout 180m
=== RUN   TestAccEC2SpotFleetRequest_basic
=== PAUSE TestAccEC2SpotFleetRequest_basic
=== CONT  TestAccEC2SpotFleetRequest_basic
--- PASS: TestAccEC2SpotFleetRequest_basic (142.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	145.979s
% make testacc TESTS=TestAccNeptuneEventSubscription_basic PKG=neptune
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/neptune/... -v -count 1 -parallel 20 -run='TestAccNeptuneEventSubscription_basic'  -timeout 180m
=== RUN   TestAccNeptuneEventSubscription_basic
=== PAUSE TestAccNeptuneEventSubscription_basic
=== CONT  TestAccNeptuneEventSubscription_basic
--- PASS: TestAccNeptuneEventSubscription_basic (130.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/neptune	135.190s
% make testacc TESTS=TestAccRedshiftSnapshotScheduleAssociation_basic PKG=redshift
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshift/... -v -count 1 -parallel 20 -run='TestAccRedshiftSnapshotScheduleAssociation_basic'  -timeout 180m
=== RUN   TestAccRedshiftSnapshotScheduleAssociation_basic
=== PAUSE TestAccRedshiftSnapshotScheduleAssociation_basic
=== CONT  TestAccRedshiftSnapshotScheduleAssociation_basic
--- PASS: TestAccRedshiftSnapshotScheduleAssociation_basic (260.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	265.418s
% make testacc TESTS=TestAccSNSTopicSubscription_basic PKG=sns            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sns/... -v -count 1 -parallel 20 -run='TestAccSNSTopicSubscription_basic'  -timeout 180m
=== RUN   TestAccSNSTopicSubscription_basic
=== PAUSE TestAccSNSTopicSubscription_basic
=== CONT  TestAccSNSTopicSubscription_basic
--- PASS: TestAccSNSTopicSubscription_basic (101.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	104.894s
% make testacc TESTS=TestAccWAFRegionalRegexMatchSet_serial/basic PKG=wafregional
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafregional/... -v -count 1 -parallel 20 -run='TestAccWAFRegionalRegexMatchSet_serial/basic'  -timeout 180m
=== RUN   TestAccWAFRegionalRegexMatchSet_serial
=== RUN   TestAccWAFRegionalRegexMatchSet_serial/basic
--- PASS: TestAccWAFRegionalRegexMatchSet_serial (25.20s)
    --- PASS: TestAccWAFRegionalRegexMatchSet_serial/basic (25.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafregional	28.857s
```