### PR TITLE
docs(aws_cloudwatch_query_definition): fixes the code example

### DIFF
--- a/website/docs/r/cloudwatch_query_definition.html.markdown
+++ b/website/docs/r/cloudwatch_query_definition.html.markdown
@@ -16,12 +16,12 @@ Provides a CloudWatch Logs query definition resource.
 resource "aws_cloudwatch_query_definition" "example" {
   name = "custom_query"
 
-  log_groups = [
+  log_group_names = [
     "/aws/logGroup1",
     "/aws/logGroup2"
   ]
 
-  query = <<EOF
+  query_string = <<EOF
 fields @timestamp, @message
 | sort @timestamp desc
 | limit 25


### PR DESCRIPTION
**Reason for change**
The input fields for the `aws_cloudwatch_query_definition` resource were updated to more closely reflect the AWS API. The code example in the documentation was not updated accordingly. This PR corrects the code block to use the updated input names:
log_groups -> log_group_names
query -> query_string

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:
N/A documentation only
