### PR TITLE
r/ssm_parameter: allow adding tags to a parameter if `overwrite` is specified

### DIFF
--- a/.changelog/18640.txt
+++ b/.changelog/18640.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_parameter: Allow `tags` to be applied to resource when `overwrite` is configured
+```

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -109,10 +111,8 @@ func resourceAwsSsmParameter() *schema.Resource {
 }
 
 func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
-	ssmconn := meta.(*AWSClient).ssmconn
+	conn := meta.(*AWSClient).ssmconn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
-
-	log.Printf("[DEBUG] Reading SSM Parameter: %s", d.Id())
 
 	input := &ssm.GetParameterInput{
 		Name:           aws.String(d.Id()),
@@ -122,9 +122,9 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	var resp *ssm.GetParameterOutput
 	err := resource.Retry(ssmParameterCreationValidationTimeout, func() *resource.RetryError {
 		var err error
-		resp, err = ssmconn.GetParameter(input)
+		resp, err = conn.GetParameter(input)
 
-		if isAWSErr(err, ssm.ErrCodeParameterNotFound, "") && d.IsNewResource() && d.Get("data_type").(string) == "aws:ec2:image" {
+		if tfawserr.ErrCodeEquals(err, ssm.ErrCodeParameterNotFound) && d.IsNewResource() && d.Get("data_type").(string) == "aws:ec2:image" {
 			return resource.RetryableError(fmt.Errorf("error reading SSM Parameter (%s) after creation: this can indicate that the provided parameter value could not be validated by SSM", d.Id()))
 		}
 
@@ -135,11 +135,11 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 		return nil
 	})
 
-	if isResourceTimeoutError(err) {
-		resp, err = ssmconn.GetParameter(input)
+	if tfresource.TimedOut(err) {
+		resp, err = conn.GetParameter(input)
 	}
 
-	if isAWSErr(err, ssm.ErrCodeParameterNotFound, "") && !d.IsNewResource() {
+	if tfawserr.ErrCodeEquals(err, ssm.ErrCodeParameterNotFound) && !d.IsNewResource() {
 		log.Printf("[WARN] SSM Parameter (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -150,7 +150,7 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	param := resp.Parameter
-	name := *param.Name
+	name := aws.StringValue(param.Name)
 	d.Set("name", name)
 	d.Set("type", param.Type)
 	d.Set("value", param.Value)
@@ -165,9 +165,9 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 			},
 		},
 	}
-	describeResp, err := ssmconn.DescribeParameters(describeParamsInput)
+	describeResp, err := conn.DescribeParameters(describeParamsInput)
 	if err != nil {
-		return fmt.Errorf("error describing SSM parameter: %w", err)
+		return fmt.Errorf("error describing SSM parameter (%s): %w", d.Id(), err)
 	}
 
 	if describeResp == nil || len(describeResp.Parameters) == 0 || describeResp.Parameters[0] == nil {
@@ -186,7 +186,7 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("allowed_pattern", detail.AllowedPattern)
 	d.Set("data_type", detail.DataType)
 
-	tags, err := keyvaluetags.SsmListTags(ssmconn, name, ssm.ResourceTypeForTaggingParameter)
+	tags, err := keyvaluetags.SsmListTags(conn, name, ssm.ResourceTypeForTaggingParameter)
 
 	if err != nil {
 		return fmt.Errorf("error listing tags for SSM Parameter (%s): %w", name, err)
@@ -202,13 +202,16 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsSsmParameterDelete(d *schema.ResourceData, meta interface{}) error {
-	ssmconn := meta.(*AWSClient).ssmconn
+	conn := meta.(*AWSClient).ssmconn
 
-	log.Printf("[INFO] Deleting SSM Parameter: %s", d.Id())
-
-	_, err := ssmconn.DeleteParameter(&ssm.DeleteParameterInput{
+	_, err := conn.DeleteParameter(&ssm.DeleteParameterInput{
 		Name: aws.String(d.Get("name").(string)),
 	})
+
+	if tfawserr.ErrCodeEquals(err, ssm.ErrCodeParameterNotFound) {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error deleting SSM Parameter (%s): %s", d.Id(), err)
 	}
@@ -217,10 +220,9 @@ func resourceAwsSsmParameterDelete(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error {
-	ssmconn := meta.(*AWSClient).ssmconn
+	conn := meta.(*AWSClient).ssmconn
 
 	name := d.Get("name").(string)
-	log.Printf("[INFO] Creating SSM Parameter: %s", name)
 
 	paramInput := &ssm.PutParameterInput{
 		Name:           aws.String(name),
@@ -244,26 +246,31 @@ func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error 
 		paramInput.SetKeyId(keyID.(string))
 	}
 
-	if v, ok := d.GetOk("tags"); ok && d.IsNewResource() {
+	// AWS SSM Service only supports PutParameter requests with Tags
+	// iff Overwrite is not provided or is false; in this resource's case,
+	// the Overwrite value is always set in the paramInput so we check for the value
+	if v, ok := d.GetOk("tags"); ok && aws.BoolValue(paramInput.Overwrite) == false {
 		paramInput.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SsmTags()
 	}
 
-	log.Printf("[DEBUG] Waiting for SSM Parameter %v to be updated", d.Get("name"))
-	_, err := ssmconn.PutParameter(paramInput)
+	_, err := conn.PutParameter(paramInput)
 
-	if isAWSErr(err, "ValidationException", "Tier is not supported") {
+	if tfawserr.ErrMessageContains(err, "ValidationException", "Tier is not supported") {
 		paramInput.Tier = nil
-		_, err = ssmconn.PutParameter(paramInput)
+		_, err = conn.PutParameter(paramInput)
 	}
 
 	if err != nil {
 		return fmt.Errorf("error creating SSM parameter: %w", err)
 	}
 
-	if !d.IsNewResource() && d.HasChange("tags") {
+	// Since the AWS SSM Service does not support PutParameter requests with
+	// Tags and Overwrite set to true, we make an additional API call
+	// to Update the resource's tags if necessary
+	if d.HasChange("tags") && paramInput.Tags == nil {
 		o, n := d.GetChange("tags")
 
-		if err := keyvaluetags.SsmUpdateTags(ssmconn, name, ssm.ResourceTypeForTaggingParameter, o, n); err != nil {
+		if err := keyvaluetags.SsmUpdateTags(conn, name, ssm.ResourceTypeForTaggingParameter, o, n); err != nil {
 			return fmt.Errorf("error updating SSM Parameter (%s) tags: %w", name, err)
 		}
 	}

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -239,6 +239,87 @@ func TestAccAWSSSMParameter_overwrite(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMParameter_overwriteWithTags(t *testing.T) {
+	var param ssm.Parameter
+	rName := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ssm.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMParameterConfigOverwriteWithTags1(rName, true, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+			{
+				Config: testAccAWSSSMParameterConfigOverwriteWithTags1(rName, true, "key1", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMParameter_updateToOverwriteWithTags(t *testing.T) {
+	var param ssm.Parameter
+	rName := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ssm.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMParameterBasicConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMParameterConfigOverwriteWithTags1(rName, true, "key1", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSSMParameterConfigOverwriteWithTags1(rName, false, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMParameter_tags(t *testing.T) {
 	var param ssm.Parameter
 	rName := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
@@ -704,6 +785,20 @@ resource "aws_ssm_parameter" "test" {
   overwrite = true
 }
 `, rName, pType, value)
