### PR TITLE
tests/redshift: Add sweeper concurrency

### DIFF
--- a/aws/resource_aws_redshift_event_subscription_test.go
+++ b/aws/resource_aws_redshift_event_subscription_test.go
@@ -29,7 +29,7 @@ func testSweepRedshiftEventSubscriptions(region string) error {
 
 	conn := client.(*AWSClient).redshiftconn
 	sweepResources := make([]*testSweepResource, 0)
-	var errors *multierror.Error
+	var errs *multierror.Error
 
 	err = conn.DescribeEventSubscriptionsPages(&redshift.DescribeEventSubscriptionsInput{}, func(page *redshift.DescribeEventSubscriptionsOutput, isLast bool) bool {
 		if page == nil {
@@ -48,22 +48,22 @@ func testSweepRedshiftEventSubscriptions(region string) error {
 	})
 
 	if err != nil {
-		errors = multierror.Append(errors, fmt.Errorf("error describing Redshift Event Subscriptions: %w", err))
+		errs = multierror.Append(errs, fmt.Errorf("error describing Redshift Event Subscriptions: %w", err))
 	}
 
 	if len(sweepResources) > 0 {
 		// any errors didn't prevent gathering of some work, so do it
 		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errors = multierror.Append(errors, fmt.Errorf("error sweeping Elasticache Replication Groups for %s: %w", region, err))
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping Elasticache Replication Groups for %s: %w", region, err))
 		}
 	}
 
-	if testSweepSkipSweepError(errors.ErrorOrNil()) {
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
 		log.Printf("[WARN] Skipping Redshift Event Subscriptions sweep for %s: %s", region, err)
 		return nil
 	}
 
-	return errors.ErrorOrNil()
+	return errs.ErrorOrNil()
 }
 
 func TestAccAWSRedshiftEventSubscription_basicUpdate(t *testing.T) {

--- a/aws/resource_aws_redshift_event_subscription_test.go
+++ b/aws/resource_aws_redshift_event_subscription_test.go
@@ -37,7 +37,7 @@ func testSweepRedshiftEventSubscriptions(region string) error {
 		}
 
 		for _, eventSubscription := range page.EventSubscriptionsList {
-			r := resourceAwsElasticacheReplicationGroup()
+			r := resourceAwsRedshiftEventSubscription()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(eventSubscription.CustSubscriptionId))
 

--- a/aws/resource_aws_redshift_snapshot_schedule_test.go
+++ b/aws/resource_aws_redshift_snapshot_schedule_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/redshift"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -23,63 +24,64 @@ func init() {
 
 func testSweepRedshiftSnapshotSchedules(region string) error {
 	client, err := sharedClientForRegion(region)
+
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
+
 	conn := client.(*AWSClient).redshiftconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errors *multierror.Error
 
-	req := &redshift.DescribeSnapshotSchedulesInput{}
+	input := &redshift.DescribeSnapshotSchedulesInput{}
+	prefixesToSweep := []string{"tf-acc-test"}
 
-	resp, err := conn.DescribeSnapshotSchedules(req)
-	if err != nil {
-		if testSweepSkipSweepError(err) {
-			log.Printf("[WARN] Skipping Redshift Regional Snapshot Schedules sweep for %s: %s", region, err)
-			return nil
+	err = conn.DescribeSnapshotSchedulesPages(input, func(page *redshift.DescribeSnapshotSchedulesOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
 		}
-		return fmt.Errorf("Error describing Redshift Regional Snapshot Schedules: %s", err)
-	}
 
-	if len(resp.SnapshotSchedules) == 0 {
-		log.Print("[DEBUG] No AWS Redshift Regional Snapshot Schedules to sweep")
-		return nil
-	}
+		for _, snapshotSchedules := range page.SnapshotSchedules {
+			id := aws.StringValue(snapshotSchedules.ScheduleIdentifier)
 
-	for _, snapshotSchedules := range resp.SnapshotSchedules {
-		identifier := aws.StringValue(snapshotSchedules.ScheduleIdentifier)
+			for _, prefix := range prefixesToSweep {
+				if strings.HasPrefix(id, prefix) {
+					r := resourceAwsRedshiftSnapshotSchedule()
+					d := r.Data(nil)
+					d.SetId(id)
 
-		hasPrefix := false
-		prefixes := []string{"tf-snapshot-schedule-"}
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(identifier, prefix) {
-				hasPrefix = true
-				break
+					break
+				}
 			}
 		}
 
-		if !hasPrefix {
-			log.Printf("[INFO] Skipping Delete Redshift Snapshot Schedule: %s", identifier)
-			continue
-		}
+		return !isLast
+	})
 
-		_, err := conn.DeleteSnapshotSchedule(&redshift.DeleteSnapshotScheduleInput{
-			ScheduleIdentifier: snapshotSchedules.ScheduleIdentifier,
-		})
-		if isAWSErr(err, redshift.ErrCodeSnapshotScheduleNotFoundFault, "") {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("Error deleting Redshift Snapshot Schedule %s: %s", identifier, err)
+	if err != nil {
+		errors = multierror.Append(errors, fmt.Errorf("error describing Redshift Snapshot Schedules: %w", err))
+	}
+
+	if len(sweepResources) > 0 {
+		// any errors didn't prevent gathering of some work, so do it
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errors = multierror.Append(errors, fmt.Errorf("error sweeping Redshift Snapshot Schedules for %s: %w", region, err))
 		}
 	}
 
-	return nil
+	if testSweepSkipSweepError(errors.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Redshift Snapshot Schedules sweep for %s: %s", region, errors)
+		return nil
+	}
+
+	return errors.ErrorOrNil()
 }
 
 func TestAccAWSRedshiftSnapshotSchedule_basic(t *testing.T) {
 	var v redshift.SnapshotSchedule
-
-	rName := acctest.RandString(8)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_redshift_snapshot_schedule.default"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -116,8 +118,7 @@ func TestAccAWSRedshiftSnapshotSchedule_basic(t *testing.T) {
 
 func TestAccAWSRedshiftSnapshotSchedule_withMultipleDefinition(t *testing.T) {
 	var v redshift.SnapshotSchedule
-
-	rName := acctest.RandString(8)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_redshift_snapshot_schedule.default"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -155,7 +156,6 @@ func TestAccAWSRedshiftSnapshotSchedule_withMultipleDefinition(t *testing.T) {
 
 func TestAccAWSRedshiftSnapshotSchedule_withIdentifierPrefix(t *testing.T) {
 	var v redshift.SnapshotSchedule
-
 	resourceName := "aws_redshift_snapshot_schedule.default"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -185,8 +185,7 @@ func TestAccAWSRedshiftSnapshotSchedule_withIdentifierPrefix(t *testing.T) {
 
 func TestAccAWSRedshiftSnapshotSchedule_withDescription(t *testing.T) {
 	var v redshift.SnapshotSchedule
-
-	rName := acctest.RandString(8)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_redshift_snapshot_schedule.default"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -217,8 +216,7 @@ func TestAccAWSRedshiftSnapshotSchedule_withDescription(t *testing.T) {
 
 func TestAccAWSRedshiftSnapshotSchedule_withTags(t *testing.T) {
 	var v redshift.SnapshotSchedule
-
-	rName := acctest.RandString(8)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_redshift_snapshot_schedule.default"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -261,7 +259,7 @@ func TestAccAWSRedshiftSnapshotSchedule_withForceDestroy(t *testing.T) {
 	var snapshotSchedule redshift.SnapshotSchedule
 	var cluster redshift.Cluster
 	rInt := acctest.RandInt()
-	rName := acctest.RandString(8)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_redshift_snapshot_schedule.default"
 	clusterResourceName := "aws_redshift_cluster.default"
 
@@ -371,7 +369,7 @@ func testAccCheckAWSRedshiftSnapshotScheduleCreateSnapshotScheduleAssociation(cl
 
 const testAccAWSRedshiftSnapshotScheduleConfigWithIdentifierPrefix = `
 resource "aws_redshift_snapshot_schedule" "default" {
-  identifier_prefix = "tf-snapshot-schedule-"
+  identifier_prefix = "tf-acc-test"
   definitions = [
     "rate(12 hours)",
   ]
@@ -381,7 +379,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 func testAccAWSRedshiftSnapshotScheduleConfig(rName, definition string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
-  identifier = "tf-snapshot-schedule-%[1]s"
+  identifier = %[1]q
   definitions = [
     "%[2]s",
   ]
@@ -392,7 +390,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 func testAccAWSRedshiftSnapshotScheduleConfigWithMultipleDefinition(rName, definition1, definition2 string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
-  identifier = "tf-snapshot-schedule-%[1]s"
+  identifier = %[1]q
   definitions = [
     "%[2]s",
     "%[3]s",
@@ -404,7 +402,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 func testAccAWSRedshiftSnapshotScheduleConfigWithDescription(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
-  identifier  = "tf-snapshot-schedule-%[1]s"
+  identifier  = %[1]q
   description = "Test Schedule"
   definitions = [
     "rate(12 hours)",
@@ -416,7 +414,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 func testAccAWSRedshiftSnapshotScheduleConfigWithTags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
-  identifier = "tf-snapshot-schedule-%[1]s"
+  identifier = %[1]q
   definitions = [
     "rate(12 hours)",
   ]
@@ -432,7 +430,7 @@ resource "aws_redshift_snapshot_schedule" "default" {
 func testAccAWSRedshiftSnapshotScheduleConfigWithTagsUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_snapshot_schedule" "default" {
-  identifier = "tf-snapshot-schedule-%[1]s"
+  identifier = %[1]q
   definitions = [
     "rate(12 hours)",
   ]
@@ -450,7 +448,7 @@ func testAccAWSRedshiftSnapshotScheduleConfigWithForceDestroy(rInt int, rName st
 %s
 
 resource "aws_redshift_snapshot_schedule" "default" {
-  identifier  = "tf-snapshot-schedule-%[2]s"
+  identifier  = %[2]q
   description = "Test Schedule"
   definitions = [
     "rate(12 hours)",

--- a/aws/resource_aws_redshift_snapshot_schedule_test.go
+++ b/aws/resource_aws_redshift_snapshot_schedule_test.go
@@ -31,7 +31,7 @@ func testSweepRedshiftSnapshotSchedules(region string) error {
 
 	conn := client.(*AWSClient).redshiftconn
 	sweepResources := make([]*testSweepResource, 0)
-	var errors *multierror.Error
+	var errs *multierror.Error
 
 	input := &redshift.DescribeSnapshotSchedulesInput{}
 	prefixesToSweep := []string{"tf-acc-test"}
@@ -61,22 +61,22 @@ func testSweepRedshiftSnapshotSchedules(region string) error {
 	})
 
 	if err != nil {
-		errors = multierror.Append(errors, fmt.Errorf("error describing Redshift Snapshot Schedules: %w", err))
+		errs = multierror.Append(errs, fmt.Errorf("error describing Redshift Snapshot Schedules: %w", err))
 	}
 
 	if len(sweepResources) > 0 {
 		// any errors didn't prevent gathering of some work, so do it
 		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errors = multierror.Append(errors, fmt.Errorf("error sweeping Redshift Snapshot Schedules for %s: %w", region, err))
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping Redshift Snapshot Schedules for %s: %w", region, err))
 		}
 	}
 
-	if testSweepSkipSweepError(errors.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping Redshift Snapshot Schedules sweep for %s: %s", region, errors)
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Redshift Snapshot Schedules sweep for %s: %s", region, errs)
 		return nil
 	}
 
-	return errors.ErrorOrNil()
+	return errs.ErrorOrNil()
 }
 
 func TestAccAWSRedshiftSnapshotSchedule_basic(t *testing.T) {

--- a/aws/resource_aws_redshift_subnet_group_test.go
+++ b/aws/resource_aws_redshift_subnet_group_test.go
@@ -33,7 +33,7 @@ func testSweepRedshiftSubnetGroups(region string) error {
 
 	conn := client.(*AWSClient).redshiftconn
 	sweepResources := make([]*testSweepResource, 0)
-	var errors *multierror.Error
+	var errs *multierror.Error
 
 	input := &redshift.DescribeClusterSubnetGroupsInput{}
 
@@ -64,22 +64,22 @@ func testSweepRedshiftSubnetGroups(region string) error {
 	})
 
 	if err != nil {
-		errors = multierror.Append(errors, fmt.Errorf("error describing Redshift Subnet Groups: %w", err))
+		errs = multierror.Append(errs, fmt.Errorf("error describing Redshift Subnet Groups: %w", err))
 	}
 
 	if len(sweepResources) > 0 {
 		// any errors didn't prevent gathering of some work, so do it
 		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errors = multierror.Append(errors, fmt.Errorf("error sweeping Redshift Subnet Groups for %s: %w", region, err))
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping Redshift Subnet Groups for %s: %w", region, err))
 		}
 	}
 
-	if testSweepSkipSweepError(errors.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping Redshift Subnet Group sweep for %s: %s", region, errors)
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Redshift Subnet Group sweep for %s: %s", region, errs)
 		return nil
 	}
 
-	return errors.ErrorOrNil()
+	return errs.ErrorOrNil()
 }
 
 func TestAccAWSRedshiftSubnetGroup_basic(t *testing.T) {

--- a/aws/resource_aws_redshift_subnet_group_test.go
+++ b/aws/resource_aws_redshift_subnet_group_test.go
@@ -26,11 +26,14 @@ func init() {
 
 func testSweepRedshiftSubnetGroups(region string) error {
 	client, err := sharedClientForRegion(region)
+
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
+
 	conn := client.(*AWSClient).redshiftconn
-	var sweeperErrs *multierror.Error
+	sweepResources := make([]*testSweepResource, 0)
+	var errors *multierror.Error
 
 	input := &redshift.DescribeClusterSubnetGroupsInput{}
 
@@ -50,32 +53,33 @@ func testSweepRedshiftSubnetGroups(region string) error {
 				continue
 			}
 
-			log.Printf("[INFO] Deleting Redshift Cluster Subnet Group: %s", name)
 			r := resourceAwsRedshiftSubnetGroup()
 			d := r.Data(nil)
 			d.SetId(name)
-			err := r.Delete(d, client)
 
-			if err != nil {
-				log.Printf("[ERROR] %s", err)
-				sweeperErrs = multierror.Append(sweeperErrs, err)
-				continue
-			}
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 		}
 
 		return !isLast
 	})
 
-	if testSweepSkipSweepError(err) {
-		log.Printf("[WARN] Skipping Redshift Cluster Subnet Group sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
-	}
-
 	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Redshift Cluster Subnet Group: %w", err))
+		errors = multierror.Append(errors, fmt.Errorf("error describing Redshift Subnet Groups: %w", err))
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	if len(sweepResources) > 0 {
+		// any errors didn't prevent gathering of some work, so do it
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errors = multierror.Append(errors, fmt.Errorf("error sweeping Redshift Subnet Groups for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errors.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Redshift Subnet Group sweep for %s: %s", region, errors)
+		return nil
+	}
+
+	return errors.ErrorOrNil()
 }
 
 func TestAccAWSRedshiftSubnetGroup_basic(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15334

Output from acceptance testing (GovCloud):
```
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withDescription (18.70s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withIdentifierPrefix (18.74s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withMultipleDefinition (30.58s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_basic (30.62s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withTags (30.66s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withForceDestroy (565.91s)
```