### PR TITLE
service/appmesh: Handle read-after-create eventual consistency in resources

### DIFF
--- a/.changelog/18529.txt
+++ b/.changelog/18529.txt
@@ -1,0 +1,27 @@
+```release-note:bug
+resource/aws_appmesh_gateway_route: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_appmesh_mesh: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_appmesh_route: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_appmesh_virtual_gateway: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_appmesh_virtual_router: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_appmesh_virtual_service: Handle read-after-create eventual consistency
+```
+
+```release-note:bug
+resource/aws_appmesh_virtual_node: Handle read-after-create eventual consistency
+```

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -236,7 +236,6 @@ rules:
         - aws/resource_aws_apigatewayv2_*.go
         - aws/resource_aws_app_cookie_stickiness_policy.go
         - aws/resource_aws_appautoscaling_*.go
-        - aws/resource_aws_appmesh_*.go
         - aws/resource_aws_appsync_*.go
         - aws/resource_aws_athena_*.go
         - aws/resource_aws_autoscaling_*.go

--- a/aws/internal/service/appmesh/waiter/waiter.go
+++ b/aws/internal/service/appmesh/waiter/waiter.go
@@ -1,0 +1,10 @@
+package waiter
+
+import (
+	"time"
+)
+
+const (
+	// Maximum amount of time to wait for Appmesh changes to propagate
+	PropagationTimeout = 2 * time.Minute
+)

--- a/aws/resource_aws_appmesh_route.go
+++ b/aws/resource_aws_appmesh_route.go
@@ -9,9 +9,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/appmesh/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsAppmeshRoute() *schema.Resource {
@@ -730,17 +734,48 @@ func resourceAwsAppmeshRouteRead(d *schema.ResourceData, meta interface{}) error
 		req.MeshOwner = aws.String(v.(string))
 	}
 
