### PR TITLE
resource/aws_backup_selection: Handle read-after-create eventual consistency

### DIFF
--- a/aws/internal/service/backup/waiter/waiter.go
+++ b/aws/internal/service/backup/waiter/waiter.go
@@ -1,0 +1,10 @@
+package waiter
+
+import (
+	"time"
+)
+
+const (
+	// Maximum amount of time to wait for Backup changes to propagate
+	PropagationTimeout = 2 * time.Minute
+)

--- a/aws/resource_aws_backup_selection.go
+++ b/aws/resource_aws_backup_selection.go
@@ -8,10 +8,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/backup/waiter"
 	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsBackupSelection() *schema.Resource {
@@ -144,16 +147,50 @@ func resourceAwsBackupSelectionRead(d *schema.ResourceData, meta interface{}) er
 		SelectionId:  aws.String(d.Id()),
 	}
 
-	resp, err := conn.GetBackupSelection(input)
-	if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") ||
-		isAWSErr(err, backup.ErrCodeInvalidParameterValueException, "Cannot find Backup plan") {
+	var resp *backup.GetBackupSelectionOutput
+
+	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		resp, err = conn.GetBackupSelection(input)
+
+		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, backup.ErrCodeResourceNotFoundException) {
+			return resource.RetryableError(err)
+		}
+
+		if d.IsNewResource() && tfawserr.ErrMessageContains(err, backup.ErrCodeInvalidParameterValueException, "Cannot find Backup plan") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		resp, err = conn.GetBackupSelection(input)
+	}
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, backup.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Backup Selection (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if !d.IsNewResource() && tfawserr.ErrMessageContains(err, backup.ErrCodeInvalidParameterValueException, "Cannot find Backup plan") {
 		log.Printf("[WARN] Backup Selection (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading Backup Selection: %s", err)
+		return fmt.Errorf("error reading Backup Selection (%s): %w", d.Id(), err)
+	}
+
+	if resp == nil {
+		return fmt.Errorf("error reading Backup Selection (%s): empty response", d.Id())
 	}
 
 	d.Set("plan_id", resp.BackupPlanId)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9914
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16796

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAwsBackupSelection_disappears_BackupPlan (19.03s)
--- PASS: TestAccAwsBackupSelection_disappears (19.13s)
--- PASS: TestAccAwsBackupSelection_withTags (24.42s)
--- PASS: TestAccAwsBackupSelection_basic (24.42s)
--- PASS: TestAccAwsBackupSelection_withResources (38.39s)
--- PASS: TestAccAwsBackupSelection_updateTag (43.16s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAwsBackupSelection_disappears_BackupPlan (28.20s)
--- PASS: TestAccAwsBackupSelection_disappears (28.54s)
--- PASS: TestAccAwsBackupSelection_withTags (31.62s)
--- PASS: TestAccAwsBackupSelection_basic (31.65s)
--- PASS: TestAccAwsBackupSelection_withResources (43.21s)
--- PASS: TestAccAwsBackupSelection_updateTag (50.91s)
```
