### PR TITLE
resource/aws_route53_resolver_firewall_domain_list: Add new resource

### DIFF
--- a/aws/internal/service/route53resolver/finder/finder.go
+++ b/aws/internal/service/route53resolver/finder/finder.go
@@ -94,3 +94,23 @@ func FirewallRuleGroupByID(conn *route53resolver.Route53Resolver, firewallGroupI
 
 	return output.FirewallRuleGroup, nil
 }
+
+// FirewallDomainListByID returns the DNS Firewall rule group corresponding to the specified ID.
+// Returns nil if no DNS Firewall rule group is found.
+func FirewallDomainListByID(conn *route53resolver.Route53Resolver, firewallDomainListId string) (*route53resolver.FirewallDomainList, error) {
+	input := &route53resolver.GetFirewallDomainListInput{
+		FirewallDomainListId: aws.String(firewallDomainListId),
+	}
+
+	output, err := conn.GetFirewallDomainList(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output.FirewallDomainList, nil
+}

--- a/aws/internal/service/route53resolver/waiter/status.go
+++ b/aws/internal/service/route53resolver/waiter/status.go
@@ -17,6 +17,9 @@ const (
 
 	resolverDnssecConfigStatusNotFound = "NotFound"
 	resolverDnssecConfigStatusUnknown  = "Unknown"
+
+	firewallDomainListStatusNotFound = "NotFound"
+	firewallDomainListStatusUnknown  = "Unknown"
 )
 
 // QueryLogConfigAssociationStatus fetches the QueryLogConfigAssociation and its Status
@@ -79,5 +82,26 @@ func DnssecConfigStatus(conn *route53resolver.Route53Resolver, dnssecConfigID st
 		}
 
 		return dnssecConfig, aws.StringValue(dnssecConfig.ValidationStatus), nil
+	}
+}
+
+// FirewallDomainListStatus fetches the FirewallDomainList and its Status
+func FirewallDomainListStatus(conn *route53resolver.Route53Resolver, firewallDomainListId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		firewallDomainList, err := finder.FirewallDomainListByID(conn, firewallDomainListId)
+
+		if tfawserr.ErrCodeEquals(err, route53resolver.ErrCodeResourceNotFoundException) {
+			return nil, firewallDomainListStatusNotFound, nil
+		}
+
+		if err != nil {
+			return nil, firewallDomainListStatusUnknown, err
+		}
+
+		if firewallDomainList == nil {
+			return nil, firewallDomainListStatusNotFound, nil
+		}
+
+		return firewallDomainList, aws.StringValue(firewallDomainList.Status), nil
 	}
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -918,6 +918,7 @@ func Provider() *schema.Provider {
 			"aws_route53_health_check":                                resourceAwsRoute53HealthCheck(),
 			"aws_route53_resolver_dnssec_config":                      resourceAwsRoute53ResolverDnssecConfig(),
 			"aws_route53_resolver_endpoint":                           resourceAwsRoute53ResolverEndpoint(),
+			"aws_route53_resolver_firewall_domain_list":               resourceAwsRoute53ResolverFirewallDomainList(),
 			"aws_route53_resolver_firewall_rule_group":                resourceAwsRoute53ResolverFirewallRuleGroup(),
 			"aws_route53_resolver_query_log_config":                   resourceAwsRoute53ResolverQueryLogConfig(),
 			"aws_route53_resolver_query_log_config_association":       resourceAwsRoute53ResolverQueryLogConfigAssociation(),

--- a/aws/resource_aws_route53_resolver_firewall_domain_list.go
+++ b/aws/resource_aws_route53_resolver_firewall_domain_list.go
@@ -29,11 +29,6 @@ func resourceAwsRoute53ResolverFirewallDomainList() *schema.Resource {
 				Computed: true,
 			},
 
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -101,7 +96,6 @@ func resourceAwsRoute53ResolverFirewallDomainListRead(d *schema.ResourceData, me
 
 	arn := aws.StringValue(firewallDomainList.Arn)
 	d.Set("arn", arn)
-	d.Set("id", firewallDomainList.Id)
 	d.Set("name", firewallDomainList.Name)
 
 	input := &route53resolver.ListFirewallDomainsInput{

--- a/aws/resource_aws_route53_resolver_firewall_domain_list.go
+++ b/aws/resource_aws_route53_resolver_firewall_domain_list.go
@@ -1,0 +1,189 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/route53resolver/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/route53resolver/waiter"
+)
+
+func resourceAwsRoute53ResolverFirewallDomainList() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53ResolverFirewallDomainListCreate,
+		Read:   resourceAwsRoute53ResolverFirewallDomainListRead,
+		Update: resourceAwsRoute53ResolverFirewallDomainListUpdate,
+		Delete: resourceAwsRoute53ResolverFirewallDomainListDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRoute53ResolverName,
+			},
+
+			"domains": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 0,
+				MaxItems: 255,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsRoute53ResolverFirewallDomainListCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	input := &route53resolver.CreateFirewallDomainListInput{
+		CreatorRequestId: aws.String(resource.PrefixedUniqueId("tf-r53-resolver-firewall-domain-list-")),
+		Name:             aws.String(d.Get("name").(string)),
+	}
+	if v, ok := d.GetOk("tags"); ok && len(v.(map[string]interface{})) > 0 {
+		input.Tags = keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().Route53resolverTags()
+	}
+
+	log.Printf("[DEBUG] Creating Route 53 Resolver DNS Firewall domain list: %#v", input)
+	output, err := conn.CreateFirewallDomainList(input)
+	if err != nil {
+		return fmt.Errorf("error creating Route 53 Resolver DNS Firewall domain list: %w", err)
+	}
+
+	d.SetId(aws.StringValue(output.FirewallDomainList.Id))
+	d.Set("arn", output.FirewallDomainList.Arn)
+
+	return resourceAwsRoute53ResolverFirewallDomainListUpdate(d, meta)
+}
+
+func resourceAwsRoute53ResolverFirewallDomainListRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	firewallDomainList, err := finder.FirewallDomainListByID(conn, d.Id())
+
+	if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Route53 Resolver DNS Firewall domain list (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error getting Route 53 Resolver DNS Firewall domain list (%s): %w", d.Id(), err)
+	}
+
+	if firewallDomainList == nil {
+		log.Printf("[WARN] Route 53 Resolver DNS Firewall domain list (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	arn := aws.StringValue(firewallDomainList.Arn)
+	d.Set("arn", arn)
+	d.Set("id", firewallDomainList.Id)
+	d.Set("name", firewallDomainList.Name)
+
+	input := &route53resolver.ListFirewallDomainsInput{
+		FirewallDomainListId: aws.String(d.Id()),
+	}
+
+	domains := []*string{}
+
+	err = conn.ListFirewallDomainsPages(input, func(output *route53resolver.ListFirewallDomainsOutput, lastPage bool) bool {
+		domains = append(domains, output.Domains...)
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error listing Route 53 Resolver DNS Firewall domain list (%s) domains: %w", d.Id(), err)
+	}
+
+	d.Set("domains", flattenStringSet(domains))
+
+	tags, err := keyvaluetags.Route53resolverListTags(conn, arn)
+	if err != nil {
+		return fmt.Errorf("error listing tags for Route53 Resolver DNS Firewall domain list (%s): %w", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53ResolverFirewallDomainListUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	if v, ok := d.GetOk("domains"); ok && d.HasChange("domains") {
+		_, err := conn.UpdateFirewallDomains(&route53resolver.UpdateFirewallDomainsInput{
+			FirewallDomainListId: aws.String(d.Id()),
+			Domains:              expandStringSet(v.(*schema.Set)),
+			Operation:            aws.String(route53resolver.FirewallDomainUpdateOperationReplace),
+		})
+
+		if err != nil {
+			return fmt.Errorf("error updating Route 53 Resolver DNS Firewall domain list (%s) domains: %w", d.Id(), err)
+		}
+
+		_, err = waiter.FirewallDomainListUpdated(conn, d.Id())
+
+		if err != nil {
+			return fmt.Errorf("error waiting for Route 53 Resolver DNS Firewall domain list (%s) domains to be updated: %w", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Route53resolverUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Route53 Resolver DNS Firewall domain list (%s) tags: %s", d.Get("arn").(string), err)
+		}
+	}
+
+	return resourceAwsRoute53ResolverFirewallDomainListRead(d, meta)
+}
+
+func resourceAwsRoute53ResolverFirewallDomainListDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	_, err := conn.DeleteFirewallDomainList(&route53resolver.DeleteFirewallDomainListInput{
+		FirewallDomainListId: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Route 53 Resolver DNS Firewall domain list (%s): %w", d.Id(), err)
+	}
+
+	_, err = waiter.FirewallDomainListDeleted(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error waiting for Route 53 Resolver DNS Firewall domain list (%s) to be deleted: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_route53_resolver_firewall_domain_list_test.go
+++ b/aws/resource_aws_route53_resolver_firewall_domain_list_test.go
@@ -1,0 +1,290 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/route53resolver/finder"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_route53_resolver_firewall_domain_list", &resource.Sweeper{
+		Name: "aws_route53_resolver_firewall_domain_list",
+		F:    testSweepRoute53ResolverFirewallDomainLists,
+		Dependencies: []string{
+			"aws_route53_resolver_firewall_domain_list_association",
+		},
+	})
+}
+
+func testSweepRoute53ResolverFirewallDomainLists(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).route53resolverconn
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListFirewallDomainListsPages(&route53resolver.ListFirewallDomainListsInput{}, func(page *route53resolver.ListFirewallDomainListsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, queryLogConfig := range page.FirewallDomainLists {
+			id := aws.StringValue(queryLogConfig.Id)
+
+			log.Printf("[INFO] Deleting Route53 Resolver DNS Firewall domain list: %s", id)
+			r := resourceAwsRoute53ResolverFirewallDomainList()
+			d := r.Data(nil)
+			d.SetId(id)
+			err := r.Delete(d, client)
+
+			if err != nil {
+				log.Printf("[ERROR] %s", err)
+				sweeperErrs = multierror.Append(sweeperErrs, err)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Route53 Resolver DNS Firewall domain lists sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Route53 Resolver DNS Firewall domain lists: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func TestAccAWSRoute53ResolverFirewallDomainList_basic(t *testing.T) {
+	var v route53resolver.FirewallDomainList
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_resolver_firewall_domain_list.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53resolver.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverFirewallDomainListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverFirewallDomainListConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallDomainListExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ResolverFirewallDomainList_domains(t *testing.T) {
+	var v route53resolver.FirewallDomainList
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_resolver_firewall_domain_list.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53resolver.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverFirewallDomainListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverFirewallDomainListConfigDomains(rName, "foo.com."),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallDomainListExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "domains.*", "foo.com."),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRoute53ResolverFirewallDomainListConfigDomains(rName, "bar.com."),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallDomainListExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "domains.*", "bar.com."),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ResolverFirewallDomainList_disappears(t *testing.T) {
+	var v route53resolver.FirewallDomainList
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_resolver_firewall_domain_list.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53resolver.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverFirewallDomainListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverFirewallDomainListConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallDomainListExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53ResolverFirewallDomainList(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ResolverFirewallDomainList_tags(t *testing.T) {
+	var v route53resolver.FirewallDomainList
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_resolver_firewall_domain_list.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53resolver.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverFirewallDomainListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverFirewallDomainListConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallDomainListExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRoute53ResolverFirewallDomainListConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallDomainListExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccRoute53ResolverFirewallDomainListConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallDomainListExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRoute53ResolverFirewallDomainListDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_resolver_firewall_domain_list" {
+			continue
+		}
+
+		// Try to find the resource
+		_, err := finder.FirewallDomainListByID(conn, rs.Primary.ID)
+		// Verify the error is what we want
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("Route 53 Resolver DNS Firewall domain list still exists: %s", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckRoute53ResolverFirewallDomainListExists(n string, v *route53resolver.FirewallDomainList) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Route 53 Resolver DNS Firewall domain list ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
+		out, err := finder.FirewallDomainListByID(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*v = *out
+
+		return nil
+	}
+}
+
+func testAccRoute53ResolverFirewallDomainListConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_firewall_domain_list" "test" {
+  name = %[1]q
+}
+`, rName)
+}
+
+func testAccRoute53ResolverFirewallDomainListConfigDomains(rName, domain string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_firewall_domain_list" "test" {
+  name    = %[1]q
+  domains = [%[2]q]
+}
+`, rName, domain)
+}
+
+func testAccRoute53ResolverFirewallDomainListConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_firewall_domain_list" "test" {
+  name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccRoute53ResolverFirewallDomainListConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_firewall_domain_list" "test" {
+  name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_route53_resolver_firewall_domain_list_test.go
+++ b/aws/resource_aws_route53_resolver_firewall_domain_list_test.go
@@ -18,9 +18,6 @@ func init() {
 	resource.AddTestSweepers("aws_route53_resolver_firewall_domain_list", &resource.Sweeper{
 		Name: "aws_route53_resolver_firewall_domain_list",
 		F:    testSweepRoute53ResolverFirewallDomainLists,
-		Dependencies: []string{
-			"aws_route53_resolver_firewall_domain_list_association",
-		},
 	})
 }
 
@@ -126,6 +123,14 @@ func TestAccAWSRoute53ResolverFirewallDomainList_domains(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "domains.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "domains.*", "bar.com."),
+				),
+			},
+			{
+				Config: testAccRoute53ResolverFirewallDomainListConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverFirewallDomainListExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "0"),
 				),
 			},
 		},

--- a/website/docs/r/route53_resolver_firewall_domain_list.markdown
+++ b/website/docs/r/route53_resolver_firewall_domain_list.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "Route53 Resolver"
+layout: "aws"
+page_title: "AWS: aws_route53_resolver_firewall_domain_list"
+description: |-
+  Provides a Route 53 Resolver DNS Firewall domain list resource.
+---
+
+# Resource: aws_route53_resolver_firewall_domain_list
+
+Provides a Route 53 Resolver DNS Firewall domain list resource.
+
+## Example Usage
+
+```terraform
+resource "aws_route53_resolver_firewall_domain_list" "example" {
+  name = "example"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `name` - (Required) A name that lets you identify the domain list, to manage and use it.
+* `domains` - (Optional) A array of domains for the firewall domain list.
+* `tags` - (Optional) A map of tags to assign to the resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN (Amazon Resource Name) of the domain list.
+* `id` - The ID of the domain list.
+
+## Import
+
+ Route 53 Resolver DNS Firewall domain lists can be imported using the Route 53 Resolver DNS Firewall domain list ID, e.g.
+
+```
+$ terraform import aws_route53_resolver_firewall_domain_list.example rslvr-fdl-0123456789abcdef
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18520

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53ResolverFirewallDomainList'        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRoute53ResolverFirewallDomainList -timeout 180m
=== RUN   TestAccAWSRoute53ResolverFirewallDomainList_basic
=== PAUSE TestAccAWSRoute53ResolverFirewallDomainList_basic
=== RUN   TestAccAWSRoute53ResolverFirewallDomainList_domains
=== PAUSE TestAccAWSRoute53ResolverFirewallDomainList_domains
=== RUN   TestAccAWSRoute53ResolverFirewallDomainList_disappears
=== PAUSE TestAccAWSRoute53ResolverFirewallDomainList_disappears
=== RUN   TestAccAWSRoute53ResolverFirewallDomainList_tags
=== PAUSE TestAccAWSRoute53ResolverFirewallDomainList_tags
=== CONT  TestAccAWSRoute53ResolverFirewallDomainList_basic
=== CONT  TestAccAWSRoute53ResolverFirewallDomainList_tags
=== CONT  TestAccAWSRoute53ResolverFirewallDomainList_disappears
=== CONT  TestAccAWSRoute53ResolverFirewallDomainList_domains
--- PASS: TestAccAWSRoute53ResolverFirewallDomainList_disappears (88.79s)
--- PASS: TestAccAWSRoute53ResolverFirewallDomainList_basic (107.95s)
--- PASS: TestAccAWSRoute53ResolverFirewallDomainList_tags (137.11s)
--- PASS: TestAccAWSRoute53ResolverFirewallDomainList_domains (348.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	352.634s
```
