### PR TITLE
fix: r/ssm_parameter description and allowed_pattern validation

### DIFF
--- a/.changelog/18588.txt
+++ b/.changelog/18588.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_parameter: Allow `allowed_pattern` and `description` arguments to be empty strings
+```

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -40,7 +40,7 @@ func resourceAwsSsmParameter() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1024),
+				ValidateFunc: validation.StringLenBetween(0, 1024),
 			},
 			"tier": {
 				Type:         schema.TypeString,
@@ -87,7 +87,7 @@ func resourceAwsSsmParameter() *schema.Resource {
 			"allowed_pattern": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1024),
+				ValidateFunc: validation.StringLenBetween(0, 1024),
 			},
 			"version": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
Closes #18552 

`description` and `allowed_pattern` should allow minimum of 0 ([aws documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_PutParameter.html#systemsmanager-PutParameter-request-AllowedPattern)).

This change was introduced in https://github.com/hashicorp/terraform-provider-aws/pull/17830 and there are few issues linked to it.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSSSMParameter_basic (151.37s)
--- PASS: TestAccAWSSSMParameter_fullPath (162.13s)
--- PASS: TestAccAWSSSMParameter_disappears (221.95s)
--- PASS: TestAccAWSSSMParameter_secure (293.26s)
--- PASS: TestAccAWSSSMParameter_DataType_AwsEc2Image (297.27s)
--- PASS: TestAccAWSSSMParameter_secure_with_key (300.38s)
--- PASS: TestAccAWSSSMParameter_updateDescription (394.64s)
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (395.52s)
--- PASS: TestAccAWSSSMParameter_updateType (397.82s)
--- PASS: TestAccAWSSSMParameter_overwrite (400.52s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (404.50s)
--- PASS: TestAccAWSSSMParameter_Tier (453.47s)
--- PASS: TestAccAWSSSMParameter_tags (455.93s)
--- PASS: TestAccAWSSSMParameter_Tier_IntelligentTieringToStandard (470.81s)
--- PASS: TestAccAWSSSMParameter_Tier_IntelligentTieringToAdvanced (472.78s)
```
