### PR TITLE
service/iam: Handle read-after-create eventual consistency in IAM User resources

### DIFF
--- a/.changelog/18458.txt
+++ b/.changelog/18458.txt
@@ -1,0 +1,23 @@
+```release-note:bug
+resource/aws_iam_user: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_iam_user_group_membership: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_iam_user_login_profile: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_iam_user_policy: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_iam_user_policy_attachment: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_iam_user_ssh_key: Handle read-after-create eventual consistency
+```

--- a/aws/internal/service/iam/finder/finder.go
+++ b/aws/internal/service/iam/finder/finder.go
@@ -1,0 +1,40 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+// UserAttachedPolicy returns the AttachedPolicy corresponding to the specified user and policy ARN.
+func UserAttachedPolicy(conn *iam.IAM, userName string, policyARN string) (*iam.AttachedPolicy, error) {
+	input := &iam.ListAttachedUserPoliciesInput{
+		UserName: aws.String(userName),
+	}
+
+	var result *iam.AttachedPolicy
+
+	err := conn.ListAttachedUserPoliciesPages(input, func(page *iam.ListAttachedUserPoliciesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, attachedPolicy := range page.AttachedPolicies {
+			if attachedPolicy == nil {
+				continue
+			}
+
+			if aws.StringValue(attachedPolicy.PolicyArn) == policyARN {
+				result = attachedPolicy
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/encryption"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsIamUserLoginProfile() *schema.Resource {
@@ -168,21 +170,40 @@ func resourceAwsIamUserLoginProfileRead(d *schema.ResourceData, meta interface{}
 		UserName: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Getting IAM User Login Profile (%s): %s", d.Id(), input)
-	output, err := conn.GetLoginProfile(input)
+	var output *iam.GetLoginProfileOutput
 
-	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = conn.GetLoginProfile(input)
+
+		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.GetLoginProfile(input)
+	}
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
 		log.Printf("[WARN] IAM User Login Profile (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error getting IAM User Login Profile (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading IAM User Login Profile (%s): %w", d.Id(), err)
 	}
 
 	if output == nil || output.LoginProfile == nil {
-		return fmt.Errorf("error getting IAM User Login Profile (%s): empty response", d.Id())
+		return fmt.Errorf("error reading IAM User Login Profile (%s): empty response", d.Id())
 	}
 
 	d.Set("user", aws.StringValue(output.LoginProfile.UserName))

--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsIamUserPolicy() *schema.Resource {
@@ -98,18 +101,40 @@ func resourceAwsIamUserPolicyRead(d *schema.ResourceData, meta interface{}) erro
 		UserName:   aws.String(user),
 	}
 
-	getResp, err := iamconn.GetUserPolicy(request)
-	if err != nil {
-		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
-			log.Printf("[WARN] IAM User Policy (%s) for %s not found, removing from state", name, user)
-			d.SetId("")
-			return nil
+	var getResp *iam.GetUserPolicyOutput
+
+	err = resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		getResp, err = iamconn.GetUserPolicy(request)
+
+		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+			return resource.RetryableError(err)
 		}
-		return fmt.Errorf("Error reading IAM policy %s from user %s: %s", name, user, err)
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		getResp, err = iamconn.GetUserPolicy(request)
 	}
 
-	if getResp.PolicyDocument == nil {
-		return fmt.Errorf("GetUserPolicy returned a nil policy document")
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+		log.Printf("[WARN] IAM User Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading IAM User Policy (%s): %w", d.Id(), err)
+	}
+
+	if getResp == nil || getResp.PolicyDocument == nil {
+		return fmt.Errorf("error reading IAM User Policy (%s): empty response", d.Id())
 	}
 
 	policy, err := url.QueryUnescape(*getResp.PolicyDocument)

--- a/aws/resource_aws_iam_user_policy_attachment.go
+++ b/aws/resource_aws_iam_user_policy_attachment.go
@@ -157,24 +157,3 @@ func detachPolicyFromUser(conn *iam.IAM, user string, arn string) error {
 	})
 	return err
 }
-
-// See also: iamRoleHasPolicyARNAttachment
-func iamUserHasPolicyARNAttachment(conn *iam.IAM, user string, policyARN string) (bool, error) {
-	hasPolicyAttachment := false
-	input := &iam.ListAttachedUserPoliciesInput{
-		UserName: aws.String(user),
-	}
-
-	err := conn.ListAttachedUserPoliciesPages(input, func(page *iam.ListAttachedUserPoliciesOutput, lastPage bool) bool {
-		for _, p := range page.AttachedPolicies {
-			if aws.StringValue(p.PolicyArn) == policyARN {
-				hasPolicyAttachment = true
-				return false
-			}
-		}
-
-		return !lastPage
-	})
-
-	return hasPolicyAttachment, err
-}

--- a/aws/resource_aws_iam_user_policy_attachment.go
+++ b/aws/resource_aws_iam_user_policy_attachment.go
@@ -6,10 +6,13 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsIamUserPolicyAttachment() *schema.Resource {
@@ -57,40 +60,57 @@ func resourceAwsIamUserPolicyAttachmentRead(d *schema.ResourceData, meta interfa
 	conn := meta.(*AWSClient).iamconn
 	user := d.Get("user").(string)
 	arn := d.Get("policy_arn").(string)
+	// Human friendly ID for error messages since d.Id() is non-descriptive
+	id := fmt.Sprintf("%s:%s", user, arn)
 
-	_, err := conn.GetUser(&iam.GetUserInput{
-		UserName: aws.String(user),
+	var attachedPolicy *iam.AttachedPolicy
+
+	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		attachedPolicy, err = finder.UserAttachedPolicy(conn, user, arn)
+
+		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if d.IsNewResource() && attachedPolicy == nil {
+			return resource.RetryableError(&resource.NotFoundError{
+				LastError: fmt.Errorf("IAM User Managed Policy Attachment (%s) not found", id),
+			})
+		}
+
+		return nil
 	})
 
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "NoSuchEntity" {
-				log.Printf("[WARN] No such entity found for Policy Attachment (%s)", user)
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
+	if tfresource.TimedOut(err) {
+		attachedPolicy, err = finder.UserAttachedPolicy(conn, user, arn)
 	}
 
-	attachedPolicies, err := conn.ListAttachedUserPolicies(&iam.ListAttachedUserPoliciesInput{
-		UserName: aws.String(user),
-	})
-	if err != nil {
-		return err
-	}
-
-	var policy string
-	for _, p := range attachedPolicies.AttachedPolicies {
-		if *p.PolicyArn == arn {
-			policy = *p.PolicyArn
-		}
-	}
-
-	if policy == "" {
-		log.Printf("[WARN] No such User found for Policy Attachment (%s)", user)
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+		log.Printf("[WARN] IAM User Managed Policy Attachment (%s) not found, removing from state", id)
 		d.SetId("")
+		return nil
 	}
+
+	if err != nil {
+		return fmt.Errorf("error reading IAM User Managed Policy Attachment (%s): %w", id, err)
+	}
+
+	if attachedPolicy == nil {
+		if d.IsNewResource() {
+			return fmt.Errorf("error reading IAM User Managed Policy Attachment (%s): not found after creation", id)
+		}
+
+		log.Printf("[WARN] IAM User Managed Policy Attachment (%s) not found, removing from state", id)
+		d.SetId("")
+		return nil
+	}
+
 	return nil
 }
 
@@ -136,4 +156,25 @@ func detachPolicyFromUser(conn *iam.IAM, user string, arn string) error {
 		PolicyArn: aws.String(arn),
 	})
 	return err
+}
+
+// See also: iamRoleHasPolicyARNAttachment
+func iamUserHasPolicyARNAttachment(conn *iam.IAM, user string, policyARN string) (bool, error) {
+	hasPolicyAttachment := false
+	input := &iam.ListAttachedUserPoliciesInput{
+		UserName: aws.String(user),
+	}
+
+	err := conn.ListAttachedUserPoliciesPages(input, func(page *iam.ListAttachedUserPoliciesOutput, lastPage bool) bool {
+		for _, p := range page.AttachedPolicies {
+			if aws.StringValue(p.PolicyArn) == policyARN {
+				hasPolicyAttachment = true
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	return hasPolicyAttachment, err
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16796

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSIAMUserPolicy_basic (38.41s)
--- PASS: TestAccAWSIAMUserPolicy_disappears (23.13s)
--- PASS: TestAccAWSIAMUserPolicy_generatedName (40.70s)
--- PASS: TestAccAWSIAMUserPolicy_multiplePolicies (48.72s)
--- PASS: TestAccAWSIAMUserPolicy_namePrefix (41.87s)

--- PASS: TestAccAWSUser_basic (36.07s)
--- PASS: TestAccAWSUser_disappears (20.47s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (27.25s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (43.02s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (24.70s)
--- PASS: TestAccAWSUser_ForceDestroy_SigningCertificate (27.38s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (26.60s)
--- PASS: TestAccAWSUser_nameChange (27.75s)
--- PASS: TestAccAWSUser_pathChange (31.26s)
--- PASS: TestAccAWSUser_permissionsBoundary (70.82s)
--- PASS: TestAccAWSUser_tags (36.07s)

--- PASS: TestAccAWSUserGroupMembership_basic (81.80s)

--- PASS: TestAccAWSUserLoginProfile_basic (32.17s)
--- PASS: TestAccAWSUserLoginProfile_keybase (48.60s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (14.41s)
--- PASS: TestAccAWSUserLoginProfile_notAKey (14.70s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (45.94s)

--- PASS: TestAccAWSUserPolicyAttachment_basic (38.58s)

--- PASS: TestAccAWSUserSSHKey_basic (26.70s)
--- PASS: TestAccAWSUserSSHKey_pemEncoding (26.11s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSIAMUserPolicy_basic (59.83s)
--- PASS: TestAccAWSIAMUserPolicy_disappears (23.85s)
--- PASS: TestAccAWSIAMUserPolicy_generatedName (54.43s)
--- PASS: TestAccAWSIAMUserPolicy_multiplePolicies (80.63s)
--- PASS: TestAccAWSIAMUserPolicy_namePrefix (53.68s)

--- PASS: TestAccAWSUser_basic (35.77s)
--- PASS: TestAccAWSUser_disappears (18.71s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (32.21s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (40.12s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (47.70s)
--- PASS: TestAccAWSUser_ForceDestroy_SigningCertificate (31.31s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (29.54s)
--- PASS: TestAccAWSUser_nameChange (36.80s)
--- PASS: TestAccAWSUser_pathChange (37.43s)
--- PASS: TestAccAWSUser_permissionsBoundary (98.35s)
--- PASS: TestAccAWSUser_tags (46.03s)

--- PASS: TestAccAWSUserGroupMembership_basic (104.29s)

--- PASS: TestAccAWSUserLoginProfile_basic (55.38s)
--- PASS: TestAccAWSUserLoginProfile_keybase (48.45s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (33.47s)
--- PASS: TestAccAWSUserLoginProfile_notAKey (27.08s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (29.66s)

--- PASS: TestAccAWSUserPolicyAttachment_basic (51.20s)

--- PASS: TestAccAWSUserSSHKey_basic (31.28s)
--- PASS: TestAccAWSUserSSHKey_pemEncoding (28.18s)
```