### PR TITLE
r/aws_api_gateway_vpc_link: Persist ID of newly created VPC Link when it fails to reach Available state

### DIFF
--- a/.changelog/18382.txt
+++ b/.changelog/18382.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_vpc_link: Persist ID of failed VPC Link to state
+```

--- a/aws/resource_aws_api_gateway_vpc_link.go
+++ b/aws/resource_aws_api_gateway_vpc_link.go
@@ -86,8 +86,7 @@ func resourceAwsApiGatewayVpcLinkCreate(d *schema.ResourceData, meta interface{}
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		d.SetId("")
-		return fmt.Errorf("Error waiting for APIGateway Vpc Link status to be \"%s\": %s", apigateway.VpcLinkStatusAvailable, err)
+		return fmt.Errorf("error waiting for APIGateway Vpc Link status to be \"%s\": %w", apigateway.VpcLinkStatusAvailable, err)
 	}
 
 	return resourceAwsApiGatewayVpcLinkRead(d, meta)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #12796.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayVpcLink_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayVpcLink_basic -timeout 180m
=== RUN   TestAccAWSAPIGatewayVpcLink_basic
=== PAUSE TestAccAWSAPIGatewayVpcLink_basic
=== CONT  TestAccAWSAPIGatewayVpcLink_basic
--- PASS: TestAccAWSAPIGatewayVpcLink_basic (750.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	750.547s
```