### PR TITLE
resource/aws_wafv2_web_acl_logging_configuration: remove incorrect deprecation warning for single_header argument

### DIFF
--- a/.changelog/18384.txt
+++ b/.changelog/18384.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/aws_wafv2_web_acl_logging_configuration: Remove deprecation warning for `redacted_fields` `single_header` argument
+```
+

--- a/aws/resource_aws_wafv2_web_acl_logging_configuration.go
+++ b/aws/resource_aws_wafv2_web_acl_logging_configuration.go
@@ -69,7 +69,6 @@ func resourceAwsWafv2WebACLLoggingConfiguration() *schema.Resource {
 											// Trying to solve it with StateFunc and/or DiffSuppressFunc resulted in hash problem of the rule field or didn't work.
 											validation.StringMatch(regexp.MustCompile(`^[a-z0-9-_]+$`), "must contain only lowercase alphanumeric characters, underscores, and hyphens"),
 										),
-										Deprecated: "Not supported by WAFv2 API",
 									},
 								},
 							},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18370 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```
