### PR TITLE
service/iam: Handle read-after-create eventual consistency in IAM Role resources

### DIFF
--- a/.changelog/18435.txt
+++ b/.changelog/18435.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_iam_role: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_iam_role_policy: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_iam_role_policy_attachment: Handle read-after-create eventual consistency
+```

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsIamRole() *schema.Resource {
@@ -235,20 +236,40 @@ func resourceAwsIamRoleRead(d *schema.ResourceData, meta interface{}) error {
 		RoleName: aws.String(d.Id()),
 	}
 
-	getResp, err := iamconn.GetRole(request)
-	if err != nil {
-		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
-			log.Printf("[WARN] IAM Role %q not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
+	var getResp *iam.GetRoleOutput
+
+	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		getResp, err = iamconn.GetRole(request)
+
+		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+			return resource.RetryableError(err)
 		}
-		return fmt.Errorf("Error reading IAM Role %s: %s", d.Id(), err)
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		getResp, err = iamconn.GetRole(request)
+	}
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+		log.Printf("[WARN] IAM Role (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading IAM Role (%s): %w", d.Id(), err)
 	}
 
 	if getResp == nil || getResp.Role == nil {
-		log.Printf("[WARN] IAM Role %q not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
+		return fmt.Errorf("error reading IAM Role (%s): empty response", d.Id())
 	}
 
 	role := getResp.Role


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12127
Closes #16247
Closes #18457
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16796

Output from acceptance testing in AWS Commerical:

```
--- PASS: TestAccAWSIAMRole_badJSON (11.02s)
--- PASS: TestAccAWSIAMRole_basic (23.54s)
--- PASS: TestAccAWSIAMRole_basicWithDescription (53.20s)
--- PASS: TestAccAWSIAMRole_disappears (46.04s)
--- PASS: TestAccAWSIAMRole_force_detach_policies (51.73s)
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (87.07s)
--- PASS: TestAccAWSIAMRole_namePrefix (24.63s)
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (124.99s)
--- PASS: TestAccAWSIAMRole_policyBasicInline (100.26s)
--- PASS: TestAccAWSIAMRole_policyBasicInlineEmpty (49.13s)
--- PASS: TestAccAWSIAMRole_policyBasicManaged (97.33s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionIgnored_inlineNonExistent (94.08s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionIgnored_managedNonExistent (74.63s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_inlineEmpty (76.32s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_inlineNonEmpty (79.85s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_managedEmpty (76.09s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_managedNonEmpty (77.20s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandRemovalAddedBack_inlineNonEmpty (77.85s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandRemovalAddedBack_managedNonEmpty (77.66s)
--- PASS: TestAccAWSIAMRole_tags (80.65s)
--- PASS: TestAccAWSIAMRole_testNameChange (82.60s)

--- PASS: TestAccAWSIAMRolePolicy_basic (49.38s)
--- PASS: TestAccAWSIAMRolePolicy_disappears (46.58s)
--- PASS: TestAccAWSIAMRolePolicy_generatedName (67.85s)
--- PASS: TestAccAWSIAMRolePolicy_invalidJSON (4.22s)
--- PASS: TestAccAWSIAMRolePolicy_namePrefix (56.10s)
--- PASS: TestAccAWSIAMRolePolicy_Policy_InvalidResource (26.78s)

--- PASS: TestAccAWSRolePolicyAttachment_basic (81.14s)
--- PASS: TestAccAWSRolePolicyAttachment_disappears (28.61s)
--- PASS: TestAccAWSRolePolicyAttachment_disappears_Role (32.83s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSIAMRole_badJSON (15.80s)
--- PASS: TestAccAWSIAMRole_basic (56.37s)
--- PASS: TestAccAWSIAMRole_basicWithDescription (117.55s)
--- PASS: TestAccAWSIAMRole_disappears (32.81s)
--- PASS: TestAccAWSIAMRole_force_detach_policies (65.18s)
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (88.44s)
--- PASS: TestAccAWSIAMRole_namePrefix (56.26s)
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (135.60s)
--- PASS: TestAccAWSIAMRole_policyBasicInline (98.21s)
--- PASS: TestAccAWSIAMRole_policyBasicInlineEmpty (39.47s)
--- PASS: TestAccAWSIAMRole_policyBasicManaged (98.71s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionIgnored_inlineNonExistent (112.38s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionIgnored_managedNonExistent (82.67s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_inlineEmpty (76.48s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_inlineNonEmpty (85.73s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_managedEmpty (84.34s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_managedNonEmpty (86.56s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandRemovalAddedBack_inlineNonEmpty (66.74s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandRemovalAddedBack_managedNonEmpty (74.49s)
--- PASS: TestAccAWSIAMRole_tags (74.03s)
--- PASS: TestAccAWSIAMRole_testNameChange (93.57s)

--- PASS: TestAccAWSIAMRolePolicy_basic (78.62s)
--- PASS: TestAccAWSIAMRolePolicy_disappears (35.25s)
--- PASS: TestAccAWSIAMRolePolicy_generatedName (100.35s)
--- PASS: TestAccAWSIAMRolePolicy_invalidJSON (9.46s)
--- PASS: TestAccAWSIAMRolePolicy_namePrefix (84.49s)
--- PASS: TestAccAWSIAMRolePolicy_Policy_InvalidResource (27.87s)

--- PASS: TestAccAWSRolePolicyAttachment_basic (88.63s)
--- PASS: TestAccAWSRolePolicyAttachment_disappears (32.95s)
--- PASS: TestAccAWSRolePolicyAttachment_disappears_Role (43.69s)
```
