### PR TITLE
Add fail_on_warnings parameter in apigatewayv2

### DIFF
--- a/aws/resource_aws_apigatewayv2_api.go
+++ b/aws/resource_aws_apigatewayv2_api.go
@@ -97,6 +97,10 @@ func resourceAwsApiGatewayV2Api() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"fail_on_warnings": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"execution_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -158,6 +162,10 @@ func resourceAwsAPIGatewayV2ImportOpenAPI(d *schema.ResourceData, meta interface
 		importReq := &apigatewayv2.ReimportApiInput{
 			ApiId: aws.String(d.Id()),
 			Body:  aws.String(body.(string)),
+		}
+
+		if value, ok := d.GetOk("fail_on_warnings"); ok {
+			importReq.FailOnWarnings = aws.Bool(value.(bool))
 		}
 
 		_, err := conn.ReimportApi(importReq)
@@ -322,7 +330,9 @@ func resourceAwsApiGatewayV2ApiUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	if d.HasChanges("api_key_selection_expression", "description", "disable_execute_api_endpoint", "name", "route_selection_expression", "version") ||
+	if d.HasChanges(
+		"api_key_selection_expression", "description", "disable_execute_api_endpoint",
+		"name", "route_selection_expression", "version") ||
 		(d.HasChange("cors_configuration") && !deleteCorsConfiguration) {
 		req := &apigatewayv2.UpdateApiInput{
 			ApiId: aws.String(d.Id()),

--- a/aws/resource_aws_apigatewayv2_api.go
+++ b/aws/resource_aws_apigatewayv2_api.go
@@ -330,9 +330,7 @@ func resourceAwsApiGatewayV2ApiUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	if d.HasChanges(
-		"api_key_selection_expression", "description", "disable_execute_api_endpoint",
-		"name", "route_selection_expression", "version") ||
+	if d.HasChanges("api_key_selection_expression", "description", "disable_execute_api_endpoint", "name", "route_selection_expression", "version") ||
 		(d.HasChange("cors_configuration") && !deleteCorsConfiguration) {
 		req := &apigatewayv2.UpdateApiInput{
 			ApiId: aws.String(d.Id()),

--- a/aws/resource_aws_apigatewayv2_api_test.go
+++ b/aws/resource_aws_apigatewayv2_api_test.go
@@ -556,6 +556,7 @@ func TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					resource.TestCheckResourceAttr(resourceName, "fail_on_warnings", "false"),
 					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /update"}),
 				),
 			},
@@ -563,7 +564,7 @@ func TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"body"},
+				ImportStateVerifyIgnore: []string{"body", "fail_on_warnings"},
 			},
 			// fail_on_warnings should be optional and false by default
 			{
@@ -579,7 +580,7 @@ func TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"body"},
+				ImportStateVerifyIgnore: []string{"body", "fail_on_warnings"},
 			},
 		},
 	})

--- a/aws/resource_aws_apigatewayv2_api_test.go
+++ b/aws/resource_aws_apigatewayv2_api_test.go
@@ -533,6 +533,58 @@ func TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings(t *testing.T) {
+	var v apigatewayv2.GetApiOutput
+	resourceName := "aws_apigatewayv2_api.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, apigatewayv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2ApiDestroy,
+		Steps: []resource.TestStep{
+			// Invalid body should not be accepted when fail_on_warnings is enabled
+			{
+				Config:      testAccAWSAPIGatewayV2ApiConfig_FailOnWarnings(rName, "fail_on_warnings = true"),
+				ExpectError: regexp.MustCompile(`BadRequestException: Warnings found during import`),
+			},
+			// Warnings do not break the deployment when fail_on_warnings is disabled
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_FailOnWarnings(rName, "fail_on_warnings = false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /update"}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"body"},
+			},
+			// fail_on_warnings should be optional and false by default
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_FailOnWarnings(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /update"}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"body"},
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAPIGatewayV2ApiRoutes(v *apigatewayv2.GetApiOutput, routes []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
@@ -1274,4 +1326,48 @@ resource "aws_apigatewayv2_api" "test" {
 EOF
 }
 `, rName, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_FailOnWarnings(rName string, failOnWarnings string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+  body          = <<EOF
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Title test",
+    "version": "2.0",
+    "description": "Description test"
+  },
+  "paths": {
+    "/update": {
+      "get": {
+        "x-amazon-apigateway-integration": {
+          "type": "HTTP_PROXY",
+          "httpMethod": "GET",
+          "payloadFormatVersion": "1.0",
+          "uri": "https://www.google.de"
+        },
+        "responses": {
+          "200": {
+            "description": "Response description",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelThatDoesNotExist"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+  %[2]s
+}
+`, rName, failOnWarnings)
 }

--- a/website/docs/r/apigatewayv2_api.html.markdown
+++ b/website/docs/r/apigatewayv2_api.html.markdown
@@ -57,6 +57,7 @@ For HTTP integrations, specify a fully qualified URL. For Lambda integrations, s
 The type of the integration will be `HTTP_PROXY` or `AWS_PROXY`, respectively. Applicable for HTTP APIs.
 * `body` - (Optional) An OpenAPI specification that defines the set of routes and integrations to create as part of the HTTP APIs. Supported only for HTTP APIs.
 * `version` - (Optional) A version identifier for the API. Must be between 1 and 64 characters in length.
+* `fail_on_warnings` - (Optional) Whether warnings should return an error while API Gateway is creating or updating the resource. Defaults to `false`
 
 __Note__: If the `body` argument is provided, the OpenAPI specification will be used to configure the integrations and route for the HTTP API. If this argument is provided, the following resources should not be managed as separate ones, as updates may cause manual resource updates to be overwritten:
 

--- a/website/docs/r/apigatewayv2_api.html.markdown
+++ b/website/docs/r/apigatewayv2_api.html.markdown
@@ -57,7 +57,7 @@ For HTTP integrations, specify a fully qualified URL. For Lambda integrations, s
 The type of the integration will be `HTTP_PROXY` or `AWS_PROXY`, respectively. Applicable for HTTP APIs.
 * `body` - (Optional) An OpenAPI specification that defines the set of routes and integrations to create as part of the HTTP APIs. Supported only for HTTP APIs.
 * `version` - (Optional) A version identifier for the API. Must be between 1 and 64 characters in length.
-* `fail_on_warnings` - (Optional) Whether warnings should return an error while API Gateway is creating or updating the resource. Defaults to `false`
+* `fail_on_warnings` - (Optional) Whether warnings should return an error while API Gateway is creating or updating the resource using an OpenAPI specification. Defaults to `false`. Applicable for HTTP APIs.
 
 __Note__: If the `body` argument is provided, the OpenAPI specification will be used to configure the integrations and route for the HTTP API. If this argument is provided, the following resources should not be managed as separate ones, as updates may cause manual resource updates to be overwritten:
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Relates OR Closes #17971
Please note that there is similar change for apigateway (not v2) in #18397 

Output from acceptance tests:
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings' ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 1 -run=TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings -timeout 180m
=== RUN   TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings
=== PAUSE TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings
=== CONT  TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings
--- PASS: TestAccAWSAPIGatewayV2Api_Openapi_FailOnWarnings (51.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	51.767s
```
