### PR TITLE
Increase IPV6 Association Timeout

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -840,7 +840,7 @@ func waitForEc2VpcIpv6CidrBlockAssociationCreate(conn *ec2.EC2, vpcID, associati
 		},
 		Target:  []string{ec2.VpcCidrBlockStateCodeAssociated},
 		Refresh: Ipv6CidrStateRefreshFunc(conn, vpcID, associationID),
-		Timeout: 1 * time.Minute,
+		Timeout: 5 * time.Minute,
 	}
 	_, err := stateConf.WaitForState()
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #18480

Output from acceptance testing:

```
➜  terraform-provider-aws git:(main) make testacc TESTARGS='-run=TestAccAWSVpc_AssignGeneratedIpv6CidrBlock'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSVpc_AssignGeneratedIpv6CidrBlock -timeout 180m
=== RUN   TestAccAWSVpc_AssignGeneratedIpv6CidrBlock
=== PAUSE TestAccAWSVpc_AssignGeneratedIpv6CidrBlock
=== CONT  TestAccAWSVpc_AssignGeneratedIpv6CidrBlock
--- PASS: TestAccAWSVpc_AssignGeneratedIpv6CidrBlock (45.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.410s
```