### PR TITLE
Clarify resource name

### DIFF
--- a/website/docs/r/cloudfront_origin_access_identity.html.markdown
+++ b/website/docs/r/cloudfront_origin_access_identity.html.markdown
@@ -20,7 +20,7 @@ origin access identities, see
 The following example below creates a CloudFront origin access identity.
 
 ```terraform
-resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+resource "aws_cloudfront_origin_access_identity" "example" {
   comment = "Some comment"
 }
 ```
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "s3_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
+      identifiers = [aws_cloudfront_origin_access_identity.example.iam_arn]
     }
   }
 }


### PR DESCRIPTION
`aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn` seems like a copy-paste error.  The `Using With CloudFront` section already uses a resource named `example`.  This updates the other lines to match.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

