### PR TITLE
[WIP] add kafka rule type to iot topic rules

### DIFF
--- a/.changelog/18639.txt
+++ b/.changelog/18639.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iot_topic_rule: Add `kafka` iot rule type
+```

--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -948,7 +948,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 							},
 						},
 						"kafka": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{

--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -264,6 +264,143 @@ func resourceAwsIotTopicRule() *schema.Resource {
 					},
 				},
 			},
+			"kafka": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"acks": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      1,
+							ValidateFunc: validation.IntBetween(0, 1),
+						},
+						"bootstrap_servers": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"compression_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "none",
+							ValidateFunc: validation.StringInSlice([]string{
+								"none",
+								"gzip",
+								"snappy",
+								"lz4",
+								"zstd",
+							}, false),
+						},
+						"destination_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"key_serializer": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "org.apache.kafka.common.serialization.StringSerializer",
+							ValidateFunc: validation.StringInSlice([]string{
+								"org.apache.kafka.common.serialization.StringSerializer",
+							}, false),
+						},
+						"partition": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sasl_kerberos_keytab": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sasl_kerberos_krb5_kdc": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sasl_kerberos_krb5_realm": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sasl_kerberos_principal": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sasl_kerberos_service_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sasl_mechanism": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"PLAIN",
+								"GSSAPI",
+								"SCRAM-SHA-512",
+							}, false),
+						},
+						"sasl_plain_username": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sasl_plain_password": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sasl_scram_username": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sasl_scram_password": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"security_protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "SSL",
+							ValidateFunc: validation.StringInSlice([]string{
+								"SSL",
+								"SASL_SSL",
+							}, false),
+						},
+						"ssl_key_password": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ssl_keystore": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ssl_keystore_password": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ssl_truststore": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ssl_truststore_password": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"topic": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value_serializer": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "org.apache.kafka.common.serialization.ByteBufferSerializer",
+							ValidateFunc: validation.StringInSlice([]string{
+								"org.apache.kafka.common.serialization.ByteBufferSerializer",
+							}, false),
+						},
+					},
+				},
+			},
 			"kinesis": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -463,6 +600,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -515,6 +653,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -587,6 +726,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -631,6 +771,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -679,6 +820,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -719,6 +861,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -754,6 +897,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -793,6 +937,163 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"kafka": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"acks": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      1,
+										ValidateFunc: validation.IntBetween(0, 1),
+									},
+									"bootstrap_servers": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"compression_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "none",
+										ValidateFunc: validation.StringInSlice([]string{
+											"none",
+											"gzip",
+											"snappy",
+											"lz4",
+											"zstd",
+										}, false),
+									},
+									"destination_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"key": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"key_serializer": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "org.apache.kafka.common.serialization.StringSerializer",
+										ValidateFunc: validation.StringInSlice([]string{
+											"org.apache.kafka.common.serialization.StringSerializer",
+										}, false),
+									},
+									"partition": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"sasl_kerberos_keytab": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"sasl_kerberos_krb5_kdc": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"sasl_kerberos_krb5_realm": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"sasl_kerberos_principal": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"sasl_kerberos_service_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"sasl_mechanism": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"PLAIN",
+											"GSSAPI",
+											"SCRAM-SHA-512",
+										}, false),
+									},
+									"sasl_plain_username": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"sasl_plain_password": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"sasl_scram_username": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"sasl_scram_password": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"security_protocol": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "SSL",
+										ValidateFunc: validation.StringInSlice([]string{
+											"SSL",
+											"SASL_SSL",
+										}, false),
+									},
+									"ssl_key_password": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"ssl_keystore": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"ssl_keystore_password": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"ssl_truststore": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"ssl_truststore_password": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"topic": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value_serializer": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "org.apache.kafka.common.serialization.ByteBufferSerializer",
+										ValidateFunc: validation.StringInSlice([]string{
+											"org.apache.kafka.common.serialization.ByteBufferSerializer",
+										}, false),
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -832,6 +1133,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -863,6 +1165,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -904,6 +1207,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -943,6 +1247,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -982,6 +1287,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -1023,6 +1329,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -1062,6 +1369,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 								"error_action.0.firehose",
 								"error_action.0.iot_analytics",
 								"error_action.0.iot_events",
+								"error_action.0.kafka",
 								"error_action.0.kinesis",
 								"error_action.0.lambda",
 								"error_action.0.republish",
@@ -1163,6 +1471,10 @@ func resourceAwsIotTopicRuleRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error setting iot_events: %w", err)
 	}
 
+	if err := d.Set("kafka", flattenIotKafkaActions(out.Rule.Actions)); err != nil {
+		return fmt.Errorf("error setting kafka: %w", err)
+	}
+
 	if err := d.Set("kinesis", flattenIotKinesisActions(out.Rule.Actions)); err != nil {
 		return fmt.Errorf("error setting kinesis: %w", err)
 	}
@@ -1212,6 +1524,7 @@ func resourceAwsIotTopicRuleUpdate(d *schema.ResourceData, meta interface{}) err
 		"firehose",
 		"iot_analytics",
 		"iot_events",
+		"kafka",
 		"kinesis",
 		"lambda",
 		"republish",
@@ -1504,6 +1817,126 @@ func expandIotIotEventsAction(tfList []interface{}) *iot.IotEventsAction {
 	return apiObject
 }
 
+func expandIotKafkaAction(tfList []interface{}) *iot.KafkaAction {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	apiObject := &iot.KafkaAction{}
+	tfMap := tfList[0].(map[string]interface{})
+	clientProperties := make(map[string]*string)
+
+	if v, ok := tfMap["acks"].(string); ok && v != "" {
+		clientProperties["acks"] = aws.String(v)
+	}
+
+	if v, ok := tfMap["bootstrap_servers"].(string); ok && v != "" {
+		clientProperties["bootstrap.servers"] = aws.String(v)
+	}
+
+	if v, ok := tfMap["compression_type"].(string); ok && v != "" {
+		clientProperties["compression.type"] = aws.String(v)
+	}
+
+	if v, ok := tfMap["destination_arn"].(string); ok && v != "" {
+		apiObject.DestinationArn = aws.String(v)
+	}
+
+	if v, ok := tfMap["key"].(string); ok && v != "" {
+		apiObject.Key = aws.String(v)
+	}
+
+	if v, ok := tfMap["key_serializer"].(string); ok && v != "" {
+		clientProperties["key.serializer"] = aws.String(v)
+	}
+
+	if v, ok := tfMap["partition"].(string); ok && v != "" {
+		apiObject.Partition = aws.String(v)
+	}
+
+	if sp, ok := tfMap["security_protocol"].(string); ok && sp != "" {
+		clientProperties["security.protocol"] = aws.String(sp)
+
+		switch sp {
+		case "SSL":
+			if v, ok := tfMap["ssl_keystore"].(string); ok && v != "" {
+				clientProperties["ssl.keystore"] = aws.String(v)
+			}
+
+			if v, ok := tfMap["ssl_keystore_password"].(string); ok && v != "" {
+				clientProperties["ssl.keystore.password"] = aws.String(v)
+			}
+
+			if v, ok := tfMap["ssl_key_password"].(string); ok && v != "" {
+				clientProperties["ssl.key.password"] = aws.String(v)
+			}
+		case "SASL":
+			if mechanism, ok := tfMap["sasl_mechanism"].(string); ok && mechanism != "" {
+				clientProperties["sasl.mechanism"] = aws.String(mechanism)
+
+				switch mechanism {
+				case "PLAIN":
+					if v, ok := tfMap["sasl_plain_username"].(string); ok && v != "" {
+						clientProperties["sasl.plain.username"] = aws.String(v)
+					}
+
+					if v, ok := tfMap["sasl_plain_password"].(string); ok && v != "" {
+						clientProperties["sasl.plain.password"] = aws.String(v)
+					}
+				case "SCRAM-SHA-512":
+					if v, ok := tfMap["sasl_scram_username"].(string); ok && v != "" {
+						clientProperties["sasl.scram.username"] = aws.String(v)
+					}
+
+					if v, ok := tfMap["sasl_scram_password"].(string); ok && v != "" {
+						clientProperties["sasl.scram.password"] = aws.String(v)
+					}
+				case "GSSAPI":
+					if v, ok := tfMap["sasl_kerberos_keytab"].(string); ok && v != "" {
+						clientProperties["sasl.kerberos.keytab"] = aws.String(v)
+					}
+
+					if v, ok := tfMap["sasl_kerberos_krb5_kdc"].(string); ok && v != "" {
+						clientProperties["sasl.kerberos.krb5.kdc"] = aws.String(v)
+					}
+
+					if v, ok := tfMap["sasl_kerberos_krb5_realm"].(string); ok && v != "" {
+						clientProperties["sasl.kerberos.krb5.realm"] = aws.String(v)
+					}
+
+					if v, ok := tfMap["sasl_kerberos_principal"].(string); ok && v != "" {
+						clientProperties["sasl.kerberos.principal"] = aws.String(v)
+					}
+
+					if v, ok := tfMap["sasl_kerberos_service_name"].(string); ok && v != "" {
+						clientProperties["sasl.kerberos.service.name"] = aws.String(v)
+					}
+				}
+			}
+		}
+	}
+
+	if v, ok := tfMap["ssl_truststore"].(string); ok && v != "" {
+		clientProperties["ssl.truststore"] = aws.String(v)
+	}
+
+	if v, ok := tfMap["ssl_truststore_password"].(string); ok && v != "" {
+		clientProperties["ssl.truststore.password"] = aws.String(v)
+	}
+
+	if v, ok := tfMap["topic"].(string); ok && v != "" {
+		apiObject.Topic = aws.String(v)
+	}
+
+	if v, ok := tfMap["value_serializer"].(string); ok && v != "" {
+		clientProperties["value.serializer"] = aws.String(v)
+	}
+
+	apiObject.ClientProperties = clientProperties
+
+	return apiObject
+}
+
 func expandIotKinesisAction(tfList []interface{}) *iot.KinesisAction {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
@@ -1749,6 +2182,17 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 	}
 
 	// Legacy root attribute handling
+	for _, tfMapRaw := range d.Get("kafka").(*schema.Set).List() {
+		action := expandIotKafkaAction([]interface{}{tfMapRaw})
+
+		if action == nil {
+			continue
+		}
+
+		actions = append(actions, &iot.Action{Kafka: action})
+	}
+
+	// Legacy root attribute handling
 	for _, tfMapRaw := range d.Get("kinesis").(*schema.Set).List() {
 		action := expandIotKinesisAction([]interface{}{tfMapRaw})
 
@@ -1915,6 +2359,16 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 					}
 
 					iotErrorAction = &iot.Action{IotEvents: action}
+				}
+			case "kafka":
+				for _, tfMapRaw := range v.([]interface{}) {
+					action := expandIotKafkaAction([]interface{}{tfMapRaw})
+
+					if action == nil {
+						continue
+					}
+
+					iotErrorAction = &iot.Action{Kafka: action}
 				}
 			case "kinesis":
 				for _, tfMapRaw := range v.([]interface{}) {
@@ -2357,6 +2811,143 @@ func flattenIotIotEventsAction(apiObject *iot.IotEventsAction) []interface{} {
 }
 
 // Legacy root attribute handling
+func flattenIotKafkaActions(actions []*iot.Action) []interface{} {
+	results := make([]interface{}, 0)
+
+	for _, action := range actions {
+		if action == nil {
+			continue
+		}
+
+		if v := action.Kafka; v != nil {
+			results = append(results, flattenIotKafkaAction(v)...)
+		}
+	}
+
+	return results
+}
+
+func flattenIotKafkaAction(apiObject *iot.KafkaAction) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := make(map[string]interface{})
+
+	if v := apiObject.DestinationArn; v != nil {
+		tfMap["destination_arn"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Key; v != nil {
+		tfMap["key"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Partition; v != nil {
+		tfMap["partition"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Topic; v != nil {
+		tfMap["topic"] = aws.StringValue(v)
+	}
+
+	if cp := apiObject.ClientProperties; cp != nil {
+		if v, ok := cp["acks"]; ok && v != nil {
+			tfMap["acks"] = aws.StringValue(v)
+		}
+
+		if v, ok := cp["bootstrap.servers"]; ok && v != nil {
+			tfMap["bootstrap_servers"] = aws.StringValue(v)
+		}
+
+		if v, ok := cp["compression.type"]; ok && v != nil {
+			tfMap["compression_type"] = aws.StringValue(v)
+		}
+
+		if v, ok := cp["key.serializer"]; ok && v != nil {
+			tfMap["key_serializer"] = aws.StringValue(v)
+		}
+
+		if v, ok := cp["value.serializer"]; ok && v != nil {
+			tfMap["value_serializer"] = aws.StringValue(v)
+		}
+
+		if v, ok := cp["ssl.truststore"]; ok && v != nil {
+			tfMap["ssl_truststore"] = aws.StringValue(v)
+		}
+
+		if v, ok := cp["ssl.truststore.password"]; ok && v != nil {
+			tfMap["ssl_truststore_password"] = aws.StringValue(v)
+		}
+
+		if sp, ok := cp["security.protocol"]; ok && sp != nil {
+			protocol := aws.StringValue(sp)
+			tfMap["security_protocol"] = protocol
+
+			switch protocol {
+			case "SSL":
+				if v, ok := cp["ssl.keystore"]; ok && v != nil {
+					tfMap["ssl_keystore"] = aws.StringValue(v)
+				}
+
+				if v, ok := cp["ssl.keystore.password"]; ok && v != nil {
+					tfMap["ssl_keystore_password"] = aws.StringValue(v)
+				}
+
+				if v, ok := cp["ssl.key.password"]; ok && v != nil {
+					tfMap["ssl_key_password"] = aws.StringValue(v)
+				}
+			case "SASL":
+				if m, ok := cp["sasl.mechanism"]; ok && m != nil {
+					mechanism := aws.StringValue(m)
+					tfMap["sasl_mechanism"] = mechanism
+
+					switch mechanism {
+					case "PLAIN":
+						if v, ok := cp["sasl.plain.username"]; ok && v != nil {
+							tfMap["sasl_plain_username"] = aws.StringValue(v)
+						}
+
+						if v, ok := cp["sasl.plain.password"]; ok && v != nil {
+							tfMap["sasl_plain_password"] = aws.StringValue(v)
+						}
+					case "SCRAM-SHA-512":
+						if v, ok := cp["sasl.scram.username"]; ok && v != nil {
+							tfMap["sasl_scram_username"] = aws.StringValue(v)
+						}
+
+						if v, ok := cp["sasl.scram.password"]; ok && v != nil {
+							tfMap["sasl_scram_password"] = aws.StringValue(v)
+						}
+					case "GSSAPI":
+						if v, ok := cp["sasl.kerberos.keytab"]; ok && v != nil {
+							tfMap["sasl_kerberos_keytab"] = aws.StringValue(v)
+						}
+
+						if v, ok := cp["sasl.kerberos.krb5.kdc"]; ok && v != nil {
+							tfMap["sasl_kerberos_krb5_kdc"] = aws.StringValue(v)
+						}
+
+						if v, ok := cp["sasl.kerberos.krb5.realm"]; ok && v != nil {
+							tfMap["sasl_kerberos_krb5_realm"] = aws.StringValue(v)
+						}
+
+						if v, ok := cp["sasl.kerberos.principal"]; ok && v != nil {
+							tfMap["sasl_kerberos_principal"] = aws.StringValue(v)
+						}
+
+						if v, ok := cp["sasl.kerberos.service.name"]; ok && v != nil {
+							tfMap["sasl_kerberos_service_name"] = aws.StringValue(v)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return []interface{}{tfMap}
+}
+
+// Legacy root attribute handling
 func flattenIotKinesisActions(actions []*iot.Action) []interface{} {
 	results := make([]interface{}, 0)
 
@@ -2650,6 +3241,10 @@ func flattenIotErrorAction(errorAction *iot.Action) []map[string]interface{} {
 	}
 	if errorAction.IotEvents != nil {
 		results = append(results, map[string]interface{}{"iot_events": flattenIotIotEventsActions(input)})
+		return results
+	}
+	if errorAction.Kafka != nil {
+		results = append(results, map[string]interface{}{"kafka": flattenIotKafkaActions(input)})
 		return results
 	}
 	if errorAction.Kinesis != nil {

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -279,6 +279,31 @@ func TestAccAWSIoTTopicRule_firehose_separator(t *testing.T) {
 	})
 }
 
+func TestAccAWSIoTTopicRule_kafka(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iot.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTTopicRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTTopicRule_kafka(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTTopicRuleExists("aws_iot_topic_rule.rule"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSIoTTopicRule_kinesis(t *testing.T) {
 	rName := acctest.RandString(5)
 	resourceName := "aws_iot_topic_rule.rule"
@@ -859,6 +884,31 @@ resource "aws_iot_topic_rule" "rule" {
   }
 }
 `, rName, separator)
