### PR TITLE
r/aws_cloudwatch_event_target & r/aws_cloudwatch_event_rule: Support partner event bus names

### DIFF
--- a/.changelog/18491.txt
+++ b/.changelog/18491.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_cloudwatch_event_target: Support partner event bus names
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_event_rule: Support partner event bus names
+```

--- a/aws/internal/service/cloudwatchevents/id.go
+++ b/aws/internal/service/cloudwatchevents/id.go
@@ -29,6 +29,14 @@ func PermissionParseID(id string) (string, string, error) {
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil
 	}
+	if len(parts) > 2 {
+		i := strings.LastIndex(id, ruleIDSeparator)
+		busName := id[:i]
+		statementID := id[i+1:]
+		if partnerEventBusPattern.MatchString(busName) && statementID != "" {
+			return busName, statementID, nil
+		}
+	}
 
 	return "", "", fmt.Errorf("unexpected format for ID (%q), expected <event-bus-name>"+PermissionIDSeparator+"<statement-id> or <statement-id>", id)
 }
@@ -52,8 +60,10 @@ func RuleParseID(id string) (string, string, error) {
 	}
 	if len(parts) > 2 {
 		i := strings.LastIndex(id, ruleIDSeparator)
-		if partnerEventBusPattern.MatchString(id[:i]) {
-			return id[:i], id[i+1:], nil
+		busName := id[:i]
+		statementID := id[i+1:]
+		if partnerEventBusPattern.MatchString(busName) && statementID != "" {
+			return busName, statementID, nil
 		}
 	}
 

--- a/aws/internal/service/cloudwatchevents/id.go
+++ b/aws/internal/service/cloudwatchevents/id.go
@@ -29,14 +29,6 @@ func PermissionParseID(id string) (string, string, error) {
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil
 	}
-	if len(parts) > 2 {
-		i := strings.LastIndex(id, ruleIDSeparator)
-		busName := id[:i]
-		statementID := id[i+1:]
-		if partnerEventBusPattern.MatchString(busName) && statementID != "" {
-			return busName, statementID, nil
-		}
-	}
 
 	return "", "", fmt.Errorf("unexpected format for ID (%q), expected <event-bus-name>"+PermissionIDSeparator+"<statement-id> or <statement-id>", id)
 }
@@ -60,10 +52,8 @@ func RuleParseID(id string) (string, string, error) {
 	}
 	if len(parts) > 2 {
 		i := strings.LastIndex(id, ruleIDSeparator)
-		busName := id[:i]
-		statementID := id[i+1:]
-		if partnerEventBusPattern.MatchString(busName) && statementID != "" {
-			return busName, statementID, nil
+		if partnerEventBusPattern.MatchString(id[:i]) {
+			return id[:i], id[i+1:], nil
 		}
 	}
 

--- a/aws/internal/service/cloudwatchevents/id.go
+++ b/aws/internal/service/cloudwatchevents/id.go
@@ -84,6 +84,16 @@ func TargetParseImportID(id string) (string, string, string, error) {
 	if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
 		return parts[0], parts[1], parts[2], nil
 	}
+	if len(parts) > 3 {
+		iTarget := strings.LastIndex(id, targetImportIDSeparator)
+		targetID := id[iTarget+1:]
+		iRule := strings.LastIndex(id[:iTarget], targetImportIDSeparator)
+		busName := id[:iRule]
+		ruleName := id[iRule+1 : iTarget]
+		if partnerEventBusPattern.MatchString(busName) && ruleName != "" && targetID != "" {
+			return busName, ruleName, targetID, nil
+		}
+	}
 
 	return "", "", "", fmt.Errorf("unexpected format for ID (%q), expected <event-bus-name>"+targetImportIDSeparator+"<rule-name>"+targetImportIDSeparator+"<target-id> or <rule-name>"+targetImportIDSeparator+"<target-id>", id)
 }

--- a/aws/internal/service/cloudwatchevents/id.go
+++ b/aws/internal/service/cloudwatchevents/id.go
@@ -52,8 +52,10 @@ func RuleParseID(id string) (string, string, error) {
 	}
 	if len(parts) > 2 {
 		i := strings.LastIndex(id, ruleIDSeparator)
-		if partnerEventBusPattern.MatchString(id[:i]) {
-			return id[:i], id[i+1:], nil
+		busName := id[:i]
+		statementID := id[i+1:]
+		if partnerEventBusPattern.MatchString(busName) && statementID != "" {
+			return busName, statementID, nil
 		}
 	}
 

--- a/aws/internal/service/cloudwatchevents/id.go
+++ b/aws/internal/service/cloudwatchevents/id.go
@@ -2,7 +2,12 @@ package cloudwatchevents
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
+)
+
+var (
+	partnerEventBusPattern = regexp.MustCompile(`^aws\.partner(/[\.\-_A-Za-z0-9]+){2,}$`)
 )
 
 const DefaultEventBusName = "default"
@@ -44,6 +49,12 @@ func RuleParseID(id string) (string, string, error) {
 	}
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil
+	}
+	if len(parts) > 2 {
+		i := strings.LastIndex(id, ruleIDSeparator)
+		if partnerEventBusPattern.MatchString(id[:i]) {
+			return id[:i], id[i+1:], nil
+		}
 	}
 
 	return "", "", fmt.Errorf("unexpected format for ID (%q), expected <event-bus-name>"+ruleIDSeparator+"<rule-name> or <rule-name>", id)

--- a/aws/internal/service/cloudwatchevents/id_test.go
+++ b/aws/internal/service/cloudwatchevents/id_test.go
@@ -53,11 +53,6 @@ func TestRuleParseID(t *testing.T) {
 			ExpectedError: true,
 		},
 		{
-			TestName:      "empty partner event rule",
-			InputID:       "aws.partner/example.com/Test/",
-			ExpectedError: true,
-		},
-		{
 			TestName:      "three parts",
 			InputID:       "TestEventBus/TestRule/Suffix",
 			ExpectedError: true,
@@ -77,97 +72,6 @@ func TestRuleParseID(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.TestName, func(t *testing.T) {
 			gotPart0, gotPart1, err := tfevents.RuleParseID(testCase.InputID)
-
-			if err == nil && testCase.ExpectedError {
-				t.Fatalf("expected error, got no error")
-			}
-
-			if err != nil && !testCase.ExpectedError {
-				t.Fatalf("got unexpected error: %s", err)
-			}
-
-			if gotPart0 != testCase.ExpectedPart0 {
-				t.Errorf("got part 0 %s, expected %s", gotPart0, testCase.ExpectedPart0)
-			}
-
-			if gotPart1 != testCase.ExpectedPart1 {
-				t.Errorf("got part 0 %s, expected %s", gotPart1, testCase.ExpectedPart1)
-			}
-		})
-	}
-}
-
-func TestPermissionParseID(t *testing.T) {
-	testCases := []struct {
-		TestName      string
-		InputID       string
-		ExpectedError bool
-		ExpectedPart0 string
-		ExpectedPart1 string
-	}{
-		{
-			TestName:      "empty ID",
-			InputID:       "",
-			ExpectedError: true,
-		},
-		{
-			TestName:      "single part",
-			InputID:       "TestStatement",
-			ExpectedPart0: "default",
-			ExpectedPart1: "TestStatement",
-		},
-		{
-			TestName:      "two parts",
-			InputID:       "TestEventBus/TestStatement",
-			ExpectedPart0: "TestEventBus",
-			ExpectedPart1: "TestStatement",
-		},
-		{
-			TestName:      "partner event bus",
-			InputID:       "aws.partner/example.com/Test/TestStatement",
-			ExpectedPart0: "aws.partner/example.com/Test",
-			ExpectedPart1: "TestStatement",
-		},
-		{
-			TestName:      "empty partner event statement",
-			InputID:       "aws.partner/example.com/Test/",
-			ExpectedError: true,
-		},
-		{
-			TestName:      "empty both parts",
-			InputID:       "/",
-			ExpectedError: true,
-		},
-		{
-			TestName:      "empty first part",
-			InputID:       "TestEventBus/",
-			ExpectedError: true,
-		},
-		{
-			TestName:      "empty second part",
-			InputID:       "/TestStatement",
-			ExpectedError: true,
-		},
-		{
-			TestName:      "three parts",
-			InputID:       "TestEventBus/TestStatement/Suffix",
-			ExpectedError: true,
-		},
-		{
-			TestName:      "four parts",
-			InputID:       "abc.partner/TestEventBus/TestStatement/Suffix",
-			ExpectedError: true,
-		},
-		{
-			TestName:      "five parts",
-			InputID:       "test/aws.partner/example.com/TestStatement/TestRule",
-			ExpectedError: true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.TestName, func(t *testing.T) {
-			gotPart0, gotPart1, err := tfevents.PermissionParseID(testCase.InputID)
 
 			if err == nil && testCase.ExpectedError {
 				t.Fatalf("expected error, got no error")

--- a/aws/internal/service/cloudwatchevents/id_test.go
+++ b/aws/internal/service/cloudwatchevents/id_test.go
@@ -53,6 +53,11 @@ func TestRuleParseID(t *testing.T) {
 			ExpectedError: true,
 		},
 		{
+			TestName:      "empty partner event rule",
+			InputID:       "aws.partner/example.com/Test/",
+			ExpectedError: true,
+		},
+		{
 			TestName:      "three parts",
 			InputID:       "TestEventBus/TestRule/Suffix",
 			ExpectedError: true,
@@ -72,6 +77,97 @@ func TestRuleParseID(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.TestName, func(t *testing.T) {
 			gotPart0, gotPart1, err := tfevents.RuleParseID(testCase.InputID)
+
+			if err == nil && testCase.ExpectedError {
+				t.Fatalf("expected error, got no error")
+			}
+
+			if err != nil && !testCase.ExpectedError {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if gotPart0 != testCase.ExpectedPart0 {
+				t.Errorf("got part 0 %s, expected %s", gotPart0, testCase.ExpectedPart0)
+			}
+
+			if gotPart1 != testCase.ExpectedPart1 {
+				t.Errorf("got part 0 %s, expected %s", gotPart1, testCase.ExpectedPart1)
+			}
+		})
+	}
+}
+
+func TestPermissionParseID(t *testing.T) {
+	testCases := []struct {
+		TestName      string
+		InputID       string
+		ExpectedError bool
+		ExpectedPart0 string
+		ExpectedPart1 string
+	}{
+		{
+			TestName:      "empty ID",
+			InputID:       "",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "single part",
+			InputID:       "TestStatement",
+			ExpectedPart0: "default",
+			ExpectedPart1: "TestStatement",
+		},
+		{
+			TestName:      "two parts",
+			InputID:       "TestEventBus/TestStatement",
+			ExpectedPart0: "TestEventBus",
+			ExpectedPart1: "TestStatement",
+		},
+		{
+			TestName:      "partner event bus",
+			InputID:       "aws.partner/example.com/Test/TestStatement",
+			ExpectedPart0: "aws.partner/example.com/Test",
+			ExpectedPart1: "TestStatement",
+		},
+		{
+			TestName:      "empty partner event statement",
+			InputID:       "aws.partner/example.com/Test/",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty both parts",
+			InputID:       "/",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty first part",
+			InputID:       "TestEventBus/",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty second part",
+			InputID:       "/TestStatement",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "three parts",
+			InputID:       "TestEventBus/TestStatement/Suffix",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "four parts",
+			InputID:       "abc.partner/TestEventBus/TestStatement/Suffix",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "five parts",
+			InputID:       "test/aws.partner/example.com/TestStatement/TestRule",
+			ExpectedError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			gotPart0, gotPart1, err := tfevents.PermissionParseID(testCase.InputID)
 
 			if err == nil && testCase.ExpectedError {
 				t.Fatalf("expected error, got no error")

--- a/aws/internal/service/cloudwatchevents/id_test.go
+++ b/aws/internal/service/cloudwatchevents/id_test.go
@@ -44,12 +44,12 @@ func TestRuleParseID(t *testing.T) {
 		},
 		{
 			TestName:      "empty first part",
-			InputID:       "TestEventBus/",
+			InputID:       "/TestRule",
 			ExpectedError: true,
 		},
 		{
 			TestName:      "empty second part",
-			InputID:       "/TestRule",
+			InputID:       "TestEventBus/",
 			ExpectedError: true,
 		},
 		{
@@ -91,7 +91,146 @@ func TestRuleParseID(t *testing.T) {
 			}
 
 			if gotPart1 != testCase.ExpectedPart1 {
-				t.Errorf("got part 0 %s, expected %s", gotPart1, testCase.ExpectedPart1)
+				t.Errorf("got part 1 %s, expected %s", gotPart1, testCase.ExpectedPart1)
+			}
+		})
+	}
+}
+
+func TestTargetParseImportID(t *testing.T) {
+	testCases := []struct {
+		TestName      string
+		InputID       string
+		ExpectedError bool
+		ExpectedPart0 string
+		ExpectedPart1 string
+		ExpectedPart2 string
+	}{
+		{
+			TestName:      "empty ID",
+			InputID:       "",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "single part",
+			InputID:       "TestRule",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "two parts",
+			InputID:       "TestTarget/TestRule",
+			ExpectedPart0: "default",
+			ExpectedPart1: "TestTarget",
+			ExpectedPart2: "TestRule",
+		},
+		{
+			TestName:      "three parts",
+			InputID:       "TestEventBus/TestRule/TestTarget",
+			ExpectedPart0: "TestEventBus",
+			ExpectedPart1: "TestRule",
+			ExpectedPart2: "TestTarget",
+		},
+		{
+			TestName:      "empty two parts",
+			InputID:       "/",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty three parts",
+			InputID:       "//",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty first part of two",
+			InputID:       "/TestTarget",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty second part of two",
+			InputID:       "TestRule/",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty first part of three",
+			InputID:       "/TestRule/TestTarget",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty second part of three",
+			InputID:       "TestEventBus//TestTarget",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty third part of three",
+			InputID:       "TestEventBus/TestRule/",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty first two of three parts",
+			InputID:       "//TestTarget",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty first and third of three parts",
+			InputID:       "/TestRule/",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty final two of three parts",
+			InputID:       "TestEventBus//",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "partner event bus",
+			InputID:       "aws.partner/example.com/Test/TestRule/TestTarget",
+			ExpectedPart0: "aws.partner/example.com/Test",
+			ExpectedPart1: "TestRule",
+			ExpectedPart2: "TestTarget",
+		},
+		{
+			TestName:      "empty partner event rule and target",
+			InputID:       "aws.partner/example.com/Test//",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "four parts",
+			InputID:       "aws.partner/example.com/Test/TestRule",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "five parts",
+			InputID:       "abc.partner/example.com/Test/TestRule/TestTarget",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "six parts",
+			InputID:       "test/aws.partner/example.com/Test/TestRule/TestTarget",
+			ExpectedError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			gotPart0, gotPart1, gotPart2, err := tfevents.TargetParseImportID(testCase.InputID)
+
+			if err == nil && testCase.ExpectedError {
+				t.Fatalf("expected error, got no error")
+			}
+
+			if err != nil && !testCase.ExpectedError {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if gotPart0 != testCase.ExpectedPart0 {
+				t.Errorf("got part 0 %s, expected %s", gotPart0, testCase.ExpectedPart0)
+			}
+
+			if gotPart1 != testCase.ExpectedPart1 {
+				t.Errorf("got part 1 %s, expected %s", gotPart1, testCase.ExpectedPart1)
+			}
+
+			if gotPart2 != testCase.ExpectedPart2 {
+				t.Errorf("got part 2 %s, expected %s", gotPart2, testCase.ExpectedPart2)
 			}
 		})
 	}

--- a/aws/internal/service/cloudwatchevents/id_test.go
+++ b/aws/internal/service/cloudwatchevents/id_test.go
@@ -22,13 +22,19 @@ func TestRuleParseID(t *testing.T) {
 		{
 			TestName:      "single part",
 			InputID:       "TestRule",
-			ExpectedPart0: "default",
+			ExpectedPart0: tfevents.DefaultEventBusName,
 			ExpectedPart1: "TestRule",
 		},
 		{
 			TestName:      "two parts",
-			InputID:       "TestEventBus/TestRule",
+			InputID:       tfevents.RuleCreateID("TestEventBus", "TestRule"),
 			ExpectedPart0: "TestEventBus",
+			ExpectedPart1: "TestRule",
+		},
+		{
+			TestName:      "two parts with default event bus",
+			InputID:       tfevents.RuleCreateID(tfevents.DefaultEventBusName, "TestRule"),
+			ExpectedPart0: tfevents.DefaultEventBusName,
 			ExpectedPart1: "TestRule",
 		},
 		{
@@ -119,7 +125,7 @@ func TestTargetParseImportID(t *testing.T) {
 		{
 			TestName:      "two parts",
 			InputID:       "TestTarget/TestRule",
-			ExpectedPart0: "default",
+			ExpectedPart0: tfevents.DefaultEventBusName,
 			ExpectedPart1: "TestTarget",
 			ExpectedPart2: "TestRule",
 		},
@@ -127,6 +133,13 @@ func TestTargetParseImportID(t *testing.T) {
 			TestName:      "three parts",
 			InputID:       "TestEventBus/TestRule/TestTarget",
 			ExpectedPart0: "TestEventBus",
+			ExpectedPart1: "TestRule",
+			ExpectedPart2: "TestTarget",
+		},
+		{
+			TestName:      "three parts with default event bus",
+			InputID:       tfevents.DefaultEventBusName + "/TestRule/TestTarget",
+			ExpectedPart0: tfevents.DefaultEventBusName,
 			ExpectedPart1: "TestRule",
 			ExpectedPart2: "TestTarget",
 		},

--- a/aws/internal/service/cloudwatchevents/id_test.go
+++ b/aws/internal/service/cloudwatchevents/id_test.go
@@ -1,0 +1,93 @@
+package cloudwatchevents_test
+
+import (
+	"testing"
+
+	tfevents "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudwatchevents"
+)
+
+func TestRuleParseID(t *testing.T) {
+	testCases := []struct {
+		TestName      string
+		InputID       string
+		ExpectedError bool
+		ExpectedPart0 string
+		ExpectedPart1 string
+	}{
+		{
+			TestName:      "empty ID",
+			InputID:       "",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "single part",
+			InputID:       "TestRule",
+			ExpectedPart0: "default",
+			ExpectedPart1: "TestRule",
+		},
+		{
+			TestName:      "two parts",
+			InputID:       "TestEventBus/TestRule",
+			ExpectedPart0: "TestEventBus",
+			ExpectedPart1: "TestRule",
+		},
+		{
+			TestName:      "partner event bus",
+			InputID:       "aws.partner/example.com/Test/TestRule",
+			ExpectedPart0: "aws.partner/example.com/Test",
+			ExpectedPart1: "TestRule",
+		},
+		{
+			TestName:      "empty both parts",
+			InputID:       "/",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty first part",
+			InputID:       "TestEventBus/",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "empty second part",
+			InputID:       "/TestRule",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "three parts",
+			InputID:       "TestEventBus/TestRule/Suffix",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "four parts",
+			InputID:       "abc.partner/TestEventBus/TestRule/Suffix",
+			ExpectedError: true,
+		},
+		{
+			TestName:      "five parts",
+			InputID:       "test/aws.partner/example.com/Test/TestRule",
+			ExpectedError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			gotPart0, gotPart1, err := tfevents.RuleParseID(testCase.InputID)
+
+			if err == nil && testCase.ExpectedError {
+				t.Fatalf("expected error, got no error")
+			}
+
+			if err != nil && !testCase.ExpectedError {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if gotPart0 != testCase.ExpectedPart0 {
+				t.Errorf("got part 0 %s, expected %s", gotPart0, testCase.ExpectedPart0)
+			}
+
+			if gotPart1 != testCase.ExpectedPart1 {
+				t.Errorf("got part 0 %s, expected %s", gotPart1, testCase.ExpectedPart1)
+			}
+		})
+	}
+}

--- a/aws/internal/service/cloudwatchevents/id_test.go
+++ b/aws/internal/service/cloudwatchevents/id_test.go
@@ -53,6 +53,11 @@ func TestRuleParseID(t *testing.T) {
 			ExpectedError: true,
 		},
 		{
+			TestName:      "empty partner event rule",
+			InputID:       "aws.partner/example.com/Test/",
+			ExpectedError: true,
+		},
+		{
 			TestName:      "three parts",
 			InputID:       "TestEventBus/TestRule/Suffix",
 			ExpectedError: true,

--- a/aws/resource_aws_cloudwatch_event_permission_test.go
+++ b/aws/resource_aws_cloudwatch_event_permission_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -315,40 +314,6 @@ func TestAccAWSCloudWatchEventPermission_Disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudWatchEventPermission_PartnerEventBus(t *testing.T) {
-	key := "EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME"
-	busName := os.Getenv(key)
-	if busName == "" {
-		t.Skipf("Environment variable %s is not set", key)
-	}
-
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_cloudwatch_event_permission.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, cloudwatchevents.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudWatchEventPermissionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAwsCloudWatchEventPermissionPartnerEventBusConfig(rName, busName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventPermissionExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "event_bus_name", busName),
-					resource.TestCheckResourceAttr(resourceName, "principal", "111111111111"),
-					resource.TestCheckResourceAttr(resourceName, "statement_id", rName),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func testAccCheckCloudWatchEventPermissionExists(pr string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn
@@ -507,14 +472,4 @@ resource "aws_cloudwatch_event_permission" "test2" {
   statement_id = "%[4]s"
 }
 `, principal1, statementID1, principal2, statementID2)
