### PR TITLE
r/sagemaker_domain - retention policy for efs file system

### DIFF
--- a/.changelog/18562.txt
+++ b/.changelog/18562.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_domain: Add support for `retention_policy`
+```

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -318,6 +318,10 @@ resource "aws_sagemaker_domain" "test" {
   default_user_settings {
     execution_role = aws_iam_role.test.arn
   }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
 }
 
 resource "aws_sagemaker_user_profile" "test" {

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -90,6 +90,7 @@ func testSweepSagemakerDomains(region string) error {
 			r := resourceAwsSagemakerDomain()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(domain.DomainId))
+			d.Set("retention_policy.0.home_efs_file_system", "Delete")
 			err = r.Delete(d, client)
 			if err != nil {
 				log.Printf("[ERROR] %s", err)

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -620,7 +620,7 @@ resource "aws_sagemaker_domain" "test" {
 
   retention_policy {
     home_efs_file_system = "Delete"
-  }  
+  }
 }
 `, rName)
 }
@@ -644,7 +644,7 @@ resource "aws_sagemaker_domain" "test" {
 
   retention_policy {
     home_efs_file_system = "Delete"
-  }  
+  }
 }
 `, rName)
 }
@@ -672,7 +672,7 @@ resource "aws_sagemaker_domain" "test" {
 
   retention_policy {
     home_efs_file_system = "Delete"
-  }  
+  }
 }
 `, rName)
 }

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -142,9 +142,10 @@ func testAccAWSSagemakerDomain_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 		},
 	})
@@ -169,9 +170,10 @@ func testAccAWSSagemakerDomain_kms(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 		},
 	})
@@ -197,9 +199,10 @@ func testAccAWSSagemakerDomain_tags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 			{
 				Config: testAccAWSSagemakerDomainConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -242,9 +245,10 @@ func testAccAWSSagemakerDomain_securityGroup(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 			{
 				Config: testAccAWSSagemakerDomainConfigSecurityGroup2(rName),
@@ -281,9 +285,10 @@ func testAccAWSSagemakerDomain_sharingSettings(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 		},
 	})
@@ -311,9 +316,10 @@ func testAccAWSSagemakerDomain_tensorboardAppSettings(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 		},
 	})
@@ -342,9 +348,10 @@ func testAccAWSSagemakerDomain_tensorboardAppSettingsWithImage(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 		},
 	})
@@ -372,9 +379,10 @@ func testAccAWSSagemakerDomain_kernelGatewayAppSettings(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 		},
 	})
@@ -410,9 +418,10 @@ func testAccAWSSagemakerDomain_kernelGatewayAppSettings_customImage(t *testing.T
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 		},
 	})
@@ -440,9 +449,10 @@ func testAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
 		},
 	})
@@ -582,6 +592,10 @@ resource "aws_sagemaker_domain" "test" {
   default_user_settings {
     execution_role = aws_iam_role.test.arn
   }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
 }
 `, rName)
 }
@@ -603,6 +617,10 @@ resource "aws_sagemaker_domain" "test" {
   default_user_settings {
     execution_role = aws_iam_role.test.arn
   }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }  
 }
 `, rName)
 }
@@ -623,6 +641,10 @@ resource "aws_sagemaker_domain" "test" {
     execution_role  = aws_iam_role.test.arn
     security_groups = [aws_security_group.test.id]
   }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }  
 }
 `, rName)
 }
@@ -647,6 +669,10 @@ resource "aws_sagemaker_domain" "test" {
     execution_role  = aws_iam_role.test.arn
     security_groups = [aws_security_group.test.id, aws_security_group.test2.id]
   }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }  
 }
 `, rName)
 }
@@ -661,6 +687,10 @@ resource "aws_sagemaker_domain" "test" {
 
   default_user_settings {
     execution_role = aws_iam_role.test.arn
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
   }
 
   tags = {
@@ -680,6 +710,10 @@ resource "aws_sagemaker_domain" "test" {
 
   default_user_settings {
     execution_role = aws_iam_role.test.arn
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
   }
 
   tags = {
@@ -718,6 +752,10 @@ resource "aws_sagemaker_domain" "test" {
       s3_output_path         = "s3://${aws_s3_bucket.test.bucket}/sharing"
     }
   }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
 }
 `, rName)
 }
@@ -738,6 +776,10 @@ resource "aws_sagemaker_domain" "test" {
         instance_type = "ml.t3.micro"
       }
     }
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
   }
 }
 `, rName)
@@ -766,6 +808,10 @@ resource "aws_sagemaker_domain" "test" {
       }
     }
   }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
 }
 `, rName)
 }
@@ -787,6 +833,10 @@ resource "aws_sagemaker_domain" "test" {
       }
     }
   }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
 }
 `, rName)
 }
@@ -807,6 +857,10 @@ resource "aws_sagemaker_domain" "test" {
         instance_type = "ml.t3.micro"
       }
     }
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
   }
 }
 `, rName)
@@ -851,6 +905,10 @@ resource "aws_sagemaker_domain" "test" {
         image_name            = aws_sagemaker_image_version.test.image_name
       }
     }
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
   }
 }
 `, rName, baseImage)

--- a/aws/resource_aws_sagemaker_user_profile_test.go
+++ b/aws/resource_aws_sagemaker_user_profile_test.go
@@ -389,6 +389,10 @@ resource "aws_sagemaker_domain" "test" {
   default_user_settings {
     execution_role = aws_iam_role.test.arn
   }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
 }
 `, rName)
 }

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -95,6 +95,7 @@ The following arguments are supported:
 * `vpc_id` - (Required) The ID of the Amazon Virtual Private Cloud (VPC) that Studio uses for communication.
 * `subnet_ids` - (Required) The VPC subnets that Studio uses for communication.
 * `default_user_settings` - (Required) The default user settings. See [Default User Settings](#default-user-settings) below.
+* `retention_policy` - (Optional) The retention policy for this domain, which specifies whether resources will be retained after the Domain is deleted. By default, all resources are retained. See [Retention Policy](#retention-policy) below.
 * `kms_key_id` - (Optional) The AWS KMS customer managed CMK used to encrypt the EFS volume attached to the domain.
 * `app_network_access_type` - (Optional) Specifies the VPC used for non-EFS traffic. The default value is `PublicInternetOnly`. Valid values are `PublicInternetOnly` and `VpcOnly`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -137,6 +138,10 @@ The following arguments are supported:
 * `app_image_config_name` - (Required) The name of the App Image Config.
 * `image_name` - (Required) The name of the Custom Image.
 * `image_version_number` - (Optional) The version number of the Custom Image.
+
+### Retention Policy
+
+* `home_efs_file_system` - (Optional) The retention policy for data stored on an Amazon Elastic File System (EFS) volume. Default value is `Retain`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17349

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerDomain_serial/Domain'
--- PASS: TestAccAWSSagemakerDomain_serial (3394.21s)
    --- PASS: TestAccAWSSagemakerDomain_serial/Domain (3394.21s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/basic (411.96s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/disappears (448.80s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/tags (318.33s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/tensorboardAppSettings (311.14s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/tensorboardAppSettingsWithImage (354.26s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/kernelGatewayAppSettings (304.79s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/jupyterServerAppSettings (298.59s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/kms (289.33s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/securityGroup (349.54s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/sharingSettings (307.47s)
```

FYI this is a breaking change.
