### PR TITLE
resource/aws_datasync_location_s3: Add `agent_arns` and `s3_storage_class` arguments

### DIFF
--- a/.changelog/18547.txt
+++ b/.changelog/18547.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_datasync_location_s3: Add `agent_arns` argument
+```

--- a/aws/resource_aws_datasync_location_s3.go
+++ b/aws/resource_aws_datasync_location_s3.go
@@ -29,6 +29,12 @@ func resourceAwsDataSyncLocationS3() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"agent_arns": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"s3_bucket_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -95,6 +101,14 @@ func resourceAwsDataSyncLocationS3Create(d *schema.ResourceData, meta interface{
 		S3Config:     expandDataSyncS3Config(d.Get("s3_config").([]interface{})),
 		Subdirectory: aws.String(d.Get("subdirectory").(string)),
 		Tags:         tags.IgnoreAws().DatasyncTags(),
+	}
+
+	if v, ok := d.GetOk("s3_storage_class"); ok {
+		input.S3StorageClass = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("agent_arns"); ok {
+		input.AgentArns = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("s3_storage_class"); ok {
@@ -170,10 +184,13 @@ func resourceAwsDataSyncLocationS3Read(d *schema.ResourceData, meta interface{})
 
 	d.Set("arn", output.LocationArn)
 
+	d.Set("agent_arns", flattenStringSet(output.AgentArns))
+
 	if err := d.Set("s3_config", flattenDataSyncS3Config(output.S3Config)); err != nil {
 		return fmt.Errorf("error setting s3_config: %s", err)
 	}
 
+	d.Set("s3_storage_class", output.S3StorageClass)
 	d.Set("subdirectory", subdirectory)
 	d.Set("uri", output.LocationUri)
 	d.Set("s3_storage_class", output.S3StorageClass)

--- a/aws/resource_aws_datasync_location_s3.go
+++ b/aws/resource_aws_datasync_location_s3.go
@@ -103,10 +103,6 @@ func resourceAwsDataSyncLocationS3Create(d *schema.ResourceData, meta interface{
 		Tags:         tags.IgnoreAws().DatasyncTags(),
 	}
 
-	if v, ok := d.GetOk("s3_storage_class"); ok {
-		input.S3StorageClass = aws.String(v.(string))
-	}
-
 	if v, ok := d.GetOk("agent_arns"); ok {
 		input.AgentArns = expandStringSet(v.(*schema.Set))
 	}
@@ -182,18 +178,14 @@ func resourceAwsDataSyncLocationS3Read(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error parsing Location S3 (%s) URI (%s): %s", d.Id(), aws.StringValue(output.LocationUri), err)
 	}
 
-	d.Set("arn", output.LocationArn)
-
 	d.Set("agent_arns", flattenStringSet(output.AgentArns))
-
+	d.Set("arn", output.LocationArn)
 	if err := d.Set("s3_config", flattenDataSyncS3Config(output.S3Config)); err != nil {
 		return fmt.Errorf("error setting s3_config: %s", err)
 	}
-
 	d.Set("s3_storage_class", output.S3StorageClass)
 	d.Set("subdirectory", subdirectory)
 	d.Set("uri", output.LocationUri)
-	d.Set("s3_storage_class", output.S3StorageClass)
 
 	tags, err := keyvaluetags.DatasyncListTags(conn, d.Id())
 

--- a/aws/resource_aws_datasync_location_s3_test.go
+++ b/aws/resource_aws_datasync_location_s3_test.go
@@ -96,11 +96,12 @@ func TestAccAWSDataSyncLocationS3_basic(t *testing.T) {
 				Config: testAccAWSDataSyncLocationS3Config(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDataSyncLocationS3Exists(resourceName, &locationS31),
+					resource.TestCheckResourceAttr(resourceName, "agent_arns.#", "0"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "datasync", regexp.MustCompile(`location/loc-.+`)),
 					resource.TestCheckResourceAttrPair(resourceName, "s3_bucket_arn", s3BucketResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "s3_config.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "s3_config.0.bucket_access_role_arn", iamRoleResourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "s3_storage_class", "STANDARD"),
+					resource.TestCheckResourceAttrSet(resourceName, "s3_storage_class"),
 					resource.TestCheckResourceAttr(resourceName, "subdirectory", "/test/"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestMatchResourceAttr(resourceName, "uri", regexp.MustCompile(`^s3://.+/`)),
