### PR TITLE
Add Lambda functions datasource

### DIFF
--- a/aws/data_source_aws_lambda_functions.go
+++ b/aws/data_source_aws_lambda_functions.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsLambdaFunctions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsLambdaFunctionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsLambdaFunctionsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+
+	input := &lambda.ListFunctionsInput{}
+
+	log.Printf("[DEBUG] Getting list of all Lambda Functions")
+	//output, err := conn.ListFunctions(input)
+
+	//var functionIds, functionNames []string
+	var lambdaFunctions []*lambda.FunctionConfiguration
+	err := conn.ListFunctionsPages(input, func(resp *lambda.ListFunctionsOutput, isLast bool) bool {
+		for _, function := range resp.Functions {
+			lambdaFunctions = append(lambdaFunctions, function)
+		}
+
+		return !isLast
+	})
+
+	if err != nil {
+		return fmt.Errorf("error getting Lambda Functions: %w", err)
+	}
+
+	if lambdaFunctions == nil {
+		return fmt.Errorf("error getting Lambda Functions: empty response")
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_lambda_functions_test.go
+++ b/aws/data_source_aws_lambda_functions_test.go
@@ -1,0 +1,10 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)


### PR DESCRIPTION
WIP Pull Request to add a Lambda functions datasource to return a list of lambda functions (see #17701).

I still have to:
- [ ] Run the acceptance tests (I might need some help with this)
- [ ] Update the documentation

Issue(s): #17701

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
