### PR TITLE
gateway config contains pre shared key

### DIFF
--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -395,6 +395,7 @@ func resourceAwsVpnConnection() *schema.Resource {
 			// Begin read only attributes
 			"customer_gateway_configuration": {
 				Type:     schema.TypeString,
+				Sensitive: true,
 				Computed: true,
 			},
 


### PR DESCRIPTION
the tunnel1_preshared_key and tunnel2_preshared_key are marked as sensitive, but are contained within the xml contained within the customer_gateway_configuration.  As such, that should be marked sensitive as well.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