-	resp, err := conn.DescribeRoute(req)
-	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
-		log.Printf("[WARN] App Mesh route (%s) not found, removing from state", d.Id())
+	var resp *appmesh.DescribeRouteOutput
+
+	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		resp, err = conn.DescribeRoute(req)
+
+		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		resp, err = conn.DescribeRoute(req)
+	}
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
+		log.Printf("[WARN] App Mesh Route (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
+
 	if err != nil {
-		return fmt.Errorf("error reading App Mesh route: %s", err)
+		return fmt.Errorf("error reading App Mesh Route: %w", err)
 	}
+
+	if resp == nil || resp.Route == nil {
+		return fmt.Errorf("error reading App Mesh Route: empty response")
+	}
+
 	if aws.StringValue(resp.Route.Status.Status) == appmesh.RouteStatusCodeDeleted {
-		log.Printf("[WARN] App Mesh route (%s) not found, removing from state", d.Id())
+		if d.IsNewResource() {
+			return fmt.Errorf("error reading App Mesh Route: %s after creation", aws.StringValue(resp.Route.Status.Status))
+		}
+
+		log.Printf("[WARN] App Mesh Route (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_appmesh_route_test.go
+++ b/aws/resource_aws_appmesh_route_test.go
@@ -1110,7 +1110,6 @@ func testAccAwsAppmeshRoute_httpHeader(t *testing.T) {
 					}),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.method", "POST"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.prefix", "/"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.scheme", "http"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.retry_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "0"),
@@ -1152,7 +1151,6 @@ func testAccAwsAppmeshRoute_httpHeader(t *testing.T) {
 					}),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.method", "PUT"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.prefix", "/path"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.scheme", "https"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.retry_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "0"),
@@ -2245,7 +2243,6 @@ resource "aws_appmesh_route" "test" {
       match {
         prefix = "/"
         method = "POST"
-        scheme = "http"
 
         header {
           name = "X-Testing1"
@@ -2276,7 +2273,6 @@ resource "aws_appmesh_route" "test" {
       match {
         prefix = "/path"
         method = "PUT"
-        scheme = "https"
 
         header {
           name   = "X-Testing1"

--- a/aws/resource_aws_appmesh_virtual_router.go
+++ b/aws/resource_aws_appmesh_virtual_router.go
@@ -8,9 +8,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/appmesh/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsAppmeshVirtualRouter() *schema.Resource {
@@ -153,17 +157,48 @@ func resourceAwsAppmeshVirtualRouterRead(d *schema.ResourceData, meta interface{
 		req.MeshOwner = aws.String(v.(string))
 	}
 
-	resp, err := conn.DescribeVirtualRouter(req)
-	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
-		log.Printf("[WARN] App Mesh virtual router (%s) not found, removing from state", d.Id())
+	var resp *appmesh.DescribeVirtualRouterOutput
+
+	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		resp, err = conn.DescribeVirtualRouter(req)
+
+		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		resp, err = conn.DescribeVirtualRouter(req)
+	}
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
+		log.Printf("[WARN] App Mesh Virtual Router (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
+
 	if err != nil {
-		return fmt.Errorf("error reading App Mesh virtual router: %s", err)
+		return fmt.Errorf("error reading App Mesh Virtual Router: %w", err)
 	}
+
+	if resp == nil || resp.VirtualRouter == nil {
+		return fmt.Errorf("error reading App Mesh Virtual Router: empty response")
+	}
+
 	if aws.StringValue(resp.VirtualRouter.Status.Status) == appmesh.VirtualRouterStatusCodeDeleted {
-		log.Printf("[WARN] App Mesh virtual router (%s) not found, removing from state", d.Id())
+		if d.IsNewResource() {
+			return fmt.Errorf("error reading App Mesh Virtual Router: %s after creation", aws.StringValue(resp.VirtualRouter.Status.Status))
+		}
+
+		log.Printf("[WARN] App Mesh Virtual Router (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15084
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16796
Closes #18528
Reference: https://blog.envoyproxy.io/embracing-eventual-consistency-in-soa-networking-32a5ee5d443d

Output from acceptance testing in AWS Commercial:

```
--- FAIL: TestAccAWSAppmesh_serial (1654.08s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualRouter (64.89s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualRouter/basic (27.55s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualRouter/tags (37.34s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualService (102.18s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualService/virtualNode (30.51s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualService/virtualRouter (27.91s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualService/tags (43.76s)
    --- PASS: TestAccAWSAppmesh_serial/GatewayRoute (180.76s)
        --- PASS: TestAccAWSAppmesh_serial/GatewayRoute/httpRoute (31.38s)
        --- PASS: TestAccAWSAppmesh_serial/GatewayRoute/http2Route (30.54s)
        --- PASS: TestAccAWSAppmesh_serial/GatewayRoute/tags (45.18s)
        --- PASS: TestAccAWSAppmesh_serial/GatewayRoute/basic (18.19s)
        --- PASS: TestAccAWSAppmesh_serial/GatewayRoute/disappears (14.95s)
        --- PASS: TestAccAWSAppmesh_serial/GatewayRoute/grpcRoute (40.53s)
    --- PASS: TestAccAWSAppmesh_serial/Mesh (73.44s)
        --- PASS: TestAccAWSAppmesh_serial/Mesh/basic (12.91s)
        --- PASS: TestAccAWSAppmesh_serial/Mesh/egressFilter (29.35s)
        --- PASS: TestAccAWSAppmesh_serial/Mesh/tags (31.18s)
    --- FAIL: TestAccAWSAppmesh_serial/Route (429.26s)
        --- PASS: TestAccAWSAppmesh_serial/Route/httpRoute (43.23s)
        --- PASS: TestAccAWSAppmesh_serial/Route/tcpRoute (42.71s)
        --- PASS: TestAccAWSAppmesh_serial/Route/tcpRouteTimeout (30.21s)
        --- PASS: TestAccAWSAppmesh_serial/Route/grpcRouteEmptyMatch (17.81s)
        --- PASS: TestAccAWSAppmesh_serial/Route/grpcRouteTimeout (31.13s)
        --- PASS: TestAccAWSAppmesh_serial/Route/http2RouteTimeout (31.08s)
        --- PASS: TestAccAWSAppmesh_serial/Route/httpRetryPolicy (32.21s)
        --- PASS: TestAccAWSAppmesh_serial/Route/routePriority (31.77s)
        --- PASS: TestAccAWSAppmesh_serial/Route/tags (44.91s)
        --- PASS: TestAccAWSAppmesh_serial/Route/grpcRoute (54.42s)
        --- PASS: TestAccAWSAppmesh_serial/Route/http2Route (30.70s)
        --- FAIL: TestAccAWSAppmesh_serial/Route/httpHeader (8.24s) # https://github.com/hashicorp/terraform-provider-aws/issues/18528
        --- PASS: TestAccAWSAppmesh_serial/Route/httpRouteTimeout (30.84s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualGateway (285.66s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/listenerConnectionPool (26.22s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/listenerHealthChecks (26.25s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/listenerTls (70.19s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/basic (17.09s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/disappears (12.66s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/backendDefaultsCertificate (15.85s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/tags (38.11s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/backendDefaults (26.15s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/listenerValidation (26.61s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualGateway/logging (26.53s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualNode (517.90s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/listenerOutlierDetection (26.74s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/listenerTimeout (26.37s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/tags (38.61s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/disappears (12.41s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/backendClientPolicyFile (26.83s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/cloudMapServiceDiscovery (99.43s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/basic (15.51s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/backendClientPolicyAcm (50.89s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/listenerTls (69.86s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/backendDefaults (27.28s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/backendDefaultsCertificate (15.92s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/listenerValidation (26.70s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/listenerConnectionPool (28.32s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/listenerHealthChecks (26.63s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/logging (26.40s)
```
