### PR TITLE
tests/service/lexmodelbuildingservice: Implement sweepers

### DIFF
--- a/aws/resource_aws_lex_bot_alias_test.go
+++ b/aws/resource_aws_lex_bot_alias_test.go
@@ -55,8 +55,8 @@ func testSweepLexBotAliases(region string) error {
 					d := r.Data(nil)
 
 					d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(bot.Name), aws.StringValue(botAlias.Name)))
-					d.Set("bot_name", aws.StringValue(bot.Name))
-					d.Set("name", aws.StringValue(botAlias.Name))
+					d.Set("bot_name", bot.Name)
+					d.Set("name", botAlias.Name)
 
 					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 				}

--- a/aws/resource_aws_lex_bot_alias_test.go
+++ b/aws/resource_aws_lex_bot_alias_test.go
@@ -83,10 +83,8 @@ func testSweepLexBotAliases(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing Lex Bot Alias for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Bot Alias for %s: %w", region, err))
-		}
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Bot Alias for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_lex_bot_alias_test.go
+++ b/aws/resource_aws_lex_bot_alias_test.go
@@ -2,16 +2,100 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_lex_bot_alias", &resource.Sweeper{
+		Name: "aws_lex_bot_alias",
+		F:    testSweepLexBotAliases,
+	})
+}
+
+func testSweepLexBotAliases(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).lexmodelconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &lexmodelbuildingservice.GetBotsInput{}
+
+	err = conn.GetBotsPages(input, func(page *lexmodelbuildingservice.GetBotsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, bot := range page.Bots {
+			input := &lexmodelbuildingservice.GetBotAliasesInput{
+				BotName: bot.Name,
+			}
+
+			err := conn.GetBotAliasesPages(input, func(page *lexmodelbuildingservice.GetBotAliasesOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, botAlias := range page.BotAliases {
+					r := resourceAwsLexBotAlias()
+					d := r.Data(nil)
+
+					d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(bot.Name), aws.StringValue(botAlias.Name)))
+					d.Set("bot_name", aws.StringValue(bot.Name))
+					d.Set("name", aws.StringValue(botAlias.Name))
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+
+			if err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("error listing Lex Bot Alias for %s: %w", region, err))
+			}
+
+			r := resourceAwsLexBotAlias()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(bot.Name))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing Lex Bot Alias for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Bot Alias for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Lex Bot Alias sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAwsLexBotAlias_basic(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotAliasOutput

--- a/aws/resource_aws_lex_bot_test.go
+++ b/aws/resource_aws_lex_bot_test.go
@@ -2,15 +2,73 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_lex_bot", &resource.Sweeper{
+		Name:         "aws_lex_bot",
+		F:            testSweepLexBots,
+		Dependencies: []string{"aws_lex_bot_alias"},
+	})
+}
+
+func testSweepLexBots(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).lexmodelconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &lexmodelbuildingservice.GetBotsInput{}
+
+	err = conn.GetBotsPages(input, func(page *lexmodelbuildingservice.GetBotsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, bot := range page.Bots {
+			r := resourceAwsLexBot()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(bot.Name))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing Lex Bot for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Bot for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Lex Bot sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAwsLexBot_basic(t *testing.T) {
 	var v lexmodelbuildingservice.GetBotOutput

--- a/aws/resource_aws_lex_bot_test.go
+++ b/aws/resource_aws_lex_bot_test.go
@@ -56,10 +56,8 @@ func testSweepLexBots(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing Lex Bot for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Bot for %s: %w", region, err))
-		}
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Bot for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_lex_intent_test.go
+++ b/aws/resource_aws_lex_intent_test.go
@@ -2,17 +2,75 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_lex_intent", &resource.Sweeper{
+		Name:         "aws_lex_intent",
+		F:            testSweepLexIntents,
+		Dependencies: []string{"aws_lex_bot"},
+	})
+}
+
+func testSweepLexIntents(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).lexmodelconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &lexmodelbuildingservice.GetIntentsInput{}
+
+	err = conn.GetIntentsPages(input, func(page *lexmodelbuildingservice.GetIntentsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, intent := range page.Intents {
+			r := resourceAwsLexIntent()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(intent.Name))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing Lex Intent for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Intent for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Lex Intent sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAwsLexIntent_basic(t *testing.T) {
 	var v lexmodelbuildingservice.GetIntentOutput

--- a/aws/resource_aws_lex_intent_test.go
+++ b/aws/resource_aws_lex_intent_test.go
@@ -58,10 +58,8 @@ func testSweepLexIntents(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing Lex Intent for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Intent for %s: %w", region, err))
-		}
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Intent for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_lex_slot_type_test.go
+++ b/aws/resource_aws_lex_slot_type_test.go
@@ -2,15 +2,73 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_lex_slot_type", &resource.Sweeper{
+		Name:         "aws_lex_slot_type",
+		F:            testSweepLexSlotTypes,
+		Dependencies: []string{"aws_lex_intent"},
+	})
+}
+
+func testSweepLexSlotTypes(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).lexmodelconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &lexmodelbuildingservice.GetSlotTypesInput{}
+
+	err = conn.GetSlotTypesPages(input, func(page *lexmodelbuildingservice.GetSlotTypesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, slotType := range page.SlotTypes {
+			r := resourceAwsLexSlotType()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(slotType.Name))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing Lex Slot Type for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Slot Type for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Lex Slot Type sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAwsLexSlotType_basic(t *testing.T) {
 	var v lexmodelbuildingservice.GetSlotTypeOutput

--- a/aws/resource_aws_lex_slot_type_test.go
+++ b/aws/resource_aws_lex_slot_type_test.go
@@ -56,10 +56,8 @@ func testSweepLexSlotTypes(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing Lex Slot Type for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Slot Type for %s: %w", region, err))
-		}
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Slot Type for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15439

Output from sweeper in AWS Commercial:

```
2021/04/07 14:08:49 [DEBUG] Running Sweepers for region (us-west-2):
2021/04/07 14:08:49 [DEBUG] Running Sweeper (aws_lex_bot_alias) in region (us-west-2)
2021/04/07 14:08:50 [DEBUG] Running Sweeper (aws_lex_bot) in region (us-west-2)
2021/04/07 14:08:51 [DEBUG] Running Sweeper (aws_lex_intent) in region (us-west-2)
2021/04/07 14:11:47 [DEBUG] Running Sweeper (aws_lex_slot_type) in region (us-west-2)
2021/04/07 14:12:16 Sweeper Tests ran successfully:
        - aws_lex_bot_alias
        - aws_lex_bot
        - aws_lex_intent
        - aws_lex_slot_type
2021/04/07 14:12:16 [DEBUG] Running Sweepers for region (us-east-1):
2021/04/07 14:12:16 [DEBUG] Running Sweeper (aws_lex_bot_alias) in region (us-east-1)
2021/04/07 14:12:17 [DEBUG] Running Sweeper (aws_lex_bot) in region (us-east-1)
2021/04/07 14:12:17 [DEBUG] Running Sweeper (aws_lex_intent) in region (us-east-1)
2021/04/07 14:12:17 [DEBUG] Running Sweeper (aws_lex_slot_type) in region (us-east-1)
2021/04/07 14:12:17 Sweeper Tests ran successfully:
        - aws_lex_bot
        - aws_lex_intent
        - aws_lex_slot_type
        - aws_lex_bot_alias
ok      github.com/terraform-providers/terraform-provider-aws/aws       211.443s
```

Output from sweeper in AWS GovCloud (US):

```
2021/04/07 14:08:53 [DEBUG] Running Sweepers for region (us-gov-west-1):
2021/04/07 14:08:53 [DEBUG] Running Sweeper (aws_lex_bot_alias) in region (us-gov-west-1)
2021/04/07 14:08:55 [DEBUG] Running Sweeper (aws_lex_bot) in region (us-gov-west-1)
2021/04/07 14:08:56 [DEBUG] Running Sweeper (aws_lex_intent) in region (us-gov-west-1)
2021/04/07 14:08:56 [DEBUG] Running Sweeper (aws_lex_slot_type) in region (us-gov-west-1)
2021/04/07 14:08:57 Sweeper Tests ran successfully:
        - aws_lex_bot
        - aws_lex_intent
        - aws_lex_slot_type
        - aws_lex_bot_alias
ok      github.com/terraform-providers/terraform-provider-aws/aws       5.994s
```
