### PR TITLE
resource/aws_route53_resolver_firewall_rule_group: Add new resource

### DIFF
--- a/aws/internal/service/route53resolver/finder/finder.go
+++ b/aws/internal/service/route53resolver/finder/finder.go
@@ -75,3 +75,22 @@ func ResolverDnssecConfigByID(conn *route53resolver.Route53Resolver, dnssecConfi
 
 	return config, nil
 }
+
+// FirewallRuleGroupByID returns the DNS Firewall rule group corresponding to the specified ID.
+// Returns nil if no DNS Firewall rule group is found.
+func FirewallRuleGroupByID(conn *route53resolver.Route53Resolver, firewallGroupId string) (*route53resolver.FirewallRuleGroup, error) {
+	input := &route53resolver.GetFirewallRuleGroupInput{
+		FirewallRuleGroupId: aws.String(firewallGroupId),
+	}
+
+	output, err := conn.GetFirewallRuleGroup(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output.FirewallRuleGroup, nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -918,6 +918,7 @@ func Provider() *schema.Provider {
 			"aws_route53_health_check":                                resourceAwsRoute53HealthCheck(),
 			"aws_route53_resolver_dnssec_config":                      resourceAwsRoute53ResolverDnssecConfig(),
 			"aws_route53_resolver_endpoint":                           resourceAwsRoute53ResolverEndpoint(),
+			"aws_route53_resolver_firewall_rule_group":                resourceAwsRoute53ResolverFirewallRuleGroup(),
 			"aws_route53_resolver_query_log_config":                   resourceAwsRoute53ResolverQueryLogConfig(),
 			"aws_route53_resolver_query_log_config_association":       resourceAwsRoute53ResolverQueryLogConfigAssociation(),
 			"aws_route53_resolver_rule_association":                   resourceAwsRoute53ResolverRuleAssociation(),

--- a/aws/resource_aws_route53_resolver_firewall_rule_group.go
+++ b/aws/resource_aws_route53_resolver_firewall_rule_group.go
@@ -1,0 +1,158 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/route53resolver/finder"
+)
+
+func resourceAwsRoute53ResolverFirewallRuleGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53ResolverFirewallRuleGroupCreate,
+		Read:   resourceAwsRoute53ResolverFirewallRuleGroupRead,
+		Update: resourceAwsRoute53ResolverFirewallRuleGroupUpdate,
+		Delete: resourceAwsRoute53ResolverFirewallRuleGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRoute53ResolverName,
+			},
+
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"share_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsRoute53ResolverFirewallRuleGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	input := &route53resolver.CreateFirewallRuleGroupInput{
+		CreatorRequestId: aws.String(resource.PrefixedUniqueId("tf-r53-resolver-firewall-rule-group-")),
+		Name:             aws.String(d.Get("name").(string)),
+	}
+	if v, ok := d.GetOk("tags"); ok && len(v.(map[string]interface{})) > 0 {
+		input.Tags = keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().Route53resolverTags()
+	}
+
+	log.Printf("[DEBUG] Creating Route 53 Resolver DNS Firewall rule group: %#v", input)
+	output, err := conn.CreateFirewallRuleGroup(input)
+	if err != nil {
+		return fmt.Errorf("error creating Route 53 Resolver DNS Firewall rule group: %w", err)
+	}
+
+	d.SetId(aws.StringValue(output.FirewallRuleGroup.Id))
+
+	return resourceAwsRoute53ResolverFirewallRuleGroupRead(d, meta)
+}
+
+func resourceAwsRoute53ResolverFirewallRuleGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	ruleGroup, err := finder.FirewallRuleGroupByID(conn, d.Id())
+
+	if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Route53 Resolver DNS Firewall rule group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error getting Route 53 Resolver DNS Firewall rule group (%s): %w", d.Id(), err)
+	}
+
+	if ruleGroup == nil {
+		log.Printf("[WARN] Route 53 Resolver DNS Firewall rule group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	arn := aws.StringValue(ruleGroup.Arn)
+	d.Set("arn", arn)
+	d.Set("id", ruleGroup.Id)
+	d.Set("name", ruleGroup.Name)
+	d.Set("owner_id", ruleGroup.OwnerId)
+	d.Set("share_status", ruleGroup.ShareStatus)
+
+	tags, err := keyvaluetags.Route53resolverListTags(conn, arn)
+	if err != nil {
+		return fmt.Errorf("error listing tags for Route53 Resolver DNS Firewall rule group (%s): %w", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53ResolverFirewallRuleGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Route53resolverUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Route53 Resolver DNS Firewall rule group (%s) tags: %s", d.Get("arn").(string), err)
+		}
+	}
+
+	return resourceAwsRoute53ResolverFirewallRuleGroupRead(d, meta)
+}
+
+func resourceAwsRoute53ResolverFirewallRuleGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	_, err := conn.DeleteFirewallRuleGroup(&route53resolver.DeleteFirewallRuleGroupInput{
+		FirewallRuleGroupId: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Route 53 Resolver DNS Firewall rule group (%s): %w", d.Id(), err)
+	}
+
+	// TODO: Check waiter is required (seems to delete immediately)
+
+	// _, err = waiter.FirewallRuleGroupDeleted(conn, d.Id())
+
+	// if err != nil {
+	// 	return fmt.Errorf("error waiting for Route 53 Resolver DNS Firewall rule group (%s) to be deleted: %w", d.Id(), err)
+	// }
+
+	return nil
+}

--- a/aws/resource_aws_route53_resolver_firewall_rule_group.go
+++ b/aws/resource_aws_route53_resolver_firewall_rule_group.go
@@ -124,7 +124,7 @@ func resourceAwsRoute53ResolverFirewallRuleGroupUpdate(d *schema.ResourceData, m
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.Route53resolverUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Route53 Resolver DNS Firewall rule group (%s) tags: %s", d.Get("arn").(string), err)
+			return fmt.Errorf("error updating Route53 Resolver DNS Firewall rule group (%s) tags: %w", d.Get("arn").(string), err)
 		}
 	}
 
