### PR TITLE
tests/provider: Fix and enable nilerr linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - makezero
     - misspell
     - nakedret
+    - nilerr
     - staticcheck
     - structcheck
     - unconvert

--- a/aws/internal/service/sagemaker/errors.go
+++ b/aws/internal/service/sagemaker/errors.go
@@ -1,0 +1,5 @@
+package sagemaker
+
+const (
+	ErrCodeValidationException = "ValidationException"
+)

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1063,7 +1063,7 @@ func testAccCheckWithProviders(f func(*terraform.State, *schema.Provider) error,
 func testAccErrorCheckSkipMessagesContaining(t *testing.T, messages ...string) resource.ErrorCheckFunc {
 	return func(err error) error {
 		if err == nil {
-			return err
+			return nil
 		}
 
 		for _, message := range messages {
@@ -1096,7 +1096,7 @@ func RegisterServiceErrorCheckFunc(endpointID string, f ServiceErrorCheckFunc) {
 func testAccErrorCheck(t *testing.T, endpointIDs ...string) resource.ErrorCheckFunc {
 	return func(err error) error {
 		if err == nil {
-			return err
+			return nil
 		}
 
 		for _, endpointID := range endpointIDs {

--- a/aws/resource_aws_cloudwatch_log_destination_policy_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_policy_test.go
@@ -44,8 +44,9 @@ func testAccCheckAWSCloudwatchLogDestinationPolicyDestroy(s *terraform.State) er
 			continue
 		}
 		_, exists, err := lookupCloudWatchLogDestination(conn, rs.Primary.ID, nil)
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading CloudWatch Log Destination (%s): %w", rs.Primary.ID, err)
 		}
 
 		if exists {

--- a/aws/resource_aws_cloudwatch_log_destination_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_test.go
@@ -74,8 +74,9 @@ func testAccCheckAWSCloudwatchLogDestinationDestroy(s *terraform.State) error {
 			continue
 		}
 		_, exists, err := lookupCloudWatchLogDestination(conn, rs.Primary.ID, nil)
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading CloudWatch Log Destination (%s): %w", rs.Primary.ID, err)
 		}
 
 		if exists {

--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -443,8 +443,9 @@ func testAccCheckAWSCloudWatchLogGroupDestroy(s *terraform.State) error {
 			continue
 		}
 		logGroup, err := lookupCloudWatchLogGroup(conn, rs.Primary.ID)
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading CloudWatch Log Group (%s): %w", rs.Primary.ID, err)
 		}
 
 		if logGroup != nil {

--- a/aws/resource_aws_cloudwatch_log_resource_policy_test.go
+++ b/aws/resource_aws_cloudwatch_log_resource_policy_test.go
@@ -133,8 +133,9 @@ func testAccCheckCloudWatchLogResourcePolicyDestroy(s *terraform.State) error {
 		}
 
 		_, exists, err := lookupCloudWatchLogResourcePolicy(conn, rs.Primary.ID, nil)
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading CloudWatch Log Resource Policy (%s): %w", rs.Primary.ID, err)
 		}
 
 		if exists {

--- a/aws/resource_aws_cloudwatch_log_stream_test.go
+++ b/aws/resource_aws_cloudwatch_log_stream_test.go
@@ -119,8 +119,9 @@ func testAccCheckAWSCloudWatchLogStreamDestroy(s *terraform.State) error {
 
 		logGroupName := rs.Primary.Attributes["log_group_name"]
 		_, exists, err := lookupCloudWatchLogStream(conn, rs.Primary.ID, logGroupName, nil)
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading CloudWatch Log Stream (%s): %w", rs.Primary.ID, err)
 		}
 
 		if exists {

--- a/aws/resource_aws_dms_replication_task_test.go
+++ b/aws/resource_aws_dms_replication_task_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -105,8 +106,12 @@ func dmsReplicationTaskDestroy(s *terraform.State) error {
 			},
 		})
 
+		if tfawserr.ErrCodeEquals(err, dms.ErrCodeResourceNotFoundFault) {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading DMS Replication Task (%s): %w", rs.Primary.ID, err)
 		}
 
 		if resp != nil && len(resp.ReplicationTasks) > 0 {

--- a/aws/resource_aws_emr_instance_fleet.go
+++ b/aws/resource_aws_emr_instance_fleet.go
@@ -244,15 +244,18 @@ func resourceAwsEMRInstanceFleetCreate(d *schema.ResourceData, meta interface{})
 func resourceAwsEMRInstanceFleetRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).emrconn
 	instanceFleets, err := fetchAllEMRInstanceFleets(conn, d.Get("cluster_id").(string))
+
 	if err != nil {
-		log.Printf("[DEBUG] EMR doesn't have any Instance Fleet ")
-		d.SetId("")
-		return nil
+		return fmt.Errorf("error listing EMR Instance Fleets for Cluster (%s): %w", d.Get("cluster_id").(string), err)
 	}
 
 	fleet := findInstanceFleetById(instanceFleets, d.Id())
 	if fleet == nil {
-		log.Printf("[DEBUG] EMR Instance Fleet (%s) not found, removing", d.Id())
+		if d.IsNewResource() {
+			return fmt.Errorf("error finding EMR Instance Fleet (%s): not found after creation", d.Id())
+		}
+
+		log.Printf("[DEBUG] EMR Instance Fleet (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -202,13 +202,20 @@ func resourceAwsLogFlowRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	resp, err := conn.DescribeFlowLogs(opts)
+
 	if err != nil {
-		log.Printf("[WARN] Flow Log (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
+		return fmt.Errorf("error reading EC2 Flow Log (%s): %w", d.Id(), err)
+	}
+
+	if resp == nil {
+		return fmt.Errorf("error reading EC2 Flow Log (%s): empty response", d.Id())
 	}
 
 	if len(resp.FlowLogs) == 0 {
+		if d.IsNewResource() {
+			return fmt.Errorf("error reading EC2 Flow Log (%s): not found after creation", d.Id())
+		}
+
 		log.Printf("[WARN] Flow Log (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/aws/resource_aws_iam_account_alias_test.go
+++ b/aws/resource_aws_iam_account_alias_test.go
@@ -103,8 +103,12 @@ func testAccCheckAWSIAMAccountAliasDestroy(s *terraform.State) error {
 
 		resp, err := conn.ListAccountAliases(params)
 
-		if err != nil || resp == nil {
-			return nil
+		if err != nil {
+			return fmt.Errorf("error reading IAM Account Alias (%s): %w", rs.Primary.ID, err)
+		}
+
+		if resp == nil {
+			return fmt.Errorf("error reading IAM Account Alias (%s): empty response", rs.Primary.ID)
 		}
 
 		if len(resp.AccountAliases) > 0 {
@@ -143,8 +147,12 @@ func testAccCheckAWSIAMAccountAliasExists(n string, a *string) resource.TestChec
 
 		resp, err := conn.ListAccountAliases(params)
 
-		if err != nil || resp == nil {
-			return nil
+		if err != nil {
+			return fmt.Errorf("error reading IAM Account Alias (%s): %w", rs.Primary.ID, err)
+		}
+
+		if resp == nil {
+			return fmt.Errorf("error reading IAM Account Alias (%s): empty response", rs.Primary.ID)
 		}
 
 		if len(resp.AccountAliases) == 0 {

--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -363,8 +363,12 @@ func resourceAwsLambdaPermissionDelete(d *schema.ResourceData, meta interface{})
 
 	statement, err := getLambdaPolicyStatement(resp, d.Id())
 
-	if err != nil {
+	if tfresource.NotFound(err) {
 		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error getting Lambda Permission (%s) statement after deletion: %w", d.Id(), err)
 	}
 
 	if statement != nil {

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func TestLambdaPermissionUnmarshalling(t *testing.T) {
@@ -678,9 +679,13 @@ func isLambdaPermissionGone(rs *terraform.ResourceState, conn *lambda.Lambda) er
 	}
 
 	state, err := findLambdaPolicyStatementById(&policy, rs.Primary.ID)
-	if err != nil {
-		// statement not found => deleted
+
+	if tfresource.NotFound(err) {
 		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error finding Lambda Policy Statement (%s): %w", rs.Primary.ID, err)
 	}
 
 	return fmt.Errorf("Policy statement expected to be gone (%s):\n%s",

--- a/aws/resource_aws_organizations_organizational_unit.go
+++ b/aws/resource_aws_organizations_organizational_unit.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -116,27 +117,36 @@ func resourceAwsOrganizationsOrganizationalUnitRead(d *schema.ResourceData, meta
 		OrganizationalUnitId: aws.String(d.Id()),
 	}
 	resp, err := conn.DescribeOrganizationalUnit(describeOpts)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, organizations.ErrCodeOrganizationalUnitNotFoundException) {
+		log.Printf("[WARN] Organizations Organizational Unit (%s) does not exist, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, organizations.ErrCodeOrganizationalUnitNotFoundException, "") {
-			log.Printf("[WARN] Organizational Unit does not exist, removing from state: %s", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("error reading Organizations Organizational Unit (%s): %w", d.Id(), err)
+	}
+
+	if resp == nil {
+		return fmt.Errorf("error reading Organizations Organizational Unit (%s): empty response", d.Id())
 	}
 
 	ou := resp.OrganizationalUnit
 	if ou == nil {
-		log.Printf("[WARN] Organizational Unit does not exist, removing from state: %s", d.Id())
+		if d.IsNewResource() {
+			return fmt.Errorf("error reading Organizations Organizational Unit (%s): not found after creation", d.Id())
+		}
+
+		log.Printf("[WARN] Organizations Organizational Unit (%s) does not exist, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	parentId, err := resourceAwsOrganizationsOrganizationalUnitGetParentId(conn, d.Id())
+
 	if err != nil {
-		log.Printf("[WARN] Unable to find parent organizational unit, removing from state: %s", d.Id())
-		d.SetId("")
-		return nil
+		return fmt.Errorf("error listing Organizations Organizational Unit (%s) parents: %w", d.Id(), err)
 	}
 
 	log.Printf("[INFO] Listing Accounts for Organizational Unit: %s", d.Id())

--- a/aws/resource_aws_organizations_organizational_unit_test.go
+++ b/aws/resource_aws_organizations_organizational_unit_test.go
@@ -42,6 +42,31 @@ func testAccAwsOrganizationsOrganizationalUnit_basic(t *testing.T) {
 	})
 }
 
+func testAccAwsOrganizationsOrganizationalUnit_disappears(t *testing.T) {
+	var unit organizations.OrganizationalUnit
+
+	rInt := acctest.RandInt()
+	name := fmt.Sprintf("tf_outest_%d", rInt)
+	resourceName := "aws_organizations_organizational_unit.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, organizations.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOrganizationsOrganizationalUnitDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsOrganizationalUnitConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsOrganizationalUnitExists(resourceName, &unit),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsOrganizationsOrganizationalUnit(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccAwsOrganizationsOrganizationalUnit_Name(t *testing.T) {
 	var unit organizations.OrganizationalUnit
 

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -21,8 +21,9 @@ func TestAccAWSOrganizations_serial(t *testing.T) {
 			"Tags":     testAccAwsOrganizationsAccount_Tags,
 		},
 		"OrganizationalUnit": {
-			"basic": testAccAwsOrganizationsOrganizationalUnit_basic,
-			"Name":  testAccAwsOrganizationsOrganizationalUnit_Name,
+			"basic":      testAccAwsOrganizationsOrganizationalUnit_basic,
+			"disappears": testAccAwsOrganizationsOrganizationalUnit_disappears,
+			"Name":       testAccAwsOrganizationsOrganizationalUnit_Name,
 		},
 		"OrganizationalUnits": {
 			"DataSource": testAccDataSourceAwsOrganizationsOrganizationalUnits_basic,

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -635,20 +635,18 @@ func testAccCheckAWSRedshiftClusterSnapshot(rInt int) resource.TestCheckFunc {
 				continue
 			}
 
-			var err error
-
 			// Try and delete the snapshot before we check for the cluster not found
 			conn := testAccProvider.Meta().(*AWSClient).redshiftconn
 
 			snapshot_identifier := fmt.Sprintf("tf-acctest-snapshot-%d", rInt)
 
 			log.Printf("[INFO] Deleting the Snapshot %s", snapshot_identifier)
-			_, snapDeleteErr := conn.DeleteClusterSnapshot(
+			_, err := conn.DeleteClusterSnapshot(
 				&redshift.DeleteClusterSnapshotInput{
 					SnapshotIdentifier: aws.String(snapshot_identifier),
 				})
-			if snapDeleteErr != nil {
-				return err
+			if err != nil {
+				return fmt.Errorf("error deleting Redshift Cluster Snapshot (%s): %w", snapshot_identifier, err)
 			}
 
 			//lastly check that the Cluster is missing

--- a/aws/resource_aws_route53_query_log_test.go
+++ b/aws/resource_aws_route53_query_log_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -136,8 +137,13 @@ func testAccCheckRoute53QueryLogDestroy(s *terraform.State) error {
 		out, err := conn.GetQueryLoggingConfig(&route53.GetQueryLoggingConfigInput{
 			Id: aws.String(rs.Primary.ID),
 		})
+
+		if tfawserr.ErrCodeEquals(err, route53.ErrCodeNoSuchQueryLoggingConfig) {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Route 53 Query Logging Configuration (%s): %w", rs.Primary.ID, err)
 		}
 
 		if out.QueryLoggingConfig != nil {

--- a/aws/resource_aws_sagemaker_app_image_config_test.go
+++ b/aws/resource_aws_sagemaker_app_image_config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -221,8 +222,13 @@ func testAccCheckAWSSagemakerAppImageConfigDestroy(s *terraform.State) error {
 		}
 
 		config, err := finder.AppImageConfigByName(conn, rs.Primary.ID)
+
+		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker App Image Config (%s): %w", rs.Primary.ID, err)
 		}
 
 		if aws.StringValue(config.AppImageConfigName) == rs.Primary.ID {

--- a/aws/resource_aws_sagemaker_app_test.go
+++ b/aws/resource_aws_sagemaker_app_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -214,8 +215,13 @@ func testAccCheckAWSSagemakerAppDestroy(s *terraform.State) error {
 		appName := rs.Primary.Attributes["app_name"]
 
 		app, err := finder.AppByName(conn, domainID, userProfileName, appType, appName)
+
+		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker App (%s): %w", rs.Primary.ID, err)
 		}
 
 		appArn := aws.StringValue(app.AppArn)

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfsagemaker "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
@@ -192,8 +194,13 @@ func testAccCheckAWSSagemakerCodeRepositoryDestroy(s *terraform.State) error {
 		}
 
 		codeRepository, err := finder.CodeRepositoryByName(conn, rs.Primary.ID)
+
+		if tfawserr.ErrMessageContains(err, tfsagemaker.ErrCodeValidationException, "Cannot find CodeRepository") {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker Code Repository (%s): %w", rs.Primary.ID, err)
 		}
 
 		if aws.StringValue(codeRepository.CodeRepositoryName) == rs.Primary.ID {

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -479,8 +480,13 @@ func testAccCheckAWSSagemakerDomainDestroy(s *terraform.State) error {
 		}
 
 		domain, err := finder.DomainByName(conn, rs.Primary.ID)
+
+		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker Domain (%s): %w", rs.Primary.ID, err)
 		}
 
 		domainArn := aws.StringValue(domain.DomainArn)

--- a/aws/resource_aws_sagemaker_feature_group_test.go
+++ b/aws/resource_aws_sagemaker_feature_group_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -368,8 +369,13 @@ func testAccCheckAWSSagemakerFeatureGroupDestroy(s *terraform.State) error {
 		}
 
 		codeRepository, err := finder.FeatureGroupByName(conn, rs.Primary.ID)
+
+		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker Feature Group (%s): %w", rs.Primary.ID, err)
 		}
 
 		if aws.StringValue(codeRepository.FeatureGroupName) == rs.Primary.ID {

--- a/aws/resource_aws_sagemaker_image_test.go
+++ b/aws/resource_aws_sagemaker_image_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -246,8 +247,13 @@ func testAccCheckAWSSagemakerImageDestroy(s *terraform.State) error {
 		}
 
 		Image, err := finder.ImageByName(conn, rs.Primary.ID)
+
+		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker Image (%s): %w", rs.Primary.ID, err)
 		}
 
 		if aws.StringValue(Image.ImageName) == rs.Primary.ID {

--- a/aws/resource_aws_sagemaker_image_version_test.go
+++ b/aws/resource_aws_sagemaker_image_version_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -118,8 +119,13 @@ func testAccCheckAWSSagemakerImageVersionDestroy(s *terraform.State) error {
 		}
 
 		imageVersion, err := finder.ImageVersionByName(conn, rs.Primary.ID)
+
+		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker Image Version (%s): %w", rs.Primary.ID, err)
 		}
 
 		if aws.StringValue(imageVersion.ImageVersionArn) == rs.Primary.Attributes["arn"] {

--- a/aws/resource_aws_sagemaker_model_package_group_test.go
+++ b/aws/resource_aws_sagemaker_model_package_group_test.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfsagemaker "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
@@ -190,8 +192,13 @@ func testAccCheckAWSSagemakerModelPackageGroupDestroy(s *terraform.State) error 
 		}
 
 		ModelPackageGroup, err := finder.ModelPackageGroupByName(conn, rs.Primary.ID)
+
+		if tfawserr.ErrMessageContains(err, tfsagemaker.ErrCodeValidationException, "does not exist") {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker Model Package Group (%s): %w", rs.Primary.ID, err)
 		}
 
 		if aws.StringValue(ModelPackageGroup.ModelPackageGroupName) == rs.Primary.ID {

--- a/aws/resource_aws_sagemaker_user_profile_test.go
+++ b/aws/resource_aws_sagemaker_user_profile_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -298,8 +299,13 @@ func testAccCheckAWSSagemakerUserProfileDestroy(s *terraform.State) error {
 		userProfileName := rs.Primary.Attributes["user_profile_name"]
 
 		userProfile, err := finder.UserProfileByName(conn, domainID, userProfileName)
+
+		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			continue
+		}
+
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker User Profile (%s): %w", rs.Primary.ID, err)
 		}
 
 		userProfileArn := aws.StringValue(userProfile.UserProfileArn)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18594

Output from acceptance testing in AWS Commercial (main account):

```
--- PASS: TestAccAWSCloudwatchLogDestination_basic (71.21s)
--- PASS: TestAccAWSCloudwatchLogDestination_disappears (86.89s)
--- PASS: TestAccAWSCloudwatchLogDestinationPolicy_basic (89.95s)

--- PASS: TestAccAWSCloudWatchLogGroup_basic (33.42s)
--- PASS: TestAccAWSCloudWatchLogGroup_disappears (15.53s)
--- PASS: TestAccAWSCloudWatchLogGroup_generatedName (14.65s)
--- PASS: TestAccAWSCloudWatchLogGroup_kmsKey (30.73s)
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (16.43s)
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix (26.31s)
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix_retention (24.71s)
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (38.65s)
--- PASS: TestAccAWSCloudWatchLogGroup_tagging (55.04s)

--- PASS: TestAccAWSCloudWatchLogResourcePolicy_basic (28.02s)

--- PASS: TestAccAWSDmsReplicationTask_basic (631.79s)

--- PASS: TestAccAWSEMRInstanceFleet_basic (512.59s)
--- PASS: TestAccAWSEMRInstanceFleet_disappears (568.84s)
--- PASS: TestAccAWSEMRInstanceFleet_ebsBasic (502.03s)
--- PASS: TestAccAWSEMRInstanceFleet_full (494.95s)
--- PASS: TestAccAWSEMRInstanceFleet_zero_count (559.52s)

--- PASS: TestAccAWSFlowLog_disappears (23.05s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs (30.68s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_MaxAggregationInterval (28.04s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3 (27.30s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3_Invalid (11.64s)
--- PASS: TestAccAWSFlowLog_LogFormat (69.09s)
--- PASS: TestAccAWSFlowLog_SubnetID (41.25s)
--- PASS: TestAccAWSFlowLog_tags (64.04s)
--- PASS: TestAccAWSFlowLog_VPCID (56.67s)

--- FAIL: TestAccAWSIAMAccountAlias_serial (26.56s) # https://github.com/hashicorp/terraform-provider-aws/issues/18617
    --- PASS: TestAccAWSIAMAccountAlias_serial/Import (11.11s)
        --- PASS: TestAccAWSIAMAccountAlias_serial/Import/import (11.11s)
    --- FAIL: TestAccAWSIAMAccountAlias_serial/Basic (15.45s) # https://github.com/hashicorp/terraform-provider-aws/issues/18617
        --- FAIL: TestAccAWSIAMAccountAlias_serial/Basic/basic (15.45s) # https://github.com/hashicorp/terraform-provider-aws/issues/18617

--- PASS: TestAccAWSLambdaPermission_basic (73.55s)
--- PASS: TestAccAWSLambdaPermission_disappears (107.56s)
--- PASS: TestAccAWSLambdaPermission_multiplePerms (75.09s)
--- PASS: TestAccAWSLambdaPermission_StatementId_Duplicate (98.31s)
--- PASS: TestAccAWSLambdaPermission_withIAMRole (60.07s)
--- PASS: TestAccAWSLambdaPermission_withQualifier (46.39s)
--- PASS: TestAccAWSLambdaPermission_withRawFunctionName (51.56s)
--- PASS: TestAccAWSLambdaPermission_withS3 (77.97s)
--- PASS: TestAccAWSLambdaPermission_withSNS (89.03s)
--- PASS: TestAccAWSLambdaPermission_withStatementIdPrefix (45.88s)

--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (654.70s)

--- PASS: TestAccAWSRoute53QueryLog_basic (47.72s)

--- PASS: TestAccAWSSagemakerAppImageConfig_basic (18.47s)
--- PASS: TestAccAWSSagemakerAppImageConfig_disappears (12.08s)
--- PASS: TestAccAWSSagemakerAppImageConfig_kernelGatewayImageConfig_fileSystemConfig (37.18s)
--- PASS: TestAccAWSSagemakerAppImageConfig_kernelGatewayImageConfig_kernalSpecs (26.62s)

--- PASS: TestAccAWSSagemakerCodeRepository_basic (20.19s)
--- PASS: TestAccAWSSagemakerCodeRepository_disappears (23.20s)
--- PASS: TestAccAWSSagemakerCodeRepository_disappears (31.14s)
--- PASS: TestAccAWSSagemakerCodeRepository_gitConfig_branch (20.19s)
--- PASS: TestAccAWSSagemakerCodeRepository_gitConfig_secret (44.54s)

--- PASS: TestAccAWSSagemakerDomain_serial (7056.73s)
    --- PASS: TestAccAWSSagemakerDomain_serial/Domain (2282.73s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/sharingSettings (203.02s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/tensorboardAppSettingsWithImage (283.87s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/kernelGatewayAppSettings (262.17s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/jupyterServerAppSettings (226.26s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/kms (192.69s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/securityGroup (211.82s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/basic (206.22s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/disappears (262.48s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/tags (230.96s)
        --- PASS: TestAccAWSSagemakerDomain_serial/Domain/tensorboardAppSettings (203.22s)
        --- SKIP: TestAccAWSSagemakerDomain_serial/Domain/kernelGatewayAppSettings_customImage (0.00s)
    --- PASS: TestAccAWSSagemakerDomain_serial/UserProfile (1646.66s)
        --- PASS: TestAccAWSSagemakerDomain_serial/UserProfile/jupyterServerAppSettings (215.22s)
        --- PASS: TestAccAWSSagemakerDomain_serial/UserProfile/basic (195.72s)
        --- PASS: TestAccAWSSagemakerDomain_serial/UserProfile/disappears (306.20s)
        --- PASS: TestAccAWSSagemakerDomain_serial/UserProfile/tags (192.47s)
        --- PASS: TestAccAWSSagemakerDomain_serial/UserProfile/tensorboardAppSettings (215.25s)
        --- PASS: TestAccAWSSagemakerDomain_serial/UserProfile/tensorboardAppSettingsWithImage (213.71s)
        --- PASS: TestAccAWSSagemakerDomain_serial/UserProfile/kernelGatewayAppSettings (308.08s)
    --- PASS: TestAccAWSSagemakerDomain_serial/App (3127.34s)
        --- PASS: TestAccAWSSagemakerDomain_serial/App/disappears (964.21s)
        --- PASS: TestAccAWSSagemakerDomain_serial/App/tags (718.55s)
        --- PASS: TestAccAWSSagemakerDomain_serial/App/resourceSpec (729.66s)
        --- PASS: TestAccAWSSagemakerDomain_serial/App/basic (714.92s)

--- PASS: TestAccAWSSagemakerFeatureGroup_basic (44.93s)
--- PASS: TestAccAWSSagemakerFeatureGroup_description (49.58s)
--- PASS: TestAccAWSSagemakerFeatureGroup_disappears (36.44s)
--- PASS: TestAccAWSSagemakerFeatureGroup_multipleFeatures (42.39s)
--- PASS: TestAccAWSSagemakerFeatureGroup_offlineConfig_basic (58.02s)
--- PASS: TestAccAWSSagemakerFeatureGroup_offlineConfig_createCatalog (69.71s)
--- PASS: TestAccAWSSagemakerFeatureGroup_offlineConfig_providedCatalog (59.54s)
--- PASS: TestAccAWSSagemakerFeatureGroup_onlineConfigSecurityConfig (57.63s)
--- PASS: TestAccAWSSagemakerFeatureGroup_tags (86.43s)

--- PASS: TestAccAWSSagemakerImage_basic (89.22s)
--- PASS: TestAccAWSSagemakerImage_description (125.18s)
--- PASS: TestAccAWSSagemakerImage_disappears (73.78s)
--- PASS: TestAccAWSSagemakerImage_displayName (114.12s)
--- PASS: TestAccAWSSagemakerImage_tags (114.60s)

--- SKIP: TestAccAWSSagemakerImageVersion_basic (0.00s)
--- SKIP: TestAccAWSSagemakerImageVersion_disappears (0.00s)
--- SKIP: TestAccAWSSagemakerImageVersion_disappears_image (0.00s)

--- PASS: TestAccAWSSagemakerModelPackageGroup_basic (24.01s)
--- PASS: TestAccAWSSagemakerModelPackageGroup_description (24.02s)
--- PASS: TestAccAWSSagemakerModelPackageGroup_disappears (17.90s)
--- PASS: TestAccAWSSagemakerModelPackageGroup_disappears (19.75s)
--- PASS: TestAccAWSSagemakerModelPackageGroup_tags (45.62s)

--- PASS: TestAccAWSSagemakerNotebookInstance_additional_code_repositories (1401.29s)
--- PASS: TestAccAWSSagemakerNotebookInstance_basic (389.57s)
--- PASS: TestAccAWSSagemakerNotebookInstance_default_code_repository (1125.27s)
--- PASS: TestAccAWSSagemakerNotebookInstance_default_code_repository_sagemakerRepo (1091.49s)
--- PASS: TestAccAWSSagemakerNotebookInstance_direct_internet_access (954.45s)
--- PASS: TestAccAWSSagemakerNotebookInstance_disappears (313.28s)
--- PASS: TestAccAWSSagemakerNotebookInstance_disappears (341.49s)
--- PASS: TestAccAWSSagemakerNotebookInstance_kms (357.50s)
--- PASS: TestAccAWSSagemakerNotebookInstance_LifecycleConfigName (1009.41s)
--- PASS: TestAccAWSSagemakerNotebookInstance_root_access (621.25s)
--- PASS: TestAccAWSSagemakerNotebookInstance_tags (328.84s)
--- PASS: TestAccAWSSagemakerNotebookInstance_update (709.47s)
--- PASS: TestAccAWSSagemakerNotebookInstance_volumesize (988.75s)
```

Output from acceptance testing in AWS Commercial (Organizations account):

```
--- PASS: TestAccAWSOrganizations_serial (64.88s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnits (0.00s)
        --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnits/DataSource (14.75s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit (50.13s)
        --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit/basic (14.70s)
        --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit/disappears (12.40s)
        --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit/Name (23.03s)
```