-}
-
-func testAccCheckAwsCloudWatchEventPermissionPartnerEventBusConfig(rName, eventBusName string) string {
-	return fmt.Sprintf(`
-resource "aws_cloudwatch_event_permission" "test" {
-  principal      = "111111111111"
-  statement_id   = %[1]q
-  event_bus_name = %[2]q
-}
-`, rName, eventBusName)
 }

--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -779,10 +779,10 @@ resource "aws_cloudwatch_event_rule" "test" {
 func testAccAWSCloudWatchEventRulePartnerEventBusConfig(rName, eventBusName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_rule" "test" {
-  name                = %[1]q
-  event_bus_name      = %[2]q
+  name           = %[1]q
+  event_bus_name = %[2]q
 
-  event_pattern  = <<PATTERN
+  event_pattern = <<PATTERN
 {
   "source": ["aws.ec2"]
 }

--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"testing"
 
@@ -480,6 +481,47 @@ func TestAccAWSCloudWatchEventRule_IsEnabled(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudWatchEventRule_PartnerEventBus(t *testing.T) {
+	key := "EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME"
+	busName := os.Getenv(key)
+	if busName == "" {
+		t.Skipf("Environment variable %s is not set", key)
+	}
+
+	var v events.DescribeRuleOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test-rule")
+	resourceName := "aws_cloudwatch_event_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, cloudwatchevents.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchEventRulePartnerEventBusConfig(rName, busName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventRuleExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "events", regexp.MustCompile(fmt.Sprintf(`rule/%s/%s$`, busName, rName))),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "event_bus_name", busName),
+					testAccCheckResourceAttrEquivalentJSON(resourceName, "event_pattern", "{\"source\":[\"aws.ec2\"]}"),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "schedule_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckCloudWatchEventRuleExists(n string, rule *events.DescribeRuleOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -732,4 +774,19 @@ resource "aws_cloudwatch_event_rule" "test" {
   role_arn            = aws_iam_role.test.arn
 }
 `, name)
+}
+
+func testAccAWSCloudWatchEventRulePartnerEventBusConfig(rName, eventBusName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_rule" "test" {
+  name                = %[1]q
+  event_bus_name      = %[2]q
+
+  event_pattern  = <<PATTERN
+{
+  "source": ["aws.ec2"]
+}
+PATTERN
+}
+`, rName, eventBusName)
 }

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -713,8 +713,6 @@ func testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName string) resou
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		fmt.Printf("%#v", rs.Primary.Attributes)
-
 		return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["event_bus_name"], rs.Primary.Attributes["rule"], rs.Primary.Attributes["target_id"]), nil
 	}
 }

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -625,6 +626,44 @@ func TestAccAWSCloudWatchEventTarget_inputTransformerJsonString(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "input_transformer.0.input_paths.instance", "$.detail.instance"),
 					resource.TestCheckResourceAttr(resourceName, "input_transformer.0.input_template", "\"<instance> is in state <status>\""),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchEventTarget_PartnerEventBus(t *testing.T) {
+	key := "EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME"
+	busName := os.Getenv(key)
+	if busName == "" {
+		t.Skipf("Environment variable %s is not set", key)
+	}
+
+	var target events.Target
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudwatch_event_target.test"
+	snsTopicResourceName := "aws_sns_topic.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, cloudwatchevents.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchEventTargetPartnerEventBusConfig(rName, busName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventTargetExists(resourceName, &target),
+					resource.TestCheckResourceAttr(resourceName, "rule", rName),
+					resource.TestCheckResourceAttr(resourceName, "event_bus_name", busName),
+					resource.TestCheckResourceAttr(resourceName, "target_id", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", snsTopicResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1573,4 +1612,30 @@ EOF
 
 data "aws_partition" "current" {}
 `, name)
+}
+
+func testAccAWSCloudWatchEventTargetPartnerEventBusConfig(rName, eventBusName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_rule" "test" {
+  name                = %[1]q
+  event_bus_name      = %[2]q
+
+  event_pattern  = <<PATTERN
+{
+  "source": ["aws.ec2"]
+}
+PATTERN
+}
+
+resource "aws_cloudwatch_event_target" "test" {
+  rule           = aws_cloudwatch_event_rule.test.name
+  event_bus_name = aws_cloudwatch_event_rule.test.event_bus_name
+  target_id      = %[1]q
+  arn            = aws_sns_topic.test.arn
+}
+
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+`, rName, eventBusName)
 }

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -1615,10 +1615,10 @@ data "aws_partition" "current" {}
 func testAccAWSCloudWatchEventTargetPartnerEventBusConfig(rName, eventBusName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_rule" "test" {
-  name                = %[1]q
-  event_bus_name      = %[2]q
+  name           = %[1]q
+  event_bus_name = %[2]q
 
-  event_pattern  = <<PATTERN
+  event_pattern = <<PATTERN
 {
   "source": ["aws.ec2"]
 }

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -387,6 +387,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `DX_CONNECTION_ID` | Identifier for Direct Connect Connection testing. |
 | `DX_VIRTUAL_INTERFACE_ID` | Identifier for Direct Connect Virtual Interface testing. |
 | `EC2_SECURITY_GROUP_RULES_PER_GROUP_LIMIT` | EC2 Quota for Rules per Security Group. Defaults to 50. **DEPRECATED:** Can be augmented or replaced with Service Quotas lookup. |
+| `EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME` | Amazon EventBridge partner event bus name. |
 | `GCM_API_KEY` | API Key for Google Cloud Messaging in Pinpoint and SNS Platform Application testing. |
 | `GITHUB_TOKEN` | GitHub token for CodePipeline testing. |
 | `MACIE_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for Macie Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18431.

The `EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME` environment variable must be set to an existing partner event bridge name to run the new acceptance tests.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME=aws.partner/datadog.com/TerraformTesting make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCloudWatchEventTarget_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventTarget_ -timeout 180m
=== RUN   TestAccAWSCloudWatchEventTarget_basic
=== PAUSE TestAccAWSCloudWatchEventTarget_basic
=== RUN   TestAccAWSCloudWatchEventTarget_EventBusName
=== PAUSE TestAccAWSCloudWatchEventTarget_EventBusName
=== RUN   TestAccAWSCloudWatchEventTarget_GeneratedTargetId
=== PAUSE TestAccAWSCloudWatchEventTarget_GeneratedTargetId
=== RUN   TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig
=== PAUSE TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig
=== RUN   TestAccAWSCloudWatchEventTarget_full
=== PAUSE TestAccAWSCloudWatchEventTarget_full
=== RUN   TestAccAWSCloudWatchEventTarget_disappears
=== PAUSE TestAccAWSCloudWatchEventTarget_disappears
=== RUN   TestAccAWSCloudWatchEventTarget_ssmDocument
=== PAUSE TestAccAWSCloudWatchEventTarget_ssmDocument
=== RUN   TestAccAWSCloudWatchEventTarget_ecs
=== PAUSE TestAccAWSCloudWatchEventTarget_ecs
=== RUN   TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== PAUSE TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== RUN   TestAccAWSCloudWatchEventTarget_batch
=== PAUSE TestAccAWSCloudWatchEventTarget_batch
=== RUN   TestAccAWSCloudWatchEventTarget_kinesis
=== PAUSE TestAccAWSCloudWatchEventTarget_kinesis
=== RUN   TestAccAWSCloudWatchEventTarget_sqs
=== PAUSE TestAccAWSCloudWatchEventTarget_sqs
=== RUN   TestAccAWSCloudWatchEventTarget_input_transformer
=== PAUSE TestAccAWSCloudWatchEventTarget_input_transformer
=== RUN   TestAccAWSCloudWatchEventTarget_inputTransformerJsonString
=== PAUSE TestAccAWSCloudWatchEventTarget_inputTransformerJsonString
=== RUN   TestAccAWSCloudWatchEventTarget_PartnerEventBus
=== PAUSE TestAccAWSCloudWatchEventTarget_PartnerEventBus
=== CONT  TestAccAWSCloudWatchEventTarget_basic
=== CONT  TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== CONT  TestAccAWSCloudWatchEventTarget_PartnerEventBus
=== CONT  TestAccAWSCloudWatchEventTarget_inputTransformerJsonString
=== CONT  TestAccAWSCloudWatchEventTarget_input_transformer
=== CONT  TestAccAWSCloudWatchEventTarget_sqs
=== CONT  TestAccAWSCloudWatchEventTarget_kinesis
=== CONT  TestAccAWSCloudWatchEventTarget_batch
=== CONT  TestAccAWSCloudWatchEventTarget_full
=== CONT  TestAccAWSCloudWatchEventTarget_ecs
=== CONT  TestAccAWSCloudWatchEventTarget_ssmDocument
=== CONT  TestAccAWSCloudWatchEventTarget_disappears
=== CONT  TestAccAWSCloudWatchEventTarget_GeneratedTargetId
=== CONT  TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig
=== CONT  TestAccAWSCloudWatchEventTarget_EventBusName
--- PASS: TestAccAWSCloudWatchEventTarget_disappears (36.09s)
--- PASS: TestAccAWSCloudWatchEventTarget_PartnerEventBus (38.80s)
--- PASS: TestAccAWSCloudWatchEventTarget_GeneratedTargetId (40.40s)
--- PASS: TestAccAWSCloudWatchEventTarget_sqs (40.45s)
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (42.26s)
--- PASS: TestAccAWSCloudWatchEventTarget_inputTransformerJsonString (50.73s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount (55.82s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (55.97s)
--- PASS: TestAccAWSCloudWatchEventTarget_EventBusName (62.47s)
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (63.21s)
--- PASS: TestAccAWSCloudWatchEventTarget_basic (72.88s)
--- PASS: TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig (78.52s)
--- PASS: TestAccAWSCloudWatchEventTarget_kinesis (80.00s)
--- PASS: TestAccAWSCloudWatchEventTarget_full (80.40s)
--- PASS: TestAccAWSCloudWatchEventTarget_batch (173.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	173.215s
$ EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME=aws.partner/datadog.com/TerraformTesting make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCloudWatchEventRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventRule_ -timeout 180m
=== RUN   TestAccAWSCloudWatchEventRule_basic
=== PAUSE TestAccAWSCloudWatchEventRule_basic
=== RUN   TestAccAWSCloudWatchEventRule_EventBusName
=== PAUSE TestAccAWSCloudWatchEventRule_EventBusName
=== RUN   TestAccAWSCloudWatchEventRule_role
=== PAUSE TestAccAWSCloudWatchEventRule_role
=== RUN   TestAccAWSCloudWatchEventRule_description
=== PAUSE TestAccAWSCloudWatchEventRule_description
=== RUN   TestAccAWSCloudWatchEventRule_pattern
=== PAUSE TestAccAWSCloudWatchEventRule_pattern
=== RUN   TestAccAWSCloudWatchEventRule_ScheduleAndPattern
=== PAUSE TestAccAWSCloudWatchEventRule_ScheduleAndPattern
=== RUN   TestAccAWSCloudWatchEventRule_NamePrefix
=== PAUSE TestAccAWSCloudWatchEventRule_NamePrefix
=== RUN   TestAccAWSCloudWatchEventRule_Name_Generated
=== PAUSE TestAccAWSCloudWatchEventRule_Name_Generated
=== RUN   TestAccAWSCloudWatchEventRule_tags
=== PAUSE TestAccAWSCloudWatchEventRule_tags
=== RUN   TestAccAWSCloudWatchEventRule_IsEnabled
=== PAUSE TestAccAWSCloudWatchEventRule_IsEnabled
=== RUN   TestAccAWSCloudWatchEventRule_PartnerEventBus
=== PAUSE TestAccAWSCloudWatchEventRule_PartnerEventBus
=== CONT  TestAccAWSCloudWatchEventRule_basic
=== CONT  TestAccAWSCloudWatchEventRule_NamePrefix
=== CONT  TestAccAWSCloudWatchEventRule_PartnerEventBus
=== CONT  TestAccAWSCloudWatchEventRule_IsEnabled
=== CONT  TestAccAWSCloudWatchEventRule_tags
=== CONT  TestAccAWSCloudWatchEventRule_Name_Generated
=== CONT  TestAccAWSCloudWatchEventRule_role
=== CONT  TestAccAWSCloudWatchEventRule_ScheduleAndPattern
=== CONT  TestAccAWSCloudWatchEventRule_pattern
=== CONT  TestAccAWSCloudWatchEventRule_description
=== CONT  TestAccAWSCloudWatchEventRule_EventBusName
--- PASS: TestAccAWSCloudWatchEventRule_ScheduleAndPattern (40.12s)
--- PASS: TestAccAWSCloudWatchEventRule_NamePrefix (42.91s)
--- PASS: TestAccAWSCloudWatchEventRule_Name_Generated (42.99s)
--- PASS: TestAccAWSCloudWatchEventRule_PartnerEventBus (43.03s)
--- PASS: TestAccAWSCloudWatchEventRule_role (55.15s)
--- PASS: TestAccAWSCloudWatchEventRule_description (58.10s)
--- PASS: TestAccAWSCloudWatchEventRule_pattern (61.72s)
--- PASS: TestAccAWSCloudWatchEventRule_basic (74.15s)
--- PASS: TestAccAWSCloudWatchEventRule_IsEnabled (74.83s)
--- PASS: TestAccAWSCloudWatchEventRule_EventBusName (77.56s)
--- PASS: TestAccAWSCloudWatchEventRule_tags (85.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	85.518s
```
