### PR TITLE
Add data source for Kinesis Firehose Delivery Stream.

### DIFF
--- a/.changelog/18445.txt
+++ b/.changelog/18445.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_kinesis_firehose_delivery_stream
+```

--- a/aws/data_source_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/data_source_aws_kinesis_firehose_delivery_stream.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsKinesisFirehoseDeliveryStreamRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsKinesisFirehoseDeliveryStreamRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).firehoseconn
+	sn := d.Get("name").(string)
+	params := &firehose.DescribeDeliveryStreamInput{
+		DeliveryStreamName: aws.String(sn),
+	}
+	log.Printf("[DEBUG] Describing Delivery Stream: %s", params)
+	resp, err := conn.DescribeDeliveryStream(params)
+	if err != nil {
+		return err
+	}
+	d.SetId(aws.StringValue(resp.DeliveryStreamDescription.DeliveryStreamARN))
+	d.Set("arn", aws.StringValue(resp.DeliveryStreamDescription.DeliveryStreamARN))
+	d.Set("name", sn)
+	return nil
+}

--- a/aws/data_source_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/data_source_aws_kinesis_firehose_delivery_stream.go
@@ -1,25 +1,24 @@
 package aws
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/firehose/finder"
 )
 
 func dataSourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAwsKinesisFirehoseDeliveryStreamRead,
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
 			},
 		},
 	}
@@ -27,17 +26,17 @@ func dataSourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 
 func dataSourceAwsKinesisFirehoseDeliveryStreamRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).firehoseconn
+
 	sn := d.Get("name").(string)
-	params := &firehose.DescribeDeliveryStreamInput{
-		DeliveryStreamName: aws.String(sn),
-	}
-	log.Printf("[DEBUG] Describing Delivery Stream: %s", params)
-	resp, err := conn.DescribeDeliveryStream(params)
+	output, err := finder.DeliveryStreamByName(conn, sn)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading Kinesis Firehose Delivery Stream (%s): %w", sn, err)
 	}
-	d.SetId(aws.StringValue(resp.DeliveryStreamDescription.DeliveryStreamARN))
-	d.Set("arn", aws.StringValue(resp.DeliveryStreamDescription.DeliveryStreamARN))
-	d.Set("name", sn)
+
+	d.SetId(aws.StringValue(output.DeliveryStreamARN))
+	d.Set("arn", output.DeliveryStreamARN)
+	d.Set("name", output.DeliveryStreamName)
+
 	return nil
 }

--- a/aws/data_source_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/data_source_aws_kinesis_firehose_delivery_stream_test.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceAwsKinesisFirehoseDeliveryStream_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_kinesis_firehose_delivery_stream.test"
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, firehose.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsKinesisFirehoseDeliveryStreamConfigBasic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsKinesisFirehoseDeliveryStreamConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "firehose" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "firehose.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "firehose" {
+  name = %[1]q
+  role = aws_iam_role.firehose.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.bucket.arn}",
+        "${aws_s3_bucket.bucket.arn}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:putLogEvents"
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.current.partition}:logs::log-group:/aws/kinesisfirehose/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = %[1]q
+  acl    = "private"
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  name        = %[1]q
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
+}
+
+data "aws_kinesis_firehose_delivery_stream" "test" {
+  name = aws_kinesis_firehose_delivery_stream.test.name
+}
+`, rName)
+}