+}
+
+func testAccAWSSSMParameterConfigOverwriteWithTags1(rName string, overwrite bool, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_parameter" "test" {
+  name      = %[1]q
+  overwrite = %[2]t
+  type      = "String"
+  value     = %[1]q
+  tags = {
+    %[3]q = %[4]q
+  }
+}
+`, rName, overwrite, tagKey1, tagValue1)
 }
 
 func testAccAWSSSMParameterSecureConfig(rName string, value string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18550 

### Description

* Tags w/Overwrite handling added to allow for both arguments; in the case of `overwrite` present in a configuration, we pass the value into the `PutParameter` request, but if `tags` is also present in a configuration, we use the SSM UpdateTags method to modify the resource after creation. if `overwrite` is not present, however, can set the `Tags` field in the `PutParameter` request without issue. 

* Previously, handling of the argument `overwrite` was handled internally in the resource code with the following, however it did not entirely respect a user configuration when no value was provided. 

```go
func shouldUpdateSsmParameter(d *schema.ResourceData) bool {
	// If the user has specified a preference, return their preference
	if value, ok := d.GetOkExists("overwrite"); ok {
		return value.(bool)
	}

	// Since the user has not specified a preference, obey lifecycle rules
	// if it is not a new resource, otherwise overwrite should be set to false.
	return !d.IsNewResource()
}

```
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSSSMParameter_fullPath (165.00s)
--- PASS: TestAccAWSSSMParameter_overwriteWithTags (165.01s)
--- PASS: TestAccAWSSSMParameter_secure (165.04s)
--- PASS: TestAccAWSSSMParameter_disappears (183.90s)
--- PASS: TestAccAWSSSMParameter_noOverwriteWithTags (192.69s)
--- PASS: TestAccAWSSSMParameter_DataType_AwsEc2Image (204.60s)
--- PASS: TestAccAWSSSMParameter_basic (226.48s)
--- PASS: TestAccAWSSSMParameter_secure_with_key (244.31s)
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (268.60s)
--- PASS: TestAccAWSSSMParameter_updateType (270.31s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (278.30s)
--- PASS: TestAccAWSSSMParameter_overwrite (279.19s)
--- PASS: TestAccAWSSSMParameter_updateDescription (279.19s)
--- PASS: TestAccAWSSSMParameter_updateToOverwriteWithTags (279.73s)
--- PASS: TestAccAWSSSMParameter_tags (310.08s)
--- PASS: TestAccAWSSSMParameter_Tier_IntelligentTieringToStandard (310.36s)
--- PASS: TestAccAWSSSMParameter_Tier (311.24s)
--- PASS: TestAccAWSSSMParameter_Tier_IntelligentTieringToAdvanced (313.25s)
```
