### PR TITLE
tests/resource/aws_cloudwatch_query_definition: Implement sweeper

### DIFF
--- a/aws/resource_aws_cloudwatch_query_definition_test.go
+++ b/aws/resource_aws_cloudwatch_query_definition_test.go
@@ -64,10 +64,8 @@ func testSweepCloudwatchlogQueryDefinitions(region string) error {
 		input.NextToken = output.NextToken
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping CloudWatch Log Query Definition for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping CloudWatch Log Query Definition for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_cloudwatch_query_definition_test.go
+++ b/aws/resource_aws_cloudwatch_query_definition_test.go
@@ -3,17 +3,80 @@ package aws
 import (
 	"context"
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudwatchlogs/finder"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_cloudwatch_query_definition", &resource.Sweeper{
+		Name: "aws_cloudwatch_query_definition",
+		F:    testSweepCloudwatchlogQueryDefinitions,
+	})
+}
+
+func testSweepCloudwatchlogQueryDefinitions(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).cloudwatchlogsconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &cloudwatchlogs.DescribeQueryDefinitionsInput{}
+
+	// AWS SDK Go does not currently provide paginator
+	for {
+		output, err := conn.DescribeQueryDefinitions(input)
+
+		if err != nil {
+			err := fmt.Errorf("error reading CloudWatch Log Query Definition: %w", err)
+			log.Printf("[ERROR] %s", err)
+			errs = multierror.Append(errs, err)
+			break
+		}
+
+		for _, queryDefinition := range output.QueryDefinitions {
+			r := resourceAwsCloudWatchQueryDefinition()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(queryDefinition.QueryDefinitionId))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping CloudWatch Log Query Definition for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping CloudWatch Log Query Definition sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSCloudWatchQueryDefinition_basic(t *testing.T) {
 	var v cloudwatchlogs.QueryDefinition


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18513

Output from sweeper in AWS Commercial:

```
2021/04/07 13:25:32 [DEBUG] Running Sweepers for region (us-west-2):
2021/04/07 13:25:32 [DEBUG] Running Sweeper (aws_cloudwatch_query_definition) in region (us-west-2)
2021/04/07 13:25:33 Sweeper Tests ran successfully:
        - aws_cloudwatch_query_definition
2021/04/07 13:25:33 [DEBUG] Running Sweepers for region (us-east-1):
2021/04/07 13:25:33 [DEBUG] Running Sweeper (aws_cloudwatch_query_definition) in region (us-east-1)
2021/04/07 13:25:34 Sweeper Tests ran successfully:
        - aws_cloudwatch_query_definition
ok
```

Output from sweeper in AWS GovCloud (US):

```
2021/04/07 13:25:39 [DEBUG] Running Sweepers for region (us-gov-west-1):
2021/04/07 13:25:39 [DEBUG] Running Sweeper (aws_cloudwatch_query_definition) in region (us-gov-west-1)
2021/04/07 13:25:41 Sweeper Tests ran successfully:
        - aws_cloudwatch_query_definition
ok      github.com/terraform-providers/terraform-provider-aws/aws       4.523s
```