### PR TITLE
docs: Add AWS_SDK_LOAD_CONFIG to env vars section

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -87,12 +87,14 @@ provider "aws" {
 ### Environment Variables
 
 You can provide your credentials via the `AWS_ACCESS_KEY_ID` and
-`AWS_SECRET_ACCESS_KEY`, environment variables, representing your AWS
-Access Key and AWS Secret Key, respectively.  Note that setting your
-AWS credentials using either these (or legacy) environment variables
-will override the use of `AWS_SHARED_CREDENTIALS_FILE` and `AWS_PROFILE`.
-The `AWS_DEFAULT_REGION` and `AWS_SESSION_TOKEN` environment variables
-are also used, if applicable:
+`AWS_SECRET_ACCESS_KEY`, environment variables, representing your AWS Access
+Key and AWS Secret Key, respectively. You may also need to set
+`AWS_SDK_LOAD_CONFIG` to a truthy value.
+
+Note that setting your AWS credentials using either these (or legacy)
+environment variables will override the use of `AWS_SHARED_CREDENTIALS_FILE`
+and `AWS_PROFILE`.  The `AWS_DEFAULT_REGION` and `AWS_SESSION_TOKEN`
+environment variables are also used, if applicable:
 
 ```terraform
 provider "aws" {}
@@ -101,6 +103,7 @@ provider "aws" {}
 Usage:
 
 ```sh
+$ export AWS_SDK_LOAD_CONFIG=1
 $ export AWS_ACCESS_KEY_ID="anaccesskey"
 $ export AWS_SECRET_ACCESS_KEY="asecretkey"
 $ export AWS_DEFAULT_REGION="us-west-2"


### PR DESCRIPTION
I was unable to get the AWS provider to load the region, key ID, and secret from env vars on a new system. Setting `AWS_SDK_LOAD_CONFIG=1` resolved this, as suggested in [hashicorp/terraform-provider-aws#13057](https://github.com/hashicorp/terraform-provider-aws/issues/13057#issuecomment-620612604).

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->