@@ -119,6 +120,7 @@ func TestAccAWSDataSyncLocationS3_basic(t *testing.T) {
 func TestAccAWSDataSyncLocationS3_storageclass(t *testing.T) {
 	var locationS31 datasync.DescribeLocationS3Output
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
 	resourceName := "aws_datasync_location_s3.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 
@@ -135,8 +137,40 @@ func TestAccAWSDataSyncLocationS3_storageclass(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "datasync", regexp.MustCompile(`location/loc-.+`)),
 					resource.TestCheckResourceAttrPair(resourceName, "s3_bucket_arn", s3BucketResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "s3_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_config.0.bucket_access_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "subdirectory", "/test/"),
+					resource.TestCheckResourceAttr(resourceName, "s3_storage_class", "STANDARD_IA"),
 					resource.TestMatchResourceAttr(resourceName, "uri", regexp.MustCompile(`^s3://.+/`)),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"s3_bucket_arn"},
+			},
+		},
+	})
+}
+
+func TestAccAWSDataSyncLocationS3_disappears(t *testing.T) {
+	var locationS31 datasync.DescribeLocationS3Output
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_datasync_location_s3.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataSync(t) },
+		ErrorCheck:   testAccErrorCheck(t, datasync.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataSyncLocationS3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSyncLocationS3Config(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataSyncLocationS3Exists(resourceName, &locationS31),
+					testAccCheckAWSDataSyncLocationS3Disappears(&locationS31),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/aws/resource_aws_datasync_location_s3_test.go
+++ b/aws/resource_aws_datasync_location_s3_test.go
@@ -100,6 +100,7 @@ func TestAccAWSDataSyncLocationS3_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "s3_bucket_arn", s3BucketResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "s3_config.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "s3_config.0.bucket_access_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "s3_storage_class", "STANDARD"),
 					resource.TestCheckResourceAttr(resourceName, "subdirectory", "/test/"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestMatchResourceAttr(resourceName, "uri", regexp.MustCompile(`^s3://.+/`)),
@@ -118,7 +119,6 @@ func TestAccAWSDataSyncLocationS3_basic(t *testing.T) {
 func TestAccAWSDataSyncLocationS3_storageclass(t *testing.T) {
 	var locationS31 datasync.DescribeLocationS3Output
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	iamRoleResourceName := "aws_iam_role.test"
 	resourceName := "aws_datasync_location_s3.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 
@@ -135,40 +135,8 @@ func TestAccAWSDataSyncLocationS3_storageclass(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "datasync", regexp.MustCompile(`location/loc-.+`)),
 					resource.TestCheckResourceAttrPair(resourceName, "s3_bucket_arn", s3BucketResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "s3_config.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "s3_config.0.bucket_access_role_arn", iamRoleResourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "subdirectory", "/test/"),
-					resource.TestCheckResourceAttr(resourceName, "s3_storage_class", "STANDARD_IA"),
 					resource.TestMatchResourceAttr(resourceName, "uri", regexp.MustCompile(`^s3://.+/`)),
 				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"s3_bucket_arn"},
-			},
-		},
-	})
-}
-
-func TestAccAWSDataSyncLocationS3_disappears(t *testing.T) {
-	var locationS31 datasync.DescribeLocationS3Output
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_datasync_location_s3.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataSync(t) },
-		ErrorCheck:   testAccErrorCheck(t, datasync.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDataSyncLocationS3Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSDataSyncLocationS3Config(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDataSyncLocationS3Exists(resourceName, &locationS31),
-					testAccCheckAWSDataSyncLocationS3Disappears(&locationS31),
-				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/website/docs/r/datasync_location_s3.html.markdown
+++ b/website/docs/r/datasync_location_s3.html.markdown
@@ -27,6 +27,7 @@ resource "aws_datasync_location_s3" "example" {
 
 The following arguments are supported:
 
+* `agent_arns` - (Optional) A list of DataSync Agent ARNs with which this location will be associated.
 * `s3_bucket_arn` - (Required) Amazon Resource Name (ARN) of the S3 Bucket.
 * `s3_config` - (Required) Configuration block containing information for connecting to S3.
 * `s3_storage_class` - (Optional) The Amazon S3 storage class that you want to store your files in when this location is used as a task destination. [Valid values](https://docs.aws.amazon.com/datasync/latest/userguide/create-s3-location.html#using-storage-classes)  


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15418

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDataSyncLocationS3_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSyncLocationS3_ -timeout 180m
=== RUN   TestAccAWSDataSyncLocationS3_basic
=== PAUSE TestAccAWSDataSyncLocationS3_basic
=== RUN   TestAccAWSDataSyncLocationS3_S3StorageClass
=== PAUSE TestAccAWSDataSyncLocationS3_S3StorageClass
=== RUN   TestAccAWSDataSyncLocationS3_disappears
=== PAUSE TestAccAWSDataSyncLocationS3_disappears
=== RUN   TestAccAWSDataSyncLocationS3_Tags
=== PAUSE TestAccAWSDataSyncLocationS3_Tags
=== CONT  TestAccAWSDataSyncLocationS3_basic
=== CONT  TestAccAWSDataSyncLocationS3_Tags
=== CONT  TestAccAWSDataSyncLocationS3_disappears
=== CONT  TestAccAWSDataSyncLocationS3_S3StorageClass
--- PASS: TestAccAWSDataSyncLocationS3_S3StorageClass (47.20s)
--- PASS: TestAccAWSDataSyncLocationS3_disappears (55.32s)
--- PASS: TestAccAWSDataSyncLocationS3_basic (60.42s)
--- PASS: TestAccAWSDataSyncLocationS3_Tags (136.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	138.004s
```
