### PR TITLE
Removes plan-time validation for `automatic_failover_enabled`

### DIFF
--- a/.changelog/18635.txt
+++ b/.changelog/18635.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Remmoves incorrect plan-time validation for `automatic_failover_enabled`
+```

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -301,27 +301,6 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				}
 				return nil
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				if v := diff.Get("automatic_failover_enabled").(bool); !v {
-					return nil
-				}
-
-				if v, ok := diff.GetOkExists("number_cache_clusters"); ok {
-					if v.(int) > 1 {
-						return nil
-					}
-					return errors.New(`if automatic_failover_enabled is true, number_cache_clusters must be greater than 1`)
-				}
-
-				if v, ok := diff.GetOkExists("cluster_mode.0.replicas_per_node_group"); ok {
-					if v.(int) > 0 {
-						return nil
-					}
-					return errors.New(`if automatic_failover_enabled is true, cluster_mode[0].replicas_per_node_group must be greater than 0`)
-				}
-
-				return nil
-			},
 			customdiff.ComputedIf("member_clusters", func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
 				return diff.HasChange("number_cache_clusters") ||
 					diff.HasChange("cluster_mode.0.num_node_groups") ||

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -433,7 +433,7 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheReplicationGroup_multiAz_NoAutomaticFailover(t *testing.T) {
+func TestAccAWSElasticacheReplicationGroup_Validation_multiAz_NoAutomaticFailover(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -445,27 +445,6 @@ func TestAccAWSElasticacheReplicationGroup_multiAz_NoAutomaticFailover(t *testin
 			{
 				Config:      testAccAWSElasticacheReplicationGroupConfig_MultiAZ_NoAutomaticFailover(rName),
 				ExpectError: regexp.MustCompile("automatic_failover_enabled must be true if multi_az_enabled is true"),
-			},
-		},
-	})
-}
-
-func TestAccAWSElasticacheReplicationGroup_AutomaticFailover_OneCacheCluster(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSElasticacheReplicationGroupConfig_MultiAZOneCacheCluster_SingleNodeGroup(rName),
-				ExpectError: regexp.MustCompile(`if automatic_failover_enabled is true, number_cache_clusters must be greater than 1`),
-			},
-			{
-				Config:      testAccAWSElasticacheReplicationGroupConfig_MultiAZOneCacheCluster_ClusterMode(rName),
-				ExpectError: regexp.MustCompile(`if automatic_failover_enabled is true, cluster_mode\[0\].replicas_per_node_group must be greater than 0`),
 			},
 		},
 	})
@@ -793,6 +772,42 @@ func TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateNumNodeGroupsAndRep
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheReplicationGroup_ClusterMode_SingleNode(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig_SingleNode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "0"),
+					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 		},
 	})
@@ -1930,36 +1945,6 @@ resource "aws_elasticache_replication_group" "test" {
 `, rName)
 }
 
-func testAccAWSElasticacheReplicationGroupConfig_MultiAZOneCacheCluster_SingleNodeGroup(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  number_cache_clusters         = 1
-  node_type                     = "cache.t3.small"
-  automatic_failover_enabled    = true
-  multi_az_enabled              = true
-}
-`, rName)
-}
-
-func testAccAWSElasticacheReplicationGroupConfig_MultiAZOneCacheCluster_ClusterMode(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  automatic_failover_enabled    = true
-  multi_az_enabled              = true
-
-  cluster_mode {
-    num_node_groups         = 1
-    replicas_per_node_group = 0
-  }
-}
-`, rName)
-}
-
 func testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
@@ -2213,6 +2198,25 @@ resource "aws_elasticache_replication_group" "test" {
   cluster_mode {
     num_node_groups         = 1
     replicas_per_node_group = 1
+  }
+}
+`, rName))
+}
+
+func testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig_SingleNode(rName string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[1]q
+  replication_group_description = "test description"
+  node_type                     = "cache.t2.medium"
+  automatic_failover_enabled    = true
+
+  parameter_group_name = "default.redis6.x.cluster.on"
+  cluster_mode {
+    num_node_groups         = 1
+    replicas_per_node_group = 0
   }
 }
 `, rName))


### PR DESCRIPTION
The plan-time validation also depends on whether the parameter group used enables Redis cluster mode, that is, setting the parameter `cluster-enabled` to `yes`. If so, `automatic_failover_enabled` must be true, otherwise, the replication group must have at least two clusters.

By disabling plan-time validation, we allow the AWS API to perform the correct validation.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18522

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_'

--- PASS: TestAccAWSElasticacheReplicationGroup_Validation_NoNodeType (69.27s)
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (875.31s)
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (7.18s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (936.69s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Validation_GlobalReplicationGroupIdAndNodeType (957.94s)
--- PASS: TestAccAWSElasticacheReplicationGroup_tags (994.14s)
--- PASS: TestAccAWSElasticacheReplicationGroup_useCmkKmsKeyId (1147.09s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (1148.37s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (1209.74s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MemberClusterDisappears_RemoveMemberCluster_AtTargetSize (1369.61s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MemberClusterDisappears_RemoveMemberCluster_ScaleDown (1400.00s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MultiAZEnabled (1607.28s)
--- PASS: TestAccAWSElasticacheReplicationGroup_FinalSnapshot (1707.20s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Validation_multiAz_NoAutomaticFailover (9.34s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (1829.12s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MemberClusterDisappears_NoChange (2134.73s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Basic (2179.75s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_SingleNode (1350.87s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NonClusteredParameterGroup (1121.13s)
--- FAIL: TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_Full (2348.58s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MemberClusterDisappears_AddMemberCluster (2413.39s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1100.41s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateReplicasPerNodeGroup (1686.20s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (915.66s)
--- PASS: TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_disappears (2756.72s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1182.39s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1390.26s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (2919.97s)
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (876.68s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (1095.95s)
--- FAIL: TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_Basic (3239.27s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (1005.35s)
--- PASS: TestAccAWSElasticacheReplicationGroup_disappears (1229.63s)
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (3532.91s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateNumNodeGroupsAndReplicasPerNodeGroup_ScaleUp (2658.64s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateNumNodeGroupsAndReplicasPerNodeGroup_ScaleDown (2788.05s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (2354.06s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateNumNodeGroups_ScaleUp (3088.55s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzNotInVpc (2000.41s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateNumNodeGroups_ScaleDown (3590.34s)
```

The test failures `TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_Full` and `TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_Basic` are related to #18625