### PR TITLE
tests/elasticsearch_domain: Add sweeper concurrency

### DIFF
--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -33,7 +33,7 @@ func testSweepElasticSearchDomains(region string) error {
 
 	conn := client.(*AWSClient).esconn
 	sweepResources := make([]*testSweepResource, 0)
-	var errors *multierror.Error
+	var errs *multierror.Error
 
 	input := &elasticsearch.ListDomainNamesInput{}
 
@@ -42,19 +42,19 @@ func testSweepElasticSearchDomains(region string) error {
 
 	if testSweepSkipSweepError(err) {
 		log.Printf("[WARN] Skipping Elasticsearch Domain sweep for %s: %s", region, err)
-		return errors.ErrorOrNil()
+		return errs.ErrorOrNil()
 	}
 
 	if err != nil {
 		sweeperErr := fmt.Errorf("error listing Elasticsearch Domains: %w", err)
 		log.Printf("[ERROR] %s", sweeperErr)
-		errors = multierror.Append(errors, sweeperErr)
-		return errors.ErrorOrNil()
+		errs = multierror.Append(errs, sweeperErr)
+		return errs.ErrorOrNil()
 	}
 
 	if output == nil {
 		log.Printf("[WARN] Skipping Elasticsearch Domain sweep for %s: empty response", region)
-		return errors.ErrorOrNil()
+		return errs.ErrorOrNil()
 	}
 
 	for _, domainInfo := range output.DomainNames {
@@ -77,7 +77,7 @@ func testSweepElasticSearchDomains(region string) error {
 		if err != nil {
 			sweeperErr := fmt.Errorf("error describing Elasticsearch Domain (%s): %w", name, err)
 			log.Printf("[ERROR] %s", sweeperErr)
-			errors = multierror.Append(errors, sweeperErr)
+			errs = multierror.Append(errs, sweeperErr)
 			continue
 		}
 
@@ -97,16 +97,16 @@ func testSweepElasticSearchDomains(region string) error {
 	if len(sweepResources) > 0 {
 		// Any errors didn't prevent gathering some sweeping work, so do it.
 		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errors = multierror.Append(errors, err)
+			errs = multierror.Append(errs, err)
 		}
 	}
 
-	if testSweepSkipSweepError(errors.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping Elasticsearch Domain sweep for %s: %s", region, errors)
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Elasticsearch Domain sweep for %s: %s", region, errs)
 		return nil
 	}
 
-	return errors.ErrorOrNil()
+	return errs.ErrorOrNil()
 }
 
 func TestAccAWSElasticSearchDomain_basic(t *testing.T) {

--- a/aws/resource_aws_waf_web_acl_test.go
+++ b/aws/resource_aws_waf_web_acl_test.go
@@ -32,7 +32,7 @@ func testSweepWafWebAcls(region string) error {
 
 	conn := client.(*AWSClient).wafconn
 	sweepResources := make([]*testSweepResource, 0)
-	var errors *multierror.Error
+	var errs *multierror.Error
 	input := &waf.ListWebACLsInput{}
 
 	err = lister.ListWebACLsPages(conn, input, func(page *waf.ListWebACLsOutput, lastPage bool) bool {
@@ -57,7 +57,7 @@ func testSweepWafWebAcls(region string) error {
 			if err != nil {
 				readErr := fmt.Errorf("error reading WAF Web ACL (%s): %w", id, err)
 				log.Printf("[ERROR] %s", readErr)
-				errors = multierror.Append(errors, readErr)
+				errs = multierror.Append(errs, readErr)
 				continue
 			}
 
@@ -73,7 +73,7 @@ func testSweepWafWebAcls(region string) error {
 	})
 
 	if err != nil {
-		errors = multierror.Append(errors, err)
+		errs = multierror.Append(errs, err)
 		// in case work can be done, don't jump out yet
 	}
 
@@ -82,16 +82,16 @@ func testSweepWafWebAcls(region string) error {
 		sweepErr := testSweepResourceOrchestrator(sweepResources)
 
 		if sweepErr != nil {
-			errors = multierror.Append(errors, sweepErr)
+			errs = multierror.Append(errs, sweepErr)
 		}
 	}
 
-	if testSweepSkipSweepError(errors.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping WAF Web ACL sweep for %s: %s", region, errors)
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping WAF Web ACL sweep for %s: %s", region, errs)
 		return nil
 	}
 
-	return errors.ErrorOrNil()
+	return errs.ErrorOrNil()
 }
 
 func TestAccAWSWafWebAcl_basic(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15334

Output from acceptance testing: N/A (handled by nightly build)

```console
% SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_elasticsearch_domain make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_elasticsearch_domain -timeout 60m
2021/04/05 16:14:37 [DEBUG] Running Sweepers for region (us-west-2):
2021/04/05 16:14:37 [DEBUG] Running Sweeper (aws_elasticsearch_domain) in region (us-west-2)
2021/04/05 16:14:38 Sweeper Tests ran successfully:
	- aws_elasticsearch_domain
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.251s
```