+}
+
+func testAccAWSIoTTopicRule_kafka(rName string) string {
+	return fmt.Sprintf(testAccAWSIoTTopicRuleRole+`
+resource "aws_vpc" "iot_vpc" {
+	cidr_block = "10.0.0.0/16"
+}
+resource "aws_secretsmanager_secret" "keystore" {
+	name = "keystore"
+}
+resource "aws_iot_topic_rule" "rule" {
+  name        = "test_rule_%[1]s"
+  description = "Example rule"
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+  kafka {
+    destination_arn    = aws_vpc.iot_vpc.arn
+		topic							 = "fake_topic"
+		bootstrap_servers = "b-1.localhost:9094"
+		ssl_keystore 					= "${get_secret("aws_secretsmanager_secret.keystore.arn", "SecretBinary", "", "aws_iam_role.iot_role.arn")}"
+		ssl_keystore_password = "password"
+  }
+}
+`, rName)
 }
 
 func testAccAWSIoTTopicRule_kinesis(rName string) string {

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -890,7 +890,7 @@ resource "aws_iot_topic_rule" "rule" {
 func testAccAWSIoTTopicRule_kafka(rName, kName string) string {
 	return fmt.Sprintf(testAccAWSIoTTopicRuleRole+`
 resource "aws_secretsmanager_secret" "%[2]s" {
-	name = "%[2]s"
+  name = "%[2]s"
 }
 resource "aws_iot_topic_rule" "rule" {
   name        = "test_rule_%[1]s"
@@ -899,11 +899,11 @@ resource "aws_iot_topic_rule" "rule" {
   sql         = "SELECT * FROM 'topic/test'"
   sql_version = "2015-10-08"
   kafka {
-    destination_arn    		= "[vpc destination arn]"
-		topic							 		= "fake_topic"
-		bootstrap_servers 		= "b-1.localhost:9094"
-		ssl_keystore 					= "$${get_secret('${aws_secretsmanager_secret.%[2]s.arn}', 'SecretBinary', '', '${aws_iam_role.iot_role.arn}')}"
-		ssl_keystore_password = "password"
+    destination_arn       = "[vpc destination arn]"
+    topic                 = "fake_topic"
+    bootstrap_servers     = "b-1.localhost:9094"
+    ssl_keystore          = "$${get_secret('${aws_secretsmanager_secret.%[2]s.arn}', 'SecretBinary', '', '${aws_iam_role.iot_role.arn}')}"
+    ssl_keystore_password = "password"
   }
 }
 `, rName, kName)

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -281,7 +281,6 @@ func TestAccAWSIoTTopicRule_firehose_separator(t *testing.T) {
 
 func TestAccAWSIoTTopicRule_kafka(t *testing.T) {
 	rName := acctest.RandString(5)
-	kName := acctest.RandomWithPrefix("secret_key")
 	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -291,7 +290,7 @@ func TestAccAWSIoTTopicRule_kafka(t *testing.T) {
 		CheckDestroy: testAccCheckAWSIoTTopicRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSIoTTopicRule_kafka(rName, kName),
+				Config: testAccAWSIoTTopicRule_kafka(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIoTTopicRuleExists("aws_iot_topic_rule.rule"),
 				),
@@ -887,11 +886,8 @@ resource "aws_iot_topic_rule" "rule" {
 `, rName, separator)
 }
 
-func testAccAWSIoTTopicRule_kafka(rName, kName string) string {
+func testAccAWSIoTTopicRule_kafka(rName string) string {
 	return fmt.Sprintf(testAccAWSIoTTopicRuleRole+`
-resource "aws_secretsmanager_secret" "%[2]s" {
-  name = "%[2]s"
-}
 resource "aws_iot_topic_rule" "rule" {
   name        = "test_rule_%[1]s"
   description = "Example rule"
@@ -902,11 +898,11 @@ resource "aws_iot_topic_rule" "rule" {
     destination_arn       = "[vpc destination arn]"
     topic                 = "fake_topic"
     bootstrap_servers     = "b-1.localhost:9094"
-    ssl_keystore          = "$${get_secret('${aws_secretsmanager_secret.%[2]s.arn}', 'SecretBinary', '', '${aws_iam_role.iot_role.arn}')}"
+    ssl_keystore          = "$${get_secret('secret_name', 'SecretBinary', '', '${aws_iam_role.iot_role.arn}')}"
     ssl_keystore_password = "password"
   }
 }
-`, rName, kName)
+`, rName)
 }
 
 func testAccAWSIoTTopicRule_kinesis(rName string) string {

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -901,10 +901,10 @@ resource "aws_iot_topic_rule" "rule" {
   sql         = "SELECT * FROM 'topic/test'"
   sql_version = "2015-10-08"
   kafka {
-    destination_arn    = aws_vpc.iot_vpc.arn
-		topic							 = "fake_topic"
-		bootstrap_servers = "b-1.localhost:9094"
-		ssl_keystore 					= "${get_secret("aws_secretsmanager_secret.keystore.arn", "SecretBinary", "", "aws_iam_role.iot_role.arn")}"
+    destination_arn    		= aws_vpc.iot_vpc.arn
+		topic							 		= "fake_topic"
+		bootstrap_servers 		= "b-1.localhost:9094"
+		ssl_keystore 					= "$${get_secret('${aws_secretsmanager_secret.keystore.arn}', 'SecretBinary', '', '${aws_iam_role.iot_role.arn}')}"
 		ssl_keystore_password = "password"
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17506

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSIoTTopicRule_kafka'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIoTTopicRule_kafka -timeout 180m
=== RUN   TestAccAWSIoTTopicRule_kafka
=== PAUSE TestAccAWSIoTTopicRule_kafka
=== CONT  TestAccAWSIoTTopicRule_kafka
    resource_aws_iot_topic_rule_test.go:287: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_iot_topic_rule.rule will be updated in-place
          ~ resource "aws_iot_topic_rule" "rule" {
                id          = "test_rule_16e88"
                name        = "test_rule_16e88"
                tags        = {}
                # (5 unchanged attributes hidden)
        
              - kafka {
                  - acks                  = 0 -> null
                  - bootstrap_servers     = "b-1.localhost:9094" -> null
                  - compression_type      = "none" -> null
                  - destination_arn       = "[ redacted ]" -> null
                  - key_serializer        = "org.apache.kafka.common.serialization.StringSerializer" -> null
                  - security_protocol     = "SSL" -> null
                  - ssl_keystore          = "${get_secret('[ redacted ]', 'SecretBinary', '', '[ redacted ]')}" -> null
                  - ssl_keystore_password = "password" -> null
                  - topic                 = "fake_topic" -> null
                  - value_serializer      = "org.apache.kafka.common.serialization.ByteBufferSerializer" -> null
                }
              + kafka {
                  + acks                  = 1
                  + bootstrap_servers     = "b-1.localhost:9094"
                  + compression_type      = "none"
                  + destination_arn       = "[ redacted ]"
                  + key_serializer        = "org.apache.kafka.common.serialization.StringSerializer"
                  + security_protocol     = "SSL"
                  + ssl_keystore          = "${get_secret('[ redacted ], 'SecretBinary', '', '[ redacted ]')}"
                  + ssl_keystore_password = "password"
                  + topic                 = "fake_topic"
                  + value_serializer      = "org.apache.kafka.common.serialization.ByteBufferSerializer"
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAWSIoTTopicRule_kafka (24.82s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	26.579s
FAIL
```
