### PR TITLE
tests/service/iot: Implement remaining sweepers

### DIFF
--- a/aws/resource_aws_iot_certificate_test.go
+++ b/aws/resource_aws_iot_certificate_test.go
@@ -58,10 +58,8 @@ func testSweepIotCertifcates(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Certificate for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Certificate for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Certificate for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_iot_certificate_test.go
+++ b/aws/resource_aws_iot_certificate_test.go
@@ -2,14 +2,75 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iot"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_iot_certificate", &resource.Sweeper{
+		Name: "aws_iot_certificate",
+		F:    testSweepIotCertifcates,
+		Dependencies: []string{
+			"aws_iot_policy_attachment",
+			"aws_iot_thing_principal_attachment",
+		},
+	})
+}
+
+func testSweepIotCertifcates(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).iotconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &iot.ListCertificatesInput{}
+
+	err = conn.ListCertificatesPages(input, func(page *iot.ListCertificatesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, certificate := range page.Certificates {
+			r := resourceAwsIotCertificate()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(certificate.CertificateId))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Certificate for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Certificate for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping IoT Certificate sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSIoTCertificate_csr(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_iot_policy_attachment_test.go
+++ b/aws/resource_aws_iot_policy_attachment_test.go
@@ -74,10 +74,8 @@ func testSweepIotPolicyAttachments(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Policy Attachment for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Policy Attachment for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Policy Attachment for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_iot_policy_attachment_test.go
+++ b/aws/resource_aws_iot_policy_attachment_test.go
@@ -2,14 +2,91 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iot"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_iot_policy_attachment", &resource.Sweeper{
+		Name: "aws_iot_policy_attachment",
+		F:    testSweepIotPolicyAttachments,
+	})
+}
+
+func testSweepIotPolicyAttachments(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).iotconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &iot.ListPoliciesInput{}
+
+	err = conn.ListPoliciesPages(input, func(page *iot.ListPoliciesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, policy := range page.Policies {
+			input := &iot.ListTargetsForPolicyInput{
+				PolicyName: policy.PolicyName,
+			}
+
+			err := conn.ListTargetsForPolicyPages(input, func(page *iot.ListTargetsForPolicyOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, target := range page.Targets {
+					r := resourceAwsIotPolicyAttachment()
+					d := r.Data(nil)
+
+					d.SetId(fmt.Sprintf("%s|%s", aws.StringValue(policy.PolicyName), aws.StringValue(target)))
+					d.Set("policy", policy.PolicyName)
+					d.Set("target", target)
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+
+			if err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("error listing IoT Policy Attachment for %s: %w", region, err))
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Policy Attachment for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Policy Attachment for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping IoT Policy Attachment sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSIotPolicyAttachment_basic(t *testing.T) {
 	policyName := acctest.RandomWithPrefix("PolicyName-")

--- a/aws/resource_aws_iot_policy_test.go
+++ b/aws/resource_aws_iot_policy_test.go
@@ -58,10 +58,8 @@ func testSweepIotPolicies(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Policy for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Policy for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Policy for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_iot_policy_test.go
+++ b/aws/resource_aws_iot_policy_test.go
@@ -2,15 +2,75 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iot"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_iot_policy", &resource.Sweeper{
+		Name: "aws_iot_policy",
+		F:    testSweepIotPolicies,
+		Dependencies: []string{
+			"aws_iot_policy_attachment",
+		},
+	})
+}
+
+func testSweepIotPolicies(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).iotconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &iot.ListPoliciesInput{}
+
+	err = conn.ListPoliciesPages(input, func(page *iot.ListPoliciesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, policy := range page.Policies {
+			r := resourceAwsIotPolicy()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(policy.PolicyName))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Policy for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Policy for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping IoT Policy sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSIoTPolicy_basic(t *testing.T) {
 	var v iot.GetPolicyOutput

--- a/aws/resource_aws_iot_role_alias_test.go
+++ b/aws/resource_aws_iot_role_alias_test.go
@@ -55,10 +55,8 @@ func testSweepIotRoleAliases(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Role Alias for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Role Alias for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Role Alias for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_iot_role_alias_test.go
+++ b/aws/resource_aws_iot_role_alias_test.go
@@ -2,14 +2,72 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iot"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_iot_role_alias", &resource.Sweeper{
+		Name: "aws_iot_role_alias",
+		F:    testSweepIotRoleAliases,
+	})
+}
+
+func testSweepIotRoleAliases(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).iotconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &iot.ListRoleAliasesInput{}
+
+	err = conn.ListRoleAliasesPages(input, func(page *iot.ListRoleAliasesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, roleAlias := range page.RoleAliases {
+			r := resourceAwsIotRoleAlias()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(roleAlias))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Role Alias for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Role Alias for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping IoT Role Alias sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSIotRoleAlias_basic(t *testing.T) {
 	alias := acctest.RandomWithPrefix("RoleAlias-")

--- a/aws/resource_aws_iot_thing_principal_attachment_test.go
+++ b/aws/resource_aws_iot_thing_principal_attachment_test.go
@@ -74,10 +74,8 @@ func testSweepIotThingPrincipalAttachments(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Thing Principal Attachment for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Thing Principal Attachment for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Thing Principal Attachment for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_iot_thing_principal_attachment_test.go
+++ b/aws/resource_aws_iot_thing_principal_attachment_test.go
@@ -2,14 +2,91 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iot"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_iot_thing_principal_attachment", &resource.Sweeper{
+		Name: "aws_iot_thing_principal_attachment",
+		F:    testSweepIotThingPrincipalAttachments,
+	})
+}
+
+func testSweepIotThingPrincipalAttachments(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).iotconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &iot.ListThingsInput{}
+
+	err = conn.ListThingsPages(input, func(page *iot.ListThingsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, thing := range page.Things {
+			input := &iot.ListThingPrincipalsInput{
+				ThingName: thing.ThingName,
+			}
+
+			err := conn.ListThingPrincipalsPages(input, func(page *iot.ListThingPrincipalsOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, principal := range page.Principals {
+					r := resourceAwsIotThingPrincipalAttachment()
+					d := r.Data(nil)
+
+					d.SetId(fmt.Sprintf("%s|%s", aws.StringValue(thing.ThingName), aws.StringValue(principal)))
+					d.Set("principal", principal)
+					d.Set("thing", thing.ThingName)
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+
+			if err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("error listing IoT Thing Principal Attachment for %s: %w", region, err))
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Thing Principal Attachment for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Thing Principal Attachment for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping IoT Thing Principal Attachment sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSIotThingPrincipalAttachment_basic(t *testing.T) {
 	thingName := acctest.RandomWithPrefix("tf-acc")

--- a/aws/resource_aws_iot_thing_test.go
+++ b/aws/resource_aws_iot_thing_test.go
@@ -2,14 +2,72 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iot"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_iot_thing", &resource.Sweeper{
+		Name:         "aws_iot_thing",
+		F:            testSweepIotThings,
+		Dependencies: []string{"aws_iot_thing_principal_attachment"},
+	})
+}
+
+func testSweepIotThings(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).iotconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &iot.ListThingsInput{}
+
+	err = conn.ListThingsPages(input, func(page *iot.ListThingsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, thing := range page.Things {
+			r := resourceAwsIotThing()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(thing.ThingName))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Thing for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Thing for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping IoT Thing sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSIotThing_basic(t *testing.T) {
 	var thing iot.DescribeThingOutput

--- a/aws/resource_aws_iot_thing_test.go
+++ b/aws/resource_aws_iot_thing_test.go
@@ -55,10 +55,8 @@ func testSweepIotThings(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Thing for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Thing for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Thing for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_iot_thing_type_test.go
+++ b/aws/resource_aws_iot_thing_type_test.go
@@ -55,10 +55,8 @@ func testSweepIotThingTypes(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Thing Type for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Thing Type for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Thing Type for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_iot_thing_type_test.go
+++ b/aws/resource_aws_iot_thing_type_test.go
@@ -2,14 +2,72 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iot"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_iot_thing_type", &resource.Sweeper{
+		Name:         "aws_iot_thing_type",
+		F:            testSweepIotThingTypes,
+		Dependencies: []string{"aws_iot_thing"},
+	})
+}
+
+func testSweepIotThingTypes(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).iotconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &iot.ListThingTypesInput{}
+
+	err = conn.ListThingTypesPages(input, func(page *iot.ListThingTypesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, thingTypes := range page.ThingTypes {
+			r := resourceAwsIotThingType()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(thingTypes.ThingTypeName))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing IoT Thing Type for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping IoT Thing Type for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping IoT Thing Type sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSIotThingType_basic(t *testing.T) {
 	rInt := acctest.RandInt()


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14963

The `aws_iot_certificate` resource sweeper required some additional resources, so just did all the remaining IoT resources.

Output from sweeper in AWS Commercial:

```
2021/04/07 15:02:21 [DEBUG] Running Sweepers for region (us-west-2):
2021/04/07 15:02:21 [DEBUG] Running Sweeper (aws_iot_policy_attachment) in region (us-west-2)
2021/04/07 15:02:25 [DEBUG] Running Sweeper (aws_iot_thing_principal_attachment) in region (us-west-2)
2021/04/07 15:02:29 [DEBUG] Running Sweeper (aws_iot_certificate) in region (us-west-2)
2021/04/07 15:02:29 [DEBUG] Running Sweeper (aws_iot_thing) in region (us-west-2)
2021/04/07 15:02:30 [DEBUG] Deleting IoT Thing: {
  ThingName: "tf-acc2-267621613065946261"
}
2021/04/07 15:02:30 [DEBUG] Deleting IoT Thing: {
  ThingName: "tf-acc2-3832025121855435663"
}
2021/04/07 15:02:30 [DEBUG] Deleting IoT Thing: {
  ThingName: "tf-acc-2734006379715404679"
}
2021/04/07 15:02:30 [DEBUG] Deleting IoT Thing: {
  ThingName: "tf-acc-7731040170511226170"
}
2021/04/07 15:02:30 [DEBUG] Deleting IoT Thing: {
  ThingName: "tf-acc2-4816803372918593609"
}
2021/04/07 15:02:30 [DEBUG] Running Sweeper (aws_iot_thing_type) in region (us-west-2)
2021/04/07 15:02:31 [DEBUG] Deprecating IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_6847254873577260292"
}
2021/04/07 15:02:31 [DEBUG] Deprecating IoT Thing Type: {
  ThingTypeName: "tf_acc_type_96nqxu17"
}
2021/04/07 15:02:31 [DEBUG] Deprecating IoT Thing Type: {
  ThingTypeName: "tf_acc_type_8o6esytm"
}
2021/04/07 15:02:31 [DEBUG] Deprecating IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_8755625355827090279"
}
2021/04/07 15:02:31 [DEBUG] Deprecating IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_5511629522525982263"
}
2021/04/07 15:02:31 [DEBUG] Deprecating IoT Thing Type: {
  ThingTypeName: "tf_acc_type_xs7cue1y"
}
2021/04/07 15:02:31 [DEBUG] Deprecating IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_2923393114004902330"
}
2021/04/07 15:02:31 [DEBUG] Deprecating IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_6106631190203262926"
}
2021/04/07 15:02:31 [DEBUG] Deleting IoT Thing Type: {
  ThingTypeName: "tf_acc_type_96nqxu17"
}
2021/04/07 15:02:31 [DEBUG] Deleting IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_5511629522525982263"
}
2021/04/07 15:02:31 [DEBUG] Deleting IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_6847254873577260292"
}
2021/04/07 15:02:31 [DEBUG] Deleting IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_8755625355827090279"
}
2021/04/07 15:02:31 [DEBUG] Deleting IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_2923393114004902330"
}
2021/04/07 15:02:31 [DEBUG] Deleting IoT Thing Type: {
  ThingTypeName: "tf_acc_type_xs7cue1y"
}
2021/04/07 15:02:32 [DEBUG] Deleting IoT Thing Type: {
  ThingTypeName: "tf_acc_type_8o6esytm"
}
2021/04/07 15:02:32 [DEBUG] Deleting IoT Thing Type: {
  ThingTypeName: "tf_acc_iot_thing_type_6106631190203262926"
}
2021/04/07 15:07:43 [DEBUG] Running Sweeper (aws_iot_policy) in region (us-west-2)
2021/04/07 15:07:45 [DEBUG] Running Sweeper (aws_iot_role_alias) in region (us-west-2)
2021/04/07 15:07:45 Sweeper Tests ran successfully:
        - aws_iot_thing_principal_attachment
        - aws_iot_certificate
        - aws_iot_thing
        - aws_iot_thing_type
        - aws_iot_policy
        - aws_iot_role_alias
        - aws_iot_policy_attachment
2021/04/07 15:07:45 [DEBUG] Running Sweepers for region (us-east-1):
2021/04/07 15:07:45 [DEBUG] Running Sweeper (aws_iot_policy_attachment) in region (us-east-1)
2021/04/07 15:07:46 [DEBUG] Running Sweeper (aws_iot_thing_principal_attachment) in region (us-east-1)
2021/04/07 15:07:46 [DEBUG] Running Sweeper (aws_iot_certificate) in region (us-east-1)
2021/04/07 15:07:46 [DEBUG] Running Sweeper (aws_iot_thing) in region (us-east-1)
2021/04/07 15:07:46 [DEBUG] Running Sweeper (aws_iot_thing_type) in region (us-east-1)
2021/04/07 15:07:46 [DEBUG] Running Sweeper (aws_iot_policy) in region (us-east-1)
2021/04/07 15:07:46 [DEBUG] Running Sweeper (aws_iot_role_alias) in region (us-east-1)
2021/04/07 15:07:46 Sweeper Tests ran successfully:
        - aws_iot_thing
        - aws_iot_thing_type
        - aws_iot_policy
        - aws_iot_role_alias
        - aws_iot_policy_attachment
        - aws_iot_thing_principal_attachment
        - aws_iot_certificate
ok      github.com/terraform-providers/terraform-provider-aws/aws       331.909s
```

Output from sweeper in AWS GovCloud (US):

```
2021/04/07 15:02:27 [DEBUG] Running Sweepers for region (us-gov-west-1):
2021/04/07 15:02:27 [DEBUG] Running Sweeper (aws_iot_thing_principal_attachment) in region (us-gov-west-1)
2021/04/07 15:02:30 [DEBUG] Running Sweeper (aws_iot_thing) in region (us-gov-west-1)
2021/04/07 15:02:31 [DEBUG] Running Sweeper (aws_iot_policy_attachment) in region (us-gov-west-1)
2021/04/07 15:02:31 [DEBUG] Running Sweeper (aws_iot_policy) in region (us-gov-west-1)
2021/04/07 15:02:32 [DEBUG] Running Sweeper (aws_iot_certificate) in region (us-gov-west-1)
2021/04/07 15:02:32 [DEBUG] Running Sweeper (aws_iot_role_alias) in region (us-gov-west-1)
2021/04/07 15:02:32 [DEBUG] Running Sweeper (aws_iot_thing_type) in region (us-gov-west-1)
2021/04/07 15:02:33 Sweeper Tests ran successfully:
        - aws_iot_role_alias
        - aws_iot_thing_type
        - aws_iot_thing_principal_attachment
        - aws_iot_thing
        - aws_iot_policy_attachment
        - aws_iot_policy
        - aws_iot_certificate
ok      github.com/terraform-providers/terraform-provider-aws/aws       8.594s
```
