### PR TITLE
tests/resource/aws_iam_server_certificate: Add missing ErrorCheck

### DIFF
--- a/aws/resource_aws_iam_server_certificate_test.go
+++ b/aws/resource_aws_iam_server_certificate_test.go
@@ -153,6 +153,7 @@ func TestAccAWSIAMServerCertificate_name_prefix(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Previously:

```
aws/resource_aws_iam_server_certificate_test.go:154:36: XAT001: missing ErrorCheck
153
154		resource.ParallelTest(t, resource.TestCase{
155			PreCheck:     func() { testAccPreCheck(t) },
```

Output from acceptance testing:

```
--- PASS: TestAccAWSIAMServerCertificate_name_prefix (15.33s)
```
