### PR TITLE
Read system parameters that exist in config

### DIFF
--- a/.changelog/18486.txt
+++ b/.changelog/18486.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_docdb_cluster_parameter_group: Read all user parameters and parameters specified in the configuration.
+```

--- a/aws/resource_aws_docdb_cluster_parameter_group.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group.go
@@ -155,7 +155,6 @@ func resourceAwsDocDBClusterParameterGroupRead(d *schema.ResourceData, meta inte
 
 	describeParametersOpts := &docdb.DescribeDBClusterParametersInput{
 		DBClusterParameterGroupName: aws.String(d.Id()),
-		Source:                      aws.String("user"),
 	}
 
 	describeParametersResp, err := conn.DescribeDBClusterParameters(describeParametersOpts)
@@ -163,7 +162,7 @@ func resourceAwsDocDBClusterParameterGroupRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("error reading DocDB Cluster Parameter Group (%s) parameters: %s", d.Id(), err)
 	}
 
-	if err := d.Set("parameter", flattenDocDBParameters(describeParametersResp.Parameters)); err != nil {
+	if err := d.Set("parameter", flattenDocDBParameters(describeParametersResp.Parameters, d)); err != nil {
 		return fmt.Errorf("error setting docdb cluster parameter: %s", err)
 	}
 

--- a/aws/resource_aws_docdb_cluster_parameter_group.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group.go
@@ -162,7 +162,7 @@ func resourceAwsDocDBClusterParameterGroupRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("error reading DocDB Cluster Parameter Group (%s) parameters: %s", d.Id(), err)
 	}
 
-	if err := d.Set("parameter", flattenDocDBParameters(describeParametersResp.Parameters, d)); err != nil {
+	if err := d.Set("parameter", flattenDocDBParameters(describeParametersResp.Parameters, d.Get("parameter").(*schema.Set).List())); err != nil {
 		return fmt.Errorf("error setting docdb cluster parameter: %s", err)
 	}
 

--- a/aws/resource_aws_docdb_cluster_parameter_group_test.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group_test.go
@@ -47,6 +47,35 @@ func TestAccAWSDocDBClusterParameterGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDocDBClusterParameterGroup_systemParameter(t *testing.T) {
+	var v docdb.DBClusterParameterGroup
+	resourceName := "aws_docdb_cluster_parameter_group.bar"
+
+	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, docdb.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDocDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig_SystemParameter(parameterGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists(resourceName, &v),
+					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster-pg:%s$", parameterGroupName))),
+					resource.TestCheckResourceAttr(resourceName, "name", parameterGroupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "docdb3.6"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDocDBClusterParameterGroup_namePrefix(t *testing.T) {
 	var v docdb.DBClusterParameterGroup
 
@@ -348,6 +377,21 @@ func testAccAWSDocDBClusterParameterGroupConfig(name string) string {
 resource "aws_docdb_cluster_parameter_group" "bar" {
   family = "docdb3.6"
   name   = "%s"
+}
+`, name)
+}
+
+func testAccAWSDocDBClusterParameterGroupConfig_SystemParameter(name string) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster_parameter_group" "bar" {
+  family = "docdb3.6"
+  name   = "%s"
+
+  parameter {
+    name         = "tls"
+    value        = "enabled"
+    apply_method = "pending-reboot"
+  }
 }
 `, name)
 }

--- a/aws/resource_aws_docdb_cluster_parameter_group_test.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group_test.go
@@ -72,6 +72,12 @@ func TestAccAWSDocDBClusterParameterGroup_systemParameter(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameter"},
+			},
 		},
 	})
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -955,7 +955,7 @@ func flattenNeptuneParameters(list []*neptune.Parameter) []map[string]interface{
 }
 
 // Flattens an array of Parameters into a []map[string]interface{}
-func flattenDocDBParameters(list []*docdb.Parameter, d *schema.ResourceData) []map[string]interface{} {
+func flattenDocDBParameters(list []*docdb.Parameter, parameterList []interface{}) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
 		if i.ParameterValue != nil {
@@ -963,7 +963,7 @@ func flattenDocDBParameters(list []*docdb.Parameter, d *schema.ResourceData) []m
 
 			// Check if any non-user parameters are specified in the configuration.
 			parameterFound := false
-			for _, configParameter := range d.Get("parameter").(*schema.Set).List() {
+			for _, configParameter := range parameterList {
 				if configParameter.(map[string]interface{})["name"] == name {
 					parameterFound = true
 				}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -955,10 +955,25 @@ func flattenNeptuneParameters(list []*neptune.Parameter) []map[string]interface{
 }
 
 // Flattens an array of Parameters into a []map[string]interface{}
-func flattenDocDBParameters(list []*docdb.Parameter) []map[string]interface{} {
+func flattenDocDBParameters(list []*docdb.Parameter, d *schema.ResourceData) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
 		if i.ParameterValue != nil {
+			name := aws.StringValue(i.ParameterName)
+
+			// Check if any non-user parameters are specified in the configuration.
+			parameterFound := false
+			for _, configParameter := range d.Get("parameter").(*schema.Set).List() {
+				if configParameter.(map[string]interface{})["name"] == name {
+					parameterFound = true
+				}
+			}
+
+			// Skip parameters that are not user defined or specified in the configuration.
+			if aws.StringValue(i.Source) != "user" && !parameterFound {
+				continue
+			}
+
 			result = append(result, map[string]interface{}{
 				"apply_method": aws.StringValue(i.ApplyMethod),
 				"name":         aws.StringValue(i.ParameterName),

--- a/website/docs/r/docdb_cluster_parameter_group.html.markdown
+++ b/website/docs/r/docdb_cluster_parameter_group.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `family` - (Required, Forces new resource) The family of the documentDB cluster parameter group.
 * `description` - (Optional, Forces new resource) The description of the documentDB cluster parameter group. Defaults to "Managed by Terraform".
-* `parameter` - (Optional) A list of documentDB parameters to apply.
+* `parameter` - (Optional) A list of documentDB parameters to apply. Setting parameters to system default values may show a difference on imported resources.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 Parameter blocks support the following:


### PR DESCRIPTION
The current behavior is to only read `user` parameters. If a `system` `parameter`is set in the configuration, the plan will result in a diff every time because the `system` parameters are never read. This changes the behavior to read all parameters, and read user parameters and any parameters that exist in the configuration.


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #13384

Output from acceptance testing:


```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDocDBClusterParameterGroup_ -timeout 180m
=== RUN   TestAccAWSDocDBClusterParameterGroup_basic
=== PAUSE TestAccAWSDocDBClusterParameterGroup_basic
=== RUN   TestAccAWSDocDBClusterParameterGroup_systemParameter
=== PAUSE TestAccAWSDocDBClusterParameterGroup_systemParameter
=== RUN   TestAccAWSDocDBClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSDocDBClusterParameterGroup_namePrefix
=== RUN   TestAccAWSDocDBClusterParameterGroup_generatedName
=== PAUSE TestAccAWSDocDBClusterParameterGroup_generatedName
=== RUN   TestAccAWSDocDBClusterParameterGroup_Description
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Description
=== RUN   TestAccAWSDocDBClusterParameterGroup_disappears
=== PAUSE TestAccAWSDocDBClusterParameterGroup_disappears
=== RUN   TestAccAWSDocDBClusterParameterGroup_Parameter
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Parameter
=== RUN   TestAccAWSDocDBClusterParameterGroup_Tags
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Tags
=== CONT  TestAccAWSDocDBClusterParameterGroup_basic
=== CONT  TestAccAWSDocDBClusterParameterGroup_disappears
=== CONT  TestAccAWSDocDBClusterParameterGroup_namePrefix
=== CONT  TestAccAWSDocDBClusterParameterGroup_generatedName
=== CONT  TestAccAWSDocDBClusterParameterGroup_Tags
=== CONT  TestAccAWSDocDBClusterParameterGroup_Description
=== CONT  TestAccAWSDocDBClusterParameterGroup_Parameter
=== CONT  TestAccAWSDocDBClusterParameterGroup_systemParameter
--- PASS: TestAccAWSDocDBClusterParameterGroup_disappears (12.65s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Description (15.72s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_systemParameter (16.03s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_basic (17.40s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_generatedName (26.79s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_namePrefix (27.98s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Parameter (28.92s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Tags (39.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.318s
```
