### PR TITLE
service/s3control: Add d.IsNewResource() checks, public access block update waiters, and standardize read handling

### DIFF
--- a/aws/internal/service/s3control/errors.go
+++ b/aws/internal/service/s3control/errors.go
@@ -1,0 +1,9 @@
+package s3control
+
+// Error code constants missing from AWS Go SDK:
+// https://docs.aws.amazon.com/sdk-for-go/api/service/s3control/#pkg-constants
+
+const (
+	ErrCodeNoSuchAccessPoint       = "NoSuchAccessPoint"
+	ErrCodeNoSuchAccessPointPolicy = "NoSuchAccessPointPolicy"
+)

--- a/aws/internal/service/s3control/finder/finder.go
+++ b/aws/internal/service/s3control/finder/finder.go
@@ -1,0 +1,24 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3control"
+)
+
+func PublicAccessBlockConfiguration(conn *s3control.S3Control, accountID string) (*s3control.PublicAccessBlockConfiguration, error) {
+	input := &s3control.GetPublicAccessBlockInput{
+		AccountId: aws.String(accountID),
+	}
+
+	output, err := conn.GetPublicAccessBlock(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output.PublicAccessBlockConfiguration, nil
+}

--- a/aws/internal/service/s3control/waiter/status.go
+++ b/aws/internal/service/s3control/waiter/status.go
@@ -1,0 +1,78 @@
+package waiter
+
+import (
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3control"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/s3control/finder"
+)
+
+// PublicAccessBlockConfigurationBlockPublicAcls fetches the PublicAccessBlockConfiguration and its BlockPublicAcls
+func PublicAccessBlockConfigurationBlockPublicAcls(conn *s3control.S3Control, accountID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		publicAccessBlockConfiguration, err := finder.PublicAccessBlockConfiguration(conn, accountID)
+
+		if err != nil {
+			return nil, "false", err
+		}
+
+		if publicAccessBlockConfiguration == nil {
+			return nil, "false", nil
+		}
+
+		return publicAccessBlockConfiguration, strconv.FormatBool(aws.BoolValue(publicAccessBlockConfiguration.BlockPublicAcls)), nil
+	}
+}
+
+// PublicAccessBlockConfigurationBlockPublicPolicy fetches the PublicAccessBlockConfiguration and its BlockPublicPolicy
+func PublicAccessBlockConfigurationBlockPublicPolicy(conn *s3control.S3Control, accountID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		publicAccessBlockConfiguration, err := finder.PublicAccessBlockConfiguration(conn, accountID)
+
+		if err != nil {
+			return nil, "false", err
+		}
+
+		if publicAccessBlockConfiguration == nil {
+			return nil, "false", nil
+		}
+
+		return publicAccessBlockConfiguration, strconv.FormatBool(aws.BoolValue(publicAccessBlockConfiguration.BlockPublicPolicy)), nil
+	}
+}
+
+// PublicAccessBlockConfigurationIgnorePublicAcls fetches the PublicAccessBlockConfiguration and its IgnorePublicAcls
+func PublicAccessBlockConfigurationIgnorePublicAcls(conn *s3control.S3Control, accountID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		publicAccessBlockConfiguration, err := finder.PublicAccessBlockConfiguration(conn, accountID)
+
+		if err != nil {
+			return nil, "false", err
+		}
+
+		if publicAccessBlockConfiguration == nil {
+			return nil, "false", nil
+		}
+
+		return publicAccessBlockConfiguration, strconv.FormatBool(aws.BoolValue(publicAccessBlockConfiguration.IgnorePublicAcls)), nil
+	}
+}
+
+// PublicAccessBlockConfigurationRestrictPublicBuckets fetches the PublicAccessBlockConfiguration and its RestrictPublicBuckets
+func PublicAccessBlockConfigurationRestrictPublicBuckets(conn *s3control.S3Control, accountID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		publicAccessBlockConfiguration, err := finder.PublicAccessBlockConfiguration(conn, accountID)
+
+		if err != nil {
+			return nil, "false", err
+		}
+
+		if publicAccessBlockConfiguration == nil {
+			return nil, "false", nil
+		}
+
+		return publicAccessBlockConfiguration, strconv.FormatBool(aws.BoolValue(publicAccessBlockConfiguration.RestrictPublicBuckets)), nil
+	}
+}

