### PR TITLE
Allow rds_global_cluster engine_version upgrade

### DIFF
--- a/.changelog/18598.txt
+++ b/.changelog/18598.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_global_cluster: Allow `engine_version` to be upgraded.
+```

--- a/.changelog/18598.txt
+++ b/.changelog/18598.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_rds_global_cluster: Allow `engine_version` to be upgraded.
+resource/aws_rds_global_cluster: Allow `engine_version` to be upgraded in place.
 ```

--- a/aws/internal/service/rds/waiter/waiter.go
+++ b/aws/internal/service/rds/waiter/waiter.go
@@ -9,7 +9,8 @@ import (
 
 const (
 	// Maximum amount of time to wait for an EventSubscription to return Deleted
-	EventSubscriptionDeletedTimeout = 10 * time.Minute
+	EventSubscriptionDeletedTimeout  = 10 * time.Minute
+	RdsClusterInitiateUpgradeTimeout = 5 * time.Minute
 )
 
 // DeploymentDeployed waits for a EventSubscription to return Deleted

--- a/aws/resource_aws_rds_global_cluster.go
+++ b/aws/resource_aws_rds_global_cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -58,7 +59,6 @@ func resourceAwsRDSGlobalCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"force_destroy": {
 				Type:     schema.TypeBool,
@@ -211,6 +211,12 @@ func resourceAwsRDSGlobalClusterUpdate(d *schema.ResourceData, meta interface{})
 		GlobalClusterIdentifier: aws.String(d.Id()),
 	}
 
+	if d.HasChange("engine_version") {
+		if err := resourceAwsRDSGlobalClusterUpgradeEngineVersion(d, conn); err != nil {
+			return err
+		}
+	}
+
 	log.Printf("[DEBUG] Updating RDS Global Cluster (%s): %s", d.Id(), input)
 	_, err := conn.ModifyGlobalCluster(input)
 
@@ -226,7 +232,20 @@ func resourceAwsRDSGlobalClusterUpdate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error waiting for RDS Global Cluster (%s) update: %s", d.Id(), err)
 	}
 
-	return nil
+	return resourceAwsRDSGlobalClusterRead(d, meta)
+}
+
+func resourceAwsRDSGlobalClusterGetIdByArn(conn *rds.RDS, arn string) string {
+	result, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{})
+	if err != nil {
+		return ""
+	}
+	for _, cluster := range result.DBClusters {
+		if aws.StringValue(cluster.DBClusterArn) == arn {
+			return aws.StringValue(cluster.DBClusterIdentifier)
+		}
+	}
+	return ""
 }
 
 func resourceAwsRDSGlobalClusterDelete(d *schema.ResourceData, meta interface{}) error {
@@ -430,10 +449,11 @@ func waitForRdsGlobalClusterCreation(conn *rds.RDS, globalClusterID string) erro
 
 func waitForRdsGlobalClusterUpdate(conn *rds.RDS, globalClusterID string) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"modifying"},
+		Pending: []string{"modifying", "upgrading"},
 		Target:  []string{"available"},
 		Refresh: rdsGlobalClusterRefreshFunc(conn, globalClusterID),
 		Timeout: 10 * time.Minute,
+		Delay:   30 * time.Second,
 	}
 
 	log.Printf("[DEBUG] Waiting for RDS Global Cluster (%s) availability", globalClusterID)
@@ -496,5 +516,97 @@ func waitForRdsGlobalClusterRemoval(conn *rds.RDS, dbClusterIdentifier string) e
 		return stillExistsErr
 	}
 
