### PR TITLE
tests/r/eks_node_group: Add EKS service ErrorCheck

### DIFF
--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func init() {
+	RegisterServiceErrorCheckFunc(eks.EndpointsID, testAccErrorCheckSkipEKS)
+
 	resource.AddTestSweepers("aws_eks_fargate_node_group", &resource.Sweeper{
 		Name: "aws_eks_fargate_node_group",
 		F:    testSweepEksFargateNodegroups,
@@ -783,6 +785,12 @@ func TestAccAWSEksNodeGroup_Version(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccErrorCheckSkipEKS(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"InvalidParameterException: The following supplied instance types do not exist",
+	)
 }
 
 func testAccCheckAWSEksNodeGroupExists(resourceName string, nodeGroup *eks.Nodegroup) resource.TestCheckFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18577

Output from acceptance testing (GovCloud):

```
=== CONT  TestAccAWSEksNodeGroup_AmiType
    provider_test.go:1071: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        
        Error: error creating EKS Node Group (tf-acc-test-4039395978000220327:tf-acc-test-4039395978000220327): InvalidParameterException: The following supplied instance types do not exist: [a1.medium]
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "c75b1389-4ba1-42d0-ad49-c80200b4bfcc"
          },
          ClusterName: "tf-acc-test-4039395978000220327",
          Message_: "The following supplied instance types do not exist: [a1.medium]",
          NodegroupName: "tf-acc-test-4039395978000220327"
        }
        
          on terraform_plugin_test.tf line 142, in resource "aws_eks_node_group" "test":
         142: resource "aws_eks_node_group" "test" {
        
        
--- SKIP: TestAccAWSEksNodeGroup_AmiType (876.36s)
```

Output from acceptance testing (`us-west-2`):

```
kommer snart
```
