### PR TITLE
tests/resource/aws_codepipeline: Implement sweeper

### DIFF
--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -58,10 +58,8 @@ func testSweepCodepipelinePipelines(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error listing Codepipeline Pipeline for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping Codepipeline Pipeline for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Codepipeline Pipeline for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -2,18 +2,75 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
 	"github.com/aws/aws-sdk-go/service/codestarconnections"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/envvar"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_codepipeline", &resource.Sweeper{
+		Name: "aws_codepipeline",
+		F:    testSweepCodepipelinePipelines,
+	})
+}
+
+func testSweepCodepipelinePipelines(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).codepipelineconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &codepipeline.ListPipelinesInput{}
+
+	err = conn.ListPipelinesPages(input, func(page *codepipeline.ListPipelinesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, pipeline := range page.Pipelines {
+			r := resourceAwsCodePipeline()
+			d := r.Data(nil)
+
+			d.SetId(aws.StringValue(pipeline.Name))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing Codepipeline Pipeline for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping Codepipeline Pipeline for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Codepipeline Pipeline sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSCodePipeline_basic(t *testing.T) {
 	var p1, p2 codepipeline.PipelineDeclaration


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12300

Output from sweeper in AWS Commercial:

```
2021/04/07 15:22:29 [DEBUG] Running Sweepers for region (us-west-2):
2021/04/07 15:22:29 [DEBUG] Running Sweeper (aws_codepipeline) in region (us-west-2)
2021/04/07 15:22:31 Sweeper Tests ran successfully:
        - aws_codepipeline
2021/04/07 15:22:31 [DEBUG] Running Sweepers for region (us-east-1):
2021/04/07 15:22:31 [DEBUG] Running Sweeper (aws_codepipeline) in region (us-east-1)
2021/04/07 15:22:31 Sweeper Tests ran successfully:
        - aws_codepipeline
ok      github.com/terraform-providers/terraform-provider-aws/aws       4.878s
```

Output from sweeper in AWS GovCloud (US):

```
2021/04/07 15:21:21 [DEBUG] Running Sweepers for region (us-gov-west-1):
2021/04/07 15:21:21 [DEBUG] Running Sweeper (aws_codepipeline) in region (us-gov-west-1)
2021/04/07 15:21:22 Sweeper Tests ran successfully:
        - aws_codepipeline
ok      github.com/terraform-providers/terraform-provider-aws/aws       5.537s
```