+	return nil
+}
+
+func resourceAwsRDSGlobalClusterUpgradeMajorEngineVersion(clusterId string, engineVersion string, conn *rds.RDS) error {
+	input := &rds.ModifyGlobalClusterInput{
+		GlobalClusterIdentifier: aws.String(clusterId),
+	}
+	input.AllowMajorVersionUpgrade = aws.Bool(true)
+	input.EngineVersion = aws.String(engineVersion)
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.ModifyGlobalCluster(input)
+		if err != nil {
+			if isAWSErr(err, rds.ErrCodeGlobalClusterNotFoundFault, "") {
+				return resource.NonRetryableError(err)
+			}
+			if isAWSErr(err, "InvalidParameterValue", "ModifyGlobalCluster only supports Major Version Upgrades. To patch the members of your global cluster to a newer minor version you need to call ModifyDbCluster in each one of them.") {
+				return resource.NonRetryableError(err)
+			}
+
+			return resource.RetryableError(err)
+		}
+
+		return nil
+	})
+	if tfresource.TimedOut(err) {
+		_, err = conn.ModifyGlobalCluster(input)
+	}
+	return err
+}
+
+func resourceAwsRDSGlobalClusterUpgradeMinorEngineVersion(clusterMembers *schema.Set, engineVersion string, conn *rds.RDS) error {
+	for _, clusterMemberRaw := range clusterMembers.List() {
+		clusterMember := clusterMemberRaw.(map[string]interface{})
+		if clusterMemberArn, ok := clusterMember["db_cluster_arn"]; ok && clusterMemberArn.(string) != "" {
+			modInput := &rds.ModifyDBClusterInput{
+				ApplyImmediately:    aws.Bool(true),
+				DBClusterIdentifier: aws.String(clusterMemberArn.(string)),
+				EngineVersion:       aws.String(engineVersion),
+			}
+			err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+				_, err := conn.ModifyDBCluster(modInput)
+				if err != nil {
+					if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
+						return resource.RetryableError(err)
+					}
+
+					if isAWSErr(err, rds.ErrCodeInvalidDBClusterStateFault, "Cannot modify engine version without a primary instance in DB cluster") {
+						return resource.NonRetryableError(err)
+					}
+
+					if isAWSErr(err, rds.ErrCodeInvalidDBClusterStateFault, "") {
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			if tfresource.TimedOut(err) {
+				_, err := conn.ModifyDBCluster(modInput)
+				if err != nil {
+					return err
+				}
+			}
+			if err != nil {
+				return fmt.Errorf("Failed to update engine_version on global cluster member (%s): %s", clusterMemberArn, err)
+			}
+		}
+	}
+	return nil
+}
+
+func resourceAwsRDSGlobalClusterUpgradeEngineVersion(d *schema.ResourceData, conn *rds.RDS) error {
+	log.Printf("[DEBUG] Upgrading RDS Global Cluster (%s) engine version: %s", d.Id(), d.Get("engine_version"))
+	err := resourceAwsRDSGlobalClusterUpgradeMajorEngineVersion(d.Id(), d.Get("engine_version").(string), conn)
+	if isAWSErr(err, "InvalidParameterValue", "ModifyGlobalCluster only supports Major Version Upgrades. To patch the members of your global cluster to a newer minor version you need to call ModifyDbCluster in each one of them.") {
+		err = resourceAwsRDSGlobalClusterUpgradeMinorEngineVersion(d.Get("global_cluster_members").(*schema.Set), d.Get("engine_version").(string), conn)
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	globalCluster, err := rdsDescribeGlobalCluster(conn, d.Id())
+	if err != nil {
+		return err
+	}
+	for _, clusterMember := range globalCluster.GlobalClusterMembers {
+		err := waitForRDSClusterUpdate(conn, resourceAwsRDSGlobalClusterGetIdByArn(conn, aws.StringValue(clusterMember.DBClusterArn)), d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/aws/resource_aws_rds_global_cluster.go
+++ b/aws/resource_aws_rds_global_cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds/waiter"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
@@ -525,7 +526,7 @@ func resourceAwsRDSGlobalClusterUpgradeMajorEngineVersion(clusterId string, engi
 	}
 	input.AllowMajorVersionUpgrade = aws.Bool(true)
 	input.EngineVersion = aws.String(engineVersion)
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(waiter.RdsClusterInitiateUpgradeTimeout, func() *resource.RetryError {
 		_, err := conn.ModifyGlobalCluster(input)
 		if err != nil {
 			if isAWSErr(err, rds.ErrCodeGlobalClusterNotFoundFault, "") {
@@ -555,7 +556,7 @@ func resourceAwsRDSGlobalClusterUpgradeMinorEngineVersion(clusterMembers *schema
 				DBClusterIdentifier: aws.String(clusterMemberArn.(string)),
 				EngineVersion:       aws.String(engineVersion),
 			}
-			err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+			err := resource.Retry(waiter.RdsClusterInitiateUpgradeTimeout, func() *resource.RetryError {
 				_, err := conn.ModifyDBCluster(modInput)
 				if err != nil {
 					if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {

--- a/aws/resource_aws_rds_global_cluster_test.go
+++ b/aws/resource_aws_rds_global_cluster_test.go
@@ -250,6 +250,75 @@ func TestAccAWSRdsGlobalCluster_EngineVersion_Aurora(t *testing.T) {
 	})
 }
 
+func TestAccAWSRdsGlobalCluster_EngineVersionUpdateMinor(t *testing.T) {
+	var globalCluster1, globalCluster2 rds.GlobalCluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_rds_global_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsGlobalClusterWithPrimaryConfigEngineVersion(rName, "aurora", "5.6.mysql_aurora.1.22.2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
+				),
+			},
+			{
+				Config: testAccAWSRdsGlobalClusterWithPrimaryConfigEngineVersion(rName, "aurora", "5.6.mysql_aurora.1.23.2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster2),
+					testAccCheckAWSRdsGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.6.mysql_aurora.1.23.2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsGlobalCluster_EngineVersionUpdateMajor(t *testing.T) {
+	var globalCluster1, globalCluster2 rds.GlobalCluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_rds_global_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsGlobalClusterWithPrimaryConfigEngineVersion(rName, "aurora", "5.6.mysql_aurora.1.22.2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
+				),
+			},
+			{
+				Config:             testAccAWSRdsGlobalClusterWithPrimaryConfigEngineVersion(rName, "aurora", "5.7.mysql_aurora.2.07.2"),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster2),
+					testAccCheckAWSRdsGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.7.mysql_aurora.2.07.2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL(t *testing.T) {
 	var globalCluster1 rds.GlobalCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -478,8 +547,8 @@ func testAccCheckAWSRdsGlobalClusterDisappears(globalCluster *rds.GlobalCluster)
 
 func testAccCheckAWSRdsGlobalClusterNotRecreated(i, j *rds.GlobalCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.StringValue(i.GlobalClusterResourceId) != aws.StringValue(j.GlobalClusterResourceId) {
-			return errors.New("RDS Global Cluster was recreated")
+		if aws.StringValue(i.GlobalClusterArn) != aws.StringValue(j.GlobalClusterArn) {
+			return fmt.Errorf("RDS Global Cluster was recreated. got: %s, expected: %s", aws.StringValue(i.GlobalClusterArn), aws.StringValue(j.GlobalClusterArn))
 		}
 
 		return nil
@@ -553,6 +622,42 @@ resource "aws_rds_global_cluster" "test" {
   engine                    = %q
   engine_version            = %q
   global_cluster_identifier = %q
+}
+`, engine, engineVersion, rName)
+}
+
+func testAccAWSRdsGlobalClusterWithPrimaryConfigEngineVersion(rName, engine, engineVersion string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_global_cluster" "test" {
+  engine                    = %[1]q
+  engine_version            = %[2]q
+  global_cluster_identifier = %[3]q
+}
+
+resource "aws_rds_cluster" "test" {
+  apply_immediately           = true
+  allow_major_version_upgrade = true
+  cluster_identifier          = %[3]q
+  master_password             = "mustbeeightcharacters"
+  master_username             = "test"
+  skip_final_snapshot         = true
+
+  global_cluster_identifier = aws_rds_global_cluster.test.global_cluster_identifier
+
+  lifecycle {
+    ignore_changes = [global_cluster_identifier]
+  }
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  apply_immediately  = true
+  cluster_identifier = aws_rds_cluster.test.id
+  identifier         = %[3]q
+  instance_class     = "db.r3.large"
+
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 }
 `, engine, engineVersion, rName)
 }

--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -94,7 +94,7 @@ The following arguments are supported:
 * `database_name` - (Optional, Forces new resources) Name for an automatically created database on cluster creation.
 * `deletion_protection` - (Optional) If the Global Cluster should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
 * `engine` - (Optional, Forces new resources) Name of the database engine to be used for this DB cluster. Terraform will only perform drift detection if a configuration value is provided. Valid values: `aurora`, `aurora-mysql`, `aurora-postgresql`. Defaults to `aurora`. Conflicts with `source_db_cluster_identifier`.
-* `engine_version` - (Optional, Forces new resources) Engine version of the Aurora global database.
+* `engine_version` - (Optional) Engine version of the Aurora global database. Upgrading the engine version will result in all cluster members being immediately updated.
     * **NOTE:** When the engine is set to `aurora-mysql`, an engine version compatible with global database is required. The earliest available version is `5.7.mysql_aurora.2.06.0`.
 * `force_destroy` - (Optional) Enable to remove DB Cluster members from Global Cluster on destroy. Required with `source_db_cluster_identifier`.
 * `source_db_cluster_identifier` - (Optional) Amazon Resource Name (ARN) to use as the primary DB Cluster of the Global Cluster on creation. Terraform cannot perform drift detection of this value.


### PR DESCRIPTION
Allow `rds_global_cluster` `engine_version` upgrades. Two different paths are required because the methods for upgrading a major version is different than upgrading a minor version. Because major version upgrades are applied immediately, minor version upgrades are applied immediately also despite the possibility to wait until a maintenance window.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #18214

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRdsGlobalCluster_ -timeout 180m
=== RUN   TestAccAWSRdsGlobalCluster_basic
=== PAUSE TestAccAWSRdsGlobalCluster_basic
=== RUN   TestAccAWSRdsGlobalCluster_disappears
=== PAUSE TestAccAWSRdsGlobalCluster_disappears
=== RUN   TestAccAWSRdsGlobalCluster_DatabaseName
=== PAUSE TestAccAWSRdsGlobalCluster_DatabaseName
=== RUN   TestAccAWSRdsGlobalCluster_DeletionProtection
=== PAUSE TestAccAWSRdsGlobalCluster_DeletionProtection
=== RUN   TestAccAWSRdsGlobalCluster_Engine_Aurora
=== PAUSE TestAccAWSRdsGlobalCluster_Engine_Aurora
=== RUN   TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== PAUSE TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== RUN   TestAccAWSRdsGlobalCluster_EngineVersionUpdateMinor
=== PAUSE TestAccAWSRdsGlobalCluster_EngineVersionUpdateMinor
=== RUN   TestAccAWSRdsGlobalCluster_EngineVersionUpdateMajor
=== PAUSE TestAccAWSRdsGlobalCluster_EngineVersionUpdateMajor
=== RUN   TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL
=== PAUSE TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL
=== RUN   TestAccAWSRdsGlobalCluster_EngineVersion_AuroraPostgresql
=== PAUSE TestAccAWSRdsGlobalCluster_EngineVersion_AuroraPostgresql
=== RUN   TestAccAWSRdsGlobalCluster_SourceDbClusterIdentifier
=== PAUSE TestAccAWSRdsGlobalCluster_SourceDbClusterIdentifier
=== RUN   TestAccAWSRdsGlobalCluster_SourceDbClusterIdentifier_StorageEncrypted
=== PAUSE TestAccAWSRdsGlobalCluster_SourceDbClusterIdentifier_StorageEncrypted
=== RUN   TestAccAWSRdsGlobalCluster_StorageEncrypted
=== PAUSE TestAccAWSRdsGlobalCluster_StorageEncrypted
=== CONT  TestAccAWSRdsGlobalCluster_basic
=== CONT  TestAccAWSRdsGlobalCluster_SourceDbClusterIdentifier
=== CONT  TestAccAWSRdsGlobalCluster_StorageEncrypted
=== CONT  TestAccAWSRdsGlobalCluster_EngineVersionUpdateMajor
=== CONT  TestAccAWSRdsGlobalCluster_EngineVersion_AuroraPostgresql
=== CONT  TestAccAWSRdsGlobalCluster_Engine_Aurora
=== CONT  TestAccAWSRdsGlobalCluster_EngineVersionUpdateMinor
=== CONT  TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL
=== CONT  TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== CONT  TestAccAWSRdsGlobalCluster_DatabaseName
=== CONT  TestAccAWSRdsGlobalCluster_SourceDbClusterIdentifier_StorageEncrypted
=== CONT  TestAccAWSRdsGlobalCluster_DeletionProtection
=== CONT  TestAccAWSRdsGlobalCluster_disappears
--- PASS: TestAccAWSRdsGlobalCluster_disappears (13.72s)
--- PASS: TestAccAWSRdsGlobalCluster_basic (17.78s)
--- PASS: TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL (18.05s)
--- PASS: TestAccAWSRdsGlobalCluster_Engine_Aurora (18.21s)
--- PASS: TestAccAWSRdsGlobalCluster_EngineVersion_Aurora (18.26s)
--- PASS: TestAccAWSRdsGlobalCluster_EngineVersion_AuroraPostgresql (18.30s)
--- PASS: TestAccAWSRdsGlobalCluster_StorageEncrypted (27.14s)
--- PASS: TestAccAWSRdsGlobalCluster_DatabaseName (28.18s)
--- PASS: TestAccAWSRdsGlobalCluster_DeletionProtection (57.28s)
--- PASS: TestAccAWSRdsGlobalCluster_SourceDbClusterIdentifier (131.91s)
--- PASS: TestAccAWSRdsGlobalCluster_SourceDbClusterIdentifier_StorageEncrypted (132.28s)
--- PASS: TestAccAWSRdsGlobalCluster_EngineVersionUpdateMinor (1151.99s)
--- PASS: TestAccAWSRdsGlobalCluster_EngineVersionUpdateMajor (1706.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1706.787s

```