### PR TITLE
tests/provider: Support (helper/schema.Resource).DeleteWithoutTimeout in testAccCheckResourceDisappears

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1018,8 +1018,14 @@ func testAccCheckResourceDisappears(provider *schema.Provider, resource *schema.
 			return fmt.Errorf("resource ID missing: %s", resourceName)
 		}
 
-		if resource.DeleteContext != nil {
-			diags := resource.DeleteContext(context.Background(), resource.Data(resourceState.Primary), provider.Meta())
+		if resource.DeleteContext != nil || resource.DeleteWithoutTimeout != nil {
+			var diags diag.Diagnostics
+
+			if resource.DeleteContext != nil {
+				diags = resource.DeleteContext(context.Background(), resource.Data(resourceState.Primary), provider.Meta())
+			} else {
+				diags = resource.DeleteWithoutTimeout(context.Background(), resource.Data(resourceState.Primary), provider.Meta())
+			}
 
 			for i := range diags {
 				if diags[i].Severity == diag.Error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15090

Output from acceptance testing:

```
# Existing Delete
--- PASS: TestAccAWSXrayGroup_disappears (15.90s)

# Existing DeleteContext
--- PASS: TestAccAWSAMPWorkspace_disappears (13.63s)
```
