### PR TITLE
tests/r/dms_replication_instance: Add sweeper concurrency

### DIFF
--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	multierror "github.com/hashicorp/go-multierror"
 	gversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -24,57 +24,45 @@ func init() {
 
 func testSweepDmsReplicationInstances(region string) error {
 	client, err := sharedClientForRegion(region)
+
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
+
 	conn := client.(*AWSClient).dmsconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
 
 	err = conn.DescribeReplicationInstancesPages(&dms.DescribeReplicationInstancesInput{}, func(page *dms.DescribeReplicationInstancesOutput, lastPage bool) bool {
 		for _, instance := range page.ReplicationInstances {
-			arn := aws.StringValue(instance.ReplicationInstanceArn)
-			input := &dms.DeleteReplicationInstanceInput{
-				ReplicationInstanceArn: instance.ReplicationInstanceArn,
-			}
+			r := resourceAwsDmsReplicationInstance()
+			d := r.Data(nil)
+			d.Set("replication_instance_arn", instance.ReplicationInstanceArn)
+			d.SetId(aws.StringValue(instance.ReplicationInstanceIdentifier))
 
-			log.Printf("[INFO] Deleting DMS Replication Instance: %s", arn)
-			_, err := conn.DeleteReplicationInstance(input)
-
-			if isAWSErr(err, dms.ErrCodeResourceNotFoundFault, "") {
-				continue
-			}
-
-			if err != nil {
-				log.Printf("[ERROR] Error deleting DMS Replication Instance (%s): %s", arn, err)
-				continue
-			}
-
-			stateConf := &resource.StateChangeConf{
-				Pending:    []string{"deleting"},
-				Target:     []string{},
-				Refresh:    resourceAwsDmsReplicationInstanceStateRefreshFunc(conn, aws.StringValue(instance.ReplicationInstanceIdentifier)),
-				Timeout:    30 * time.Minute,
-				MinTimeout: 10 * time.Second,
-				Delay:      30 * time.Second,
-			}
-
-			if _, err := stateConf.WaitForState(); err != nil {
-				log.Printf("[ERROR] Error waiting for DMS Replication Instance (%s) deletion: %s", arn, err)
-			}
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 		}
 
 		return !lastPage
 	})
 
-	if testSweepSkipSweepError(err) {
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing DMS Replication Instances: %w", err))
+	}
+
+	if len(sweepResources) > 0 {
+		// any errors didn't prevent gathering of some work, so do it
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping DMS Replication Instances for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
 		log.Printf("[WARN] Skipping DMS Replication Instance sweep for %s: %s", region, err)
 		return nil
 	}
 
-	if err != nil {
-		return fmt.Errorf("Error retrieving DMS Replication Instances: %s", err)
-	}
-
-	return nil
+	return errs.ErrorOrNil()
 }
 
 func TestAccAWSDmsReplicationInstance_basic(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15334

Output from acceptance testing: N/A