--- a/aws/internal/service/s3control/waiter/waiter.go
+++ b/aws/internal/service/s3control/waiter/waiter.go
@@ -1,0 +1,92 @@
+package waiter
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/s3control"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	// Minimum amount of times to verify change propagation
+	PropagationContinuousTargetOccurence = 2
+
+	// Minimum amount of time to wait between S3control change polls
+	PropagationMinTimeout = 5 * time.Second
+
+	// Maximum amount of time to wait for S3control changes to propagate
+	PropagationTimeout = 1 * time.Minute
+)
+
+func PublicAccessBlockConfigurationBlockPublicAclsUpdated(conn *s3control.S3Control, accountID string, expectedValue bool) (*s3control.PublicAccessBlockConfiguration, error) {
+	stateConf := &resource.StateChangeConf{
+		Target:                    []string{strconv.FormatBool(expectedValue)},
+		Refresh:                   PublicAccessBlockConfigurationBlockPublicAcls(conn, accountID),
+		Timeout:                   PropagationTimeout,
+		MinTimeout:                PropagationMinTimeout,
+		ContinuousTargetOccurence: PropagationContinuousTargetOccurence,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*s3control.PublicAccessBlockConfiguration); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func PublicAccessBlockConfigurationBlockPublicPolicyUpdated(conn *s3control.S3Control, accountID string, expectedValue bool) (*s3control.PublicAccessBlockConfiguration, error) {
+	stateConf := &resource.StateChangeConf{
+		Target:                    []string{strconv.FormatBool(expectedValue)},
+		Refresh:                   PublicAccessBlockConfigurationBlockPublicPolicy(conn, accountID),
+		Timeout:                   PropagationTimeout,
+		MinTimeout:                PropagationMinTimeout,
+		ContinuousTargetOccurence: PropagationContinuousTargetOccurence,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*s3control.PublicAccessBlockConfiguration); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func PublicAccessBlockConfigurationIgnorePublicAclsUpdated(conn *s3control.S3Control, accountID string, expectedValue bool) (*s3control.PublicAccessBlockConfiguration, error) {
+	stateConf := &resource.StateChangeConf{
+		Target:                    []string{strconv.FormatBool(expectedValue)},
+		Refresh:                   PublicAccessBlockConfigurationIgnorePublicAcls(conn, accountID),
+		Timeout:                   PropagationTimeout,
+		MinTimeout:                PropagationMinTimeout,
+		ContinuousTargetOccurence: PropagationContinuousTargetOccurence,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*s3control.PublicAccessBlockConfiguration); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func PublicAccessBlockConfigurationRestrictPublicBucketsUpdated(conn *s3control.S3Control, accountID string, expectedValue bool) (*s3control.PublicAccessBlockConfiguration, error) {
+	stateConf := &resource.StateChangeConf{
+		Target:                    []string{strconv.FormatBool(expectedValue)},
+		Refresh:                   PublicAccessBlockConfigurationRestrictPublicBuckets(conn, accountID),
+		Timeout:                   PropagationTimeout,
+		MinTimeout:                PropagationMinTimeout,
+		ContinuousTargetOccurence: PropagationContinuousTargetOccurence,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*s3control.PublicAccessBlockConfiguration); ok {
+		return output, err
+	}
+
+	return nil, err
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16796
Closes #18530

Other s3control resources already implement `d.IsNewResource()` checking.

Output from acceptance testing:

```
--- PASS: TestAccAWSS3AccessPoint_basic (28.97s)
--- PASS: TestAccAWSS3AccessPoint_disappears (24.96s)
--- PASS: TestAccAWSS3AccessPoint_disappears_Bucket (20.92s)
--- PASS: TestAccAWSS3AccessPoint_Policy (72.29s)
--- PASS: TestAccAWSS3AccessPoint_PublicAccessBlockConfiguration (28.96s)
--- PASS: TestAccAWSS3AccessPoint_VpcConfiguration (29.37s)
--- SKIP: TestAccAWSS3AccessPoint_Bucket_Arn (1.78s)

--- PASS: TestAccAWSS3Account_serial (253.40s)
    --- PASS: TestAccAWSS3Account_serial/PublicAccessBlock (253.40s)
        --- PASS: TestAccAWSS3Account_serial/PublicAccessBlock/BlockPublicPolicy (47.72s)
        --- PASS: TestAccAWSS3Account_serial/PublicAccessBlock/IgnorePublicAcls (52.10s)
        --- PASS: TestAccAWSS3Account_serial/PublicAccessBlock/RestrictPublicBuckets (51.18s)
        --- PASS: TestAccAWSS3Account_serial/PublicAccessBlock/basic (18.16s)
        --- PASS: TestAccAWSS3Account_serial/PublicAccessBlock/disappears (14.86s)
        --- PASS: TestAccAWSS3Account_serial/PublicAccessBlock/AccountId (18.18s)
        --- PASS: TestAccAWSS3Account_serial/PublicAccessBlock/BlockPublicAcls (51.19s)
```