### PR TITLE
tests/r/redshift_cluser: Add sweeper concurrency

### DIFF
--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -49,6 +49,7 @@ func testSweepRedshiftClusters(region string) error {
 
 			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 		}
+
 		return !isLast
 	})
 
@@ -60,7 +61,7 @@ func testSweepRedshiftClusters(region string) error {
 	if len(sweepResources) > 0 {
 		// any errors didn't prevent gathering of some work, so do it
 		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errors = multierror.Append(errors, err)
+			errors = multierror.Append(errors, fmt.Errorf("error sweeping Redshift Clusters for %s: %w", region, err))
 		}
 	}
 

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -33,7 +33,7 @@ func testSweepRedshiftClusters(region string) error {
 
 	conn := client.(*AWSClient).redshiftconn
 	sweepResources := make([]*testSweepResource, 0)
-	var errors *multierror.Error
+	var errs *multierror.Error
 
 	err = conn.DescribeClustersPages(&redshift.DescribeClustersInput{}, func(resp *redshift.DescribeClustersOutput, isLast bool) bool {
 		if len(resp.Clusters) == 0 {
@@ -54,23 +54,23 @@ func testSweepRedshiftClusters(region string) error {
 	})
 
 	if err != nil {
-		errors = multierror.Append(errors, fmt.Errorf("error describing Redshift Clusters: %w", err))
+		errs = multierror.Append(errs, fmt.Errorf("error describing Redshift Clusters: %w", err))
 		// in case work can be done, don't jump out yet
 	}
 
 	if len(sweepResources) > 0 {
 		// any errors didn't prevent gathering of some work, so do it
 		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errors = multierror.Append(errors, fmt.Errorf("error sweeping Redshift Clusters for %s: %w", region, err))
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping Redshift Clusters for %s: %w", region, err))
 		}
 	}
 
-	if testSweepSkipSweepError(errors.ErrorOrNil()) {
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
 		log.Printf("[WARN] Skipping Redshift Cluster sweep for %s: %s", region, err)
 		return nil
 	}
 
-	return errors.ErrorOrNil()
+	return errs.ErrorOrNil()
 }
 
 func TestAccAWSRedshiftCluster_basic(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15334

Output from acceptance testing: N/A

Sweeper testing configuration:
```terraform
resource "aws_redshift_cluster" "test" {
  cluster_identifier                  = "yakluster"
  availability_zone                   = data.aws_availability_zones.available.names[0]
  database_name                       = "mydb"
  master_username                     = "foo_test"
  master_password                     = "Mustbe8characters"
  node_type                           = "dc1.large"
  automated_snapshot_retention_period = 0
  allow_version_upgrade               = false
  skip_final_snapshot                 = true
}

resource "aws_redshift_cluster" "test2" {
  cluster_identifier                  = "yakluster2"
  availability_zone                   = data.aws_availability_zones.available.names[0]
  database_name                       = "mydb"
  master_username                     = "foo_test"
  master_password                     = "Mustbe8characters"
  node_type                           = "dc1.large"
  automated_snapshot_retention_period = 0
  allow_version_upgrade               = false
  skip_final_snapshot                 = true
}

data "aws_availability_zones" "available" {
  state = "available"

  filter {
    name   = "opt-in-status"
    values = ["opt-in-not-required"]
  }
}
```

Sweeper test:
```
% SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_redshift_cluster make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_redshift_cluster -timeout 60m
2021/04/05 21:37:05 [DEBUG] Running Sweepers for region (us-west-2):
2021/04/05 21:37:05 [DEBUG] Sweeper (aws_redshift_cluster_snapshot) has dependency (aws_redshift_cluster), running..
2021/04/05 21:37:05 [DEBUG] Running Sweeper (aws_redshift_cluster) in region (us-west-2)
2021/04/05 21:37:06 [DEBUG] Destroying Redshift Cluster (yakluster2)
2021/04/05 21:37:06 [DEBUG] Destroying Redshift Cluster (yakluster)
2021/04/05 21:37:06 [DEBUG] Deleting Redshift Cluster: {
  ClusterIdentifier: "yakluster2",
  SkipFinalClusterSnapshot: true
}
2021/04/05 21:37:06 [DEBUG] schema.TimeoutDelete: 40m0s
2021/04/05 21:37:06 [INFO] Deleting Redshift Cluster "yakluster2"
2021/04/05 21:37:06 [DEBUG] Waiting for state to become: [success]
2021/04/05 21:37:06 [DEBUG] Deleting Redshift Cluster: {
  ClusterIdentifier: "yakluster",
  SkipFinalClusterSnapshot: true
}
2021/04/05 21:37:06 [DEBUG] schema.TimeoutDelete: 40m0s
2021/04/05 21:37:06 [INFO] Deleting Redshift Cluster "yakluster"
2021/04/05 21:37:06 [DEBUG] Waiting for state to become: [success]
2021/04/05 21:37:06 [DEBUG] Waiting for state to become: [destroyed]
2021/04/05 21:37:06 [INFO] Reading Redshift Cluster Information: yakluster
2021/04/05 21:37:06 [DEBUG] Waiting for state to become: [destroyed]
2021/04/05 21:37:06 [INFO] Reading Redshift Cluster Information: yakluster2
2021/04/05 21:37:07 [DEBUG] Redshift Cluster status (yakluster): deleting
2021/04/05 21:37:07 [TRACE] Waiting 5s before next try
2021/04/05 21:37:07 [DEBUG] Redshift Cluster status (yakluster2): deleting
2021/04/05 21:37:07 [TRACE] Waiting 5s before next try
2021/04/05 21:37:12 [INFO] Reading Redshift Cluster Information: yakluster
2021/04/05 21:37:12 [INFO] Reading Redshift Cluster Information: yakluster2
2021/04/05 21:37:12 [DEBUG] Redshift Cluster status (yakluster): deleting
2021/04/05 21:37:12 [TRACE] Waiting 10s before next try
2021/04/05 21:37:12 [DEBUG] Redshift Cluster status (yakluster2): deleting
2021/04/05 21:37:12 [TRACE] Waiting 10s before next try
2021/04/05 21:37:22 [INFO] Reading Redshift Cluster Information: yakluster
2021/04/05 21:37:22 [INFO] Reading Redshift Cluster Information: yakluster2
2021/04/05 21:37:23 [DEBUG] Redshift Cluster status (yakluster): deleting
2021/04/05 21:37:23 [TRACE] Waiting 10s before next try
2021/04/05 21:37:23 [DEBUG] Redshift Cluster status (yakluster2): deleting
2021/04/05 21:37:23 [TRACE] Waiting 10s before next try
2021/04/05 21:37:33 [INFO] Reading Redshift Cluster Information: yakluster
2021/04/05 21:37:33 [INFO] Reading Redshift Cluster Information: yakluster2
2021/04/05 21:37:33 [DEBUG] Redshift Cluster status (yakluster): deleting
2021/04/05 21:37:33 [TRACE] Waiting 10s before next try
2021/04/05 21:37:33 [DEBUG] Redshift Cluster status (yakluster2): deleting
2021/04/05 21:37:33 [TRACE] Waiting 10s before next try
2021/04/05 21:37:43 [INFO] Reading Redshift Cluster Information: yakluster
2021/04/05 21:37:43 [INFO] Reading Redshift Cluster Information: yakluster2
2021/04/05 21:37:44 [DEBUG] Redshift Cluster status (yakluster2): deleting
2021/04/05 21:37:44 [TRACE] Waiting 10s before next try
2021/04/05 21:37:44 [DEBUG] Redshift Cluster status (yakluster): deleting
2021/04/05 21:37:44 [TRACE] Waiting 10s before next try
2021/04/05 21:37:54 [INFO] Reading Redshift Cluster Information: yakluster
2021/04/05 21:37:54 [INFO] Reading Redshift Cluster Information: yakluster2
2021/04/05 21:37:54 [DEBUG] Redshift Cluster status (yakluster): deleting
2021/04/05 21:37:54 [TRACE] Waiting 10s before next try
2021/04/05 21:37:54 [DEBUG] Redshift Cluster status (yakluster2): deleting
2021/04/05 21:37:54 [TRACE] Waiting 10s before next try
2021/04/05 21:38:04 [INFO] Reading Redshift Cluster Information: yakluster
2021/04/05 21:38:04 [INFO] Reading Redshift Cluster Information: yakluster2
2021/04/05 21:38:05 [DEBUG] Redshift Cluster status (yakluster): deleting
2021/04/05 21:38:05 [TRACE] Waiting 10s before next try
2021/04/05 21:38:05 [DEBUG] Redshift Cluster status (yakluster2): deleting
2021/04/05 21:38:05 [TRACE] Waiting 10s before next try
2021/04/05 21:38:15 [INFO] Reading Redshift Cluster Information: yakluster
2021/04/05 21:38:15 [INFO] Reading Redshift Cluster Information: yakluster2
2021/04/05 21:38:15 [INFO] Redshift Cluster yakluster2 successfully deleted
2021/04/05 21:38:15 [INFO] Redshift Cluster yakluster successfully deleted
2021/04/05 21:38:15 [DEBUG] Running Sweeper (aws_redshift_cluster_snapshot) in region (us-west-2)
2021/04/05 21:38:15 [DEBUG] No Redshift cluster snapshots to sweep
2021/04/05 21:38:15 [DEBUG] Sweeper (aws_redshift_cluster) already ran in region (us-west-2)
2021/04/05 21:38:15 Sweeper Tests ran successfully:
	- aws_redshift_cluster
	- aws_redshift_cluster_snapshot
ok  	github.com/terraform-providers/terraform-provider-aws/aws	71.867s
% SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_redshift_cluster make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_redshift_cluster -timeout 60m
2021/04/05 21:38:31 [DEBUG] Running Sweepers for region (us-west-2):
2021/04/05 21:38:31 [DEBUG] Running Sweeper (aws_redshift_cluster) in region (us-west-2)
2021/04/05 21:38:32 [DEBUG] No Redshift clusters to sweep
2021/04/05 21:38:32 [DEBUG] Sweeper (aws_redshift_cluster_snapshot) has dependency (aws_redshift_cluster), running..
2021/04/05 21:38:32 [DEBUG] Sweeper (aws_redshift_cluster) already ran in region (us-west-2)
2021/04/05 21:38:32 [DEBUG] Running Sweeper (aws_redshift_cluster_snapshot) in region (us-west-2)
2021/04/05 21:38:32 [DEBUG] No Redshift cluster snapshots to sweep
2021/04/05 21:38:32 Sweeper Tests ran successfully:
	- aws_redshift_cluster_snapshot
	- aws_redshift_cluster
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.681s
```