--- a/aws/internal/service/firehose/finder/finder.go
+++ b/aws/internal/service/firehose/finder/finder.go
@@ -1,0 +1,48 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func DeliveryStreamByName(conn *firehose.Firehose, name string) (*firehose.DeliveryStreamDescription, error) {
+	input := &firehose.DescribeDeliveryStreamInput{
+		DeliveryStreamName: aws.String(name),
+	}
+
+	output, err := conn.DescribeDeliveryStream(input)
+
+	if tfawserr.ErrCodeEquals(err, firehose.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.DeliveryStreamDescription == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.DeliveryStreamDescription, nil
+}
+
+func DeliveryStreamEncryptionConfigurationByName(conn *firehose.Firehose, name string) (*firehose.DeliveryStreamEncryptionConfiguration, error) {
+	output, err := DeliveryStreamByName(conn, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output.DeliveryStreamEncryptionConfiguration == nil {
+		return nil, tfresource.NewEmptyResultError(nil)
+	}
+
+	return output.DeliveryStreamEncryptionConfiguration, nil
+}

--- a/aws/internal/service/firehose/waiter/status.go
+++ b/aws/internal/service/firehose/waiter/status.go
@@ -1,0 +1,41 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/firehose/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func DeliveryStreamStatus(conn *firehose.Firehose, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.DeliveryStreamByName(conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.DeliveryStreamStatus), nil
+	}
+}
+
+func DeliveryStreamEncryptionConfigurationStatus(conn *firehose.Firehose, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.DeliveryStreamEncryptionConfigurationByName(conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/aws/internal/service/firehose/waiter/waiter.go
+++ b/aws/internal/service/firehose/waiter/waiter.go
@@ -1,0 +1,103 @@
+package waiter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+const (
+	DeliveryStreamCreatedTimeout = 20 * time.Minute
+	DeliveryStreamDeletedTimeout = 20 * time.Minute
+
+	DeliveryStreamEncryptionEnabledTimeout  = 10 * time.Minute
+	DeliveryStreamEncryptionDisabledTimeout = 10 * time.Minute
+)
+
+func DeliveryStreamCreated(conn *firehose.Firehose, name string) (*firehose.DeliveryStreamDescription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{firehose.DeliveryStreamStatusCreating},
+		Target:  []string{firehose.DeliveryStreamStatusActive},
+		Refresh: DeliveryStreamStatus(conn, name),
+		Timeout: DeliveryStreamCreatedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*firehose.DeliveryStreamDescription); ok {
+		if status, failureDescription := aws.StringValue(output.DeliveryStreamStatus), output.FailureDescription; status == firehose.DeliveryStreamStatusCreatingFailed && failureDescription != nil {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(failureDescription.Type), aws.StringValue(failureDescription.Details)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func DeliveryStreamDeleted(conn *firehose.Firehose, name string) (*firehose.DeliveryStreamDescription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{firehose.DeliveryStreamStatusDeleting},
+		Target:  []string{},
+		Refresh: DeliveryStreamStatus(conn, name),
+		Timeout: DeliveryStreamDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*firehose.DeliveryStreamDescription); ok {
+		if status, failureDescription := aws.StringValue(output.DeliveryStreamStatus), output.FailureDescription; status == firehose.DeliveryStreamStatusDeletingFailed && failureDescription != nil {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(failureDescription.Type), aws.StringValue(failureDescription.Details)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func DeliveryStreamEncryptionEnabled(conn *firehose.Firehose, name string) (*firehose.DeliveryStreamEncryptionConfiguration, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{firehose.DeliveryStreamEncryptionStatusEnabling},
+		Target:  []string{firehose.DeliveryStreamEncryptionStatusEnabled},
+		Refresh: DeliveryStreamEncryptionConfigurationStatus(conn, name),
+		Timeout: DeliveryStreamEncryptionEnabledTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*firehose.DeliveryStreamEncryptionConfiguration); ok {
+		if status, failureDescription := aws.StringValue(output.Status), output.FailureDescription; status == firehose.DeliveryStreamEncryptionStatusEnablingFailed && failureDescription != nil {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(failureDescription.Type), aws.StringValue(failureDescription.Details)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func DeliveryStreamEncryptionDisabled(conn *firehose.Firehose, name string) (*firehose.DeliveryStreamEncryptionConfiguration, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{firehose.DeliveryStreamEncryptionStatusDisabling},
+		Target:  []string{firehose.DeliveryStreamEncryptionStatusDisabled},
+		Refresh: DeliveryStreamEncryptionConfigurationStatus(conn, name),
+		Timeout: DeliveryStreamEncryptionDisabledTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*firehose.DeliveryStreamEncryptionConfiguration); ok {
+		if status, failureDescription := aws.StringValue(output.Status), output.FailureDescription; status == firehose.DeliveryStreamEncryptionStatusDisablingFailed && failureDescription != nil {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(failureDescription.Type), aws.StringValue(failureDescription.Details)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -333,6 +333,7 @@ func Provider() *schema.Provider {
 			"aws_internet_gateway":                           dataSourceAwsInternetGateway(),
 			"aws_iot_endpoint":                               dataSourceAwsIotEndpoint(),
 			"aws_ip_ranges":                                  dataSourceAwsIPRanges(),
+			"aws_kinesis_firehose_delivery_stream":           dataSourceAwsKinesisFirehoseDeliveryStream(),
 			"aws_kinesis_stream":                             dataSourceAwsKinesisStream(),
 			"aws_kinesis_stream_consumer":                    dataSourceAwsKinesisStreamConsumer(),
 			"aws_kms_alias":                                  dataSourceAwsKmsAlias(),

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -15,11 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/firehose/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/firehose/waiter"
 	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
-)
-
-const (
-	firehoseDeliveryStreamStatusDeleted = "DESTROYED"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -2560,9 +2558,10 @@ func resourceAwsKinesisFirehoseDeliveryStreamCreate(d *schema.ResourceData, meta
 		return fmt.Errorf("error creating Kinesis Firehose Delivery Stream: %s", err)
 	}
 
-	s, err := waitForKinesisFirehoseDeliveryStreamCreation(conn, sn)
+	s, err := waiter.DeliveryStreamCreated(conn, sn)
+
 	if err != nil {
-		return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) creation: %s", sn, err)
+		return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) create: %w", sn, err)
 	}
 
 	d.SetId(aws.StringValue(s.DeliveryStreamARN))
@@ -2575,12 +2574,13 @@ func resourceAwsKinesisFirehoseDeliveryStreamCreate(d *schema.ResourceData, meta
 		}
 
 		_, err := conn.StartDeliveryStreamEncryption(startInput)
+
 		if err != nil {
-			return fmt.Errorf("error starting Kinesis Firehose Delivery Stream (%s) encryption: %s", sn, err)
+			return fmt.Errorf("error starting Kinesis Firehose Delivery Stream (%s) encryption: %w", sn, err)
 		}
 
-		if err := waitForKinesisFirehoseDeliveryStreamSSEEnabled(conn, sn); err != nil {
-			return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) encryption to be enabled: %s", sn, err)
+		if _, err := waiter.DeliveryStreamEncryptionEnabled(conn, sn); err != nil {
+			return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) encryption enable: %w", sn, err)
 		}
 	}
 
@@ -2724,12 +2724,13 @@ func resourceAwsKinesisFirehoseDeliveryStreamUpdate(d *schema.ResourceData, meta
 			_, err := conn.StopDeliveryStreamEncryption(&firehose.StopDeliveryStreamEncryptionInput{
 				DeliveryStreamName: aws.String(sn),
 			})
+
 			if err != nil {
-				return fmt.Errorf("error stopping Kinesis Firehose Delivery Stream (%s) encryption: %s", sn, err)
+				return fmt.Errorf("error stopping Kinesis Firehose Delivery Stream (%s) encryption: %w", sn, err)
 			}
 
-			if err := waitForKinesisFirehoseDeliveryStreamSSEDisabled(conn, sn); err != nil {
-				return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) encryption to be disabled: %s", sn, err)
+			if _, err := waiter.DeliveryStreamEncryptionDisabled(conn, sn); err != nil {
+				return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) encryption disable: %w", sn, err)
 			}
 		} else {
 			startInput := &firehose.StartDeliveryStreamEncryptionInput{
@@ -2741,12 +2742,11 @@ func resourceAwsKinesisFirehoseDeliveryStreamUpdate(d *schema.ResourceData, meta
 
 			if err != nil {
 				return fmt.Errorf(
-					"error starting Kinesis Firehose Delivery Stream (%s) encryption: %s", sn, err)
+					"error starting Kinesis Firehose Delivery Stream (%s) encryption: %w", sn, err)
 			}
 
-			if err := waitForKinesisFirehoseDeliveryStreamSSEEnabled(conn, sn); err != nil {
-				return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) "+
-					"encryption to be enabled: %s", sn, err)
+			if _, err := waiter.DeliveryStreamEncryptionEnabled(conn, sn); err != nil {
+				return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) encryption enable: %w", sn, err)
 			}
 		}
 	}
@@ -2760,21 +2760,20 @@ func resourceAwsKinesisFirehoseDeliveryStreamRead(d *schema.ResourceData, meta i
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	sn := d.Get("name").(string)
-	resp, err := conn.DescribeDeliveryStream(&firehose.DescribeDeliveryStreamInput{
-		DeliveryStreamName: aws.String(sn),
-	})
+	s, err := finder.DeliveryStreamByName(conn, sn)
 
-	if err != nil {
-		if isAWSErr(err, firehose.ErrCodeResourceNotFoundException, "") {
-			log.Printf("[WARN] Kinesis Firehose Delivery Stream (%s) not found, removing from state", sn)
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("error reading Kinesis Firehose Delivery Stream: %s", err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Kinesis Firehose Delivery Stream (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
-	s := resp.DeliveryStreamDescription
+	if err != nil {
+		return fmt.Errorf("error reading Kinesis Firehose Delivery Stream (%s): %w", sn, err)
+	}
+
 	err = flattenKinesisFirehoseDeliveryStream(d, s)
+
 	if err != nil {
 		return err
 	}
@@ -2782,7 +2781,7 @@ func resourceAwsKinesisFirehoseDeliveryStreamRead(d *schema.ResourceData, meta i
 	tags, err := keyvaluetags.FirehoseListTags(conn, sn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Kinesis Firehose Delivery Stream (%s): %s", sn, err)
+		return fmt.Errorf("error listing tags for Kinesis Firehose Delivery Stream (%s): %w", sn, err)
 	}
 
 	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
@@ -2803,110 +2802,26 @@ func resourceAwsKinesisFirehoseDeliveryStreamDelete(d *schema.ResourceData, meta
 	conn := meta.(*AWSClient).firehoseconn
 
 	sn := d.Get("name").(string)
+	log.Printf("[DEBUG] Deleting Kinesis Firehose Delivery Stream: (%s)", sn)
 	_, err := conn.DeleteDeliveryStream(&firehose.DeleteDeliveryStreamInput{
 		DeliveryStreamName: aws.String(sn),
 	})
-	if err != nil {
-		return fmt.Errorf("error deleting Kinesis Firehose Delivery Stream (%s): %s", sn, err)
+
+	if tfawserr.ErrCodeEquals(err, firehose.ErrCodeResourceNotFoundException) {
+		return nil
 	}
 
-	if err := waitForKinesisFirehoseDeliveryStreamDeletion(conn, sn); err != nil {
-		return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) deletion: %s", sn, err)
+	if err != nil {
+		return fmt.Errorf("error deleting Kinesis Firehose Delivery Stream (%s): %w", sn, err)
+	}
+
+	_, err = waiter.DeliveryStreamDeleted(conn, sn)
+
+	if err != nil {
+		return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) delete: %w", sn, err)
 	}
 
 	return nil
-}
-
-func firehoseDeliveryStreamStateRefreshFunc(conn *firehose.Firehose, sn string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeDeliveryStream(&firehose.DescribeDeliveryStreamInput{
-			DeliveryStreamName: aws.String(sn),
-		})
-		if err != nil {
-			if isAWSErr(err, firehose.ErrCodeResourceNotFoundException, "") {
-				return &firehose.DeliveryStreamDescription{}, firehoseDeliveryStreamStatusDeleted, nil
-			}
-			return nil, "", err
-		}
-
-		return resp.DeliveryStreamDescription, aws.StringValue(resp.DeliveryStreamDescription.DeliveryStreamStatus), nil
-	}
-}
-
-func firehoseDeliveryStreamSSEStateRefreshFunc(conn *firehose.Firehose, sn string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeDeliveryStream(&firehose.DescribeDeliveryStreamInput{
-			DeliveryStreamName: aws.String(sn),
-		})
-		if err != nil {
-			return nil, "", err
-		}
-
-		return resp.DeliveryStreamDescription, aws.StringValue(resp.DeliveryStreamDescription.DeliveryStreamEncryptionConfiguration.Status), nil
-	}
-}
-
-func waitForKinesisFirehoseDeliveryStreamCreation(conn *firehose.Firehose, deliveryStreamName string) (*firehose.DeliveryStreamDescription, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{firehose.DeliveryStreamStatusCreating},
-		Target:     []string{firehose.DeliveryStreamStatusActive},
-		Refresh:    firehoseDeliveryStreamStateRefreshFunc(conn, deliveryStreamName),
-		Timeout:    20 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	v, err := stateConf.WaitForState()
-	if err != nil {
-		return nil, err
-	}
-
-	return v.(*firehose.DeliveryStreamDescription), nil
-}
-
-func waitForKinesisFirehoseDeliveryStreamDeletion(conn *firehose.Firehose, deliveryStreamName string) error {
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{firehose.DeliveryStreamStatusDeleting},
-		Target:     []string{firehoseDeliveryStreamStatusDeleted},
-		Refresh:    firehoseDeliveryStreamStateRefreshFunc(conn, deliveryStreamName),
-		Timeout:    20 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err := stateConf.WaitForState()
-
-	return err
-}
-
-func waitForKinesisFirehoseDeliveryStreamSSEEnabled(conn *firehose.Firehose, deliveryStreamName string) error {
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{firehose.DeliveryStreamEncryptionStatusEnabling},
-		Target:     []string{firehose.DeliveryStreamEncryptionStatusEnabled},
-		Refresh:    firehoseDeliveryStreamSSEStateRefreshFunc(conn, deliveryStreamName),
-		Timeout:    10 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err := stateConf.WaitForState()
-
-	return err
-}
-
-func waitForKinesisFirehoseDeliveryStreamSSEDisabled(conn *firehose.Firehose, deliveryStreamName string) error {
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{firehose.DeliveryStreamEncryptionStatusDisabling},
-		Target:     []string{firehose.DeliveryStreamEncryptionStatusDisabled},
-		Refresh:    firehoseDeliveryStreamSSEStateRefreshFunc(conn, deliveryStreamName),
-		Timeout:    10 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err := stateConf.WaitForState()
-
-	return err
 }
 
 func isKinesisFirehoseDeliveryStreamOptionDisabled(v interface{}) bool {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/firehose/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func init() {
@@ -27,12 +29,12 @@ func testSweepKinesisFirehoseDeliveryStreams(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-
 	conn := client.(*AWSClient).firehoseconn
 	input := &firehose.ListDeliveryStreamsInput{}
+	sweepResources := make([]*testSweepResource, 0)
 
 	for {
-		output, err := conn.ListDeliveryStreams(input)
+		page, err := conn.ListDeliveryStreams(input)
 
 		if testSweepSkipSweepError(err) {
 			log.Printf("[WARN] Skipping Kinesis Firehose Delivery Streams sweep for %s: %s", region, err)
@@ -40,39 +42,27 @@ func testSweepKinesisFirehoseDeliveryStreams(region string) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("error listing Kinesis Firehose Delivery Streams: %s", err)
+			return fmt.Errorf("error listing Kinesis Firehose Delivery Streams: %w", err)
 		}
 
-		if len(output.DeliveryStreamNames) == 0 {
-			log.Print("[DEBUG] No Kinesis Firehose Delivery Streams to sweep")
-			return nil
+		for _, sn := range page.DeliveryStreamNames {
+			r := resourceAwsKinesisFirehoseDeliveryStream()
+			d := r.Data(nil)
+			d.SetId("???")
+			d.Set("name", sn)
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 		}
 
-		for _, deliveryStreamNamePtr := range output.DeliveryStreamNames {
-			input := &firehose.DeleteDeliveryStreamInput{
-				DeliveryStreamName: deliveryStreamNamePtr,
-			}
-			name := aws.StringValue(deliveryStreamNamePtr)
-
-			log.Printf("[INFO] Deleting Kinesis Firehose Delivery Stream: %s", name)
-			_, err := conn.DeleteDeliveryStream(input)
-
-			if isAWSErr(err, firehose.ErrCodeResourceNotFoundException, "") {
-				continue
-			}
-
-			if err != nil {
-				return fmt.Errorf("error deleting Kinesis Firehose Delivery Stream (%s): %s", name, err)
-			}
-
-			if err := waitForKinesisFirehoseDeliveryStreamDeletion(conn, name); err != nil {
-				return fmt.Errorf("error waiting for Kinesis Firehose Delivery Stream (%s) deletion: %s", name, err)
-			}
-		}
-
-		if !aws.BoolValue(output.HasMoreDeliveryStreams) {
+		if !aws.BoolValue(page.HasMoreDeliveryStreams) {
 			break
 		}
+	}
+
+	err = testSweepResourceOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Kinesis Firehose Delivery Streams (%s): %w", region, err)
 	}
 
 	return nil
@@ -1482,28 +1472,27 @@ func TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration(t *t
 	})
 }
 
-func testAccCheckKinesisFirehoseDeliveryStreamExists(n string, stream *firehose.DeliveryStreamDescription) resource.TestCheckFunc {
+func testAccCheckKinesisFirehoseDeliveryStreamExists(n string, v *firehose.DeliveryStreamDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
-		log.Printf("State: %#v", s.RootModule().Resources)
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Kinesis Firehose ID is set")
+			return fmt.Errorf("No Kinesis Firehose Delivery Stream ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).firehoseconn
-		describeOpts := &firehose.DescribeDeliveryStreamInput{
-			DeliveryStreamName: aws.String(rs.Primary.Attributes["name"]),
-		}
-		resp, err := conn.DescribeDeliveryStream(describeOpts)
+
+		sn := rs.Primary.Attributes["name"]
+		output, err := finder.DeliveryStreamByName(conn, sn)
+
 		if err != nil {
 			return err
 		}
 
-		*stream = *resp.DeliveryStreamDescription
+		*v = *output
 
 		return nil
 	}
@@ -1697,19 +1686,21 @@ func testAccCheckKinesisFirehoseDeliveryStreamDestroy(s *terraform.State) error 
 		if rs.Type != "aws_kinesis_firehose_delivery_stream" {
 			continue
 		}
+
 		conn := testAccProvider.Meta().(*AWSClient).firehoseconn
-		describeOpts := &firehose.DescribeDeliveryStreamInput{
-			DeliveryStreamName: aws.String(rs.Primary.Attributes["name"]),
-		}
-		resp, err := conn.DescribeDeliveryStream(describeOpts)
-		if err == nil {
-			if resp.DeliveryStreamDescription != nil && *resp.DeliveryStreamDescription.DeliveryStreamStatus != "DELETING" {
-				return fmt.Errorf("Error: Delivery Stream still exists")
-			}
+
+		sn := rs.Primary.Attributes["name"]
+		_, err := finder.DeliveryStreamByName(conn, sn)
+
+		if tfresource.NotFound(err) {
+			continue
 		}
 
-		return nil
+		if err != nil {
+			return err
+		}
 
+		return fmt.Errorf("Kinesis Firehose Delivery Stream %s still exists", rs.Primary.ID)
 	}
 
 	return nil

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2704,7 +2704,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccKinesisFirehoseDeliveryStreamRedshiftConfigBase(rName string, rInt int) string {
 	return composeConfig(
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt),
-		testAccAvailableAZsNoOptInExcludeConfig("usw2-az2"),
+		testAccAvailableAZsNoOptInExcludeConfig("usw2-az2", "usgw1-az2"),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2704,16 +2704,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccKinesisFirehoseDeliveryStreamRedshiftConfigBase(rName string, rInt int) string {
 	return composeConfig(
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt),
+		testAccAvailableAZsNoOptInExcludeConfig("usw2-az2"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 

--- a/website/docs/d/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/d/kinesis_firehose_delivery_stream.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "Kinesis Firehose"
+layout: "aws"
+page_title: "AWS: aws_kinesis_firehose_delivery_stream"
+description: |-
+  Provides an AWS Kinesis Firehose Delivery Stream data source.
+---
+
+# Data Source: aws_kinesis_firehose_delivery_stream
+
+Use this data source to get information about a Kinesis Firehose Delivery Stream for use in other resources.
+
+For more details, see the [Amazon Kinesis Firehose Documentation][1].
+
+## Example Usage
+
+```terraform
+data "aws_kinesis_firehose_delivery_stream" "stream" {
+  name = "stream-name"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Kinesis Stream.
+
+## Attributes Reference
+
+`id` is set to the Amazon Resource Name (ARN) of the Kinesis Stream. In addition, the following attributes
+are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the Kinesis Stream (same as id).
+* `name` - The name of the Kinesis Stream.
+
+[1]: https://aws.amazon.com/documentation/firehose/

--- a/website/docs/d/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/d/kinesis_firehose_delivery_stream.html.markdown
@@ -30,6 +30,5 @@ data "aws_kinesis_firehose_delivery_stream" "stream" {
 are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the Kinesis Stream (same as id).
-* `name` - The name of the Kinesis Stream.
 
 [1]: https://aws.amazon.com/documentation/firehose/


### PR DESCRIPTION
The goal is to simply allow referencing preexisting Delivery Streams.
This is a feature a few have sought. Fixes #3865.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3865

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜  terraform-provider-aws (f-add-kinesis-delivery-stream-data-source) ✗ make testacc TESTARGS='-v -run=TestAccDataSourceAwsKinesisFirehoseDeliveryStream'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -v -run=TestAccDataSourceAwsKinesisFirehoseDeliveryStream -timeout 180m
=== RUN   TestAccDataSourceAwsKinesisFirehoseDeliveryStream_basic
=== PAUSE TestAccDataSourceAwsKinesisFirehoseDeliveryStream_basic
=== CONT  TestAccDataSourceAwsKinesisFirehoseDeliveryStream_basic
--- PASS: TestAccDataSourceAwsKinesisFirehoseDeliveryStream_basic (116.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       116.108s
```
