### PR TITLE
service/s3: Add d.IsNewResource checks and standardize retry logic

### DIFF
--- a/aws/internal/service/s3/errors.go
+++ b/aws/internal/service/s3/errors.go
@@ -4,6 +4,7 @@ package s3
 // https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#pkg-constants
 
 const (
+	ErrCodeNoSuchConfiguration                  = "NoSuchConfiguration"
 	ErrCodeNoSuchPublicAccessBlockConfiguration = "NoSuchPublicAccessBlockConfiguration"
 	ErrCodeNoSuchTagSet                         = "NoSuchTagSet"
 )

--- a/aws/internal/service/s3/waiter/waiter.go
+++ b/aws/internal/service/s3/waiter/waiter.go
@@ -1,0 +1,10 @@
+package waiter
+
+import (
+	"time"
+)
+
+const (
+	// Maximum amount of time to wait for S3 changes to propagate
+	PropagationTimeout = 1 * time.Minute
+)

--- a/aws/resource_aws_s3_bucket_metric.go
+++ b/aws/resource_aws_s3_bucket_metric.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	tfs3 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/s3"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/s3/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsS3BucketMetric() *schema.Resource {
@@ -81,21 +84,26 @@ func resourceAwsS3BucketMetricPut(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Putting metric configuration: %s", input)
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
 		_, err := conn.PutBucketMetricsConfiguration(input)
+
+		if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
-			if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") {
-				return resource.RetryableError(err)
-			}
 			return resource.NonRetryableError(err)
 		}
+
 		return nil
 	})
-	if isResourceTimeoutError(err) {
+
+	if tfresource.TimedOut(err) {
 		_, err = conn.PutBucketMetricsConfiguration(input)
 	}
+
 	if err != nil {
-		return fmt.Errorf("Error putting S3 metric configuration: %s", err)
+		return fmt.Errorf("error putting S3 Bucket Metric Configuration: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", bucket, name))
@@ -118,11 +126,17 @@ func resourceAwsS3BucketMetricDelete(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Deleting S3 bucket metric configuration: %s", input)
 	_, err = conn.DeleteBucketMetricsConfiguration(input)
+
+	if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		return nil
+	}
+
+	if tfawserr.ErrCodeEquals(err, tfs3.ErrCodeNoSuchConfiguration) {
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {
-			return nil
-		}
-		return fmt.Errorf("Error deleting S3 metric configuration: %w", err)
+		return fmt.Errorf("error deleting S3 Bucket Metric Configuration (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -146,13 +160,25 @@ func resourceAwsS3BucketMetricRead(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Reading S3 bucket metrics configuration: %s", input)
 	output, err := conn.GetBucketMetricsConfiguration(input)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket Metrics Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, tfs3.ErrCodeNoSuchConfiguration) {
+		log.Printf("[WARN] S3 Bucket Metrics Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {
-			log.Printf("[WARN] %s S3 bucket metrics configuration not found, removing from state.", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("error reading S3 Bucket Metrics Configuration (%s): %w", d.Id(), err)
+	}
+
+	if output == nil || output.MetricsConfiguration == nil {
+		return fmt.Errorf("error reading S3 Bucket Metrics Configuration (%s): empty response", d.Id())
 	}
 
 	if output.MetricsConfiguration.Filter != nil {

--- a/aws/resource_aws_s3_bucket_metric.go
+++ b/aws/resource_aws_s3_bucket_metric.go
@@ -83,7 +83,7 @@ func resourceAwsS3BucketMetricPut(d *schema.ResourceData, meta interface{}) erro
 		MetricsConfiguration: metricsConfiguration,
 	}
 
-	log.Printf("[DEBUG] Putting metric configuration: %s", input)
+	log.Printf("[DEBUG] Putting S3 Bucket Metrics Configuration: %s", input)
 	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
 		_, err := conn.PutBucketMetricsConfiguration(input)
 
@@ -103,7 +103,7 @@ func resourceAwsS3BucketMetricPut(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if err != nil {
-		return fmt.Errorf("error putting S3 Bucket Metric Configuration: %w", err)
+		return fmt.Errorf("error putting S3 Bucket Metrics Configuration: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", bucket, name))
@@ -124,7 +124,7 @@ func resourceAwsS3BucketMetricDelete(d *schema.ResourceData, meta interface{}) e
 		Id:     aws.String(name),
 	}
 
-	log.Printf("[DEBUG] Deleting S3 bucket metric configuration: %s", input)
+	log.Printf("[DEBUG] Deleting S3 Bucket Metrics Configuration: %s", input)
 	_, err = conn.DeleteBucketMetricsConfiguration(input)
 
 	if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
@@ -136,7 +136,7 @@ func resourceAwsS3BucketMetricDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting S3 Bucket Metric Configuration (%s): %w", d.Id(), err)
+		return fmt.Errorf("error deleting S3 Bucket Metrics Configuration (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -158,7 +158,7 @@ func resourceAwsS3BucketMetricRead(d *schema.ResourceData, meta interface{}) err
 		Id:     aws.String(name),
 	}
 
-	log.Printf("[DEBUG] Reading S3 bucket metrics configuration: %s", input)
+	log.Printf("[DEBUG] Reading S3 Bucket Metrics Configuration: %s", input)
 	output, err := conn.GetBucketMetricsConfiguration(input)
 
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10587
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16796

Output from acceptance testing:

```
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_basic (38.97s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_removed (56.16s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_updateBasic (87.68s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty (12.16s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_MultipleTags (60.16s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Prefix (60.97s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_PrefixAndTags (60.97s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Remove (61.00s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_SingleTag (60.97s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Default (39.98s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty (12.14s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Full (39.60s)

--- PASS: TestAccAWSS3BucketInventory_basic (26.27s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (26.34s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (26.45s)

--- PASS: TestAccAWSS3BucketMetric_basic (26.21s)
--- PASS: TestAccAWSS3BucketMetric_WithEmptyFilter (2.25s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (46.71s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefix (45.51s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (46.55s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (45.88s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (46.49s)

--- PASS: TestAccAWSS3BucketNotification_LambdaFunction (45.26s)
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias (40.24s)
--- PASS: TestAccAWSS3BucketNotification_Queue (27.96s)
--- PASS: TestAccAWSS3BucketNotification_Topic (28.53s)
--- PASS: TestAccAWSS3BucketNotification_Topic_Multiple (29.23s)
--- PASS: TestAccAWSS3BucketNotification_update (49.26s)

--- PASS: TestAccAWSS3BucketPublicAccessBlock_basic (29.52s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls (68.84s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy (68.21s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_disappears (26.48s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_disappears_Bucket (18.16s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls (68.18s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets (68.83s)
```