### PR TITLE
r/codedeploy_app - add arn attribute & tagging support & sweeper

### DIFF
--- a/.changelog/18564.txt
+++ b/.changelog/18564.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_codedeploy_app: Add `arn`, `linked_to_github`, `github_account_name`, `application_id` attributes
+```
+
+```release-note:enhancement
+resource/aws_codedeploy_app: Add `tags` argument
+```
+
+```release-note:enhancement
+resource/aws_codedeploy_app: Add plan time validation for `name`
+```

--- a/aws/resource_aws_codedeploy_app.go
+++ b/aws/resource_aws_codedeploy_app.go
@@ -141,6 +141,10 @@ func resourceAwsCodeDeployAppRead(d *schema.ResourceData, meta interface{}) erro
 	app := resp.Application
 	appName := aws.StringValue(app.ApplicationName)
 
+     if !strings.Contains(d.Id(), appName) {
+         d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(app.ApplicationId), appName))
+     }
+     
 	appArn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Service:   "codedeploy",

--- a/aws/resource_aws_codedeploy_app.go
+++ b/aws/resource_aws_codedeploy_app.go
@@ -120,6 +120,9 @@ func resourceAwsCodeDeployAppRead(d *schema.ResourceData, meta interface{}) erro
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	application := resourceAwsCodeDeployAppParseId(d.Id())
+	if application != d.Get("name").(string) {
+	    application = d.Get("name").(string)
+	}
 	log.Printf("[DEBUG] Reading CodeDeploy application %s", application)
 	resp, err := conn.GetApplication(&codedeploy.GetApplicationInput{
 		ApplicationName: aws.String(application),

--- a/aws/resource_aws_codedeploy_app.go
+++ b/aws/resource_aws_codedeploy_app.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsCodeDeployApp() *schema.Resource {
@@ -52,30 +53,37 @@ func resourceAwsCodeDeployApp() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"arn": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Computed: true,
+			},
+			"application_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 
 			"compute_platform": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					codedeploy.ComputePlatformEcs,
-					codedeploy.ComputePlatformLambda,
-					codedeploy.ComputePlatformServer,
-				}, false),
-				Default: codedeploy.ComputePlatformServer,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(codedeploy.ComputePlatform_Values(), false),
+				Default:      codedeploy.ComputePlatformServer,
 			},
-
-			// The unique ID is set by AWS on create.
-			"unique_id": {
+			"github_account_name": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
+			"linked_to_github": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -90,6 +98,7 @@ func resourceAwsCodeDeployAppCreate(d *schema.ResourceData, meta interface{}) er
 	resp, err := conn.CreateApplication(&codedeploy.CreateApplicationInput{
 		ApplicationName: aws.String(application),
 		ComputePlatform: aws.String(computePlatform),
+		Tags:            keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().CodedeployTags(),
 	})
 	if err != nil {
 		return err
@@ -101,7 +110,7 @@ func resourceAwsCodeDeployAppCreate(d *schema.ResourceData, meta interface{}) er
 	// the state file. This allows us to reliably detect both when the TF
 	// config file changes and when the user deletes the app without removing
 	// it first from the TF config.
-	d.SetId(fmt.Sprintf("%s:%s", *resp.ApplicationId, application))
+	d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(resp.ApplicationId), application))
 
 	return resourceAwsCodeDeployAppRead(d, meta)
 }
@@ -115,17 +124,33 @@ func resourceAwsCodeDeployAppRead(d *schema.ResourceData, meta interface{}) erro
 		ApplicationName: aws.String(application),
 	})
 	if err != nil {
-		if codedeployerr, ok := err.(awserr.Error); ok && codedeployerr.Code() == "ApplicationDoesNotExistException" {
+		if isAWSErr(err, codedeploy.ErrCodeApplicationDoesNotExistException, "") {
 			d.SetId("")
+			log.Printf("[WARN] CodeDeploy Application (%s) not found, removing from state", d.Id())
 			return nil
-		} else {
-			log.Printf("[ERROR] Error finding CodeDeploy application: %s", err)
-			return err
 		}
+
+		log.Printf("[ERROR] Error finding CodeDeploy application: %s", err)
+		return err
 	}
 
-	d.Set("compute_platform", resp.Application.ComputePlatform)
-	d.Set("name", resp.Application.ApplicationName)
+	app := resp.Application
+	appName := aws.StringValue(app.ApplicationName)
+
+	appArn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "codedeploy",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("application:%s", appName),
+	}.String()
+
+	d.Set("arn", appArn)
+	d.Set("application_id", app.ApplicationId)
+	d.Set("compute_platform", app.ComputePlatform)
+	d.Set("name", appName)
+	d.Set("github_account_name", app.GitHubAccountName)
+	d.Set("linked_to_github", app.LinkedToGitHub)
 
 	return nil
 }
@@ -133,20 +158,15 @@ func resourceAwsCodeDeployAppRead(d *schema.ResourceData, meta interface{}) erro
 func resourceAwsCodeDeployUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codedeployconn
 
-	o, n := d.GetChange("name")
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
 
-	_, err := conn.UpdateApplication(&codedeploy.UpdateApplicationInput{
-		ApplicationName:    aws.String(o.(string)),
-		NewApplicationName: aws.String(n.(string)),
-	})
-	if err != nil {
-		return err
+		if err := keyvaluetags.CodedeployUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating CodeDeploy Application (%s) tags: %w", d.Get("arn").(string), err)
+		}
 	}
-	log.Printf("[DEBUG] CodeDeploy application %s updated", n)
 
-	d.Set("name", n)
-
-	return nil
+	return resourceAwsCodeDeployAppRead(d, meta)
 }
 
 func resourceAwsCodeDeployAppDelete(d *schema.ResourceData, meta interface{}) error {
@@ -156,12 +176,12 @@ func resourceAwsCodeDeployAppDelete(d *schema.ResourceData, meta interface{}) er
 		ApplicationName: aws.String(d.Get("name").(string)),
 	})
 	if err != nil {
-		if cderr, ok := err.(awserr.Error); ok && cderr.Code() == "InvalidApplicationNameException" {
+		if isAWSErr(err, codedeploy.ErrCodeApplicationDoesNotExistException, "") {
 			return nil
-		} else {
-			log.Printf("[ERROR] Error deleting CodeDeploy application: %s", err)
-			return err
 		}
+
+		log.Printf("[ERROR] Error deleting CodeDeploy application: %s", err)
+		return err
 	}
 
 	return nil

--- a/aws/resource_aws_codedeploy_app_test.go
+++ b/aws/resource_aws_codedeploy_app_test.go
@@ -211,7 +211,6 @@ func TestAccAWSCodeDeployApp_name(t *testing.T) {
 				Config: testAccAWSCodeDeployAppConfigName(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployAppExists(resourceName, &application2),
-					testAccCheckAWSCodeDeployAppRecreated(&application1, &application2),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 				),
 			},

--- a/aws/resource_aws_codedeploy_app_test.go
+++ b/aws/resource_aws_codedeploy_app_test.go
@@ -232,7 +232,7 @@ func TestAccAWSCodeDeployApp_disappears(t *testing.T) {
 				Config: testAccAWSCodeDeployAppConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployAppExists(resourceName, &application1),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsAmi(), resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCodeDeployApp(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_codedeploy_app_test.go
+++ b/aws/resource_aws_codedeploy_app_test.go
@@ -341,7 +341,7 @@ resource "aws_codedeploy_app" "test" {
 
   tags = {
     %[2]q = %[3]q
-    %[4]q = %[5]q	
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -254,6 +254,7 @@ This functionality is only supported in the following resources:
     - [`aws_apigatewayv2_stage` resource](/docs/providers/aws/r/apigatewayv2_stage.html)
     - [`aws_athena_workgroup` resource](/docs/providers/aws/r/athena_workgroup.html)
     - [`aws_budgets_budget` resource](/docs/providers/aws/r/budgets_budget.html)
+    - [`aws_codedeploy_app` resource](/docs/providers/aws/r/codedeploy_app.html)
     - [`aws_cognito_identity_pool` resource](/docs/providers/aws/r/cognito_identity_pool.html)
     - [`aws_cognito_user_pools` data source](/docs/providers/aws/d/cognito_user_pools.html)
     - [`aws_default_vpc_dhcp_options`](/docs/providers/aws/r/default_vpc_dhcp_options.html)

--- a/website/docs/r/codedeploy_app.html.markdown
+++ b/website/docs/r/codedeploy_app.html.markdown
@@ -45,13 +45,18 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the application.
 * `compute_platform` - (Optional) The compute platform can either be `ECS`, `Lambda`, or `Server`. Default is `Server`.
+* `tags` - (Optional) Key-value map of resource tags
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the CodeDeploy application.
+* `application_id` - The application ID.
 * `id` - Amazon's assigned ID for the application.
 * `name` - The application's name.
+* `github_account_name` - The name for a connection to a GitHub account.
+* `linked_to_github` - Whether the user has authenticated with GitHub for the specified application.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/8774

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeDeployApp_'
--- PASS: TestAccAWSCodeDeployApp_disappears (29.33s)
--- PASS: TestAccAWSCodeDeployApp_computePlatform_Lambda (38.70s)
--- PASS: TestAccAWSCodeDeployApp_computePlatform_ECS (39.01s)
--- PASS: TestAccAWSCodeDeployApp_basic (44.33s)
--- PASS: TestAccAWSCodeDeployApp_computePlatform (61.79s)
--- PASS: TestAccAWSCodeDeployApp_name (64.22s)
--- PASS: TestAccAWSCodeDeployApp_tags (93.42s)
```
