### PR TITLE
docs/resource/aws_cloudwatch_query_definition: Fix Example Usage code block language

### DIFF
--- a/website/docs/r/cloudwatch_query_definition.html.markdown
+++ b/website/docs/r/cloudwatch_query_definition.html.markdown
@@ -12,7 +12,7 @@ Provides a CloudWatch Logs query definition resource.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "aws_cloudwatch_query_definition" "example" {
   name = "custom_query"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Previously:

```
Error checking Terraform Provider documentation: 1 error occurred:
	* website/docs/r/cloudwatch_query_definition.html.markdown: error checking file contents: example section code block language (hcl) should be: ```terraform
```

Output from acceptance testing: N/A (documentation)