### PR TITLE
Concurrent modification protection for AppSync sub-API resources

### DIFF
--- a/aws/resource_aws_appsync_api_key_test.go
+++ b/aws/resource_aws_appsync_api_key_test.go
@@ -113,6 +113,35 @@ func TestAccAWSAppsyncApiKey_Expires(t *testing.T) {
 	})
 }
 
+func TestAccAwsAppsyncApiKey_multipleApiKeys(t *testing.T) {
+	var apiKey appsync.ApiKey
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_api_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appsync.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncApiKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncApiKey_multipleApiKeys(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"1", &apiKey),
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"2", &apiKey),
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"3", &apiKey),
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"4", &apiKey),
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"5", &apiKey),
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"6", &apiKey),
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"7", &apiKey),
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"8", &apiKey),
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"9", &apiKey),
+					testAccCheckAwsAppsyncApiKeyExists(resourceName+"10", &apiKey),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsAppsyncApiKeyDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).appsyncconn
 	for _, rs := range s.RootModule().Resources {
@@ -222,4 +251,25 @@ resource "aws_appsync_api_key" "test" {
   api_id = aws_appsync_graphql_api.test.id
 }
 `, rName)
+}
+
+func testAccAppsyncApiKey_multipleApiKeys(rName string) string {
+	var datasourceResources string
+	for i := 1; i <= 10; i++ {
+		datasourceResources = datasourceResources + fmt.Sprintf(`
+		resource "aws_appsync_api_key" "test%d" {
+			api_id = aws_appsync_graphql_api.test.id
+		}
+`, i)
+	}
+
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+%s
+
+`, rName, datasourceResources)
 }

--- a/aws/resource_aws_appsync_api_key_test.go
+++ b/aws/resource_aws_appsync_api_key_test.go
@@ -254,9 +254,9 @@ resource "aws_appsync_api_key" "test" {
 }
 
 func testAccAppsyncApiKey_multipleApiKeys(rName string) string {
-	var datasourceResources string
+	var resources string
 	for i := 1; i <= 10; i++ {
-		datasourceResources = datasourceResources + fmt.Sprintf(`
+		resources = resources + fmt.Sprintf(`
 		resource "aws_appsync_api_key" "test%d" {
 			api_id = aws_appsync_graphql_api.test.id
 		}
@@ -271,5 +271,5 @@ resource "aws_appsync_graphql_api" "test" {
 
 %s
 
-`, rName, datasourceResources)
+`, rName, resources)
 }

--- a/aws/resource_aws_appsync_api_key_test.go
+++ b/aws/resource_aws_appsync_api_key_test.go
@@ -113,13 +113,14 @@ func TestAccAWSAppsyncApiKey_Expires(t *testing.T) {
 	})
 }
 
-func TestAccAwsAppsyncApiKey_multipleApiKeys(t *testing.T) {
+func TestAccAWSAppsyncApiKey_multipleApiKeys(t *testing.T) {
 	var apiKey appsync.ApiKey
 	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
 	resourceName := "aws_appsync_api_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appsync.EndpointsID, t) },
+		ErrorCheck:   testAccErrorCheck(t, appsync.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncApiKeyDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_appsync_datasource_test.go
+++ b/aws/resource_aws_appsync_datasource_test.go
@@ -460,6 +460,7 @@ func TestAccAwsAppsyncDatasource_multipleDatasources(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appsync.EndpointsID, t) },
+		ErrorCheck:   testAccErrorCheck(t, appsync.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_appsync_function_test.go
+++ b/aws/resource_aws_appsync_function_test.go
@@ -145,6 +145,7 @@ func TestAccAwsAppsyncFunction_multipleFunctions(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appsync.EndpointsID, t) },
+		ErrorCheck:   testAccErrorCheck(t, appsync.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncFunctionDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR extends the work done in 85574e51ac0f1ec5b20da1693de92e653b29724c to three new resources:
* aws_appsync_datasource
* aws_appsync_api_key
* aws_appsync_function

In short, it uses a provider-level mutex to prevent concurrent modification to an AppSync API by multiple resources, and adds retry logic if a ConcurrentExecution exception is received from the AWS API anyway.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16211

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsAppsyncApiKey_multipleApiKeys'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAppsyncApiKey_multipleApiKeys -timeout 120m
=== RUN   TestAccAwsAppsyncApiKey_multipleApiKeys
=== PAUSE TestAccAwsAppsyncApiKey_multipleApiKeys
=== CONT  TestAccAwsAppsyncApiKey_multipleApiKeys
--- PASS: TestAccAwsAppsyncApiKey_multipleApiKeys (49.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	52.086s

$ make testacc TESTARGS='-run=TestAccAwsAppsyncFunction_multipleFunctions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAppsyncFunction_multipleFunctions -timeout 120m
=== RUN   TestAccAwsAppsyncFunction_multipleFunctions
=== PAUSE TestAccAwsAppsyncFunction_multipleFunctions
=== CONT  TestAccAwsAppsyncFunction_multipleFunctions
--- PASS: TestAccAwsAppsyncFunction_multipleFunctions (57.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	60.454s

$ make testacc TESTARGS='-run=TestAccAwsAppsyncDatasource_multipleDatasources'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAppsyncDatasource_multipleDatasources -timeout 120m
=== RUN   TestAccAwsAppsyncDatasource_multipleDatasources
=== PAUSE TestAccAwsAppsyncDatasource_multipleDatasources
=== CONT  TestAccAwsAppsyncDatasource_multipleDatasources
--- PASS: TestAccAwsAppsyncDatasource_multipleDatasources (67.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.590s
```