@@ -145,14 +145,6 @@ func resourceAwsRoute53ResolverFirewallRuleGroupDelete(d *schema.ResourceData, m
 	if err != nil {
 		return fmt.Errorf("error deleting Route 53 Resolver DNS Firewall rule group (%s): %w", d.Id(), err)
 	}
-
-	// TODO: Check waiter is required (seems to delete immediately)
-
-	// _, err = waiter.FirewallRuleGroupDeleted(conn, d.Id())
-
-	// if err != nil {
-	// 	return fmt.Errorf("error waiting for Route 53 Resolver DNS Firewall rule group (%s) to be deleted: %w", d.Id(), err)
-	// }
 
 	return nil
 }

--- a/aws/resource_aws_route53_resolver_firewall_rule_group_test.go
+++ b/aws/resource_aws_route53_resolver_firewall_rule_group_test.go
@@ -1,0 +1,251 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/route53resolver/finder"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_route53_resolver_firewall_rule_group", &resource.Sweeper{
+		Name: "aws_route53_resolver_firewall_rule_group",
+		F:    testSweepRoute53ResolverFirewallRuleGroups,
+		Dependencies: []string{
+			"aws_route53_resolver_firewall_rule_group_association",
+		},
+	})
+}
+
+func testSweepRoute53ResolverFirewallRuleGroups(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).route53resolverconn
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListFirewallRuleGroupsPages(&route53resolver.ListFirewallRuleGroupsInput{}, func(page *route53resolver.ListFirewallRuleGroupsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, queryLogConfig := range page.FirewallRuleGroups {
+			id := aws.StringValue(queryLogConfig.Id)
+
+			log.Printf("[INFO] Deleting Route53 Resolver DNS Firewall rule group: %s", id)
+			r := resourceAwsRoute53ResolverFirewallRuleGroup()
+			d := r.Data(nil)
+			d.SetId(id)
+			err := r.Delete(d, client)
+
+			if err != nil {
+				log.Printf("[ERROR] %s", err)
+				sweeperErrs = multierror.Append(sweeperErrs, err)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Route53 Resolver DNS Firewall rule groups sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Route53 Resolver DNS Firewall rule groups: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func TestAccAWSRoute53ResolverFirewallRuleGroup_basic(t *testing.T) {
+	var v route53resolver.FirewallRuleGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_resolver_firewall_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53resolver.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverFirewallRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverFirewallRuleGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallRuleGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ResolverFirewallRuleGroup_disappears(t *testing.T) {
+	var v route53resolver.FirewallRuleGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_resolver_firewall_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53resolver.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverFirewallRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverFirewallRuleGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallRuleGroupExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53ResolverFirewallRuleGroup(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ResolverFirewallRuleGroup_tags(t *testing.T) {
+	var v route53resolver.FirewallRuleGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_resolver_firewall_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53resolver.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverFirewallRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverFirewallRuleGroupConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallRuleGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRoute53ResolverFirewallRuleGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallRuleGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccRoute53ResolverFirewallRuleGroupConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallRuleGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRoute53ResolverFirewallRuleGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_resolver_firewall_rule_group" {
+			continue
+		}
+
+		// Try to find the resource
+		_, err := finder.FirewallRuleGroupByID(conn, rs.Primary.ID)
+		// Verify the error is what we want
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("Route 53 Resolver DNS Firewall rule group still exists: %s", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckRoute53ResolverFirewallRuleGroupExists(n string, v *route53resolver.FirewallRuleGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Route 53 Resolver DNS Firewall rule group ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
+		out, err := finder.FirewallRuleGroupByID(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*v = *out
+
+		return nil
+	}
+}
+
+func testAccRoute53ResolverFirewallRuleGroupConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_firewall_rule_group" "test" {
+  name = %[1]q
+}
+`, rName)
+}
+
+func testAccRoute53ResolverFirewallRuleGroupConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_firewall_rule_group" "test" {
+  name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccRoute53ResolverFirewallRuleGroupConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_firewall_rule_group" "test" {
+  name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_route53_resolver_firewall_rule_group_test.go
+++ b/aws/resource_aws_route53_resolver_firewall_rule_group_test.go
@@ -37,8 +37,8 @@ func testSweepRoute53ResolverFirewallRuleGroups(region string) error {
 			return !isLast
 		}
 
-		for _, queryLogConfig := range page.FirewallRuleGroups {
-			id := aws.StringValue(queryLogConfig.Id)
+		for _, firewallRuleGroup := range page.FirewallRuleGroups {
+			id := aws.StringValue(firewallRuleGroup.Id)
 
 			log.Printf("[INFO] Deleting Route53 Resolver DNS Firewall rule group: %s", id)
 			r := resourceAwsRoute53ResolverFirewallRuleGroup()

--- a/website/docs/r/route53_resolver_firewall_rule_group.markdown
+++ b/website/docs/r/route53_resolver_firewall_rule_group.markdown
@@ -31,6 +31,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN (Amazon Resource Name) of the rule group.
 * `id` - The ID of the rule group.
+* `owner_id` - The AWS account ID for the account that created the rule group. When a rule group is shared with your account, this is the account that has shared the rule group with you.
+* `share_status` - Whether the rule group is shared with other AWS accounts, or was shared with the current account by another AWS account. Sharing is configured through AWS Resource Access Manager (AWS RAM). Valid values: `NOT_SHARED`, `SHARED_BY_ME`, `SHARED_WITH_ME`
 
 ## Import
 

--- a/website/docs/r/route53_resolver_firewall_rule_group.markdown
+++ b/website/docs/r/route53_resolver_firewall_rule_group.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Route53 Resolver"
+layout: "aws"
+page_title: "AWS: aws_route53_resolver_firewall_rule_group"
+description: |-
+  Provides a Route 53 Resolver DNS Firewall rule group resource.
+---
+
+# Resource: aws_route53_resolver_firewall_rule_group
+
+Provides a Route 53 Resolver DNS Firewall rule group resource.
+
+## Example Usage
+
+```terraform
+resource "aws_route53_resolver_firewall_rule_group" "example" {
+  name = "example"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `name` - (Required) A name that lets you identify the rule group, to manage and use it.
+* `tags` - (Optional) A map of tags to assign to the resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN (Amazon Resource Name) of the rule group.
+* `id` - The ID of the rule group.
+
+## Import
+
+ Route 53 Resolver DNS Firewall rule groups can be imported using the Route 53 Resolver DNS Firewall rule group ID, e.g.
+
+```
+$ terraform import aws_route53_resolver_firewall_rule_group.example rslvr-frg-0123456789abcdef
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18520

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53ResolverFirewallRuleGroup_'                       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRoute53ResolverFirewallRuleGroup_ -timeout 180m
=== RUN   TestAccAWSRoute53ResolverFirewallRuleGroup_basic
=== PAUSE TestAccAWSRoute53ResolverFirewallRuleGroup_basic
=== RUN   TestAccAWSRoute53ResolverFirewallRuleGroup_disappears
=== PAUSE TestAccAWSRoute53ResolverFirewallRuleGroup_disappears
=== RUN   TestAccAWSRoute53ResolverFirewallRuleGroup_tags
=== PAUSE TestAccAWSRoute53ResolverFirewallRuleGroup_tags
=== CONT  TestAccAWSRoute53ResolverFirewallRuleGroup_basic
=== CONT  TestAccAWSRoute53ResolverFirewallRuleGroup_tags
=== CONT  TestAccAWSRoute53ResolverFirewallRuleGroup_disappears
--- PASS: TestAccAWSRoute53ResolverFirewallRuleGroup_disappears (18.43s)
--- PASS: TestAccAWSRoute53ResolverFirewallRuleGroup_basic (25.56s)
--- PASS: TestAccAWSRoute53ResolverFirewallRuleGroup_tags (61.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	63.040s
```
