### PR TITLE
resource/aws_security_group_rule: Validate conflicting arguments are not simultaneously specified

### DIFF
--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -96,6 +96,7 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validateCIDRNetworkAddress,
 				},
+				ConflictsWith: []string{"source_security_group_id", "self"},
 			},
 
 			"ipv6_cidr_blocks": {
@@ -106,6 +107,7 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validateCIDRNetworkAddress,
 				},
+				ConflictsWith: []string{"source_security_group_id", "self"},
 			},
 
 			"prefix_list_ids": {
@@ -126,7 +128,7 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-				ConflictsWith: []string{"cidr_blocks", "self"},
+				ConflictsWith: []string{"cidr_blocks", "ipv6_cidr_blocks", "self"},
 			},
 
 			"self": {
@@ -134,6 +136,7 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 				Optional: true,
 				Default:  false,
 				ForceNew: true,
+				ConflictsWith: []string{"cidr_blocks", "ipv6_cidr_blocks", "source_security_group_id"},
 			},
 
 			"description": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15606

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
