### PR TITLE
r/aws_s3outposts_endpoint: Fix timeout duration for creation

### DIFF
--- a/aws/internal/service/s3outposts/waiter/waiter.go
+++ b/aws/internal/service/s3outposts/waiter/waiter.go
@@ -15,7 +15,7 @@ const (
 	EndpointStatusPending = "Pending"
 
 	// Maximum amount of time to wait for Endpoint to return Available on creation
-	EndpointStatusCreatedTimeout = 5 * time.Minute
+	EndpointStatusCreatedTimeout = 20 * time.Minute
 )
 
 // EndpointStatusCreated waits for Endpoint to return Available


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The [documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-outposts-create-bucket.html) about creating an Outpost S3 endpoint says:
> It can take up to 20 minutes for your Outposts endpoint to be created and your bucket to be ready to use.

I am aware the [API doc](https://docs.aws.amazon.com/AmazonS3/latest/API/API_s3outposts_CreateEndpoint.html) says that it should only take 5 minutes. An issue has been raised on the AWS to update this documentation. Currently 5 mins is too short and it timeouts when the endpoint is created through Terraform.

Output from acceptance testing:

I could not run the acceptance test on outpost.